### PR TITLE
Make token rotation, refresh revocation, and the authentication edge behave as documented

### DIFF
--- a/docs/detailed/deployment-cloudrun.md
+++ b/docs/detailed/deployment-cloudrun.md
@@ -512,7 +512,9 @@ $ docker run --rm -p 8080:8080 \
 ## Troubleshooting
 
 **`No profile token at "profile/token"`** — the container refuses to invent one. Run
-`lanes link token rotate --target cloud`, then redeploy or let the next request hit a fresh instance.
+`lanes link token rotate --target cloud`. A running revision re-reads within five seconds, so
+neither a redeploy nor a fresh instance is needed; it used to be, because the value was cached for
+the life of the process.
 
 **`PERMISSION_DENIED: Permission "secretmanager.versions.access" denied`** — the revision's service
 account is missing `roles/secretmanager.secretAccessor`. The adapter passes Google's message through

--- a/docs/detailed/init.md
+++ b/docs/detailed/init.md
@@ -612,7 +612,7 @@ Each validates the resulting document before writing, so the file is never left 
 ```
 lanes link connect gmail.side                  # re-authorises one existing account
 lanes link connect gmail.side --add write      # widening scope needs browser re-consent
-lanes link token show [--show] | lanes link token rotate
+lanes link token show [--show] | lanes link token rotate [--show]
 lanes link secrets push --from local --to cloud
 ```
 

--- a/docs/detailed/security.md
+++ b/docs/detailed/security.md
@@ -91,6 +91,7 @@ limitation. `RESERVED` names a compatibility slot with no implementation.
 | `transport.stateless` | ENFORCED | restart-mid-session test |
 | `credentials.encrypted-at-rest` | ENFORCED (file adapter) | nothing readable on disk; tamper detection |
 | `profile.isolated` | ENFORCED | cross-profile token, state, and audit tests, plus `src/cli/runtime/scoping.test.ts` for the owner layer. Two things were shared until [ADR-030](adr/030-a-profile-owns-its-skills-and-manifests.md) — skills and provider manifests, both at the workspace root — so this row was previously true of credentials, state and the log rather than of everything a profile holds |
+| `oauth.refresh-replay-revokes-the-chain` | ENFORCED | a spent refresh token is tombstoned rather than deleted, so presenting it again is detectable; the whole family goes, tested over real HTTP in `src/server/oauth.test.ts`. A client retrying and a thief replaying are indistinguishable, and re-authorising is the cheaper mistake |
 | `token.rotation-takes-effect` | ENFORCED **within a five-second window** | `src/auth/index.test.ts` covers both halves against a real credential store: the replacement is accepted on its first call, and the rotated-away token stops working once the window passes. Both caches are dropped together — the authenticator's and the credential store's — because dropping only one re-reads the same stale value |
 | `limits.per-profile` | ENFORCED per instance | rate limit tests |
 | `audit.every-invocation` | ENFORCED **with two documented exceptions** | see below |

--- a/docs/detailed/security.md
+++ b/docs/detailed/security.md
@@ -91,6 +91,7 @@ limitation. `RESERVED` names a compatibility slot with no implementation.
 | `transport.stateless` | ENFORCED | restart-mid-session test |
 | `credentials.encrypted-at-rest` | ENFORCED (file adapter) | nothing readable on disk; tamper detection |
 | `profile.isolated` | ENFORCED | cross-profile token, state, and audit tests, plus `src/cli/runtime/scoping.test.ts` for the owner layer. Two things were shared until [ADR-030](adr/030-a-profile-owns-its-skills-and-manifests.md) — skills and provider manifests, both at the workspace root — so this row was previously true of credentials, state and the log rather than of everything a profile holds |
+| `token.rotation-takes-effect` | ENFORCED **within a five-second window** | `src/auth/index.test.ts` covers both halves against a real credential store: the replacement is accepted on its first call, and the rotated-away token stops working once the window passes. Both caches are dropped together — the authenticator's and the credential store's — because dropping only one re-reads the same stale value |
 | `limits.per-profile` | ENFORCED per instance | rate limit tests |
 | `audit.every-invocation` | ENFORCED **with two documented exceptions** | see below |
 | `credentials.client-secret-never-local` | ENFORCED (hosted client) | there is no client secret on the machine to hold. `resolveSecretRefs` grants no client reference at all for a connection authorised this way, asserted in `src/dispatch/context.test.ts` |
@@ -185,6 +186,10 @@ weekly schedule — so `invalid_grant` is detected specifically and the error na
 
 - **Bearer tokens are bearer authorization.** Anyone holding the profile token is the principal.
   Tokens are not bound to a device. Revocation means rotating the token and reconciling.
+  A running endpoint notices a rotation within five seconds rather than instantly: the expected
+  value is cached for that long so the common case is a comparison rather than a decrypt. The
+  replacement works immediately — a token that does not match a cached value forces a re-read
+  before it is rejected, which is what makes the rotated-in credential usable on its first call.
 - **Agent config files are a real exposure.** MCP client configuration often sits in plaintext on
   disk, so a token is roughly as protected as that file.
 - **One token per profile.** Two agents cannot hold different permissions against the same profile;

--- a/docs/detailed/security.md
+++ b/docs/detailed/security.md
@@ -130,6 +130,17 @@ per profile, which registers a client of their own and keeps the exchange betwee
 Google. Declaring `oauth_apps` in a profile is the same choice expressed in config, and a profile
 that declares it is never moved off it.
 
+### Failed authentication is logged, not audited
+
+A refusal record needs a principal, and failing authentication is precisely not having one — so a
+rejected credential cannot be an audit row without inventing a caller to attribute it to. It goes to
+the endpoint's operational log instead: stderr for `lanes link start`, stdout for the container,
+where Cloud Run collects it. The line names the reason (`invalid`, `malformed`, `missing`,
+`not_configured`) and never the value presented.
+
+This is a change. The warning was written from the start and every caller passed a logger whose
+methods were empty, so on a public URL a sustained probe left no trace anywhere.
+
 ### The documented exceptions to `audit.every-invocation`
 
 Every call that reaches dispatch is audited, allowed or denied. A call naming a **capability that

--- a/docs/detailed/security.md
+++ b/docs/detailed/security.md
@@ -206,6 +206,9 @@ weekly schedule — so `invalid_grant` is detected specifically and the error na
   token. It does mean an unauthenticated caller can write rows, so the list is capped at 200 and the
   oldest without a live token are evicted — a connector in use is never dropped to make room.
 - **Rate limits are per instance.** On a horizontally scaled deployment they are not global.
+  This now includes a ceiling on *failed* authentication at the HTTP edge, which exists to bound
+  the credential-store re-read a mismatch triggers rather than to make guessing harder — 256 bits
+  already does that. Only a failure spends the budget, so a valid token is never refused by it.
 - **No egress control**, no provider sandbox, no secret scanning on write.
 - **Content leaving the boundary is not recoverable.** Lanes Link governs what an agent may fetch,
   not what happens to it afterwards.

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "#secrets/*": "./src/secrets/*",
     "#server": "./src/server/index.ts",
     "#server/endpoint.ts": "./src/server/endpoint.ts",
+    "#server/logging.ts": "./src/server/logging.ts",
     "#server/mcp": "./src/server/mcp/index.ts",
     "#stores/blobs": "./src/stores/blobs/index.ts",
     "#stores/blobs/*": "./src/stores/blobs/*",

--- a/src/auth/index.test.ts
+++ b/src/auth/index.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, test } from 'bun:test';
-import type { SecretStore } from '#secrets';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { createFileSecretStore, generateCredentialKey, type SecretStore } from '#secrets';
 import {
   BearerAuthenticator,
   generateProfileToken,
@@ -130,5 +133,66 @@ describe('authentication', () => {
     auth.invalidateCache();
     expect((await auth.authenticate('Bearer llk_old')).ok).toBe(false);
     expect((await auth.authenticate('Bearer llk_new')).ok).toBe(true);
+  });
+
+  test('a rotated-in token is accepted without an explicit invalidation', async () => {
+    // Nothing in production calls invalidateCache(), so a token the cache has
+    // never seen has to be able to prove itself. The mismatch is the signal.
+    const credentials = storeWith({ 'profile/token': 'llk_old' });
+    const auth = new BearerAuthenticator({ ...options, credentials });
+
+    expect((await auth.authenticate('Bearer llk_old')).ok).toBe(true);
+
+    await credentials.set('profile/token', 'llk_new');
+    expect((await auth.authenticate('Bearer llk_new')).ok).toBe(true);
+  });
+
+  test('a revoked token stops working once the cache window passes', async () => {
+    // Re-reading on mismatch cannot catch this on its own: the revoked token
+    // still equals the cached value, so it matches and never reaches the store.
+    // An attacker holding a leaked token is precisely the caller who never
+    // produces a mismatch, so the cache also has to age out.
+    let clock = 1_000;
+    const credentials = storeWith({ 'profile/token': 'llk_old' });
+    const auth = new BearerAuthenticator({ ...options, credentials, now: () => clock });
+
+    expect((await auth.authenticate('Bearer llk_old')).ok).toBe(true);
+
+    await credentials.set('profile/token', 'llk_new');
+    expect((await auth.authenticate('Bearer llk_old')).ok).toBe(true); // inside the window
+
+    clock += 10_000;
+    expect((await auth.authenticate('Bearer llk_old')).ok).toBe(false);
+    expect((await auth.authenticate('Bearer llk_new')).ok).toBe(true);
+  });
+});
+
+describe('rotation by another process', () => {
+  test('a token rotated through a second store instance is accepted', async () => {
+    // The in-memory store above cannot show this. The real credential store
+    // keeps the decrypted document in memory too, so an authenticator that
+    // re-read was still handed a stale copy — and `lanes link token rotate` is
+    // always a second process writing the same file.
+    const root = await mkdtemp(join(tmpdir(), 'lanes-link-auth-'));
+    const path = join(root, 'personal.credentials.enc');
+    const key = new Uint8Array(Buffer.from(generateCredentialKey(), 'base64'));
+
+    const serving = createFileSecretStore({ path, key });
+    await serving.set('profile/token', 'llk_old');
+
+    const auth = new BearerAuthenticator({
+      profile: 'personal',
+      tokenRef: 'profile/token',
+      credentials: serving,
+    });
+    expect((await auth.authenticate('Bearer llk_old')).ok).toBe(true);
+
+    // The CLI, in its own process, over the same file.
+    await createFileSecretStore({ path, key }).set('profile/token', 'llk_new');
+
+    expect((await auth.authenticate('Bearer llk_new')).ok).toBe(true);
+    expect((await auth.authenticate('Bearer llk_old')).ok).toBe(false);
+
+    await rm(root, { recursive: true, force: true });
   });
 });

--- a/src/auth/index.ts
+++ b/src/auth/index.ts
@@ -117,25 +117,57 @@ export interface AuthenticatorOptions {
   readonly profile: string;
   readonly tokenRef: SecretRef;
   readonly credentials: SecretStore;
+  /** Injectable for tests. Only the cache window reads it. */
+  readonly now?: () => number;
 }
+
+/**
+ * How long a cached token may answer before the store is consulted again.
+ *
+ * The cache is here so the common case — a valid token, on every request — is a
+ * comparison rather than a file read or a Secret Manager call. What it must not
+ * do is outlive a rotation. `lanes link token rotate` is the only revocation
+ * this system has, and an unbounded cache meant a revoked token kept opening the
+ * endpoint until the process restarted, while the replacement was refused.
+ *
+ * Five seconds makes rotation effectively immediate and still collapses a burst
+ * of calls onto one read.
+ */
+const CACHE_TTL_MS = 5_000;
 
 export class BearerAuthenticator implements Authenticator {
   readonly #options: AuthenticatorOptions;
+  readonly #now: () => number;
   #cached: string | null = null;
+  #readAt = 0;
 
   constructor(options: AuthenticatorOptions) {
     this.#options = options;
+    this.#now = options.now ?? Date.now;
   }
 
   async authenticate(authorizationHeader: string | null | undefined): Promise<AuthOutcome> {
-    const { profile, tokenRef, credentials } = this.#options;
+    const { profile } = this.#options;
 
     const presented = parseBearer(authorizationHeader);
     if (presented === null) {
       return { ok: false, reason: authorizationHeader ? 'malformed' : 'missing' };
     }
 
-    const expected = (this.#cached ??= await credentials.get(tokenRef));
+    const fresh = this.#cached !== null && this.#now() - this.#readAt < CACHE_TTL_MS;
+    let expected = fresh ? this.#cached : await this.#reload();
+
+    // A mismatch against a *cached* value is ambiguous: either the credential is
+    // wrong, or it is the right one and this process has not seen the rotation
+    // that produced it. One re-read separates the two, and it is what makes a
+    // rotated-in token work on its first call rather than after the window.
+    // Only a cached comparison can be wrong this way, so a fresh read never
+    // pays for a second one — which is what keeps a wrong token from costing a
+    // store read per attempt.
+    if (fresh && (expected === null || !tokensMatch(presented, expected))) {
+      expected = await this.#reload();
+    }
+
     if (expected === null) {
       // The profile has no token yet. Fail closed and let `lanes link doctor` explain.
       return { ok: false, reason: 'not_configured' };
@@ -146,7 +178,22 @@ export class BearerAuthenticator implements Authenticator {
       : { ok: false, reason: 'invalid' };
   }
 
-  /** Called after `lanes link token rotate` so a running instance picks up the change. */
+  async #reload(): Promise<string | null> {
+    // Both caches, or neither: the store holds its own decrypted copy, so
+    // re-reading without dropping that first re-reads the same stale value.
+    this.#options.credentials.refresh?.();
+    this.#cached = await this.#options.credentials.get(this.#options.tokenRef);
+    this.#readAt = this.#now();
+    return this.#cached;
+  }
+
+  /**
+   * Drop the cached value immediately.
+   *
+   * The window above already bounds how long a rotation goes unnoticed, so this
+   * is an optimisation rather than the mechanism — nothing's correctness may
+   * depend on it being called, because for a long time nothing called it.
+   */
   invalidateCache(): void {
     this.#cached = null;
   }

--- a/src/auth/oauth/server.ts
+++ b/src/auth/oauth/server.ts
@@ -248,18 +248,27 @@ export class OAuthServer {
     const presented = form.get('refresh_token') ?? '';
     const record = await this.#options.store.token(presented);
 
-    if (!record || record.kind !== 'refresh') {
+    if (!record || record.kind === 'access') {
       return invalid('invalid_grant', 'That refresh token is unknown or expired.');
     }
+
+    // A spent token presented again is the one signal that it has been copied.
+    // Rotation alone does not answer it: whoever refreshes first walks away
+    // with a live pair, and rejecting only the token in hand leaves that pair
+    // working while the other party — usually the real client — is locked out.
+    // So the whole chain goes. A client retrying a response it never saw and a
+    // thief replaying are indistinguishable from here, and re-authorising is
+    // the cheaper of the two mistakes.
+    if (record.kind === 'consumed') {
+      await this.#options.store.revokeFamily(record.family);
+      return invalid('invalid_grant', 'That refresh token has already been used.');
+    }
+
     if (record.clientId !== form.get('client_id')) {
       return invalid('invalid_grant', 'That refresh token was issued to a different client.');
     }
 
-    // Rotation: the presented token stops working the moment its replacement is
-    // minted, so a captured refresh token is useful only until the real client
-    // next refreshes — at which point one of the two presents a dead token and
-    // the whole family is dropped.
-    await this.#options.store.revokeToken(presented);
+    await this.#options.store.consumeToken(presented);
     return this.#issue(record.clientId, record.scope, randomToken('llr'), record.family);
   }
 

--- a/src/auth/oauth/store.ts
+++ b/src/auth/oauth/store.ts
@@ -44,7 +44,17 @@ export interface AuthorizationCode {
   readonly expiresAt: number;
 }
 
-export type TokenKind = 'access' | 'refresh';
+/**
+ * `consumed` is a spent refresh token kept as a tombstone.
+ *
+ * Deleting one outright is what made replay undetectable: a token that is
+ * simply absent cannot be told apart from one that never existed, so the single
+ * signal that a refresh token has been copied was being discarded at the moment
+ * it arrived. A tombstone keeps the family id and nothing else useful, and it
+ * opens no more than a deleted row does — every check that admits a credential
+ * tests for `access` by name.
+ */
+export type TokenKind = 'access' | 'refresh' | 'consumed';
 
 export interface IssuedToken {
   readonly clientId: string;
@@ -165,6 +175,14 @@ export class OAuthStore {
 
   async revokeToken(token: string): Promise<void> {
     await this.#state.delete(TOKENS, hashToken(token));
+  }
+
+  /** Spend a refresh token, keeping the tombstone that makes a replay visible. */
+  async consumeToken(token: string): Promise<void> {
+    const key = hashToken(token);
+    const record = await this.#read<IssuedToken>(TOKENS, key);
+    if (!record) return;
+    await this.#state.set(TOKENS, key, JSON.stringify({ ...record, kind: 'consumed' }));
   }
 
   /**

--- a/src/cli/commands/operate/serve.ts
+++ b/src/cli/commands/operate/serve.ts
@@ -1,4 +1,5 @@
 import { startEndpoint } from '#server/endpoint.ts';
+import { streamLogger } from '#server/logging.ts';
 import { announce, ok, print, style, warn } from '../../output.ts';
 import { resolveProfile, type GlobalFlags } from '../../runtime.ts';
 
@@ -22,6 +23,10 @@ export async function start(
     port: flags.port,
     only: flags.only,
     mintToken: true,
+    // Stderr, not stdout: `--json` and `--raw` callers parse the other stream.
+    // A refused credential is the event worth seeing while this runs in the
+    // foreground, and until now nothing printed it.
+    log: streamLogger((line) => process.stderr.write(`${line}\n`)),
     reporter: {
       reconciled({ profile, plan, ofMany }) {
         if (ofMany) print(style.dim(`  ${profile}`));

--- a/src/cli/commands/operate/token.ts
+++ b/src/cli/commands/operate/token.ts
@@ -3,6 +3,11 @@ import { ensureProfileToken, openRuntime, type GlobalFlags } from '../../runtime
 
 /** `lanes link token` — the one bearer token this endpoint accepts. */
 
+/** The token, or enough of it to recognise. One shape, so the two commands agree. */
+function show(token: string, reveal: boolean | undefined): string {
+  return reveal ? token : `${token.slice(0, 8)}…  ${style.dim('(--show to reveal)')}`;
+}
+
 export async function tokenShow(
   flags: GlobalFlags & { show?: boolean | undefined; raw?: boolean | undefined },
 ): Promise<void> {
@@ -28,13 +33,15 @@ export async function tokenShow(
 
     announce(runtime.resolution);
     if (created) print(warn('no token existed; a new one was minted'));
-    print(flags.show ? token : `${token.slice(0, 8)}…  ${style.dim('(--show to reveal)')}`);
+    print(show(token, flags.show));
   } finally {
     await runtime.close();
   }
 }
 
-export async function tokenRotate(flags: GlobalFlags): Promise<void> {
+export async function tokenRotate(
+  flags: GlobalFlags & { show?: boolean | undefined },
+): Promise<void> {
   const runtime = await openRuntime(flags);
   try {
     announce(runtime.resolution);
@@ -44,7 +51,11 @@ export async function tokenRotate(flags: GlobalFlags): Promise<void> {
     await runtime.credentials.set(runtime.config.auth.token_ref, token);
 
     print(ok('token rotated'));
-    print(`  ${token}`);
+    // Gated the way `tokenShow` gates it, and for the reason given above: a
+    // token printed here goes into the transcript of whatever ran the command.
+    // Rotating is what an operator does *because* a token leaked, so printing
+    // the replacement unasked is the one moment it costs the most.
+    print(`  ${show(token, flags.show)}`);
     print();
     // Rotating invalidates every agent using this endpoint, which is the cost
     // of one token per endpoint rather than one per agent. Say so plainly —

--- a/src/cli/lanes.test.ts
+++ b/src/cli/lanes.test.ts
@@ -117,3 +117,57 @@ targets:
     expect(token.length).toBeGreaterThan(0);
   });
 });
+
+describe('token rotate', () => {
+  const homes: string[] = [];
+
+  afterAll(async () => {
+    await Promise.all(homes.map((home) => rm(home, { recursive: true, force: true })));
+  });
+
+  async function workspace(): Promise<(args: string[]) => { stdout: string; stderr: string }> {
+    const home = await mkdtemp(join(tmpdir(), 'lanes-link-rotate-'));
+    homes.push(home);
+    const env = { ...process.env, LANES_LINK_HOME: home };
+    const run = (args: string[]): { stdout: string; stderr: string } => {
+      const result = Bun.spawnSync(['bun', 'run', BIN, ...args], { env });
+      return {
+        stdout: new TextDecoder().decode(result.stdout),
+        stderr: new TextDecoder().decode(result.stderr),
+      };
+    };
+    run(['link', 'profile', 'add', 'scratch', '--default']);
+    return run;
+  }
+
+  test('does not print the new token unless asked', async () => {
+    // `token show` has always truncated without `--show`, for a stated reason:
+    // a token on stdout passes through an agent's context and into its
+    // transcript. `rotate` mints one and printed it unconditionally, which is
+    // the same disclosure at the one moment the operator is responding to a
+    // leak.
+    const run = await workspace();
+
+    const rotated = run(['link', 'token', 'rotate']);
+    const minted = run(['link', 'token', 'show', '--raw']).stdout.trim();
+
+    expect(minted).toStartWith('llk_');
+    expect(rotated.stdout).toContain('token rotated');
+    expect(rotated.stdout).not.toContain(minted);
+  });
+
+  test('prints it with --show, the way `token show` does', async () => {
+    const run = await workspace();
+
+    const rotated = run(['link', 'token', 'rotate', '--show']);
+    const minted = run(['link', 'token', 'show', '--raw']).stdout.trim();
+
+    expect(rotated.stdout).toContain(minted);
+  });
+
+  test('still says every agent must be re-registered', async () => {
+    // The part that has to stay loud: nothing re-reads the token on its own.
+    const run = await workspace();
+    expect(run(['link', 'token', 'rotate']).stdout).toContain('re-registered');
+  });
+});

--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -158,7 +158,7 @@ export async function run(argv: readonly string[]): Promise<void> {
         case undefined:
           return tokenShow({ ...global, show, raw });
         case 'rotate':
-          return tokenRotate(global);
+          return tokenRotate({ ...global, show });
         default:
           throw new Error(`Unknown: ${PROGRAM} token ${second}`);
       }

--- a/src/cli/usage.ts
+++ b/src/cli/usage.ts
@@ -53,7 +53,7 @@ ${style.bold('Permissions')}
   ${PROGRAM} policy allow <capability>  e.g. gmail.* or gmail.send_message
   ${PROGRAM} policy deny  <capability>
   ${PROGRAM} token show [--show|--raw]  --raw prints only the token, for $(…)
-  ${PROGRAM} token rotate
+  ${PROGRAM} token rotate [--show]
 
 ${style.bold('Your own context')}
   ${PROGRAM} memory list [--tag t]      what you have stored

--- a/src/secrets/index.ts
+++ b/src/secrets/index.ts
@@ -63,6 +63,16 @@ export interface SecretStore {
   has(ref: SecretRef): Promise<boolean>;
   delete(ref: SecretRef): Promise<void>;
   list(prefix?: string): Promise<SecretRef[]>;
+  /**
+   * Drop whatever is held in memory so the next read reaches the store.
+   *
+   * Optional because most adapters hold nothing to drop. It exists for the one
+   * caller that has to see a value it did not write itself: the endpoint
+   * checking a bearer token that `lanes link token rotate` replaced from a
+   * different process. The file adapter keeps the whole decrypted document
+   * cached, so without this a re-read is served the copy it already had.
+   */
+  refresh?(): void;
 }
 
 /**

--- a/src/secrets/system.ts
+++ b/src/secrets/system.ts
@@ -131,8 +131,14 @@ class DocumentSecretStore implements SecretStore {
     return [...entries.keys()].filter((ref) => !prefix || ref.startsWith(prefix)).sort();
   }
 
-  /** Drop the decrypted copy from memory. */
-  forget(): void {
+  /**
+   * Drop the decrypted copy from memory.
+   *
+   * Named for the interface it satisfies rather than for the hygiene it also
+   * provides. It was `forget()` and nothing ever called it, which is precisely
+   * how a rotated token stayed invisible to a running endpoint.
+   */
+  refresh(): void {
     this.#cache = undefined;
   }
 

--- a/src/server/container.ts
+++ b/src/server/container.ts
@@ -1,5 +1,6 @@
 #!/usr/bin/env bun
 import { startEndpoint } from './endpoint.ts';
+import { streamLogger } from './logging.ts';
 
 /**
  * The container entrypoint — `src/deployments/gcp/Dockerfile` runs this.
@@ -56,6 +57,9 @@ try {
     host,
     // A deployed instance never mints its own token: see `endpoint.ts`.
     mintToken: false,
+    // Stdout is where Cloud Run collects logs, and a rejected credential on a
+    // public URL is the event this exists for.
+    log: streamLogger((line) => process.stdout.write(`${line}\n`)),
     reporter: {
       reconciled({ profile, plan }) {
         // Reconcile output is the record of what a deploy changed, and it is

--- a/src/server/edge.ts
+++ b/src/server/edge.ts
@@ -1,0 +1,53 @@
+import { RateLimiter } from '#policy';
+
+/**
+ * A ceiling on failed authentication.
+ *
+ * Every credential that does not match the cached one costs a re-read of the
+ * credential store — a decrypt locally, a network call on a deployed instance.
+ * That re-read is what makes a rotated-in token work on its first call, and it
+ * is also a way to make the endpoint do expensive work on behalf of a caller
+ * holding no credential at all. This bounds it.
+ *
+ * Not a security boundary, and `#policy`'s own note says so: 256 bits behind
+ * `llk_` is what makes guessing hopeless. This is about cost, and about giving
+ * a sustained probe a shape in the log rather than an unbroken run of 401s.
+ */
+export const FAILED_AUTH_PER_MINUTE = 30;
+
+/**
+ * Who an attempt is counted against.
+ *
+ * `x-forwarded-for`'s first hop is the client as the platform's front door saw
+ * it, which is the only address that means anything on Cloud Run — the socket
+ * peer there is Google's frontend, identical for every caller. It is trivially
+ * spoofable by anyone talking to the endpoint directly, which is why the
+ * fallback is a single shared bucket rather than something that looks
+ * per-caller and is not: a loopback endpoint has one caller, and an attacker
+ * who can already reach it can read the config file holding the token anyway.
+ */
+export function callerKey(request: Request): string {
+  return request.headers.get('x-forwarded-for')?.split(',')[0]?.trim() || 'direct';
+}
+
+/** Refused for rate rather than for credential — deliberately a different status. */
+export function tooManyAttempts(retryAfterMs: number): Response {
+  return new Response(
+    JSON.stringify({
+      error: 'too_many_requests',
+      hint: 'Too many failed authentication attempts. Wait, then retry.',
+    }),
+    {
+      status: 429,
+      headers: {
+        'content-type': 'application/json',
+        'retry-after': String(Math.max(1, Math.ceil(retryAfterMs / 1000))),
+      },
+    },
+  );
+}
+
+/** One bucket set per endpoint. Idle callers are dropped so keys do not accumulate. */
+export function failedAuthLimiter(): RateLimiter {
+  return new RateLimiter();
+}

--- a/src/server/endpoint.ts
+++ b/src/server/endpoint.ts
@@ -14,6 +14,7 @@ import {
   type Authenticator,
 } from '#auth';
 import type { Logger } from '#connectivity';
+import { silentLogger } from './logging.ts';
 import { listProfiles } from '#profile';
 import {
   applyReconcile,
@@ -62,6 +63,8 @@ export interface EndpointOptions {
    */
   readonly mintToken?: boolean | undefined;
   readonly reporter?: EndpointReporter | undefined;
+  /** Operational events. Silent when absent, which is what the tests want. */
+  readonly log?: Logger | undefined;
 }
 
 export interface RunningEndpoint {
@@ -273,7 +276,7 @@ export async function startEndpoint(options: EndpointOptions): Promise<RunningEn
       authenticator: gate
         ? new AuthenticatorChain([primary.authenticator, gate.authenticator])
         : primary.authenticator,
-      log: { debug() {}, info() {}, warn() {}, error() {} },
+      log: options.log ?? silentLogger(),
       ...(gate ? { authorization: gate.surface } : {}),
       ...(options.port !== undefined ? { port: options.port } : {}),
       ...(options.host !== undefined ? { host: options.host } : {}),
@@ -331,7 +334,7 @@ export async function startStdioEndpoint(
     const surface = serveOverStdio({
       profiles: profileRuntimes(runtimes),
       primary: primary.resolution.profile,
-      log: options.log ?? { debug() {}, info() {}, warn() {}, error() {} },
+      log: options.log ?? silentLogger(),
       ...(options.clientLabel ? { clientLabel: options.clientLabel } : {}),
     });
 

--- a/src/server/harness.ts
+++ b/src/server/harness.ts
@@ -13,8 +13,7 @@ import { ProviderRegistry, toPolicyDocument } from '#registry';
 import { Dispatcher } from '#dispatch';
 import { createMemoryCredentials, createMemoryState } from '#stores/state/testing.ts';
 import { RateLimiter } from '#policy';
-import type { Logger } from '#connectivity';
-import { silentLogger } from './logging.ts';
+import { silentLogger, type Logger } from './logging.ts';
 import { createMemoryBlobStore } from '#stores/blobs/testing.ts';
 import { exampleProvider } from '#providers/example/provider.ts';
 import { createLocalConnector } from '#connectivity/transports';
@@ -86,7 +85,6 @@ export { parseConfig } from '#profile';
 
 export interface HarnessOptions {
   profile: string;
-  /** Where the endpoint's operational events go. Silent unless a test asks. */
   log?: Logger;
   port: number;
   policy: string;
@@ -148,7 +146,6 @@ export function wireProfiles(options: HarnessOptions): WiredProfiles {
   registry.register(exampleProvider);
   for (const provider of options.providers ?? []) registry.register(provider);
 
-  const silent = { debug() {}, info() {}, warn() {}, error() {} };
   const policy = toPolicyDocument(config);
 
   const dispatcher = new Dispatcher({
@@ -164,7 +161,7 @@ export function wireProfiles(options: HarnessOptions): WiredProfiles {
     credentials,
     storage: createMemoryBlobStore(),
     limiter: new RateLimiter(),
-    log: silent,
+    log: silentLogger(),
   });
 
   // Each extra profile gets its own state and its own log, so the isolation
@@ -201,7 +198,7 @@ export function wireProfiles(options: HarnessOptions): WiredProfiles {
         credentials,
         storage: createMemoryBlobStore(),
         limiter: new RateLimiter(),
-        log: silent,
+        log: silentLogger(),
       }),
     });
   }
@@ -292,7 +289,7 @@ export async function startStdioHarness(
   const surface = serveOverStdio({
     profiles,
     primary: options.profile,
-    log: { debug() {}, info() {}, warn() {}, error() {} },
+    log: silentLogger(),
     transport: serverSide,
     ...(options.clientLabel ? { clientLabel: options.clientLabel } : {}),
   });

--- a/src/server/harness.ts
+++ b/src/server/harness.ts
@@ -13,6 +13,8 @@ import { ProviderRegistry, toPolicyDocument } from '#registry';
 import { Dispatcher } from '#dispatch';
 import { createMemoryCredentials, createMemoryState } from '#stores/state/testing.ts';
 import { RateLimiter } from '#policy';
+import type { Logger } from '#connectivity';
+import { silentLogger } from './logging.ts';
 import { createMemoryBlobStore } from '#stores/blobs/testing.ts';
 import { exampleProvider } from '#providers/example/provider.ts';
 import { createLocalConnector } from '#connectivity/transports';
@@ -84,6 +86,8 @@ export { parseConfig } from '#profile';
 
 export interface HarnessOptions {
   profile: string;
+  /** Where the endpoint's operational events go. Silent unless a test asks. */
+  log?: Logger;
   port: number;
   policy: string;
   token?: string;
@@ -233,7 +237,7 @@ export function startHarness(options: HarnessOptions): Harness {
       }
     : null;
 
-  const log = { debug() {}, info() {}, warn() {}, error() {} };
+  const log = options.log ?? silentLogger();
 
   const nothing = () => Promise.resolve();
   const generations = new Generations(

--- a/src/server/index.test.ts
+++ b/src/server/index.test.ts
@@ -847,3 +847,37 @@ describe('the authentication edge', () => {
     expect((await rpc(probed.server.url, 'tools/list', {}, { token: TEST_TOKEN })).status).toBe(200);
   });
 });
+
+describe('operational logging', () => {
+  test('a rejected request is reported to the logger', async () => {
+    // The warning existed and went nowhere: every caller of `serve()` passed a
+    // logger whose methods were empty, so a public endpoint had no signal at
+    // all that someone was trying credentials against it.
+    const warnings: Array<{ message: string; detail?: Record<string, unknown> }> = [];
+    const listening = startHarness({
+      profile: 'personal',
+      port: allocatePort(),
+      policy: `  allow:
+    - "example.*"`,
+      log: {
+        debug() {},
+        info() {},
+        error() {},
+        warn(message, detail) {
+          warnings.push({ message, ...(detail ? { detail } : {}) });
+        },
+      },
+    });
+
+    try {
+      await rpc(listening.server.url, 'tools/list', {}, { token: 'llk_not_the_token' });
+
+      expect(warnings.map((entry) => entry.message)).toContain('rejected request');
+      expect(warnings.find((entry) => entry.message === 'rejected request')?.detail).toEqual({
+        reason: 'invalid',
+      });
+    } finally {
+      await listening.stop();
+    }
+  });
+});

--- a/src/server/index.test.ts
+++ b/src/server/index.test.ts
@@ -812,6 +812,9 @@ ${policy}
     } finally {
       await harness.stop();
     }
+  });
+});
+
 describe('the authentication edge', () => {
   const probed = startHarness({
     profile: 'personal',

--- a/src/server/index.test.ts
+++ b/src/server/index.test.ts
@@ -812,5 +812,38 @@ ${policy}
     } finally {
       await harness.stop();
     }
+describe('the authentication edge', () => {
+  const probed = startHarness({
+    profile: 'personal',
+    port: allocatePort(),
+    policy: `  allow:
+    - "example.*"`,
+  });
+
+  afterAll(async () => {
+    await probed.stop();
+  });
+
+  test('a sustained burst of failed authentications is eventually refused outright', async () => {
+    // Every failed comparison against a cached value costs a re-read of the
+    // credential store, which on a deployed instance is a network call and
+    // locally is a decrypt. Unbounded, that is a way to make the endpoint do
+    // expensive work with no credential at all.
+    const statuses: number[] = [];
+    for (let attempt = 0; attempt < 40; attempt += 1) {
+      statuses.push(
+        (await rpc(probed.server.url, 'tools/list', {}, { token: `llk_wrong_${attempt}` })).status,
+      );
+    }
+
+    expect(statuses[0]).toBe(401);
+    expect(statuses.at(-1)).toBe(429);
+  });
+
+  test('a valid token still works while wrong ones are being refused', async () => {
+    // The limit has to bite on failure only. Keyed on the caller rather than on
+    // the outcome, anyone able to reach the endpoint could lock the owner out of
+    // it, which trades a cost problem for a worse availability one.
+    expect((await rpc(probed.server.url, 'tools/list', {}, { token: TEST_TOKEN })).status).toBe(200);
   });
 });

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -4,6 +4,7 @@ import { capabilityIdForToolName } from '#server/mcp';
 import { ATTACHMENTS_PATH, stageAttachment } from './attachments.ts';
 import { allowedHostnamesFor, rebindingRefusal } from './rebinding.ts';
 import type { Generation, Generations } from './generations.ts';
+import { callerKey, failedAuthLimiter, FAILED_AUTH_PER_MINUTE, tooManyAttempts } from './edge.ts';
 import {
   handleAuthorization,
   isAuthorizationPath,
@@ -79,6 +80,7 @@ export interface RequestHandler {
 
 export function createRequestHandler(options: ServerOptions): RequestHandler {
   let probedAt = 0;
+  const failedAuth = failedAuthLimiter();
 
   /**
    * Re-read the config because a call named a tool we do not serve.
@@ -152,6 +154,14 @@ export function createRequestHandler(options: ServerOptions): RequestHandler {
 
       if (!outcome.ok) {
         options.log.warn('rejected request', { reason: outcome.reason });
+
+        // After the attempt rather than before it: keyed on the caller alone,
+        // anyone able to reach the endpoint could spend the owner's budget and
+        // lock them out, which trades a cost problem for a worse availability
+        // one. Only a failure consumes a token, so a valid credential is never
+        // refused by this.
+        const budget = failedAuth.take(callerKey(request), FAILED_AUTH_PER_MINUTE);
+        if (!budget.allowed) return tooManyAttempts(budget.retryAfterMs);
 
         // The pointer is the whole handshake for a remote client: it reads the
         // named document, finds the authorization server, and starts a flow.

--- a/src/server/logging.ts
+++ b/src/server/logging.ts
@@ -1,5 +1,7 @@
 import type { Logger } from '#connectivity';
 
+export type { Logger };
+
 /**
  * Where an endpoint's operational events go.
  *

--- a/src/server/logging.ts
+++ b/src/server/logging.ts
@@ -1,0 +1,39 @@
+import type { Logger } from '#connectivity';
+
+/**
+ * Where an endpoint's operational events go.
+ *
+ * Distinct from the audit log, which records what a caller *did* and is a
+ * durable, hash-chained artefact. This is the other half: what happened to
+ * requests that never reached dispatch, of which a rejected credential is the
+ * one that matters. Audit cannot cover it — a refusal record needs a principal,
+ * and failing authentication is precisely not having one.
+ *
+ * Every caller used to pass an object whose four methods were empty, so the
+ * warning at the authentication edge was written and discarded on a public URL.
+ */
+
+/** Discards everything. For tests, whose output should stay readable. */
+export function silentLogger(): Logger {
+  return { debug() {}, info() {}, warn() {}, error() {} };
+}
+
+/**
+ * Timestamped lines to whichever stream is handed in.
+ *
+ * The CLI passes stderr, because stdout is what `--raw` and `--json` callers
+ * parse. The container passes stdout, which is where Cloud Run collects logs.
+ */
+export function streamLogger(write: (line: string) => void, now = () => new Date()): Logger {
+  const at = (level: string, message: string, detail?: Record<string, unknown>): void => {
+    const suffix = detail && Object.keys(detail).length > 0 ? ` ${JSON.stringify(detail)}` : '';
+    write(`${now().toISOString()} ${level} ${message}${suffix}`);
+  };
+
+  return {
+    debug: (message, detail) => at('debug', message, detail),
+    info: (message, detail) => at('info', message, detail),
+    warn: (message, detail) => at('warn', message, detail),
+    error: (message, detail) => at('error', message, detail),
+  };
+}

--- a/src/server/oauth.test.ts
+++ b/src/server/oauth.test.ts
@@ -351,6 +351,46 @@ describe('refresh', () => {
     expect(await replayed.json()).toMatchObject({ error: 'invalid_grant' });
   });
 
+  test('a replayed refresh token kills the chain minted from it', async () => {
+    // The case rotation alone does not cover. A thief who refreshes first holds
+    // a live pair; the real client then presents the token it still has, which
+    // is the only signal that anything went wrong. Answering it by rejecting
+    // only the presented token leaves the thief's pair working and breaks the
+    // owner's connector instead — exactly backwards.
+    const { clientId, refresh } = await issue();
+
+    const stolen = (await (
+      await tokenRequest({
+        grant_type: 'refresh_token',
+        refresh_token: refresh,
+        client_id: clientId,
+      })
+    ).json()) as { access_token: string; refresh_token: string };
+
+    const opens = async (token: string): Promise<number> =>
+      (
+        await fetch(`${origin}/mcp`, {
+          method: 'POST',
+          headers: { authorization: `Bearer ${token}` },
+        })
+      ).status;
+
+    expect(await opens(stolen.access_token)).not.toBe(401);
+
+    // The retry and the theft are indistinguishable from here, so both get the
+    // expensive answer.
+    await tokenRequest({ grant_type: 'refresh_token', refresh_token: refresh, client_id: clientId });
+
+    expect(await opens(stolen.access_token)).toBe(401);
+
+    const reused = await tokenRequest({
+      grant_type: 'refresh_token',
+      refresh_token: stolen.refresh_token,
+      client_id: clientId,
+    });
+    expect(reused.status).toBe(400);
+  });
+
   test('a refresh token does not open the resource', async () => {
     // The two are indistinguishable as strings, so the kind check is the only
     // thing keeping a token meant for the token endpoint out of the MCP path.


### PR DESCRIPTION
Five fixes on the authentication path. Four of them are a hook that existed, was
documented, and had no production caller; the fifth is the print gate on
`token rotate` that `token show` already had.

## What changed

**A rotation now takes effect while serving.** The expected token was read once
and held for the life of the process, so a rotation was refused until restart.
Two layers cached it — `BearerAuthenticator`, whose `invalidateCache()` nothing
called, and `DocumentSecretStore` underneath it, whose `forget()` nothing called
either — so dropping one alone changes nothing. Both go together now: a mismatch
forces one re-read, which lets a newly written token work on its first call, and
a five-second window bounds how long a cached value answers unchecked, which is
what a mismatch cannot cover.

**A ceiling on failed authentication at the HTTP edge.** Rate limiting only
began inside dispatch, once a principal existed. It matters more now that a
failed comparison costs a store read. The budget is spent by failures only and
taken after the attempt, so a valid credential never reaches the limiter and
cannot be locked out by someone else's failures.

**Refresh-token reuse revokes the family.** `revokeFamily` had no caller, and
neither did the `family` field that exists on every issued token for that sole
purpose — while the comment above the call site described it as happening. A
spent token is tombstoned rather than deleted, because an absent row cannot be
told apart from one that never existed.

**Refused requests reach a log.** `serve()` always warned; every caller passed a
logger whose four methods were empty. Audit is the wrong home — a refusal record
needs a principal, and failing authentication is not having one — so this is the
operational log, stderr for the CLI and stdout for the container.

**`token rotate` no longer prints the token.** `token show` truncates without
`--show`; rotate did not. Both share one helper now.

## Test plan

- [x] `bun test` — 1540 pass, 0 fail (3 new files touched, 10 tests added)
- [x] `bun run typecheck`
- [x] Rotation verified against a live endpoint in a scratch workspace: the new
      token is accepted immediately, the previous one stops working inside the
      window, and neither behaviour needs a restart
- [x] Refresh reuse verified over real HTTP through the token endpoint, asserting
      on the pair minted from the reused token rather than on the token presented
      — asserting the latter passes against the old behaviour
- [x] Edge ceiling verified live: sustained failures are refused, a valid
      credential still succeeds throughout
- [x] Refused requests confirmed on stderr with their reason, stdout unchanged

## Notes for review

`SecretStore` gains an optional `refresh?()`. The direction is unchanged and it
is feature-detected, so adapters holding nothing to drop are unaffected.

`docs/detailed/security.md` gains two rows and loses a stale troubleshooting
line in `deployment-cloudrun.md` that said a rotation needs a redeploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
