### PR TITLE
A hosted OAuth client is the default, and registering your own is one flag away

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,12 @@ config/*.yaml
 !config/*.example.yaml
 lanes-link.yaml
 
+# Custom provider manifests. `WORKSPACE_PROVIDER_DIR` is 'providers', and the
+# console writes one here from a browser form, so a workspace rooted at the
+# repo during local dev drops them straight into an untracked directory.
+providers/*.yaml
+!providers/*.example.yaml
+
 # Local state: sqlite databases, encrypted credential stores, blobs.
 data/
 
@@ -41,6 +47,11 @@ coverage/
 # Machine-local tooling state
 # ---------------------------------------------------------------------------
 .claude/settings.local.json
+
+# Playwright MCP's default output directory: screenshots, network logs, traces.
+# A screenshot of the console taken mid-connect carries a real address, and
+# possibly a token in the URL bar.
+.playwright-mcp/
 
 # Worktrees live inside the repo, so git sees them as untracked files on the
 # branch they were made from. Both spellings: `.claude/worktrees/` is where the

--- a/README.md
+++ b/README.md
@@ -96,8 +96,9 @@ One command per account. Run it again to add a second mailbox, a second calendar
 | Drive (Google MCP) | `lanes link connect drive_mcp` |
 
 Two things worth knowing up front: `lanes link connect icloud` sets up Mail, Calendar, and Contacts
-together, because one app-specific password covers all three. And Google is the only one that asks
-you to register an OAuth client of your own — `lanes link connect gmail` walks you through it.
+together, because one app-specific password covers all three. And Google needs no OAuth client of
+your own: `lanes link connect gmail` authorises against the one Lanes operates, so there is no
+Cloud console to visit. Add `--own-client` if you would rather register your own.
 
 Full guide — what each one gives your agent, what it needs, and adding your own:
 **[docs/connect.md](docs/connect.md)**.

--- a/docs/connect.md
+++ b/docs/connect.md
@@ -4,8 +4,8 @@ Each account is one connection, with its own credential, its own permissions, an
 `lanes link connect <provider>` once per account you want reachable.
 
 ```console
-$ lanes link connect gmail        # prompts for a client id/secret once, then a browser
-$ lanes link connect gmail        # straight to the browser, a second mailbox
+$ lanes link connect gmail        # straight to the browser, nothing to register
+$ lanes link connect gmail        # again, for a second mailbox
 ```
 
 `lanes link status` shows what is connected and what that makes reachable.
@@ -43,8 +43,22 @@ app-specific password covers all three. iCloud Drive is separate — it holds no
 reading your sync folder through the filesystem. Full walkthrough:
 [`detailed/setup/icloud.md`](detailed/setup/icloud.md).
 
-**Only Google needs an OAuth client you register yourself.** Notion and Linear register themselves,
-and iCloud takes an app-specific password you generate at appleid.apple.com.
+**No provider asks you to register an OAuth client.** Google authorises against the client Lanes
+operates, Notion and Linear register themselves, and iCloud takes an app-specific password you
+generate at appleid.apple.com.
+
+For Google you can still register your own, and some people have to — an organisation that forbids
+third-party clients, a Workspace app that must be "Internal", or a hosted client that has reached
+its account limit:
+
+```console
+$ lanes link connect gmail --own-client
+```
+
+That walks through the Google Cloud console once, stores the client id and secret, and records the
+choice in your profile, so every later Google connection on that profile uses your client without
+the flag. See [`detailed/setup/google.md`](detailed/setup/google.md) for the walkthrough and what
+the two paths trade against each other.
 
 ## See what one takes before you start
 

--- a/docs/detailed/adr/028-a-hosted-oauth-client-is-the-default.md
+++ b/docs/detailed/adr/028-a-hosted-oauth-client-is-the-default.md
@@ -1,0 +1,96 @@
+# ADR-028: A hosted OAuth client is the default, and registering your own is one flag away
+
+**Status:** accepted · **Amends** [ADR-005](005-the-cli-performs-the-oauth-exchange.md)
+
+## Context
+
+Connecting Gmail cost an operator nine console steps: create a Cloud project, enable two APIs,
+fill in a branding screen, set an audience, transcribe four scope URLs, create a Desktop client,
+and copy two values out. Then it cost them a weekly interruption forever, because nobody publishes
+a personal project and **Google expires refresh tokens after seven days for any project whose
+publishing status is "Testing"**. `doctor` grew a warning for it. `setup/google.md` grew a
+paragraph explaining that the alternative was a verification review with a CASA assessment taking
+months.
+
+That is not a policy anyone chose. It is what happens when the only two options are "the operator
+registers a client" and "the client secret ships in the binary" — and the second is not an option,
+because an installed application cannot hold a confidential client.
+
+There is a third: somebody runs one, and performs the exchange.
+
+## Decision
+
+A provider manifest may declare `auth.broker`, naming a service that holds an OAuth client secret
+and exposes `/config`, `/exchange`, and `/refresh`. Every Google REST provider declares the client
+Lanes operates. Where one is declared and the profile has not registered a client of its own, that
+is what `connect` authorises against.
+
+**The manifest does not choose between the two — the profile does.** Declaring an `oauth_apps`
+entry means "I registered a client, use it"; leaving it out means "use the one the broker
+operates". `registration: manual` stays true either way, because the vendor does still require a
+pre-registered client. That is why this is a second field rather than a third `registration`
+value: a manifest that claimed one arrangement would be wrong half the time.
+
+`lanes link connect <provider> --own-client` takes the other path. It writes the `oauth_apps`
+entry, so the choice is made once and then sticks.
+
+Two scopes are added on the brokered path only: `openid` and `email`. The exchange returns an
+identity assertion, which is presented on every later refresh so the broker can tell one caller
+from another. On the bring-your-own path there is nobody to identify to, so the scope set is
+byte-identical to what it was.
+
+## What this does not change
+
+ADR-005's argument survives intact, and the parts that survive are worth naming because "the
+endpoint calls a Lanes API" sounds like it might have moved them:
+
+- The **CLI** still runs the flow. The server still never participates.
+- The redirect is still a **loopback listener** this process opened on a port the OS picked.
+- The browser still talks to the **vendor** directly. Consent is between the operator and Google.
+- The credential still lands in **whichever store the config names**, so a deployed instance is
+  unaffected and needs no inbound path.
+- The client is still registered as a **Desktop app**, for the same reason: loopback.
+
+What moves is step 2 of ADR-005's list — *who holds the client secret* — and therefore step 4,
+*where the code becomes a token*.
+
+It is **not** ADR-025. No consent moves to a server, there is no `/callback` route, no
+pending-authorization state, no IAM widening, and an agent still cannot connect an account.
+`connect` remains CLI-only and `control-plane.test.ts` is untouched, so ADR-007 is untouched.
+
+It is compatible with **ADR-026** unchanged: a brokered connection still rewrites exactly one
+secret while serving, its own token blob.
+
+## Consequences
+
+**The exchange stops being local, and the guarantee table says so.** The authorization code goes
+to the Lanes API, the refresh token comes back through it, and passes through it again on every
+refresh. Nothing in this repository can verify what that API does with what it sees. This is
+recorded as `credentials.exchange-is-local: NOT-GUARANTEED` in
+[`security.md`](../security.md), with the alternative named in the same paragraph.
+
+**The hosted client is capped, and the cap is permanent.** Google limits an app with unapproved
+sensitive or restricted scopes to 100 accounts, counted over the entire lifetime of the project,
+with no way to reset it. Until verification completes that is the ceiling. `/config` reports
+consumption so the CLI can warn before it is reached, and reports a `status` the broker controls so
+the tap can be closed with wording chosen at the time rather than shipped in a release.
+
+**Users see an unverified-app interstitial** until verification completes. The client is
+nevertheless published "In production" rather than left in "Testing", because that is precisely
+what removes the seven-day expiry — which was the larger of the two costs this ADR set out to
+remove, and the one an operator cannot work around.
+
+**A shared client is a shared dependency.** An outage in it stops `refresh`, not merely `connect`,
+which means it can fail in the middle of an agent's work rather than only at setup. The refusal
+names a command the owner runs, and `--own-client` is the exit.
+
+**A brokered token cannot be migrated to an own client.** Which client minted a refresh token is
+stamped on the token itself (`authorized_via`), not read from config, because a refresh token
+minted by one client is refused by another. So adding an `oauth_apps` entry later does not move
+existing connections onto it — they keep refreshing where they were issued, and only a fresh
+`connect` moves them. The alternative, reading the current config, would turn an unrelated-looking
+config edit into `invalid_grant` on every connection at once.
+
+**An MCP provider cannot be brokered.** The SDK owns that exchange and there is no seam to route
+it without reimplementing its auth path. `defineProvider` refuses the combination at definition
+rather than letting it fail after the operator has already approved a consent screen.

--- a/docs/detailed/adr/README.md
+++ b/docs/detailed/adr/README.md
@@ -35,6 +35,7 @@ Nothing in the codebase depends on it.
 | [024](024-telemetry-is-a-copy.md) | Extra audit sinks are copies; the durable log is never a network call |
 | [025](025-connecting-an-account-from-a-deployed-endpoint.md) | **Proposed, not decided.** Whether a deployed endpoint may run the OAuth flow itself — the mechanical objection has expired, the authorisation one has not |
 | [026](026-a-revision-rotates-its-own-credentials.md) | A revision may add a version to each secret it rotates, and may still never create one |
+| [028](028-a-hosted-oauth-client-is-the-default.md) | A client Lanes operates is what `connect` uses by default; `--own-client` registers your own |
 
 Where an ADR departs from init.md, it says so at the top. Three are significant:
 
@@ -48,6 +49,11 @@ Where an ADR departs from init.md, it says so at the top. Three are significant:
 - **ADR-018** amends ADR-003 and replaces init.md's "optionally behind Cloud Run IAM" (M3, point 5).
   IAM in front of the endpoint is not a second layer over the bearer token — it is an alternative
   that excludes every remote MCP client, so the gate moved into the application instead.
+- **ADR-028** amends ADR-005's step 2, "read the provider's `oauth_app` entry and resolve the client
+  id and secret … prompting for them on first use", which stops being the default. Everything else
+  in ADR-005 survives — the CLI still runs the flow, the listener is still loopback, the browser
+  still talks to the vendor, the server still never participates. What moves is who holds the
+  client secret, and therefore where the code becomes a token.
 - **ADR-019** does not supersede ADR-007. It records why a *read-only* setup surface is outside
   those exclusions — the rule is about authorisation, not information — and names the two things
   that keep it there: it reports only what policy already permits, and it never reports whether a

--- a/docs/detailed/configuration.md
+++ b/docs/detailed/configuration.md
@@ -42,6 +42,11 @@ limits:
   upstream_calls_per_minute: 60   # per connection, protects vendor quota
 
 # App registrations, shared by every connection of that vendor.
+#
+# Also the switch. A provider whose manifest names a broker — every Google REST
+# provider does — authorises against the client that broker operates when there
+# is no entry here, and against yours when there is. Written for you by
+# "lanes link connect <provider> --own-client"; delete it to go back.
 oauth_apps:
   google:
     client_id_ref: google/client_id
@@ -85,6 +90,38 @@ This value looked like a credential:
 ```
 
 There is deliberately no suppression flag.
+
+## A profile that uses the hosted OAuth client
+
+The default, and the shorter file: there is no `oauth_apps` block at all, because there is no client
+to point at. The Google connections below authorise against the client Lanes operates, and its
+secret is never on this machine.
+
+```yaml
+contract: 1
+
+instance:
+  profile: personal
+  default_target: local
+
+targets:
+  local:
+    credentials: { adapter: file }
+    storage: { adapter: filesystem, path: ./data }
+
+connections:
+  - id: ada_lovelace
+    provider: gmail
+    account: ada.lovelace@example.com
+
+policy:
+  allow: ['gmail.*']
+```
+
+Adding an `oauth_apps` entry later does not move an existing connection onto your client: which
+client minted a refresh token is recorded with the token, because one client's refresh token is
+refused by another. Run `connect` again for any connection you want moved. See
+[ADR-028](adr/028-a-hosted-oauth-client-is-the-default.md).
 
 ## Validation rules
 

--- a/docs/detailed/deployment-cloudrun.md
+++ b/docs/detailed/deployment-cloudrun.md
@@ -546,3 +546,19 @@ value, not the command, so a rotated token needs re-registration. `lanes link ou
 
 **`lanes link outputs` shows a local URL for a cloud target** — it asks Cloud Run for the service URL and
 falls back to the configured host and port when `gcloud` is absent or the service is not deployed yet.
+
+## A brokered Google connection on Cloud Run
+
+Nothing extra to bind. A connection authorised against the OAuth client Lanes operates rewrites
+exactly one secret while serving — its own token blob — which is already in the rotation grant, and
+it needs no client id or secret anywhere in the target's store.
+
+The one requirement is **outbound HTTPS to the broker host**, which Cloud Run has by default. It
+only becomes a question if you have set VPC egress to route all traffic: the revision refreshes
+through `api.lanes.sh`, so that host has to be reachable or every Google call fails an hour after
+the revision reports healthy.
+
+A profile that registered its own client is the other way round: its `oauth_apps` refs are bound
+**readable** by `deploy` so the refresh path can sign with them, and never writable —
+[ADR-026](adr/026-a-revision-rotates-its-own-credentials.md)'s line is that a revision rotates what
+is its own and never rewrites the operator's client.

--- a/docs/detailed/local-development.md
+++ b/docs/detailed/local-development.md
@@ -27,6 +27,38 @@ $ bun run lanes link connect example
 $ bun run lanes link start
 ```
 
+## Pointing the OAuth broker somewhere else
+
+A provider whose manifest declares `auth.broker` — every Google REST provider does — authorises
+against a client somebody else operates, and the exchange happens at that operator's origin. For
+production that is the right answer and there is nothing to configure. For working *on* the broker
+it is not: you want the one on your machine, or the one on stage.
+
+`LANES_LINK_BROKER_ORIGIN` replaces the origin and leaves the path alone, for every provider at
+once:
+
+```console
+$ export LANES_LINK_BROKER_ORIGIN=http://127.0.0.1:8080
+$ bun run lanes link connect gmail
+warn  LANES_LINK_BROKER_ORIGIN is set — the authorization code will be exchanged at
+      http://127.0.0.1:8080, not by Lanes.
+```
+
+It reaches both callers, because both read the same manifest field: the CLI performing the first
+exchange, and the endpoint refreshing while it serves.
+
+Three things it deliberately will not do:
+
+- **Fall back when the value is malformed.** It throws. A variable that is ignored when wrong is how
+  you send a real authorization code to production while believing you are testing locally.
+- **Accept `http` for anything but loopback.** Off this machine that puts an authorization code on
+  the wire in the clear. Use `https` for a remote broker.
+- **Keep a path.** `https://stage.example.com/v9/nope` becomes `https://stage.example.com`. The
+  provider owns its path; two places deciding where `/exchange` lives would disagree eventually.
+
+The warning above is the point of the feature as much as the redirect is — an override left
+exported in a shell is otherwise invisible.
+
 ## Layout
 
 Dependencies run one way: infrastructure interfaces → provider SDK → core → mcp → server/cli.

--- a/docs/detailed/providers.md
+++ b/docs/detailed/providers.md
@@ -29,8 +29,10 @@ modify — the smallest demonstration that bundles do something.
 
 ## `gmail`
 
-Setup: [`setup/google.md`](setup/google.md). You register your own Google Cloud OAuth client; there
-is no Lanes-operated app anywhere in the flow.
+Setup: [`setup/google.md`](setup/google.md). By default this authorises against the Google OAuth
+client Lanes operates, whose secret stays in the Lanes API and never reaches your machine;
+`--own-client` registers one of your own instead. [ADR-028](adr/028-a-hosted-oauth-client-is-the-default.md)
+records what each path trades.
 
 | Capability | Kind | Bundle | Why |
 |---|---|---|---|

--- a/docs/detailed/security.md
+++ b/docs/detailed/security.md
@@ -43,7 +43,7 @@ damaging single mistake available.
 
 | | **Credentials** (`SecretStore`) | **Vault items** (M3) |
 |---|---|---|
-| What | refresh tokens, OAuth app secrets, the profile token | the owner's own passwords, API keys |
+| What | refresh tokens, the profile token, and an OAuth client secret where the operator registered one of their own | the owner's own passwords, API keys |
 | Authorises | the system itself | nothing — they are data the owner stores |
 | Agent-reachable | **never, in any form** | yes, under policy, default deny |
 | Store | encrypted file, its own key | separate store, **separate key** |
@@ -93,11 +93,40 @@ limitation. `RESERVED` names a compatibility slot with no implementation.
 | `profile.isolated` | ENFORCED | cross-profile token, state, and audit tests |
 | `limits.per-profile` | ENFORCED per instance | rate limit tests |
 | `audit.every-invocation` | ENFORCED **with two documented exceptions** | see below |
+| `credentials.client-secret-never-local` | ENFORCED (hosted client) | there is no client secret on the machine to hold. `resolveSecretRefs` grants no client reference at all for a connection authorised this way, asserted in `src/dispatch/context.test.ts` |
+| `credentials.exchange-is-local` | **NOT-GUARANTEED for a connection authorised against the hosted client** | see below |
 | `credentials.plaintext-in-use` | NOT-GUARANTEED | inherent |
 | `provider.sandboxed` | NOT-GUARANTEED | provider code is trusted |
 | `egress.controlled` | NOT-GUARANTEED | follows from the above |
 | `policy.approval_required` | RESERVED | the model carries the state; no engine, and it fails closed |
 | `delegation.external-clients` | RESERVED | the principal parameter; nothing more |
+
+### What `credentials.exchange-is-local` gives up
+
+Since [ADR-028](adr/028-a-hosted-oauth-client-is-the-default.md) a Google connection authorises,
+by default, against an OAuth client Lanes operates rather than one the operator registers. That
+removes a nine-step console walkthrough and the seven-day refresh-token expiry that comes with an
+unpublished project. It also moves one step off this machine, and the honest statement of that is
+worth more than the convenience:
+
+- The **authorization code** is sent to the Lanes API, because redeeming it needs the client
+  secret and that secret is deliberately not here.
+- The **refresh token** comes back through the Lanes API, and passes through it again on every
+  later refresh.
+- An **identity assertion** (a Google `id_token`, obtained from the `openid` and `email` scopes
+  the flow adds for this purpose) is sent with each refresh, so the API can attribute and
+  rate-limit per account. It is stored beside the tokens and never decoded here.
+
+Everything else is unchanged: the browser still talks to Google directly, the redirect still lands
+on a loopback listener this process opened, the endpoint still never participates, and the tokens
+still live in whichever credential store the config names.
+
+**Nothing in this repository can verify what the Lanes API does with what it sees.** That is the
+whole of the trade, and it is why this is a row in the table rather than a paragraph in a guide.
+An operator who does not want to make it runs `lanes link connect <provider> --own-client` once
+per profile, which registers a client of their own and keeps the exchange between this machine and
+Google. Declaring `oauth_apps` in a profile is the same choice expressed in config, and a profile
+that declares it is never moved off it.
 
 ### The documented exceptions to `audit.every-invocation`
 

--- a/docs/detailed/setup/google.md
+++ b/docs/detailed/setup/google.md
@@ -1,11 +1,48 @@
 # Connecting Gmail, Drive, Sheets, Docs, Calendar, Tasks, and Contacts
 
-Google is the one provider where you must register your own OAuth client. Notion and Linear register
-themselves automatically; Google does not offer that, **even for Google's own MCP servers**. No
-architecture avoids it — it is their policy.
+```console
+$ lanes link connect gmail
+```
 
-The good news: you do this **once**, and one client covers **every** Google account you connect —
-personal Gmail and Workspace alike, across as many accounts as you like.
+That is the whole of it. A browser opens, you approve the scopes, the connection is made.
+
+Google requires a pre-registered OAuth client — Notion and Linear register themselves automatically,
+Google does not offer that, **even for Google's own MCP servers**, and no architecture avoids it.
+But it does not follow that *you* have to be the one who registers it. By default Lanes Link
+authorises against a client Lanes operates, whose secret stays in the Lanes API and never reaches
+your machine.
+
+Two things that costs you, both worth knowing before you start:
+
+- Until Google's verification completes you will see a **"Google hasn't verified this app"**
+  screen. Choose **Advanced → Go to Lanes** to continue.
+- The hosted client is limited to **100 Google accounts**, a cap Google counts for the lifetime of
+  the project. `lanes link connect` warns as it fills and tells you what to do if it is full.
+
+What it saves you is the rest of this page.
+
+## Registering a client of your own
+
+You would want to, and the rest of this page is how, if:
+
+- your organisation does not permit third-party OAuth clients;
+- all your accounts are on one Workspace domain and you want an **Internal** app, which never
+  expires a refresh token and shows no warning screen;
+- you would rather the authorization code and refresh token never passed through the Lanes API
+  ([`../security.md`](../security.md) states exactly what that gives up);
+- or the hosted client is at capacity.
+
+```console
+$ lanes link connect gmail --own-client
+```
+
+It asks for a client id and secret, stores them, and writes an `oauth_apps` entry to your profile.
+That entry is the switch: once it is there, every Google connection on that profile uses your
+client and you never need the flag again. Delete it to go back to the hosted one — though existing
+connections keep refreshing against whichever client issued them, so moving one across means
+running `connect` for it again.
+
+Everything below is that path.
 
 ---
 
@@ -47,8 +84,9 @@ providers are simply unavailable to you — use `gmail` and `drive`, which have 
 
 ## Choose the right path first
 
-This is the decision that determines everything else, and getting it wrong is what sends people into
-Google's verification centre.
+For a client of your own, this is the decision that determines everything else, and getting it
+wrong is what sends people into Google's verification centre. None of it applies to the hosted
+client, which is published and carries no seven-day expiry.
 
 | Your accounts | User type | Verification | Refresh tokens |
 |---|---|---|---|
@@ -298,11 +336,15 @@ app, registered in your own project, and the credentials never leave your machin
 
 Each run adds one account. The client ID and secret are asked for once per *profile*, not once per
 account — all your Google connections authorise against the same registered client, which is what the
-`oauth_apps` block in your config exists for.
+`oauth_apps` block in your config exists for, and what its presence tells Lanes Link to keep using
+instead of the hosted client.
 
 ---
 
 ## The weekly re-authorisation
+
+This is a property of **your own** External app while it is in Testing. Connections made against
+the hosted client do not expire weekly, and `doctor` does not warn about their age.
 
 With an External app in Testing, refresh tokens die after seven days. When one does, a call fails
 with a message naming the cause and the fix:
@@ -319,15 +361,18 @@ $ lanes link doctor
 warn  gmail.personal credential is 8 days old — Testing-status apps expire at 7. Run: lanes link connect gmail.personal
 ```
 
-If the weekly cycle becomes annoying, the only genuine escapes are:
+If the weekly cycle becomes annoying, the escapes are:
 
+- **Use the hosted client** — drop `--own-client`, delete the `oauth_apps` entry from your profile,
+  and run `lanes link connect` again for each account. That client is published, so its refresh
+  tokens do not expire weekly.
 - **Move those accounts to a Workspace domain** and use an Internal app — no expiry, no warning
   screen, no verification.
-- **Complete Google's verification** for the External app — weeks to months, and for restricted
+- **Complete Google's verification** for your External app — weeks to months, and for restricted
   scopes it includes a paid third-party security assessment.
 
-There is no third option. Anything claiming otherwise is either using non-restricted scopes or is
-about to stop working.
+There is no fourth. Anything claiming otherwise is either using non-restricted scopes or is about
+to stop working.
 
 ---
 

--- a/docs/detailed/workflow.md
+++ b/docs/detailed/workflow.md
@@ -82,8 +82,8 @@ One command, run once per account. The second run skips whatever the first estab
 ```console
 $ lanes link connect example      # → example.main
 $ lanes link connect example      # → example.main2
-$ lanes link connect gmail        # → prompts for client id/secret once, then a browser
-$ lanes link connect gmail        # → straight to the browser, another account
+$ lanes link connect gmail        # → straight to the browser, nothing to register
+$ lanes link connect gmail        # → again, another account
 ```
 
 `lanes link connect gmail.main` re-authorises one existing account. `--id` overrides the derived connection

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -99,8 +99,9 @@ A mail or calendar account is the first thing that costs any setup:
 $ lanes link connect gmail
 ```
 
-Google asks you to register an OAuth client of your own; the command walks you through it. See
-[Connect your accounts](connect.md) for every provider and what each one needs.
+That opens a browser and nothing else — Google authorises against the OAuth client Lanes operates,
+so there is no Cloud project to create. See [Connect your accounts](connect.md) for every provider,
+what each one needs, and how to use an OAuth client of your own instead.
 
 A new connection is served after the endpoint restarts — stop `lanes link start` and run it again.
 

--- a/src/cli/commands/connect/authorise.ts
+++ b/src/cli/commands/connect/authorise.ts
@@ -7,6 +7,10 @@ import { captureOAuthCallback, defaultOpenBrowser, runOAuthFlow } from '../../oa
 import { ok, progress, style, warn } from '../../output.ts';
 import { terminalPrompter, type Prompter } from '../../prompt.ts';
 import { describeScopes, shortScope } from '../../scopes.ts';
+import { BROKERED, BrokerError } from '#connectivity/auth/index.ts';
+import { brokerExchangeVia } from '../../oauth-exchange.ts';
+import { brokeredScopes, hostedClientRefusal, resolveOAuthClient } from './client.ts';
+import { confirmScopes } from './scopes-gate.ts';
 import { ensureOAuthApp } from './setup.ts';
 
 /**
@@ -37,130 +41,6 @@ export function oauthProviderFor(
 }
 
 /**
- * Warn when a manifest's pinned scopes have drifted from the server's.
- *
- * Pinning is deliberate — it stops a vendor widening a grant by editing its own
- * metadata — but a pinned list is a list that can go stale, and both directions
- * of staleness are worth different words:
- *
- * - the server declares a scope we do not request → calls fail, and Google's
- *   servers say only "The caller does not have permission", which points
- *   nowhere near the cause. This is the failure that cost an afternoon.
- * - we request one it no longer declares → probably harmless, possibly a scope
- *   that has been withdrawn; worth seeing, not worth stopping for.
- *
- * Advisory in both directions. Discovery failing must not block a connect that
- * would otherwise work, so a broken probe is silent.
- */
-async function reportScopeDrift(pinned: readonly string[], serverUrl: string): Promise<void> {
-  let advertised: readonly string[] = [];
-
-  try {
-    const metadata = await discoverOAuthProtectedResourceMetadata(serverUrl);
-    advertised = (metadata as { scopes_supported?: string[] }).scopes_supported ?? [];
-  } catch {
-    return;
-  }
-
-  if (advertised.length === 0) return;
-
-  const missing = advertised.filter((scope) => !pinned.includes(scope));
-  const extra = pinned.filter((scope) => !advertised.includes(scope));
-
-  if (missing.length > 0) {
-    progress('');
-    progress(
-      style.dim(
-        `${new URL(serverUrl).host} advertises ${missing.length} scope(s) not requested: ` +
-          `${missing.map(shortScope).join(', ')}.`,
-      ),
-    );
-    progress(
-      style.dim(
-        '  Deliberate — an advertised scope is not necessarily a required one, and these are broader than the docs ask for. Worth revisiting only if calls fail on permission.',
-      ),
-    );
-  }
-
-  if (extra.length > 0) {
-    progress('');
-    progress(style.dim(`Note: ${extra.map(shortScope).join(', ')} is no longer declared by the server.`));
-  }
-}
-
-/**
- * Show what is about to be granted, and stop on the broad ones.
- *
- * The consent screen that follows lists the same scopes in the vendor's own
- * wording, where "Read, compose, send, and permanently delete all your email"
- * sits in a list of five and reads like boilerplate. This is the same
- * information a step earlier, in our words, with the account still unconnected
- * — the last point where declining costs nothing.
- */
-async function confirmScopes(
-  manifest: ProviderManifest,
-  serverUrl: string,
-  prompter: Prompter,
-  acceptBroadScopes: boolean,
-): Promise<boolean> {
-  if (manifest.auth.kind !== 'oauth' || manifest.auth.scopes.length === 0) return true;
-
-  await reportScopeDrift(manifest.auth.scopes, serverUrl);
-
-  const described = describeScopes(manifest.auth.scopes);
-
-  progress('');
-  progress(`${manifest.name} will be granted:`);
-  for (const { scope, meaning, broad } of described) {
-    const name = broad ? style.bold(shortScope(scope)) : shortScope(scope);
-    progress(`  ${broad ? '!' : '·'} ${name}${meaning ? style.dim(`  — ${meaning}`) : ''}`);
-  }
-
-  if (!described.some((entry) => entry.broad)) {
-    progress('');
-    return true;
-  }
-
-  // Why the broad ones cannot simply be dropped — otherwise the obvious next
-  // question is why we ask instead of asking for less.
-  progress('');
-  progress(
-    warn(
-      'The marked scopes are broader than this provider needs. Grant them only if you ' +
-        'mean to — policy can restrict what an agent calls, but it cannot un-grant a token.',
-    ),
-  );
-  progress(
-    style.dim(
-      '  Policy still applies: only capabilities you allow are reachable, and every call is audited.',
-    ),
-  );
-  progress('');
-
-  // Answered ahead of time, by a person, in their own shell. The flag is long
-  // enough that repeating it is a deliberate act, and it lands in the history of
-  // whoever typed it — which is the property that matters, since the point of
-  // this gate is that the decision does not originate with the agent.
-  if (acceptBroadScopes) {
-    progress(style.dim('Broad scopes accepted with --accept-broad-scopes.'));
-    return true;
-  }
-
-  // Fail closed rather than defaulting to no. A non-interactive run cannot
-  // answer, and inventing an answer here would remove the last point at which
-  // declining is free — the vendor's own consent screen is next, where the same
-  // sentence sits in a list of five and reads like boilerplate.
-  if (!prompter.interactive) {
-    throw new Error(
-      `${manifest.name} asks for scopes broader than it needs, and this run is non-interactive.\n` +
-        `  Nothing was authorised. Re-run in a terminal, or add --accept-broad-scopes if you mean to grant them.`,
-    );
-  }
-
-  return prompter.confirm('Authorise with these scopes?', false);
-}
-
-/**
  * Drive the SDK's OAuth flow over a loopback callback.
  *
  * The SDK does discovery, registration, PKCE, and the exchange. We supply
@@ -175,19 +55,25 @@ export async function authorise(input: {
   changes: string[];
   /** No connection of this provider exists yet, so its console setup is undone. */
   firstForProvider: boolean;
+  /** How the operator spelled the target, so a refusal names a command they typed. */
+  target?: string;
+  profile: string;
+  /** `--own-client`: register a client rather than using the one a broker runs. */
+  ownClient?: boolean;
   prompter?: Prompter;
   /** The operator has already said yes to scopes broader than the provider needs. */
   acceptBroadScopes?: boolean;
+  /** Injected for tests. The broker is the only thing `connect` fetches. */
+  fetch?: typeof globalThis.fetch;
 }): Promise<void> {
   const { manifest, connectionId, credentials, document, changes } = input;
   const prompter = input.prompter ?? terminalPrompter;
   const acceptBroadScopes = input.acceptBroadScopes === true;
   if (manifest.auth.kind !== 'oauth') return;
 
-  if (manifest.auth.registration === 'manual') {
-    await ensureOAuthApp(input);
-  }
-
+  // `authoriseDirect` owns the client decision now: a brokered provider has
+  // nothing to prompt for, and asking first would ask for what it does not need.
+  //
   // A non-MCP connector has nothing to discover auth from: a REST API is a base
   // URL, and where its authorization server lives is not something it
   // announces. So the manifest names the endpoints and we run the flow
@@ -196,6 +82,12 @@ export async function authorise(input: {
   if (manifest.connector.kind !== 'mcp') {
     await authoriseDirect(input);
     return;
+  }
+
+  // An MCP provider is always bring-your-own: `defineProvider` refuses a broker
+  // on one, because the SDK owns the exchange and there is no seam to route it.
+  if (manifest.auth.registration === 'manual') {
+    await ensureOAuthApp(input);
   }
 
   const serverUrl = manifest.connector.endpoint;
@@ -283,8 +175,15 @@ async function authoriseDirect(input: {
   manifest: ProviderManifest;
   connectionId: string;
   credentials: SecretStore;
+  document: ConfigDocument;
+  changes: string[];
+  firstForProvider: boolean;
+  target?: string;
+  profile: string;
+  ownClient?: boolean;
   prompter?: Prompter;
   acceptBroadScopes?: boolean;
+  fetch?: typeof globalThis.fetch;
 }): Promise<void> {
   const { manifest, connectionId, credentials } = input;
   const prompter = input.prompter ?? terminalPrompter;
@@ -298,36 +197,80 @@ async function authoriseDirect(input: {
     );
   }
 
-  const [clientId, clientSecret] = app
-    ? await Promise.all([
-        credentials.get(`${app}/client_id`),
-        credentials.get(`${app}/client_secret`),
-      ])
-    : [null, null];
+  const client = await resolveOAuthClient({
+    manifest,
+    credentials,
+    document: input.document,
+    changes: input.changes,
+    firstForProvider: input.firstForProvider,
+    ownClient: input.ownClient === true,
+    target: input.target ?? manifest.id,
+    profile: input.profile,
+    ...(input.prompter ? { prompter: input.prompter } : {}),
+    ...(input.fetch ? { fetch: input.fetch } : {}),
+  });
 
-  if (!clientId || !clientSecret) {
-    throw new Error(`No OAuth client stored for "${app}". Run: lanes link connect ${manifest.id}`);
-  }
+  const scopes =
+    client.kind === 'brokered'
+      ? brokeredScopes(manifest.auth.scopes, client.config).scopes
+      : manifest.auth.scopes;
 
   if (
-    !(await confirmScopes(manifest, authorizeUrl, prompter, input.acceptBroadScopes === true))
+    !(await confirmScopes(
+      manifest,
+      authorizeUrl,
+      prompter,
+      input.acceptBroadScopes === true,
+      scopes,
+    ))
   ) {
     throw new Error('Cancelled — nothing was authorised.');
   }
 
-  const tokens = await runOAuthFlow({
-    authorizeUrl,
-    tokenUrl,
-    clientId,
-    clientSecret,
-    scopes: manifest.auth.scopes,
-    connectionLabel: manifest.name,
-    ...(manifest.auth.authorize_params ? { authorizeParams: manifest.auth.authorize_params } : {}),
-    onPrompt: (url) => {
-      progress(style.dim('Opening your browser to authorise…'));
-      progress(style.dim(`If it did not open: ${url}`));
-    },
-  });
+  let tokens;
+  try {
+    tokens = await runOAuthFlow({
+      authorizeUrl,
+      clientId: client.kind === 'own' ? client.clientId : client.config.clientId,
+      ...(client.kind === 'own'
+        ? { tokenUrl, clientSecret: client.clientSecret }
+        : {
+            exchange: brokerExchangeVia({
+              url: client.url,
+              ...(input.fetch ? { fetch: input.fetch } : {}),
+            }),
+          }),
+      scopes,
+      connectionLabel: manifest.name,
+      ...(manifest.auth.authorize_params
+        ? { authorizeParams: manifest.auth.authorize_params }
+        : {}),
+      onPrompt: (url) => {
+        progress(style.dim('Opening your browser to authorise…'));
+        progress(style.dim(`If it did not open: ${url}`));
+      },
+    });
+  } catch (cause) {
+    // A broker refusal after consent is worth its own sentence: the operator
+    // has already approved the screen, and "nothing was stored" is the fact
+    // they need before they decide whether to try again.
+    if (cause instanceof BrokerError && client.kind === 'brokered') {
+      throw hostedClientRefusal({
+        manifest,
+        target: input.target ?? manifest.id,
+        profile: input.profile,
+        operator: manifest.auth.broker?.operator ?? 'this project',
+        cause: cause.message,
+        ...(cause.notice ? { notice: cause.notice } : {}),
+        ...(cause.docsUrl ? { docsUrl: cause.docsUrl } : {}),
+        afterConsent: true,
+        // A replayed code is not solved by an hour in a console, and the broker
+        // is the one that knows which of its refusals are.
+        ownClient: cause.ownClient,
+      });
+    }
+    throw cause;
+  }
 
   await credentials.set(
     `${manifest.id}/${connectionId}`,
@@ -339,6 +282,15 @@ async function authoriseDirect(input: {
       expires_at: Date.now() + tokens.expiresIn * 1000,
       scope: tokens.scope,
       issuer: new URL(authorizeUrl).origin,
+      ...(tokens.idToken ? { id_token: tokens.idToken } : {}),
+      // Which client issued this, stamped once at connect.
+      //
+      // A property of the token, not of the profile: a refresh token minted by
+      // one client is refused by another, so an operator who registers a client
+      // of their own six months from now must not drag existing connections
+      // onto it. Absent means "the profile's own", which every credential
+      // written before this feature already is.
+      ...(client.kind === 'brokered' ? { authorized_via: BROKERED } : {}),
     }),
   );
 

--- a/src/cli/commands/connect/client.test.ts
+++ b/src/cli/commands/connect/client.test.ts
@@ -303,3 +303,83 @@ describe('hostedClientRefusal', () => {
     expect(message).not.toContain('--own-client');
   });
 });
+
+/**
+ * Notes on the way to a connection go to stderr, and they have to actually
+ * arrive there.
+ *
+ * `warn` formats a line; `progress` is what writes it. Calling `warn` bare
+ * type-checks, runs, builds the sentence and discards it — which is what had
+ * happened to the near-capacity notice below. Nothing but a test that reads the
+ * stream catches that, because every other signal says the code ran.
+ */
+async function captured(body: () => Promise<void>): Promise<string> {
+  const errWrite = process.stderr.write.bind(process.stderr);
+  let err = '';
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (process.stderr as any).write = (chunk: string) => ((err += chunk), true);
+  try {
+    await body();
+  } finally {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (process.stderr as any).write = errWrite;
+  }
+  return err;
+}
+
+describe('what a brokered connect says out loud', () => {
+  test('says the shared client is filling up, on the stream', async () => {
+    const nearlyFull = {
+      success: true,
+      data: { ...OPEN.data, capacity: { accounts: 93, cap: 100 } },
+    };
+
+    const err = await captured(async () => {
+      await resolveOAuthClient(await choice({ fetch: brokerAnswering(nearlyFull) }));
+    });
+
+    expect(err).toContain('near capacity');
+    expect(err).toContain('93 of 100');
+  });
+
+  test('stays quiet while there is room, so the notice keeps its weight', async () => {
+    const roomy = {
+      success: true,
+      data: { ...OPEN.data, capacity: { accounts: 12, cap: 100 } },
+    };
+
+    const err = await captured(async () => {
+      await resolveOAuthClient(await choice({ fetch: brokerAnswering(roomy) }));
+    });
+
+    expect(err).not.toContain('near capacity');
+  });
+
+  test('says so when the broker origin has been moved', async () => {
+    // The case worth catching is not the deliberate one — it is the variable
+    // still exported in a shell three days later, deciding where a real
+    // authorization code goes.
+    const before = process.env['LANES_LINK_BROKER_ORIGIN'];
+    process.env['LANES_LINK_BROKER_ORIGIN'] = 'http://127.0.0.1:8080';
+    try {
+      const err = await captured(async () => {
+        await resolveOAuthClient(await choice());
+      });
+
+      expect(err).toContain('LANES_LINK_BROKER_ORIGIN is set');
+      expect(err).toContain('http://127.0.0.1:8080');
+      expect(err).toContain('not by Someone');
+    } finally {
+      if (before === undefined) delete process.env['LANES_LINK_BROKER_ORIGIN'];
+      else process.env['LANES_LINK_BROKER_ORIGIN'] = before;
+    }
+  });
+
+  test('says nothing about an origin nobody moved', async () => {
+    const err = await captured(async () => {
+      await resolveOAuthClient(await choice());
+    });
+
+    expect(err).not.toContain('LANES_LINK_BROKER_ORIGIN');
+  });
+});

--- a/src/cli/commands/connect/client.test.ts
+++ b/src/cli/commands/connect/client.test.ts
@@ -1,0 +1,305 @@
+import { afterAll, describe, expect, test } from 'bun:test';
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { defineProvider } from '#connectivity';
+import type { SecretRef, SecretStore } from '#secrets';
+import { ConfigDocument, newProfileTemplate } from '../../config-edit.ts';
+import { nonInteractivePrompter } from '../../prompt.ts';
+import { brokeredScopes, hostedClientRefusal, resolveOAuthClient } from './client.ts';
+
+/**
+ * Which client a connection authorises against, and who decides.
+ *
+ * The manifest cannot: a provider that declares a broker is still one an
+ * operator may want to register their own client for, so the decision belongs
+ * to the profile. Declaring an `oauth_apps` entry is how a profile says "mine";
+ * leaving it out is how it says "yours". These pin that, and pin the one thing
+ * that must never happen — a profile silently moving off a client it registered,
+ * which would refuse every refresh token it already holds.
+ */
+
+const BROKER = { url: 'https://api.example.com/v1/auth/link/vendor', operator: 'Someone' };
+
+const manifest = (broker: object | null = BROKER, withPrompts = true) =>
+  defineProvider({
+    id: 'vendor_mail',
+    name: 'Vendor Mail',
+    connector: { kind: 'http', base_url: 'https://api.test', openapi: './t.json' },
+    auth: {
+      kind: 'oauth',
+      registration: 'manual',
+      app: 'vendor',
+      scopes: ['https://api.test/auth/mail.read'],
+      authorize_url: 'https://accounts.example.com/o/oauth2/v2/auth',
+      token_url: 'https://oauth2.example.com/token',
+      ...(broker ? { broker } : {}),
+    },
+    ...(withPrompts
+      ? {
+          setup: {
+            prompts: [
+              { key: 'client_id', label: 'Client id', credential_ref: 'vendor/client_id' },
+              {
+                key: 'client_secret',
+                label: 'Client secret',
+                secret: true,
+                credential_ref: 'vendor/client_secret',
+              },
+            ],
+          },
+        }
+      : {}),
+  });
+
+function memoryStore(seed: Record<string, string> = {}): SecretStore {
+  const map = new Map<string, string>(Object.entries(seed));
+  return {
+    get: async (ref) => map.get(ref) ?? null,
+    set: async (ref, value) => void map.set(ref, value),
+    has: async (ref) => map.has(ref),
+    delete: async (ref) => void map.delete(ref),
+    list: async (prefix) =>
+      [...map.keys()].filter((k) => !prefix || k.startsWith(prefix)) as SecretRef[],
+  };
+}
+
+const roots: string[] = [];
+afterAll(async () => {
+  await Promise.all(roots.map((root) => rm(root, { recursive: true, force: true })));
+});
+
+async function document(body?: string): Promise<ConfigDocument> {
+  const root = await mkdtemp(join(tmpdir(), 'lanes-link-client-'));
+  roots.push(root);
+  await mkdir(join(root, 'profiles'), { recursive: true });
+  await writeFile(join(root, 'profiles', 'personal.yaml'), body ?? newProfileTemplate('personal', 7337));
+  return await ConfigDocument.open(root, 'personal');
+}
+
+function brokerAnswering(body: unknown, status = 200): typeof globalThis.fetch {
+  return (async () =>
+    new Response(JSON.stringify(body), {
+      status,
+      headers: { 'content-type': 'application/json' },
+    })) as unknown as typeof globalThis.fetch;
+}
+
+const OPEN = {
+  success: true,
+  data: {
+    client_id: 'hosted-client',
+    scopes_supported: ['https://api.test/auth/mail.read'],
+    identity_scopes: ['openid', 'email'],
+    status: 'open',
+  },
+};
+
+const choice = async (over: Partial<Parameters<typeof resolveOAuthClient>[0]> = {}) => ({
+  manifest: manifest(),
+  credentials: memoryStore(),
+  document: await document(),
+  changes: [] as string[],
+  firstForProvider: true,
+  ownClient: false,
+  target: 'vendor_mail',
+  profile: 'personal',
+  fetch: brokerAnswering(OPEN),
+  ...over,
+});
+
+describe('which client a connect uses', () => {
+  test('no broker declared is the path that was always here', async () => {
+    const client = await resolveOAuthClient(
+      await choice({
+        manifest: manifest(null),
+        credentials: memoryStore({ 'vendor/client_id': 'id', 'vendor/client_secret': 'secret' }),
+      }),
+    );
+
+    expect(client.kind).toBe('own');
+  });
+
+  test('a broker and an unconfigured profile is brokered', async () => {
+    const client = await resolveOAuthClient(await choice());
+
+    expect(client.kind).toBe('brokered');
+    if (client.kind === 'brokered') expect(client.config.clientId).toBe('hosted-client');
+  });
+
+  test('a profile that declares oauth_apps is never moved off its own client', async () => {
+    // The tokens it already holds were minted by that client; another one would
+    // refuse every refresh. So the declaration wins over the default, silently
+    // and always.
+    const doc = await document();
+    doc.setIn(['oauth_apps', 'vendor'], {
+      client_id_ref: 'vendor/client_id',
+      client_secret_ref: 'vendor/client_secret',
+    });
+
+    const client = await resolveOAuthClient(
+      await choice({
+        document: doc,
+        credentials: memoryStore({ 'vendor/client_id': 'id', 'vendor/client_secret': 'secret' }),
+      }),
+    );
+
+    expect(client.kind).toBe('own');
+  });
+
+  test('a client sitting in the store counts, even with the config block gone', async () => {
+    // Someone who placed the two values by hand keeps their client rather than
+    // being quietly moved onto a different one.
+    const client = await resolveOAuthClient(
+      await choice({
+        credentials: memoryStore({ 'vendor/client_id': 'id', 'vendor/client_secret': 'secret' }),
+      }),
+    );
+
+    expect(client.kind).toBe('own');
+  });
+
+  test('--own-client opts out, and writes the entry that makes it stick', async () => {
+    const doc = await document();
+    const changes: string[] = [];
+
+    const client = await resolveOAuthClient(
+      await choice({
+        document: doc,
+        changes,
+        ownClient: true,
+        credentials: memoryStore({ 'vendor/client_id': 'id', 'vendor/client_secret': 'secret' }),
+      }),
+    );
+
+    expect(client.kind).toBe('own');
+    expect(doc.getIn(['oauth_apps', 'vendor'])).toBeDefined();
+    expect(changes).toContain('oauth_apps.vendor declared');
+  });
+
+  test('--own-client on a provider that describes no client refuses, and says why', async () => {
+    await expect(
+      resolveOAuthClient(
+        await choice({ manifest: manifest(BROKER, false), ownClient: true }),
+      ),
+    ).rejects.toThrow(/no bring-your-own client path/);
+  });
+});
+
+describe('refusing before the browser opens', () => {
+  test('a closed broker refuses with its own words and the way out', async () => {
+    const error = (await resolveOAuthClient(
+      await choice({
+        fetch: brokerAnswering({
+          success: true,
+          data: { client_id: 'c', status: 'closed', notice: 'At capacity.' },
+        }),
+      }),
+    ).catch((e) => e)) as Error;
+
+    expect(error.message).toContain('At capacity.');
+    expect(error.message).toContain('Nothing was written');
+    expect(error.message).toContain(
+      'lanes link connect vendor_mail --profile personal --own-client',
+    );
+  });
+
+  test('a scope the hosted client cannot grant is caught here, not at the consent screen', async () => {
+    const error = (await resolveOAuthClient(
+      await choice({
+        fetch: brokerAnswering({
+          success: true,
+          data: { client_id: 'c', scopes_supported: ['something.else'], status: 'open' },
+        }),
+      }),
+    ).catch((e) => e)) as Error;
+
+    expect(error.message).toContain('mail.read');
+  });
+
+  test('an unreachable broker is a refusal, not a stack trace', async () => {
+    const fetch = (async () => {
+      throw new Error('ECONNREFUSED');
+    }) as unknown as typeof globalThis.fetch;
+
+    const error = (await resolveOAuthClient(await choice({ fetch })).catch((e) => e)) as Error;
+
+    expect(error.message).toContain('ECONNREFUSED');
+    expect(error.message).toContain('--own-client');
+  });
+
+  test('a broker that does not advertise its scopes is trusted rather than refused', async () => {
+    // Silence is not the same as "supports nothing". Treating it as refusal
+    // would break every connection against a broker that simply does not say.
+    const client = await resolveOAuthClient(
+      await choice({
+        fetch: brokerAnswering({ success: true, data: { client_id: 'c', status: 'open' } }),
+      }),
+    );
+
+    expect(client.kind).toBe('brokered');
+  });
+
+  test('a non-interactive run still reaches the broker rather than prompting', async () => {
+    const client = await resolveOAuthClient(
+      await choice({ prompter: nonInteractivePrompter('lanes link setup plan vendor_mail') }),
+    );
+
+    expect(client.kind).toBe('brokered');
+  });
+});
+
+describe('brokeredScopes', () => {
+  const config = {
+    clientId: 'c',
+    scopesSupported: ['a', 'b'],
+    identityScopes: ['openid', 'email'],
+    open: true,
+    notice: undefined,
+    docsUrl: undefined,
+    capacity: undefined,
+  };
+
+  test('appends the identity scopes the broker asks for', () => {
+    expect(brokeredScopes(['a'], config).scopes).toEqual(['a', 'openid', 'email']);
+  });
+
+  test('does not duplicate one the provider already wanted', () => {
+    expect(brokeredScopes(['a', 'openid'], config).scopes).toEqual(['a', 'openid', 'email']);
+  });
+
+  test('names what the broker cannot grant rather than silently dropping it', () => {
+    expect(brokeredScopes(['a', 'zzz'], config).unsupported).toEqual(['zzz']);
+  });
+});
+
+describe('hostedClientRefusal', () => {
+  test('says nothing was kept once consent has already been given', () => {
+    const message = hostedClientRefusal({
+      manifest: manifest(),
+      target: 'vendor_mail.ada',
+      profile: 'work',
+      operator: 'Someone',
+      cause: 'the exchange was refused',
+      afterConsent: true,
+    }).message;
+
+    expect(message).toContain('You approved the consent screen');
+    expect(message).toContain('--profile work');
+    // The real target, not the provider id, so the line can be pasted as-is.
+    expect(message).toContain('vendor_mail.ada');
+  });
+
+  test('does not offer a console visit for something a console visit will not fix', () => {
+    const message = hostedClientRefusal({
+      manifest: manifest(),
+      target: 'vendor_mail',
+      profile: 'personal',
+      operator: 'Someone',
+      cause: 'invalid_grant',
+      ownClient: false,
+    }).message;
+
+    expect(message).not.toContain('--own-client');
+  });
+});

--- a/src/cli/commands/connect/client.ts
+++ b/src/cli/commands/connect/client.ts
@@ -1,4 +1,10 @@
-import { BrokerError, brokerConfig, type BrokerConfig } from '#connectivity/auth/index.ts';
+import {
+  BROKER_ORIGIN_ENV,
+  BrokerError,
+  brokerConfig,
+  brokerOriginOverride,
+  type BrokerConfig,
+} from '#connectivity/auth/index.ts';
 import type { ProviderManifest } from '#connectivity';
 import type { SecretStore } from '#secrets';
 import { ConfigDocument } from '../../config-edit.ts';
@@ -82,6 +88,18 @@ export async function resolveOAuthClient(input: ClientChoice): Promise<OAuthClie
       );
     }
     return { kind: 'own', clientId, clientSecret };
+  }
+
+  // Before the fetch, so it is said even when the broker cannot be reached.
+  // The danger is not someone who set this deliberately; it is the variable
+  // still exported in a shell three days later, quietly sending a real
+  // authorization code somewhere other than where the operator believes.
+  const overridden = brokerOriginOverride();
+  if (overridden) {
+    warn(
+      `${BROKER_ORIGIN_ENV} is set — the authorization code will be exchanged at ${overridden}, ` +
+        `not by ${broker.operator}.`,
+    );
   }
 
   let config: BrokerConfig;

--- a/src/cli/commands/connect/client.ts
+++ b/src/cli/commands/connect/client.ts
@@ -1,0 +1,260 @@
+import { BrokerError, brokerConfig, type BrokerConfig } from '#connectivity/auth/index.ts';
+import type { ProviderManifest } from '#connectivity';
+import type { SecretStore } from '#secrets';
+import { ConfigDocument } from '../../config-edit.ts';
+import { progress, style, warn } from '../../output.ts';
+import type { Prompter } from '../../prompt.ts';
+import { shortScope } from '../../scopes.ts';
+import { declareOwnClient, ensureOAuthApp } from './setup.ts';
+
+/**
+ * Which OAuth client this authorisation uses, and whether it can be used.
+ *
+ * Two arrangements, and the manifest does not pick between them — the profile
+ * does. Declaring an `oauth_apps` entry means "I registered a client, use it";
+ * leaving it out means "use the one the broker operates". So a profile that has
+ * already taken the trouble to register one is never moved off it, and everyone
+ * else gets the path with no console in it.
+ *
+ * Everything here happens *before the browser opens*. A refusal after consent
+ * has been given is a refusal the operator has already paid for, so the
+ * checks that can be made early are made early.
+ */
+
+export type OAuthClient =
+  | { readonly kind: 'own'; readonly clientId: string; readonly clientSecret: string }
+  | { readonly kind: 'brokered'; readonly url: string; readonly config: BrokerConfig };
+
+export interface ClientChoice {
+  readonly manifest: ProviderManifest;
+  readonly credentials: SecretStore;
+  readonly document: ConfigDocument;
+  readonly changes: string[];
+  /** No connection of this provider exists yet, so its console setup is undone. */
+  readonly firstForProvider: boolean;
+  /** `--own-client`: register one rather than using the client the broker runs. */
+  readonly ownClient: boolean;
+  /** How the operator spelled the target, so a refusal names a command they typed. */
+  readonly target: string;
+  readonly profile: string;
+  readonly prompter?: Prompter | undefined;
+  readonly fetch?: typeof globalThis.fetch | undefined;
+}
+
+export async function resolveOAuthClient(input: ClientChoice): Promise<OAuthClient> {
+  const { manifest, credentials, document } = input;
+  if (manifest.auth.kind !== 'oauth') {
+    throw new Error(`Provider "${manifest.id}" does not use OAuth.`);
+  }
+
+  const { app, broker } = manifest.auth;
+
+  if (!broker || (await profileHasOwnClient(app, document, credentials)) || input.ownClient) {
+    if (input.ownClient && broker && !hasClientPrompts(manifest)) {
+      // `defineProvider` permits a broker with no prompts — a provider with no
+      // bring-your-own path is a legal thing to be. This is where that absence
+      // becomes a sentence rather than a prompt for a value nothing collects.
+      throw new Error(
+        `${manifest.name} has no bring-your-own client path: it does not describe what to ` +
+          `register. Drop --own-client to authorise against the client ${broker.operator} operates.`,
+      );
+    }
+    await ensureOAuthApp({
+      manifest,
+      credentials,
+      document,
+      changes: input.changes,
+      firstForProvider: input.firstForProvider,
+      ...(input.prompter ? { prompter: input.prompter } : {}),
+    });
+    if (input.ownClient) declareOwnClient(document, manifest, input.changes);
+
+    const [clientId, clientSecret] = app
+      ? await Promise.all([
+          credentials.get(`${app}/client_id`),
+          credentials.get(`${app}/client_secret`),
+        ])
+      : [null, null];
+
+    if (!clientId || !clientSecret) {
+      throw new Error(
+        `No OAuth client stored for "${app}". Run: lanes link connect ${manifest.id}`,
+      );
+    }
+    return { kind: 'own', clientId, clientSecret };
+  }
+
+  let config: BrokerConfig;
+  try {
+    config = await brokerConfig(broker.url, input.fetch ?? globalThis.fetch);
+  } catch (cause) {
+    throw hostedClientRefusal({
+      manifest,
+      target: input.target,
+      profile: input.profile,
+      operator: broker.operator,
+      cause: cause instanceof Error ? cause.message : String(cause),
+      ...(cause instanceof BrokerError && cause.notice ? { notice: cause.notice } : {}),
+      docsUrl: broker.docs_url,
+    });
+  }
+
+  if (!config.open) {
+    throw hostedClientRefusal({
+      manifest,
+      target: input.target,
+      profile: input.profile,
+      operator: broker.operator,
+      cause: 'it is not accepting new connections.',
+      ...(config.notice ? { notice: config.notice } : {}),
+      docsUrl: config.docsUrl ?? broker.docs_url,
+    });
+  }
+
+  const { unsupported } = brokeredScopes(manifest.auth.scopes, config);
+  if (unsupported.length > 0) {
+    throw hostedClientRefusal({
+      manifest,
+      target: input.target,
+      profile: input.profile,
+      operator: broker.operator,
+      cause:
+        `it is not registered for ${unsupported.length === 1 ? 'a scope' : `${unsupported.length} scopes`} ` +
+        `${manifest.name} needs:\n      ${unsupported.map(shortScope).join('\n      ')}`,
+      docsUrl: config.docsUrl ?? broker.docs_url,
+    });
+  }
+
+  if (config.capacity && config.capacity.cap > 0) {
+    const left = config.capacity.cap - config.capacity.accounts;
+    // Advisory, never a refusal. The vendor is the authority on its own cap and
+    // still admits accounts that have already granted once, so refusing here
+    // would lock out exactly the people it would still let through.
+    if (left <= 10) {
+      warn(
+        `The ${broker.operator} client is near capacity (${config.capacity.accounts} of ${config.capacity.cap} accounts).`,
+      );
+    }
+  }
+
+  progress(
+    style.dim(
+      `Authorising against the OAuth client ${broker.operator} operates — nothing to register.`,
+    ),
+  );
+
+  return { kind: 'brokered', url: broker.url, config };
+}
+
+/**
+ * Whether this profile holds a client of its own.
+ *
+ * The config entry is the declaration, but the store is consulted too: someone
+ * who placed the two values by hand and whose config lost the block keeps their
+ * client rather than being quietly moved onto a different one, where every
+ * existing refresh token would stop working.
+ */
+async function profileHasOwnClient(
+  app: string | undefined,
+  document: ConfigDocument,
+  credentials: SecretStore,
+): Promise<boolean> {
+  if (!app) return false;
+  if (document.getIn(['oauth_apps', app]) !== undefined) return true;
+
+  const [id, secret] = await Promise.all([
+    credentials.get(`${app}/client_id`),
+    credentials.get(`${app}/client_secret`),
+  ]);
+  return Boolean(id && secret);
+}
+
+function hasClientPrompts(manifest: ProviderManifest): boolean {
+  return (manifest.setup?.prompts ?? []).some((prompt) => prompt.scope === 'shared');
+}
+
+/**
+ * What is actually asked for, and what the broker cannot grant.
+ *
+ * The identity scopes are appended rather than assumed: they are what lets the
+ * broker tell one caller's refresh from another's, and the broker says which
+ * ones it wants so it can change them without a new CLI. They are added *only*
+ * on this path — for a client the operator registered there is nobody to
+ * identify to, and asking would cost them a re-consent and two extra lines in
+ * their own console for no benefit at all.
+ */
+export function brokeredScopes(
+  wanted: readonly string[],
+  config: BrokerConfig,
+): { readonly scopes: readonly string[]; readonly unsupported: readonly string[] } {
+  // An empty `scopes_supported` means the broker did not say, not that it
+  // supports nothing. Treating silence as refusal would break every connection
+  // against a broker that simply does not advertise.
+  const unsupported =
+    config.scopesSupported.length > 0
+      ? wanted.filter((scope) => !config.scopesSupported.includes(scope))
+      : [];
+
+  const scopes = [...wanted];
+  for (const scope of config.identityScopes) if (!scopes.includes(scope)) scopes.push(scope);
+
+  return { scopes, unsupported };
+}
+
+/** The refusal that names the way out, with the command already filled in. */
+export function hostedClientRefusal(input: {
+  manifest: ProviderManifest;
+  target: string;
+  profile: string;
+  operator: string;
+  cause: string;
+  notice?: string | undefined;
+  docsUrl?: string | undefined;
+  /** Consent has already been given, so say so before saying nothing was kept. */
+  afterConsent?: boolean | undefined;
+  /**
+   * Whether registering a client of your own is the way past this.
+   *
+   * The broker knows and this does not: a spent capacity and a replayed
+   * authorization code are both a 4xx, and offering an hour in a cloud console
+   * as the fix for the second is worse than offering nothing. Defaults to true
+   * because the refusals raised before the browser opens are all of the first
+   * kind — a broker that is closed, unreachable, or short a scope.
+   */
+  ownClient?: boolean | undefined;
+}): Error {
+  const lines = [
+    `${input.manifest.name} could not be authorised against the OAuth client ${input.operator} operates.`,
+    '',
+  ];
+
+  if (input.afterConsent) {
+    lines.push(
+      '  You approved the consent screen, but the token exchange was refused, so nothing',
+      '  was stored.',
+      '',
+    );
+  }
+
+  // The reason is the broker's to word, so a spent capacity, a suspension and a
+  // maintenance window can read differently without shipping a new CLI.
+  lines.push(`  ${input.notice ?? input.cause}`, '');
+  if (input.notice) lines.push(`  (${input.cause})`, '');
+
+  lines.push('  Nothing was written and no account was connected.');
+
+  if (input.ownClient !== false) {
+    lines.push(
+      '',
+      '  Register your own OAuth client instead:',
+      `    lanes link connect ${input.target} --profile ${input.profile} --own-client`,
+      '',
+      '  That walks through the vendor’s console once and then covers every account on',
+      '  this profile.',
+    );
+  }
+
+  if (input.docsUrl) lines.push(`  ${input.docsUrl}`);
+
+  return new Error(lines.join('\n'));
+}

--- a/src/cli/commands/connect/client.ts
+++ b/src/cli/commands/connect/client.ts
@@ -96,9 +96,11 @@ export async function resolveOAuthClient(input: ClientChoice): Promise<OAuthClie
   // authorization code somewhere other than where the operator believes.
   const overridden = brokerOriginOverride();
   if (overridden) {
-    warn(
-      `${BROKER_ORIGIN_ENV} is set — the authorization code will be exchanged at ${overridden}, ` +
-        `not by ${broker.operator}.`,
+    progress(
+      warn(
+        `${BROKER_ORIGIN_ENV} is set — the authorization code will be exchanged at ${overridden}, ` +
+          `not by ${broker.operator}.`,
+      ),
     );
   }
 
@@ -149,8 +151,12 @@ export async function resolveOAuthClient(input: ClientChoice): Promise<OAuthClie
     // still admits accounts that have already granted once, so refusing here
     // would lock out exactly the people it would still let through.
     if (left <= 10) {
-      warn(
-        `The ${broker.operator} client is near capacity (${config.capacity.accounts} of ${config.capacity.cap} accounts).`,
+      // `warn` formats; `progress` is what puts it on the stream. Called bare it
+      // builds the sentence and drops it, which is how this one went unsaid.
+      progress(
+        warn(
+          `The ${broker.operator} client is near capacity (${config.capacity.accounts} of ${config.capacity.cap} accounts).`,
+        ),
       );
     }
   }

--- a/src/cli/commands/connect/index.ts
+++ b/src/cli/commands/connect/index.ts
@@ -38,6 +38,17 @@ export interface ConnectOptions extends GlobalFlags {
   readonly nonInteractive?: boolean | undefined;
   /** The operator has already agreed to scopes broader than the provider needs. */
   readonly acceptBroadScopes?: boolean | undefined;
+  /**
+   * Register an OAuth client of your own rather than using a hosted one.
+   *
+   * Sticky by consequence rather than by flag: it writes the `oauth_apps` entry,
+   * and a profile that declares one is never moved off it. So this is typed once
+   * and then forgotten, which is the right shape for a decision about a client
+   * that is shared by every connection of that vendor.
+   */
+  readonly ownClient?: boolean | undefined;
+  /** Injected for tests. The broker is the only thing `connect` fetches. */
+  readonly fetch?: typeof globalThis.fetch | undefined;
   readonly json?: boolean | undefined;
 }
 
@@ -192,8 +203,12 @@ async function runConnect(target: string, options: ConnectOptions): Promise<Conn
         document,
         changes,
         firstForProvider: !runtime.config.connections.some((c) => c.provider === providerId),
+        target,
+        profile,
+        ownClient: options.ownClient === true,
         prompter,
         acceptBroadScopes: options.acceptBroadScopes === true,
+        ...(options.fetch ? { fetch: options.fetch } : {}),
       });
     } else if (manifest.auth.kind !== 'none') {
       await ensureStaticCredential({

--- a/src/cli/commands/connect/requirements.test.ts
+++ b/src/cli/commands/connect/requirements.test.ts
@@ -78,6 +78,7 @@ describe('setupRequirements', () => {
     expect(setupRequirements(NO_AUTH, undefined, 'personal')).toEqual({
       requirements: [],
       needsId: false,
+      brokered: false,
     });
   });
 

--- a/src/cli/commands/connect/scopes-gate.ts
+++ b/src/cli/commands/connect/scopes-gate.ts
@@ -1,0 +1,146 @@
+import { discoverOAuthProtectedResourceMetadata } from '@modelcontextprotocol/client';
+import type { ProviderManifest } from '#connectivity';
+import { progress, style, warn } from '../../output.ts';
+import type { Prompter } from '../../prompt.ts';
+import { describeScopes, shortScope } from '../../scopes.ts';
+
+/**
+ * Saying what a grant will be able to do, while declining still costs nothing.
+ *
+ * Its own file because both halves of `authorise` run it — the SDK path and the
+ * direct one — and because the file it came out of had grown past the budget.
+ * The seam is real: everything here happens before any client is chosen and
+ * before any listener is opened.
+ */
+
+/**
+ * Warn when a manifest's pinned scopes have drifted from the server's.
+ *
+ * Pinning is deliberate — it stops a vendor widening a grant by editing its own
+ * metadata — but a pinned list is a list that can go stale, and both directions
+ * of staleness are worth different words:
+ *
+ * - the server declares a scope we do not request → calls fail, and Google's
+ *   servers say only "The caller does not have permission", which points
+ *   nowhere near the cause. This is the failure that cost an afternoon.
+ * - we request one it no longer declares → probably harmless, possibly a scope
+ *   that has been withdrawn; worth seeing, not worth stopping for.
+ *
+ * Advisory in both directions. Discovery failing must not block a connect that
+ * would otherwise work, so a broken probe is silent.
+ */
+async function reportScopeDrift(pinned: readonly string[], serverUrl: string): Promise<void> {
+  let advertised: readonly string[] = [];
+
+  try {
+    const metadata = await discoverOAuthProtectedResourceMetadata(serverUrl);
+    advertised = (metadata as { scopes_supported?: string[] }).scopes_supported ?? [];
+  } catch {
+    return;
+  }
+
+  if (advertised.length === 0) return;
+
+  const missing = advertised.filter((scope) => !pinned.includes(scope));
+  const extra = pinned.filter((scope) => !advertised.includes(scope));
+
+  if (missing.length > 0) {
+    progress('');
+    progress(
+      style.dim(
+        `${new URL(serverUrl).host} advertises ${missing.length} scope(s) not requested: ` +
+          `${missing.map(shortScope).join(', ')}.`,
+      ),
+    );
+    progress(
+      style.dim(
+        '  Deliberate — an advertised scope is not necessarily a required one, and these are broader than the docs ask for. Worth revisiting only if calls fail on permission.',
+      ),
+    );
+  }
+
+  if (extra.length > 0) {
+    progress('');
+    progress(style.dim(`Note: ${extra.map(shortScope).join(', ')} is no longer declared by the server.`));
+  }
+}
+
+/**
+ * Show what is about to be granted, and stop on the broad ones.
+ *
+ * The consent screen that follows lists the same scopes in the vendor's own
+ * wording, where "Read, compose, send, and permanently delete all your email"
+ * sits in a list of five and reads like boilerplate. This is the same
+ * information a step earlier, in our words, with the account still unconnected
+ * — the last point where declining costs nothing.
+ */
+export async function confirmScopes(
+  manifest: ProviderManifest,
+  serverUrl: string,
+  prompter: Prompter,
+  acceptBroadScopes: boolean,
+  /**
+   * What will actually be asked for, which is not always what the manifest
+   * declares: a brokered flow appends the broker's identity scopes. Showing the
+   * manifest's set instead would put a scope on the vendor's screen that this
+   * gate never mentioned, which is precisely the surprise it exists to prevent.
+   */
+  scopes: readonly string[] = manifest.auth.kind === 'oauth' ? manifest.auth.scopes : [],
+): Promise<boolean> {
+  if (manifest.auth.kind !== 'oauth' || scopes.length === 0) return true;
+
+  await reportScopeDrift(scopes, serverUrl);
+
+  const described = describeScopes(scopes);
+
+  progress('');
+  progress(`${manifest.name} will be granted:`);
+  for (const { scope, meaning, broad } of described) {
+    const name = broad ? style.bold(shortScope(scope)) : shortScope(scope);
+    progress(`  ${broad ? '!' : '·'} ${name}${meaning ? style.dim(`  — ${meaning}`) : ''}`);
+  }
+
+  if (!described.some((entry) => entry.broad)) {
+    progress('');
+    return true;
+  }
+
+  // Why the broad ones cannot simply be dropped — otherwise the obvious next
+  // question is why we ask instead of asking for less.
+  progress('');
+  progress(
+    warn(
+      'The marked scopes are broader than this provider needs. Grant them only if you ' +
+        'mean to — policy can restrict what an agent calls, but it cannot un-grant a token.',
+    ),
+  );
+  progress(
+    style.dim(
+      '  Policy still applies: only capabilities you allow are reachable, and every call is audited.',
+    ),
+  );
+  progress('');
+
+  // Answered ahead of time, by a person, in their own shell. The flag is long
+  // enough that repeating it is a deliberate act, and it lands in the history of
+  // whoever typed it — which is the property that matters, since the point of
+  // this gate is that the decision does not originate with the agent.
+  if (acceptBroadScopes) {
+    progress(style.dim('Broad scopes accepted with --accept-broad-scopes.'));
+    return true;
+  }
+
+  // Fail closed rather than defaulting to no. A non-interactive run cannot
+  // answer, and inventing an answer here would remove the last point at which
+  // declining is free — the vendor's own consent screen is next, where the same
+  // sentence sits in a list of five and reads like boilerplate.
+  if (!prompter.interactive) {
+    throw new Error(
+      `${manifest.name} asks for scopes broader than it needs, and this run is non-interactive.\n` +
+        `  Nothing was authorised. Re-run in a terminal, or add --accept-broad-scopes if you mean to grant them.`,
+    );
+  }
+
+  return prompter.confirm('Authorise with these scopes?', false);
+}
+

--- a/src/cli/commands/connect/setup.ts
+++ b/src/cli/commands/connect/setup.ts
@@ -219,6 +219,7 @@ export async function ensureOAuthApp(input: {
           'APIs and scopes above are per product, and this is the first connection of this one.',
       );
     }
+    declareOwnClient(document, manifest, changes);
     return;
   }
 
@@ -237,6 +238,29 @@ export async function ensureOAuthApp(input: {
     await credentials.set(prompt.credential_ref!, answers.get(prompt.key)!);
   }
 
+  declareOwnClient(document, manifest, changes);
+}
+
+/**
+ * Record that this profile uses a client of its own.
+ *
+ * The entry is not merely a pair of pointers — it is the switch. A provider
+ * that can also authorise against a broker reads its presence as "this profile
+ * registered a client, use it", so writing it is what makes `--own-client`
+ * stick without a second flag to remember. Which is also why it is called on
+ * both of `ensureOAuthApp`'s exits: someone whose credentials were already in
+ * the store but whose config lost the block would otherwise be moved onto the
+ * hosted client at the next connect.
+ */
+export function declareOwnClient(
+  document: ConfigDocument,
+  manifest: ProviderManifest,
+  changes: string[],
+): void {
+  if (manifest.auth.kind !== 'oauth' || !manifest.auth.app) return;
+  const app = manifest.auth.app;
+
+  const shared = (manifest.setup?.prompts ?? []).filter((p) => p.scope === 'shared');
   const idPrompt = shared.find((p) => p.key === 'client_id');
   const secretPrompt = shared.find((p) => p.key === 'client_secret');
 

--- a/src/cli/commands/operate/inspect.ts
+++ b/src/cli/commands/operate/inspect.ts
@@ -1,5 +1,6 @@
 import { ownerPrincipal } from '#auth';
 import type { DiscoveredCapability } from '#connectivity';
+import { BROKERED } from '#connectivity/auth/index.ts';
 import { allowedConnections } from '#policy';
 import {
   credentialRefFor,
@@ -106,7 +107,12 @@ export async function doctor(flags: DoctorFlags): Promise<void> {
         // days. That is a policy setting rather than a fault, but it presents
         // as an authentication failure mid-task — so say it before the call
         // fails rather than after.
-        if (staleness !== null && staleness.days >= 7) {
+        //
+        // Only for a client the operator registered. The hosted one is in
+        // production and does not expire refresh tokens weekly, so this warning
+        // would simply be false there — and a warning that is wrong once is a
+        // warning that gets scrolled past every time after.
+        if (staleness !== null && !staleness.brokered && staleness.days >= 7) {
           warnings.push({
             kind: 'stale_credential',
             key,
@@ -116,7 +122,10 @@ export async function doctor(flags: DoctorFlags): Promise<void> {
             fix: forProfile(`lanes link connect ${key}`),
           });
         } else {
-          checks.push(`${key} credential resolves${staleness ? ` (${staleness.days}d old)` : ''}`);
+          const age = staleness
+            ? ` (${staleness.days}d old${staleness.brokered ? ', hosted client' : ''})`
+            : '';
+          checks.push(`${key} credential resolves${age}`);
         }
       } else {
         problems.push({
@@ -222,16 +231,23 @@ export async function doctor(flags: DoctorFlags): Promise<void> {
 async function credentialAge(
   credentials: { get(ref: string): Promise<string | null> },
   ref: string,
-): Promise<{ days: number } | null> {
+): Promise<{ days: number; brokered: boolean } | null> {
   const raw = await credentials.get(ref);
   if (!raw) return null;
 
   try {
-    const parsed = JSON.parse(raw) as { expires_at?: number; expires_in?: number };
+    const parsed = JSON.parse(raw) as {
+      expires_at?: number;
+      expires_in?: number;
+      authorized_via?: string;
+    };
     if (typeof parsed.expires_at !== 'number') return null;
 
     const issued = parsed.expires_at - (parsed.expires_in ?? 3600) * 1000;
-    return { days: Math.floor((Date.now() - issued) / 86_400_000) };
+    return {
+      days: Math.floor((Date.now() - issued) / 86_400_000),
+      brokered: parsed.authorized_via === BROKERED,
+    };
   } catch {
     return null;
   }

--- a/src/cli/commands/setup.ts
+++ b/src/cli/commands/setup.ts
@@ -25,6 +25,10 @@ export async function setupPlan(provider: string | undefined, flags: SetupFlags)
     const context = {
       profile: runtime.resolution.profile,
       connections: runtime.config.connections.map((c) => `${c.provider}.${c.id}`),
+      // Declaring an `oauth_apps` entry is how a profile says "use my own
+      // client". Without this the plan would tell someone who has already
+      // registered one that they need nothing.
+      ownClients: Object.keys(runtime.config.oauth_apps),
     };
 
     const manifests = runtime.registry.list().map((entry) => entry.manifest);
@@ -96,9 +100,16 @@ function renderOne(plan: ProviderPlan, missing: ReadonlySet<string>): void {
     print(`  ${style.green('connected')}  ${plan.connected.join(', ')}`);
   }
 
-  if (plan.steps.length > 0) {
+  if (plan.steps.length > 0 && !plan.brokered) {
     heading('First, in the vendor’s console');
     plan.steps.forEach((step, index) => print(`  ${index + 1}. ${step}`));
+  }
+
+  if (plan.brokered) {
+    heading('Values it needs');
+    print(
+      `  ${style.dim(`none — the OAuth client is operated by ${plan.clientOperator}, and its secret never reaches this machine.`)}`,
+    );
   }
 
   if (plan.requires.length > 0) {
@@ -115,6 +126,19 @@ function renderOne(plan: ProviderPlan, missing: ReadonlySet<string>): void {
 
   heading('Then');
   print(`  ${plan.command}`);
+
+  // Last, and headed as the alternative it is. Someone reading this wants the
+  // one line that connects an account; the console walkthrough is for the
+  // minority who cannot use the hosted client, and putting it first taught
+  // everyone else that this provider is the hard one.
+  if (plan.brokered && plan.ownClientCommand) {
+    heading('Or register a client of your own');
+    print(`  ${plan.ownClientCommand}`);
+    if (plan.steps.length > 0) {
+      print();
+      plan.steps.forEach((step, index) => print(`  ${index + 1}. ${step}`));
+    }
+  }
   if (plan.browser) {
     print();
     print(

--- a/src/cli/lanes.ts
+++ b/src/cli/lanes.ts
@@ -1,6 +1,5 @@
 #!/usr/bin/env bun
 import { ConfigError } from '#profile';
-import { run as runLink } from './main.ts';
 import { print, printErr, style } from './output.ts';
 
 /**
@@ -39,7 +38,15 @@ async function main(argv: readonly string[]): Promise<void> {
     return;
   }
 
-  if (area === 'link') return runLink(rest);
+  if (area === 'link') {
+    // Loaded here rather than at the top of the file so that a failure while
+    // the area's module graph evaluates — a malformed environment variable read
+    // at import time, say — is caught below and printed as an `error` line. A
+    // static import throws before this file's try block is reached, and Bun
+    // renders that as a stack trace with the message buried in it.
+    const { run: runLink } = await import('./main.ts');
+    return await runLink(rest);
+  }
 
   throw new Error(
     `Unknown area "${area}". Available: ${Object.keys(AREAS).join(', ')}.\n` +

--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -80,6 +80,7 @@ export async function run(argv: readonly string[]): Promise<void> {
         replace: flags['replace'] === true,
         nonInteractive: flags['non-interactive'] === true,
         acceptBroadScopes: flags['accept-broad-scopes'] === true,
+        ownClient: flags['own-client'] === true,
         json,
       });
 

--- a/src/cli/oauth-error.ts
+++ b/src/cli/oauth-error.ts
@@ -1,0 +1,13 @@
+/**
+ * The one error type the OAuth flow throws.
+ *
+ * Its own file because both halves of the flow raise it — the listener in
+ * `oauth.ts` and the exchange in `oauth-exchange.ts` — and having either import
+ * the other would be a cycle for the sake of one class.
+ */
+export class OAuthError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'OAuthError';
+  }
+}

--- a/src/cli/oauth-exchange.test.ts
+++ b/src/cli/oauth-exchange.test.ts
@@ -1,0 +1,124 @@
+import { describe, expect, test } from 'bun:test';
+import { BrokerError } from '#connectivity/auth/index.ts';
+import { brokerExchangeVia, directExchange } from './oauth-exchange.ts';
+import { OAuthError } from './oauth-error.ts';
+
+const INPUT = {
+  code: 'the-code',
+  redirectUri: 'http://127.0.0.1:53412/callback',
+  codeVerifier: 'the-verifier',
+  scopes: ['scope.a', 'scope.b'],
+};
+
+function answering(status: number, body: unknown, headers: Record<string, string> = {}) {
+  const calls: { url: string; init?: RequestInit }[] = [];
+  const fetch = (async (url: string, init?: RequestInit) => {
+    calls.push({ url, ...(init ? { init } : {}) });
+    return new Response(JSON.stringify(body), {
+      status,
+      headers: { 'content-type': 'application/json', ...headers },
+    });
+  }) as unknown as typeof globalThis.fetch;
+  return { fetch, calls };
+}
+
+describe('directExchange', () => {
+  test('posts the client and the verifier to the vendor', async () => {
+    const { fetch, calls } = answering(200, {
+      access_token: 'at',
+      refresh_token: 'rt',
+      expires_in: 1200,
+      scope: 'granted.a',
+    });
+
+    const tokens = await directExchange({
+      tokenUrl: 'https://oauth2.example.com/token',
+      clientId: 'cid',
+      clientSecret: 'secret',
+      fetch,
+    })(INPUT);
+
+    const sent = new URLSearchParams(String(calls[0]!.init!.body));
+    expect(calls[0]!.url).toBe('https://oauth2.example.com/token');
+    expect(sent.get('client_secret')).toBe('secret');
+    expect(sent.get('code_verifier')).toBe('the-verifier');
+    expect(sent.get('grant_type')).toBe('authorization_code');
+    expect(tokens).toEqual({
+      refreshToken: 'rt',
+      accessToken: 'at',
+      expiresIn: 1200,
+      scope: 'granted.a',
+    });
+  });
+
+  test('falls back to what was asked for when the vendor omits the granted scope', async () => {
+    const { fetch } = answering(200, { access_token: 'at', refresh_token: 'rt' });
+
+    const tokens = await directExchange({
+      tokenUrl: 'https://oauth2.example.com/token',
+      clientId: 'cid',
+      clientSecret: 'secret',
+      fetch,
+    })(INPUT);
+
+    expect(tokens.scope).toBe('scope.a scope.b');
+    expect(tokens.expiresIn).toBe(3600);
+  });
+
+  test('surfaces an id_token when one comes back, and omits the field when not', async () => {
+    const withId = answering(200, { access_token: 'at', refresh_token: 'rt', id_token: 'idt' });
+    const without = answering(200, { access_token: 'at', refresh_token: 'rt' });
+    const make = (fetch: typeof globalThis.fetch) =>
+      directExchange({
+        tokenUrl: 'https://oauth2.example.com/token',
+        clientId: 'cid',
+        clientSecret: 'secret',
+        fetch,
+      })(INPUT);
+
+    expect((await make(withId.fetch)).idToken).toBe('idt');
+    expect('idToken' in (await make(without.fetch))).toBe(false);
+  });
+});
+
+describe('brokerExchangeVia', () => {
+  test('redeems the code through the broker and never touches a token url', async () => {
+    const { fetch, calls } = answering(200, {
+      success: true,
+      data: { access_token: 'at', refresh_token: 'rt', id_token: 'idt', expires_in: 900 },
+    });
+
+    const tokens = await brokerExchangeVia({ url: 'https://api.example.com/b', fetch })(INPUT);
+
+    expect(calls[0]!.url).toBe('https://api.example.com/b/exchange');
+    expect(tokens.idToken).toBe('idt');
+    expect(tokens.expiresIn).toBe(900);
+  });
+
+  test('a broker refusal reaches the caller whole, not flattened to a string', async () => {
+    // The notice and the "your own client would fix this" flag are what the
+    // connect command renders. Wrapping this in an OAuthError would drop both.
+    const { fetch } = answering(403, {
+      success: false,
+      error: 'The hosted client is full.',
+      own_client: true,
+      notice: 'At capacity.',
+    });
+
+    const error = (await brokerExchangeVia({ url: 'https://api.example.com/b', fetch })(
+      INPUT,
+    ).catch((e) => e)) as BrokerError;
+
+    expect(error).toBeInstanceOf(BrokerError);
+    expect(error.ownClient).toBe(true);
+    expect(error.notice).toBe('At capacity.');
+  });
+
+  test('a broker that returns no refresh token fails now rather than in an hour', async () => {
+    const { fetch } = answering(200, { success: true, data: { access_token: 'at' } });
+
+    await expect(
+      brokerExchangeVia({ url: 'https://api.example.com/b', fetch })(INPUT),
+    ).rejects.toBeInstanceOf(OAuthError);
+  });
+});

--- a/src/cli/oauth-exchange.ts
+++ b/src/cli/oauth-exchange.ts
@@ -1,0 +1,146 @@
+import { BrokerError, brokerExchange } from '#connectivity/auth/index.ts';
+import { OAuthError } from './oauth-error.ts';
+
+/**
+ * Turning an authorization code into tokens — the one step that needs a secret.
+ *
+ * Split from `oauth.ts` because it is the only part of the flow that differs
+ * between a client the operator registered and a client somebody operates on
+ * their behalf. Everything else — the loopback listener, PKCE, the state check,
+ * the browser — is identical either way, and keeping it that way is the point:
+ * a connection should not behave differently at runtime because of where its
+ * client came from.
+ */
+
+export interface OAuthTokens {
+  readonly refreshToken: string;
+  readonly accessToken: string;
+  readonly expiresIn: number;
+  readonly scope: string;
+  /**
+   * An identity assertion, present when `openid` was granted.
+   *
+   * Opaque here on purpose. It is stored and handed back to whoever asked for
+   * it, never decoded — the claim inside is unverified, and a tamperable local
+   * store is not somewhere to read an identity from. What names an account is
+   * the provider's own identity call, which asks and gets a checkable answer.
+   */
+  readonly idToken?: string;
+}
+
+export interface ExchangeInput {
+  readonly code: string;
+  readonly redirectUri: string;
+  readonly codeVerifier: string;
+  /** What was asked for, used only to fill in a response that omits `scope`. */
+  readonly scopes: readonly string[];
+}
+
+export type ExchangeCode = (input: ExchangeInput) => Promise<OAuthTokens>;
+
+/** Straight to the vendor, signed with a client this machine holds. */
+export function directExchange(options: {
+  readonly tokenUrl: string;
+  readonly clientId: string;
+  readonly clientSecret: string;
+  readonly fetch?: typeof globalThis.fetch | undefined;
+}): ExchangeCode {
+  return async (input) => {
+    const doFetch = options.fetch ?? globalThis.fetch;
+
+    const response = await doFetch(options.tokenUrl, {
+      method: 'POST',
+      headers: { 'content-type': 'application/x-www-form-urlencoded' },
+      body: new URLSearchParams({
+        grant_type: 'authorization_code',
+        code: input.code,
+        redirect_uri: input.redirectUri,
+        client_id: options.clientId,
+        client_secret: options.clientSecret,
+        code_verifier: input.codeVerifier,
+      }),
+    });
+
+    const body = (await response.json().catch(() => ({}))) as {
+      access_token?: string;
+      refresh_token?: string;
+      id_token?: string;
+      expires_in?: number;
+      scope?: string;
+      error?: string;
+      error_description?: string;
+    };
+
+    if (!response.ok || !body.access_token) {
+      throw new OAuthError(
+        `Token exchange failed: ${body.error ?? response.status} ${body.error_description ?? ''}`.trim(),
+      );
+    }
+
+    return settle(body, input.scopes);
+  };
+}
+
+/** Through a broker, which holds the secret this machine does not have. */
+export function brokerExchangeVia(options: {
+  readonly url: string;
+  readonly fetch?: typeof globalThis.fetch | undefined;
+}): ExchangeCode {
+  return async (input) => {
+    let tokens;
+    try {
+      tokens = await brokerExchange(
+        options.url,
+        {
+          code: input.code,
+          codeVerifier: input.codeVerifier,
+          redirectUri: input.redirectUri,
+        },
+        options.fetch ?? globalThis.fetch,
+      );
+    } catch (cause) {
+      // Rethrown as-is when it is a BrokerError: it carries the notice and the
+      // "your own client would fix this" flag that the caller renders, and
+      // flattening it to a string here would throw both away.
+      if (cause instanceof BrokerError) throw cause;
+      throw new OAuthError(`Token exchange failed: ${String(cause)}`);
+    }
+
+    if (!tokens.access_token) {
+      throw new OAuthError('The token exchange returned no access token.');
+    }
+
+    return settle(tokens, input.scopes);
+  };
+}
+
+function settle(
+  body: {
+    access_token?: string | undefined;
+    refresh_token?: string | undefined;
+    id_token?: string | undefined;
+    expires_in?: number | undefined;
+    scope?: string | undefined;
+  },
+  scopes: readonly string[],
+): OAuthTokens {
+  if (!body.refresh_token) {
+    // Without one, the connection works until the access token expires and then
+    // quietly stops. Better to fail now with the actual cause. Google is named
+    // because Google is who reaches this path: every provider that redeems a
+    // code here is a Google REST one, and the others hand the exchange to the
+    // MCP SDK. Naming the page beats describing it.
+    throw new OAuthError(
+      'Google returned no refresh token. This usually means the account was already authorised ' +
+        'for this app; revoke it at https://myaccount.google.com/permissions and try again.',
+    );
+  }
+
+  return {
+    refreshToken: body.refresh_token,
+    accessToken: body.access_token!,
+    expiresIn: body.expires_in ?? 3600,
+    scope: body.scope ?? scopes.join(' '),
+    ...(body.id_token ? { idToken: body.id_token } : {}),
+  };
+}

--- a/src/cli/oauth.test.ts
+++ b/src/cli/oauth.test.ts
@@ -376,3 +376,52 @@ describe('the SDK-driven callback listener', () => {
     }
   });
 });
+
+describe('the exchange is a seam', () => {
+  test('an injected exchange is used, and the token endpoint is never called', async () => {
+    // The point of the seam: a brokered provider has no client secret to post,
+    // so the flow must be able to redeem the code somewhere else entirely while
+    // the listener, PKCE, and the state check stay exactly as they are.
+    let redeemed: { code: string; redirectUri: string; codeVerifier: string } | undefined;
+    const tokenEndpoint = mockTokenEndpoint({});
+
+    const tokens = await runOAuthFlow({
+      authorizeUrl: 'https://accounts.example.com/authorize',
+      clientId: 'cid',
+      scopes: ['scope.a'],
+      openBrowser: browserThatApproves(),
+      fetch: tokenEndpoint.fetch,
+      exchange: async (input) => {
+        redeemed = {
+          code: input.code,
+          redirectUri: input.redirectUri,
+          codeVerifier: input.codeVerifier,
+        };
+        return { refreshToken: 'rt', accessToken: 'at', expiresIn: 60, scope: 'scope.a' };
+      },
+    });
+
+    expect(tokens.accessToken).toBe('at');
+    expect(tokenEndpoint.calls).toHaveLength(0);
+    expect(redeemed?.code).toBe('auth-code-1');
+    expect(redeemed?.redirectUri).toMatch(/^http:\/\/127\.0\.0\.1:\d+\/callback$/);
+    // The verifier is the one the flow generated, so PKCE still binds the code
+    // to this process rather than to whoever supplied the exchange.
+    expect(redeemed?.codeVerifier).toMatch(/^[\w-]{43}$/);
+  });
+
+  test('a flow with neither an exchange nor a client to redeem with refuses', async () => {
+    const error = await runOAuthFlow({
+      authorizeUrl: 'https://accounts.example.com/authorize',
+      clientId: 'cid',
+      scopes: ['scope.a'],
+      openBrowser: browserThatApproves(),
+    }).then(
+      () => undefined,
+      (caught: unknown) => caught as Error,
+    );
+
+    expect(error).toBeInstanceOf(OAuthError);
+    expect(error?.message).toMatch(/tokenUrl and clientSecret/);
+  });
+});

--- a/src/cli/oauth.ts
+++ b/src/cli/oauth.ts
@@ -1,5 +1,7 @@
 import { createHash, randomBytes, timingSafeEqual } from 'node:crypto';
 import { completionPage } from './callback-page.ts';
+import { OAuthError } from './oauth-error.ts';
+import { directExchange, type ExchangeCode, type OAuthTokens } from './oauth-exchange.ts';
 
 /**
  * The OAuth authorization-code exchange, run entirely from the CLI.
@@ -19,10 +21,21 @@ import { completionPage } from './callback-page.ts';
 
 export interface OAuthFlowOptions {
   readonly authorizeUrl: string;
-  readonly tokenUrl: string;
+  /** Where a client this machine holds redeems the code. Unused with `exchange`. */
+  readonly tokenUrl?: string;
   readonly clientId: string;
-  readonly clientSecret: string;
+  /** Unused with `exchange` — a brokered flow has no secret to hold. */
+  readonly clientSecret?: string;
   readonly scopes: readonly string[];
+  /**
+   * How the code becomes a token. Defaults to posting to `tokenUrl` with the
+   * client above; a brokered provider supplies one that posts to its broker.
+   *
+   * Everything before this point is identical either way, which is the whole
+   * reason it is a parameter rather than a branch: the listener, PKCE, the
+   * state check, and the browser cannot drift apart between the two paths.
+   */
+  readonly exchange?: ExchangeCode;
   readonly authorizeParams?: Readonly<Record<string, string>>;
   /** What the completion page names as connected. A provider's display name. */
   readonly connectionLabel?: string;
@@ -33,19 +46,10 @@ export interface OAuthFlowOptions {
   readonly fetch?: typeof globalThis.fetch;
 }
 
-export interface OAuthTokens {
-  readonly refreshToken: string;
-  readonly accessToken: string;
-  readonly expiresIn: number;
-  readonly scope: string;
-}
-
-export class OAuthError extends Error {
-  constructor(message: string) {
-    super(message);
-    this.name = 'OAuthError';
-  }
-}
+// Re-exported so the flow stays one import for its callers even though the
+// exchange half now lives next door.
+export { OAuthError };
+export type { ExchangeCode, OAuthTokens };
 
 const base64url = (input: Buffer): string => input.toString('base64url');
 
@@ -180,7 +184,13 @@ export async function runOAuthFlow(options: OAuthFlowOptions): Promise<OAuthToke
       `Timed out after ${Math.round(timeoutMs / 1000)}s waiting for the browser.`,
     );
 
-    return await exchangeCode(code, redirectUri, verifier, options);
+    const exchange = options.exchange ?? defaultExchange(options);
+    return await exchange({
+      code,
+      redirectUri,
+      codeVerifier: verifier,
+      scopes: options.scopes,
+    });
   } finally {
     await shutdown(server);
   }
@@ -235,57 +245,18 @@ async function withTimeout<T>(promise: Promise<T>, ms: number, message?: string)
   }
 }
 
-async function exchangeCode(
-  code: string,
-  redirectUri: string,
-  verifier: string,
-  options: OAuthFlowOptions,
-): Promise<OAuthTokens> {
-  const doFetch = options.fetch ?? globalThis.fetch;
-
-  const response = await doFetch(options.tokenUrl, {
-    method: 'POST',
-    headers: { 'content-type': 'application/x-www-form-urlencoded' },
-    body: new URLSearchParams({
-      grant_type: 'authorization_code',
-      code,
-      redirect_uri: redirectUri,
-      client_id: options.clientId,
-      client_secret: options.clientSecret,
-      code_verifier: verifier,
-    }),
+function defaultExchange(options: OAuthFlowOptions): ExchangeCode {
+  if (!options.tokenUrl || !options.clientSecret) {
+    throw new OAuthError(
+      'runOAuthFlow needs either a tokenUrl and clientSecret to redeem the code with, or an exchange to redeem it through.',
+    );
+  }
+  return directExchange({
+    tokenUrl: options.tokenUrl,
+    clientId: options.clientId,
+    clientSecret: options.clientSecret,
+    ...(options.fetch ? { fetch: options.fetch } : {}),
   });
-
-  const body = (await response.json().catch(() => ({}))) as {
-    access_token?: string;
-    refresh_token?: string;
-    expires_in?: number;
-    scope?: string;
-    error?: string;
-    error_description?: string;
-  };
-
-  if (!response.ok || !body.access_token) {
-    throw new OAuthError(
-      `Token exchange failed: ${body.error ?? response.status} ${body.error_description ?? ''}`.trim(),
-    );
-  }
-
-  if (!body.refresh_token) {
-    // Without one, the connection would work until the access token expires
-    // and then quietly stop. Better to fail now with the actual cause.
-    throw new OAuthError(
-      'Google returned no refresh token. This usually means the account was already authorised ' +
-        'for this app; revoke it at https://myaccount.google.com/permissions and try again.',
-    );
-  }
-
-  return {
-    refreshToken: body.refresh_token,
-    accessToken: body.access_token,
-    expiresIn: body.expires_in ?? 3600,
-    scope: body.scope ?? options.scopes.join(' '),
-  };
 }
 
 

--- a/src/cli/runtime/open.ts
+++ b/src/cli/runtime/open.ts
@@ -232,6 +232,7 @@ export async function openRuntime(flags: GlobalFlags): Promise<Runtime> {
       profile: config.instance.profile,
       profiles: await listProfiles(root),
       catalogue: PROVIDER_MANIFESTS,
+      ownClients: Object.keys(config.oauth_apps),
       reachable,
     },
   });

--- a/src/cli/usage.ts
+++ b/src/cli/usage.ts
@@ -100,6 +100,8 @@ ${style.bold('Global flags')}
   --non-interactive              never prompt: connect refuses with what to store,
                                  deploy takes the answers its config already holds
   --accept-broad-scopes          agree in advance to scopes broader than a provider needs
+  --own-client                   register your own OAuth client instead of using the
+                                 one this project operates (connect only)
   --port <n>                     override the configured port (start only)
 
 Every command prints the resolved profile and target before acting.

--- a/src/connectivity/auth/index.ts
+++ b/src/connectivity/auth/index.ts
@@ -22,3 +22,12 @@ export {
   type OAuthProviderOptions,
 } from './oauth-authcode/provider.ts';
 export { resolveUpstreamToken } from './oauth-authcode/index.ts';
+export {
+  BROKERED,
+  BrokerError,
+  brokerConfig,
+  brokerExchange,
+  brokerRefresh,
+  type BrokerConfig,
+  type BrokerTokens,
+} from './oauth-authcode/broker.ts';

--- a/src/connectivity/auth/index.ts
+++ b/src/connectivity/auth/index.ts
@@ -23,10 +23,12 @@ export {
 } from './oauth-authcode/provider.ts';
 export { resolveUpstreamToken } from './oauth-authcode/index.ts';
 export {
+  BROKER_ORIGIN_ENV,
   BROKERED,
   BrokerError,
   brokerConfig,
   brokerExchange,
+  brokerOriginOverride,
   brokerRefresh,
   type BrokerConfig,
   type BrokerTokens,

--- a/src/connectivity/auth/oauth-authcode/broker.test.ts
+++ b/src/connectivity/auth/oauth-authcode/broker.test.ts
@@ -1,0 +1,197 @@
+import { describe, expect, test } from 'bun:test';
+import { BrokerError, brokerConfig, brokerExchange, brokerRefresh } from './broker.ts';
+
+const URL_ = 'https://api.example.com/v1/auth/link/vendor';
+
+/** A fetch that answers once and records what it was asked. */
+function answering(
+  status: number,
+  body: unknown,
+  headers: Record<string, string> = {},
+): { fetch: typeof globalThis.fetch; calls: { url: string; init?: RequestInit }[] } {
+  const calls: { url: string; init?: RequestInit }[] = [];
+  const fetch = (async (url: string, init?: RequestInit) => {
+    calls.push({ url, ...(init ? { init } : {}) });
+    return new Response(typeof body === 'string' ? body : JSON.stringify(body), {
+      status,
+      headers: { 'content-type': 'application/json', ...headers },
+    });
+  }) as unknown as typeof globalThis.fetch;
+  return { fetch, calls };
+}
+
+describe('brokerConfig', () => {
+  test('reads the client and what it covers out of the envelope', async () => {
+    const { fetch, calls } = answering(200, {
+      success: true,
+      data: {
+        client_id: 'shared-client',
+        scopes_supported: ['a', 'b'],
+        identity_scopes: ['openid', 'email'],
+        status: 'open',
+        capacity: { accounts: 12, cap: 95 },
+        docs_url: 'https://example.com/docs',
+      },
+    });
+
+    const config = await brokerConfig(URL_, fetch);
+
+    expect(calls[0]!.url).toBe(`${URL_}/config`);
+    expect(config.clientId).toBe('shared-client');
+    expect(config.scopesSupported).toEqual(['a', 'b']);
+    expect(config.identityScopes).toEqual(['openid', 'email']);
+    expect(config.open).toBe(true);
+    expect(config.capacity).toEqual({ accounts: 12, cap: 95 });
+  });
+
+  test('a closed broker carries the reason it is closed', async () => {
+    // The wording is the broker's, so a spent cap, a suspension, and a
+    // maintenance window can read differently without shipping a new CLI.
+    const { fetch } = answering(200, {
+      success: true,
+      data: { client_id: 'c', status: 'closed', notice: 'At capacity.' },
+    });
+
+    const config = await brokerConfig(URL_, fetch);
+
+    expect(config.open).toBe(false);
+    expect(config.notice).toBe('At capacity.');
+  });
+
+  test('missing optional fields are absent rather than invented', async () => {
+    const { fetch } = answering(200, { success: true, data: { client_id: 'c' } });
+
+    const config = await brokerConfig(URL_, fetch);
+
+    expect(config.scopesSupported).toEqual([]);
+    expect(config.notice).toBeUndefined();
+    expect(config.capacity).toBeUndefined();
+    expect(config.open).toBe(true);
+  });
+
+  test('a response with no client id is a refusal, not a config with a blank one', async () => {
+    const { fetch } = answering(200, { success: true, data: {} });
+
+    await expect(brokerConfig(URL_, fetch)).rejects.toThrow(/did not return a client id/);
+  });
+
+  test('an unreachable broker names the cause instead of a bare TypeError', async () => {
+    const fetch = (async () => {
+      throw new Error('ECONNREFUSED');
+    }) as unknown as typeof globalThis.fetch;
+
+    const error = (await brokerConfig(URL_, fetch).catch((e) => e)) as BrokerError;
+
+    expect(error).toBeInstanceOf(BrokerError);
+    expect(error.status).toBe(0);
+    expect(error.message).toContain('ECONNREFUSED');
+  });
+
+  test('an HTML error page does not surface as a JSON parse error', async () => {
+    // A captive portal or a proxy is a real failure mode here, and
+    // "Unexpected token <" says nothing about what went wrong.
+    const { fetch } = answering(502, '<html>Bad Gateway</html>');
+
+    const error = (await brokerConfig(URL_, fetch).catch((e) => e)) as BrokerError;
+
+    expect(error).toBeInstanceOf(BrokerError);
+    expect(error.status).toBe(502);
+    expect(error.message).not.toContain('JSON');
+  });
+});
+
+describe('brokerExchange', () => {
+  test('sends the code, the verifier, and the redirect it was issued for', async () => {
+    const { fetch, calls } = answering(200, {
+      success: true,
+      data: { access_token: 'at', refresh_token: 'rt', id_token: 'idt', expires_in: 3599 },
+    });
+
+    const tokens = await brokerExchange(
+      URL_,
+      { code: 'c', codeVerifier: 'v', redirectUri: 'http://127.0.0.1:1234/callback' },
+      fetch,
+    );
+
+    expect(calls[0]!.url).toBe(`${URL_}/exchange`);
+    expect(JSON.parse(String(calls[0]!.init!.body))).toEqual({
+      code: 'c',
+      code_verifier: 'v',
+      redirect_uri: 'http://127.0.0.1:1234/callback',
+    });
+    expect(tokens.refresh_token).toBe('rt');
+    expect(tokens.id_token).toBe('idt');
+  });
+
+  test('a refusal that your own client would solve says so', async () => {
+    const { fetch } = answering(403, {
+      success: false,
+      error: 'The hosted client is full.',
+      own_client: true,
+      docs_url: 'https://example.com/docs',
+    });
+
+    const error = (await brokerExchange(
+      URL_,
+      { code: 'c', codeVerifier: 'v', redirectUri: 'http://127.0.0.1:1/callback' },
+      fetch,
+    ).catch((e) => e)) as BrokerError;
+
+    expect(error.ownClient).toBe(true);
+    expect(error.docsUrl).toBe('https://example.com/docs');
+    expect(error.message).toBe('The hosted client is full.');
+  });
+
+  test('a replayed code is not dressed up as something a console visit fixes', async () => {
+    const { fetch } = answering(400, { success: false, error: 'invalid_grant' });
+
+    const error = (await brokerExchange(
+      URL_,
+      { code: 'c', codeVerifier: 'v', redirectUri: 'http://127.0.0.1:1/callback' },
+      fetch,
+    ).catch((e) => e)) as BrokerError;
+
+    expect(error.ownClient).toBe(false);
+  });
+
+  test('a rate limit carries how long to wait', async () => {
+    const { fetch } = answering(429, { success: false, error: 'slow down' }, { 'retry-after': '42' });
+
+    const error = (await brokerExchange(
+      URL_,
+      { code: 'c', codeVerifier: 'v', redirectUri: 'http://127.0.0.1:1/callback' },
+      fetch,
+    ).catch((e) => e)) as BrokerError;
+
+    expect(error.retryAfterSeconds).toBe(42);
+  });
+});
+
+describe('brokerRefresh', () => {
+  test('presents the identity assertion as a bearer header', async () => {
+    const { fetch, calls } = answering(200, {
+      success: true,
+      data: { access_token: 'fresh', id_token: 'newer' },
+    });
+
+    const tokens = await brokerRefresh(URL_, { refreshToken: 'rt', idToken: 'idt' }, fetch);
+
+    const headers = calls[0]!.init!.headers as Record<string, string>;
+    expect(calls[0]!.url).toBe(`${URL_}/refresh`);
+    expect(headers['authorization']).toBe('Bearer idt');
+    expect(JSON.parse(String(calls[0]!.init!.body))).toEqual({ refresh_token: 'rt' });
+    expect(tokens.access_token).toBe('fresh');
+    expect(tokens.id_token).toBe('newer');
+  });
+
+  test('omits the header when there is no assertion to present', async () => {
+    // A credential stored before brokering existed carries no id_token, and
+    // sending `Bearer undefined` would turn that into a 401 rather than the
+    // fallback the broker has for exactly this case.
+    const { fetch, calls } = answering(200, { success: true, data: { access_token: 'fresh' } });
+
+    await brokerRefresh(URL_, { refreshToken: 'rt' }, fetch);
+
+    expect((calls[0]!.init!.headers as Record<string, string>)['authorization']).toBeUndefined();
+  });
+});

--- a/src/connectivity/auth/oauth-authcode/broker.test.ts
+++ b/src/connectivity/auth/oauth-authcode/broker.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, test } from 'bun:test';
-import { BrokerError, brokerConfig, brokerExchange, brokerRefresh } from './broker.ts';
+import {
+  BrokerError,
+  brokerConfig,
+  brokerExchange,
+  brokerOriginOverride,
+  brokerRefresh,
+} from './broker.ts';
 
 const URL_ = 'https://api.example.com/v1/auth/link/vendor';
 
@@ -193,5 +199,55 @@ describe('brokerRefresh', () => {
     await brokerRefresh(URL_, { refreshToken: 'rt' }, fetch);
 
     expect((calls[0]!.init!.headers as Record<string, string>)['authorization']).toBeUndefined();
+  });
+});
+
+describe('brokerOriginOverride', () => {
+  test('is absent unless the variable is set to something', () => {
+    expect(brokerOriginOverride({})).toBeUndefined();
+    expect(brokerOriginOverride({ LANES_LINK_BROKER_ORIGIN: '' })).toBeUndefined();
+    expect(brokerOriginOverride({ LANES_LINK_BROKER_ORIGIN: '   ' })).toBeUndefined();
+  });
+
+  test('keeps the origin and discards everything after it', () => {
+    // The provider owns the path. Accepting one here would mean two places
+    // decide where `/exchange` lives, and they would disagree eventually.
+    expect(brokerOriginOverride({ LANES_LINK_BROKER_ORIGIN: 'https://stage.example.com/v9/nope' })).toBe(
+      'https://stage.example.com',
+    );
+    expect(brokerOriginOverride({ LANES_LINK_BROKER_ORIGIN: 'http://127.0.0.1:8080' })).toBe(
+      'http://127.0.0.1:8080',
+    );
+  });
+
+  test('refuses a value it cannot read rather than falling back', () => {
+    // Falling back would send a real authorization code to production while
+    // the operator believes they are exercising a local broker.
+    expect(() => brokerOriginOverride({ LANES_LINK_BROKER_ORIGIN: 'not a url' })).toThrow(
+      /is not a URL/,
+    );
+    expect(() => brokerOriginOverride({ LANES_LINK_BROKER_ORIGIN: 'ftp://example.com' })).toThrow(
+      /must be an http or https URL/,
+    );
+  });
+
+  test('names the scheme it read, because a missing one still parses', () => {
+    // `localhost:8080` is a URL whose scheme is "localhost". Without this the
+    // refusal reads as nonsense to someone who just forgot `http://`.
+    expect(() => brokerOriginOverride({ LANES_LINK_BROKER_ORIGIN: 'localhost:8080' })).toThrow(
+      /reads as scheme "localhost"/,
+    );
+  });
+
+  test('permits http only for a loopback host', () => {
+    expect(brokerOriginOverride({ LANES_LINK_BROKER_ORIGIN: 'http://localhost:8080' })).toBe(
+      'http://localhost:8080',
+    );
+    expect(() => brokerOriginOverride({ LANES_LINK_BROKER_ORIGIN: 'http://stage.example.com' })).toThrow(
+      /in the clear/,
+    );
+    expect(brokerOriginOverride({ LANES_LINK_BROKER_ORIGIN: 'https://stage.example.com' })).toBe(
+      'https://stage.example.com',
+    );
   });
 });

--- a/src/connectivity/auth/oauth-authcode/broker.ts
+++ b/src/connectivity/auth/oauth-authcode/broker.ts
@@ -1,0 +1,209 @@
+/**
+ * Talking to a service that holds an OAuth client secret this machine cannot.
+ *
+ * Three requests, one shape each, and no knowledge of whose client is on the
+ * other end — the URL arrives as declared manifest data. Both callers live in
+ * different components (the CLI performs the first exchange, the dispatcher
+ * refreshes while serving), and putting the wire format here is what stops the
+ * two drifting into disagreeing about it.
+ *
+ * Everything here is a plain `fetch` against an operator-declared origin. There
+ * is deliberately no retry: a broker that is down should surface as a refusal
+ * the operator can read, not as a command that hangs.
+ */
+
+/**
+ * Stamped on a credential this broker issued, and read back at refresh.
+ *
+ * The one fact the refresh path cannot derive: which client minted the token it
+ * is holding. Config cannot answer it, because config can change afterwards.
+ */
+export const BROKERED = 'broker';
+
+/** What the broker will authorise, and whether it is currently doing so. */
+export interface BrokerConfig {
+  readonly clientId: string;
+  /** Every scope the client is registered for. Empty means "unstated". */
+  readonly scopesSupported: readonly string[];
+  /** Added to every request so the exchange returns an identity assertion. */
+  readonly identityScopes: readonly string[];
+  readonly open: boolean;
+  /** Why it is closed, or near capacity. The broker's words, printed verbatim. */
+  readonly notice: string | undefined;
+  readonly docsUrl: string | undefined;
+  /** How full the shared client is, when the broker says. Advisory. */
+  readonly capacity: { readonly accounts: number; readonly cap: number } | undefined;
+}
+
+/** A token response, in the vendor's own field names. */
+export interface BrokerTokens {
+  readonly access_token?: string;
+  readonly refresh_token?: string;
+  readonly id_token?: string;
+  readonly expires_in?: number;
+  readonly scope?: string;
+  readonly token_type?: string;
+}
+
+/**
+ * A refusal, carrying what the caller needs to explain it.
+ *
+ * `ownClient` is the broker saying "registering a client of your own is the way
+ * past this". It matters because the two failures look identical otherwise: a
+ * shared client at capacity and a replayed authorization code are both a 4xx,
+ * and only one of them is solved by an hour in a cloud console.
+ */
+export class BrokerError extends Error {
+  readonly status: number;
+  readonly code: string | undefined;
+  readonly notice: string | undefined;
+  readonly ownClient: boolean;
+  readonly docsUrl: string | undefined;
+  readonly retryAfterSeconds: number | undefined;
+
+  constructor(
+    message: string,
+    fields: {
+      status: number;
+      code?: string | undefined;
+      notice?: string | undefined;
+      ownClient?: boolean | undefined;
+      docsUrl?: string | undefined;
+      retryAfterSeconds?: number | undefined;
+    },
+  ) {
+    super(message);
+    this.name = 'BrokerError';
+    this.status = fields.status;
+    this.code = fields.code;
+    this.notice = fields.notice;
+    this.ownClient = fields.ownClient === true;
+    this.docsUrl = fields.docsUrl;
+    this.retryAfterSeconds = fields.retryAfterSeconds;
+  }
+}
+
+type Fetch = typeof globalThis.fetch;
+
+/** The `{success, data}` envelope, unwrapped, or thrown as a `BrokerError`. */
+async function unwrap(response: Response, what: string): Promise<Record<string, unknown>> {
+  const text = await response.text();
+  let body: Record<string, unknown> = {};
+  try {
+    body = text ? (JSON.parse(text) as Record<string, unknown>) : {};
+  } catch {
+    // A proxy or a captive portal answering in HTML is a real failure mode, and
+    // "Unexpected token <" tells the operator nothing about what went wrong.
+    if (response.ok) {
+      throw new BrokerError(`${what} returned a response that was not JSON.`, {
+        status: response.status,
+      });
+    }
+  }
+
+  if (!response.ok || body['success'] === false) {
+    const retry = Number(response.headers.get('retry-after'));
+    throw new BrokerError(str(body['error']) ?? `${what} failed (${response.status}).`, {
+      status: response.status,
+      code: str(body['code']),
+      notice: str(body['notice']),
+      ownClient: body['own_client'] === true,
+      docsUrl: str(body['docs_url']),
+      retryAfterSeconds: Number.isFinite(retry) && retry > 0 ? retry : undefined,
+    });
+  }
+
+  const data = body['data'];
+  return data !== null && typeof data === 'object' ? (data as Record<string, unknown>) : body;
+}
+
+const str = (value: unknown): string | undefined =>
+  typeof value === 'string' && value.length > 0 ? value : undefined;
+
+const strings = (value: unknown): string[] =>
+  Array.isArray(value) ? value.filter((entry): entry is string => typeof entry === 'string') : [];
+
+async function post(
+  url: string,
+  body: unknown,
+  what: string,
+  fetchImpl: Fetch,
+  headers: Record<string, string> = {},
+): Promise<Record<string, unknown>> {
+  let response: Response;
+  try {
+    response = await fetchImpl(url, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json', ...headers },
+      body: JSON.stringify(body),
+    });
+  } catch (cause) {
+    throw new BrokerError(`${what} could not be reached (${String(cause)}).`, { status: 0 });
+  }
+  return await unwrap(response, what);
+}
+
+export async function brokerConfig(
+  url: string,
+  fetchImpl: Fetch = globalThis.fetch,
+): Promise<BrokerConfig> {
+  let response: Response;
+  try {
+    response = await fetchImpl(`${url}/config`, { headers: { accept: 'application/json' } });
+  } catch (cause) {
+    throw new BrokerError(`${url} could not be reached (${String(cause)}).`, { status: 0 });
+  }
+  const data = await unwrap(response, url);
+
+  const clientId = str(data['client_id']);
+  if (!clientId) {
+    throw new BrokerError(`${url} did not return a client id.`, { status: response.status });
+  }
+
+  const capacity = data['capacity'];
+  return {
+    clientId,
+    scopesSupported: strings(data['scopes_supported']),
+    identityScopes: strings(data['identity_scopes']),
+    open: data['status'] !== 'closed',
+    notice: str(data['notice']),
+    docsUrl: str(data['docs_url']),
+    capacity:
+      capacity !== null && typeof capacity === 'object'
+        ? {
+            accounts: Number((capacity as Record<string, unknown>)['accounts']) || 0,
+            cap: Number((capacity as Record<string, unknown>)['cap']) || 0,
+          }
+        : undefined,
+  };
+}
+
+export async function brokerExchange(
+  url: string,
+  input: { code: string; codeVerifier: string; redirectUri: string },
+  fetchImpl: Fetch = globalThis.fetch,
+): Promise<BrokerTokens> {
+  return (await post(
+    `${url}/exchange`,
+    { code: input.code, code_verifier: input.codeVerifier, redirect_uri: input.redirectUri },
+    url,
+    fetchImpl,
+  )) as BrokerTokens;
+}
+
+export async function brokerRefresh(
+  url: string,
+  input: { refreshToken: string; idToken?: string | undefined },
+  fetchImpl: Fetch = globalThis.fetch,
+): Promise<BrokerTokens> {
+  // The assertion goes in a header rather than the body so the broker can
+  // attribute and rate-limit the call before it parses anything, and so it does
+  // not land in whatever logs request bodies.
+  return (await post(
+    `${url}/refresh`,
+    { refresh_token: input.refreshToken },
+    url,
+    fetchImpl,
+    input.idToken ? { authorization: `Bearer ${input.idToken}` } : {},
+  )) as BrokerTokens;
+}

--- a/src/connectivity/auth/oauth-authcode/broker.ts
+++ b/src/connectivity/auth/oauth-authcode/broker.ts
@@ -85,6 +85,58 @@ export class BrokerError extends Error {
 
 type Fetch = typeof globalThis.fetch;
 
+export const BROKER_ORIGIN_ENV = 'LANES_LINK_BROKER_ORIGIN';
+
+/** Loopback, in the spellings a `URL` will hand back for one. */
+const LOOPBACK = new Set(['127.0.0.1', 'localhost', '::1', '[::1]']);
+
+/**
+ * Aiming the exchange somewhere other than the origin the manifest declares.
+ *
+ * A broker running on this machine and a staging deployment are the same
+ * problem: everything about the flow is unchanged except which host holds the
+ * secret. An origin is the whole of the difference, so a provider keeps its own
+ * path and only the origin in front of it moves.
+ *
+ * It refuses rather than falls back, because the failure it would otherwise
+ * cause is the expensive kind — believing you are exercising a local broker
+ * while a real authorization code goes to production. A variable that is
+ * ignored when malformed is worse than one that stops the command.
+ *
+ * `http` is confined to loopback for the same reason the redirect is: off this
+ * machine it puts an authorization code on the wire in the clear.
+ */
+export function brokerOriginOverride(
+  env: Record<string, string | undefined> = process.env as Record<string, string | undefined>,
+): string | undefined {
+  const raw = env[BROKER_ORIGIN_ENV]?.trim();
+  if (!raw) return undefined;
+
+  let url: URL;
+  try {
+    url = new URL(raw);
+  } catch {
+    throw new Error(`${BROKER_ORIGIN_ENV} is not a URL: ${raw}`);
+  }
+
+  if (url.protocol !== 'https:' && url.protocol !== 'http:') {
+    // `localhost:8080` is the mistake people make, and it *parses* — as a URL
+    // whose scheme is "localhost". Saying which scheme it read is what turns
+    // that from a baffling refusal into an obvious missing `http://`.
+    throw new Error(
+      `${BROKER_ORIGIN_ENV} must be an http or https URL. "${raw}" reads as scheme ` +
+        `"${url.protocol.replace(':', '')}" — a host and port with no scheme becomes one.`,
+    );
+  }
+  if (url.protocol === 'http:' && !LOOPBACK.has(url.hostname)) {
+    throw new Error(
+      `${BROKER_ORIGIN_ENV} may only be http for a loopback host. "${url.hostname}" over http ` +
+        `would put the authorization code on the wire in the clear — use https.`,
+    );
+  }
+  return url.origin;
+}
+
 /** The `{success, data}` envelope, unwrapped, or thrown as a `BrokerError`. */
 async function unwrap(response: Response, what: string): Promise<Record<string, unknown>> {
   const text = await response.text();

--- a/src/connectivity/auth/oauth-authcode/refresh.test.ts
+++ b/src/connectivity/auth/oauth-authcode/refresh.test.ts
@@ -1,0 +1,189 @@
+import { describe, expect, test } from 'bun:test';
+import { defineProvider } from '#connectivity';
+import type { SecretRef, SecretStore } from '#secrets';
+import { refreshDirectly } from './refresh.ts';
+import type { CredentialOAuthProvider } from './provider.ts';
+
+/**
+ * Where a refresh is sent, which is a property of the token and not the config.
+ *
+ * A refresh token minted by one OAuth client is refused by another. So an
+ * operator who registers a client of their own six months after connecting must
+ * not have their existing connections quietly pointed at it — they would all
+ * answer `invalid_grant`, and the config change would look unrelated.
+ */
+
+const BROKER = { url: 'https://api.example.com/v1/auth/link/vendor', operator: 'Someone' };
+
+const manifest = (broker: object | null = BROKER) =>
+  defineProvider({
+    id: 'vendor_mail',
+    name: 'Vendor Mail',
+    connector: { kind: 'http', base_url: 'https://api.test', openapi: './t.json' },
+    auth: {
+      kind: 'oauth',
+      registration: 'manual',
+      app: 'vendor',
+      scopes: ['a'],
+      authorize_url: 'https://accounts.example.com/o/oauth2/v2/auth',
+      token_url: 'https://oauth2.example.com/token',
+      ...(broker ? { broker } : {}),
+    },
+    ...(broker
+      ? {}
+      : {
+          setup: {
+            prompts: [{ key: 'client_id', label: 'Client id', credential_ref: 'vendor/client_id' }],
+          },
+        }),
+  });
+
+/** A provider whose stored blob is a plain object, so saves are observable. */
+function stubProvider(initial: Record<string, unknown>) {
+  let blob = { ...initial };
+  return {
+    provider: {
+      tokens: async () => blob,
+      saveTokens: async (next: Record<string, unknown>) => void (blob = { ...next }),
+    } as unknown as CredentialOAuthProvider,
+    current: () => blob,
+  };
+}
+
+const store = (seed: Record<string, string> = {}): SecretStore => {
+  const map = new Map(Object.entries(seed));
+  return {
+    get: async (ref) => map.get(ref) ?? null,
+    set: async (ref, value) => void map.set(ref, value),
+    has: async (ref) => map.has(ref),
+    delete: async (ref) => void map.delete(ref),
+    list: async () => [...map.keys()] as SecretRef[],
+  };
+};
+
+function recording(status: number, body: unknown) {
+  const calls: { url: string; init?: RequestInit }[] = [];
+  const fetch = (async (url: string, init?: RequestInit) => {
+    calls.push({ url, ...(init ? { init } : {}) });
+    return new Response(JSON.stringify(body), {
+      status,
+      headers: { 'content-type': 'application/json' },
+    });
+  }) as unknown as typeof globalThis.fetch;
+  return { fetch, calls };
+}
+
+describe('refreshDirectly', () => {
+  test('a token stamped as brokered refreshes through the broker', async () => {
+    const { fetch, calls } = recording(200, { success: true, data: { access_token: 'fresh' } });
+    const { provider } = stubProvider({
+      refresh_token: 'rt',
+      id_token: 'idt',
+      authorized_via: 'broker',
+    });
+
+    await refreshDirectly(manifest(), provider, 'https://oauth2.example.com/token', store(), fetch);
+
+    expect(calls[0]!.url).toBe(`${BROKER.url}/refresh`);
+    expect((calls[0]!.init!.headers as Record<string, string>)['authorization']).toBe('Bearer idt');
+  });
+
+  test('an unstamped token on a brokered provider still uses the stored client', async () => {
+    // The one that matters: a connection made before this feature existed, on a
+    // profile that has since stopped declaring its own client. It was minted by
+    // the operator's client, so it must keep going there.
+    const { fetch, calls } = recording(200, { access_token: 'fresh' });
+    const { provider } = stubProvider({ refresh_token: 'rt' });
+
+    await refreshDirectly(
+      manifest(),
+      provider,
+      'https://oauth2.example.com/token',
+      store({ 'vendor/client_id': 'id', 'vendor/client_secret': 'secret' }),
+      fetch,
+    );
+
+    expect(calls[0]!.url).toBe('https://oauth2.example.com/token');
+    expect(new URLSearchParams(String(calls[0]!.init!.body)).get('client_secret')).toBe('secret');
+  });
+
+  test('a provider with no broker is untouched', async () => {
+    const { fetch, calls } = recording(200, { access_token: 'fresh' });
+    const { provider } = stubProvider({ refresh_token: 'rt', authorized_via: 'broker' });
+
+    await refreshDirectly(
+      manifest(null),
+      provider,
+      'https://oauth2.example.com/token',
+      store({ 'vendor/client_id': 'id', 'vendor/client_secret': 'secret' }),
+      fetch,
+    );
+
+    expect(calls[0]!.url).toBe('https://oauth2.example.com/token');
+  });
+
+  test('the stamp, the assertion, and the refresh token all survive a refresh', async () => {
+    // Neither the vendor nor the broker echoes these unless there is a new one.
+    // Dropping any of the three leaves the *next* refresh with no token, no
+    // attribution, or pointed at the wrong client.
+    const { fetch } = recording(200, { success: true, data: { access_token: 'fresh' } });
+    const { provider, current } = stubProvider({
+      refresh_token: 'rt',
+      id_token: 'idt',
+      authorized_via: 'broker',
+    });
+
+    await refreshDirectly(manifest(), provider, 'https://oauth2.example.com/token', store(), fetch);
+
+    expect(current()).toMatchObject({
+      refresh_token: 'rt',
+      id_token: 'idt',
+      authorized_via: 'broker',
+      access_token: 'fresh',
+    });
+  });
+
+  test('a fresher assertion from the broker replaces the stored one', async () => {
+    const { fetch } = recording(200, {
+      success: true,
+      data: { access_token: 'fresh', id_token: 'newer' },
+    });
+    const { provider, current } = stubProvider({
+      refresh_token: 'rt',
+      id_token: 'stale',
+      authorized_via: 'broker',
+    });
+
+    await refreshDirectly(manifest(), provider, 'https://oauth2.example.com/token', store(), fetch);
+
+    expect(current()['id_token']).toBe('newer');
+  });
+
+  test('a broker refusal names the command the owner runs, not the agent', async () => {
+    // This reaches an agent mid-request. It must not read as something the
+    // agent could do next.
+    const { fetch } = recording(403, { success: false, error: 'withdrawn', notice: 'Revoked.' });
+    const { provider } = stubProvider({ refresh_token: 'rt', authorized_via: 'broker' });
+
+    const error = (await refreshDirectly(
+      manifest(),
+      provider,
+      'https://oauth2.example.com/token',
+      store(),
+      fetch,
+    ).catch((e) => e)) as Error;
+
+    expect(error.message).toContain('lanes link connect vendor_mail');
+    expect(error.message).toContain('Revoked.');
+  });
+
+  test('no refresh token at all is said plainly rather than sent anywhere', async () => {
+    const { fetch, calls } = recording(200, {});
+    const { provider } = stubProvider({ authorized_via: 'broker' });
+
+    await expect(
+      refreshDirectly(manifest(), provider, 'https://oauth2.example.com/token', store(), fetch),
+    ).rejects.toThrow(/No refresh token stored/);
+    expect(calls).toEqual([]);
+  });
+});

--- a/src/connectivity/auth/oauth-authcode/refresh.ts
+++ b/src/connectivity/auth/oauth-authcode/refresh.ts
@@ -1,14 +1,25 @@
 import type { ProviderManifest } from '#connectivity';
 import type { SecretStore } from '#secrets';
+import { BROKERED, BrokerError, brokerRefresh } from './broker.ts';
 import type { CredentialOAuthProvider } from './provider.ts';
+
+/** What a stored OAuth credential carries beyond the tokens themselves. */
+interface StoredTokens {
+  readonly refresh_token?: string;
+  /** An identity assertion, presented to the broker so it knows whose refresh this is. */
+  readonly id_token?: string;
+  /** Which client minted this. Absent means the profile's own. */
+  readonly authorized_via?: string;
+}
 
 export async function refreshDirectly(
   manifest: ProviderManifest,
   provider: CredentialOAuthProvider,
   tokenUrl: string,
   credentials: SecretStore,
+  fetchImpl: typeof globalThis.fetch = globalThis.fetch,
 ): Promise<unknown> {
-  const existing = (await provider.tokens()) as { refresh_token?: string } | undefined;
+  const existing = (await provider.tokens()) as StoredTokens | undefined;
   const refreshToken = existing?.refresh_token;
 
   if (!refreshToken) {
@@ -17,7 +28,65 @@ export async function refreshDirectly(
     );
   }
 
-  const app = manifest.auth.kind === 'oauth' ? manifest.auth.app : undefined;
+  const auth = manifest.auth.kind === 'oauth' ? manifest.auth : undefined;
+
+  // Which client issued this token is a property of the *token*, not of the
+  // profile. A refresh token minted by one client is refused by another, so an
+  // operator who registers a client of their own after the fact must not drag
+  // existing connections onto it — they keep refreshing where they were issued,
+  // and only a fresh `connect` moves them.
+  const broker = auth?.broker;
+  const brokered = broker !== undefined && existing?.authorized_via === BROKERED;
+
+  const refreshed = brokered
+    ? await viaBroker(manifest, broker.url, refreshToken, existing, fetchImpl)
+    : await viaStoredClient(manifest, auth?.app, tokenUrl, refreshToken, credentials, fetchImpl);
+
+  // `existing` first, so what the response does not mention survives it. Neither
+  // the vendor nor the broker echoes `refresh_token`, `id_token`, or
+  // `authorized_via` unless there is a new one, and dropping any of the three
+  // would leave the *next* refresh with no token, no attribution, or pointed at
+  // the wrong client.
+  await provider.saveTokens({ ...existing, ...refreshed, refresh_token: refreshToken } as never);
+  return (await provider.tokens()) as unknown;
+}
+
+async function viaBroker(
+  manifest: ProviderManifest,
+  url: string,
+  refreshToken: string,
+  existing: StoredTokens,
+  fetchImpl: typeof globalThis.fetch,
+): Promise<Record<string, unknown>> {
+  try {
+    return (await brokerRefresh(
+      url,
+      { refreshToken, ...(existing.id_token ? { idToken: existing.id_token } : {}) },
+      fetchImpl,
+    )) as Record<string, unknown>;
+  } catch (cause) {
+    // This surfaces to an agent in the middle of a request, so it must name a
+    // command the *owner* runs and nothing the agent could mistake for its own
+    // next step. Same shape as the stored-client message below, deliberately:
+    // where the credential came from is not the reader's problem here.
+    const notice = cause instanceof BrokerError && cause.notice ? `\n${cause.notice}` : '';
+    throw new Error(
+      `The credential for ${manifest.id} could not be refreshed. ` +
+        `Re-authorise with: lanes link connect ${manifest.id}\n${String(
+          cause instanceof Error ? cause.message : cause,
+        ).slice(0, 200)}${notice}`,
+    );
+  }
+}
+
+async function viaStoredClient(
+  manifest: ProviderManifest,
+  app: string | undefined,
+  tokenUrl: string,
+  refreshToken: string,
+  credentials: SecretStore,
+  fetchImpl: typeof globalThis.fetch,
+): Promise<Record<string, unknown>> {
   const [clientId, clientSecret] = app
     ? await Promise.all([
         credentials.get(`${app}/client_id`),
@@ -29,7 +98,7 @@ export async function refreshDirectly(
   if (clientId) body.set('client_id', clientId);
   if (clientSecret) body.set('client_secret', clientSecret);
 
-  const response = await fetch(tokenUrl, {
+  const response = await fetchImpl(tokenUrl, {
     method: 'POST',
     headers: { 'content-type': 'application/x-www-form-urlencoded' },
     body,
@@ -45,10 +114,5 @@ export async function refreshDirectly(
     );
   }
 
-  const refreshed = JSON.parse(text) as Record<string, unknown>;
-
-  // Google omits `refresh_token` on a refresh: it is still the original one, and
-  // dropping it here would make the *next* refresh fail with no token at all.
-  await provider.saveTokens({ refresh_token: refreshToken, ...refreshed } as never);
-  return (await provider.tokens()) as unknown;
+  return JSON.parse(text) as Record<string, unknown>;
 }

--- a/src/connectivity/index.ts
+++ b/src/connectivity/index.ts
@@ -53,6 +53,7 @@ export { defineLocalProvider, defineProviderWithCapabilities } from './provider.
 export type {
   ProviderManifest,
   ConnectorConfig,
+  AuthBroker,
   AuthConfig,
   SetupDeclaration,
   SetupPrompt,

--- a/src/connectivity/manifest/auth.ts
+++ b/src/connectivity/manifest/auth.ts
@@ -12,6 +12,28 @@ import { credentialRef, identifier } from './primitives.ts';
 
 export const authNoneSchema = z.object({ kind: z.literal('none') });
 
+/**
+ * A client somebody else operates, so the operator does not have to register one.
+ *
+ * An installed application cannot hold a confidential client: whatever ships in
+ * the binary is readable by whoever runs it. That leaves exactly two honest
+ * arrangements, and this declares the second — the operator registers their own,
+ * or somebody runs one and performs the exchange on their behalf. The secret
+ * lives behind these endpoints and never reaches this machine.
+ *
+ * Vendor-free by construction. The URL is data a provider supplies, so nothing
+ * in this component learns whose client is behind it, or whose broker.
+ */
+export const authBrokerSchema = z.object({
+  /** Base URL. `<url>/config`, `<url>/exchange`, `<url>/refresh`. */
+  url: z.url(),
+  /** Who runs it, named in the sentence shown before consent. */
+  operator: z.string().min(1),
+  docs_url: z.url().optional(),
+});
+
+export type AuthBroker = z.infer<typeof authBrokerSchema>;
+
 export const authOAuthSchema = z.object({
   kind: z.literal('oauth'),
   /**
@@ -24,6 +46,17 @@ export const authOAuthSchema = z.object({
   registration: z.enum(['dynamic', 'manual']).default('dynamic'),
   /** Which `oauth_apps` entry holds the client, for `manual`. Shared across providers of a vendor. */
   app: identifier.optional(),
+  /**
+   * Where to authorise when the profile declares no `oauth_apps` entry of its own.
+   *
+   * Additive rather than a third `registration` value, because the manifest is
+   * not what chooses. `registration: manual` stays true either way — the vendor
+   * does require a pre-registered client — and `app` still names the entry that
+   * overrides this. What decides is the profile: declaring the entry means "my
+   * own client", leaving it out means "the one the broker operates". A manifest
+   * that claimed one or the other would be wrong half the time.
+   */
+  broker: authBrokerSchema.optional(),
   scopes: z.array(z.string()).default([]),
   /**
    * Usually discovered from the resource's metadata; set only to override.

--- a/src/connectivity/manifest/index.ts
+++ b/src/connectivity/manifest/index.ts
@@ -22,10 +22,12 @@ export {
 
 export {
   authNoneSchema,
+  authBrokerSchema,
   authOAuthSchema,
   authSchema,
   authStrategySchema,
   authTokenSchema,
+  type AuthBroker,
   type AuthConfig,
 } from './auth.ts';
 

--- a/src/connectivity/manifest/manifest.test.ts
+++ b/src/connectivity/manifest/manifest.test.ts
@@ -79,3 +79,53 @@ describe('defineProvider cross-field rules', () => {
     expect(() => provider({ kind: 'bearer' })).not.toThrow();
   });
 });
+
+describe('a broker as the other answer to "where does the client come from"', () => {
+  const broker = { url: 'https://api.example.com/v1/auth/link/vendor', operator: 'Someone' };
+  const oauth = (extra: Record<string, unknown> = {}) => ({
+    kind: 'oauth',
+    registration: 'manual',
+    app: 'vendor',
+    scopes: ['a'],
+    authorize_url: 'https://accounts.example.com/o/oauth2/v2/auth',
+    token_url: 'https://oauth2.example.com/token',
+    ...extra,
+  });
+
+  test('setup prompts stop being mandatory once a broker can supply the client', () => {
+    // Without a broker this is the error that says a manual registration with
+    // no prompts leaves nobody able to learn what to provide. With one, there
+    // is simply nothing to provide.
+    expect(() => provider(oauth())).toThrow(/must declare setup prompts/);
+    expect(() => provider(oauth({ broker }))).not.toThrow();
+  });
+
+  test('a broker still names the oauth_apps entry that overrides it', () => {
+    // Without `app` there is no way for a profile to say "use mine instead",
+    // which would make the broker the only option rather than the default.
+    expect(() => provider(oauth({ broker, app: undefined }))).toThrow(/registration "manual"/);
+    expect(() => provider(oauth({ broker, registration: 'dynamic' }))).toThrow(/"app"/);
+  });
+
+  test('a broker needs the authorize url, because the browser still goes to the vendor', () => {
+    expect(() => provider(oauth({ broker, authorize_url: undefined }))).toThrow(/authorize_url/);
+  });
+
+  test('an mcp connector is refused, because the SDK owns its exchange', () => {
+    // Discovered at definition rather than after the operator has already
+    // approved a consent screen.
+    expect(() =>
+      defineProvider({
+        id: 'vendor_mcp',
+        name: 'Vendor',
+        connector: { kind: 'mcp', endpoint: 'https://mcp.example.com/sse' },
+        auth: oauth({ broker }),
+      }),
+    ).toThrow(/cannot route it through a broker/);
+  });
+
+  test('tokens still land per provider, not under the app the broker names', () => {
+    const gmailish = provider(oauth({ broker }), 'vendor_mail');
+    expect(credentialRefForConnection(gmailish, 'main')).toBe('vendor_mail/main');
+  });
+});

--- a/src/connectivity/manifest/provider.ts
+++ b/src/connectivity/manifest/provider.ts
@@ -97,9 +97,35 @@ export function defineProvider(input: unknown): ProviderManifest {
         `Provider "${manifest.id}": OAuth with registration "manual" needs an "app" naming the oauth_apps entry that holds the client.`,
       );
     }
-    if (!manifest.setup || manifest.setup.prompts.length === 0) {
+    // Prompts are required only when asking is the *only* way to get a client.
+    // A broker is the other way, so a provider that declares one and no prompts
+    // simply has no bring-your-own path — a legal thing to be. The CLI is where
+    // that absence becomes visible, by refusing the flag and saying why.
+    if (!manifest.auth.broker && (!manifest.setup || manifest.setup.prompts.length === 0)) {
       throw new Error(
         `Provider "${manifest.id}": OAuth with registration "manual" requires the operator to supply a client, so it must declare setup prompts. Otherwise there is no way to learn what to provide.`,
+      );
+    }
+  }
+
+  if (manifest.auth.kind === 'oauth' && manifest.auth.broker) {
+    if (manifest.auth.registration !== 'manual' || !manifest.auth.app) {
+      throw new Error(
+        `Provider "${manifest.id}": a broker supplies a pre-registered client, so auth must declare registration "manual" and an "app" naming the oauth_apps entry that overrides it.`,
+      );
+    }
+    // An MCP provider hands the exchange to the SDK, which posts to the token
+    // endpoint with whatever `clientInformation()` returned. There is no seam
+    // to route that through a broker without reimplementing its auth path, so
+    // this is refused at definition rather than discovered after consent.
+    if (manifest.connector.kind === 'mcp') {
+      throw new Error(
+        `Provider "${manifest.id}": an mcp connector runs the exchange through the SDK, which cannot route it through a broker. Register a client (registration "manual") or use dynamic registration.`,
+      );
+    }
+    if (!manifest.auth.authorize_url) {
+      throw new Error(
+        `Provider "${manifest.id}": a broker performs the exchange, but the browser still goes to the vendor, so auth.authorize_url is required.`,
       );
     }
   }

--- a/src/connectivity/manifest/requirements.ts
+++ b/src/connectivity/manifest/requirements.ts
@@ -45,6 +45,16 @@ export interface SetupNeeds {
    * anyone wants — so a non-interactive run has to be told the name up front.
    */
   readonly needsId: boolean;
+  /**
+   * The client comes from a broker, so there is nothing here to supply.
+   *
+   * Distinct from an empty `requirements`: a provider that needs nothing and a
+   * provider whose client somebody else operates read the same in a list of
+   * requirements and mean different things to a person deciding what to do
+   * next. A form built from this would render a required field for a value
+   * `connect` will never ask for.
+   */
+  readonly brokered: boolean;
 }
 
 /**
@@ -74,10 +84,23 @@ export function setupRequirements(
   manifest: ProviderManifest,
   connectionId: string | undefined,
   profile: string,
+  options: {
+    /** `oauth_apps` entries this profile declares — the clients that are its own. */
+    readonly ownClients?: readonly string[];
+  } = {},
 ): SetupNeeds {
   const prompts = manifest.setup?.prompts ?? [];
 
-  const shared = prompts.filter((prompt) => prompt.scope === 'shared');
+  // A shared prompt exists to collect a client the operator registers. When a
+  // broker supplies one and this profile has not declared its own, there is
+  // nothing to collect — the prompts stay in the manifest because `--own-client`
+  // still needs them, but they are not what this connect will ask for.
+  const brokered =
+    manifest.auth.kind === 'oauth' &&
+    manifest.auth.broker !== undefined &&
+    !(manifest.auth.app !== undefined && (options.ownClients ?? []).includes(manifest.auth.app));
+
+  const shared = brokered ? [] : prompts.filter((prompt) => prompt.scope === 'shared');
   const perConnection = prompts.filter((prompt) => prompt.scope === 'connection');
 
   const requirements: SetupRequirement[] = [];
@@ -115,5 +138,9 @@ export function setupRequirements(
     }
   }
 
-  return { requirements, needsId: perConnection.length > 0 && connectionId === undefined };
+  return {
+    requirements,
+    needsId: perConnection.length > 0 && connectionId === undefined,
+    brokered,
+  };
 }

--- a/src/deployments/grants.test.ts
+++ b/src/deployments/grants.test.ts
@@ -7,6 +7,7 @@ import {
 } from '#connectivity';
 import { CredentialOAuthProvider } from '#connectivity/auth/index.ts';
 import { WORKSPACE_SKILL_DIR, layout, type Config, type DeployConfig, type TargetConfig } from '#profile';
+import { ownClientRefsFor } from '#registry';
 import { encodeRef } from './adapters/gcp-secret-manager.ts';
 import { provisionSteps } from './gcp/provision.ts';
 import { openStorage } from './target.ts';
@@ -392,5 +393,61 @@ describe('the credentials a revision rotates, against what it is bound to', () =
       expect(step.argv[0]).toBe('secrets');
       expect(step.argv).not.toContain('projects');
     }
+  });
+});
+
+describe('the client a revision signs a refresh with, where the profile holds one', () => {
+  const manifestOf = (broker?: object) =>
+    defineProvider({
+      id: 'vendor_mail',
+      name: 'Vendor Mail',
+      connector: { kind: 'http', base_url: 'https://api.test', openapi: './t.json' },
+      auth: {
+        kind: 'oauth',
+        registration: 'manual',
+        app: 'vendor',
+        scopes: ['a'],
+        authorize_url: 'https://accounts.example.com/o/oauth2/v2/auth',
+        token_url: 'https://oauth2.example.com/token',
+        ...(broker ? { broker } : {}),
+      },
+      ...(broker
+        ? {}
+        : {
+            setup: {
+              prompts: [
+                { key: 'client_id', label: 'Client id', credential_ref: 'vendor/client_id' },
+              ],
+            },
+          }),
+    });
+
+  const declaredApps = {
+    vendor: { client_id_ref: 'vendor/client_id', client_secret_ref: 'vendor/client_secret' },
+  };
+
+  test('a declared client is readable, because the refresh path signs with it', () => {
+    // It was not, and the failure was silent in the worst way: the adapter
+    // answers null only on a 404, so an *unbound* secret is a 403 that throws.
+    // The revision served until its access token expired and then failed every
+    // call, an hour after reporting healthy.
+    expect(ownClientRefsFor(manifestOf(), declaredApps)).toEqual([
+      'vendor/client_id',
+      'vendor/client_secret',
+    ]);
+  });
+
+  test('a profile that declares none binds none', () => {
+    // Which is every profile that authorises against a broker.
+    expect(ownClientRefsFor(manifestOf({ url: 'https://api.example.com/b', operator: 'X' }), {})).toEqual([]);
+  });
+
+  test('readable is not rotatable: a revision never rewrites the operator’s client', () => {
+    // ADR-026's line. Sharing one entry across a vendor's providers is exactly
+    // why: rewriting it would break every other connection authorised against it.
+    const brokered = manifestOf({ url: 'https://api.example.com/b', operator: 'X' });
+
+    expect(rotatableCredentialRefs(brokered, CONNECTION)).toEqual(['vendor_mail/ada_lovelace']);
+    expect(rotatableCredentialRefs(manifestOf(), CONNECTION)).toEqual(['vendor_mail/ada_lovelace']);
   });
 });

--- a/src/deployments/prepare.ts
+++ b/src/deployments/prepare.ts
@@ -1,4 +1,4 @@
-import { credentialRefFor, rotatableCredentialRefsFor } from '#registry';
+import { credentialRefFor, ownClientRefsFor, rotatableCredentialRefsFor } from '#registry';
 import { listProfiles, loadProfileConfig, type Config, type TargetConfig } from '#profile';
 import { VAULT_DOCUMENT_REF, VAULT_KEY_REF, generateVaultKey, type SecretStore } from '#secrets';
 import { ok, print, style, warn } from '#cli/output.ts';
@@ -151,6 +151,7 @@ export async function readableRefs(
       const ref = credentialRefFor(connection, manifest);
       if (ref) refs.add(ref);
       for (const rotatable of rotatableCredentialRefsFor(connection, manifest)) refs.add(rotatable);
+      for (const client of ownClientRefsFor(manifest, config.oauth_apps)) refs.add(client);
     }
   }
 

--- a/src/dispatch/context.test.ts
+++ b/src/dispatch/context.test.ts
@@ -80,3 +80,70 @@ describe('the scoped store enforces it', () => {
     expect(scoped.get('profile/token')).rejects.toThrow(/not in scope/);
   });
 });
+
+describe('a client the profile does not hold is not granted', () => {
+  const oauth = (broker?: object) =>
+    defineProvider({
+      id: 'vendor_mail',
+      name: 'Vendor Mail',
+      connector: { kind: 'http', base_url: 'https://api.test', openapi: './t.json' },
+      auth: {
+        kind: 'oauth',
+        registration: 'manual',
+        app: 'vendor',
+        scopes: ['a'],
+        authorize_url: 'https://accounts.example.com/o/oauth2/v2/auth',
+        token_url: 'https://oauth2.example.com/token',
+        ...(broker ? { broker } : {}),
+      },
+      ...(broker
+        ? {}
+        : {
+            setup: {
+              prompts: [
+                { key: 'client_id', label: 'Client id', credential_ref: 'vendor/client_id' },
+              ],
+            },
+          }),
+    });
+
+  const brokered = oauth({ url: 'https://api.example.com/b', operator: 'Someone' });
+
+  test('a brokered connection reaches its tokens and no client refs at all', () => {
+    // There is no client id, secret, or registration anywhere in this store.
+    // Naming the three would grant reach to nothing while describing an
+    // arrangement that does not exist, and a grant list is read by people.
+    const refs = resolveSecretRefs(brokered, connection('vendor_mail', 'ada'));
+
+    expect(refs).toEqual(['vendor_mail/ada']);
+  });
+
+  test('the same provider on a profile that registered its own client reaches it', () => {
+    const refs = resolveSecretRefs(brokered, connection('vendor_mail', 'ada'), undefined, [
+      'vendor',
+    ]);
+
+    expect(refs).toContain('vendor/client_id');
+    expect(refs).toContain('vendor/client_secret');
+  });
+
+  test('a provider with no broker is unchanged, whatever the profile declares', () => {
+    // Every provider that exists today takes this path, so it is the one that
+    // must not move.
+    const refs = resolveSecretRefs(oauth(), connection('vendor_mail', 'ada'));
+
+    expect(refs).toContain('vendor/client_id');
+    expect(refs).toContain('vendor/client_secret');
+    expect(refs).toContain('vendor/client');
+  });
+
+  test('a sibling account is still out of reach on either arrangement', async () => {
+    const scoped = scopeSecrets(
+      createMemoryCredentials({ 'vendor_mail/ada': 'a', 'vendor_mail/sam': 's' }),
+      resolveSecretRefs(brokered, connection('vendor_mail', 'ada')),
+    );
+
+    expect(await scoped.get('vendor_mail/ada')).toBe('a');
+    await expect(scoped.get('vendor_mail/sam')).rejects.toThrow(/not in scope/);
+  });
+});

--- a/src/dispatch/context.ts
+++ b/src/dispatch/context.ts
@@ -65,6 +65,14 @@ export function resolveSecretRefs(
   manifest: ProviderManifest,
   connection: ConnectionConfig,
   definition?: ProviderDefinition,
+  /**
+   * Which `app` entries this profile declares a client of its own for.
+   *
+   * Only consulted for a provider that could also authorise against a broker.
+   * Defaults to none, which is correct for every provider that declares no
+   * broker: the gate below leaves those exactly as they were.
+   */
+  ownClients: readonly string[] = [],
 ): SecretRef[] {
   const refs = new Set<SecretRef>(
     definition?.credentialRefs?.(connection.id, connection.config ?? {}) ?? [],
@@ -80,9 +88,16 @@ export function resolveSecretRefs(
     // against. Nothing wider: `gmail.main` must not reach `gmail/side`.
     refs.add(`${manifest.id}/${connection.id}`);
     if (auth.registration === 'manual' && auth.app) {
-      refs.add(`${auth.app}/client_id`);
-      refs.add(`${auth.app}/client_secret`);
-      refs.add(`${auth.app}/client`);
+      // Only where this profile holds a client of its own. When the client is
+      // the broker's there is no id, secret, or registration anywhere in this
+      // store, so naming the three refs would grant reach to nothing while
+      // describing an arrangement that does not exist — and a grant list is
+      // read by people deciding what a provider can see.
+      if (!auth.broker || ownClients.includes(auth.app)) {
+        refs.add(`${auth.app}/client_id`);
+        refs.add(`${auth.app}/client_secret`);
+        refs.add(`${auth.app}/client`);
+      }
     } else {
       refs.add(`${manifest.id}/client`);
     }
@@ -114,6 +129,8 @@ export interface BuildContextOptions {
   readonly signal: AbortSignal;
   /** The same closure the connector context gets. Absent for `local` providers. */
   readonly authorize?: ((request: Request) => Promise<Request>) | undefined;
+  /** `oauth_apps` entries this profile declares. See `resolveSecretRefs`. */
+  readonly ownClients?: readonly string[] | undefined;
 }
 
 export function buildProviderContext(options: BuildContextOptions): ProviderContext {
@@ -133,7 +150,7 @@ export function buildProviderContext(options: BuildContextOptions): ProviderCont
     storage: scopeBlobStore(options.storage, namespace),
     credentials: scopeSecrets(
       options.credentials,
-      resolveSecretRefs(manifest, connection, definition),
+      resolveSecretRefs(manifest, connection, definition, options.ownClients ?? []),
     ),
     audit: options.audit,
     log: options.log,

--- a/src/dispatch/dispatch.ts
+++ b/src/dispatch/dispatch.ts
@@ -270,6 +270,10 @@ export class Dispatcher {
         audit: auditLogger,
         log: createProviderLogger(this.#deps.log, providerId, declared.id),
         signal: request.signal ?? new AbortController().signal,
+        // Which vendors this profile registered a client of its own for. A
+        // provider that could be brokered but is not reads its client from the
+        // store, so it has to be able to.
+        ownClients: Object.keys(this.#deps.config.oauth_apps),
         ...(entry.manifest.connector.kind === 'local' ? {} : { authorize }),
       });
 

--- a/src/providers/google/shared/oauth.test.ts
+++ b/src/providers/google/shared/oauth.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, test } from 'bun:test';
+import { GOOGLE_BROKER, GOOGLE_OAUTH, googleBroker } from './oauth.ts';
+
+describe('googleBroker', () => {
+  test('points at the client Lanes operates when nothing overrides it', () => {
+    expect(googleBroker({}).url).toBe('https://api.lanes.sh/v1/auth/link/google');
+    expect(GOOGLE_BROKER.url).toBe('https://api.lanes.sh/v1/auth/link/google');
+  });
+
+  test('moves the origin and keeps the path', () => {
+    // The path is this provider's; only the host holding the secret moves.
+    expect(googleBroker({ LANES_LINK_BROKER_ORIGIN: 'http://127.0.0.1:8080' }).url).toBe(
+      'http://127.0.0.1:8080/v1/auth/link/google',
+    );
+  });
+
+  test('names its operator either way, because consent says who it is', () => {
+    expect(googleBroker({}).operator).toBe('Lanes');
+    expect(googleBroker({ LANES_LINK_BROKER_ORIGIN: 'https://stage.example.com' }).operator).toBe(
+      'Lanes',
+    );
+  });
+
+  test('is what every REST provider spreads, so one switch moves all of them', () => {
+    expect(GOOGLE_OAUTH.broker).toBe(GOOGLE_BROKER);
+  });
+});

--- a/src/providers/google/shared/oauth.ts
+++ b/src/providers/google/shared/oauth.ts
@@ -8,6 +8,30 @@
  */
 export const GOOGLE_APP = 'google';
 
+/**
+ * The Google OAuth client Lanes operates, and where its secret stays.
+ *
+ * Its own Cloud project, separate from the one that signs people into Lanes:
+ * this client asks for Gmail and Drive and carries a verification review that
+ * can be rejected, and a rejection must not be able to take sign-in with it.
+ *
+ * The secret is not confidential in Google's sense — an installed app cannot
+ * hold one — and is held back anyway. Shipping it would hand anyone the shared
+ * quota and standing of a single client that every Lanes Link user depends on,
+ * and there is no way to withdraw one copy of a secret.
+ *
+ * What this buys the operator is the whole of `setup/google.md`: no project, no
+ * console, no scope list to transcribe, and no seven-day refresh-token expiry,
+ * because that expiry is a property of a project left in "Testing" and this one
+ * is not. What it costs is recorded in ADR-028 and in the guarantee table in
+ * `docs/detailed/security.md` — chiefly that the exchange stops being local.
+ */
+export const GOOGLE_BROKER = {
+  url: 'https://api.lanes.sh/v1/auth/link/google',
+  operator: 'Lanes',
+  docs_url: 'https://lanes.sh/link#google',
+} as const;
+
 export const GOOGLE_OAUTH = {
   authorize_url: 'https://accounts.google.com/o/oauth2/v2/auth',
   token_url: 'https://oauth2.googleapis.com/token',
@@ -16,6 +40,11 @@ export const GOOGLE_OAUTH = {
   // whichever account the browser is already signed into and never offers a
   // choice, so connecting a second mailbox silently re-authorises the first.
   authorize_params: { access_type: 'offline', prompt: 'select_account consent' },
+  // Every REST provider here spreads this block, so one line turns brokering on
+  // for all seven. `gmail_mcp` and `drive_mcp` write their auth longhand and do
+  // not spread it, which is what keeps them bring-your-own — the SDK owns their
+  // exchange and `defineProvider` refuses a broker on an mcp connector.
+  broker: GOOGLE_BROKER,
 } as const;
 
 /**

--- a/src/providers/google/shared/oauth.ts
+++ b/src/providers/google/shared/oauth.ts
@@ -1,3 +1,6 @@
+import type { AuthBroker } from '#connectivity';
+import { brokerOriginOverride } from '#connectivity/auth/index.ts';
+
 /**
  * Google's OAuth endpoints, shared by every Google provider.
  *
@@ -26,11 +29,28 @@ export const GOOGLE_APP = 'google';
  * is not. What it costs is recorded in ADR-028 and in the guarantee table in
  * `docs/detailed/security.md` — chiefly that the exchange stops being local.
  */
-export const GOOGLE_BROKER = {
-  url: 'https://api.lanes.sh/v1/auth/link/google',
-  operator: 'Lanes',
-  docs_url: 'https://lanes.sh/link#google',
-} as const;
+const BROKER_ORIGIN = 'https://api.lanes.sh';
+const BROKER_PATH = '/v1/auth/link/google';
+
+/**
+ * The same client, reached at a different origin.
+ *
+ * Two callers need it: the CLI performing the first exchange and the dispatcher
+ * refreshing while it serves. Both read `manifest.auth.broker.url`, so building
+ * it once here is what keeps them from disagreeing about where the broker is —
+ * and what makes `LANES_LINK_BROKER_ORIGIN` reach both at once. The path stays
+ * fixed; only the host in front of it moves. See `../../../connectivity/auth/
+ * oauth-authcode/broker.ts` for what an override is allowed to be.
+ */
+export function googleBroker(env?: Record<string, string | undefined>): AuthBroker {
+  return {
+    url: `${brokerOriginOverride(env) ?? BROKER_ORIGIN}${BROKER_PATH}`,
+    operator: 'Lanes',
+    docs_url: 'https://lanes.sh/link#google',
+  };
+}
+
+export const GOOGLE_BROKER: AuthBroker = googleBroker();
 
 export const GOOGLE_OAUTH = {
   authorize_url: 'https://accounts.google.com/o/oauth2/v2/auth',

--- a/src/providers/google/shared/scopes.ts
+++ b/src/providers/google/shared/scopes.ts
@@ -14,6 +14,14 @@ import type { ScopeMeaning } from '../../scopes.ts';
  * here.
  */
 export const GOOGLE_SCOPE_MEANINGS: Record<string, ScopeMeaning> = {
+  // Asked for only when authorising against the client Lanes operates, which
+  // needs to tell one caller's refresh from another's. Neither reaches any
+  // Google service, and describing them matters precisely because they are the
+  // two the operator did not ask for.
+  openid: { meaning: 'a signed statement of which Google account this is — no access to anything' },
+  email: {
+    meaning: 'your address, so the hosted client can tell whose connection this is. Not the mailbox',
+  },
   'https://mail.google.com/': {
     meaning: 'full mailbox — read, send, and permanently delete any message',
     broad: true,

--- a/src/providers/google/shared/setup.ts
+++ b/src/providers/google/shared/setup.ts
@@ -4,11 +4,16 @@ import { GOOGLE_APP } from './oauth.ts';
  * The walkthrough every Google provider prints before asking for anything.
  *
  * Google requires a pre-registered OAuth client — even for Google's own MCP
- * servers. No architecture avoids that; it is their policy, and it is the one
- * piece of setup that could not be deleted.
+ * servers. That is their policy and no architecture avoids it, but it does not
+ * follow that *you* have to be the one to register it: since ADR-028 the client
+ * Lanes operates is the default, and this walkthrough is what `--own-client`
+ * opts into. It stays complete, because the people who need it — an
+ * organisation that forbids third-party clients, a Workspace "Internal" app —
+ * need all of it.
  *
  * Gmail and Drive share the `google` app, which is why `oauth_apps` exists:
- * every connection of a vendor authorises against the same registered client.
+ * every connection of a vendor authorises against the same registered client,
+ * and declaring that entry is also how a profile says it has one of its own.
  */
 export const googleSetup = (
   product: string,
@@ -32,7 +37,7 @@ export const googleSetup = (
       : ['gmail.googleapis.com', 'drive.googleapis.com']);
 
   return {
-    summary: `${product} needs a Google Cloud OAuth client that you register yourself. Lanes Link never operates one on your behalf — the credentials stay yours. This is asked once per profile and then covers every Google account you connect.`,
+    summary: `${product} signs in with Google. By default it authorises against the OAuth client Lanes operates, so there is nothing to register and no client secret on this machine — the code is exchanged for a token by the Lanes API, which holds that secret. Pass --own-client to register a client of your own instead; the steps below are that path, asked once per profile and then covering every Google account you connect.`,
     docs: 'docs/detailed/setup/google.md',
     docs_url: 'https://console.cloud.google.com/auth',
     steps: [

--- a/src/providers/setup/plan.test.ts
+++ b/src/providers/setup/plan.test.ts
@@ -97,3 +97,61 @@ describe('planAll', () => {
     expect(ids).toEqual([...ids].sort());
   });
 });
+
+describe('a provider whose client somebody else operates', () => {
+  const broker = { url: 'https://api.example.com/v1/auth/link/vendor', operator: 'Someone' };
+
+  const brokered = defineProvider({
+    id: 'vendor_mail',
+    name: 'Vendor Mail',
+    description: 'Mail.',
+    connector: { kind: 'http', base_url: 'https://api.test', openapi: './t.json' },
+    auth: {
+      kind: 'oauth',
+      registration: 'manual',
+      app: 'vendor',
+      scopes: ['a'],
+      authorize_url: 'https://accounts.example.com/o/oauth2/v2/auth',
+      token_url: 'https://oauth2.example.com/token',
+      broker,
+    },
+    setup: {
+      steps: ['Create a project', 'Copy the client id and secret'],
+      prompts: [
+        { key: 'client_id', label: 'Client id', credential_ref: 'vendor/client_id' },
+        { key: 'client_secret', label: 'Client secret', secret: true, credential_ref: 'vendor/client_secret' },
+      ],
+    },
+  });
+
+  test('needs nothing, and says the difference between that and needing nothing', () => {
+    const plan = planFor(brokered, { profile: 'personal', connections: [] });
+
+    expect(plan.requires).toEqual([]);
+    expect(plan.brokered).toBe(true);
+    expect(plan.clientOperator).toBe('Someone');
+    expect(plan.ownClientCommand).toBe(
+      'lanes link connect vendor_mail --profile personal --own-client',
+    );
+  });
+
+  test('a profile that has registered its own client is asked for it, as before', () => {
+    // Declaring the oauth_apps entry is the opt-out. Someone who has already
+    // taken it must not be told they need nothing and then asked for two values.
+    const plan = planFor(brokered, {
+      profile: 'personal',
+      connections: [],
+      ownClients: ['vendor'],
+    });
+
+    expect(plan.brokered).toBe(false);
+    expect(plan.requires.map((r) => r.ref)).toEqual(['vendor/client_id', 'vendor/client_secret']);
+    expect(plan.ownClientCommand).toBeUndefined();
+  });
+
+  test('the console walkthrough survives in the data for whoever still needs it', () => {
+    // Suppressing it is a rendering decision. A console with a disclosure and a
+    // terminal that heads it "or register your own" both need it present.
+    expect(planFor(brokered, { profile: 'personal', connections: [] }).steps).toHaveLength(2);
+  });
+});

--- a/src/providers/setup/plan.ts
+++ b/src/providers/setup/plan.ts
@@ -59,12 +59,28 @@ export interface ProviderPlan {
   readonly needsId: boolean;
   /** The one line that connects it. */
   readonly command: string;
+  /**
+   * The OAuth client is operated by somebody else, so `requires` is empty
+   * because there is nothing to register — not because setup is trivial.
+   */
+  readonly brokered: boolean;
+  /** Who operates that client, for the sentence shown before consent. */
+  readonly clientOperator?: string;
+  /** The line that opts out of it and registers one of your own instead. */
+  readonly ownClientCommand?: string;
 }
 
 export interface PlanContext {
   readonly profile: string;
   /** Every configured connection this caller may see, as `provider.id`. */
   readonly connections: readonly string[];
+  /**
+   * `oauth_apps` entries this profile declares.
+   *
+   * Which clients are the operator's own, so a profile that has registered one
+   * is described as needing it rather than as needing nothing.
+   */
+  readonly ownClients?: readonly string[];
 }
 
 export function planFor(
@@ -72,7 +88,12 @@ export function planFor(
   context: PlanContext,
   connectionId?: string,
 ): ProviderPlan {
-  const { requirements, needsId } = setupRequirements(manifest, connectionId, context.profile);
+  const { requirements, needsId, brokered } = setupRequirements(
+    manifest,
+    connectionId,
+    context.profile,
+    { ...(context.ownClients ? { ownClients: context.ownClients } : {}) },
+  );
 
   const connected = context.connections.filter((key) => key.startsWith(`${manifest.id}.`));
 
@@ -97,6 +118,16 @@ export function planFor(
     requires: requirements,
     needsId,
     command,
+    brokered,
+    ...(brokered && manifest.auth.kind === 'oauth' && manifest.auth.broker
+      ? {
+          clientOperator: manifest.auth.broker.operator,
+          // The steps stay in `steps` either way. A renderer decides whether to
+          // show a console walkthrough for a path nobody has asked for; the
+          // plan's job is to say the path exists and what opens it.
+          ownClientCommand: `${command} --own-client`,
+        }
+      : {}),
   };
 }
 

--- a/src/providers/setup/provider.ts
+++ b/src/providers/setup/provider.ts
@@ -49,6 +49,15 @@ export interface SetupProviderOptions {
   readonly profile: string;
   /** Sibling profile names on this endpoint. Names only; already at `/health`. */
   readonly profiles?: readonly string[];
+  /**
+   * `oauth_apps` entries this profile declares.
+   *
+   * Configuration, not a credential: it names which vendors this profile holds
+   * a client of its own for, never whether the client is stored. Reporting a
+   * provider as needing nothing when the profile has in fact registered one
+   * would send the owner to a command that then asks for two values.
+   */
+  readonly ownClients?: readonly string[];
   /** Every provider this build ships. Shipped code, identical for every caller. */
   readonly catalogue?: readonly ProviderManifest[];
   /**
@@ -71,6 +80,7 @@ export function createSetupProvider(options: SetupProviderOptions): ProviderDefi
   const context = () => ({
     profile: options.profile,
     connections: reachable().map((connection) => connection.key),
+    ...(options.ownClients ? { ownClients: options.ownClients } : {}),
   });
 
   return defineLocalProvider({
@@ -253,9 +263,20 @@ function renderProvider(plan: ProviderPlan): string {
     }
   }
 
-  if (plan.steps.length > 0) {
+  // A console walkthrough is withheld from this surface when it does not apply.
+  // A model handed nine steps it has no reason to relay will relay them, and
+  // the owner ends up registering a client they did not need.
+  if (plan.steps.length > 0 && !plan.brokered) {
     lines.push('', 'The owner does this first, in the vendor’s own console:');
     plan.steps.forEach((step, index) => lines.push(`  ${index + 1}. ${step}`));
+  }
+
+  if (plan.brokered) {
+    lines.push(
+      '',
+      `There is nothing to register: the OAuth client is operated by ${plan.clientOperator}, ` +
+        'and its secret never reaches this machine. The command below is the whole of it.',
+    );
   }
 
   // Labels, never the credential references they resolve to. The command below
@@ -277,6 +298,16 @@ function renderProvider(plan: ProviderPlan): string {
   }
 
   lines.push('', 'The command:', `  ${plan.command}`);
+
+  if (plan.brokered && plan.ownClientCommand) {
+    lines.push(
+      '',
+      'If the owner would rather use an OAuth client they register themselves — some ' +
+        'organisations require it — the same command takes --own-client and then asks for ' +
+        `the client id and secret:`,
+      `  ${plan.ownClientCommand}`,
+    );
+  }
 
   if (plan.browser) {
     lines.push(

--- a/src/registry/index.ts
+++ b/src/registry/index.ts
@@ -26,6 +26,7 @@ export {
   formatPlan,
   planIsNoop,
   planReconcile,
+  ownClientRefsFor,
   rotatableCredentialRefsFor,
   type AuthenticatingProviders,
   type ReconcileAction,

--- a/src/registry/reconcile.ts
+++ b/src/registry/reconcile.ts
@@ -61,6 +61,37 @@ export function rotatableCredentialRefsFor(
 }
 
 /**
+ * The OAuth client a revision signs its refreshes with, where the profile holds one.
+ *
+ * Read-only, and only for a profile that declares the entry: the client is the
+ * operator's, shared by every connection of that vendor, and ADR-026's line is
+ * that a revision rotates what is its own and never rewrites somebody else's.
+ * So this is deliberately *not* part of `rotatableCredentialRefsFor`.
+ *
+ * These were missing, and the failure was silent in the worst way. The
+ * gcp-secret-manager adapter answers `null` only on a 404 — an *unbound* secret
+ * is a 403, which throws — so a bring-your-own Google connection on Cloud Run
+ * would serve until its access token expired and then fail every call, an hour
+ * after the revision reported healthy. A profile that authorises against a
+ * broker declares no entry and so adds nothing here, which is the arrangement
+ * this is meant to leave alone.
+ *
+ * Here rather than in `#deployments` for the reason its sibling gives: that
+ * component cannot import `#connectivity`, and this needs the manifest.
+ */
+export function ownClientRefsFor(
+  manifest: ProviderManifest | undefined,
+  oauthApps: Readonly<Record<string, { client_id_ref: string; client_secret_ref: string }>>,
+): readonly string[] {
+  if (manifest?.auth.kind !== 'oauth' || manifest.auth.registration !== 'manual') return [];
+  const app = manifest.auth.app;
+  if (!app) return [];
+
+  const declared = oauthApps[app];
+  return declared ? [declared.client_id_ref, declared.client_secret_ref] : [];
+}
+
+/**
  * How to find a provider's manifest, so a missing `credential_ref` can derive.
  *
  * A lookup rather than a boolean: "does this authenticate" was never enough to


### PR DESCRIPTION
Connecting Gmail costs an operator nine console steps, and then a **weekly interruption forever**, because nobody publishes a personal project and Google expires refresh tokens after seven days for anything in "Testing". `doctor` grew a warning for it. `setup/google.md` grew a paragraph explaining the alternative was a verification review taking months.

That is not a policy anyone chose. It is what happens when the only two options are "the operator registers a client" and "the client secret ships in the binary" — and the second is not an option, because an installed application cannot hold a confidential client.

There is a third: somebody runs one, and performs the exchange.

```console
$ lanes link connect gmail                # browser opens, nothing to register
$ lanes link connect gmail --own-client   # the old path, still whole
```

## The shape

**The manifest does not choose — the profile does.** `auth.broker` is additive rather than a third `registration` value, because `registration: manual` stays true either way. Declaring `oauth_apps.<app>` means "I registered a client, use it"; leaving it out means "use the broker's". A manifest that claimed one or the other would be wrong half the time. `configSchema` is unchanged, so every existing profile is byte-identical.

**Which client minted a token is stamped on the token**, not read from config. A refresh token minted by one client is refused by another, so adding an `oauth_apps` entry six months from now does not drag existing connections onto it — reading the current config instead would turn an unrelated-looking config edit into `invalid_grant` on every connection at once.

One line in `GOOGLE_OAUTH` turns it on for all seven REST providers. `gmail_mcp` and `drive_mcp` stay bring-your-own with no edit, which `defineProvider` now enforces rather than leaves to chance.

## Eight commits, and the first four are inert

Nothing declares a broker until commit 7, so 1–4 leave every output byte-identical. Commit 3 is a pure split that makes room under the 400-line budget. Reviewable in order.

## Two things I'd want a second opinion on

**`security.md` loses a guarantee, in the same commit that causes it.** `credentials.exchange-is-local` becomes NOT-GUARANTEED for a brokered connection: the authorization code goes to the Lanes API, the refresh token comes back through it and passes through it again on every refresh, and *nothing in this repository can verify what that API does with what it sees*. CONTRIBUTING is explicit that a weakened guarantee changes in the same commit; I'd rather that row read too harshly than too kindly.

**A pre-existing bug fixed along the way.** `readableRefs` never bound the `oauth_apps` refs, and the gcp-secret-manager adapter answers `null` only on a 404 — an *unbound* secret is a 403 that throws. So a bring-your-own Google connection deployed to Cloud Run served until its access token expired and then failed every call, an hour after the revision reported healthy. Bound read-only, deliberately not rotatable, with a `grants.test.ts` case.

## Checks

`bun test` → **1517 pass, 2 skip, 0 fail** (was 1459). `bun run typecheck` clean. `src/architecture.test.ts` green: no vendor name reached `src/connectivity/`, nothing joined `KNOWN_LONG`, no real identifiers.

`lanes link setup plan gmail --json` on a scratch workspace: `brokered: true`, `requires: []`, `clientOperator: "Lanes"`, `ownClientCommand: "... --own-client"` — which is also what the unmerged `link-ui` console form will read.

`lanes link connect` itself grants scopes against a real account, so it is unrun here by design (CLAUDE.md).

## Depends on

lanes-sh/api#6, which is the broker. `GOOGLE_BROKER.url` points at it. Until that ships and the client is provisioned, `/config` answers 503 and `connect` refuses before opening a browser, naming `--own-client` as the way through.

ADR-028 amends ADR-005. It does not touch ADR-007 and is not ADR-025 — both stated explicitly, because "the endpoint calls a Lanes API" sounds like it might be.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
