### PR TITLE
Remove a profile, and everything it owns

### DIFF
--- a/docs/detailed/configuration.md
+++ b/docs/detailed/configuration.md
@@ -46,7 +46,11 @@ limits:
 # Also the switch. A provider whose manifest names a broker — every Google REST
 # provider does — authorises against the client that broker operates when there
 # is no entry here, and against yours when there is. Written for you by
-# "lanes link connect <provider> --own-client"; delete it to go back.
+# "lanes link connect <provider> --own-client". Deleting it is not enough to go
+# back: the client is also looked for in the credential store, so that a profile
+# whose config lost this block is not silently moved onto a different client and
+# left holding refresh tokens the new one refuses. Removing both is what
+# switches — see the lifecycle section below.
 oauth_apps:
   google:
     client_id_ref: google/client_id
@@ -122,6 +126,48 @@ Adding an `oauth_apps` entry later does not move an existing connection onto you
 client minted a refresh token is recorded with the token, because one client's refresh token is
 refused by another. Run `connect` again for any connection you want moved. See
 [ADR-028](adr/028-a-hosted-oauth-client-is-the-default.md).
+
+## Removing a profile
+
+```console
+$ lanes link profile remove work
+```
+
+It prints what it would delete, then asks you to type the profile name. `--dry-run` stops after the
+preview, `--yes` skips the prompt, and `--target <name>` decommissions one target while leaving the
+profile itself in place.
+
+What goes: the profile's config, and — in **every target it declares** — its credentials, state,
+audit log, provider blobs, and vault. For a target whose home is a bucket, the copy of the config a
+deployed revision reads goes too.
+
+What stays, and each for a reason:
+
+- **`skills/`** is workspace-wide. Every profile sees every skill, so one profile's removal has no
+  business taking them.
+- **`lanes-link.yaml`.** If it named this profile as `default_profile`, that key is cleared rather
+  than repointed at whatever remains — choosing a new default would silently change what every
+  other command in the workspace acts on.
+- **Infrastructure.** No Cloud Run service, bucket, or service account is touched. `deploy` created
+  those and can recreate them; removing them needs permissions this command should not hold.
+- **Credentials this profile does not declare.** In Secret Manager, references are flat names in
+  one project, so two profiles deployed to the same project share a namespace. Only what this
+  profile declares is deleted; anything else is listed in the preview and left alone.
+
+Removal is best effort. If a store cannot be reached — a project deleted, an expired login — the
+rest still goes, every survivor is named with the command that finishes it, and the exit code is
+non-zero. The profile's config is **kept** in that case, so nothing is stranded and the retry is the
+same command again.
+
+A deployed target is called out in the preview: the service keeps answering, and every call fails,
+because what it served is gone.
+
+### Going back to the hosted OAuth client
+
+This is the blunt instrument for it. The precise one is to remove the `oauth_apps` entry *and* the
+stored `google/client_id` and `google/client_secret` — both, because the client is looked for in the
+credential store as well as in config. Then run `connect` again for each account: a refresh token is
+only accepted by the client that minted it.
 
 ## Validation rules
 

--- a/docs/detailed/setup/google.md
+++ b/docs/detailed/setup/google.md
@@ -38,9 +38,14 @@ $ lanes link connect gmail --own-client
 
 It asks for a client id and secret, stores them, and writes an `oauth_apps` entry to your profile.
 That entry is the switch: once it is there, every Google connection on that profile uses your
-client and you never need the flag again. Delete it to go back to the hosted one — though existing
-connections keep refreshing against whichever client issued them, so moving one across means
-running `connect` for it again.
+client and you never need the flag again.
+
+Going back to the hosted one takes two steps, not one. Deleting the entry leaves the client id and
+secret in your credential store, and they still count — deliberately, so a profile whose config
+lost the block is not moved onto a different client and left holding refresh tokens the new one
+refuses. Remove the stored pair as well, or remove the profile
+([`../configuration.md`](../configuration.md)). Either way, existing connections keep refreshing
+against whichever client issued them, so moving one across means running `connect` for it again.
 
 Everything below is that path.
 
@@ -363,9 +368,10 @@ warn  gmail.personal credential is 8 days old — Testing-status apps expire at 
 
 If the weekly cycle becomes annoying, the escapes are:
 
-- **Use the hosted client** — drop `--own-client`, delete the `oauth_apps` entry from your profile,
-  and run `lanes link connect` again for each account. That client is published, so its refresh
-  tokens do not expire weekly.
+- **Use the hosted client** — drop `--own-client`, remove the `oauth_apps` entry *and* the stored
+  `google/client_id` and `google/client_secret` (both, for the reason above), then run
+  `lanes link connect` again for each account. That client is published, so its refresh tokens do
+  not expire weekly.
 - **Move those accounts to a Workspace domain** and use an Internal app — no expiry, no warning
   screen, no verification.
 - **Complete Google's verification** for your External app — weeks to months, and for restricted

--- a/src/cli/commands/profile/removal.test.ts
+++ b/src/cli/commands/profile/removal.test.ts
@@ -1,7 +1,14 @@
 import { describe, expect, test } from 'bun:test';
 import type { Config, TargetConfig } from '#profile';
+import type { SecretRef, SecretStore } from '#secrets';
+import type { BlobMetadata, BlobStore } from '#stores/blobs';
 import { buildRegistry } from '../../runtime/registry.ts';
-import { declaredRefs } from './removal.ts';
+import {
+  declaredRefs,
+  removalPlan,
+  type RemovalItem,
+  type RemovalPlan,
+} from './removal.ts';
 
 /**
  * Which credentials a profile may have its removal delete.
@@ -99,5 +106,143 @@ describe('declaredRefs', () => {
     expect(refs.filter((ref) => ref === 'google/client_id')).toHaveLength(1);
     expect(refs).toContain('gmail/a');
     expect(refs).toContain('drive/b');
+  });
+});
+
+// --- removalPlan -----------------------------------------------------------
+
+function fakeSecrets(refs: string[]): SecretStore {
+  const held = new Map(refs.map((ref) => [ref, 'value']));
+  return {
+    get: async (ref) => held.get(ref) ?? null,
+    set: async (ref, value) => void held.set(ref, value),
+    has: async (ref) => held.has(ref),
+    delete: async (ref) => void held.delete(ref),
+    list: async () => [...held.keys()] as SecretRef[],
+  };
+}
+
+function fakeBlobs(keys: string[]): BlobStore {
+  const held = new Set(keys);
+  return {
+    put: async (key) => void held.add(key),
+    get: async () => null,
+    has: async (key) => held.has(key),
+    delete: async (key) => void held.delete(key),
+    list: async () =>
+      [...held].map((key) => ({ key, size: 0, modifiedAt: new Date(0) })) as BlobMetadata[],
+  };
+}
+
+const ids = (plan: RemovalPlan, kind: RemovalItem['kind']): string[] =>
+  plan.items.filter((item) => item.kind === kind).map((item) => item.id);
+
+describe('removalPlan', () => {
+  test('plans every declared target, and the workspace items exactly once', async () => {
+    const two = config({
+      targets: { local: target(), cloud: target({ storage: { adapter: 'gcs', bucket: 'your-bucket' } } as never) },
+    } as never);
+
+    const plan = await removalPlan(two, '/ws', 'personal', registry, {
+      openSecrets: async () => fakeSecrets(['profile/token']),
+      openBlobs: async () => fakeBlobs(['state.kv/a']),
+    });
+
+    expect(plan.items.filter((i) => i.target === 'local')).not.toHaveLength(0);
+    expect(plan.items.filter((i) => i.target === 'cloud')).not.toHaveLength(0);
+    expect(ids(plan, 'config').filter((id) => !id.startsWith('profiles/'))).toHaveLength(1);
+  });
+
+  test('deletes secrets before blobs, because the file store is itself a blob', async () => {
+    // `layout.credentials(p)` is `data/<p>/credentials.enc`, inside the blob
+    // root `data/<p>`. Delete blobs first and the store the secret deletions
+    // read through is gone.
+    const plan = await removalPlan(config(), '/ws', 'personal', registry, {
+      openSecrets: async () => fakeSecrets(['profile/token']),
+      openBlobs: async () => fakeBlobs(['credentials.enc']),
+    });
+
+    const kinds = plan.items.filter((i) => i.target === 'local').map((i) => i.kind);
+    expect(kinds.indexOf('secret')).toBeLessThan(kinds.indexOf('blob'));
+  });
+
+  test('the local config is the last item, because it is the record of where things are', async () => {
+    const plan = await removalPlan(config(), '/ws', 'personal', registry, {
+      openSecrets: async () => fakeSecrets(['profile/token']),
+      openBlobs: async () => fakeBlobs(['a']),
+    });
+
+    expect(plan.items.at(-1)?.kind).toBe('config');
+  });
+
+  test('a ref the profile does not declare is reported, never planned', async () => {
+    const plan = await removalPlan(config(), '/ws', 'personal', registry, {
+      openSecrets: async () => fakeSecrets(['profile/token', 'gmail/someone_else']),
+      openBlobs: async () => fakeBlobs([]),
+    });
+
+    expect(ids(plan, 'secret')).toContain('profile/token');
+    expect(ids(plan, 'secret')).not.toContain('gmail/someone_else');
+    expect(plan.untouched.flatMap((u) => u.refs)).toContain('gmail/someone_else');
+  });
+
+  test('--target restricts to it, and leaves the profile itself alone', async () => {
+    const two = config({
+      targets: { local: target(), cloud: target() },
+    } as never);
+
+    const plan = await removalPlan(two, '/ws', 'personal', registry, {
+      target: 'cloud',
+      openSecrets: async () => fakeSecrets(['profile/token']),
+      openBlobs: async () => fakeBlobs(['a']),
+    });
+
+    expect(plan.items.every((item) => item.target === 'cloud')).toBe(true);
+    expect(ids(plan, 'config')).toHaveLength(0);
+    expect(ids(plan, 'workspace-key')).toHaveLength(0);
+  });
+
+  test('a deployed target warns that its endpoint keeps answering with nothing behind it', async () => {
+    const deployed = config({
+      targets: {
+        cloud: target({ deploy: { platform: 'cloudrun', project: 'my-project' } } as never),
+      },
+    } as never);
+
+    const plan = await removalPlan(deployed, '/ws', 'personal', registry, {
+      openSecrets: async () => fakeSecrets([]),
+      openBlobs: async () => fakeBlobs([]),
+    });
+
+    expect(plan.warnings.join(' ')).toMatch(/keep answering|still answer/i);
+  });
+
+  test('a store that cannot be opened warns, and the other target still plans', async () => {
+    const two = config({
+      targets: { local: target(), cloud: target() },
+    } as never);
+
+    const plan = await removalPlan(two, '/ws', 'personal', registry, {
+      openSecrets: async (name) => {
+        if (name === 'cloud') throw new Error('no credentials for this project');
+        return fakeSecrets(['profile/token']);
+      },
+      openBlobs: async () => fakeBlobs(['a']),
+    });
+
+    expect(plan.warnings.join(' ')).toMatch(/cloud/);
+    expect(plan.items.some((item) => item.target === 'local')).toBe(true);
+  });
+
+  test('skills are never planned — every profile sees them', async () => {
+    // The blob store is rooted at the profile's own tree, so workspace-wide
+    // skills are outside it by construction. Asserted because "shared by every
+    // profile" is exactly the thing a future refactor could quietly break.
+    const plan = await removalPlan(config(), '/ws', 'personal', registry, {
+      openSecrets: async () => fakeSecrets([]),
+      openBlobs: async () => fakeBlobs(['state.kv/a', 'audit.log/b']),
+    });
+
+    expect(plan.items.every((item) => !item.id.startsWith('skills/'))).toBe(true);
   });
 });

--- a/src/cli/commands/profile/removal.test.ts
+++ b/src/cli/commands/profile/removal.test.ts
@@ -6,6 +6,7 @@ import { buildRegistry } from '../../runtime/registry.ts';
 import {
   declaredRefs,
   removalPlan,
+  renderPlan,
   type RemovalItem,
   type RemovalPlan,
 } from './removal.ts';
@@ -244,5 +245,67 @@ describe('removalPlan', () => {
     });
 
     expect(plan.items.every((item) => !item.id.startsWith('skills/'))).toBe(true);
+  });
+});
+
+// --- renderPlan ------------------------------------------------------------
+
+function captured(body: () => void): string {
+  const write = process.stdout.write.bind(process.stdout);
+  let out = '';
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (process.stdout as any).write = (chunk: string) => ((out += chunk), true);
+  try {
+    body();
+  } finally {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (process.stdout as any).write = write;
+  }
+  return out;
+}
+
+const samplePlan = (over: Partial<RemovalPlan> = {}): RemovalPlan => ({
+  profile: 'personal',
+  items: [
+    { target: 'local', kind: 'secret', id: 'gmail/someone' },
+    { target: 'local', kind: 'blob', id: 'state.kv/a' },
+    { target: null, kind: 'config', id: '/ws/profiles/personal.yaml' },
+  ],
+  untouched: [],
+  warnings: [],
+  ...over,
+});
+
+describe('renderPlan', () => {
+  test('names the profile and groups what goes by target', () => {
+    const out = captured(() => renderPlan(samplePlan()));
+
+    expect(out).toContain('personal');
+    expect(out).toContain('local');
+    expect(out).toContain('gmail/someone');
+  });
+
+  test('says untouched refs are left alone, so they do not read as pending', () => {
+    const out = captured(() =>
+      renderPlan(samplePlan({ untouched: [{ target: 'cloud', refs: ['gmail/other'] }] })),
+    );
+
+    expect(out).toContain('gmail/other');
+    expect(out).toMatch(/left alone|not removed|leaves them/i);
+  });
+
+  test('prints every warning', () => {
+    const out = captured(() =>
+      renderPlan(samplePlan({ warnings: ['Target "cloud" is deployed.', 'Another thing.'] })),
+    );
+
+    expect(out).toContain('cloud');
+    expect(out).toContain('Another thing.');
+  });
+
+  test('an empty plan says so rather than printing a blank preview', () => {
+    const out = captured(() => renderPlan(samplePlan({ items: [] })));
+
+    expect(out).toMatch(/nothing/i);
   });
 });

--- a/src/cli/commands/profile/removal.test.ts
+++ b/src/cli/commands/profile/removal.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, test } from 'bun:test';
+import type { Config, TargetConfig } from '#profile';
+import { buildRegistry } from '../../runtime/registry.ts';
+import { declaredRefs } from './removal.ts';
+
+/**
+ * Which credentials a profile may have its removal delete.
+ *
+ * The question only looks trivial on a local target, where the profile owns a
+ * file and the file is the boundary. In Secret Manager every profile deployed
+ * to one project shares a flat namespace, so `list()` answers with other
+ * profiles' credentials too — and deleting those is not recoverable.
+ */
+
+const registry = buildRegistry();
+
+const target = (over: Partial<TargetConfig> = {}): TargetConfig =>
+  ({
+    credentials: { adapter: 'file' },
+    storage: { adapter: 'filesystem' },
+    ...over,
+  }) as unknown as TargetConfig;
+
+const config = (over: Partial<Config> = {}): Config =>
+  ({
+    contract: 1,
+    instance: { profile: 'personal', default_target: 'local' },
+    auth: { mode: 'bearer', token_ref: 'profile/token' },
+    oauth_apps: {
+      google: { client_id_ref: 'google/client_id', client_secret_ref: 'google/client_secret' },
+    },
+    connections: [{ id: 'someone', provider: 'gmail', account: 'someone@example.com' }],
+    targets: { local: target() },
+    policy: { allow: [] },
+    ...over,
+  }) as unknown as Config;
+
+describe('declaredRefs', () => {
+  test('covers the profile token, the connection, and the oauth client', () => {
+    const refs = declaredRefs(config(), registry, target());
+
+    expect(refs).toContain('profile/token');
+    expect(refs).toContain('gmail/someone');
+    expect(refs).toContain('google/client_id');
+    expect(refs).toContain('google/client_secret');
+  });
+
+  test('the vault ref comes from the target, because that is where it is declared', () => {
+    // `vaultTargetSchema` sits inside `targetSchema`. Two targets may seal the
+    // same profile's items in different places, so reading this off the profile
+    // would attach one target's vault to another's removal.
+    const sealed = target({ vault: { adapter: 'secret', ref: 'vault/document' } } as never);
+
+    expect(declaredRefs(config(), registry, sealed)).toContain('vault/document');
+    expect(declaredRefs(config(), registry, target())).not.toContain('vault/document');
+  });
+
+  test('a secret adapter with no ref falls back to the documented default', () => {
+    const sealed = target({ vault: { adapter: 'secret' } } as never);
+
+    expect(declaredRefs(config(), registry, sealed)).toContain('vault/document');
+  });
+
+  test('a connection whose provider no longer resolves contributes nothing', () => {
+    // Its secret is reported as untouched rather than guessed at. A guessed
+    // `<provider>/<id>` in a shared namespace could name someone else's.
+    const gone = config({
+      connections: [{ id: 'x', provider: 'no_such_provider', account: 'x' }],
+    } as never);
+
+    const refs = declaredRefs(gone, registry, target());
+
+    expect(refs).not.toContain('no_such_provider/x');
+    expect(refs).toContain('profile/token');
+  });
+
+  test('an explicit credential_ref still counts when the manifest is gone', () => {
+    // `credentialRefFor` is the single authority: the manifest answers first,
+    // and the connection's own field is the answer when it gives none.
+    const explicit = config({
+      connections: [
+        { id: 'x', provider: 'no_such_provider', account: 'x', credential_ref: 'mything/api_key' },
+      ],
+    } as never);
+
+    expect(declaredRefs(explicit, registry, target())).toContain('mything/api_key');
+  });
+
+  test('returns each ref once, even when two connections share a client', () => {
+    const two = config({
+      connections: [
+        { id: 'a', provider: 'gmail', account: 'a@example.com' },
+        { id: 'b', provider: 'drive', account: 'b@example.com' },
+      ],
+    } as never);
+
+    const refs = declaredRefs(two, registry, target());
+
+    expect(refs.filter((ref) => ref === 'google/client_id')).toHaveLength(1);
+    expect(refs).toContain('gmail/a');
+    expect(refs).toContain('drive/b');
+  });
+});

--- a/src/cli/commands/profile/removal.ts
+++ b/src/cli/commands/profile/removal.ts
@@ -1,0 +1,63 @@
+import type { Config, TargetConfig } from '#profile';
+import { credentialRefFor, ownClientRefsFor, type ProviderRegistry } from '#registry';
+
+/**
+ * What a profile's removal is allowed to delete, worked out before any of it
+ * happens.
+ *
+ * Everything here is a read. The plan is a value, and the preview an operator
+ * confirms from is that value rendered — which is what stops what they were
+ * shown and what runs from drifting apart. `../../../deployments/driver.ts`
+ * gives the same reason for the same shape.
+ */
+
+/**
+ * The credential references this profile declares, and only those.
+ *
+ * Locally the profile is the boundary: its credentials are a file inside its own
+ * directory, and deleting the directory is the whole operation. In Secret
+ * Manager they are flat names in one project, so two profiles deployed to the
+ * same project share a namespace and `list()` hands back the other one's as
+ * readily as its own. Deriving from what this profile declares is the only
+ * answer that cannot delete something that was never ours, and a secret deleted
+ * in the wrong project is not recoverable.
+ *
+ * The cost is that a genuinely orphaned ref — one whose connection was removed
+ * from config long ago — is not derivable and so is not deleted. The caller
+ * reports those rather than guessing, which is the honest position: a guess
+ * here is indistinguishable from another profile's credential.
+ */
+export function declaredRefs(
+  config: Config,
+  registry: ProviderRegistry,
+  declared: TargetConfig,
+): string[] {
+  const refs = new Set<string>([config.auth.token_ref]);
+
+  // Read off the *target*, not the profile. `vaultTargetSchema` sits inside
+  // `targetSchema`, so two targets may seal the same profile's items in
+  // different places; taking it from the profile would attach one target's
+  // vault to another target's removal.
+  if (declared.vault?.adapter === 'secret') {
+    refs.add(declared.vault.ref ?? 'vault/document');
+  }
+
+  for (const connection of config.connections) {
+    const manifest = registry.manifest(connection.provider);
+
+    // `credentialRefFor` rather than `credentialRefForConnection`: it is the
+    // single authority on where a connection's credential lives, and it exists
+    // because two callers once derived the answer differently and disagreed.
+    // Asking the lower-level one here would open that gap again from a third
+    // side — and it would miss a `local` provider, whose only ref is the one
+    // the connection declares itself.
+    const ref = credentialRefFor(connection, manifest);
+    if (ref) refs.add(ref);
+
+    if (manifest) {
+      for (const own of ownClientRefsFor(manifest, config.oauth_apps)) refs.add(own);
+    }
+  }
+
+  return [...refs];
+}

--- a/src/cli/commands/profile/removal.ts
+++ b/src/cli/commands/profile/removal.ts
@@ -1,4 +1,4 @@
-import { profilePath, type Config, type TargetConfig } from '#profile';
+import { layout, profilePath, type Config, type TargetConfig } from '#profile';
 import type { SecretStore } from '#secrets';
 import type { BlobStore } from '#stores/blobs';
 import { credentialRefFor, ownClientRefsFor, type ProviderRegistry } from '#registry';
@@ -146,6 +146,20 @@ export async function removalPlan(
       warnings.push(
         `Target "${name}": its storage could not be opened (${reason(cause)}), so nothing in it will be removed.`,
       );
+    }
+
+    // The blob store's root is the profile's own directory, and an adapter must
+    // never delete the root it was configured with — so emptying it leaves the
+    // directory. `layout.ts` frames that directory as the unit ("rm -r
+    // data/work is exactly remove the work profile's data"), and one left
+    // behind is silently reused by a later `profile add` of the same name.
+    if (declared.storage.adapter === 'filesystem') {
+      items.push({
+        target: name,
+        kind: 'file',
+        id: declared.storage.path ?? layout.blobs(profile),
+        note: 'the profile directory, once emptied',
+      });
     }
 
     // A deployed revision reads its config from the bucket rather than the

--- a/src/cli/commands/profile/removal.ts
+++ b/src/cli/commands/profile/removal.ts
@@ -2,6 +2,7 @@ import { profilePath, type Config, type TargetConfig } from '#profile';
 import type { SecretStore } from '#secrets';
 import type { BlobStore } from '#stores/blobs';
 import { credentialRefFor, ownClientRefsFor, type ProviderRegistry } from '#registry';
+import { print, style, warn } from '../../output.ts';
 
 /**
  * What a profile's removal is allowed to delete, worked out before any of it
@@ -186,4 +187,52 @@ export async function removalPlan(
   }
 
   return { profile, items, untouched, warnings };
+}
+
+const KIND_LABEL: Record<RemovalItem['kind'], string> = {
+  secret: 'credential',
+  blob: 'object',
+  file: 'file',
+  config: 'config',
+  'workspace-key': 'workspace',
+};
+
+/**
+ * The plan, as the thing an operator decides from.
+ *
+ * Rendered from the same value that is executed, so there is no second
+ * description of the work to fall out of step with the first. It prints
+ * references and keys and never a value — the plan holds no values to print.
+ */
+export function renderPlan(plan: RemovalPlan): void {
+  print();
+  print(`Removing profile ${style.bold(plan.profile)} would delete:`);
+  print();
+
+  if (plan.items.length === 0) {
+    print(style.dim('  nothing — there is no trace of this profile left to remove.'));
+  }
+
+  const targets = [...new Set(plan.items.map((item) => item.target))];
+  for (const target of targets) {
+    const items = plan.items.filter((item) => item.target === target);
+    print(`  ${style.bold(target ?? 'workspace')}`);
+    for (const item of items) {
+      const note = item.note ? style.dim(` — ${item.note}`) : '';
+      print(`    ${KIND_LABEL[item.kind].padEnd(10)} ${item.id}${note}`);
+    }
+    print();
+  }
+
+  for (const { target, refs } of plan.untouched) {
+    // Named rather than counted, because the operator is the only one who can
+    // tell an orphan from another profile's live credential — and this command
+    // deliberately will not guess.
+    print(`  ${style.bold(target)}: present but not declared by this profile, so left alone`);
+    for (const ref of refs) print(style.dim(`    ${ref}`));
+    print();
+  }
+
+  for (const warning of plan.warnings) print(warn(warning));
+  if (plan.warnings.length > 0) print();
 }

--- a/src/cli/commands/profile/removal.ts
+++ b/src/cli/commands/profile/removal.ts
@@ -1,4 +1,6 @@
-import type { Config, TargetConfig } from '#profile';
+import { profilePath, type Config, type TargetConfig } from '#profile';
+import type { SecretStore } from '#secrets';
+import type { BlobStore } from '#stores/blobs';
 import { credentialRefFor, ownClientRefsFor, type ProviderRegistry } from '#registry';
 
 /**
@@ -60,4 +62,128 @@ export function declaredRefs(
   }
 
   return [...refs];
+}
+
+export interface RemovalItem {
+  /** `null` for a workspace-level item — the config file, the default-profile key. */
+  readonly target: string | null;
+  readonly kind: 'secret' | 'blob' | 'file' | 'config' | 'workspace-key';
+  readonly id: string;
+  readonly note?: string;
+}
+
+export interface RemovalPlan {
+  readonly profile: string;
+  readonly items: readonly RemovalItem[];
+  /** Present in a target's store, not declared by this profile. Left alone. */
+  readonly untouched: readonly { readonly target: string; readonly refs: readonly string[] }[];
+  readonly warnings: readonly string[];
+}
+
+export interface PlanOptions {
+  /** Restrict to one target. The profile itself then survives. */
+  readonly target?: string | undefined;
+  readonly openSecrets: (target: string) => Promise<SecretStore>;
+  readonly openBlobs: (target: string, area?: string) => Promise<BlobStore>;
+  readonly readDefaultProfile?: (() => Promise<string | undefined>) | undefined;
+}
+
+const reason = (cause: unknown): string => (cause instanceof Error ? cause.message : String(cause));
+
+/**
+ * Everything removing this profile would delete, before any of it is deleted.
+ *
+ * Read-only. A store that will not open becomes a warning rather than a throw,
+ * because a target whose project is gone must not be able to strand a profile
+ * on the machine forever — and the operator sees that warning in the preview,
+ * before they confirm, rather than discovering it half way through.
+ */
+export async function removalPlan(
+  config: Config,
+  root: string,
+  profile: string,
+  registry: ProviderRegistry,
+  options: PlanOptions,
+): Promise<RemovalPlan> {
+  const items: RemovalItem[] = [];
+  const untouched: { target: string; refs: string[] }[] = [];
+  const warnings: string[] = [];
+
+  const names = options.target ? [options.target] : Object.keys(config.targets);
+
+  for (const name of names) {
+    const declared = config.targets[name];
+    if (!declared) {
+      warnings.push(`Target "${name}" is not declared by this profile, so nothing was planned.`);
+      continue;
+    }
+
+    // Secrets first, and this ordering is load-bearing rather than tidy:
+    // `layout.credentials(p)` is `data/<p>/credentials.enc`, *inside* the blob
+    // root `data/<p>`. For the file adapter the credential store is itself a
+    // blob, so blobs-first would delete the store the secret deletions read
+    // through and turn every one of them into a failure.
+    try {
+      const secrets = await options.openSecrets(name);
+      const present = await secrets.list();
+      const mine = new Set(declaredRefs(config, registry, declared));
+
+      for (const ref of present) if (mine.has(ref)) items.push({ target: name, kind: 'secret', id: ref });
+
+      const theirs = present.filter((ref) => !mine.has(ref));
+      if (theirs.length > 0) untouched.push({ target: name, refs: theirs });
+    } catch (cause) {
+      warnings.push(
+        `Target "${name}": its credential store could not be opened (${reason(cause)}), so nothing in it will be removed.`,
+      );
+    }
+
+    try {
+      const blobs = await options.openBlobs(name);
+      for (const blob of await blobs.list()) items.push({ target: name, kind: 'blob', id: blob.key });
+    } catch (cause) {
+      warnings.push(
+        `Target "${name}": its storage could not be opened (${reason(cause)}), so nothing in it will be removed.`,
+      );
+    }
+
+    // A deployed revision reads its config from the bucket rather than the
+    // image (ADR-023), so that copy is the profile too — and it is outside the
+    // profile's blob tree, which is why it needs its own area.
+    if (declared.storage.adapter === 'gcs' || declared.storage.adapter === 's3') {
+      items.push({
+        target: name,
+        kind: 'config',
+        id: `profiles/${profile}.yaml`,
+        note: 'the copy a deployed revision reads',
+      });
+    }
+
+    // `deploy` only: the schema folds the deprecated `cloudrun` block into it,
+    // so the resolved config has one answer rather than two that could differ.
+    if (declared.deploy) {
+      warnings.push(
+        `Target "${name}" is deployed. The service will keep answering, and every call will fail, because what it served is gone. Tearing it down is not part of this.`,
+      );
+    }
+  }
+
+  // Only when the whole profile is going. With `--target` it still exists.
+  if (!options.target) {
+    const defaultProfile = await options.readDefaultProfile?.();
+    if (defaultProfile === profile) {
+      items.push({
+        target: null,
+        kind: 'workspace-key',
+        id: 'default_profile',
+        note: 'cleared, not repointed at whatever remains',
+      });
+    }
+
+    // Last. It is the only record of where everything else lives, so a failure
+    // before this point leaves data a later run can still find.
+    items.push({ target: null, kind: 'config', id: profilePath(root, profile) });
+  }
+
+  return { profile, items, untouched, warnings };
 }

--- a/src/cli/commands/profile/remove.test.ts
+++ b/src/cli/commands/profile/remove.test.ts
@@ -76,6 +76,7 @@ function deps(over: Partial<RunDeps> = {}): RunDeps & { removedConfig: string[];
     openSecrets: async () => store(['gmail/someone']),
     openBlobs: async () => blobs(['state.kv/a']),
     removeConfig: async (path: string) => void removedConfig.push(path),
+    removeDirectory: async (path: string) => void removedConfig.push(path),
     clearDefaultProfile: async () => void (cleared += 1),
     ...over,
   } as RunDeps & { removedConfig: string[]; cleared: number };

--- a/src/cli/commands/profile/remove.test.ts
+++ b/src/cli/commands/profile/remove.test.ts
@@ -2,7 +2,12 @@ import { describe, expect, test } from 'bun:test';
 import type { SecretRef, SecretStore } from '#secrets';
 import type { BlobMetadata, BlobStore } from '#stores/blobs';
 import type { RemovalItem, RemovalPlan } from './removal.ts';
-import { executeRemoval, type RunDeps } from './remove.ts';
+import {
+  executeRemoval,
+  renderOutcome,
+  type RemovalOutcome,
+  type RunDeps,
+} from './remove.ts';
 
 /**
  * Performing a removal, and being honest about the parts that did not happen.
@@ -178,5 +183,103 @@ describe('executeRemoval', () => {
     );
 
     expect(opened).toBe(1);
+  });
+});
+
+// --- renderOutcome ---------------------------------------------------------
+
+function captured(body: () => void): { out: string; err: string } {
+  const outWrite = process.stdout.write.bind(process.stdout);
+  const errWrite = process.stderr.write.bind(process.stderr);
+  let out = '';
+  let err = '';
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (process.stdout as any).write = (chunk: string) => ((out += chunk), true);
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (process.stderr as any).write = (chunk: string) => ((err += chunk), true);
+  try {
+    body();
+  } finally {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (process.stdout as any).write = outWrite;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (process.stderr as any).write = errWrite;
+  }
+  return { out, err };
+}
+
+const outcome = (over: Partial<RemovalOutcome> = {}): RemovalOutcome => ({
+  profile: 'personal',
+  results: [{ item: item({ kind: 'secret', id: 'gmail/someone' }), status: 'removed' }],
+  survived: 0,
+  ...over,
+});
+
+describe('renderOutcome', () => {
+  test('a clean run says so, and leaves the exit code alone', () => {
+    const before = process.exitCode;
+    const { out } = captured(() => renderOutcome(outcome()));
+
+    expect(out).toMatch(/personal/);
+    expect(process.exitCode).toBe(before);
+  });
+
+  test('a survivor is named with the command that finishes it', () => {
+    const { out } = captured(() =>
+      renderOutcome(
+        outcome({
+          results: [
+            {
+              item: item({ kind: 'secret', id: 'a/one' }),
+              status: 'failed',
+              error: 'permission denied',
+              retry: 'gcloud secrets delete a__one --project my-project',
+            },
+          ],
+          survived: 1,
+        }),
+      ),
+    );
+
+    expect(out).toContain('a/one');
+    expect(out).toContain('permission denied');
+    expect(out).toContain('gcloud secrets delete a__one');
+
+    process.exitCode = 0;
+  });
+
+  test('anything surviving sets a non-zero exit code', () => {
+    // Silence would read as success to a script, and the thing left behind is
+    // a live credential.
+    process.exitCode = 0;
+    captured(() =>
+      renderOutcome(
+        outcome({
+          results: [{ item: item({ kind: 'secret', id: 'a/one' }), status: 'failed' }],
+          survived: 1,
+        }),
+      ),
+    );
+
+    expect(process.exitCode).toBe(1);
+    process.exitCode = 0;
+  });
+
+  test('a kept config says the removal can simply be run again', () => {
+    process.exitCode = 0;
+    const { out } = captured(() =>
+      renderOutcome(
+        outcome({
+          results: [
+            { item: item({ kind: 'secret', id: 'a/one' }), status: 'failed', error: 'nope' },
+            { item: item({ target: null, kind: 'config', id: '/ws/p.yaml' }), status: 'kept' },
+          ],
+          survived: 2,
+        }),
+      ),
+    );
+
+    expect(out).toMatch(/again|re-run|rerun/i);
+    process.exitCode = 0;
   });
 });

--- a/src/cli/commands/profile/remove.test.ts
+++ b/src/cli/commands/profile/remove.test.ts
@@ -1,8 +1,10 @@
 import { describe, expect, test } from 'bun:test';
 import type { SecretRef, SecretStore } from '#secrets';
 import type { BlobMetadata, BlobStore } from '#stores/blobs';
+import type { Prompter } from '../../prompt.ts';
 import type { RemovalItem, RemovalPlan } from './removal.ts';
 import {
+  confirmedByName,
   executeRemoval,
   renderOutcome,
   type RemovalOutcome,
@@ -281,5 +283,51 @@ describe('renderOutcome', () => {
 
     expect(out).toMatch(/again|re-run|rerun/i);
     process.exitCode = 0;
+  });
+});
+
+// --- confirmedByName -------------------------------------------------------
+
+function prompter(answer: string, interactive = true): Prompter & { asked: string[] } {
+  const asked: string[] = [];
+  return {
+    asked,
+    interactive,
+    ask: async (question: string) => {
+      asked.push(question);
+      return answer;
+    },
+    askSecret: async () => '',
+    confirm: async () => true,
+  };
+}
+
+describe('confirmedByName', () => {
+  test('--yes proceeds without asking anything', async () => {
+    const p = prompter('');
+
+    expect(await confirmedByName('personal', { yes: true, prompter: p })).toBe(true);
+    expect(p.asked).toHaveLength(0);
+  });
+
+  test('refuses when there is nobody to ask, and says how to proceed', async () => {
+    // Fails closed. The same shape `agreed()` uses, for the same reason: a
+    // non-interactive run must not be able to default its way into a deletion.
+    await expect(
+      confirmedByName('personal', { prompter: prompter('personal', false) }),
+    ).rejects.toThrow(/--yes/);
+  });
+
+  test('the wrong name does not proceed', async () => {
+    expect(await confirmedByName('personal', { prompter: prompter('persona') })).toBe(false);
+  });
+
+  test('the exact name proceeds', async () => {
+    expect(await confirmedByName('personal', { prompter: prompter('personal') })).toBe(true);
+  });
+
+  test('surrounding whitespace is forgiven, a different name is not', async () => {
+    expect(await confirmedByName('personal', { prompter: prompter('  personal \n') })).toBe(true);
+    expect(await confirmedByName('personal', { prompter: prompter('work') })).toBe(false);
   });
 });

--- a/src/cli/commands/profile/remove.test.ts
+++ b/src/cli/commands/profile/remove.test.ts
@@ -1,0 +1,182 @@
+import { describe, expect, test } from 'bun:test';
+import type { SecretRef, SecretStore } from '#secrets';
+import type { BlobMetadata, BlobStore } from '#stores/blobs';
+import type { RemovalItem, RemovalPlan } from './removal.ts';
+import { executeRemoval, type RunDeps } from './remove.ts';
+
+/**
+ * Performing a removal, and being honest about the parts that did not happen.
+ *
+ * Best effort by choice: a target whose project has been deleted must not be
+ * able to strand a profile on the machine forever. The price is that a failed
+ * deletion leaves a live credential behind, so everything here is about making
+ * that visible and recoverable rather than quiet.
+ */
+
+function store(refs: string[] = [], failOn?: string): SecretStore & { deleted: string[] } {
+  const held = new Map(refs.map((ref) => [ref, 'value']));
+  const deleted: string[] = [];
+  return {
+    deleted,
+    get: async (ref) => held.get(ref) ?? null,
+    set: async () => {},
+    has: async (ref) => held.has(ref),
+    delete: async (ref) => {
+      if (ref === failOn) throw new Error('permission denied');
+      deleted.push(ref);
+      held.delete(ref);
+    },
+    list: async () => [...held.keys()] as SecretRef[],
+  };
+}
+
+function blobs(keys: string[] = [], failOn?: string): BlobStore & { deleted: string[] } {
+  const held = new Set(keys);
+  const deleted: string[] = [];
+  return {
+    deleted,
+    put: async () => {},
+    get: async () => null,
+    has: async (key) => held.has(key),
+    delete: async (key) => {
+      if (key === failOn) throw new Error('bucket is gone');
+      deleted.push(key);
+      held.delete(key);
+    },
+    list: async () =>
+      [...held].map((key) => ({ key, size: 0, modifiedAt: new Date(0) })) as BlobMetadata[],
+  };
+}
+
+const item = (over: Partial<RemovalItem>): RemovalItem =>
+  ({ target: 'local', kind: 'secret', id: 'gmail/someone', ...over }) as RemovalItem;
+
+const plan = (items: RemovalItem[]): RemovalPlan => ({
+  profile: 'personal',
+  items,
+  untouched: [],
+  warnings: [],
+});
+
+function deps(over: Partial<RunDeps> = {}): RunDeps & { removedConfig: string[]; cleared: number } {
+  const removedConfig: string[] = [];
+  let cleared = 0;
+  return {
+    removedConfig,
+    get cleared() {
+      return cleared;
+    },
+    openSecrets: async () => store(['gmail/someone']),
+    openBlobs: async () => blobs(['state.kv/a']),
+    removeConfig: async (path: string) => void removedConfig.push(path),
+    clearDefaultProfile: async () => void (cleared += 1),
+    ...over,
+  } as RunDeps & { removedConfig: string[]; cleared: number };
+}
+
+describe('executeRemoval', () => {
+  test('removes every item when every store accepts', async () => {
+    const d = deps();
+    const outcome = await executeRemoval(
+      plan([
+        item({ kind: 'secret', id: 'gmail/someone' }),
+        item({ kind: 'blob', id: 'state.kv/a' }),
+        item({ target: null, kind: 'config', id: '/ws/profiles/personal.yaml' }),
+      ]),
+      d,
+    );
+
+    expect(outcome.survived).toBe(0);
+    expect(outcome.results.every((r) => r.status === 'removed')).toBe(true);
+    expect(d.removedConfig).toContain('/ws/profiles/personal.yaml');
+  });
+
+  test('a failing delete does not stop the ones after it', async () => {
+    const secrets = store(['a/one', 'a/two'], 'a/one');
+    const outcome = await executeRemoval(
+      plan([item({ kind: 'secret', id: 'a/one' }), item({ kind: 'secret', id: 'a/two' })]),
+      deps({ openSecrets: async () => secrets }),
+    );
+
+    expect(outcome.survived).toBe(1);
+    expect(secrets.deleted).toContain('a/two');
+    expect(outcome.results[0]?.status).toBe('failed');
+    expect(outcome.results[0]?.error).toMatch(/permission denied/);
+  });
+
+  test('a survivor carries the command that finishes the job by hand', async () => {
+    const outcome = await executeRemoval(
+      plan([item({ kind: 'secret', id: 'a/one' })]),
+      deps({
+        openSecrets: async () => store(['a/one'], 'a/one'),
+        retry: () => 'gcloud secrets delete a__one --project my-project',
+      }),
+    );
+
+    expect(outcome.results[0]?.retry).toContain('gcloud secrets delete');
+  });
+
+  test('the config is kept when anything survived, so the command can be re-run', async () => {
+    // Config-last exists because it is the only record of where everything
+    // lives. Deleting it after a failure would strand exactly the credential
+    // that failed — the operator would be left with a live secret and nothing
+    // that knows where it is. Keeping it makes the retry `profile remove`.
+    const d = deps({ openSecrets: async () => store(['a/one'], 'a/one') });
+    const outcome = await executeRemoval(
+      plan([
+        item({ kind: 'secret', id: 'a/one' }),
+        item({ target: null, kind: 'workspace-key', id: 'default_profile' }),
+        item({ target: null, kind: 'config', id: '/ws/profiles/personal.yaml' }),
+      ]),
+      d,
+    );
+
+    expect(d.removedConfig).toHaveLength(0);
+    expect(d.cleared).toBe(0);
+    expect(outcome.results.filter((r) => r.status === 'kept')).toHaveLength(2);
+  });
+
+  test('deleting what is already gone is removal, not failure', async () => {
+    // The GCP adapter treats a 404 as a no-op on purpose; a second run of the
+    // same removal should report success rather than invent a problem.
+    const outcome = await executeRemoval(
+      plan([item({ kind: 'secret', id: 'not/there' })]),
+      deps({ openSecrets: async () => store([]) }),
+    );
+
+    expect(outcome.survived).toBe(0);
+  });
+
+  test('a store that will not open fails its items and spares the rest', async () => {
+    const outcome = await executeRemoval(
+      plan([
+        item({ target: 'cloud', kind: 'secret', id: 'a/one' }),
+        item({ target: 'local', kind: 'blob', id: 'state.kv/a' }),
+      ]),
+      deps({
+        openSecrets: async () => {
+          throw new Error('no credentials for this project');
+        },
+      }),
+    );
+
+    expect(outcome.results[0]?.status).toBe('failed');
+    expect(outcome.results[1]?.status).toBe('removed');
+  });
+
+  test('opens each store once, however many items it holds', async () => {
+    let opened = 0;
+    const shared = store(['a/one', 'a/two']);
+    await executeRemoval(
+      plan([item({ kind: 'secret', id: 'a/one' }), item({ kind: 'secret', id: 'a/two' })]),
+      deps({
+        openSecrets: async () => {
+          opened += 1;
+          return shared;
+        },
+      }),
+    );
+
+    expect(opened).toBe(1);
+  });
+});

--- a/src/cli/commands/profile/remove.ts
+++ b/src/cli/commands/profile/remove.ts
@@ -1,0 +1,122 @@
+import type { SecretStore } from '#secrets';
+import type { BlobStore } from '#stores/blobs';
+import type { RemovalItem, RemovalPlan } from './removal.ts';
+
+/**
+ * Performing a removal, and being honest about the parts that did not happen.
+ *
+ * Best effort by choice: a target whose project has been deleted must not be
+ * able to strand a profile on the machine forever, so one refusal does not stop
+ * the rest. The price is real — a deletion that fails leaves a live credential
+ * behind — and everything here exists to make that visible rather than quiet.
+ */
+
+export interface RemovalResult {
+  readonly item: RemovalItem;
+  /** `kept` is deliberate: not attempted, because something before it failed. */
+  readonly status: 'removed' | 'failed' | 'kept';
+  readonly error?: string;
+  /** The exact command that finishes this one by hand. */
+  readonly retry?: string;
+}
+
+export interface RemovalOutcome {
+  readonly profile: string;
+  readonly results: readonly RemovalResult[];
+  /** How many items are still there. Non-zero means a credential is still live. */
+  readonly survived: number;
+}
+
+export interface RunDeps {
+  openSecrets: (target: string) => Promise<SecretStore>;
+  openBlobs: (target: string, area?: string) => Promise<BlobStore>;
+  removeConfig: (path: string) => Promise<void>;
+  clearDefaultProfile: () => Promise<void>;
+  retry?: ((item: RemovalItem, cause: string) => string | undefined) | undefined;
+}
+
+const reason = (cause: unknown): string => (cause instanceof Error ? cause.message : String(cause));
+
+/** The items that only make sense once everything else is actually gone. */
+const isRecordOfWhereThingsAre = (item: RemovalItem): boolean =>
+  item.target === null && (item.kind === 'config' || item.kind === 'workspace-key');
+
+export async function executeRemoval(
+  plan: RemovalPlan,
+  deps: RunDeps,
+): Promise<RemovalOutcome> {
+  const results: RemovalResult[] = [];
+  let failed = 0;
+
+  // One store per target, however many items it holds. Opening a Secret
+  // Manager client per secret would turn a tidy removal into a rate limit.
+  const secrets = new Map<string, Promise<SecretStore>>();
+  const blobs = new Map<string, Promise<BlobStore>>();
+
+  const secretStore = (target: string): Promise<SecretStore> => {
+    const existing = secrets.get(target) ?? deps.openSecrets(target);
+    secrets.set(target, existing);
+    return existing;
+  };
+
+  const blobStore = (target: string, area?: string): Promise<BlobStore> => {
+    const key = `${target}:${area ?? ''}`;
+    const existing = blobs.get(key) ?? deps.openBlobs(target, area);
+    blobs.set(key, existing);
+    return existing;
+  };
+
+  for (const item of plan.items) {
+    // The config is the only record of where everything else lives. Deleting it
+    // after a failure would strand precisely the credential that failed: still
+    // live, and nothing left that knows where it is. Keeping it means the retry
+    // is this same command rather than a hand-assembled console session.
+    if (failed > 0 && isRecordOfWhereThingsAre(item)) {
+      results.push({ item, status: 'kept' });
+      continue;
+    }
+
+    try {
+      switch (item.kind) {
+        case 'secret':
+          await (await secretStore(item.target!)).delete(item.id);
+          break;
+
+        case 'blob':
+          await (await blobStore(item.target!)).delete(item.id);
+          break;
+
+        case 'config':
+          if (item.target === null) await deps.removeConfig(item.id);
+          else {
+            // `profiles/<name>.yaml` in the target's bucket — outside the
+            // profile's blob tree, so it needs its own area.
+            const [area, ...rest] = item.id.split('/');
+            await (await blobStore(item.target, area)).delete(rest.join('/'));
+          }
+          break;
+
+        case 'workspace-key':
+          await deps.clearDefaultProfile();
+          break;
+
+        case 'file':
+          await deps.removeConfig(item.id);
+          break;
+      }
+
+      results.push({ item, status: 'removed' });
+    } catch (cause) {
+      const error = reason(cause);
+      const retry = deps.retry?.(item, error);
+      failed += 1;
+      results.push({ item, status: 'failed', error, ...(retry ? { retry } : {}) });
+    }
+  }
+
+  return {
+    profile: plan.profile,
+    results,
+    survived: results.filter((result) => result.status !== 'removed').length,
+  };
+}

--- a/src/cli/commands/profile/remove.ts
+++ b/src/cli/commands/profile/remove.ts
@@ -1,5 +1,6 @@
 import type { SecretStore } from '#secrets';
 import type { BlobStore } from '#stores/blobs';
+import { fail, ok, print, style } from '../../output.ts';
 import type { RemovalItem, RemovalPlan } from './removal.ts';
 
 /**
@@ -119,4 +120,52 @@ export async function executeRemoval(
     results,
     survived: results.filter((result) => result.status !== 'removed').length,
   };
+}
+
+/**
+ * What happened, and what is still out there.
+ *
+ * The exit code is the load-bearing part. Best effort means the command can
+ * finish having left a live credential behind, and to a script silence is
+ * indistinguishable from success — so anything that survived makes this exit
+ * non-zero, and names itself with the command that finishes it.
+ */
+export function renderOutcome(outcome: RemovalOutcome): void {
+  const removed = outcome.results.filter((result) => result.status === 'removed');
+  const failed = outcome.results.filter((result) => result.status === 'failed');
+  const kept = outcome.results.filter((result) => result.status === 'kept');
+
+  print();
+  if (outcome.survived === 0) {
+    print(ok(`Removed profile ${style.bold(outcome.profile)} — ${removed.length} item(s).`));
+    print();
+    return;
+  }
+
+  print(
+    fail(
+      `Removed ${removed.length} item(s) of profile ${style.bold(outcome.profile)}, and ${failed.length} refused.`,
+    ),
+  );
+  print();
+
+  for (const result of failed) {
+    print(`  ${result.item.id}`);
+    if (result.error) print(style.dim(`    ${result.error}`));
+    if (result.retry) print(style.dim(`    finish it with: ${result.retry}`));
+  }
+  print();
+
+  if (kept.length > 0) {
+    // Said plainly, because the alternative reading — that the profile is
+    // half-gone and needs unpicking by hand — is the one an operator will
+    // assume from a failure report.
+    print(
+      `The profile's config was kept, so nothing is stranded: fix the above and run the same command again.`,
+    );
+    print();
+  }
+
+  // A live credential left behind must not look like success to a script.
+  process.exitCode = 1;
 }

--- a/src/cli/commands/profile/remove.ts
+++ b/src/cli/commands/profile/remove.ts
@@ -1,5 +1,7 @@
 import type { SecretStore } from '#secrets';
 import type { BlobStore } from '#stores/blobs';
+import { ConfigError } from '#profile';
+import { terminalPrompter, type Prompter } from '../../prompt.ts';
 import { fail, ok, print, style } from '../../output.ts';
 import type { RemovalItem, RemovalPlan } from './removal.ts';
 
@@ -168,4 +170,47 @@ export function renderOutcome(outcome: RemovalOutcome): void {
 
   // A live credential left behind must not look like success to a script.
   process.exitCode = 1;
+}
+
+/**
+ * The confirmation, which asks for the name rather than a keystroke.
+ *
+ * A step up from `agreed()`, deliberately. That helper is `y/N` and is right
+ * for `vault remove`, which drops one item the operator can put back. This
+ * drops every live OAuth refresh token a profile holds, and putting those back
+ * means visiting each vendor again — so the gesture should be one you cannot
+ * make by leaning on the keyboard.
+ *
+ * Local rather than shared for the same reason it is not `agreed()`: the shape
+ * differs, and bending the existing helper for a single caller in another
+ * command folder would leave both worse. If a second consumer appears, promote
+ * it then.
+ */
+export async function confirmedByName(
+  profile: string,
+  options: { yes?: boolean | undefined; prompter?: Prompter | undefined },
+): Promise<boolean> {
+  if (options.yes) return true;
+
+  // A prompter that was passed in is the caller's answer to "is there anyone
+  // to ask" — the console passes one that replays a form. Only the default
+  // needs stdin consulted, and conflating the two makes an injected prompter
+  // untestable and a real terminal the only place this works.
+  const prompter = options.prompter ?? terminalPrompter;
+  const someoneToAsk = options.prompter ? prompter.interactive : process.stdin.isTTY;
+
+  if (!someoneToAsk) {
+    throw new ConfigError(
+      `Removing "${profile}" cannot be undone, and stdin is not a terminal, so there is nobody to ask. Pass --yes to proceed.`,
+    );
+  }
+
+  const typed = (await prompter.ask(`Type ${profile} to remove it, or anything else to stop: `))
+    .trim();
+
+  if (typed !== profile) {
+    print(style.dim('  cancelled — nothing was removed'));
+    return false;
+  }
+  return true;
 }

--- a/src/cli/commands/profile/remove.ts
+++ b/src/cli/commands/profile/remove.ts
@@ -1,9 +1,24 @@
 import type { SecretStore } from '#secrets';
 import type { BlobStore } from '#stores/blobs';
-import { ConfigError } from '#profile';
+import {
+  ConfigError,
+  WORKSPACE_FILE,
+  readWorkspace,
+  readWorkspaceFile,
+  workspaceFiles,
+  writeWorkspaceFile,
+} from '#profile';
+import { parseDocument } from 'yaml';
 import { terminalPrompter, type Prompter } from '../../prompt.ts';
-import { fail, ok, print, style } from '../../output.ts';
-import type { RemovalItem, RemovalPlan } from './removal.ts';
+import { announce, emit, fail, ok, print, style } from '../../output.ts';
+import {
+  buildRegistryWithWorkspace,
+  openBlobStoreFor,
+  openSecretStoreFor,
+  resolveProfile,
+  type GlobalFlags,
+} from '../../runtime.ts';
+import { removalPlan, renderPlan, type RemovalItem, type RemovalPlan } from './removal.ts';
 
 /**
  * Performing a removal, and being honest about the parts that did not happen.
@@ -213,4 +228,83 @@ export async function confirmedByName(
     return false;
   }
   return true;
+}
+
+export interface RemoveFlags extends GlobalFlags {
+  readonly dryRun?: boolean | undefined;
+  readonly yes?: boolean | undefined;
+  readonly json?: boolean | undefined;
+  /** Injected by a caller that has already asked — the console, and tests. */
+  readonly prompter?: Prompter | undefined;
+}
+
+/**
+ * `lanes link profile remove <name>` — the profile, and everything it owns.
+ *
+ * Deliberately not reachable from MCP. This writes credentials and mutates
+ * config, which ADR-007 keeps CLI-only, and it is the most destructive thing
+ * in the tool.
+ */
+export async function removeProfile(name: string, flags: RemoveFlags): Promise<void> {
+  const { resolution, config } = await resolveProfile({ ...flags, profile: name });
+  announce(resolution);
+
+  const root = resolution.workspaceRoot;
+  const registry = await buildRegistryWithWorkspace(root);
+  const files = workspaceFiles(root);
+
+  const plan = await removalPlan(config, root, name, registry, {
+    target: flags.target,
+    openSecrets: (target) => openSecretStoreFor(config, root, target),
+    openBlobs: (target, area) => openBlobStoreFor(config, root, target, area),
+    readDefaultProfile: async () => (await readWorkspace(root))?.default_profile,
+  });
+
+  renderPlan(plan);
+
+  if (flags.dryRun) {
+    print(style.dim('  --dry-run: nothing was removed, and no store was written to.'));
+    print();
+    return emit(flags.json, plan, () => {});
+  }
+
+  if (!(await confirmedByName(name, { yes: flags.yes, prompter: flags.prompter }))) return;
+
+  const outcome = await executeRemoval(plan, {
+    openSecrets: (target) => openSecretStoreFor(config, root, target),
+    openBlobs: (target, area) => openBlobStoreFor(config, root, target, area),
+    removeConfig: async (path) => await files.delete(relativeToRoot(root, path)),
+    clearDefaultProfile: async () => await clearDefault(root),
+    retry: retryCommand,
+  });
+
+  return emit(flags.json, outcome, () => renderOutcome(outcome));
+}
+
+/** `profiles/<name>.yaml`, however the path was spelled for display. */
+function relativeToRoot(root: string, path: string): string {
+  const at = path.indexOf('profiles/');
+  return at === -1 ? path.replace(`${root}/`, '') : path.slice(at);
+}
+
+/**
+ * Clear the key, never repoint it.
+ *
+ * Choosing a new default on the operator's behalf would silently change what
+ * every other command in that workspace acts on — the one thing a removal
+ * should not decide for them.
+ */
+async function clearDefault(root: string): Promise<void> {
+  const text = await readWorkspaceFile(workspaceFiles(root), WORKSPACE_FILE);
+  if (text === null) return;
+
+  const document = parseDocument(text);
+  document.delete('default_profile');
+  await writeWorkspaceFile(workspaceFiles(root), WORKSPACE_FILE, String(document));
+}
+
+/** The command that finishes a refusal by hand, where one can be named. */
+function retryCommand(item: RemovalItem): string | undefined {
+  if (item.kind !== 'secret') return undefined;
+  return `lanes link profile remove <name> --target ${item.target} # or delete ${item.id} in that store`;
 }

--- a/src/cli/commands/profile/remove.ts
+++ b/src/cli/commands/profile/remove.ts
@@ -6,9 +6,11 @@ import {
   readWorkspace,
   readWorkspaceFile,
   workspaceFiles,
+  workspacePath,
   writeWorkspaceFile,
 } from '#profile';
 import { parseDocument } from 'yaml';
+import { rm } from 'node:fs/promises';
 import { terminalPrompter, type Prompter } from '../../prompt.ts';
 import { announce, emit, fail, ok, print, style } from '../../output.ts';
 import {
@@ -49,6 +51,8 @@ export interface RunDeps {
   openSecrets: (target: string) => Promise<SecretStore>;
   openBlobs: (target: string, area?: string) => Promise<BlobStore>;
   removeConfig: (path: string) => Promise<void>;
+  /** The emptied profile directory. A blob delete cannot remove a directory. */
+  removeDirectory: (path: string) => Promise<void>;
   clearDefaultProfile: () => Promise<void>;
   retry?: ((item: RemovalItem, cause: string) => string | undefined) | undefined;
 }
@@ -119,7 +123,7 @@ export async function executeRemoval(
           break;
 
         case 'file':
-          await deps.removeConfig(item.id);
+          await deps.removeDirectory(item.id);
           break;
       }
 
@@ -274,6 +278,7 @@ export async function removeProfile(name: string, flags: RemoveFlags): Promise<v
     openSecrets: (target) => openSecretStoreFor(config, root, target),
     openBlobs: (target, area) => openBlobStoreFor(config, root, target, area),
     removeConfig: async (path) => await files.delete(relativeToRoot(root, path)),
+    removeDirectory: async (path) => await rm(workspacePath(root, path), { recursive: true, force: true }),
     clearDefaultProfile: async () => await clearDefault(root),
     retry: retryCommand,
   });

--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -16,6 +16,7 @@ import {
   tokenShow,
 } from './commands/operate.ts';
 import { profileAdd, profileDefault, profileList } from './commands/profile.ts';
+import { removeProfile as profileRemove } from './commands/profile/remove.ts';
 import { targetList, targetShow, targetUse } from './commands/target.ts';
 import { setupPlan } from './commands/setup.ts';
 import { mcpAdd, mcpList, mcpStdio, skillDocument } from './commands/mcp.ts';
@@ -101,6 +102,18 @@ export async function run(argv: readonly string[]): Promise<void> {
         case 'default':
           if (!rest[0]) throw new Error(`Usage: ${PROGRAM} profile default <name>`);
           return profileDefault(rest[0]);
+        case 'remove':
+          if (!rest[0]) {
+            throw new Error(
+              `Usage: ${PROGRAM} profile remove <name> [--target t] [--dry-run] [--yes]`,
+            );
+          }
+          return profileRemove(rest[0], {
+            ...global,
+            json,
+            dryRun: flags['dry-run'] === true,
+            yes: flags['yes'] === true,
+          });
         default:
           throw new Error(`Unknown: ${PROGRAM} profile ${second}`);
       }

--- a/src/cli/runtime.ts
+++ b/src/cli/runtime.ts
@@ -18,6 +18,7 @@
 
 export {
   ensureProfileToken,
+  openBlobStoreFor,
   openSecretStoreFor,
   ownerPrincipal,
   resolveProfile,

--- a/src/cli/runtime/select.test.ts
+++ b/src/cli/runtime/select.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, test } from 'bun:test';
+import { mkdtemp } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import type { Config } from '#profile';
+import { openBlobStoreFor } from './select.ts';
+
+/**
+ * Opening one target's stores, without opening a runtime.
+ *
+ * `openSecretStoreFor` exists because two callers need exactly this much and a
+ * full runtime would fail on the part neither uses. Removal is the third, and
+ * it needs the blob store for the same reason: it enumerates a target's objects
+ * and never dispatches a call.
+ */
+
+const config = (): Config =>
+  ({
+    contract: 1,
+    instance: { profile: 'personal', default_target: 'local' },
+    targets: {
+      local: {
+        credentials: { adapter: 'file' },
+        storage: { adapter: 'filesystem' },
+      },
+    },
+    connections: [],
+    policy: { allow: [] },
+  }) as unknown as Config;
+
+async function workspace(): Promise<string> {
+  return await mkdtemp(join(tmpdir(), 'lanes-link-select-'));
+}
+
+describe('openBlobStoreFor', () => {
+  test('opens the target storage, rooted where the layout says', async () => {
+    const root = await workspace();
+
+    const store = await openBlobStoreFor(config(), root, 'local');
+    await store.put('note.txt', new TextEncoder().encode('x'));
+
+    expect((await store.list()).map((blob) => blob.key)).toContain('note.txt');
+  });
+
+  test('an area reaches a root other than the profile’s own', async () => {
+    // `profiles` is where a deployed revision reads its config from (ADR-023),
+    // and it is outside the profile's blob tree — so removing the remote copy
+    // needs a store that is not rooted at `data/<profile>`.
+    const root = await workspace();
+
+    const own = await openBlobStoreFor(config(), root, 'local');
+    const elsewhere = await openBlobStoreFor(config(), root, 'local', 'profiles');
+
+    await own.put('a.txt', new TextEncoder().encode('x'));
+
+    expect((await elsewhere.list()).map((blob) => blob.key)).not.toContain('a.txt');
+  });
+
+  test('refuses a target the profile does not declare', async () => {
+    const root = await workspace();
+
+    await expect(openBlobStoreFor(config(), root, 'cloud')).rejects.toThrow(/cloud/);
+  });
+});

--- a/src/cli/runtime/select.test.ts
+++ b/src/cli/runtime/select.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from 'bun:test';
 import { mkdtemp } from 'node:fs/promises';
+import { existsSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import type { Config } from '#profile';
@@ -54,6 +55,22 @@ describe('openBlobStoreFor', () => {
     await own.put('a.txt', new TextEncoder().encode('x'));
 
     expect((await elsewhere.list()).map((blob) => blob.key)).not.toContain('a.txt');
+  });
+
+  test('a declared storage path wins over the layout default', async () => {
+    // Layout entries are defaults, and `layout.ts` says so: a profile that
+    // declares its own paths keeps them. Removal enumerates whatever the store
+    // is rooted at, so assuming `data/<profile>/` would quietly half-remove
+    // any profile that declares somewhere else.
+    const root = await workspace();
+    const declared = config();
+    (declared.targets['local'] as { storage: { path?: string } }).storage.path = 'elsewhere/mine';
+
+    const store = await openBlobStoreFor(declared, root, 'local');
+    await store.put('note.txt', new TextEncoder().encode('x'));
+
+    expect(existsSync(join(root, 'elsewhere/mine/note.txt'))).toBe(true);
+    expect(existsSync(join(root, 'data/personal/note.txt'))).toBe(false);
   });
 
   test('refuses a target the profile does not declare', async () => {

--- a/src/cli/runtime/select.ts
+++ b/src/cli/runtime/select.ts
@@ -1,5 +1,6 @@
 import { generateProfileToken, ownerPrincipal } from '#auth';
 import type { SecretStore } from '#secrets';
+import type { BlobStore } from '#stores/blobs';
 import {
   loadProfileConfig,
   resolveSelection,
@@ -8,7 +9,7 @@ import {
   type Config,
   type Resolution,
 } from '#profile';
-import { openSecrets } from '#deployments/target.ts';
+import { openSecrets, openStorage } from '#deployments/target.ts';
 
 /**
  * Which profile and target a command acts on, and the credentials that go with
@@ -79,6 +80,32 @@ export async function openSecretStoreFor(
   const declared = config.targets[target];
   if (!declared) throw undeclaredTarget(target, config);
   return openSecrets({ declared, config, root, target });
+}
+
+/**
+ * One target's blob store, for a caller with no use for a runtime.
+ *
+ * The sibling of `openSecretStoreFor` above, and here for the reason this file
+ * already gives: removal enumerates a target's objects and never dispatches a
+ * call, so a registry and a reconcile would only add parts that can fail.
+ *
+ * `area` reaches a root other than the profile's own. The default is the
+ * profile's blob tree; `profiles` is where a deployed revision reads its config
+ * from (ADR-023), which lives outside that tree and still belongs to the
+ * profile being removed.
+ */
+export async function openBlobStoreFor(
+  config: Config,
+  root: string,
+  target: string,
+  area?: string,
+): Promise<BlobStore> {
+  const declared = config.targets[target];
+  if (!declared) throw undeclaredTarget(target, config);
+
+  const input = { declared, config, root, target };
+  const storage = await openStorage(input, await openSecrets(input));
+  return area === undefined ? storage() : storage(area);
 }
 
 /** Mint the profile token if it does not exist yet. Returns it either way. */

--- a/src/cli/usage.ts
+++ b/src/cli/usage.ts
@@ -40,6 +40,8 @@ ${style.bold('Profiles')}
   ${PROGRAM} profile add <name> [--default] [--json]
   ${PROGRAM} profile list [--json]
   ${PROGRAM} profile default <name>
+  ${PROGRAM} profile remove <name> [--target t] [--dry-run] [--yes] [--json]
+                                 the profile, its credentials, and its data
 
 ${style.bold('Targets')}
   ${PROGRAM} target list [--urls]      where this profile can run, and which one is in play

--- a/src/deployments/adapters/filesystem.test.ts
+++ b/src/deployments/adapters/filesystem.test.ts
@@ -1,5 +1,6 @@
 import { afterAll, describe, expect, test } from 'bun:test';
 import { mkdtemp, readdir, rm, stat, writeFile } from 'node:fs/promises';
+import { existsSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { describeBlobStoreContract, type ContractBlobStore } from '#stores/blobs/conformance.ts';
@@ -122,5 +123,35 @@ describe('what the bytes are readable by', () => {
     // The sidecar too — it lands beside the blob and took the same default.
     expect((await stat(join(directory, 'a.md'))).mode & 0o777).toBe(0o600);
     expect((await stat(join(directory, 'a.md.meta'))).mode & 0o777).toBe(0o600);
+  });
+});
+
+describe('deleting the last object under a prefix', () => {
+  test('leaves no empty directory behind', async () => {
+    // An object store has no directories: `a/b/c.txt` is one flat key, and
+    // removing it leaves nothing called `a/b`. This adapter emulates that
+    // interface, so an empty directory surviving a delete is a filesystem
+    // artifact leaking through — visible as a `data/<profile>` that outlives
+    // the profile whose objects it held.
+    const root = await mkdtemp(join(tmpdir(), 'lanes-link-fs-'));
+    const store = createFilesystemBlobStore({ root });
+
+    await store.put('deep/nested/thing.txt', new TextEncoder().encode('x'));
+    await store.delete('deep/nested/thing.txt');
+
+    expect(existsSync(join(root, 'deep/nested'))).toBe(false);
+    expect(existsSync(join(root, 'deep'))).toBe(false);
+    expect(existsSync(root)).toBe(true);
+  });
+
+  test('keeps a directory that still holds something', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'lanes-link-fs-'));
+    const store = createFilesystemBlobStore({ root });
+
+    await store.put('shared/gone.txt', new TextEncoder().encode('x'));
+    await store.put('shared/stays.txt', new TextEncoder().encode('y'));
+    await store.delete('shared/gone.txt');
+
+    expect(existsSync(join(root, 'shared/stays.txt'))).toBe(true);
   });
 });

--- a/src/deployments/adapters/filesystem.ts
+++ b/src/deployments/adapters/filesystem.ts
@@ -1,4 +1,4 @@
-import { mkdir, readdir, readFile, rename, rm, stat, writeFile } from 'node:fs/promises';
+import { mkdir, readdir, readFile, rename, rm, rmdir, stat, writeFile } from 'node:fs/promises';
 import { existsSync } from 'node:fs';
 import { dirname, join, relative, resolve, sep } from 'node:path';
 import type { BlobKey, BlobMetadata, BlobStore } from '#stores/blobs';
@@ -20,6 +20,31 @@ export interface FilesystemBlobStoreOptions {
 
 export function createFilesystemBlobStore(options: FilesystemBlobStoreOptions): BlobStore {
   const root = resolve(options.root);
+
+  /**
+   * Remove directories a delete has just emptied, up to but never including
+   * the root.
+   *
+   * An object store has no directories: `a/b/c.txt` is one flat key, and
+   * removing it leaves nothing called `a/b`. This adapter emulates that
+   * interface, so a surviving empty directory is a filesystem artifact leaking
+   * through it — and the one that matters is `data/<profile>`, which would
+   * otherwise outlive the profile whose objects it held.
+   *
+   * `rmdir` rather than a recursive remove, and the error swallowed: it fails
+   * when the directory is not empty, which is exactly the signal to stop.
+   */
+  const pruneEmptyParents = async (directory: string): Promise<void> => {
+    let current = directory;
+    while (current.startsWith(root) && current !== root) {
+      try {
+        await rmdir(current);
+      } catch {
+        return;
+      }
+      current = dirname(current);
+    }
+  };
 
   /**
    * Resolve a key to an absolute path, refusing anything that lands outside
@@ -85,6 +110,7 @@ export function createFilesystemBlobStore(options: FilesystemBlobStoreOptions): 
       const path = pathFor(key);
       await rm(path, { force: true });
       await rm(`${path}.meta`, { force: true });
+      await pruneEmptyParents(dirname(path));
     },
 
     async list(prefix) {


### PR DESCRIPTION
`lanes link profile remove <name>` deletes a profile's config and, in every target it declares, its
credentials, state, audit log, provider blobs, and vault.

## Why

There was no way to remove a profile, or anything a profile holds. `remove`/`forget` exist for
`memory`, `skills`, and `vault` — the owner's own content — and nowhere else.

The gap surfaced while moving a profile from its own Google OAuth client to the hosted one from
ADR-028. Three documents said the switch is "delete the `oauth_apps` entry". It is not:
`resolveOAuthClient` also consults the credential store, and `client.test.ts` has always pinned it —
*"a client sitting in the store counts, even with the config block gone"*. That check is deliberate,
so the fix is the documentation, and all three places now name both steps.

## What it does

```console
$ lanes link profile remove work [--target t] [--dry-run] [--yes] [--json]
```

Prints what it would delete, then asks you to **type the profile name** — a step up from the
`y/N` of `vault remove`, which drops one recoverable item; this drops every live refresh token a
profile holds.

**Stays, each for a reason:** `skills/` (workspace-wide, shared by every profile) · `lanes-link.yaml`
(`default_profile` is *cleared*, never repointed — choosing a new default would silently change what
every other command acts on) · infrastructure (no Cloud Run service, bucket, or service account) ·
**credentials this profile does not declare**.

That last one is the sharpest edge. In Secret Manager, refs are flat names in one project, so two
profiles deployed to the same project share a namespace and `list()` returns both. Refs are derived
from what the profile declares — via `credentialRefFor`, the documented single authority — and
anything else is shown in the preview as left alone.

## Design notes

**Plan then execute**, mirroring `deployments/driver.ts`. The preview *is* the plan value rendered,
so what you confirm and what runs cannot drift; `--dry-run` is an early return and `--json` is
serialisation.

**Secrets before blobs**, per target. `layout.credentials(p)` is `data/<p>/credentials.enc`, *inside*
the blob root — for the file adapter the credential store is itself a blob, so blobs-first would
destroy the store the secret deletions read through.

**Best effort, with one refinement.** A target whose project is gone must not strand a profile
forever, so one refusal does not stop the rest. But config-last plus best-effort taken literally
gives the worst outcome available: a credential that failed to delete, then deletion of the only
file recording where it lives. So a failure leaves the config untouched — reported as `kept` — and
the retry is this same command. Anything surviving sets a non-zero exit code.

## Verification

1570 pass, 2 skip, 0 fail (baseline 1530). `bun run typecheck` clean. Architecture guard green.

Exercised end to end against a scratch workspace: profile and its directory gone, `default_profile`
cleared rather than repointed, other profiles and workspace skills untouched, non-TTY without
`--yes` refuses having touched nothing.

Two defects found by that verification, both fixed here:

- The filesystem blob store left every directory a delete emptied. An object store has no
  directories, so a surviving empty one is an artifact leaking through an interface emulating object
  storage.
- That could not fix `data/<profile>` itself, which *is* the store's configured root — an adapter
  must never delete its own root. The plan names the directory explicitly instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)