### PR TITLE
A profile owns its skills and its manifests

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,8 @@ calendar are the next step. **[Full quickstart →](docs/quickstart.md)**
 | **Skills** | your own procedures, handed to an agent as instructions | `lanes link skills` |
 | **Vault** | passwords and API keys, released only where you allow it | `lanes link vault` |
 
-Memory and skills are plain Markdown files, so a text editor and an agent reach the same bytes.
+Memory and skills are plain Markdown files, so a text editor and an agent reach the same bytes. All
+four belong to one profile: what you add under `work` is invisible under `personal`.
 
 ## Connect an account
 

--- a/docs/connect.md
+++ b/docs/connect.md
@@ -119,7 +119,7 @@ output, and in any transcript.
 ## Add your own
 
 Any MCP server, any REST API with an OpenAPI spec, any IMAP mailbox, any CalDAV or CardDAV server.
-Most are a fifteen-line YAML manifest in `~/.lanes-link/providers/` and no code at all. See
+Most are a fifteen-line YAML manifest in `~/.lanes-link/data/<profile>/providers.d/` and no code at all. See
 [`detailed/creating-a-provider.md`](detailed/creating-a-provider.md).
 
 ---

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -88,7 +88,7 @@ one. For claude.ai, ChatGPT, or a phone, add a custom connector by URL — see
 
 ## Storage is not optional up here
 
-State, the audit log, memory, and skills all live in the bucket. A container filesystem loses every
+State, the audit log, memory, skills, and your own provider manifests all live in the bucket. A container filesystem loses every
 one of them on an instance recycle without reporting anything, so the deploy configures the bucket
 for you rather than leaving it to a flag.
 

--- a/docs/detailed/adr/008-connectors.md
+++ b/docs/detailed/adr/008-connectors.md
@@ -20,6 +20,11 @@ The manifest schema is the same whether it arrives as a typed module in `provide
 YAML in `<workspace>/providers/*.yaml`. That is the point: a service we have never heard of is a
 file, not a pull request.
 
+> That directory moved to `data/<profile>/providers.d/` in
+> [ADR-030](030-a-profile-owns-its-skills-and-manifests.md). The equivalence claimed here is
+> untouched — what changed is which profiles can reach one, which was every profile in the
+> workspace and is now the one that owns it.
+
 ## Why
 
 `providers/gmail` reached **612 lines** for one read-only integration. `packages/policy` — the

--- a/docs/detailed/adr/009-one-endpoint-per-workspace.md
+++ b/docs/detailed/adr/009-one-endpoint-per-workspace.md
@@ -41,7 +41,10 @@ endpoint as trusting whoever holds the token with everything the workspace holds
 - **Policy is still evaluated per profile.** The named profile's rules decide, and a capability no
   profile grants is not registered at all.
 - **Profiles still share no database and no credential store.** What one holds is invisible to
-  another; a note written through `personal` is simply absent in `work`.
+  another; a note written through `personal` is simply absent in `work`. This had two exceptions
+  when it was written — skills and provider manifests, both at the workspace root — and
+  [ADR-030](030-a-profile-owns-its-skills-and-manifests.md) removed them, so it is now true
+  without qualification.
 - **Every call records its profile** in the audit log.
 - **A mismatched pairing is refused.** The `connection` enum is a union across profiles, so a caller
   can name a valid profile and a connection belonging to a different one. That is checked before

--- a/docs/detailed/adr/012-owner-layer-primitives.md
+++ b/docs/detailed/adr/012-owner-layer-primitives.md
@@ -1,8 +1,14 @@
 # ADR-012: The owner layer's primitives, and how the vault is governed
 
-**Status:** accepted, **§1 superseded in part by [ADR-014](014-owner-layer-is-managed.md)** ·
+**Status:** accepted, **§1 superseded in part by [ADR-014](014-owner-layer-is-managed.md) and
+again by [ADR-030](030-a-profile-owns-its-skills-and-manifests.md)** ·
 **Milestone:** M4 · **Extends [ADR-006](006-tools-resources-prompts.md)**
 
+> §1's *location* — `<workspace>/skills/` — was reversed by ADR-030, which moves skills into
+> `data/<profile>/skills.d/` on the grounds that "a procedure is not private to a profile" is not
+> true of any procedure worth writing. The primitive argument below is untouched: a skill is
+> still a prompt, still not a resource, and still routed by arguments.
+>
 > §1's conclusion that no capability may write a skill was reversed by ADR-014, which keeps the
 > argument and replaces the answer: authoring is a capability in a non-default bundle, the way
 > `memory.write` already was in §2 below. Reading a skill's body stays out of the read bundle, so the
@@ -45,7 +51,9 @@ more than the convenience of self-selection.
 **Consequences.**
 
 - Skills are authored **as files in `<workspace>/skills/`**, the way custom providers are files in
-  `<workspace>/providers/`. There is no `skills.write` capability, and there should not be: a skill
+  `<workspace>/providers/`. *(Both directories moved into the profile in ADR-030; the analogy
+  between them survived the move.)* There is no `skills.write` capability, and there should not
+  be: a skill
   *is* instructions, so an agent that could write one could author its own future behaviour and
   persist it. That is §2's problem in its sharpest form, and the answer is that the write path never
   existed rather than that it is default-denied.

--- a/docs/detailed/adr/014-owner-layer-is-managed.md
+++ b/docs/detailed/adr/014-owner-layer-is-managed.md
@@ -1,7 +1,9 @@
 # ADR-014: the owner layer is managed — a write path for skills, one storage shape for all three
 
-**Status:** accepted · **Milestone:** M5 · **Supersedes [ADR-012](012-owner-layer-primitives.md) §1
-in part**, and closes a gap ADR-012 did not see.
+**Status:** accepted, **§2's placement of skills superseded by
+[ADR-030](030-a-profile-owns-its-skills-and-manifests.md)** · **Milestone:** M5 ·
+**Supersedes [ADR-012](012-owner-layer-primitives.md) §1 in part**, and closes a gap ADR-012 did
+not see.
 
 ## Context
 
@@ -99,6 +101,11 @@ the one store holding the owner's passwords.
 written before this keeps working. Skills follow the target for the same class of reason: a
 filesystem path is baked into a container image at build time, so a deployed instance could only ever
 serve the skills that existed when its image was built.
+
+> This section moved memory and the vault into the profile's directory and left skills at the
+> workspace root. ADR-030 finished the job — the reasoning for *following the target* is
+> unaffected by *which* prefix they follow it into, but the deploy's upload allowlist is, and
+> ADR-030 pays that cost rather than reintroducing the regression named just above.
 
 **There is no secret-manager adapter**, and that is a decision rather than an omission. The vault
 encrypts the whole document as one, so item *names* are encrypted alongside their values — a property

--- a/docs/detailed/adr/016-what-the-endpoint-says-about-itself.md
+++ b/docs/detailed/adr/016-what-the-endpoint-says-about-itself.md
@@ -87,11 +87,14 @@ revision still has to describe itself.
 **Decision: bundled client-facing documents live under `instructions/`, not `skills/` and
 `agents/`.**
 
-A repository-root `skills/` claimed a word this project had already spent. `<workspace>/skills/` is
-the owner's own procedures — `lanes link skills add`, served as MCP prompts — and `main.ts` already
-described the collision between that and `lanes link mcp skill` as *"a trap worth closing"*. Two
-directories called `skills`, meaning different things, in one repository, was the same trap one
-level up.
+A repository-root `skills/` claimed a word this project had already spent. The owner's own
+procedures — reached by `lanes link skills add` and served as MCP prompts — already held it, and
+`main.ts` described the collision between that and `lanes link mcp skill` as *"a trap worth
+closing"*. Two directories called `skills`, meaning different things, in one repository, was the
+same trap one level up. (They lived at `<workspace>/skills/` when this was written and now live at
+`data/<profile>/skills.d/`, per
+[ADR-030](030-a-profile-owns-its-skills-and-manifests.md) — which does not free the word, because
+the collision was over what the name *means*.)
 
 `instructions/skills/` and `instructions/agents/` keep the kind explicit, because the installer maps
 kind to a harness directory, while naming the category honestly: these are what we tell a client.

--- a/docs/detailed/adr/023-the-workspace-is-not-in-the-image.md
+++ b/docs/detailed/adr/023-the-workspace-is-not-in-the-image.md
@@ -53,6 +53,13 @@ now an IAM condition on the one bucket, along the boundary the layout already dr
 - `roles/storage.objectAdmin` on `data/` and `skills/` — skills are writable under policy (ADR-014)
 - `roles/storage.objectViewer` on `lanes-link.yaml`, `profiles/`, and `providers/`
 
+[ADR-030](030-a-profile-owns-its-skills-and-manifests.md) moved both of those root directories
+into `data/<profile>/`, so the boundary is now drawn inside one prefix rather than between two:
+the write grant is `data/` with each profile's `providers.d/` excluded by name, and the read grant
+picks the manifests back up. The property this section claims is unchanged — a revision still
+cannot rewrite what declares what it is — but the condition carries a negation to keep it, which
+is the part worth knowing before editing it.
+
 Conditions on `resource.name` work under the uniform bucket-level access `provision.ts` already
 sets. This is stronger than the version it replaces: image immutability protected config only for
 as long as config lived in the image.

--- a/docs/detailed/adr/030-a-profile-owns-its-skills-and-manifests.md
+++ b/docs/detailed/adr/030-a-profile-owns-its-skills-and-manifests.md
@@ -1,0 +1,100 @@
+# ADR-030: a profile owns its skills and its manifests
+
+**Status:** accepted · **Supersedes [ADR-012](012-owner-layer-primitives.md) §1's storage
+location and part of [ADR-014](014-owner-layer-is-managed.md) §2** · **Restores
+[ADR-009](009-one-endpoint-per-workspace.md)'s "profiles share nothing"**
+
+## Context
+
+ADR-009 says what a profile is, in one line under *What survives*:
+
+> **Profiles still share no database and no credential store.** What one holds is invisible to
+> another; a note written through `personal` is simply absent in `work`.
+
+Two things were outside that. Skills lived at `<workspace>/skills/`, placed there by ADR-012 §1
+and kept there by ADR-014 §2 when the other two owner stores moved into the profile. Custom
+provider manifests lived at `<workspace>/providers/`, placed there by ADR-008 before profiles
+had a data directory to hold anything.
+
+`profile/layout.ts` defended the first in a comment:
+
+> Skills stay workspace-wide rather than per-profile, which is how they have always loaded:
+> every profile sees every skill, and policy still gates `skills.<name>` per profile. A
+> procedure is not private to a profile the way its knowledge is.
+
+## The argument, and why it does not hold
+
+**"Policy still gates it" is a smaller claim than it sounds.** Policy decides who may *invoke*
+`skills.<name>`. It never decided who could see that the skill existed, and — since ADR-014 gave
+`skills.manage.get` a real read path — it is the only thing standing between a granted agent in
+one profile and the full text of a procedure written in another. The isolation was one policy
+line deep in a system whose other four owner stores are isolated by not sharing bytes at all.
+
+**"A procedure is not private the way its knowledge is" describes a skill that does not exist.**
+A useful procedure names things: which mailbox to file into, which people to copy, which of the
+owner's conventions apply. A work incident-review skill is a description of how a particular
+employer runs incidents. The distinction between a procedure and the knowledge it operates on is
+not one the file format makes and not one an owner would recognise.
+
+**ADR-014 §1 already conceded the shape of this.** It made authoring a skill a grant worth
+governing, on the reasoning that a skill *is* instructions an agent will later be handed. That
+argument does not stop at the write. Something worth a separate capability to write is not
+something to hand every profile by default on read.
+
+**A manifest is infrastructure.** It names a host, an OpenAPI document, and the credential refs
+that reach them. Two profiles exist precisely when those differ.
+
+## Decision
+
+**`data/<profile>/skills.d/` and `data/<profile>/providers.d/`.** One profile, one directory,
+with no exceptions left in it — `rm -r data/work` remains the whole answer to "remove the work
+profile's data", and now it is also the whole answer to "what could work reach".
+
+Both names carry a dot, which `profile/layout.ts` requires of every reserved name under the blob
+root: a provider is namespaced `<provider>/<connection>` there and a provider id is
+`[a-z][a-z0-9_]*`, so a dotted name is one no provider can be scoped onto. For skills this is not
+hypothetical. `skills` is a real provider id, so `data/<profile>/skills/` is exactly the prefix
+its own connection blobs would occupy.
+
+Nothing changes about how either is read. The skills store was already handed a `BlobStore` and
+never knew where it was rooted; the manifest loader gained a profile and a path from `layout`.
+
+## What this costs, stated plainly
+
+**A deploy now reaches into `data/`, which it has never done.** `isWorkspaceConfig` sent the
+whole of `skills/` and `providers/` and none of `data/` — and that exclusion is what keeps the
+encrypted credential store and its key file out of a bucket. Skills that do not go up are the
+regression ADR-014 §2 fixed, so the allowlist now names two directories inside the tree it
+otherwise refuses. It matches them by whole path segment: `data/personal/skills.detour/` is not
+`skills.d`, and the thing on the other side of that boundary is a decryptable credential
+document. `deployments/deploy.test.ts` holds both halves.
+
+**The IAM write grant needed an exclusion, where it had only unions.** `objectsUnder('data/')`
+now includes a profile's manifests, and ADR-007 says a deployed instance never mutates its own
+configuration. So the condition is `objectsUnder('data/') && !<manifests>`, anchored to the
+profile segment rather than matched loosely, and the manifests move to the read binding.
+`deployments/grants.test.ts` evaluates the shipped expression rather than scanning it for
+prefixes, because an exclusion is the clause a substring scan reads straight past.
+
+**`data/` is gitignored, and skills were not.** An operator keeping procedures in version control
+loses that. Not repaired by un-ignoring a path here: this repository is public and doubles as a
+workspace during development, so a negation would invite committing a real one. The trade is
+recorded in `configuration.md` rather than worked around.
+
+**There is no migration.** A skill or manifest left at the old workspace-root path loads for
+nobody — not silently for everybody, which is the failure worth ruling out, and
+`cli/runtime/scoping.test.ts` pins it. This follows `layout.ts`'s existing position on the
+`data/` reshuffle that preceded it: machinery to move an old layout is more code than the thing
+it moves and has to keep working forever. Moving them is one `mv` per profile that should see
+them, and the profile that should see them is a question only the owner can answer — copying to
+all of them would be a guess that then diverges.
+
+## What is unchanged
+
+- **Authoring is still not in the default bundle** (ADR-014 §1), and reading a skill's body is
+  still in the author bundle rather than the read one (ADR-012 §1's surviving half).
+- **`skills.<name>` still merges across profiles** on the MCP surface, the way every other
+  capability does (ADR-009). Two profiles with a `triage` skill are one prompt whose `profile`
+  enum lists both, dispatching to whichever store the caller named.
+- **A manifest still cannot shadow a built-in**, and `skills`, `memory` and `vault` are still
+  reserved provider ids.

--- a/docs/detailed/adr/README.md
+++ b/docs/detailed/adr/README.md
@@ -37,6 +37,7 @@ Nothing in the codebase depends on it.
 | [026](026-a-revision-rotates-its-own-credentials.md) | A revision may add a version to each secret it rotates, and may still never create one |
 | [028](028-a-hosted-oauth-client-is-the-default.md) | A client Lanes operates is what `connect` uses by default; `--own-client` registers your own |
 | [029](029-connecting-is-not-deploying.md) | Connecting publishes its own config and the endpoint re-reads it; deploying is only code |
+| [030](030-a-profile-owns-its-skills-and-manifests.md) | Skills and provider manifests move into `data/<profile>/`; nothing is shared between profiles any more |
 
 Where an ADR departs from init.md, it says so at the top. Three are significant:
 
@@ -59,6 +60,11 @@ Where an ADR departs from init.md, it says so at the top. Three are significant:
   those exclusions — the rule is about authorisation, not information — and names the two things
   that keep it there: it reports only what policy already permits, and it never reports whether a
   credential is present.
+- **ADR-030** supersedes ADR-012 §1's storage location and part of ADR-014 §2, and is the only
+  departure that makes the system guarantee *more* than it did: ADR-009's "profiles share no
+  database and no credential store" had two exceptions left in it, and now has none. The half of
+  ADR-012 §1 that survives is the one about self-selection — reading a skill's body stays in the
+  author bundle.
 - **ADR-029** amends ADR-004's "exposes no administrative API", which stops being true: there is one
   authenticated route that is not `/mcp`. The clause that carried the weight survives intact — a
   deployed instance still never mutates its own configuration, and `/reload` takes no parameters, so

--- a/docs/detailed/architecture.md
+++ b/docs/detailed/architecture.md
@@ -15,7 +15,9 @@ instructions the model is asked to respect. Everything below exists to make that
 | **Skills** | `BlobStore` — one Markdown file per skill | prompts, plus `skills.manage.*` | `lanes link skills` |
 | **Vault** | one encrypted document, its own key | tools, tightly scoped | `lanes link vault` |
 
-All four are **providers** behind the same policy layer, audit log, profile boundary, and endpoint.
+All four are **providers** behind the same policy layer, audit log, profile boundary, and endpoint —
+and since [ADR-030](adr/030-a-profile-owns-its-skills-and-manifests.md) the profile boundary holds
+for all four rather than three, because a skill is no longer a workspace-wide file.
 `memory.search = allow` is evaluated by the identical code path as `gmail.search`. The core cannot
 tell them apart and must not try.
 

--- a/docs/detailed/configuration.md
+++ b/docs/detailed/configuration.md
@@ -7,10 +7,32 @@ lanes-link.yaml          workspace settings: contract, default_profile
 profiles/
   personal.yaml
   work.yaml
-data/                   local state per profile, gitignored
+data/                   everything each profile owns, gitignored
+  personal/
+    state.kv/           connections, provider state, cursors
+    audit.log/          one object per event
+    credentials.enc     system credentials, and its .key
+    vault.enc           the owner's items, its own key
+    skills.d/           procedures, one <name>/SKILL.md each
+    providers.d/        your own provider manifests
+    <provider>/<connection>/…
+  work/
+    …
 ```
 
 A real config is gitignored; only `*.example.yaml` is committed.
+
+Nothing under `data/` is shared. Skills and provider manifests used to sit at the workspace root
+where every profile read them; [ADR-030](adr/030-a-profile-owns-its-skills-and-manifests.md) moved
+both into the profile that owns them. Two consequences worth knowing:
+
+- **A skill or manifest left at the old `skills/` or `providers/` loads for nobody.** There is no
+  migration. Move each one into the profile that should have it — `mv skills/review-diff
+  data/personal/skills.d/` — and delete what is left.
+- **`data/` is gitignored, so skills are no longer committable where they sit.** If you keep
+  procedures in version control, keep them in their own repository and copy them in. Un-ignoring a
+  path inside `data/` is not worth it: the directory beside them holds an encrypted credential
+  store and the key that opens it.
 
 ## A complete profile
 
@@ -138,13 +160,15 @@ preview, `--yes` skips the prompt, and `--target <name>` decommissions one targe
 profile itself in place.
 
 What goes: the profile's config, and — in **every target it declares** — its credentials, state,
-audit log, provider blobs, and vault. For a target whose home is a bucket, the copy of the config a
-deployed revision reads goes too.
+audit log, provider blobs, vault, skills, and provider manifests. For a target whose home is a
+bucket, the copy of the config a deployed revision reads goes too.
+
+Skills and manifests go because they are inside the profile's own directory
+([ADR-030](adr/030-a-profile-owns-its-skills-and-manifests.md)); before that they were shared and
+this command left them alone. Nothing another profile can see is deleted.
 
 What stays, and each for a reason:
 
-- **`skills/`** is workspace-wide. Every profile sees every skill, so one profile's removal has no
-  business taking them.
 - **`lanes-link.yaml`.** If it named this profile as `default_profile`, that key is cleared rather
   than repointed at whatever remains — choosing a new default would silently change what every
   other command in the workspace acts on.

--- a/docs/detailed/creating-a-provider.md
+++ b/docs/detailed/creating-a-provider.md
@@ -6,7 +6,7 @@ A provider declares *how to reach a vendor*, not *what the vendor can do*
 ([ADR-008](adr/008-connectors.md)). Capabilities are discovered — from the vendor's own MCP server,
 or from an OpenAPI document — so there is nothing per-endpoint to write.
 
-Drop one of these in `<workspace>/providers/*.yaml` and it registers with no code and no rebuild:
+Drop one of these in `<workspace>/data/<profile>/providers.d/*.yaml` and it registers with no code and no rebuild — for that profile, which is the only one that can reach it ([ADR-030](adr/030-a-profile-owns-its-skills-and-manifests.md)):
 
 ```yaml
 # Any MCP server — a vendor's, a colleague's, your own.

--- a/docs/detailed/deployment-cloudrun.md
+++ b/docs/detailed/deployment-cloudrun.md
@@ -262,8 +262,8 @@ Four bindings, each narrower than it looks:
 |---|---|---|
 | `roles/secretmanager.secretAccessor` | the project | Read at boot: OAuth refresh tokens, the endpoint's own bearer token. |
 | `roles/secretmanager.secretVersionAdder` | **one binding per secret it rotates** | The vault document, and each connection's OAuth token. Add a version, never create — see below. |
-| `roles/storage.objectAdmin` | **conditioned** on `data/` and `skills/` | What the endpoint owns and writes: state, the log, attachments, memory, and skills (writable under policy, ADR-014). |
-| `roles/storage.objectViewer` | the bucket | Reading its own config. Deliberately *not* admin — see below. |
+| `roles/storage.objectAdmin` | **conditioned** on `data/`, less each profile's `providers.d/` | What the endpoint owns and writes: state, the log, attachments, memory, and skills (writable under policy, ADR-014). Manifests are carved back out — they are config, and ADR-007 says a revision never rewrites its own. |
+| `roles/storage.objectViewer` | `profiles/`, `lanes-link.yaml`, and each `providers.d/` | Reading its own config. Deliberately *not* admin — see below. |
 
 `deploy` creates the account and all of them on a first run; `--dry-run` shows them, and
 `--service-account` names a different one.
@@ -479,11 +479,13 @@ the conditioned `objectAdmin` binding, which is why the condition is worth keepi
 
 What that costs is rollback. A revision no longer fully describes what it serves, so rolling back
 to an earlier revision does not roll back a config change made since; the bucket holds one current
-copy. The upload is an allowlist — `lanes-link.yaml`, `profiles/<profile>.yaml`, `providers/`,
-`skills/` — so `data/` cannot travel by accident, for the same reason `.dockerignore` excludes it.
+copy. The upload is an allowlist — `lanes-link.yaml`, `profiles/<profile>.yaml`, and the two
+authored directories inside the profile, `data/<profile>/skills.d/` and
+`data/<profile>/providers.d/` — so the rest of `data/` cannot travel by accident, for the same
+reason `.dockerignore` excludes it.
 
-**`data/` is excluded, and that exclusion is load bearing.** The local encrypted credential store and
-its key live there. The root `.dockerignore` keeps them out of the build context; a credential baked
+**Everything else under `data/` is excluded, and that exclusion is load bearing.** The local
+encrypted credential store and its key live there. The root `.dockerignore` keeps them out of the build context; a credential baked
 into an image is pushed to a registry, cached on every builder that touched it, and readable by anyone
 who can pull the tag. The deployed target reads credentials from Secret Manager and wants nothing from
 that directory.
@@ -539,8 +541,9 @@ Google's and the problem is real.
 
 **`GCS refused to write "…" (403)`** — the revision's service account is not granted
 `roles/storage.objectAdmin` on the bucket, or the deploy's IAM step was skipped. The message names
-the role. Note the grant is conditioned: the revision may write under `data/` and `skills/` and may
-only *read* the config paths, so a 403 on `profiles/…` is the guarantee working rather than a
+the role. Note the grant is conditioned: the revision may write under `data/` and may only *read*
+the config paths, so a 403 on `profiles/…` — or on a `providers.d/…` key, which sits inside `data/`
+and is excluded from the write grant by name — is the guarantee working rather than a
 misconfiguration.
 
 **The endpoint answers 401 for a token you just printed** — `claude mcp add` stores the substituted

--- a/docs/detailed/init.md
+++ b/docs/detailed/init.md
@@ -534,7 +534,6 @@ Because provider code is trusted (see Security model), `docs/detailed/creating-a
     deployments/       # adapters/, local/, gcp/, azure/
   docs/
     adr/
-  skills/
 ```
 
 TypeScript on **Bun**, MCP SDK v2, Zod for schemas, and `bun:sqlite` directly for typed database access — the schema is four tables and every query is single-table, so an ORM would add a dependency and a migration toolchain for nothing this code needs. Modular monolith. No Kubernetes, Redis, Kafka, Temporal, or microservices.
@@ -751,8 +750,11 @@ Three owner providers, all local:
   `memory.search`. `memory.write` is a *separate* capability from read, precisely so read-only agents
   are a real configuration.
 - **`skills`** — reusable procedures, on the MCP prompts primitive reserved in M1. Authored as files
-  in `<workspace>/skills/`, the way custom providers are files in `<workspace>/providers/`; there is
-  no capability that writes one.
+  in `data/<profile>/skills.d/`, the way custom providers are files in the `providers.d/` beside
+  them ([ADR-030](adr/030-a-profile-owns-its-skills-and-manifests.md); both sat at the workspace
+  root until then). There is a capability that writes one, in a non-default bundle
+  ([ADR-014](adr/014-owner-layer-is-managed.md) §1) — this said there was none, and the reversal is
+  the argument that structural absence read stronger than it was.
 - **`vault`** — the owner's secret material. Tools only, never resources: resources are listable and
   cacheable, which is wrong for secrets. Default deny, per-item policy, aggressive audit redaction.
   Per-item is reached by making the item id part of the capability name, so an item written today is

--- a/docs/detailed/providers.md
+++ b/docs/detailed/providers.md
@@ -427,11 +427,15 @@ one encrypted document. Locally that is files under the workspace, and in a depl
 in S3. Before ADR-014 the vault had no target switch at all, so a Cloud Run instance wrote it to a
 container filesystem that the next revision discarded.
 
+**All three are the profile's**, and so is the `providers.d/` beside them — see
+[ADR-030](adr/030-a-profile-owns-its-skills-and-manifests.md). Skills were workspace-wide until
+then, which made them the one owner-layer store a second profile could read.
+
 | | Local | Cloud |
 |---|---|---|
-| skills | `<workspace>/skills/<name>.md` | `s3://…/skills/<name>.md` |
+| skills | `<workspace>/data/<profile>/skills.d/<name>.md` | the same key, in the bucket |
 | memory | `<storage>/memory/<connection>/entry/<id>.md` | the same key, in the bucket |
-| vault | `<workspace>/data/<profile>.vault.enc` | one object, `targets.<t>.vault.adapter: blob` |
+| vault | `<workspace>/data/<profile>/vault.enc` | one object, `targets.<t>.vault.adapter: blob` |
 
 ### `memory`
 
@@ -476,7 +480,7 @@ its arguments — a resource is a function of its URI alone. A prompt's messages
 conversation, which is what a procedure wants; a tool result comes back as data the model reasons
 about.
 
-A skill is a file in `<workspace>/skills/`, either `name.md` or `name/SKILL.md`, with YAML frontmatter
+A skill is a file in `<workspace>/data/<profile>/skills.d/`, either `name.md` or `name/SKILL.md`, with YAML frontmatter
 carrying `description` and optional `arguments`; `{{argument}}` is substituted into the body. An
 argument the caller omits leaves its placeholder visible rather than becoming empty — "review the diff
 below" with nothing below it is a worse failure than one that names what is missing.

--- a/docs/detailed/security.md
+++ b/docs/detailed/security.md
@@ -81,7 +81,7 @@ limitation. `RESERVED` names a compatibility slot with no implementation.
 | `credentials.not-agent-reachable` | ENFORCED | context surface assertion |
 | `state.provider-scoped` | ENFORCED | `ScopedStore` isolation tests |
 | `storage.namespace-contained` | ENFORCED | traversal rejection tests |
-| `deployed.config-not-self-writable` | ENFORCED (deployed target) | the revision's `objectAdmin` grant is conditioned on the prefixes it owns, so `profiles/`, `providers/` and `lanes-link.yaml` are readable and not writable. Enforced by the platform; `src/deployments/grants.test.ts` asserts the keys the endpoint writes fall inside the condition and the config paths fall outside. This replaces the read-only image that carried the guarantee before [ADR-023](adr/023-the-workspace-is-not-in-the-image.md) |
+| `deployed.config-not-self-writable` | ENFORCED (deployed target) | the revision's `objectAdmin` grant is conditioned on the prefixes it owns, so `profiles/`, `lanes-link.yaml` and each profile's `providers.d/` are readable and not writable. The last of those sits *inside* the granted `data/` prefix since [ADR-030](adr/030-a-profile-owns-its-skills-and-manifests.md), so the condition carries an explicit exclusion rather than simply not naming it. Enforced by the platform; `src/deployments/grants.test.ts` evaluates the shipped expression — not a scan for prefixes, which would read straight past a negation — and asserts the keys the endpoint writes fall inside it and the config paths fall outside. This replaces the read-only image that carried the guarantee before [ADR-023](adr/023-the-workspace-is-not-in-the-image.md) |
 | `audit.append-only` | ENFORCED | the store interface has no update or delete |
 | `audit.tamper-evident` | ENFORCED **for edits and mid-run removals** | records are hash-chained per run; `lanes link audit verify`. Truncating a run killed mid-write, or deleting a run whole, is not detectable — see [ADR-020](adr/020-the-log-is-objects.md) |
 | `audit.redaction` | ENFORCED | provider redaction tests, including on denials |
@@ -90,7 +90,7 @@ limitation. `RESERVED` names a compatibility slot with no implementation.
 | `setup.no-credential-presence` | ENFORCED | `missingRequirements` is CLI-only; the surface reports requirements, not what is stored |
 | `transport.stateless` | ENFORCED | restart-mid-session test |
 | `credentials.encrypted-at-rest` | ENFORCED (file adapter) | nothing readable on disk; tamper detection |
-| `profile.isolated` | ENFORCED | cross-profile token, state, and audit tests |
+| `profile.isolated` | ENFORCED | cross-profile token, state, and audit tests, plus `src/cli/runtime/scoping.test.ts` for the owner layer. Two things were shared until [ADR-030](adr/030-a-profile-owns-its-skills-and-manifests.md) — skills and provider manifests, both at the workspace root — so this row was previously true of credentials, state and the log rather than of everything a profile holds |
 | `limits.per-profile` | ENFORCED per instance | rate limit tests |
 | `audit.every-invocation` | ENFORCED **with two documented exceptions** | see below |
 | `credentials.client-secret-never-local` | ENFORCED (hosted client) | there is no client secret on the machine to hold. `resolveSecretRefs` grants no client reference at all for a connection authorised this way, asserted in `src/dispatch/context.test.ts` |

--- a/docs/detailed/workflow.md
+++ b/docs/detailed/workflow.md
@@ -290,8 +290,10 @@ $ lanes link skills remove review-diff
 ```
 
 A skill becomes the MCP prompt `skills_<name>`. A running endpoint picks up a new one within a few
-seconds — no restart. Agents can author skills too, under `skills.manage.*`, which is **not** in the
-default bundle; `lanes link connect skills` grants it anyway, so narrowing it is one line:
+seconds — no restart. Skills belong to the profile they were added under and no other sees them, so
+`--profile work` is worth being deliberate about here. Agents can author skills too, under
+`skills.manage.*`, which is **not** in the default bundle; `lanes link connect skills` grants it
+anyway, so narrowing it is one line:
 
 ```console
 $ lanes link policy deny skills.manage.*

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -48,6 +48,9 @@ $ lanes link connect vault
 `connect` takes one provider at a time. Connecting grants that provider's whole namespace, write
 half included — `lanes link policy deny memory.write` narrows it.
 
+All three belong to the profile you ran them under. A second profile starts empty and stays that
+way: nothing you store in one is visible from another.
+
 ## 4. Start the endpoint
 
 ```console

--- a/src/cli/commands/owner/skills.ts
+++ b/src/cli/commands/owner/skills.ts
@@ -1,6 +1,6 @@
 import { ConfigError } from '#profile';
 import {
-  loadWorkspaceSkills,
+  loadProfileSkills,
   readSkill,
   removeSkill,
   writeSkill,
@@ -12,7 +12,7 @@ import { agreed, readStdin, required, withRuntime, type OwnerFlags } from './sha
 
 export async function skillsList(flags: OwnerFlags): Promise<void> {
   await withRuntime(flags, async (runtime) => {
-    const skills = await loadWorkspaceSkills(runtime.skills);
+    const skills = await loadProfileSkills(runtime.skills);
 
     heading(`Skills (${skills.length})`);
     if (skills.length === 0) {

--- a/src/cli/commands/profile/removal.test.ts
+++ b/src/cli/commands/profile/removal.test.ts
@@ -235,16 +235,76 @@ describe('removalPlan', () => {
     expect(plan.items.some((item) => item.target === 'local')).toBe(true);
   });
 
-  test('skills are never planned — every profile sees them', async () => {
-    // The blob store is rooted at the profile's own tree, so workspace-wide
-    // skills are outside it by construction. Asserted because "shared by every
-    // profile" is exactly the thing a future refactor could quietly break.
+  test('skills and manifests go with the profile that owns them — ADR-030', async () => {
+    // They used to be workspace-wide, and this test used to assert the
+    // opposite: that removal never touched them, because every profile saw
+    // them. Now they are inside the profile's own blob root, so the sweep has
+    // them for the same reason it has state and the log.
     const plan = await removalPlan(config(), '/ws', 'personal', registry, {
       openSecrets: async () => fakeSecrets([]),
-      openBlobs: async () => fakeBlobs(['state.kv/a', 'audit.log/b']),
+      openBlobs: async () =>
+        fakeBlobs([
+          'state.kv/a',
+          'audit.log/b',
+          'skills.d/review-diff/SKILL.md',
+          'providers.d/acme.yaml',
+        ]),
     });
 
-    expect(plan.items.every((item) => !item.id.startsWith('skills/'))).toBe(true);
+    const blobs = plan.items.filter((item) => item.kind === 'blob').map((item) => item.id);
+    expect(blobs).toContain('skills.d/review-diff/SKILL.md');
+    expect(blobs).toContain('providers.d/acme.yaml');
+  });
+
+  test('a declared storage path does not leave the authored areas behind', async () => {
+    // `layout.skills` and `layout.providers` are explicit areas, like state and
+    // the log — so a profile that points `storage.path` elsewhere moves its
+    // provider blobs and nothing else. The sweep walks the declared root, so
+    // without these two items the skills and manifests would survive a removal
+    // that reported success.
+    const moved = config({
+      targets: { local: target({ storage: { adapter: 'filesystem', path: './elsewhere' } }) },
+    } as Partial<Config>);
+
+    const plan = await removalPlan(moved, '/ws', 'personal', registry, {
+      openSecrets: async () => fakeSecrets([]),
+      openBlobs: async () => fakeBlobs([]),
+    });
+
+    const files = plan.items.filter((item) => item.kind === 'file').map((item) => item.id);
+    expect(files).toContain('./elsewhere');
+    expect(files).toContain('data/personal/skills.d');
+    expect(files).toContain('data/personal/providers.d');
+  });
+
+  test('the ordinary layout names them once, not twice', async () => {
+    // Inside the blob root, the sweep already has them. A second `file` item
+    // for the same bytes would read as two things to delete in the preview the
+    // operator confirms.
+    const plan = await removalPlan(config(), '/ws', 'personal', registry, {
+      openSecrets: async () => fakeSecrets([]),
+      openBlobs: async () => fakeBlobs(['skills.d/review-diff/SKILL.md']),
+    });
+
+    const files = plan.items.filter((item) => item.kind === 'file').map((item) => item.id);
+    expect(files).toEqual(['data/personal']);
+  });
+
+  test('"./data/personal" is the same directory as "data/personal"', async () => {
+    // What `newProfileTemplate` actually writes, against what `layout` returns.
+    // Compared as strings these differ, and every default profile would have
+    // its skills and manifests named twice in the preview.
+    const declared = config({
+      targets: { local: target({ storage: { adapter: 'filesystem', path: './data/personal' } }) },
+    } as Partial<Config>);
+
+    const plan = await removalPlan(declared, '/ws', 'personal', registry, {
+      openSecrets: async () => fakeSecrets([]),
+      openBlobs: async () => fakeBlobs([]),
+    });
+
+    const files = plan.items.filter((item) => item.kind === 'file').map((item) => item.id);
+    expect(files).toEqual(['./data/personal']);
   });
 });
 

--- a/src/cli/commands/profile/removal.ts
+++ b/src/cli/commands/profile/removal.ts
@@ -1,4 +1,4 @@
-import { layout, profilePath, type Config, type TargetConfig } from '#profile';
+import { layout, profilePath, workspacePath, type Config, type TargetConfig } from '#profile';
 import type { SecretStore } from '#secrets';
 import type { BlobStore } from '#stores/blobs';
 import { credentialRefFor, ownClientRefsFor, type ProviderRegistry } from '#registry';
@@ -154,12 +154,38 @@ export async function removalPlan(
     // data/work is exactly remove the work profile's data"), and one left
     // behind is silently reused by a later `profile add` of the same name.
     if (declared.storage.adapter === 'filesystem') {
+      const blobRoot = declared.storage.path ?? layout.blobs(profile);
       items.push({
         target: name,
         kind: 'file',
-        id: declared.storage.path ?? layout.blobs(profile),
+        id: blobRoot,
         note: 'the profile directory, once emptied',
       });
+
+      // Skills and manifests sit at fixed areas under `data/<profile>/`, the
+      // same way state and the log do — an explicit area, so a profile that
+      // declares its own `storage.path` moves its provider blobs and leaves
+      // these where `layout` says they are. The sweep above walks the blob root
+      // and would then walk straight past them, so they are named. Ordinary
+      // case: both are already inside `blobRoot` and the sweep has them, which
+      // is why this only fires when the two have been pointed apart.
+      //
+      // Resolved before comparing, because they are not compared as paths
+      // otherwise: `newProfileTemplate` writes `./data/<profile>` and
+      // `layout.blobs` returns `data/<profile>`, which is one directory spelled
+      // two ways — the same leading `./` that `profile/layout.ts` has a
+      // paragraph about. Comparing the strings names every default profile's
+      // skills twice in the preview an operator confirms.
+      if (workspacePath(root, blobRoot) !== workspacePath(root, layout.blobs(profile))) {
+        for (const area of [layout.skills(profile), layout.providers(profile)]) {
+          items.push({
+            target: name,
+            kind: 'file',
+            id: area,
+            note: 'outside the declared storage path, so not swept with it',
+          });
+        }
+      }
     }
 
     // A deployed revision reads its config from the bucket rather than the

--- a/src/cli/commands/profile/remove.ts
+++ b/src/cli/commands/profile/remove.ts
@@ -254,7 +254,7 @@ export async function removeProfile(name: string, flags: RemoveFlags): Promise<v
   announce(resolution);
 
   const root = resolution.workspaceRoot;
-  const registry = await buildRegistryWithWorkspace(root);
+  const registry = await buildRegistryWithWorkspace(root, name);
   const files = workspaceFiles(root);
 
   const plan = await removalPlan(config, root, name, registry, {

--- a/src/cli/runtime.test.ts
+++ b/src/cli/runtime.test.ts
@@ -2,6 +2,7 @@ import { afterAll, describe, expect, test } from 'bun:test';
 import { mkdtemp, mkdir, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
+import { layout } from '#profile';
 import { createFileSecretStore } from '#secrets';
 import { openSecretStoreFor, openRuntime, resolveProfile } from './runtime.ts';
 
@@ -89,12 +90,19 @@ describe('the local target', () => {
 });
 
 describe('the owner layer follows the target — ADR-014', () => {
-  test('skills load from the workspace directory, as they always have', async () => {
+  test("skills load from the profile's own directory — ADR-030", async () => {
     const root = await workspace();
+    // Not `<root>/skills/`, which is where they lived while every profile
+    // shared them. A skill left there now loads for nobody, deliberately.
+    await mkdir(join(root, layout.skills('personal')), { recursive: true });
+    await writeFile(
+      join(root, layout.skills('personal'), 'review-diff.md'),
+      '---\ndescription: Review a diff\n---\nReview it.\n',
+    );
     await mkdir(join(root, 'skills'), { recursive: true });
     await writeFile(
-      join(root, 'skills', 'review-diff.md'),
-      '---\ndescription: Review a diff\n---\nReview it.\n',
+      join(root, 'skills', 'stale.md'),
+      '---\ndescription: Left at the old workspace path\n---\nIgnored.\n',
     );
 
     const runtime = await openRuntime({ target: 'local' });
@@ -105,6 +113,9 @@ describe('the owner layer follows the target — ADR-014', () => {
       // The same store the provider reads, exposed so `lanes link skills` cannot drift
       // into a second spelling of the same layout.
       expect((await runtime.skills.list()).map((blob) => blob.key)).toEqual(['review-diff.md']);
+      expect(runtime.registry.capabilities().map((entry) => entry.id)).not.toContain(
+        'skills.stale',
+      );
     } finally {
       await runtime.close();
     }

--- a/src/cli/runtime/open.ts
+++ b/src/cli/runtime/open.ts
@@ -15,7 +15,6 @@ import {
 } from '#profile';
 import { ProviderRegistry, toPolicyDocument } from '#registry';
 import { Dispatcher, createConsoleLogger } from '#dispatch';
-import { WORKSPACE_SKILL_DIR } from '#providers/skills/store.ts';
 import { PROVIDER_MANIFESTS } from '#providers/index.ts';
 import {
   createBlobVaultStore,
@@ -55,7 +54,7 @@ export interface Runtime {
   readonly audit: AuditReader;
   readonly credentials: SecretStore;
   readonly storage: BlobStore;
-  /** Where skills are kept — `<workspace>/skills/` locally. */
+  /** Where skills are kept — `data/<profile>/skills.d/` locally. */
   readonly skills: BlobStore;
   /** The vault's own store, so `lanes link vault` reaches the same bytes MCP does. */
   readonly vault: VaultStore;
@@ -77,21 +76,26 @@ export interface Runtime {
 }
 
 /**
- * Where skills live, in either target.
+ * Where this profile's skills live, in either target.
  *
- * Locally this is `<workspace>/skills/` — the same directory, holding the same
- * files, as before skills went through a store at all. What changes is that a
- * deployment now has somewhere to keep them: a filesystem path is baked into a
- * container image at build time and an S3 prefix is not, so before ADR-014 a
- * deployed instance could only ever serve the skills that existed when its
- * image was built.
+ * Locally `data/<profile>/skills.d/`; deployed, the same key under the bucket
+ * prefix. Going through the store rather than a filesystem path is what gives a
+ * deployment skills at all — a path is baked into a container image at build
+ * time and an object key is not, so before ADR-014 a deployed instance could
+ * only ever serve the skills that existed when its image was built.
  *
- * Workspace-wide rather than per-profile, which is how they have always loaded.
- * Every profile sees every skill, and policy still gates `skills.<name>` per
- * profile — a procedure is not private to a profile the way its knowledge is.
+ * **Per profile**, which reverses ADR-012 §1. Policy gating `skills.<name>`
+ * was the whole isolation story while the bytes were shared, and it is a weak
+ * one: it decides who may *run* a procedure, not who may read that it exists or
+ * what it says. A skill written for work names work's accounts and work's
+ * people. ADR-030.
+ *
+ * An explicit area, matching `openState` and `openAudit` — a profile that
+ * declares its own `storage.path` moves its provider blobs, not the reserved
+ * roots beside them.
  */
-function skillStore(storage: StorageFactory): BlobStore {
-  return storage(WORKSPACE_SKILL_DIR);
+function skillStore(storage: StorageFactory, profile: string): BlobStore {
+  return storage(layout.skills(profile));
 }
 
 /**
@@ -164,7 +168,7 @@ export async function openRuntime(flags: GlobalFlags): Promise<Runtime> {
     (message) => logger.warn(message),
   );
 
-  const skills = skillStore(storageFor);
+  const skills = skillStore(storageFor, config.instance.profile);
 
   // The vault's own store, beside the credential store and never it: a separate
   // document, a separate key, and a separate environment variable
@@ -224,7 +228,7 @@ export async function openRuntime(flags: GlobalFlags): Promise<Runtime> {
         account: connection.account,
       }));
 
-  registry = await buildRegistryWithWorkspace(root, {
+  registry = await buildRegistryWithWorkspace(root, config.instance.profile, {
     skillStore: skills,
     onSkillsChanged: refreshSkills,
     vault: { store: vaultStore, items: await vaultStore.ids() },

--- a/src/cli/runtime/registry.ts
+++ b/src/cli/runtime/registry.ts
@@ -2,11 +2,8 @@ import type { BlobStore } from '#stores/blobs';
 import type { ProviderDefinition } from '#connectivity';
 import { ConfigError } from '#profile';
 import { ProviderRegistry } from '#registry';
-import { loadWorkspaceProviders } from '#providers/custom/index.ts';
-import {
-  loadWorkspaceSkills,
-  type LoadedSkill,
-} from '#providers/skills/store.ts';
+import { loadProfileProviders } from '#providers/custom/index.ts';
+import { loadProfileSkills, type LoadedSkill } from '#providers/skills/store.ts';
 import { exampleProvider } from '#providers/example/provider.ts';
 import {
   createMemoryVaultStore,
@@ -107,21 +104,27 @@ export function buildRegistry(owner: OwnerLayerOptions = {}): ProviderRegistry {
 }
 
 /**
- * Built-ins plus whatever the operator has dropped into the workspace.
+ * Built-ins plus whatever the operator has dropped into this profile.
  *
- * A workspace manifest registering under a built-in id is refused rather than
- * silently overriding it — an operator shadowing `gmail` by accident would be
- * very hard to diagnose from the outside.
+ * A manifest registering under a built-in id is refused rather than silently
+ * overriding it — an operator shadowing `gmail` by accident would be very hard
+ * to diagnose from the outside.
+ *
+ * The profile is a parameter rather than read from a config here because two of
+ * the three callers do not have one: `deploy` walks every profile in turn, and
+ * `profile remove` is holding the name of the one being deleted. Passing it
+ * makes "which profile's manifests" a question the caller has already answered.
  */
 export async function buildRegistryWithWorkspace(
   root: string,
+  profile: string,
   owner: OwnerLayerOptions = {},
 ): Promise<ProviderRegistry> {
   const skills =
-    owner.skills ?? (owner.skillStore ? await loadWorkspaceSkills(owner.skillStore) : []);
+    owner.skills ?? (owner.skillStore ? await loadProfileSkills(owner.skillStore) : []);
   const registry = buildRegistry({ ...owner, skills });
 
-  for (const { manifest, path } of await loadWorkspaceProviders(root)) {
+  for (const { manifest, path } of await loadProfileProviders(root, profile)) {
     if (registry.has(manifest.id)) {
       throw new ConfigError(
         `${path}: provider "${manifest.id}" is already built in. Rename it, or remove the file to use the built-in.`,
@@ -166,7 +169,7 @@ export async function reloadSkills(
 
   registry.replace(
     skillsProviderFor({
-      skills: await loadWorkspaceSkills(store),
+      skills: await loadProfileSkills(store),
       skillStore: store,
       onSkillsChanged: onChange,
     }),

--- a/src/cli/runtime/scoping.test.ts
+++ b/src/cli/runtime/scoping.test.ts
@@ -1,0 +1,166 @@
+import { afterAll, describe, expect, test } from 'bun:test';
+import { mkdtemp, mkdir, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { layout } from '#profile';
+import { openRuntime, type Runtime } from '../runtime.ts';
+
+/**
+ * That a profile's owner layer is the profile's — ADR-030.
+ *
+ * Skills and provider manifests used to live at the workspace root, shared by
+ * every profile, with policy gating `skills.<name>` as the whole isolation
+ * story. Policy decides who may *run* a procedure; it never hid that the
+ * procedure existed, or what it said, or which host a manifest names.
+ *
+ * These tests open two real runtimes over one real workspace, because that is
+ * the only arrangement where the bug was reachable: one profile is never wrong
+ * about whose skills it is holding.
+ */
+
+const roots: string[] = [];
+const previousHome = process.env['LANES_LINK_HOME'];
+
+const profileConfig = (name: string): string => `contract: 1
+
+instance:
+  profile: ${name}
+  default_target: local
+
+targets:
+  local:
+    credentials: { adapter: file,       path: ./data/${name}/credentials.enc }
+    storage:     { adapter: filesystem, path: ./data/${name} }
+
+policy:
+  allow: ['*']
+`;
+
+const skill = (description: string, body: string): string =>
+  `---\ndescription: ${description}\n---\n${body}\n`;
+
+const manifest = (id: string, host: string): string =>
+  `id: ${id}\nname: ${id}\nconnector: { kind: http, base_url: https://${host}, openapi: https://${host}/openapi.json }\nauth: { kind: header, header: X-API-Key, credential_ref: ${id}/api_key }\n`;
+
+async function workspace(files: Record<string, string>): Promise<string> {
+  const root = await mkdtemp(join(tmpdir(), 'lanes-link-scoping-'));
+  roots.push(root);
+
+  await mkdir(join(root, 'profiles'), { recursive: true });
+  await writeFile(join(root, 'lanes-link.yaml'), 'contract: 1\ndefault_profile: personal\n');
+  for (const name of ['personal', 'work']) {
+    await writeFile(join(root, 'profiles', `${name}.yaml`), profileConfig(name));
+  }
+
+  for (const [key, contents] of Object.entries(files)) {
+    await mkdir(join(root, key, '..'), { recursive: true });
+    await writeFile(join(root, key), contents);
+  }
+
+  process.env['LANES_LINK_HOME'] = root;
+  return root;
+}
+
+/** Both runtimes, closed however the assertions end. */
+async function bothProfiles<T>(
+  body: (runtimes: Record<'personal' | 'work', Runtime>) => Promise<T>,
+): Promise<T> {
+  const personal = await openRuntime({ target: 'local', profile: 'personal' });
+  const work = await openRuntime({ target: 'local', profile: 'work' });
+
+  try {
+    return await body({ personal, work });
+  } finally {
+    await personal.close();
+    await work.close();
+  }
+}
+
+const capabilities = (runtime: Runtime): string[] =>
+  runtime.registry.capabilities().map((entry) => entry.id);
+
+afterAll(async () => {
+  if (previousHome === undefined) delete process.env['LANES_LINK_HOME'];
+  else process.env['LANES_LINK_HOME'] = previousHome;
+  await Promise.all(roots.map((root) => rm(root, { recursive: true, force: true })));
+});
+
+describe('skills belong to one profile', () => {
+  test("a profile's skills are invisible to its sibling", async () => {
+    await workspace({
+      [`${layout.skills('personal')}/holiday-plan/SKILL.md`]: skill('Plan a holiday', 'Plan it.'),
+      [`${layout.skills('work')}/incident-review/SKILL.md`]: skill('Review an incident', 'Review it.'),
+    });
+
+    await bothProfiles(async ({ personal, work }) => {
+      expect(capabilities(personal)).toContain('skills.holiday-plan');
+      expect(capabilities(personal)).not.toContain('skills.incident-review');
+
+      expect(capabilities(work)).toContain('skills.incident-review');
+      expect(capabilities(work)).not.toContain('skills.holiday-plan');
+    });
+  });
+
+  test('one name in two profiles is two different procedures', async () => {
+    // The capability id is the same on both sides, which is the case a shared
+    // directory could not represent at all: whichever file existed won, for
+    // everyone. Here each store answers for its own profile.
+    await workspace({
+      [`${layout.skills('personal')}/triage.md`]: skill('Triage', 'Sort the personal inbox.'),
+      [`${layout.skills('work')}/triage.md`]: skill('Triage', 'Page the on-call engineer.'),
+    });
+
+    const personal = await openRuntime({ target: 'local', profile: 'personal' });
+    const work = await openRuntime({ target: 'local', profile: 'work' });
+
+    try {
+      const body = async (runtime: typeof personal): Promise<string> =>
+        new TextDecoder().decode((await runtime.skills.get('triage.md'))!);
+
+      expect(await body(personal)).toContain('Sort the personal inbox.');
+      expect(await body(work)).toContain('Page the on-call engineer.');
+    } finally {
+      await personal.close();
+      await work.close();
+    }
+  });
+
+  test('a skill left at the old workspace path loads for nobody', async () => {
+    // No migration, deliberately — `profile/layout.ts` says so. The failure
+    // mode worth pinning is that it is *absent*, not that it silently keeps
+    // working for every profile.
+    await workspace({
+      'skills/review-diff/SKILL.md': skill('Review a diff', 'Review it.'),
+    });
+
+    await bothProfiles(async ({ personal, work }) => {
+      expect(capabilities(personal)).not.toContain('skills.review-diff');
+      expect(capabilities(work)).not.toContain('skills.review-diff');
+    });
+  });
+});
+
+describe('provider manifests belong to one profile', () => {
+  test('a manifest one profile declares is not registered in the other', async () => {
+    await workspace({
+      [`${layout.providers('work')}/ledger.yaml`]: manifest('ledger', 'ledger.example.com'),
+    });
+
+    // `has`, not `capabilities()`: an http provider's capability list comes
+    // from its OpenAPI document, which nothing here fetches. Whether the
+    // manifest was registered at all is the question this change decides.
+    await bothProfiles(async ({ personal, work }) => {
+      expect(work.registry.has('ledger')).toBe(true);
+      expect(personal.registry.has('ledger')).toBe(false);
+    });
+  });
+
+  test('a manifest left at the old workspace path is not registered either', async () => {
+    await workspace({ 'providers/ledger.yaml': manifest('ledger', 'ledger.example.com') });
+
+    await bothProfiles(async ({ personal, work }) => {
+      expect(personal.registry.has('ledger')).toBe(false);
+      expect(work.registry.has('ledger')).toBe(false);
+    });
+  });
+});

--- a/src/connectivity/manifest/provider.ts
+++ b/src/connectivity/manifest/provider.ts
@@ -17,7 +17,7 @@ import { setupSchema } from './setup.ts';
  *
  *   - built-ins, written as typed TS modules under `#providers/` and validated
  *     at import
- *   - workspace manifests in `~/.lanes-link/providers/*.yaml`, validated on load
+ *   - the profile's own manifests in `data/<profile>/providers.d/*.yaml`, validated on load
  *
  * That second one is the scalability claim. A service nobody has integrated is
  * a YAML file the operator writes, not a pull request they wait on.

--- a/src/deployments/deploy.test.ts
+++ b/src/deployments/deploy.test.ts
@@ -3,8 +3,14 @@ import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { rotatableRefs } from './prepare.ts';
-import { deployedWorkspace, isWorkspaceConfig, publishWorkspace, repairSetupSurface } from './upload.ts';
-import { parseConfig } from '#profile';
+import {
+  deployedWorkspace,
+  isWorkspaceConfig,
+  publishWorkspace,
+  repairSetupSurface,
+  uploadWorkspace,
+} from './upload.ts';
+import { layout, parseConfig, workspaceFiles } from '#profile';
 
 const roots: string[] = [];
 
@@ -25,8 +31,20 @@ describe('what a deploy sends up', () => {
   test('config goes', () => {
     expect(isWorkspaceConfig('lanes-link.yaml')).toBe(true);
     expect(isWorkspaceConfig('profiles/personal.yaml')).toBe(true);
-    expect(isWorkspaceConfig('providers/acme.yaml')).toBe(true);
-    expect(isWorkspaceConfig('skills/review-diff/SKILL.md')).toBe(true);
+  });
+
+  test('the authored areas inside a profile go — they are config, not state', () => {
+    // ADR-030 moved both into the profile. They still have to go up: a skill
+    // that does not is the ADR-014 §2 regression, and a manifest that does not
+    // is a provider the revision has never heard of.
+    expect(isWorkspaceConfig('data/personal/skills.d/review-diff/SKILL.md')).toBe(true);
+    expect(isWorkspaceConfig('data/personal/skills.d/review-diff.md')).toBe(true);
+    expect(isWorkspaceConfig('data/personal/providers.d/acme.yaml')).toBe(true);
+  });
+
+  test('the old workspace-wide paths do not go — nothing reads them now', () => {
+    expect(isWorkspaceConfig('providers/acme.yaml')).toBe(false);
+    expect(isWorkspaceConfig('skills/review-diff/SKILL.md')).toBe(false);
   });
 
   test('credentials never go, however they are spelled', () => {
@@ -34,10 +52,30 @@ describe('what a deploy sends up', () => {
       'data/personal/credentials.enc',
       'data/personal/credentials.enc.key',
       'data/personal/vault.enc',
+      'data/personal/vault.enc.key',
       'data/personal/state.kv/connections%2Ev1/gmail%2Emain.json',
       'data/personal/audit.log/2026/08/12/x.json',
+      'data/personal/memory/main/note.md',
+      'data/personal/gmail/ada_lovelace/attachments/x.pdf',
     ]) {
       expect(isWorkspaceConfig(key)).toBe(false);
+    }
+  });
+
+  test('reaching into data/ matches whole segments, never prefixes', () => {
+    // The allowlist now names two directories inside the tree it otherwise
+    // refuses wholesale. A prefix match would send anything merely starting
+    // with the same letters, and the thing on the other side of that boundary
+    // is the credential store.
+    for (const key of [
+      'data/personal/skills.detour/leak.md',
+      'data/personal/providers.disabled/acme.yaml',
+      'data/personal/skills.d',
+      'data/personal/providers.d',
+      'data/skills.d/review-diff.md',
+      'data//skills.d/review-diff.md',
+    ]) {
+      expect({ key, sent: isWorkspaceConfig(key) }).toEqual({ key, sent: false });
     }
   });
 
@@ -55,6 +93,12 @@ describe('what a deploy sends up', () => {
     // that only one of them is for.
     expect(isWorkspaceConfig('profiles/personal.yaml', 'personal')).toBe(true);
     expect(isWorkspaceConfig('profiles/work.yaml', 'personal')).toBe(false);
+
+    // Same question for the authored areas, which are now the larger half of
+    // what goes up.
+    expect(isWorkspaceConfig('data/personal/skills.d/a.md', 'personal')).toBe(true);
+    expect(isWorkspaceConfig('data/work/skills.d/a.md', 'personal')).toBe(false);
+    expect(isWorkspaceConfig('data/work/providers.d/acme.yaml', 'personal')).toBe(false);
   });
 });
 
@@ -335,5 +379,96 @@ policy:
     // covered above.
     expect(deployedWorkspace(config.targets['cloud']!)).toBe('gs://your-bucket/workspace');
     expect(deployedWorkspace(config.targets['local']!)).toBeUndefined();
+  });
+});
+
+/**
+ * The allowlist against a real listing, rather than against keys typed by hand.
+ *
+ * `uploadWorkspace` walks `list('')` over the whole workspace, which descends
+ * into `data/` and returns `credentials.enc` along with everything else — the
+ * filter is the only thing between that listing and a bucket. Testing the
+ * predicate alone leaves the pairing untested, and the pairing is where a
+ * credential would leak: a listing that stopped recursing would make the
+ * skills half silently do nothing, and one that recursed further than the
+ * filter expects would send the rest.
+ *
+ * Driven between two directories because a `BlobStore` over a local path and
+ * one over a bucket are the same interface. No bucket required.
+ */
+describe('the allowlist against a real workspace listing', () => {
+  const roots: string[] = [];
+
+  afterAll(async () => {
+    await Promise.all(roots.map((root) => rm(root, { recursive: true, force: true })));
+  });
+
+  async function populated(): Promise<{ source: string; destination: string }> {
+    const source = await mkdtemp(join(tmpdir(), 'lanes-link-upload-'));
+    const destination = await mkdtemp(join(tmpdir(), 'lanes-link-bucket-'));
+    roots.push(source, destination);
+
+    const files: Record<string, string> = {
+      'lanes-link.yaml': 'contract: 1\ndefault_profile: personal\n',
+      'profiles/personal.yaml': 'contract: 1\n',
+      'profiles/work.yaml': 'contract: 1\n',
+      [`${layout.skills('personal')}/review-diff/SKILL.md`]: '---\ndescription: d\n---\nb\n',
+      [`${layout.providers('personal')}/acme.yaml`]: 'id: acme\n',
+      [`${layout.skills('work')}/triage.md`]: '---\ndescription: d\n---\nb\n',
+      'data/personal/credentials.enc': 'ciphertext',
+      'data/personal/credentials.enc.key': 'the key that opens it',
+      'data/personal/vault.enc': 'ciphertext',
+      'data/personal/state.kv/connections%2Ev1/example%2Ea.json': '{}',
+      'data/personal/audit.log/2026/08/24/x.json': '{}',
+      'data/personal/memory/main/note.md': 'a note',
+      'data/personal/example/a/attachments/x.pdf': 'bytes',
+    };
+
+    for (const [key, contents] of Object.entries(files)) {
+      await mkdir(join(source, key, '..'), { recursive: true });
+      await writeFile(join(source, key), contents);
+    }
+
+    return { source, destination };
+  }
+
+  const landed = async (root: string): Promise<string[]> =>
+    (await workspaceFiles(root).list('')).map((entry) => entry.key).sort();
+
+  test('the whole workspace goes, and nothing else in data/ does', async () => {
+    const { source, destination } = await populated();
+
+    await uploadWorkspace(source, destination, undefined);
+
+    expect(await landed(destination)).toEqual([
+      'data/personal/providers.d/acme.yaml',
+      'data/personal/skills.d/review-diff/SKILL.md',
+      'data/work/skills.d/triage.md',
+      'lanes-link.yaml',
+      'profiles/personal.yaml',
+      'profiles/work.yaml',
+    ]);
+  });
+
+  test('naming a profile sends that profile and the workspace file', async () => {
+    const { source, destination } = await populated();
+
+    await uploadWorkspace(source, destination, 'personal');
+
+    expect(await landed(destination)).toEqual([
+      'data/personal/providers.d/acme.yaml',
+      'data/personal/skills.d/review-diff/SKILL.md',
+      'lanes-link.yaml',
+      'profiles/personal.yaml',
+    ]);
+  });
+
+  test('the source really does offer the credential store to the filter', async () => {
+    // Without this, the test above passes just as well against a listing that
+    // never descends into `data/` — which would mean the skills never go up
+    // either, silently.
+    const { source } = await populated();
+
+    expect(await landed(source)).toContain('data/personal/credentials.enc.key');
   });
 });

--- a/src/deployments/gcp/driver.test.ts
+++ b/src/deployments/gcp/driver.test.ts
@@ -246,8 +246,12 @@ describe('first-run provisioning', () => {
     expect(condition).not.toContain('expression=true');
     expect(condition).toContain('/objects/profiles/');
     expect(condition).toContain('/objects/lanes-link.yaml');
-    // Not the data it writes, and not the whole bucket.
-    expect(condition).not.toContain('/objects/data/');
+    // It does reach into `data/` now, for the manifests ADR-030 moved in there
+    // — but by the anchored pattern only. A blanket `startsWith(".../data/")`
+    // here would hand the revision read on every credential-adjacent object in
+    // the profile, which is the narrowing this condition exists to make.
+    expect(condition).toContain('providers\\.d/');
+    expect(condition).not.toMatch(/startsWith\("[^"]*\/objects\/data\/"\)/);
   });
 
   test('the revision may write its data but only read its config', async () => {
@@ -261,17 +265,23 @@ describe('first-run provisioning', () => {
 
     const write = conditions.find((condition) => condition.includes('owns-its-data'))!;
     expect(write).toContain('/objects/data/');
-    expect(write).toContain('/objects/skills/');
-    // The config paths are conspicuously absent from the writable set.
+    // Skills are inside `data/` since ADR-030 rather than beside it, so there
+    // is no second prefix to grant.
+    expect(write).not.toContain('/objects/skills/');
+    // The config paths are conspicuously absent from the writable set — and
+    // that now includes the manifests living inside the tree this grants, which
+    // is why the expression carries a negation at all.
     expect(write).not.toContain('profiles/');
     expect(write).not.toContain('lanes-link.yaml');
+    expect(write).toContain('!resource.name.matches(');
+    expect(write).toContain('providers\\.d/');
 
     expect(conditions.some((condition) => condition.includes('reads-its-config'))).toBe(true);
   });
 
   test('a gcs target gets a bucket, the same as an s3 one', async () => {
     // Deployed, every target addresses a bucket: config, state, the log,
-    // memory, skills and attachments are all objects in it.
+    // memory, skills, manifests and attachments are all objects in it.
     const steps = await provision({ adapter: 'gcs', bucket: 'lanes-link-blobs' });
     expect(steps.flatMap((step) => step.argv)).toContain('buckets');
   });

--- a/src/deployments/gcp/provision.ts
+++ b/src/deployments/gcp/provision.ts
@@ -236,8 +236,16 @@ export function provisionSteps(input: ProvisionInput): Promise<DeployStep[]> {
       const objectIs = (path: string): string =>
         `resource.name == "projects/_/buckets/${bucket}/objects/${path}"`;
 
+      // A provider manifest is configuration that happens to live inside the
+      // profile's directory (ADR-030), so `data/` alone no longer separates
+      // what the revision owns from what declares what it is. Anchored to the
+      // profile segment rather than matched loosely: `contains("/providers.d/")`
+      // would also catch a blob whose own key happened to spell it.
+      const providerManifests =
+        `resource.name.matches("^projects/_/buckets/${bucket}/objects/data/[^/]+/providers\\.d/")`;
+
       steps.push({
-        title: 'let the revision write its own data and skills',
+        title: 'let the revision write its own data, but not the manifests in it',
         argv: [
           'storage',
           'buckets',
@@ -250,7 +258,7 @@ export function provisionSteps(input: ProvisionInput): Promise<DeployStep[]> {
           '--role',
           'roles/storage.objectAdmin',
           '--condition',
-          `title=owns-its-data,expression=${objectsUnder('data/')} || ${objectsUnder('skills/')}`,
+          `title=owns-its-data,expression=${objectsUnder('data/')} && !${providerManifests}`,
         ],
         tolerateFailure: true,
       });
@@ -268,10 +276,10 @@ export function provisionSteps(input: ProvisionInput): Promise<DeployStep[]> {
           'roles/storage.objectViewer',
           // `expression=true` was here, which is every object in the bucket —
           // the step title and ADR-023 both claim a narrowing this did not do.
-          // The config the revision reads is the workspace file and the
-          // profiles beside it, so name exactly those.
+          // The config the revision reads is the workspace file, the profiles
+          // beside it, and each profile's own manifests, so name exactly those.
           '--condition',
-          `title=reads-its-config,expression=${objectsUnder('profiles/')} || ${objectIs('lanes-link.yaml')}`,
+          `title=reads-its-config,expression=${objectsUnder('profiles/')} || ${objectIs('lanes-link.yaml')} || ${providerManifests}`,
         ],
         tolerateFailure: true,
       });

--- a/src/deployments/grants.test.ts
+++ b/src/deployments/grants.test.ts
@@ -6,7 +6,7 @@ import {
   type ProviderManifest,
 } from '#connectivity';
 import { CredentialOAuthProvider } from '#connectivity/auth/index.ts';
-import { WORKSPACE_SKILL_DIR, layout, type Config, type DeployConfig, type TargetConfig } from '#profile';
+import { layout, type Config, type DeployConfig, type TargetConfig } from '#profile';
 import { ownClientRefsFor } from '#registry';
 import { encodeRef } from './adapters/gcp-secret-manager.ts';
 import { provisionSteps } from './gcp/provision.ts';
@@ -70,7 +70,7 @@ const AREAS: Record<string, [string | undefined, string]> = {
   'the audit log': [layout.audit(PROFILE), '2026/08/13/1755075600000-abc.json'],
   'a memory entry': [undefined, 'memory/main/note.md'],
   'an attachment': [undefined, 'gmail/ada_lovelace/attachments/x.pdf'],
-  'a skill': [WORKSPACE_SKILL_DIR, 'review-diff/SKILL.md'],
+  'a skill': [layout.skills(PROFILE), 'review-diff/SKILL.md'],
 };
 
 const WRITES: Record<string, string> = {};
@@ -116,22 +116,42 @@ afterAll(() => {
 const READS = {
   'its own profile': `profiles/${PROFILE}.yaml`,
   'the workspace file': 'lanes-link.yaml',
-  'a provider manifest': 'providers/acme.yaml',
+  // Inside `data/` since ADR-030, so the write condition has to carve it back
+  // out rather than simply not mentioning it.
+  'a provider manifest': `${layout.providers(PROFILE)}/acme.yaml`,
 };
 
 async function writeCondition(): Promise<string> {
   const steps = await provisionSteps({ deploy: cloudrun, declared: target, target: 'cloud' });
   const step = steps.find((candidate) => candidate.argv.join(' ').includes('owns-its-data'));
 
-  return step!.argv[step!.argv.indexOf('--condition') + 1]!;
+  // `title=…,expression=…`; only the expression is evaluable.
+  const condition = step!.argv[step!.argv.indexOf('--condition') + 1]!;
+  const marker = 'expression=';
+  return condition.slice(condition.indexOf(marker) + marker.length);
 }
 
-/** `a.startsWith("x") || a.startsWith("y")`, evaluated for one resource name. */
+/**
+ * Evaluate the shipped condition for one resource name.
+ *
+ * The subset of CEL these expressions use — `||`, `&&`, `!`, parentheses,
+ * `startsWith`, `matches`, and `==` against a string literal — is also valid
+ * JavaScript, so the expression runs rather than being pattern-matched. That
+ * matters more since the write grant stopped being a flat `||` of prefixes: an
+ * exclusion is exactly the kind of clause a regex scan reads straight past,
+ * reporting a permission the revision does not have.
+ *
+ * `name` is a `String` object so the methods can hang off it while
+ * `resource.name == "…"` still compares equal by coercion.
+ */
 function permits(condition: string, key: string): boolean {
-  const prefixes = [...condition.matchAll(/startsWith\("([^"]+)"\)/g)].map((match) => match[1]!);
-  expect(prefixes.length).toBeGreaterThan(0);
+  const full = `${OBJECTS}${key}`;
+  const name = Object.assign(new String(full), {
+    contains: (needle: string) => full.includes(needle),
+    matches: (pattern: string) => new RegExp(pattern).test(full),
+  });
 
-  return prefixes.some((prefix) => `${OBJECTS}${key}`.startsWith(prefix));
+  return new Function('resource', `return ${condition};`)({ name }) === true;
 }
 
 describe('what the revision is granted, against what it writes', () => {

--- a/src/deployments/prepare.ts
+++ b/src/deployments/prepare.ts
@@ -62,7 +62,6 @@ export interface PrepareResult {
  * config and manifests only, and touches no credential.
  */
 export async function rotatableRefs(root: string, profile: string | undefined): Promise<string[]> {
-  const registry = await buildRegistryWithWorkspace(root);
   const refs = new Set<string>();
 
   for (const name of await listProfiles(root)) {
@@ -74,6 +73,12 @@ export async function rotatableRefs(root: string, profile: string | undefined): 
     } catch {
       continue;
     }
+
+    // Inside the loop because manifests are the profile's own (ADR-030): a
+    // connection in `work` naming a provider only `work` declares resolves to
+    // nothing against `personal`'s registry, and a missed ref here is a 403 an
+    // hour after the revision reports healthy.
+    const registry = await buildRegistryWithWorkspace(root, name);
 
     for (const connection of config.connections) {
       const manifest = registry.manifest(connection.provider);
@@ -119,7 +124,6 @@ export async function readableRefs(
   profile: string | undefined,
   declared: TargetConfig | undefined,
 ): Promise<string[]> {
-  const registry = await buildRegistryWithWorkspace(root);
   const refs = new Set<string>();
 
   if (declared?.vault?.adapter === 'secret') {
@@ -145,6 +149,10 @@ export async function readableRefs(
     if (config.auth.authorization?.mode === 'oidc') {
       refs.add(config.auth.authorization.client_id_ref);
     }
+
+    // Per profile, for the reason `rotatableRefs` gives: a manifest is this
+    // profile's, so the registry that resolves its connections must be too.
+    const registry = await buildRegistryWithWorkspace(root, name);
 
     for (const connection of config.connections) {
       const manifest = registry.manifest(connection.provider);
@@ -174,7 +182,7 @@ export async function prepareSecrets(input: PrepareInput): Promise<PrepareResult
   // The command is spelled out rather than described. This is the one manual
   // step a deploy genuinely cannot take for you, so it should cost a paste
   // rather than a trip to the docs to work out how the id is spelled.
-  const registry = await buildRegistryWithWorkspace(root);
+  const registry = await buildRegistryWithWorkspace(root, config.instance.profile);
   for (const connection of config.connections) {
     const ref = credentialRefFor(connection, registry.manifest(connection.provider));
     if (!ref || (await credentials.has(ref))) continue;

--- a/src/deployments/upload.ts
+++ b/src/deployments/upload.ts
@@ -1,5 +1,7 @@
 import {
+  DATA_DIR,
   WORKSPACE_FILE,
+  layout,
   listProfiles,
   workspaceFiles,
   type Config,
@@ -52,15 +54,45 @@ export function deployedWorkspace(declared: TargetConfig): string | undefined {
  * An allowlist because the failure modes are not symmetric: a config file this
  * forgets means an endpoint that will not boot, and a credential this includes
  * by accident means a credential in a bucket. Forgetting is loud.
+ *
+ * **Two areas inside `data/` are authored rather than accumulated**, since
+ * ADR-030 moved skills and provider manifests into the profile that owns them.
+ * They have to go up or a deployed instance loses both — the regression ADR-014
+ * §2 fixed for skills, reintroduced by where they now live. So this reaches
+ * into `data/` for exactly those two, by whole path segment and never by
+ * prefix: `data/personal/skills.detour/` is not `skills.d`, and the difference
+ * between matching it and not is a credential in a bucket.
  */
 export function isWorkspaceConfig(key: string, profile?: string | undefined): boolean {
   if (key === WORKSPACE_FILE) return true;
-  if (key.startsWith('providers/') || key.startsWith('skills/')) return true;
-  if (!key.startsWith('profiles/') || !key.endsWith('.yaml')) return false;
 
   // One profile when the deploy names one, so a workspace holding personal and
-  // work does not push both into a bucket only one of them is for.
+  // work does not push both into a bucket only one of them is for. The same
+  // question for both shapes, asked once.
+  const owner = authoredAreaOwner(key);
+  if (owner !== null) return profile === undefined || owner === profile;
+
+  if (!key.startsWith('profiles/') || !key.endsWith('.yaml')) return false;
   return profile === undefined || key === `profiles/${profile}.yaml`;
+}
+
+/**
+ * The profile whose authored area holds `key`, or null for anything else.
+ *
+ * Composed back out of `layout` rather than compared against literals, so a
+ * renamed directory moves both this and the store that reads it, or neither.
+ * Requires a fourth segment: `data/personal/skills.d` names the directory, and
+ * a directory is not a file to send.
+ */
+function authoredAreaOwner(key: string): string | null {
+  const segments = key.split('/');
+  if (segments.length < 4 || segments[0] !== DATA_DIR) return null;
+
+  const owner = segments[1]!;
+  if (owner.length === 0) return null;
+
+  const area = `${DATA_DIR}/${owner}/${segments[2]}`;
+  return area === layout.skills(owner) || area === layout.providers(owner) ? owner : null;
 }
 
 /**

--- a/src/profile/index.ts
+++ b/src/profile/index.ts
@@ -71,7 +71,6 @@ export {
 
 export {
   DATA_DIR,
-  WORKSPACE_SKILL_DIR,
   layout,
   profileDir,
 } from './layout.ts';

--- a/src/profile/layout.ts
+++ b/src/profile/layout.ts
@@ -3,15 +3,16 @@
  *
  * ```
  * ~/.lanes-link/
- * ├── lanes-link.yaml            which profiles exist, which is default
+ * ├── lanes-link.yaml           which profiles exist, which is default
  * ├── profiles/<name>.yaml      each profile's declared config
- * ├── providers/*.yaml          the operator's own provider manifests
- * ├── skills/<name>/SKILL.md    procedures, shared by every profile
  * └── data/
  *     └── <profile>/            everything one profile owns
- *         ├── lanes-link.db      state, connections, audit
+ *         ├── state.kv/         state, connections, cursors
+ *         ├── audit.log/        one object per event
  *         ├── credentials.enc   system credentials, and its .key
  *         ├── vault.enc         the owner's items, its own key
+ *         ├── skills.d/         procedures, one <name>/SKILL.md each
+ *         ├── providers.d/      the operator's own provider manifests
  *         └── <provider>/<connection>/…   whatever that provider stores
  * ```
  *
@@ -31,10 +32,20 @@
  * files beside it: a provider id is `[a-z][a-z0-9_]*` and every reserved name
  * here contains a dot.
  *
- * Skills stay workspace-wide rather than per-profile, which is how they have
- * always loaded: every profile sees every skill, and policy still gates
- * `skills.<name>` per profile. A procedure is not private to a profile the way
- * its knowledge is.
+ * **Skills and provider manifests are the profile's too**, which reverses where
+ * both used to sit. They were at the workspace root, shared by every profile, on
+ * the reasoning that a procedure is not private to a profile the way its
+ * knowledge is. That was wrong twice over. A skill is instructions an agent will
+ * be handed, and ADR-014 §1 already treats authoring one as a grant worth
+ * governing — an odd thing to say about a document every profile reads anyway.
+ * And a procedure written for work names work's accounts, its people, and its
+ * conventions, so it is exactly as private as the knowledge it operates on.
+ * ADR-030 has the argument; ADR-009's "profiles share nothing" is what it
+ * restores.
+ *
+ * The `.d` suffix is the dot rule above rather than decoration. A plain
+ * `data/<profile>/skills/` is precisely the namespace the skills provider's own
+ * blobs scope into, so the one name that could not be used is the obvious one.
  *
  * These are **defaults**. A profile that declares its own paths keeps them.
  *
@@ -42,14 +53,13 @@
  * workspace is profiles, credentials, and whatever the owner has stored, and
  * re-creating one is `lanes link profile add` plus `lanes link connect` per account. Machinery
  * to move an old one would be more code than the thing it moves, and it would
- * have to keep working forever to be worth having.
+ * have to keep working forever to be worth having. Skills and manifests left at
+ * the old workspace-root paths are the same case: they stop loading, and moving
+ * them is one `mv` per profile that should see them.
  */
 
 /** The directory under the workspace root that holds every profile's data. */
 export const DATA_DIR = 'data';
-
-/** Workspace-wide skills. Not per profile — see the note above. */
-export const WORKSPACE_SKILL_DIR = 'skills';
 
 /**
  * Everything one profile owns, relative to the workspace root.
@@ -80,6 +90,23 @@ export const layout = {
   credentials: (profile: string): string => `${profileDir(profile)}/credentials.enc`,
   /** The owner's own items, under their own key. */
   vault: (profile: string): string => `${profileDir(profile)}/vault.enc`,
+  /**
+   * This profile's skills — `<name>.md` or `<name>/SKILL.md`, either layout.
+   *
+   * The dot carries the same weight it does for `state` and `audit`, and here
+   * it is not hypothetical: `skills` is a real provider id, so `skills/` under
+   * the blob root is the prefix its own connection blobs would scope into.
+   */
+  skills: (profile: string): string => `${profileDir(profile)}/skills.d`,
+  /**
+   * The provider manifests this profile declares.
+   *
+   * Per profile for the same reason a connection is. A manifest names a host,
+   * an OpenAPI document, and the credential refs that reach them — which is a
+   * description of somebody's infrastructure, and work's is not personal's to
+   * read.
+   */
+  providers: (profile: string): string => `${profileDir(profile)}/providers.d`,
   /** The blob root every provider is namespaced under. */
   blobs: (profile: string): string => profileDir(profile),
   /**

--- a/src/providers/custom/index.ts
+++ b/src/providers/custom/index.ts
@@ -1,9 +1,10 @@
 /**
  * Custom providers — the ones an operator writes.
  *
- * A YAML manifest in `~/.lanes-link/providers/`, validated by exactly the schema
- * the built-ins are validated by, registered into exactly the same registry. A
- * service nobody has integrated is a file, not a pull request someone waits on.
+ * A YAML manifest in `~/.lanes-link/data/<profile>/providers.d/`, validated by
+ * exactly the schema the built-ins are validated by, registered into exactly
+ * the same registry. A service nobody has integrated is a file, not a pull
+ * request someone waits on.
  *
  * That equivalence is the scalability claim of the manifest design, and it is
  * only worth anything if it is literally true — so nothing here is a reduced
@@ -12,8 +13,7 @@
  */
 
 export {
-  WORKSPACE_PROVIDER_DIR,
-  loadWorkspaceProviders,
+  loadProfileProviders,
   parseManifest,
   parseManifestFile,
   type LoadedManifest,

--- a/src/providers/custom/load.test.ts
+++ b/src/providers/custom/load.test.ts
@@ -2,7 +2,8 @@ import { afterAll, describe, expect, test } from 'bun:test';
 import { mkdtemp, mkdir, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { loadWorkspaceProviders, parseManifest } from './load.ts';
+import { layout } from '#profile';
+import { loadProfileProviders, parseManifest } from './load.ts';
 import { manifestTemplate } from './template.ts';
 
 /**
@@ -12,12 +13,16 @@ import { manifestTemplate } from './template.ts';
 
 const roots: string[] = [];
 
+/** Manifests are the profile's own, so a workspace here is a profile's directory. */
+const PROFILE = 'personal';
+
 async function workspaceWith(files: Record<string, string>): Promise<string> {
   const root = await mkdtemp(join(tmpdir(), 'lanes-link-manifests-'));
   roots.push(root);
-  await mkdir(join(root, 'providers'), { recursive: true });
+  const directory = join(root, layout.providers(PROFILE));
+  await mkdir(directory, { recursive: true });
   for (const [name, contents] of Object.entries(files)) {
-    await writeFile(join(root, 'providers', name), contents);
+    await writeFile(join(directory, name), contents);
   }
   return root;
 }
@@ -38,9 +43,9 @@ auth:
   registration: dynamic
 `;
 
-  test('loads from the workspace', async () => {
+  test('loads from the profile', async () => {
     const root = await workspaceWith({ 'acme.yaml': manifest });
-    const [loaded] = await loadWorkspaceProviders(root);
+    const [loaded] = await loadProfileProviders(root, PROFILE);
 
     expect(loaded?.manifest.id).toBe('acme');
     expect(loaded?.manifest.connector).toMatchObject({
@@ -155,7 +160,7 @@ describe('workspace loading', () => {
   test('an absent providers directory is the normal case, not an error', async () => {
     const root = await mkdtemp(join(tmpdir(), 'lanes-link-empty-'));
     roots.push(root);
-    expect(await loadWorkspaceProviders(root)).toEqual([]);
+    expect(await loadProfileProviders(root, PROFILE)).toEqual([]);
   });
 
   test('ignores non-YAML and example files', async () => {
@@ -165,13 +170,13 @@ describe('workspace loading', () => {
       'template.example.yaml': 'id: bad',
     });
 
-    const loaded = await loadWorkspaceProviders(root);
+    const loaded = await loadProfileProviders(root, PROFILE);
     expect(loaded.map((entry) => entry.manifest.id)).toEqual(['acme']);
   });
 
   test('names the file when one manifest is broken', async () => {
     const root = await workspaceWith({ 'broken.yaml': 'id: acme\nname: Acme' });
-    await expect(loadWorkspaceProviders(root)).rejects.toThrow(/broken\.yaml/);
+    await expect(loadProfileProviders(root, PROFILE)).rejects.toThrow(/broken\.yaml/);
   });
 });
 
@@ -186,10 +191,10 @@ describe('a relative openapi path', () => {
         'connector: { kind: http, base_url: https://api.mything.test, openapi: ./mything.json }',
     });
 
-    const [loaded] = await loadWorkspaceProviders(root);
+    const [loaded] = await loadProfileProviders(root, PROFILE);
     const connector = loaded!.manifest.connector as { openapi: string };
 
-    expect(connector.openapi).toBe(join(root, 'providers', 'mything.json'));
+    expect(connector.openapi).toBe(join(root, layout.providers(PROFILE), 'mything.json'));
   });
 
   test('a URL is left alone', async () => {
@@ -199,7 +204,7 @@ describe('a relative openapi path', () => {
         'connector: { kind: http, base_url: https://api.remote.test, openapi: https://api.remote.test/openapi.json }',
     });
 
-    const [loaded] = await loadWorkspaceProviders(root);
+    const [loaded] = await loadProfileProviders(root, PROFILE);
 
     expect((loaded!.manifest.connector as { openapi: string }).openapi).toBe(
       'https://api.remote.test/openapi.json',

--- a/src/providers/custom/load.ts
+++ b/src/providers/custom/load.ts
@@ -2,29 +2,37 @@ import { readdir, readFile } from 'node:fs/promises';
 import { dirname, isAbsolute, join, resolve } from 'node:path';
 import { parse as parseYaml } from 'yaml';
 import { defineProvider, type ProviderManifest } from '#connectivity';
-import { ConfigError } from '#profile';
+import { ConfigError, layout } from '#profile';
 import { findSecrets, formatSecretFindings } from '#profile';
 
 /**
  * Provider manifests supplied by the operator.
  *
  * The built-in list is a convenience, never a boundary. Anything not shipped is
- * a YAML file in `<workspace>/providers/`, validated by the same schema the
- * built-ins are — no code, no rebuild, no pull request.
+ * a YAML file in `<workspace>/data/<profile>/providers.d/`, validated by the
+ * same schema the built-ins are — no code, no rebuild, no pull request.
  *
  * That is the whole scalability claim of this milestone: a service nobody has
  * integrated costs a file.
+ *
+ * **Per profile**, which the workspace-wide directory this replaced was not. A
+ * manifest names a host, an OpenAPI document, and the credential refs that
+ * reach them, so it describes somebody's infrastructure — and work's is not
+ * personal's to read. The path comes from `layout` for the same reason every
+ * other profile-owned path does: one place that knows the on-disk shape.
+ * ADR-030.
  */
-
-export const WORKSPACE_PROVIDER_DIR = 'providers';
 
 export interface LoadedManifest {
   readonly manifest: ProviderManifest;
   readonly path: string;
 }
 
-export async function loadWorkspaceProviders(workspaceRoot: string): Promise<LoadedManifest[]> {
-  const directory = join(workspaceRoot, WORKSPACE_PROVIDER_DIR);
+export async function loadProfileProviders(
+  workspaceRoot: string,
+  profile: string,
+): Promise<LoadedManifest[]> {
+  const directory = join(workspaceRoot, layout.providers(profile));
 
   let entries: string[];
   try {

--- a/src/providers/custom/template.ts
+++ b/src/providers/custom/template.ts
@@ -1,13 +1,11 @@
-import { WORKSPACE_PROVIDER_DIR } from './load.ts';
-
 /**
  * The scaffold `lanes link` writes, one per connectivity type.
  *
  * A custom provider is the same declaration a built-in is — this is the *only*
  * difference between `#providers/google/gmail/` and a file an operator drops in
- * `~/.lanes-link/providers/`, and the point of the whole manifest design. So the
- * template offers one starting point per `connector.kind` rather than a single
- * generic one that would have to be edited into shape.
+ * their profile's `providers.d/`, and the point of the whole manifest design.
+ * So the template offers one starting point per `connector.kind` rather than a
+ * single generic one that would have to be edited into shape.
  */
 
 export function manifestTemplate(kind: 'mcp' | 'http' | 'imap' | 'dav' | 'fs'): string {

--- a/src/providers/index.ts
+++ b/src/providers/index.ts
@@ -27,7 +27,7 @@ import { notion } from './notion/index.ts';
  * vendored specification. Adding a provider is a folder and a line below.
  *
  * The list is a convenience, not a boundary: anything not here is a YAML
- * manifest in `~/.lanes-link/providers/`, validated by the same schema and
+ * manifest in the profile's own `providers.d/`, validated by the same schema and
  * loaded by `./custom/load.ts`.
  *
  * The owner layer — `memory/`, `skills/`, `vault/` — is deliberately absent

--- a/src/providers/skills/provider.ts
+++ b/src/providers/skills/provider.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod';
 import {
-  loadWorkspaceSkills,
+  loadProfileSkills,
   readSkill,
   removeSkill,
   renderSkill,
@@ -165,7 +165,7 @@ function managementCapabilities(
         'Every skill that exists, with its description and arguments. The prompt list shows only the ones policy permits; this shows what is stored.',
       inputSchema: z.object({}),
       async handler(_input, context) {
-        const skills = await loadWorkspaceSkills(store);
+        const skills = await loadProfileSkills(store);
 
         if (skills.length === 0) {
           return { content: [{ type: 'text', text: `No skills on ${context.connection.key}.` }] };

--- a/src/providers/skills/store.test.ts
+++ b/src/providers/skills/store.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, test } from 'bun:test';
 import { createMemoryBlobStore } from '#stores/blobs/testing.ts';
 import type { BlobStore } from '#stores/blobs';
 import {
-  loadWorkspaceSkills,
+  loadProfileSkills,
   parseSkill,
   readSkill,
   removeSkill,
@@ -17,8 +17,10 @@ import {
  * instructions an agent receives as its own turn.
  *
  * The store is a `BlobStore` rather than a directory (ADR-014): locally it is
- * still `<workspace>/skills/`, holding the same files, but a deployed instance
- * has no writable directory that survives a revision and does have a bucket.
+ * `data/<profile>/skills.d/`, holding the same files it always has, but a
+ * deployed instance has no writable directory that survives a revision and does
+ * have a bucket. Nothing below names either path — the store arrives rooted, so
+ * ADR-030 moving it into the profile changed no test in this file.
  */
 
 async function skillsIn(files: Record<string, string> = {}): Promise<BlobStore> {
@@ -37,7 +39,7 @@ Review the following diff.`;
 
 describe('finding skills in the store', () => {
   test('an empty store is the normal case, not an error', async () => {
-    expect(await loadWorkspaceSkills(await skillsIn())).toEqual([]);
+    expect(await loadProfileSkills(await skillsIn())).toEqual([]);
   });
 
   test('reads both layouts: a flat file and a SKILL.md in a directory', async () => {
@@ -46,7 +48,7 @@ describe('finding skills in the store', () => {
       'nested/SKILL.md': `---\ndescription: A nested one\n---\nBody`,
     });
 
-    expect((await loadWorkspaceSkills(store)).map((skill) => skill.name).sort()).toEqual([
+    expect((await loadProfileSkills(store)).map((skill) => skill.name).sort()).toEqual([
       'flat',
       'nested',
     ]);
@@ -54,7 +56,7 @@ describe('finding skills in the store', () => {
 
   test('the name falls back to the filename', async () => {
     const store = await skillsIn({ 'draft-reply.md': `---\ndescription: d\n---\nBody` });
-    expect((await loadWorkspaceSkills(store))[0]?.name).toBe('draft-reply');
+    expect((await loadProfileSkills(store))[0]?.name).toBe('draft-reply');
   });
 
   test('a directory without a SKILL.md is skipped rather than failing the load', async () => {
@@ -65,7 +67,7 @@ describe('finding skills in the store', () => {
       'real.md': `---\ndescription: d\n---\nBody`,
     });
 
-    expect((await loadWorkspaceSkills(store)).map((skill) => skill.name)).toEqual(['real']);
+    expect((await loadProfileSkills(store)).map((skill) => skill.name)).toEqual(['real']);
   });
 });
 
@@ -74,7 +76,7 @@ describe('writing a skill — ADR-014', () => {
     const store = await skillsIn();
     await writeSkill(store, 'review-diff', MINIMAL);
 
-    expect((await loadWorkspaceSkills(store)).map((skill) => skill.name)).toEqual(['review-diff']);
+    expect((await loadProfileSkills(store)).map((skill) => skill.name)).toEqual(['review-diff']);
     expect((await readSkill(store, 'review-diff'))?.description).toBe(
       'Review a diff for correctness',
     );
@@ -86,7 +88,7 @@ describe('writing a skill — ADR-014', () => {
     const store = await skillsIn();
 
     await expect(writeSkill(store, 'broken', 'no frontmatter here')).rejects.toThrow(/frontmatter/);
-    expect(await loadWorkspaceSkills(store)).toEqual([]);
+    expect(await loadProfileSkills(store)).toEqual([]);
   });
 
   test('rewriting a nested skill stays nested, rather than forking into two files', async () => {
@@ -118,7 +120,7 @@ describe('writing a skill — ADR-014', () => {
 
     expect(await removeSkill(store, 'nested')).toBe(true);
     expect(await removeSkill(store, 'nested')).toBe(false);
-    expect(await loadWorkspaceSkills(store)).toEqual([]);
+    expect(await loadProfileSkills(store)).toEqual([]);
   });
 
   test('reading one that is not there is null, not a throw', async () => {

--- a/src/providers/skills/store.ts
+++ b/src/providers/skills/store.ts
@@ -6,15 +6,20 @@ import { ConfigError } from '#profile';
  * Skills the owner has written.
  *
  * A skill is a **document in the owner layer's store**, which locally is a file
- * in `<workspace>/skills/` — the same place, in the same format, as before the
- * store existed. Going through `BlobStore` rather than `node:fs` is what lets a
- * deployed instance have skills at all: a filesystem path is baked into a
- * container image at build time, and an S3 key is not.
+ * in `<workspace>/data/<profile>/skills.d/`, in the same format it has always
+ * had. Going through `BlobStore` rather than `node:fs` is what lets a deployed
+ * instance have skills at all: a filesystem path is baked into a container
+ * image at build time, and an S3 key is not.
+ *
+ * **One profile's skills, not the workspace's.** Nothing in this file knows
+ * that — the store it is handed is already rooted at one profile's directory,
+ * which is why moving skills under the profile (ADR-030) changed where the
+ * store is opened and nothing about how it is read.
  *
  * Two layouts, because both are conventional and neither is worth refusing:
  *
- *     skills/review-diff.md
- *     skills/review-diff/SKILL.md
+ *     skills.d/review-diff.md
+ *     skills.d/review-diff/SKILL.md
  *
  * Frontmatter is YAML between `---` fences, matching every other tool that
  * reads a skill file. `description` is the only required key; the body after
@@ -25,8 +30,6 @@ import { ConfigError } from '#profile';
  * authoring stays out of the default bundle, so an agent reaches it only where
  * policy says so, and the control plane reaches it always.
  */
-
-export { WORKSPACE_SKILL_DIR } from '#profile';
 
 /** The nested layout's filename, kept so a rewrite lands on the file it read. */
 const NESTED = 'SKILL.md';
@@ -73,7 +76,7 @@ export function assertSkillName(name: string, source = 'skill'): void {
  * a skill and is malformed still throws, because that one is a mistake the
  * owner wants to hear about.
  */
-export async function loadWorkspaceSkills(store: BlobStore): Promise<LoadedSkill[]> {
+export async function loadProfileSkills(store: BlobStore): Promise<LoadedSkill[]> {
   const keys = (await store.list()).map((blob) => blob.key).sort();
   const loaded: LoadedSkill[] = [];
 
@@ -137,8 +140,8 @@ export async function writeSkill(
   }
 
   // No contentType: on the filesystem adapter that writes a `<key>.meta`
-  // sidecar, and `<workspace>/skills/` is a directory the owner edits and
-  // commits. Nothing reads a skill's stored content type.
+  // sidecar, and `skills.d/` is a directory the owner opens and edits by hand.
+  // Nothing reads a skill's stored content type.
   await store.put(key, new TextEncoder().encode(text));
   return skill;
 }

--- a/src/server/mcp/instructions.ts
+++ b/src/server/mcp/instructions.ts
@@ -66,8 +66,9 @@ a different agent — so write when asked to remember something, not by habit.`;
 
 const SKILLS = `**Skills are the owner's procedures**, surfaced as prompts rather than tools.
 That is deliberate: a procedure is selected by the person, not chosen by the
-model, and you cannot read one's body. If a task has a skill for it, say so and
-let them invoke it rather than improvising your own version.`;
+model, and you cannot read one's body. They belong to one profile, so a skill
+you saw under one is not available under another. If a task has a skill for it,
+say so and let them invoke it rather than improvising your own version.`;
 
 const VAULT = `**Vault values are credentials.** Use one to do the thing that needs it. Do not
 quote it back, summarise it, or write it anywhere.`;

--- a/src/server/skills-authoring.test.ts
+++ b/src/server/skills-authoring.test.ts
@@ -1,7 +1,7 @@
 import { afterAll, describe, expect, test } from 'bun:test';
 import { parseConfig } from '#profile';
 import { type ProviderRegistry } from '#registry';
-import { loadWorkspaceSkills } from '#providers/skills/store.ts';
+import { loadProfileSkills } from '#providers/skills/store.ts';
 import { createSkillsProvider } from '#providers/owner.ts';
 import { createMemoryBlobStore } from '#stores/blobs/testing.ts';
 import type { BlobStore } from '#stores/blobs';
@@ -57,7 +57,7 @@ function skillsFixture(): { store: BlobStore; refresh: (registry: ProviderRegist
 
     registry.replace(
       createSkillsProvider({
-        skills: await loadWorkspaceSkills(store),
+        skills: await loadProfileSkills(store),
         store,
         onChange: () => refresh(registry),
       }),
@@ -103,7 +103,7 @@ const author = startHarness({
   policy: '',
   providers: [
     createSkillsProvider({
-      skills: await loadWorkspaceSkills(authorFixture.store),
+      skills: await loadProfileSkills(authorFixture.store),
       store: authorFixture.store,
     }),
   ],
@@ -122,7 +122,7 @@ const invokeOnly = startHarness({
   token: 'llk_readonly_token_value',
   providers: [
     createSkillsProvider({
-      skills: await loadWorkspaceSkills(invokeFixture.store),
+      skills: await loadProfileSkills(invokeFixture.store),
       store: invokeFixture.store,
     }),
   ],


### PR DESCRIPTION
## What changed

Skills move from `<workspace>/skills/` to `data/<profile>/skills.d/`, and custom provider manifests from `<workspace>/providers/` to `data/<profile>/providers.d/`. They were the last two things a profile did not own on its own, so `data/<profile>/` is now the complete answer to what a profile holds — and to what it can reach.

New [ADR-030](https://github.com/lanes-sh/link/blob/per-profile-owner-layer/docs/detailed/adr/030-a-profile-owns-its-skills-and-manifests.md). ADR-009, 012, 014, 023, 008 and 016 carry pointers to it.

## Why this approach

ADR-009 says profiles share no database and no credential store — *"a note written through `personal` is simply absent in `work`"*. It had two exceptions, and `layout.ts` defended one of them: *"a procedure is not private to a profile the way its knowledge is"*, with policy gating `skills.<name>` as the isolation.

Policy decides who may **invoke** a skill. It never decided who could see one existed, and since ADR-014 gave `skills.manage.get` a real read path it was the only thing between a granted agent in one profile and the full text of a procedure written in another. A useful procedure also names things — which mailbox, which people, which conventions — so the line it drew between a procedure and its knowledge is not one an owner would recognise. ADR-014 §1 had already conceded the shape of this by making authoring a grant worth governing.

A manifest names a host, an OpenAPI document, and credential refs. Two profiles exist precisely when those differ.

**`skills.d` / `providers.d`, not `skills` / `providers`.** `layout.ts` requires a dot in every reserved name under the blob root — a provider is namespaced `<provider>/<connection>` there and a provider id cannot contain one. For skills that is not hypothetical: `skills` is a real provider id, so `data/<profile>/skills/` is the prefix its own connection blobs would occupy.

**Rejected: `<workspace>/skills/<profile>/`**, which would have cost nothing below. It leaves `data/<profile>` not meaning *everything this profile owns*, which is the property that makes `rm -r data/work` a complete answer.

### Two costs, paid rather than absorbed

**`deploy` never sent `data/`, and that exclusion keeps `credentials.enc` and its key out of a bucket.** Skills that do not go up is the regression ADR-014 §2 fixed, so `isWorkspaceConfig` now reaches in for exactly these two directories, matched by **whole path segment** — `skills.detour/` is not `skills.d`. `deploy.test.ts` drives `uploadWorkspace` between two directories over a real `list('')`, which does return `credentials.enc`, so the filter is tested against the enumeration it guards rather than against keys typed by hand.

**`objectsUnder('data/')` now covers a profile's manifests, and ADR-007 says a revision never rewrites its own config.** The write condition became `data/ && !<manifests>`, anchored to the profile segment; the manifests moved to the read binding. `grants.test.ts` now **evaluates** the shipped CEL instead of scanning it for `startsWith` prefixes — a scan reads straight past a negation and would report a permission the revision does not have.

### No migration

Following `layout.ts` on the `data/` reshuffle before it. A skill left at the old path loads for nobody rather than silently for everybody, and `scoping.test.ts` pins that. Which profile should inherit one is a question only the owner can answer; copying to all of them is a guess that then diverges. `configuration.md` gives the `mv`, and notes the consequence that `data/` is gitignored where `skills/` was not — not repaired with a `.gitignore` negation, because this repo doubles as a workspace in development and that would invite committing a real one.

### Incidental

- `profile remove` picks both up from the blob sweep, except when a profile declares its own `storage.path` — layout areas do not move with it, so those two are planned explicitly. Compared as **resolved** paths: `newProfileTemplate` writes `./data/<profile>` and `layout.blobs` returns `data/<profile>`, and comparing the strings names every default profile's skills twice in the preview an operator confirms.
- `rotatableRefs` / `readableRefs` built one registry outside their per-profile loop. With manifests per profile that resolves a `work` connection against `personal`'s registry, so the build moved inside.
- `WORKSPACE_PROVIDER_DIR` moved from `providers/custom/load.ts` into `layout.ts`, the one path that sat outside the layout module.

### Verified beyond the suite

Two profiles in a scratch workspace, each with a `holiday-plan` skill: one merged MCP prompt whose `profile` enum lists both, `prompts/get` returning a different body per profile — which a shared directory could not represent at all. A `ledger` manifest in `work` appeared only in work's `setup plan`. `profile remove work` took its skills and manifests and left `personal` intact.

## Checks

- [x] `bun test` passes — 1612 pass, 2 skip, 0 fail
- [x] `bun run typecheck` passes
- [x] Tests added for what changed — new `src/cli/runtime/scoping.test.ts`; `removal.test.ts`, `deploy.test.ts`, `grants.test.ts`, `driver.test.ts`, `load.test.ts`, `runtime.test.ts` updated
- [x] No guarantee got weaker. `docs/detailed/security.md` moved anyway: `profile.isolated` was previously true of credentials, state and the log rather than of everything a profile holds, and `deployed.config-not-self-writable` now describes an exclusion where it described an omission

🤖 Generated with [Claude Code](https://claude.com/claude-code)
