### PR TITLE
Make the target explicit, switchable, and nameable

### DIFF
--- a/docs/clients.md
+++ b/docs/clients.md
@@ -99,6 +99,9 @@ thing this client cannot be given.
 
 These need a [deployment](deploy.md) — there is no address they can be given that reaches a laptop.
 
+`cloud` in these commands is a target name — whatever your deployment is called. `lanes link target
+list` shows yours.
+
 Add a custom connector by URL, using the address `lanes link outputs --target cloud` prints. The
 client registers itself, a browser opens on your endpoint's own approval page, and you paste that
 target's token once — from `lanes link outputs --show --target cloud`. Same flow on a laptop and on a

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -31,9 +31,31 @@ $ lanes link outputs --target cloud        # the URL your agent needs
 to write a credential. The second deploy is what gets a revision to pick up the accounts you just
 authorised.
 
+`cloud` there is a name, not a keyword — it is what the first deploy calls the target it creates.
+`lanes link target list` shows what your profile declares and which one commands are using.
+
 Already built a workspace locally? `lanes link secrets push --from local --to cloud` migrates it
 instead of the `connect` step. It copies and never deletes, and skips anything the destination
 already holds unless you pass `--overwrite`.
+
+## A second one
+
+Name it, and everything downstream takes the same flag:
+
+```console
+$ lanes link deploy --target staging       # its own project, bucket, and service
+$ lanes link outputs --target staging
+```
+
+Tired of typing it? `export LANES_LINK_TARGET=staging` for the shell, or
+`lanes link target use staging` to make it this profile's default. Every command prints which target
+it resolved and where that came from, so neither can act on you silently.
+
+## Which profiles it serves
+
+`lanes link deploy` uploads **every** profile in your workspace unless you name one with
+`--profile`, and the endpoint serves all of them under one token. Pass `--profile personal` if you
+want just the one; use a second workspace if you want a boundary that holds.
 
 ## Two answers in the first run decide whether an agent can reach it
 

--- a/docs/detailed/configuration.md
+++ b/docs/detailed/configuration.md
@@ -146,6 +146,56 @@ beside it (ADR-020). A profile written before that keeps its `database:` key and
 
 Credentials follow the target, because each target has its own credential store.
 
+### More than one deployment
+
+`local` and `cloud` are conventions, not keywords — nothing reserves either name, and a profile may
+declare as many targets as it has places to run. A second deployment is named on the deploy that
+creates it (`lanes link deploy --target staging`), which surveys for what it does not know and
+writes the block below.
+
+```yaml
+contract: 1
+
+instance:
+  profile: personal
+  default_target: local
+
+targets:
+  local:
+    credentials: { adapter: file }
+    storage: { adapter: filesystem }
+
+  cloud:
+    credentials: { adapter: gcp-secret-manager, project: my-project }
+    storage: { adapter: gcs, bucket: your-bucket }
+    vault: { adapter: secret }
+    deploy:
+      platform: cloudrun
+      project: my-project
+      region: europe-west1
+      service: my-service
+      access: public
+
+  staging:
+    credentials: { adapter: gcp-secret-manager, project: my-other-project }
+    storage: { adapter: gcs, bucket: your-other-bucket }
+    vault: { adapter: secret }
+    deploy:
+      platform: cloudrun
+      project: my-other-project
+      region: europe-west1
+      service: my-other-service
+      access: public
+```
+
+`lanes link target list` prints what a profile declares and which target is in play;
+`lanes link target use <name>` rewrites `instance.default_target`. Once two targets declare a
+`deploy` block, a bare `lanes link deploy` asks which you meant rather than picking.
+
+Each target's credential store is its own, so a connection authorised against `cloud` is absent from
+`staging` — `lanes link secrets push --from cloud --to staging` copies them across instead of
+re-running every consent.
+
 Two cloud blob adapters, and the difference is setup rather than capability. `gcs` authenticates
 as the identity already present — the service account `lanes link deploy` grants `objectAdmin`, or
 your own gcloud credentials locally — so the bucket needs **no credential of its own**. `s3` needs
@@ -177,7 +227,7 @@ unreadable while appearing to work. Mint one with `lanes link vault key generate
 |---|---|
 | `LANES_LINK_HOME` | Workspace root. Otherwise the nearest ancestor holding `lanes-link.yaml`, else `~/.lanes-link`. |
 | `LANES_LINK_PROFILE` | Profile, below `--profile` and above the workspace default. |
-| `LANES_LINK_TARGET` | Target, for the container entrypoint. |
+| `LANES_LINK_TARGET` | Target, below `--target` and above `instance.default_target`. Not read by `deploy`. Also how the container entrypoint selects its adapter set. |
 | `LANES_LINK_HOST` / `PORT` | Bind address and port in a container. |
 | `LANES_LINK_CREDENTIAL_KEY` | base64 32-byte key for the encrypted credential store. |
 | `LANES_LINK_VAULT_KEY` | base64 32-byte key for the vault. **A different key, deliberately** — one master secret reused across purposes turns any single compromise into a total one. |

--- a/docs/detailed/deployment-cloudrun.md
+++ b/docs/detailed/deployment-cloudrun.md
@@ -127,11 +127,36 @@ $ lanes link deploy                        # again, so the revision sees them
 $ lanes link outputs --target cloud        # the URL an agent needs
 ```
 
-**No `--target` on `deploy`.** It deploys the target that declares a deployment — one is the answer,
-none means a first run and creates `cloud`, and several is a real question it asks rather than
-guesses. It used to be required, and the reason was an accident: an absent flag fell back to
-`instance.default_target`, which is `local` — a target that is by definition not deployed. The
-commands around it keep the flag, because `connect` and `outputs` are just as usable against `local`.
+### More than one deployment
+
+`cloud` is a target name rather than a keyword. A second deployment is named on the deploy that
+creates it, and everything downstream takes the same flag:
+
+```console
+$ lanes link deploy --target staging       # surveys, writes targets.staging, rolls a revision
+$ lanes link target list                   # what this profile declares, and which is in play
+$ lanes link secrets push --from cloud --to staging
+$ lanes link outputs --target staging
+```
+
+The revision carries its own name — the rollout sets `LANES_LINK_TARGET=<target>` on the service, so
+a `staging` container opens `staging`'s adapters. Give each its own project and bucket unless you
+intend them to share a credential store; the survey proposes fresh names, so pressing return through
+it is the safe answer.
+
+Once two targets declare a `deploy` block, a bare `lanes link deploy` refuses and asks which you
+meant. Rolling a revision to whichever came first in a YAML mapping is the one answer that cannot be
+right on purpose.
+
+**`deploy` needs no `--target` when there is one deployment to mean.** It deploys the target that
+declares one; none means a first run and creates `cloud`; several is a real question it asks rather
+than guesses. It used to be *required*, and the reason was an accident: an absent flag fell back to
+`instance.default_target`, which is `local` — a target that is by definition not deployed.
+
+You still name one to deploy a second — see [More than one deployment](#more-than-one-deployment).
+`deploy` is also the only command that may name a target which does not exist yet, since creating it
+is what a first deploy is for; that is why it does not read `LANES_LINK_TARGET`, where a typo would
+be surveyed and rolled out rather than refused.
 
 `lanes link deploy` runs `check`, asks for anything the config does not say yet and writes the
 answers into your profile, creates the project-level resources on a first run, gets the credential

--- a/docs/detailed/init.md
+++ b/docs/detailed/init.md
@@ -563,13 +563,15 @@ Workspace root resolves from `LANES_LINK_HOME`, else the nearest ancestor direct
 
 Profile resolves from `--profile <name>`, then `LANES_LINK_PROFILE`, then `default_profile` in the workspace file, then an error listing available profiles. A profile name maps to `profiles/<name>.yaml`.
 
-Target resolves from `--target <name>`, defaulting to `instance.default_target`. `lanes link start` implies `local`; `lanes link deploy` implies `cloud`.
+Target resolves from `--target <name>`, then `LANES_LINK_TARGET`, then `instance.default_target`. `lanes link deploy` resolves it differently — the one target declaring a `deploy` block, else `cloud` — and deliberately does not read the environment variable, because it is the one command that may name a target which does not exist yet.
 
 **Every command prints the resolved profile and target before acting**, read-only commands included. This is the primary guard against operating on the wrong instance, and it costs one line.
 
-Do not implement a sticky `lanes link use` that persists a current selection. Persisted context state is the standard way operators run destructive commands against the wrong target. `export LANES_LINK_PROFILE=work` gives the same convenience while remaining visible in the shell.
+Do not implement a sticky `lanes link use` that persists a *hidden* current selection. Persisted context state is the standard way operators run destructive commands against the wrong target, and the version that bites is the one nothing prints. What is offered instead is visible in both directions: `export LANES_LINK_PROFILE=work` / `export LANES_LINK_TARGET=cloud` for a shell, and `lanes link profile default <name>` / `lanes link target use <name>` for a value written into a config file that `check` validates.
 
 Profile management: `lanes link profile add <name> [--default]`, `lanes link profile list`, `lanes link profile remove <name>`, `lanes link profile default <name>`.
+
+Target management: `lanes link target list [--urls]`, `lanes link target show [<name>]`, `lanes link target use <name>`. Listing must not refuse when the resolved target is undeclared — that is precisely the state an operator runs it to diagnose.
 
 ### Command groups
 
@@ -601,7 +603,7 @@ lanes link policy allow "gmail.*" gmail.main
 lanes link policy deny  gmail.send gmail.main
 lanes link connection add gmail.side --display-name "Side projects"   # scripting escape hatch
 lanes link provider enable gmail --oauth-app google                   # scripting escape hatch
-lanes link target set cloud --project P --region R --service S
+lanes link target use cloud                                           # instance.default_target
 ```
 
 Each validates the resulting document before writing, so the file is never left invalid. Connection arguments use the `provider.id` notation used everywhere else.

--- a/docs/detailed/workflow.md
+++ b/docs/detailed/workflow.md
@@ -173,6 +173,42 @@ credential store, so what one holds is invisible to another — but they now sha
 token, so an agent holding that token can reach either by asking. **If you need a boundary that
 holds against the agent itself, use a second workspace**, which shares nothing at all.
 
+## Where a profile runs
+
+A **target** names an adapter set — a credential store and a blob store, and optionally a
+deployment. Connections, providers, policy and limits are declared once and apply to every target,
+so moving between them changes where the bytes go and nothing above them.
+
+```console
+$ lanes link target list
+profile personal (workspace-default)  target local (config-default)  ~/.lanes-link
+
+       cloud    gcp-secret-manager  gcs         cloudrun  my-service  europe-west1
+       staging  gcp-secret-manager  gcs         —
+  * →  local    file                filesystem  —
+
+  *  instance.default_target — what commands run against
+  →  what this shell resolves to right now
+```
+
+Two markers, because two things choose and they can disagree. `*` is the profile's
+`instance.default_target`; `→` is what *this shell* resolves to, which `LANES_LINK_TARGET` or
+`--target` may have moved. When they differ, the listing says which variable did it.
+
+```console
+$ lanes link target use cloud       # rewrite instance.default_target, for good
+$ export LANES_LINK_TARGET=cloud    # or just for this shell
+$ lanes link target show cloud      # adapters, deployment, and the address it answers on
+```
+
+`target list` reads the file and asks nobody; `--urls` adds one platform lookup per deployable
+target. `target show` always asks, because it is one target and you named it.
+
+Note what `--target` does *not* do: it never points the CLI at a running endpoint. Every command
+opens that target's stores directly, so `lanes link connect gmail --target cloud` runs the browser
+consent on your machine and writes the refresh token into the deployment's credential store. The
+deployed revision picks it up when it next boots, which is what the second `deploy` below is for.
+
 ## Resolution order
 
 **Workspace root:** `LANES_LINK_HOME` → nearest ancestor containing `lanes-link.yaml` → `~/.lanes-link`
@@ -180,16 +216,31 @@ holds against the agent itself, use a second workspace**, which shares nothing a
 **Profile:** `--profile` → `LANES_LINK_PROFILE` → `default_profile` → an error listing what exists.
 Never a silent pick: the wrong guess operates on the wrong accounts.
 
-**Target:** `--target` → `instance.default_target`
+**Target:** `--target` → `LANES_LINK_TARGET` → `instance.default_target`
 
 `deploy` alone resolves it differently: `--target` → the one target declaring a `deploy` block →
 `cloud`. `instance.default_target` is where commands *run*, which is the local target — never an
 answer to "deploy what", so falling back to it made the one unambiguous command the one that
 insisted you say it. Several deployable targets is a real question and is asked rather than guessed.
 
-There is deliberately **no sticky `lanes link use`**. Persisted context state is the standard way operators
-run destructive commands against the wrong target; `export LANES_LINK_PROFILE=work` gives the same
-convenience while staying visible in the shell.
+**`deploy` does not read `LANES_LINK_TARGET` either**, for the same reason and one more: it is the
+only command that may name a target which does not exist yet, so an exported typo would not be
+refused — it would be surveyed, written into your profile, and rolled out as a new service. An
+environment variable must not be able to name a Cloud Run service into existence.
+
+There is deliberately **no sticky `lanes link use`** — no hidden per-shell file recording a current
+selection. Persisted context state is the standard way operators run destructive commands against
+the wrong target, and the version that bites is the one nothing prints.
+
+Both ways of not retyping a flag are therefore visible ones:
+
+| | Profile | Target | Where it lives |
+|---|---|---|---|
+| This shell | `LANES_LINK_PROFILE` | `LANES_LINK_TARGET` | your environment, where `env` shows it |
+| This workspace | `lanes link profile default <name>` | `lanes link target use <name>` | a config file `check` validates |
+
+Every command prints which one it landed on, and where that came from — the parenthesised source on
+the first line is `flag`, `environment`, `config-default`, or `workspace-default`.
 
 ## Permissions
 
@@ -295,9 +346,9 @@ $ lanes link deploy                        # again, so the revision sees them
 $ lanes link outputs --target cloud        # the deployed URL an agent needs
 ```
 
-`deploy` takes no `--target`: it deploys the target that has a deployment, and there is only ever
-one worth meaning. The commands around it do take one, because `connect` and `outputs` are just as
-usable against `local`.
+`deploy` needs no `--target` when there is one deployment to mean: it deploys the target that has
+one, creates `cloud` when none does, and *asks* rather than guessing when several do. Naming one is
+how you deploy a second — see below.
 
 The first `deploy` writes the target if there is not one, and creates the project resources it
 names. `connect` comes after it rather than before, because a credential store it has not created
@@ -306,6 +357,47 @@ reconcile the accounts you just authorised.
 
 `lanes link secrets push --from local --to cloud` migrates a setup you already built locally,
 instead of the `connect` step.
+
+### More than one deployment
+
+`cloud` is a target name, not a keyword — nothing in the code reserves it, and a profile may declare
+as many deployable targets as you like. The second one is named on the deploy that creates it:
+
+```console
+$ lanes link deploy --target staging      # surveys and writes targets.staging, then rolls it
+$ lanes link target list                  # what this profile declares, and which is in play
+$ lanes link connect gmail --target staging
+$ lanes link outputs --target staging
+```
+
+Once two targets declare a deployment, a bare `lanes link deploy` refuses and asks which you meant —
+rolling a revision to whichever came first in a YAML mapping is the one answer that cannot be right
+on purpose.
+
+Each target has its own credential store, so a connection authorised against one is absent from the
+other. `lanes link secrets push --from cloud --to staging` copies them instead of re-running every
+consent.
+
+### Which profiles a deploy uploads
+
+`deploy` uploads the workspace config the revision will read, and **the scope is the `--profile`
+flag rather than the resolved profile**:
+
+| Invocation | Uploads |
+|---|---|
+| `lanes link deploy --profile work` | `profiles/work.yaml` alone |
+| `LANES_LINK_PROFILE=work lanes link deploy` | **every** profile in the workspace |
+| `lanes link deploy` (profile from `default_profile`) | **every** profile in the workspace |
+
+That is surprising, and it is the behaviour rather than a description of a bug being fixed: the flag
+is read directly, so a profile resolved any other way leaves the scope undefined and the whole
+workspace travels. The endpoint then serves every profile whose YAML is in the bucket, under one
+token (ADR-009).
+
+No credential ever travels — `data/` is never uploaded and each target has its own store, so a
+connection you have not migrated reconciles as `unauthorized` rather than silently working. If you
+want one profile deployed, pass `--profile` explicitly; if you want a boundary that holds, use a
+second workspace.
 
 ```console
 $ lanes link secrets list --target cloud     # reference names only; no command prints a value
@@ -338,7 +430,7 @@ rules:
 
 ```
 --profile <name>    overrides LANES_LINK_PROFILE and the workspace default
---target  <name>    overrides instance.default_target
+--target  <name>    overrides LANES_LINK_TARGET and instance.default_target
 --connection <id>   which memory/skills/vault connection, when a profile has several
 --yes               skip the confirmation a destructive command would otherwise ask for
 --port    <n>       override the configured port (start only)

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -68,6 +68,11 @@ the next step hands it over for you.
 Every command prints the profile and target it resolved before it acts — that first line is how you
 know you are operating on the instance you meant.
 
+A **target** is where the profile runs: `local` keeps credentials in an encrypted file and data in a
+directory, and a deployed target keeps them in your cloud instead. Everything above them —
+connections, permissions, limits — is declared once and applies to both. `lanes link target list`
+shows what you have.
+
 ## 5. Register it with your agents
 
 In another shell:

--- a/src/cli/commands/operate/status.ts
+++ b/src/cli/commands/operate/status.ts
@@ -3,6 +3,7 @@ import { oneProfile, visibleCapabilities } from '#server/mcp';
 import { toPolicyDocument } from '#registry';
 import { announce, emit, heading, print, style, table } from '../../output.ts';
 import { openRuntime, ownerPrincipal, type GlobalFlags } from '../../runtime.ts';
+import { deploymentIdentity } from '../../endpoint-url.ts';
 
 /** `lanes link status` — connections, what is reachable through them, and where. */
 
@@ -16,6 +17,19 @@ export interface StatusFlags extends GlobalFlags {
  * `status` answers from config, the database, and policy — no network call. A
  * health probe would make the command that tells you what is configured depend
  * on something being up, and `outputs --json` already reports liveness.
+ *
+ * Which is why a deployed target prints its *identity* rather than its address.
+ * This used to print `http://<host>:<port>/mcp` unconditionally, so
+ * `status --target cloud` named a loopback port with nothing behind it — the
+ * bug `endpoint-url.ts` records having already fixed in `mcp add`. Reaching for
+ * `endpointUrl` here would fix the lie by surrendering the property above: it
+ * shells out to `gcloud`, costs seconds, needs the CLI installed and
+ * authenticated, and swallows every failure back into loopback — so on a fresh
+ * machine or in CI it would print the same wrong answer, more slowly.
+ *
+ * A deployment's address is the platform's to assign and `outputs --target` is
+ * the command that asks. Which service it is, though, is in the config, and a
+ * config-only command can say that much honestly.
  */
 export async function status(flags: StatusFlags): Promise<void> {
   const runtime = await openRuntime(flags);
@@ -53,7 +67,13 @@ export async function status(flags: StatusFlags): Promise<void> {
       .filter((id) => !connected.has(id))
       .sort();
 
-    const endpoint = `http://${runtime.config.instance.host}:${runtime.config.instance.port}/mcp`;
+    // Null rather than a different shape: `endpoint` stays a string-or-null so a
+    // consumer that reads it keeps working, and `deployment` carries what
+    // replaces it. Silently turning a string into an object would be a cost
+    // paid by every reader for the benefit of none.
+    const local = `http://${runtime.config.instance.host}:${runtime.config.instance.port}/mcp`;
+    const deployment = deploymentIdentity(runtime.config.targets[runtime.target]?.deploy);
+    const endpoint = deployment ? null : local;
 
     return emit(
       flags.json,
@@ -62,6 +82,7 @@ export async function status(flags: StatusFlags): Promise<void> {
         profiles: await listProfiles(runtime.resolution.workspaceRoot),
         target: runtime.target,
         endpoint,
+        deployment,
         connections,
         capabilities,
         notConnected,
@@ -92,7 +113,18 @@ export async function status(flags: StatusFlags): Promise<void> {
         }
 
         heading('Endpoint');
-        print(`  ${endpoint}  ${style.dim('(when running)')}`);
+        if (!deployment) {
+          print(`  ${local}  ${style.dim('(when running)')}`);
+        } else {
+          const { platform, service, region } = deployment;
+          print(`  ${platform} service ${style.bold(service)} in ${region}`);
+          print(
+            style.dim(
+              '  the address is the platform\'s to assign — run: ' +
+                `lanes link outputs --target ${runtime.target}`,
+            ),
+          );
+        }
       },
     );
   } finally {

--- a/src/cli/commands/target.test.ts
+++ b/src/cli/commands/target.test.ts
@@ -1,0 +1,268 @@
+import { afterAll, beforeEach, describe, expect, test } from 'bun:test';
+import { mkdtemp, mkdir, readFile, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { readTargets, targetList, targetUse } from './target.ts';
+
+/**
+ * `lanes link target` — what a profile declares, and which one is in play.
+ *
+ * The property that matters most here is not the table. It is that this command
+ * keeps working when `LANES_LINK_TARGET` names something that does not exist:
+ * that is the state in which every *other* command has just started refusing,
+ * and this is the one somebody runs to find out why.
+ */
+
+const roots: string[] = [];
+const previousHome = process.env['LANES_LINK_HOME'];
+const previousTarget = process.env['LANES_LINK_TARGET'];
+
+const PROFILE = `contract: 1
+
+instance:
+  profile: personal
+  # A comment nobody asked this command to remove.
+  default_target: local
+  port: 7337
+
+targets:
+  local:
+    credentials: { adapter: file }
+    storage: { adapter: filesystem }
+  cloud:
+    credentials: { adapter: gcp-secret-manager, project: my-project }
+    storage: { adapter: gcs, bucket: your-bucket }
+    deploy:
+      platform: cloudrun
+      project: my-project
+      region: europe-west1
+      service: my-service
+  staging:
+    credentials: { adapter: gcp-secret-manager, project: my-other-project }
+    storage: { adapter: gcs, bucket: your-other-bucket }
+`;
+
+/**
+ * A throwaway workspace, and the environment that points at it.
+ *
+ * Both, deliberately. An injected `env` replaces `process.env` wholesale — so
+ * `{ env: {} }` does not mean "no variables set", it means `LANES_LINK_HOME` is
+ * gone too, and `resolveWorkspaceRoot` then walks up to `~/.lanes-link`: the
+ * operator's real profiles, credentials and audit log. Every call here passes
+ * `env` from this helper so that cannot happen.
+ */
+async function workspace(): Promise<{
+  root: string;
+  env: Record<string, string | undefined>;
+}> {
+  const root = await mkdtemp(join(tmpdir(), 'lanes-link-target-'));
+  roots.push(root);
+  process.env['LANES_LINK_HOME'] = root;
+
+  await mkdir(join(root, 'profiles'), { recursive: true });
+  await writeFile(join(root, 'lanes-link.yaml'), 'contract: 1\ndefault_profile: personal\n');
+  await writeFile(join(root, 'profiles', 'personal.yaml'), PROFILE);
+  return { root, env: { LANES_LINK_HOME: root } };
+}
+
+beforeEach(() => {
+  delete process.env['LANES_LINK_TARGET'];
+});
+
+afterAll(async () => {
+  if (previousHome === undefined) delete process.env['LANES_LINK_HOME'];
+  else process.env['LANES_LINK_HOME'] = previousHome;
+
+  // Restored rather than merely deleted: this file is the one place that writes
+  // the variable, and leaking it would change what every other test file
+  // resolves to — which is the failure it exists to prevent, one level up.
+  if (previousTarget === undefined) delete process.env['LANES_LINK_TARGET'];
+  else process.env['LANES_LINK_TARGET'] = previousTarget;
+
+  await Promise.all(roots.map((root) => rm(root, { recursive: true, force: true })));
+});
+
+/** Everything written to stdout while `body` runs. */
+async function captureStdout(body: () => Promise<void>): Promise<string> {
+  const original = process.stdout.write.bind(process.stdout);
+  let captured = '';
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (process.stdout as any).write = (chunk: string | Uint8Array): boolean => {
+    captured += typeof chunk === 'string' ? chunk : new TextDecoder().decode(chunk);
+    return true;
+  };
+
+  try {
+    await body();
+  } finally {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (process.stdout as any).write = original;
+  }
+
+  return captured;
+}
+
+describe('what a profile declares', () => {
+  test('reports every target, its adapters, and whether it deploys', async () => {
+    const { env } = await workspace();
+
+    const listing = await readTargets({}, { env });
+
+    expect(listing.targets.map((target) => target.name).sort()).toEqual([
+      'cloud',
+      'local',
+      'staging',
+    ]);
+
+    const cloud = listing.targets.find((target) => target.name === 'cloud')!;
+    expect(cloud.credentials).toBe('gcp-secret-manager');
+    expect(cloud.storage).toBe('gcs');
+    expect(cloud.deployed).toBe(true);
+    expect(cloud.deployment).toMatchObject({ service: 'my-service', region: 'europe-west1' });
+
+    // Declared with no deployment: the distinction `deployed` exists to carry.
+    const staging = listing.targets.find((target) => target.name === 'staging')!;
+    expect(staging.deployed).toBe(false);
+    expect(staging.deployment).toBeNull();
+  });
+
+  test('no url key unless somebody asked for one', async () => {
+    const { env } = await workspace();
+
+    // Absent means "not asked" and null would mean "asked, no answer". A reader
+    // that cannot tell those apart has to shell out to find out.
+    const listing = await readTargets({}, { env });
+    for (const target of listing.targets) expect('url' in target).toBe(false);
+  });
+
+  test('the default and the selection are the same until something separates them', async () => {
+    const { env } = await workspace();
+
+    const listing = await readTargets({}, { env });
+
+    expect(listing.default).toBe('local');
+    expect(listing.selected).toBe('local');
+    expect(listing.selectedSource).toBe('config-default');
+    expect(listing.selectedDeclared).toBe(true);
+  });
+
+  test('LANES_LINK_TARGET moves the selection without moving the default', async () => {
+    const { root } = await workspace();
+
+    const listing = await readTargets(
+      {},
+      { env: { LANES_LINK_HOME: root, LANES_LINK_TARGET: 'cloud' } },
+    );
+
+    expect(listing.default).toBe('local');
+    expect(listing.selected).toBe('cloud');
+    expect(listing.selectedSource).toBe('environment');
+    expect(listing.targets.find((target) => target.name === 'local')!.isDefault).toBe(true);
+    expect(listing.targets.find((target) => target.name === 'cloud')!.isSelected).toBe(true);
+  });
+
+  test('--target beats the environment', async () => {
+    const { root } = await workspace();
+
+    const listing = await readTargets(
+      { target: 'staging' },
+      { env: { LANES_LINK_HOME: root, LANES_LINK_TARGET: 'cloud' } },
+    );
+
+    expect(listing.selected).toBe('staging');
+    expect(listing.selectedSource).toBe('flag');
+  });
+});
+
+describe('when the environment names a target that does not exist', () => {
+  test('the listing survives and says so', async () => {
+    const { root } = await workspace();
+
+    // Every other command is refusing by now. This one has to answer, because
+    // it is the one that shows the name is wrong and what it was measured
+    // against — going through `resolveProfile` here would throw instead.
+    const listing = await readTargets(
+      {},
+      { env: { LANES_LINK_HOME: root, LANES_LINK_TARGET: 'clod' } },
+    );
+
+    expect(listing.selected).toBe('clod');
+    expect(listing.selectedDeclared).toBe(false);
+    expect(listing.targets).toHaveLength(3);
+  });
+
+  test('and the printed output names the variable', async () => {
+    await workspace();
+    process.env['LANES_LINK_TARGET'] = 'clod';
+
+    const written = await captureStdout(() => targetList({}));
+
+    expect(written).toContain('LANES_LINK_TARGET');
+    expect(written).toContain('clod');
+  });
+});
+
+describe('target list --json', () => {
+  test('puts nothing but JSON on stdout', async () => {
+    await workspace();
+
+    const written = await captureStdout(() => targetList({ json: true }));
+
+    // The assertion is the parse: the resolution line every command prints
+    // would throw here and nowhere else.
+    const parsed = JSON.parse(written) as { default: string; targets: { name: string }[] };
+    expect(parsed.default).toBe('local');
+    expect(parsed.targets.map((target) => target.name).sort()).toEqual([
+      'cloud',
+      'local',
+      'staging',
+    ]);
+  });
+});
+
+describe('target use', () => {
+  test('rewrites default_target and leaves the comments alone', async () => {
+    const { root, env } = await workspace();
+
+    await captureStdout(() => targetUse('cloud', {}));
+
+    const written = await readFile(join(root, 'profiles', 'personal.yaml'), 'utf8');
+    expect(written).toContain('default_target: cloud');
+    expect(written).toContain('# A comment nobody asked this command to remove.');
+
+    expect((await readTargets({}, { env })).default).toBe('cloud');
+  });
+
+  test('refuses a target that is not declared, and lists what is', async () => {
+    await workspace();
+
+    await expect(captureStdout(() => targetUse('clod', {}))).rejects.toThrow(
+      /Target "clod" is not declared.*local, cloud, staging/s,
+    );
+  });
+
+  test('writing the value it already holds does not touch the file', async () => {
+    const { root } = await workspace();
+    const path = join(root, 'profiles', 'personal.yaml');
+    const before = await readFile(path, 'utf8');
+
+    await captureStdout(() => targetUse('local', {}));
+
+    // A no-op rewrite churns mtime for nothing, and on a bucket workspace it
+    // costs a PUT.
+    expect(await readFile(path, 'utf8')).toBe(before);
+  });
+
+  test('says when the environment will keep winning anyway', async () => {
+    await workspace();
+    process.env['LANES_LINK_TARGET'] = 'staging';
+
+    const written = await captureStdout(() => targetUse('cloud', {}));
+
+    // Otherwise the operator edits the file, sees nothing change, and concludes
+    // the command is broken.
+    expect(written).toContain('default target is now');
+    expect(written).toMatch(/LANES_LINK_TARGET=staging.*still wins/);
+  });
+});

--- a/src/cli/commands/target.ts
+++ b/src/cli/commands/target.ts
@@ -1,0 +1,310 @@
+import {
+  TARGET_ENV,
+  askedTarget,
+  loadProfileConfig,
+  resolveSelection,
+  undeclaredTarget,
+  type Config,
+  type Resolution,
+} from '#profile';
+import { deployedUrl, deploymentIdentity, type DeploymentIdentity } from '../endpoint-url.ts';
+import { ConfigDocument } from '../config-edit.ts';
+import { announce, emit, heading, ok, print, style, table, waiting, warn } from '../output.ts';
+import type { GlobalFlags } from '../runtime.ts';
+
+/**
+ * `lanes link target` — the adapter sets a profile declares, and which one is in play.
+ *
+ * A target names *where a profile runs*: a credential store and a blob store,
+ * and optionally a deployment. Connections, providers, policy and limits are
+ * declared once and apply to every target, so changing one changes where the
+ * bytes go and nothing above them.
+ *
+ * Two answers are worth telling apart and this is the only place that does.
+ * `instance.default_target` is what commands run against when nobody says, and
+ * it lives in the profile. `LANES_LINK_TARGET` is what *this shell* says, and it
+ * wins. When they disagree — the case that sends someone hunting a bug — `list`
+ * marks both and names the variable.
+ *
+ * Each command is a data function plus a printing wrapper, the split
+ * `profile.ts` uses and for the same reason: `--json` wants the facts without
+ * the rendering.
+ */
+
+export interface TargetSummary {
+  readonly name: string;
+  /** `instance.default_target` — what the file says. */
+  readonly isDefault: boolean;
+  /** What this shell resolves to right now, which may not be the above. */
+  readonly isSelected: boolean;
+  readonly credentials: string;
+  readonly storage: string;
+  readonly vault: string;
+  /** Whether a deployment is declared. Free, and always present. */
+  readonly deployed: boolean;
+  readonly deployment: DeploymentIdentity | null;
+  /** Only when asked for; absent is "not asked", null is "asked, no answer". */
+  readonly url?: string | null;
+}
+
+export interface TargetListing {
+  readonly root: string;
+  readonly profile: string;
+  readonly path: string;
+  readonly default: string;
+  readonly selected: string;
+  readonly selectedSource: 'flag' | 'environment' | 'config-default';
+  /**
+   * Whether `selected` names a target that exists.
+   *
+   * False is the interesting case, and the reason this command does not resolve
+   * its target the ordinary way — see `survey`.
+   */
+  readonly selectedDeclared: boolean;
+  readonly targets: readonly TargetSummary[];
+}
+
+export interface TargetFlags extends GlobalFlags {
+  readonly json?: boolean | undefined;
+  readonly urls?: boolean | undefined;
+}
+
+/**
+ * The profile, its config, and what it declares — in one pass.
+ *
+ * **Deliberately not `resolveProfile`.** That helper resolves the target the way
+ * every other command needs it resolved: by refusing a name that is not
+ * declared. Here that is exactly backwards. `LANES_LINK_TARGET=clod` is the
+ * state in which every other command has just started failing, and this is the
+ * command someone runs to find out why — so it has to survive the condition it
+ * exists to diagnose. It resolves the name with `askedTarget` and reports
+ * whether it landed on anything, rather than throwing. `readProfiles` in
+ * `profile.ts` declines to parse configs for the same reason.
+ */
+async function survey(
+  flags: TargetFlags,
+  options: { urls?: boolean; env?: Record<string, string | undefined> } = {},
+): Promise<{ resolution: Resolution; config: Config; listing: TargetListing }> {
+  const env = options.env ?? (process.env as Record<string, string | undefined>);
+
+  const selection = await resolveSelection({
+    ...(flags.profile !== undefined ? { profileFlag: flags.profile } : {}),
+    ...(flags.target !== undefined ? { targetFlag: flags.target } : {}),
+    ...(options.env !== undefined ? { env: options.env } : {}),
+  });
+
+  const { config } = await loadProfileConfig(selection.workspaceRoot, selection.profile);
+
+  const asked = askedTarget(flags.target, env);
+  const selected = asked.target ?? config.instance.default_target;
+  const names = Object.keys(config.targets);
+
+  const summaries: TargetSummary[] = names.map((name) => {
+    const declared = config.targets[name]!;
+    return {
+      name,
+      isDefault: name === config.instance.default_target,
+      isSelected: name === selected,
+      credentials: declared.credentials.adapter,
+      storage: declared.storage.adapter,
+      vault: declared.vault?.adapter ?? 'file',
+      deployed: declared.deploy !== undefined,
+      deployment: deploymentIdentity(declared.deploy),
+    };
+  });
+
+  return {
+    resolution: { ...selection, target: selected, targetSource: asked.source ?? 'config-default' },
+    config,
+    listing: {
+      root: selection.workspaceRoot,
+      profile: selection.profile,
+      path: selection.profilePath,
+      default: config.instance.default_target,
+      selected,
+      selectedSource: asked.source ?? 'config-default',
+      selectedDeclared: names.includes(selected),
+      // Asking the platform is opt-in: one `gcloud` subprocess per deployable
+      // target, and the profiles that make this command worth running are
+      // exactly the ones with several. A discovery command that takes ten
+      // seconds and needs a cloud CLI installed is one nobody runs twice —
+      // `outputs --target X` is already the command that asks.
+      targets: options.urls === true ? await withUrls(config, summaries) : summaries,
+    },
+  };
+}
+
+/** What `--json` and the tests want, without the rendering. */
+export async function readTargets(
+  flags: TargetFlags,
+  options: { urls?: boolean; env?: Record<string, string | undefined> } = {},
+): Promise<TargetListing> {
+  return (await survey(flags, options)).listing;
+}
+
+/** Every deployable target's address, asked for at once rather than in turn. */
+async function withUrls(
+  config: Config,
+  summaries: readonly TargetSummary[],
+): Promise<TargetSummary[]> {
+  return waiting('asking the platform for addresses', () =>
+    Promise.all(
+      summaries.map(async (summary) => ({
+        ...summary,
+        // Resolves to null immediately for a target with no deployment, and
+        // swallows a missing or unauthenticated `gcloud` — neither is a reason
+        // for a listing to fail.
+        url: await deployedUrl(config.targets[summary.name]?.deploy),
+      })),
+    ),
+  );
+}
+
+export async function targetList(flags: TargetFlags): Promise<void> {
+  const { resolution, listing } = await survey(flags, { urls: flags.urls === true });
+
+  return emit(flags.json, listing, () => {
+    announce(resolution);
+    print();
+
+    table(
+      listing.targets.map((target) => [
+        `  ${target.isDefault ? style.green('*') : ' '} ${target.isSelected ? style.cyan('→') : ' '}`,
+        style.bold(target.name),
+        style.dim(target.credentials),
+        style.dim(target.storage),
+        deploymentCell(target),
+      ]),
+    );
+
+    print();
+    print(style.dim(`  ${style.green('*')}  instance.default_target — what commands run against`));
+    print(style.dim(`  ${style.cyan('→')}  what this shell resolves to right now`));
+
+    // Printed only when the two disagree, which is the whole reason both markers
+    // exist. Saying it every time would train people to stop reading it.
+    if (listing.selectedSource === 'environment') {
+      print(
+        style.dim(
+          `     ${TARGET_ENV}=${listing.selected} is set in this shell and overrides the file.`,
+        ),
+      );
+    }
+
+    if (!listing.selectedDeclared) {
+      print();
+      print(
+        warn(
+          `"${listing.selected}" is not declared here — every command will refuse until it is ` +
+            (listing.selectedSource === 'environment' ? `unset (${TARGET_ENV}).` : 'corrected.'),
+        ),
+      );
+    }
+  });
+}
+
+function deploymentCell(target: TargetSummary): string {
+  if (target.url) return style.dim(target.url);
+  if (!target.deployment) return style.dim('—');
+
+  const { platform, service, region } = target.deployment;
+  // `url === null` means the platform was asked and did not answer; a missing
+  // `url` key means nobody asked. Saying which beats printing the same dash.
+  const asked = target.url === null ? style.dim('  (no address yet)') : '';
+  return `${style.dim(`${platform}  ${service}  ${region}`)}${asked}`;
+}
+
+/**
+ * `lanes link target use <name>` — rewrite `instance.default_target`.
+ *
+ * The persisted half of the switch, and a *declared* one: the value lands in the
+ * profile YAML, where the operator can read it, `check` validates it, and every
+ * command prints that it came from there. That is the distinction `#profile`'s
+ * `workspace.ts` draws — what was rejected is hidden per-shell state in a
+ * dotfile nothing prints, not a default written where defaults already live.
+ */
+export async function targetUse(name: string | undefined, flags: GlobalFlags): Promise<void> {
+  if (!name) throw new Error('Usage: lanes link target use <name>');
+
+  const selection = await resolveSelection({
+    ...(flags.profile !== undefined ? { profileFlag: flags.profile } : {}),
+  });
+  const { config } = await loadProfileConfig(selection.workspaceRoot, selection.profile);
+
+  // Where this profile stands before the edit, not what the edit will make true.
+  announce({
+    ...selection,
+    target: config.instance.default_target,
+    targetSource: 'config-default',
+  });
+
+  // `name` is an argument being validated, not a selection being resolved, so
+  // no environment gets a say in whether it exists.
+  if (!(name in config.targets)) throw undeclaredTarget(name, config);
+
+  if (config.instance.default_target === name) {
+    print(ok(`${style.bold(name)} is already the default`));
+    return;
+  }
+
+  const document = await ConfigDocument.open(selection.workspaceRoot, selection.profile);
+  document.setIn(['instance', 'default_target'], name);
+  await document.save();
+
+  print(ok(`default target is now ${style.bold(name)}`));
+
+  // Otherwise the operator edits the file, sees nothing change, and concludes
+  // the command is broken. The variable is the thing that is winning.
+  const fromEnv = process.env[TARGET_ENV];
+  if (fromEnv && fromEnv !== name) {
+    print(warn(`${TARGET_ENV}=${fromEnv} is set in this shell, and still wins over the file.`));
+  }
+}
+
+/**
+ * `lanes link target show [name]` — one target's adapters, and where it answers.
+ *
+ * The deep counterpart to `list`, and the one that *does* ask the platform: one
+ * target, one subprocess, and you named it. Nothing else prints a target's
+ * adapter set — `config show` dumps the whole file as JSON — which is what earns
+ * this its place beside `outputs`.
+ */
+export async function targetShow(name: string | undefined, flags: TargetFlags): Promise<void> {
+  const { config, listing } = await survey(flags);
+  const wanted = name ?? listing.selected;
+  const summary = listing.targets.find((candidate) => candidate.name === wanted);
+
+  if (!summary) throw undeclaredTarget(wanted, config, listing.selectedSource);
+
+  const url = summary.deployment
+    ? await waiting('asking the platform for an address', () =>
+        deployedUrl(config.targets[wanted]?.deploy),
+      )
+    : null;
+
+  return emit(flags.json, { ...summary, url }, () => {
+    print(style.dim(`${listing.profile}  ${listing.path}`));
+
+    heading(summary.name);
+    table([
+      ['  credentials', summary.credentials],
+      ['  storage', summary.storage],
+      ['  vault', summary.vault],
+    ]);
+
+    if (!summary.deployment) {
+      print();
+      print(style.dim('  No deployment — this target runs wherever the CLI does.'));
+      return;
+    }
+
+    heading('Deployment');
+    table([
+      ['  platform', summary.deployment.platform],
+      ['  service', summary.deployment.service],
+      ['  region', summary.deployment.region],
+      ...(summary.deployment.project ? [['  project', summary.deployment.project]] : []),
+      ['  address', url ?? style.dim('not answering — is it deployed?')],
+    ]);
+  });
+}

--- a/src/cli/endpoint-url.test.ts
+++ b/src/cli/endpoint-url.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from 'bun:test';
 import type { Config } from '#profile';
-import { endpointUrl } from './endpoint-url.ts';
+import { deploymentIdentity, endpointUrl } from './endpoint-url.ts';
 
 /**
  * Which address a command hands to an agent.
@@ -50,5 +50,47 @@ describe('the endpoint address for a target', () => {
     const declared = { platform: 'nowhere', region: 'r', service: 's', access: 'public' };
 
     expect(await endpointUrl(config('cloud', declared), 'cloud')).toBe('http://127.0.0.1:7337/mcp');
+  });
+});
+
+describe('which service a target deploys to', () => {
+  // `status` promises to answer without depending on anything being up, so it
+  // cannot ask the platform for an address. It used to print the local URL
+  // regardless, which named a loopback port with nothing behind it. This is what
+  // it prints instead, and it comes from the file rather than the network.
+  test('a target with no deployment has no identity', () => {
+    expect(deploymentIdentity(undefined)).toBeNull();
+  });
+
+  test('a deployed target names its service without asking anyone', () => {
+    expect(
+      deploymentIdentity({
+        platform: 'cloudrun',
+        region: 'europe-west1',
+        service: 'my-service',
+        access: 'public',
+        project: 'my-project',
+      } as never),
+    ).toEqual({
+      platform: 'cloudrun',
+      region: 'europe-west1',
+      service: 'my-service',
+      project: 'my-project',
+    });
+  });
+
+  test('an absent project is absent rather than undefined', () => {
+    // `exactOptionalPropertyTypes` is on, and a key present with an undefined
+    // value serialises into `--json` as `"project": null`. A reader cannot tell
+    // that apart from a project that is genuinely null.
+    const identity = deploymentIdentity({
+      platform: 'cloudrun',
+      region: 'r',
+      service: 's',
+      access: 'iam',
+    } as never);
+
+    expect(identity).not.toBeNull();
+    expect('project' in identity!).toBe(false);
   });
 });

--- a/src/cli/endpoint-url.ts
+++ b/src/cli/endpoint-url.ts
@@ -41,3 +41,37 @@ export async function deployedUrl(declared: DeployConfig | undefined): Promise<s
     return null;
   }
 }
+
+/**
+ * Which service a target deploys to, from config alone.
+ *
+ * Separate from the two functions above because it answers a different question
+ * at a different cost. They ask the platform where a service *ended up*, which
+ * is a subprocess and a network call; this reads what the profile already
+ * declares, which is free and always available.
+ *
+ * That difference is exactly why `status` needs it. `status` promises to answer
+ * without depending on anything being up, so it cannot ask for an address — but
+ * printing a loopback URL for a deployed target, which is what it used to do, is
+ * worse than printing no URL at all. Naming the service is the honest answer a
+ * config-only command can give.
+ */
+export function deploymentIdentity(
+  declared: DeployConfig | undefined,
+): DeploymentIdentity | null {
+  if (!declared) return null;
+
+  return {
+    platform: declared.platform,
+    service: declared.service,
+    region: declared.region,
+    ...(declared.project !== undefined ? { project: declared.project } : {}),
+  };
+}
+
+export interface DeploymentIdentity {
+  readonly platform: string;
+  readonly service: string;
+  readonly region: string;
+  readonly project?: string;
+}

--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -16,6 +16,7 @@ import {
   tokenShow,
 } from './commands/operate.ts';
 import { profileAdd, profileDefault, profileList } from './commands/profile.ts';
+import { targetList, targetShow, targetUse } from './commands/target.ts';
 import { setupPlan } from './commands/setup.ts';
 import { mcpAdd, mcpList, mcpStdio, skillDocument } from './commands/mcp.ts';
 import { deploy } from '#deployments/deploy.ts';
@@ -101,6 +102,20 @@ export async function run(argv: readonly string[]): Promise<void> {
           return profileDefault(rest[0]);
         default:
           throw new Error(`Unknown: ${PROGRAM} profile ${second}`);
+      }
+
+    case 'target':
+      switch (second) {
+        case 'list':
+        case undefined:
+          return targetList({ ...global, json, urls: flags['urls'] === true });
+        case 'use':
+          if (!rest[0]) throw new Error(`Usage: ${PROGRAM} target use <name>`);
+          return targetUse(rest[0], global);
+        case 'show':
+          return targetShow(rest[0], { ...global, json });
+        default:
+          throw new Error(`Unknown: ${PROGRAM} target ${second}`);
       }
 
     case 'policy':

--- a/src/cli/runtime/select.ts
+++ b/src/cli/runtime/select.ts
@@ -1,10 +1,10 @@
 import { generateProfileToken, ownerPrincipal } from '#auth';
 import type { SecretStore } from '#secrets';
 import {
-  ConfigError,
   loadProfileConfig,
   resolveSelection,
   resolveTarget,
+  undeclaredTarget,
   type Config,
   type Resolution,
 } from '#profile';
@@ -28,21 +28,32 @@ export interface GlobalFlags {
 
 export async function resolveProfile(
   flags: GlobalFlags,
-  /** `deploy` creates the target it is given; see `resolveTarget`. */
-  options: { allowUndeclaredTarget?: boolean } = {},
+  options: {
+    /** `deploy` creates the target it is given; see `resolveTarget`. */
+    allowUndeclaredTarget?: boolean;
+    /** Injected by tests. Both resolutions must read the same one. */
+    env?: Record<string, string | undefined>;
+  } = {},
 ): Promise<{
   resolution: Resolution;
   config: Config;
   target: string;
 }> {
+  // Spread rather than assigned: `exactOptionalPropertyTypes` makes an explicit
+  // `env: undefined` a different type from an absent one, and the absent one is
+  // what means "read the real environment".
+  const env = options.env !== undefined ? { env: options.env } : {};
+
   const selection = await resolveSelection({
     profileFlag: flags.profile,
     targetFlag: flags.target,
+    ...env,
   });
 
   const { config } = await loadProfileConfig(selection.workspaceRoot, selection.profile);
   const { target, source } = resolveTarget(config, flags.target, {
     allowUndeclared: options.allowUndeclaredTarget === true,
+    ...env,
   });
 
   return {
@@ -66,11 +77,7 @@ export async function openSecretStoreFor(
   target: string,
 ): Promise<SecretStore> {
   const declared = config.targets[target];
-  if (!declared) {
-    throw new ConfigError(
-      `Target "${target}" is not declared in this profile (have: ${Object.keys(config.targets).join(', ') || 'none'})`,
-    );
-  }
+  if (!declared) throw undeclaredTarget(target, config);
   return openSecrets({ declared, config, root, target });
 }
 

--- a/src/cli/usage.ts
+++ b/src/cli/usage.ts
@@ -41,6 +41,11 @@ ${style.bold('Profiles')}
   ${PROGRAM} profile list [--json]
   ${PROGRAM} profile default <name>
 
+${style.bold('Targets')}
+  ${PROGRAM} target list [--urls]      where this profile can run, and which one is in play
+  ${PROGRAM} target show [<name>]      one target's adapters, and the address it answers on
+  ${PROGRAM} target use <name>         make one the profile's default_target
+
 ${style.bold('Permissions')}
   ${PROGRAM} policy list
   ${PROGRAM} policy allow <capability>  e.g. gmail.* or gmail.send_message
@@ -69,6 +74,7 @@ ${style.bold('Deploying')}
   ${PROGRAM} deploy [--dry-run]         set up, build, and roll a revision
   ${PROGRAM} deploy --non-interactive   take the stored answers, never prompt
   ${PROGRAM} deploy --access iam|public who gets past the platform's own door
+  ${PROGRAM} deploy --target <name>     deploy a second one, under its own name
   ${PROGRAM} secrets list               credential references in this target
   ${PROGRAM} secrets set <ref>          store one value, read from stdin
   ${PROGRAM} secrets push --from local --to cloud
@@ -87,7 +93,7 @@ ${style.bold('Attachments')}
 
 ${style.bold('Global flags')}
   --profile <name>               overrides LANES_LINK_PROFILE and the workspace default
-  --target <name>                overrides instance.default_target
+  --target <name>                overrides LANES_LINK_TARGET and instance.default_target
   --connection <id>              which memory/skills/vault connection, if a profile has several
   --yes                          skip the confirmation a destructive command would ask for
   --json                         machine-readable output, where a command offers it

--- a/src/profile/index.ts
+++ b/src/profile/index.ts
@@ -48,11 +48,16 @@ export {
   profilePath,
   readWorkspace,
   resolveSelection,
-  resolveDeployTarget,
-  resolveTarget,
   resolveWorkspaceRoot,
   workspacePath,
 } from './workspace.ts';
+export {
+  TARGET_ENV,
+  askedTarget,
+  resolveDeployTarget,
+  resolveTarget,
+  undeclaredTarget,
+} from './targets.ts';
 export {
   isRemoteWorkspace,
   readWorkspaceFile,

--- a/src/profile/targets.test.ts
+++ b/src/profile/targets.test.ts
@@ -1,0 +1,173 @@
+import { describe, expect, test } from 'bun:test';
+import { parseConfig } from './load.ts';
+import { resolveDeployTarget, resolveTarget } from './targets.ts';
+
+/**
+ * Which target a command acts on, and where that answer came from.
+ *
+ * Every case passes an explicit `env`. A developer who exports
+ * `LANES_LINK_TARGET` in their own shell would otherwise change what these
+ * assert, which is the failure mode the variable itself exists to make visible
+ * and the last place it should be able to hide.
+ */
+
+describe('target resolution', () => {
+  const twoTargets = parseConfig(`
+contract: 1
+instance:
+  profile: personal
+  default_target: local
+targets:
+  local:
+    credentials: { adapter: file, path: ./data/personal.credentials.enc }
+    storage: { adapter: filesystem, path: ./data/files }
+  cloud:
+    credentials: { adapter: gcp-secret-manager }
+    storage: { adapter: s3, bucket: lanes-link-demo }
+    cloudrun: { project: p, region: r, service: s }
+`).config;
+
+  const localOnly = parseConfig(`
+contract: 1
+instance:
+  profile: personal
+  default_target: local
+targets:
+  local:
+    credentials: { adapter: file, path: ./data/personal.credentials.enc }
+    storage: { adapter: filesystem, path: ./data/files }
+`).config;
+
+  const twoDeployable = parseConfig(`
+contract: 1
+instance:
+  profile: personal
+  default_target: cloud
+targets:
+  cloud:
+    credentials: { adapter: gcp-secret-manager, project: p }
+    storage: { adapter: gcs, bucket: b }
+    deploy: { platform: cloudrun, project: p, region: r, service: s }
+  staging:
+    credentials: { adapter: gcp-secret-manager, project: p2 }
+    storage: { adapter: gcs, bucket: b2 }
+    deploy: { platform: cloudrun, project: p2, region: r, service: s2 }
+`).config;
+
+  test('defaults to instance.default_target', () => {
+    expect(resolveTarget(twoTargets, undefined, { env: {} })).toEqual({
+      target: 'local',
+      source: 'config-default',
+    });
+  });
+
+  test('--target overrides it', () => {
+    expect(resolveTarget(twoTargets, 'cloud', { env: {} })).toEqual({
+      target: 'cloud',
+      source: 'flag',
+    });
+  });
+
+  test('one config yields a different adapter set per target', () => {
+    // Connections, providers, and policy are declared once and apply to every
+    // target; only the adapters differ.
+    expect(twoTargets.targets['local']?.storage.adapter).toBe('filesystem');
+    expect(twoTargets.targets['cloud']?.storage.adapter).toBe('s3');
+    expect(twoTargets.targets['local']?.credentials.adapter).toBe('file');
+    expect(twoTargets.targets['cloud']?.credentials.adapter).toBe('gcp-secret-manager');
+  });
+
+  test('an undeclared target fails and lists what exists', () => {
+    expect(() => resolveTarget(twoTargets, 'staging', { env: {} })).toThrow(
+      /Target "staging" is not declared.*local, cloud/s,
+    );
+  });
+
+  test('a deploy works out which target it meant', () => {
+    // `--target cloud` was required on every deploy because an absent flag fell
+    // back to `instance.default_target` — `local`, a target that is by
+    // definition not deployed. The one command whose subject is never ambiguous
+    // was the one that made you say it.
+    expect(resolveDeployTarget(twoTargets)).toEqual({ target: 'cloud', source: 'deployable' });
+  });
+
+  test('--target still wins, which is how you deploy the second one', () => {
+    expect(resolveDeployTarget(twoTargets, 'staging')).toEqual({
+      target: 'staging',
+      source: 'flag',
+    });
+  });
+
+  test('with nothing deployable it proposes the conventional name', () => {
+    // The first run: no target has a deployment yet, and `cloud` is what every
+    // example names. The survey then creates it.
+    expect(resolveDeployTarget(localOnly)).toEqual({ target: 'cloud', source: 'deployable' });
+  });
+
+  test('two deployable targets is a real question, so it asks', () => {
+    // Rolling a revision to whichever came first in a YAML mapping is the one
+    // answer that cannot be right on purpose.
+    expect(() => resolveDeployTarget(twoDeployable)).toThrow(
+      /2 deployable targets \(cloud, staging\).*--target/s,
+    );
+  });
+
+  test('unless the caller is going to create it', () => {
+    // `deploy` on a first run: the target it names is the one it is about to
+    // write. Refusing there made a command whose whole job is bootstrapping
+    // demand that the thing already exist. Nothing else passes this — a typo
+    // in `--target` should still hit the list above rather than quietly
+    // deploying a target nobody declared.
+    expect(resolveTarget(twoTargets, 'staging', { allowUndeclared: true, env: {} })).toEqual({
+      target: 'staging',
+      source: 'flag',
+    });
+  });
+
+  test('LANES_LINK_TARGET sits between the flag and the config default', () => {
+    const env = { LANES_LINK_TARGET: 'cloud' };
+
+    expect(resolveTarget(twoTargets, undefined, { env })).toEqual({
+      target: 'cloud',
+      source: 'environment',
+    });
+    expect(resolveTarget(twoTargets, 'local', { env })).toEqual({
+      target: 'local',
+      source: 'flag',
+    });
+  });
+
+  test('an empty LANES_LINK_TARGET is not an answer', () => {
+    // `export LANES_LINK_TARGET=` leaves the name set to the empty string, which
+    // is a target nobody declared. Reading it as "unset" is the only reading
+    // that does not fail every command in the shell with a puzzle.
+    expect(resolveTarget(twoTargets, undefined, { env: { LANES_LINK_TARGET: '' } })).toEqual({
+      target: 'local',
+      source: 'config-default',
+    });
+  });
+
+  test('an undeclared target from the environment says so, and how to undo it', () => {
+    // Without this, an exported typo fails every command in the shell with a
+    // message that reads as a problem with the config file — and the file is
+    // fine. The variable is the only thing that knows where the name came from.
+    expect(() =>
+      resolveTarget(twoTargets, undefined, { env: { LANES_LINK_TARGET: 'clod' } }),
+    ).toThrow(/LANES_LINK_TARGET=clod is set in this shell/);
+  });
+
+  test('deploy ignores LANES_LINK_TARGET, deliberately', () => {
+    // `deploy` is the one caller that may name an undeclared target, so an
+    // exported typo would not be refused here — it would be surveyed, written
+    // into the profile, and rolled out as a new service. An environment
+    // variable must not be able to name a Cloud Run service into existence.
+    const previous = process.env['LANES_LINK_TARGET'];
+    process.env['LANES_LINK_TARGET'] = 'local';
+    try {
+      expect(resolveDeployTarget(twoTargets)).toEqual({ target: 'cloud', source: 'deployable' });
+    } finally {
+      if (previous === undefined) delete process.env['LANES_LINK_TARGET'];
+      else process.env['LANES_LINK_TARGET'] = previous;
+    }
+  });
+});

--- a/src/profile/targets.ts
+++ b/src/profile/targets.ts
@@ -1,0 +1,152 @@
+import { ConfigError } from './load.ts';
+import type { Config } from './schema.ts';
+
+/**
+ * Which target a command acts on.
+ *
+ * A target names an adapter set — where credentials are kept and where bytes
+ * go — and choosing one is a different subject from finding the workspace and
+ * the profile, which is why it is a different file. `workspace.ts` reached the
+ * size budget holding both, and the budget's job is to say which of the two
+ * things a file is doing should leave.
+ *
+ * The order is `--target`, then `LANES_LINK_TARGET`, then
+ * `instance.default_target`. `deploy` resolves it differently and deliberately;
+ * see `resolveDeployTarget`.
+ */
+
+/** The variable that names a target for every command in a shell. */
+export const TARGET_ENV = 'LANES_LINK_TARGET';
+
+/**
+ * The target somebody asked for, before the config gets a say.
+ *
+ * Split out because two callers need this precedence and must not disagree
+ * about it: `resolveSelection` records a provisional answer for `announce`
+ * before any config is loaded, and `resolveTarget` settles it afterwards. While
+ * the flag was the only source, both could spell it `targetFlag ?? …` and stay
+ * accidentally correct. With a second source, one of them learning about it and
+ * the other not is a line reading `config-default` beside a target the
+ * environment chose — which is the one line that exists to prevent exactly that.
+ *
+ * Returns no target rather than a default: what an unanswered question falls
+ * back to is `instance.default_target`, and that is the config's to supply.
+ */
+export function askedTarget(
+  targetFlag: string | undefined,
+  env: Record<string, string | undefined>,
+): { target: string | undefined; source: 'flag' | 'environment' | undefined } {
+  if (targetFlag) return { target: targetFlag, source: 'flag' };
+
+  const fromEnv = env[TARGET_ENV];
+  if (fromEnv) return { target: fromEnv, source: 'environment' };
+
+  return { target: undefined, source: undefined };
+}
+
+/**
+ * The refusal for a target that is not in the file, in one spelling.
+ *
+ * It was two — here and in the CLI's `openSecretStoreFor` — which is one more
+ * than a sentence naming the available targets survives: the copies drift the
+ * moment either learns something the other does not. This one knows about
+ * `LANES_LINK_TARGET`, and that is precisely the knowledge a copy would lack —
+ * an exported typo otherwise fails every command in the shell with a message
+ * that reads as a problem with the config file.
+ */
+export function undeclaredTarget(
+  target: string,
+  config: Config,
+  source?: 'flag' | 'environment' | 'config-default',
+): ConfigError {
+  const have = Object.keys(config.targets).join(', ') || 'none';
+  return new ConfigError(
+    `Target "${target}" is not declared in this profile (have: ${have})` +
+      (source === 'environment'
+        ? `\n${TARGET_ENV}=${target} is set in this shell — unset it, or pass --target.`
+        : ''),
+  );
+}
+
+/**
+ * Fill in the target once the profile's config has been loaded.
+ *
+ * Order: `--target`, then `LANES_LINK_TARGET`, then `instance.default_target`.
+ * The middle one is the same bargain `LANES_LINK_PROFILE` already offers — a
+ * shell's worth of commands without retyping a flag, somewhere `env` shows it.
+ *
+ * `allowUndeclared` is for the one command whose job is to create the target it
+ * was given — `deploy`, on a first run. Every other command naming a target that
+ * does not exist has made a typo, and the list of what does exist is the useful
+ * answer; refusing there is what stops `--target clod` opening the default one.
+ */
+export function resolveTarget(
+  config: Config,
+  targetFlag?: string,
+  options: {
+    allowUndeclared?: boolean;
+    env?: Record<string, string | undefined>;
+  } = {},
+): { target: string; source: 'flag' | 'environment' | 'config-default' } {
+  const env = options.env ?? (process.env as Record<string, string | undefined>);
+  const asked = askedTarget(targetFlag, env);
+
+  const target = asked.target ?? config.instance.default_target;
+  const source = asked.source ?? 'config-default';
+
+  if (options.allowUndeclared !== true && !(target in config.targets)) {
+    throw undeclaredTarget(target, config, source);
+  }
+  return { target, source };
+}
+
+/**
+ * The target a deploy means, when nobody said.
+ *
+ * `--target cloud` was required on every deploy, and the reason was an accident:
+ * an absent flag falls back to `instance.default_target`, which is `local` —
+ * a target that by definition is not deployed anywhere. So the one command whose
+ * subject is never ambiguous was the one command that made you say it, and the
+ * default it would otherwise have taken was not merely unhelpful but wrong.
+ *
+ * The rule is what someone would say out loud: deploy the target that has a
+ * deployment. One is the answer; none means the first run, which conventionally
+ * creates `cloud` and is what every example in the docs names; several is a
+ * genuine question, and asking beats rolling a revision to whichever came first
+ * in a YAML mapping.
+ *
+ * `--target` still wins, which is how you deploy the second one.
+ *
+ * **`LANES_LINK_TARGET` is deliberately not read here.** It is the same kind of
+ * answer as `instance.default_target` — a shell-wide "where do my commands
+ * run" — and the paragraph above is why that kind of answer is the wrong one
+ * for this question. It is also the only place where being wrong creates cloud
+ * resources rather than an error: `deploy` is the one caller that passes
+ * `allowUndeclared`, so an exported typo would not be refused, it would be
+ * surveyed, written into the profile, and rolled out as a new service. An
+ * environment variable must not be able to name a Cloud Run service into
+ * existence. Say `--target`; `deploy` is rare enough to afford it.
+ */
+export const CONVENTIONAL_DEPLOY_TARGET = 'cloud';
+
+export function resolveDeployTarget(
+  config: Config,
+  targetFlag?: string,
+): { target: string; source: 'flag' | 'deployable' } {
+  if (targetFlag) return { target: targetFlag, source: 'flag' };
+
+  // `deploy` alone: the legacy `cloudrun:` spelling is normalised into it by the
+  // loader, so exactly one shape reaches here.
+  const deployable = Object.entries(config.targets)
+    .filter(([, declared]) => declared.deploy !== undefined)
+    .map(([name]) => name);
+
+  if (deployable.length > 1) {
+    throw new ConfigError(
+      `This profile declares ${deployable.length} deployable targets (${deployable.join(', ')}). ` +
+        'Name the one you mean with --target.',
+    );
+  }
+
+  return { target: deployable[0] ?? CONVENTIONAL_DEPLOY_TARGET, source: 'deployable' };
+}

--- a/src/profile/workspace.test.ts
+++ b/src/profile/workspace.test.ts
@@ -2,13 +2,10 @@ import { afterAll, describe, expect, test } from 'bun:test';
 import { mkdtemp, mkdir, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { parseConfig } from './load.ts';
 import {
   describeSelection,
   listProfiles,
-  resolveDeployTarget,
   resolveSelection,
-  resolveTarget,
   resolveWorkspaceRoot,
 } from './workspace.ts';
 
@@ -105,113 +102,6 @@ describe('profile listing', () => {
   });
 });
 
-describe('target resolution', () => {
-  const twoTargets = parseConfig(`
-contract: 1
-instance:
-  profile: personal
-  default_target: local
-targets:
-  local:
-    credentials: { adapter: file, path: ./data/personal.credentials.enc }
-    storage: { adapter: filesystem, path: ./data/files }
-  cloud:
-    credentials: { adapter: gcp-secret-manager }
-    storage: { adapter: s3, bucket: lanes-link-demo }
-    cloudrun: { project: p, region: r, service: s }
-`).config;
-
-  const localOnly = parseConfig(`
-contract: 1
-instance:
-  profile: personal
-  default_target: local
-targets:
-  local:
-    credentials: { adapter: file, path: ./data/personal.credentials.enc }
-    storage: { adapter: filesystem, path: ./data/files }
-`).config;
-
-  const twoDeployable = parseConfig(`
-contract: 1
-instance:
-  profile: personal
-  default_target: cloud
-targets:
-  cloud:
-    credentials: { adapter: gcp-secret-manager, project: p }
-    storage: { adapter: gcs, bucket: b }
-    deploy: { platform: cloudrun, project: p, region: r, service: s }
-  staging:
-    credentials: { adapter: gcp-secret-manager, project: p2 }
-    storage: { adapter: gcs, bucket: b2 }
-    deploy: { platform: cloudrun, project: p2, region: r, service: s2 }
-`).config;
-
-  test('defaults to instance.default_target', () => {
-    expect(resolveTarget(twoTargets)).toEqual({ target: 'local', source: 'config-default' });
-  });
-
-  test('--target overrides it', () => {
-    expect(resolveTarget(twoTargets, 'cloud')).toEqual({ target: 'cloud', source: 'flag' });
-  });
-
-  test('one config yields a different adapter set per target', () => {
-    // Connections, providers, and policy are declared once and apply to every
-    // target; only the adapters differ.
-    expect(twoTargets.targets['local']?.storage.adapter).toBe('filesystem');
-    expect(twoTargets.targets['cloud']?.storage.adapter).toBe('s3');
-    expect(twoTargets.targets['local']?.credentials.adapter).toBe('file');
-    expect(twoTargets.targets['cloud']?.credentials.adapter).toBe('gcp-secret-manager');
-  });
-
-  test('an undeclared target fails and lists what exists', () => {
-    expect(() => resolveTarget(twoTargets, 'staging')).toThrow(
-      /Target "staging" is not declared.*local, cloud/s,
-    );
-  });
-
-  test('a deploy works out which target it meant', () => {
-    // `--target cloud` was required on every deploy because an absent flag fell
-    // back to `instance.default_target` — `local`, a target that is by
-    // definition not deployed. The one command whose subject is never ambiguous
-    // was the one that made you say it.
-    expect(resolveDeployTarget(twoTargets)).toEqual({ target: 'cloud', source: 'deployable' });
-  });
-
-  test('--target still wins, which is how you deploy the second one', () => {
-    expect(resolveDeployTarget(twoTargets, 'staging')).toEqual({
-      target: 'staging',
-      source: 'flag',
-    });
-  });
-
-  test('with nothing deployable it proposes the conventional name', () => {
-    // The first run: no target has a deployment yet, and `cloud` is what every
-    // example names. The survey then creates it.
-    expect(resolveDeployTarget(localOnly)).toEqual({ target: 'cloud', source: 'deployable' });
-  });
-
-  test('two deployable targets is a real question, so it asks', () => {
-    // Rolling a revision to whichever came first in a YAML mapping is the one
-    // answer that cannot be right on purpose.
-    expect(() => resolveDeployTarget(twoDeployable)).toThrow(
-      /2 deployable targets \(cloud, staging\).*--target/s,
-    );
-  });
-
-  test('unless the caller is going to create it', () => {
-    // `deploy` on a first run: the target it names is the one it is about to
-    // write. Refusing there made a command whose whole job is bootstrapping
-    // demand that the thing already exist. Nothing else passes this — a typo
-    // in `--target` should still hit the list above rather than quietly
-    // deploying a target nobody declared.
-    expect(resolveTarget(twoTargets, 'staging', { allowUndeclared: true })).toEqual({
-      target: 'staging',
-      source: 'flag',
-    });
-  });
-});
 
 describe('the selection line every command prints', () => {
   test('names both the value and where it came from', () => {

--- a/src/profile/workspace.ts
+++ b/src/profile/workspace.ts
@@ -6,6 +6,7 @@ import { homedir } from 'node:os';
 import { parse as parseYaml } from 'yaml';
 import { ConfigError } from './load.ts';
 import { workspaceSchema, type Config, type WorkspaceConfig } from './schema.ts';
+import { askedTarget } from './targets.ts';
 
 /**
  * Workspace and profile resolution.
@@ -18,10 +19,18 @@ import { workspaceSchema, type Config, type WorkspaceConfig } from './schema.ts'
  *     work.yaml
  *   data/               local state per profile, gitignored
  *
- * There is deliberately no sticky `lanes link use` that persists a current selection.
- * Persisted context state is the standard way operators run destructive
- * commands against the wrong target; `export LANES_LINK_PROFILE=work` gives the
- * same convenience while staying visible in the shell.
+ * There is deliberately no sticky `lanes link use` that persists a *hidden*
+ * current selection. Persisted context state is the standard way operators run
+ * destructive commands against the wrong target, and the version of it that
+ * bites is the dotfile nothing prints.
+ *
+ * So both ways of not retyping a flag are visible ones.
+ * `export LANES_LINK_PROFILE=work` and `export LANES_LINK_TARGET=cloud` live in
+ * the shell, where `env` shows them; `default_profile` and
+ * `instance.default_target` live in files the operator reads and `check`
+ * validates, written by `lanes link profile default` and `lanes link target
+ * use`. Every command prints which of the four it landed on and where that came
+ * from — see `announce`.
  */
 
 export const WORKSPACE_FILE = 'lanes-link.yaml';
@@ -41,8 +50,14 @@ export interface Resolution {
    * every other command that is the local target. Printing "config-default"
    * beside a target the config does not default to would be a lie on the one
    * line that exists to say how the command got here.
+   *
+   * `environment` is `LANES_LINK_TARGET`, and it earns its own name for the
+   * same reason: a target chosen by a variable exported in another terminal an
+   * hour ago is the one an operator is most likely to be surprised by, and the
+   * fix — `unset` — is not the fix for a config default. `deploy` never
+   * produces it; `resolveDeployTarget` says why.
    */
-  readonly targetSource: 'flag' | 'config-default' | 'deployable';
+  readonly targetSource: 'flag' | 'environment' | 'config-default' | 'deployable';
 }
 
 export interface ResolveOptions {
@@ -192,6 +207,11 @@ export async function resolveSelection(options: ResolveOptions = {}): Promise<Re
     );
   }
 
+  // Provisional: the config has not been read yet, so `instance.default_target`
+  // is not available to fall back to. `resolveTarget` settles it, from the same
+  // helper, so the two cannot disagree about what beats what.
+  const asked = askedTarget(options.targetFlag, env);
+
   const path = profilePath(workspaceRoot, profile);
   if (!(await workspaceFiles(workspaceRoot).has(`profiles/${profile}.yaml`))) {
     const available = await listProfiles(workspaceRoot);
@@ -205,73 +225,10 @@ export async function resolveSelection(options: ResolveOptions = {}): Promise<Re
     workspaceRoot,
     profile,
     profilePath: path,
-    target: options.targetFlag ?? '',
+    target: asked.target ?? '',
     profileSource,
-    targetSource: options.targetFlag ? 'flag' : 'config-default',
+    targetSource: asked.source ?? 'config-default',
   };
-}
-
-/**
- * Fill in the target once the profile's config has been loaded.
- *
- * `allowUndeclared` is for the one command whose job is to create the target it
- * was given — `deploy`, on a first run. Every other command naming a target that
- * does not exist has made a typo, and the list of what does exist is the useful
- * answer; refusing there is what stops `--target clod` opening the default one.
- */
-export function resolveTarget(
-  config: Config,
-  targetFlag?: string,
-  options: { allowUndeclared?: boolean } = {},
-): { target: string; source: 'flag' | 'config-default' } {
-  const target = targetFlag ?? config.instance.default_target;
-  if (options.allowUndeclared !== true && !(target in config.targets)) {
-    throw new ConfigError(
-      `Target "${target}" is not declared in this profile (have: ${Object.keys(config.targets).join(', ') || 'none'})`,
-    );
-  }
-  return { target, source: targetFlag ? 'flag' : 'config-default' };
-}
-
-/**
- * The target a deploy means, when nobody said.
- *
- * `--target cloud` was required on every deploy, and the reason was an accident:
- * an absent flag falls back to `instance.default_target`, which is `local` —
- * a target that by definition is not deployed anywhere. So the one command whose
- * subject is never ambiguous was the one command that made you say it, and the
- * default it would otherwise have taken was not merely unhelpful but wrong.
- *
- * The rule is what someone would say out loud: deploy the target that has a
- * deployment. One is the answer; none means the first run, which conventionally
- * creates `cloud` and is what every example in the docs names; several is a
- * genuine question, and asking beats rolling a revision to whichever came first
- * in a YAML mapping.
- *
- * `--target` still wins, which is how you deploy the second one.
- */
-export const CONVENTIONAL_DEPLOY_TARGET = 'cloud';
-
-export function resolveDeployTarget(
-  config: Config,
-  targetFlag?: string,
-): { target: string; source: 'flag' | 'deployable' } {
-  if (targetFlag) return { target: targetFlag, source: 'flag' };
-
-  // `deploy` alone: the legacy `cloudrun:` spelling is normalised into it by the
-  // loader, so exactly one shape reaches here.
-  const deployable = Object.entries(config.targets)
-    .filter(([, declared]) => declared.deploy !== undefined)
-    .map(([name]) => name);
-
-  if (deployable.length > 1) {
-    throw new ConfigError(
-      `This profile declares ${deployable.length} deployable targets (${deployable.join(', ')}). ` +
-        'Name the one you mean with --target.',
-    );
-  }
-
-  return { target: deployable[0] ?? CONVENTIONAL_DEPLOY_TARGET, source: 'deployable' };
 }
 
 /**


### PR DESCRIPTION
Moving between a local instance and a deployed one was hard to do, and addressing a *second* deployment was undiscoverable. Three things were behind that, and one of them was only ever a documentation problem.

## The shape of it

The nesting is `workspace → profile → targets` — targets are declared *inside* each profile, which is the opposite of the way it reads from outside. And `--target` never pointed the CLI at a running server: every command opens that target's stores directly, which is why `lanes link connect gmail --target cloud` runs the browser consent on your own machine and writes the refresh token into Secret Manager. That part is unchanged; it is just now said out loud in the docs.

## `LANES_LINK_TARGET` works in the CLI

The variable already existed and already meant "which target's adapters to open" — but only `src/server/container.ts` read it. So profile resolution was flag → env → default while target resolution was flag → default, and staying on one target meant retyping `--target` on every command.

Precedence is now `--target` → `LANES_LINK_TARGET` → `instance.default_target`, and `targetSource` gains `environment` so the line every command already prints says which terminal chose it:

```
profile personal (workspace-default)  target cloud (environment)  ~/.lanes-link
```

An undeclared name arriving from the environment says where it came from, because otherwise an exported typo fails every command in the shell with a message that reads as a problem with the config file:

```
Target "clod" is not declared in this profile (have: cloud, staging, local)
LANES_LINK_TARGET=clod is set in this shell — unset it, or pass --target.
```

**`deploy` deliberately does not read it.** Its fallback is already not `instance.default_target`, for the reason recorded in `resolveDeployTarget`, and it is the one command that may name a target which does not exist yet — so an exported typo would not be refused, it would be surveyed, written into the profile, and rolled out. An environment variable must not be able to name a Cloud Run service into existence. There is a regression test and a docstring paragraph so the next person does not "complete" this.

## A `target` command group

There was none at all, so seeing what a profile declares meant reading YAML.

```console
$ lanes link target list
profile personal (workspace-default)  target local (config-default)  ~/.lanes-link

       cloud    gcp-secret-manager  gcs         cloudrun  my-service  europe-west1
       staging  gcp-secret-manager  gcs         —
  * →  local    file                filesystem  —

  *  instance.default_target — what commands run against
  →  what this shell resolves to right now
```

Two markers, because two things choose and they can disagree. They are usually the same; the case that sends someone hunting a bug is when they are not, and then the listing names the variable that did it.

- `list` reads the file and asks nobody. `--urls` opts into one platform lookup per deployable target — a discovery command that shells out by default is one nobody runs twice.
- `list` also refuses to go through `resolveProfile`, because a bad `LANES_LINK_TARGET` is precisely the state it exists to diagnose and that path throws.
- `use <name>` rewrites `instance.default_target` through `ConfigDocument`, so comments survive, the schema validates before the write lands, and a bucket-backed workspace works. Writing the value it already holds does not touch the file.
- `show [name]` always asks the platform — one target, one subprocess, and you named it.

On the standing refusal of a sticky `lanes link use`: that rule is about *hidden* per-shell state in a dotfile nothing prints. `profile default` already persists a visible default, and `target use` writes a declared one into a file `check` validates. The docstrings and `workflow.md` now draw that line explicitly rather than leaving it to be re-litigated.

## `status` no longer lies about a deployed target

It printed `http://<host>:<port>/mcp` for every target, so `status --target cloud` named a loopback port with nothing behind it — the bug `endpoint-url.ts` records having already fixed in `mcp add`.

Routing it through `endpointUrl` would have traded that lie for a slower one: it shells out to `gcloud`, and swallows every failure back into loopback, so on a fresh machine or in CI it would print the same wrong answer — and `status` would lose its promise to answer without depending on anything being up. A deployed target now prints which service it is, from config, and points at `outputs` for the address. `endpoint` becomes nullable rather than changing shape, and `deployment` carries the rest.

## Multi-deployment already worked — two docs said it did not

`deploy --target staging` has always created a second deployment. `workflow.md` and `deployment-cloudrun.md` both asserted `deploy` takes no `--target`, which is what hid it, and `init.md` documented a `lanes link target set` that has never existed.

Also now recorded: which profiles a deploy uploads. The scope keys on the `--profile` **flag** rather than the resolved profile, so `LANES_LINK_PROFILE=work lanes link deploy` uploads the whole workspace while `--profile work` uploads one. That behaviour is unchanged here — only documented.

## Also

`workspace.ts` reached the 400-line budget holding two subjects, so target resolution moved to `src/profile/targets.ts` with its tests alongside. The undeclared-target refusal was duplicated in two places and is now one function that knows about the environment variable — which is exactly the knowledge a copy would have lacked.

## Verification

`bun test` — 1459 pass, 0 fail. `bun run typecheck` clean.

Exercised end to end against a scratch `LANES_LINK_HOME`: the full precedence chain (`config-default` → `environment` → `flag`, then `target use` moving the default), comment preservation, `--json` cleanliness, and the undeclared-env diagnostic path.

`lanes link deploy` and `lanes link connect` touch a real cloud account and a real mailbox, so neither was run — the deployed-target rendering is covered by unit tests on `deploymentIdentity` instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
