### PR TITLE
Report the endpoint's own mark, description, and home in serverInfo

### DIFF
--- a/src/server/index.test.ts
+++ b/src/server/index.test.ts
@@ -1,7 +1,9 @@
 import { afterAll, describe, expect, test } from 'bun:test';
+import type { Icon } from '@modelcontextprotocol/server';
 import { allocatePort, rpc, startHarness, wireProfiles, TEST_TOKEN } from './harness.ts';
 import { isLoopback } from './index.ts';
 import { parseConfig, type Config } from '#profile';
+import manifest from '../../package.json' with { type: 'json' };
 
 /**
  * End-to-end tests against a real HTTP server on a real port.
@@ -209,6 +211,60 @@ describe('discovery is filtered by policy', () => {
 
     expect(result.supportedVersions).toContain('2026-07-28');
     expect(result._meta?.['io.modelcontextprotocol/serverInfo']?.name).toBe('lanes-link');
+  });
+
+  test('the endpoint reports its own branding, not just its name', async () => {
+    // SEP-973 fields, and the reason to assert them is where they live rather
+    // than what they say: `icons`, `description` and `websiteUrl` belong to
+    // `Implementation` — the first argument to `McpServer` — and the second
+    // argument would accept all three as unknown extras and drop them from the
+    // wire without an error. The comment in `build.ts` warns about that trap in
+    // the other direction for `instructions`; this is the test that notices.
+    const response = await rpc(personal.server.url, 'server/discover', {});
+    const info = (
+      response.body['result'] as {
+        _meta?: Record<string, { description?: string; websiteUrl?: string; icons?: Icon[] }>;
+      }
+    )._meta?.['io.modelcontextprotocol/serverInfo'];
+
+    // Held equal to the manifest rather than compared to a copy of the string,
+    // so the two cannot drift into describing the same endpoint differently.
+    expect(info?.description).toBe(manifest.description);
+    expect(info?.websiteUrl).toBe('https://github.com/lanes-sh/link');
+
+    // One entry, and no `theme` on it. `theme` claims there is another icon to
+    // pick instead, and this one carries its own ground and looks the same on
+    // either — two identical entries labelled `light` and `dark` would be
+    // metadata describing a variation that does not exist.
+    expect(info?.icons).toHaveLength(1);
+    const icon = info?.icons?.[0];
+    expect(icon?.theme).toBeUndefined();
+    expect(icon?.mimeType).toBe('image/svg+xml');
+    expect(icon?.src.startsWith('data:image/svg+xml;base64,')).toBe(true);
+
+    // Decoded, because a truncated or double-encoded src is still a string
+    // that starts with the right prefix. What a client renders is the SVG.
+    const svg = Buffer.from(icon?.src.split(',')[1] ?? '', 'base64').toString('utf8');
+    expect(svg.startsWith('<svg xmlns="http://www.w3.org/2000/svg"')).toBe(true);
+    expect(svg.endsWith('</svg>')).toBe(true);
+
+    // No `currentColor`: a client renders the icon in a document that sets no
+    // colour for it, so an inherited ink resolves to whatever is nearest, or
+    // to black.
+    expect(svg).not.toContain('currentColor');
+
+    // The ground is painted across the whole box rather than left transparent.
+    // The published mark lets the page behind it supply the ground, which is
+    // right for a favicon on lanes.sh and wrong for an icon a client draws on
+    // a surface we know nothing about.
+    expect(svg).toContain('fill="#121214"');
+
+    // The mark is inset rather than bleeding to its own edges. Without the
+    // margin a circular avatar crop takes the silhouette and leaves anonymous
+    // diagonals. A negative viewBox origin is that margin, square on both axes.
+    const [x, y] = (svg.match(/viewBox="(-?[\d.]+) (-?[\d.]+)/) ?? []).slice(1).map(Number);
+    expect(x).toBeLessThan(0);
+    expect(y).toBe(x);
   });
 
   test('server/discover leaks no capability names past the policy filter', async () => {

--- a/src/server/mcp/build.ts
+++ b/src/server/mcp/build.ts
@@ -1,5 +1,6 @@
 import { McpServer } from '@modelcontextprotocol/server';
 import { isPrompt, isResource, isTool } from '#connectivity';
+import { SERVER_ICONS } from './icon.ts';
 import { serverInstructions } from './instructions.ts';
 import { SERVER_NAME } from './naming.ts';
 import { registerPrompt } from './prompts.ts';
@@ -28,6 +29,18 @@ export function buildMcpServer(options: BuildServerOptions): McpServer {
       name: SERVER_NAME,
       version: options.version ?? '0.0.0',
       title: `Lanes Link — ${names.join(', ')}`,
+      // First argument, and this is the half of the pairing below that is easy
+      // to get wrong in the other direction: `icons`, `description` and
+      // `websiteUrl` are `Implementation` fields that SEP-973 added, so they
+      // belong here and would be dropped from `ServerOptions`.
+      //
+      // `description` is `package.json`'s, and the test holds the two equal
+      // rather than trusting a copy to stay one. It is the whole endpoint being
+      // described, not this connection, so it does not name the profiles the
+      // way `title` does.
+      description: 'A self-hosted MCP gateway for your accounts, memory, skills, and secrets',
+      websiteUrl: 'https://github.com/lanes-sh/link',
+      icons: SERVER_ICONS,
     },
     // Second argument, not the first: `instructions` is a `ServerOptions` field,
     // and `Implementation` would take it as an unknown extra and drop it from

--- a/src/server/mcp/icon.ts
+++ b/src/server/mcp/icon.ts
@@ -1,0 +1,146 @@
+import type { Icon } from '@modelcontextprotocol/server';
+
+/**
+ * The mark the endpoint reports to a client that renders one.
+ *
+ * SEP-973 (protocol revision 2025-11-25) added `icons` to `Implementation`, so
+ * `initialize.result.serverInfo` can carry the server's own branding rather
+ * than leaving every client to generate a letter avatar from the name.
+ *
+ * **Nothing renders this in Claude today.** claude.ai shows custom connectors
+ * with a generated avatar and ignores `serverInfo.icons` entirely — as does
+ * Claude Code. That is a client gap, tracked in anthropics/claude-ai-mcp#152,
+ * where the reporter ruled out every server-side route in turn: `icons` with an
+ * https src, `icons` with a data URI, `/favicon.ico` and `/favicon.png` at the
+ * origin, and an HTML `<link rel="icon">`. None are fetched.
+ *
+ * It is here anyway because the cost is a few kilobytes on `initialize` and the
+ * alternative is a release the day the gap closes. Other clients already
+ * honour the field.
+ */
+
+/** The published mark's own box, before the margin this file adds around it. */
+const TILE = 738;
+
+/**
+ * How far the mark is inset inside the icon's box, in the mark's own units.
+ *
+ * The published mark bleeds to its own edges — it is a rounded square *made of*
+ * the stripes, so at the edges there is nothing between the artwork and the
+ * boundary. An avatar is cropped, usually to a circle, and a mark that reaches
+ * its own edge loses the silhouette to the crop and reads as anonymous
+ * diagonals. A tenth of the box on each side is enough for the stripes to stop
+ * clear of a circular crop.
+ */
+const MARGIN = Math.round(TILE / 10);
+
+/** The icon's outer box, and the ground the whole of it is painted on. */
+const BOX = TILE + MARGIN * 2;
+const GROUND = '#121214';
+const INK = '#ffffff';
+
+/**
+ * The corner radius, carried across from the mark rather than picked.
+ *
+ * The published tile is `rx="150"` on a 737.28 box. Scaling that ratio to the
+ * padded box keeps the same curve rather than a tighter or looser one that
+ * happens to look close at 220px and wrong at 32.
+ */
+const RADIUS = Math.round((BOX * 150) / 737.28);
+
+/**
+ * The icon: the published Lanes mark, inset, on its own dark ground.
+ *
+ * This is the mark lanes.sh serves as `/icon-light.svg` and `/icon-dark.svg`.
+ * It is *not* the glyph beside "Any MCP client" in the README diagram: that one
+ * is the Model Context Protocol's own logo, sitting in the client column next
+ * to the Anthropic and OpenAI marks, and shipping it here would have branded
+ * this endpoint with someone else's mark.
+ *
+ * Copied into `src/` rather than read from disk or fetched: the Dockerfile
+ * (`src/deployments/gcp/Dockerfile`) copies `package.json`, the lockfile,
+ * `bunfig.toml` and `src/` and nothing else, so a runtime read of a checked-in
+ * asset outside `src/` works from a checkout and returns nothing from every
+ * deployed target — the half of the bug that only shows up in production. A
+ * fetch would be worse: an icon that depends on the network resolving is an
+ * icon that is sometimes missing.
+ *
+ * **The ground is painted, not inherited.** The published pair leaves the gaps
+ * between the stripes transparent and lets the page supply the ground, which is
+ * right for a favicon on lanes.sh and wrong here: a client draws an icon on a
+ * surface this file knows nothing about, and transparent gaps mean the mark is
+ * a different thing on each one and invisible on some. Painting `#121214`
+ * across the whole box — margin included — is what makes the result the same
+ * icon everywhere, and it is why there is one entry below rather than two.
+ *
+ * The twenty-four stripes are generated rather than pasted. In the published
+ * file they are an exact arithmetic progression — same step on both axes, the
+ * export's own rounding never off by more than 0.02 units, which is under a
+ * thousandth of a pixel at 32px — so a loop says what twenty-four near-
+ * identical lines only imply.
+ */
+function mark(): string {
+  const stripes: string[] = [];
+  for (let i = 0; i < 24; i += 1) {
+    const x = (345.141 + i * 203.2425).toFixed(3);
+    const y = (-4382.52 + i * 203.2425).toFixed(3);
+    stripes.push(
+      `<rect x="${x}" y="${y}" width="143.715" height="6661.17"` +
+        ` transform="rotate(45 ${x} ${y})" fill="${INK}" />`,
+    );
+  }
+
+  return [
+    `<svg xmlns="http://www.w3.org/2000/svg" viewBox="${-MARGIN} ${-MARGIN} ${BOX} ${BOX}"`,
+    ' role="img">',
+    '<title>Lanes Link</title>',
+    `<rect x="${-MARGIN}" y="${-MARGIN}" width="${BOX}" height="${BOX}"`,
+    ` rx="${RADIUS}" fill="${GROUND}" />`,
+    // The rounded square is a mask rather than a drawn shape, which is what
+    // makes the stripes stop where they do. Its id has to be stable but not
+    // unique — the icon is its own `data:` document, so nothing else is in
+    // scope to collide with it. Its own corners never show: it is inset on a
+    // ground of the same colour, so what reads is where the stripes end.
+    '<mask id="tile" maskUnits="userSpaceOnUse" x="0" y="0" width="738" height="739">',
+    '<rect x="0.360107" y="0.859375" width="737.28" height="737.28" rx="150" fill="#fff" />',
+    '</mask>',
+    `<g mask="url(#tile)">${stripes.join('')}</g>`,
+    '</svg>',
+  ].join('');
+}
+
+/**
+ * Base64 rather than percent-encoding, and `Buffer` rather than `btoa`.
+ *
+ * Both forms are legal in a `data:` URI and the percent-encoded one is smaller
+ * and readable in a log, but every example in the spec and every client that
+ * has shipped support reads base64 — this is not the field to be clever in.
+ *
+ * `Buffer.from(…, 'utf8')` for the reason `src/connectivity/auth/basic/index.ts`
+ * gives: `btoa` throws above U+00FF and mangles what it does not throw on.
+ * Nothing above ASCII is in the mark today, but the failure mode of the day
+ * something is would be a corrupt icon rather than an error.
+ */
+function dataUri(svg: string): string {
+  return `data:image/svg+xml;base64,${Buffer.from(svg, 'utf8').toString('base64')}`;
+}
+
+/**
+ * One entry, and deliberately no `theme`.
+ *
+ * `theme` says which UI a client should pick this icon *for*, so it is a claim
+ * that there is another one to pick instead. The icon carries its own ground
+ * and looks the same on either, and two identical entries labelled `light` and
+ * `dark` would be metadata describing a variation that does not exist. If a
+ * theme-specific mark is ever wanted, that is the point at which the field
+ * earns its place.
+ *
+ * `sizes: ['any']` is what the spec spells for a scalable icon. SVG is a SHOULD
+ * for clients and PNG a MUST, so a client could honour `icons` and still skip
+ * this one — a rasterised entry is the fix for that, and it can wait until a
+ * client we care about needs it, because a PNG blob checked in here is one
+ * nobody can regenerate from a clean checkout.
+ */
+export const SERVER_ICONS: Icon[] = [
+  { src: dataUri(mark()), mimeType: 'image/svg+xml', sizes: ['any'] },
+];


### PR DESCRIPTION
## What

SEP-973 (protocol revision `2025-11-25`) added `icons`, `description`, and `websiteUrl` to `Implementation`, so a server can say what it is and what it looks like instead of leaving every client to generate a letter avatar from the name. The endpoint sent none of them; it now sends all three.

## What this does not do

**It will not change what you see in Claude.** claude.ai renders custom connectors with a generated letter avatar and ignores `serverInfo.icons` entirely, as does Claude Code. [anthropics/claude-ai-mcp#152](https://github.com/anthropics/claude-ai-mcp/issues/152) is open on it, and the reporter there ruled out every server-side route in turn: `icons` with an https src, `icons` with a data URI, `/favicon.ico` and `/favicon.png` at the origin, and an HTML `<link rel="icon">`. None are fetched. [modelcontextprotocol#2573](https://github.com/modelcontextprotocol/modelcontextprotocol/discussions/2573) reaches the same conclusion — only first-party connectors get a branded icon, configured on Anthropic's side.

Shipping it anyway costs a few kilobytes on `initialize`. The alternative costs a release on the day the gap closes, and the clients that already honour the field get the mark now.

## Which mark

The published Lanes mark — what lanes.sh serves as `/icon-light.svg` and `/icon-dark.svg`.

Explicitly **not** the glyph beside "Any MCP client" in the README diagram. That one is the Model Context Protocol's own logo, sitting in the client column next to the Anthropic and OpenAI marks, and it is what the first push of this branch shipped by mistake. It would have branded this endpoint with someone else's logo.

## Choices worth the reasoning

**A constant under `src/`, not a read and not a fetch.** The Dockerfile copies the manifest, the lockfile, `bunfig.toml`, and `src/` and nothing else, so reading a checked-in asset from outside `src/` would work from a checkout and return nothing from every deployed target — a failure that only appears in production. A fetch would be worse: an icon that depends on the network resolving is an icon that is sometimes missing. A `data:` URI also avoids the problem with an https src, which is that this endpoint is OAuth-gated and a self-hosted `/icon.svg` would have to be punched through the auth edge for an unauthenticated client to fetch it.

**The ground is painted, and the mark is inset by a tenth of its box.** The published pair leaves the gaps between the stripes transparent and lets the page supply the ground — right for a favicon on lanes.sh, wrong for an icon a client draws on a surface this code knows nothing about, where transparent gaps make the mark a different thing on every surface and invisible on some. The inset is for the crop: the mark bleeds to its own edges, and an avatar is usually cropped to a circle, which takes the silhouette and leaves anonymous diagonals.

**One entry, no `theme`.** `theme` says which UI a client should pick an icon *for*, so it claims there is another to pick instead. This one carries its own ground and looks the same on either; two identical entries labelled `light` and `dark` would be metadata describing a variation that does not exist.

**SVG only.** The spec makes PNG a MUST for clients and SVG a SHOULD, so a rasterised entry would be strictly more compatible — but a PNG blob checked in here is one nobody can regenerate from a clean checkout, and there is no renderer in the toolchain to regenerate it with.

**The twenty-four stripes are generated, not pasted.** In the published file they are an exact arithmetic progression — same step on both axes, the export's own rounding never off by more than 0.02 units, which is under a thousandth of a pixel at 32px.

**`description` duplicates `package.json`, and the test holds the two equal** rather than trusting the copy to stay one. The test also decodes the src before asserting on it: a truncated or double-encoded string still starts with the right prefix, and the SVG is what a client actually renders.

## Verification

- `bun test` — 1623 pass, 0 fail (1622 before)
- `bun run typecheck` — clean
- `bun test src/architecture.test.ts` — 6 pass
- Negative control: deleting `icons` from the `Implementation` fails the new test, so it is not asserting on nothing.
- End to end against a running endpoint on a scratch `LANES_LINK_HOME`, over the legacy `initialize` handshake claude.ai performs — all six fields returned, the icon decoding to well-formed SVG.
- Rendered in a browser on both a white and a near-black surface at 120px and 48px, and under circular crops at 64px and 32px.

## Note for the reviewer

`initialize` is not the surface the test asserts on. This endpoint negotiates 2026-07-28, which is handshake-less, so `initialize` returns *Method not found* under that envelope and serverInfo travels in `server/discover`'s `_meta`. The legacy `initialize` path still carries the same fields, which is what the end-to-end check above exercises.

🤖 Generated with [Claude Code](https://claude.com/claude-code)