### PR TITLE
Run the required checks on every pull request

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,3 @@
+# Every PR requests a review from the owner. Paired with the `main` ruleset's
+# require_code_owner_review, this is what stops a change landing unreviewed.
+* @sqave

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,16 @@
+## What changed
+
+<!-- One or two sentences. The diff shows what; this says what it is for. -->
+
+## Why this approach
+
+<!-- CONTRIBUTING.md asks for the reasoning, especially where a simpler option
+     was rejected — that is the part that is expensive to reconstruct later.
+     If this PR adds a dependency, say here why it earns its place. -->
+
+## Checks
+
+- [ ] `bun test` passes
+- [ ] `bun run typecheck` passes
+- [ ] Tests added for what changed
+- [ ] If a guarantee got weaker, the table in `docs/detailed/security.md` was updated in the same commit

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,41 @@
+# The two commands CONTRIBUTING.md requires before a pull request, run where a
+# reviewer can see them. A fork PR gets the same gate as a branch PR, which is
+# the point: the contributor does not have to be trusted for the check to mean
+# something.
+name: ci
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+# A force-push to a PR branch supersedes the run it interrupted.
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+# This repository holds live OAuth refresh tokens. The job reads the tree and
+# needs nothing else, so it is granted nothing else.
+permissions:
+  contents: read
+
+jobs:
+  ci:
+    name: ci
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          # The floor in CONTRIBUTING.md. Pinned rather than `latest` so a Bun
+          # release cannot change what green means without a commit saying so.
+          bun-version: 1.3.11
+
+      # --frozen-lockfile so bun.lock is the only thing deciding what installs.
+      # bunfig.toml sets a seven-day release-age floor for the same reason, and
+      # resolving afresh here would route around it.
+      - run: bun install --frozen-lockfile
+
+      - run: bun test
+      - run: bun run typecheck


### PR DESCRIPTION
## What changed

Adds `.github/` — a CI workflow running the two commands `CONTRIBUTING.md` already requires, a `CODEOWNERS`, and a pull request template. The repository had no `.github/` directory at all.

## Why this approach

`bun test` and `bun run typecheck` have been documented as required since the repository opened, and nothing enforced them. For a branch PR that is a formality; for a fork PR on a public repository it is not — asking an unknown contributor in a markdown file to have run the tests is not a check.

Three choices worth naming:

- **`--frozen-lockfile`** — `bunfig.toml` sets a seven-day release-age floor precisely so a version yanked hours after a compromise cannot reach the lockfile. Resolving afresh in CI would route around that control while appearing to test the same tree.
- **`bun-version: 1.3.11` pinned, not `latest`** — the floor `CONTRIBUTING.md` names. A Bun release should not change what green means without a commit saying so.
- **`permissions: contents: read`** — the job reads the tree and needs nothing else, and this repository holds live OAuth refresh tokens.

A local pre-push hook was the simpler option and was rejected: it protects the people already following the contributing guide and does nothing about the contributions the guide was written for.

The job is named `ci` because a `main` ruleset will require that context by name.

## Checks

- [x] `bun test` passes — 1440 pass, 2 skip, 0 fail
- [x] `bun run typecheck` passes
- [x] Tests added for what changed — n/a; `src/architecture.test.ts` already covers the new files, verified by probe (it scans `.github/**` for real addresses)
- [x] If a guarantee got weaker, `docs/detailed/security.md` updated — n/a, no guarantee changed

🤖 Generated with [Claude Code](https://claude.com/claude-code)