### PR TITLE
Name the target in every hint that sends someone to fetch a token

### DIFF
--- a/docs/detailed/deployment-cloudrun.md
+++ b/docs/detailed/deployment-cloudrun.md
@@ -415,8 +415,15 @@ what this instance holds, and a deployed URL is readable by anyone.
 `mode: self` means this endpoint issues the tokens, and there is nothing to set up: no OAuth client,
 no console, no redirect URI. Deploy, then add a custom connector by URL in Claude or ChatGPT. The
 client registers itself, a browser opens on this endpoint's approval page, and you paste the
-endpoint token once — the string `lanes link outputs --show` prints. That is the whole flow, and it
-works the same on a laptop and on a phone.
+endpoint token once — the string `lanes link outputs --show --target cloud` prints. That is the
+whole flow, and it works the same on a laptop and on a phone.
+
+Name the target. Credentials are per-target, and a bare `lanes link outputs --show` resolves to
+`instance.default_target` — `local` on a scaffolded profile, whose token this endpoint has never
+seen and will refuse. Worse, when that store is empty the command mints a fresh local token rather
+than reporting that it has none, so what you paste looks like an answer and fails as a wrong
+password. The approval page prints the target it is actually running as, so the command it shows
+you is the one to run.
 
 What makes it work is a handshake worth knowing about when it does not: `/mcp` answers `401` with a
 `WWW-Authenticate` header pointing at `/.well-known/oauth-protected-resource`, which names this

--- a/src/architecture.test.ts
+++ b/src/architecture.test.ts
@@ -229,7 +229,7 @@ const MAX_LINES = 400;
  * The files still over the budget, named so the debt is visible.
  *
  * An allowlist rather than a higher number, because the two say different
- * things: a higher number says 450 lines is fine, and this says these four are
+ * things: a higher number says 450 lines is fine, and this says these five are
  * not yet done. Adding to it should feel like the concession it is; removing
  * from it is the point.
  *
@@ -246,12 +246,20 @@ const MAX_LINES = 400;
  * it out took them to 322 and 290 lines without either being split. That is
  * the seam the budget exists to point at: they were not too long, they were
  * two things.
+ *
+ * `server/harness.ts` is the newest entry and the one with a seam already
+ * visible: `startStdioHarness` and `StdioHarness` are 135 lines serving the
+ * same profiles over a different transport, and only two tests import them.
+ * It crossed the line by one, adding the target an endpoint runs as to the
+ * authorization surface, and splitting it was a larger change than the one
+ * that revealed it. Cut there when something needs to touch this file next.
  */
 const KNOWN_LONG = new Set([
   'connectivity/transports/dav/ical.ts',
   'deployments/adapters/gcp-secret-manager.ts',
   'providers/google/specs/vendor.ts',
   'providers/memory/provider.ts',
+  'server/harness.ts',
 ]);
 
 describe('file size', () => {

--- a/src/cli/callback-page.test.ts
+++ b/src/cli/callback-page.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from 'bun:test';
-import { completionPage } from './callback-page.ts';
+import { approvalPage, completionPage } from './callback-page.ts';
 
 /**
  * The page nobody sees until the one moment it is the whole product.
@@ -124,5 +124,44 @@ describe('untrusted text', () => {
     expect(body).not.toContain('<script>alert(1)</script>');
     expect(body).toContain('&lt;script&gt;alert(1)&lt;/script&gt;');
     expect(body).toContain('Tom &amp; Jerry &quot;quoted&quot;');
+  });
+});
+
+describe('the approval page', () => {
+  const approval = (target: string) =>
+    approvalPage({
+      client: 'Claude',
+      redirectHost: 'claude.ai',
+      action: 'https://endpoint.example/authorize',
+      fields: { client_id: 'abc' },
+      retry: false,
+      target,
+    });
+
+  test('names the target whose store holds the token it is asking for', async () => {
+    // The reader runs this in a shell that resolves a target of its own, and
+    // credentials are per-target. A bare `--show` sends the owner of a deployed
+    // endpoint to the local store, which either holds a token this endpoint
+    // will refuse or holds none and has one minted on the spot.
+    const body = await html(approval('cloud'));
+
+    expect(body).toContain('lanes link outputs --show --target cloud');
+    expect(body).not.toContain('outputs --show</code>');
+  });
+
+  test('names it even when it is the default, so the flag is never ambiguous', async () => {
+    const body = await html(approval('local'));
+
+    expect(body).toContain('lanes link outputs --show --target local');
+  });
+
+  test('a target name cannot inject markup', async () => {
+    // It comes from config rather than from a request, but everything else on
+    // this page is escaped and a value reaching HTML is not where to make an
+    // exception.
+    const body = await html(approval('<script>alert(1)</script>'));
+
+    expect(body).not.toContain('<script>alert(1)</script>');
+    expect(body).toContain('&lt;script&gt;alert(1)&lt;/script&gt;');
   });
 });

--- a/src/cli/callback-page.ts
+++ b/src/cli/callback-page.ts
@@ -118,6 +118,8 @@ export interface ApprovalPage {
   readonly action: string;
   /** A previous attempt presented the wrong token. */
   readonly retry: boolean;
+  /** The target this endpoint runs as, so the hint below names the right store. */
+  readonly target: string;
 }
 
 /**
@@ -128,6 +130,12 @@ export interface ApprovalPage {
  * the endpoint token — the string `lanes link outputs` prints — because that is
  * already the proof of being the owner and inventing a second one would mean
  * inventing a password to go with it.
+ *
+ * The hint names the target rather than leaving it out. Credentials are
+ * per-target, and the reader runs that command in a shell resolving a target of
+ * its own — `local` by default, which is the one store a deployed endpoint's
+ * token is never in. Omitting it sends them to fetch the wrong secret, and
+ * `outputs` mints a fresh one when that store is empty rather than saying so.
  *
  * `autocomplete="off"` and `type="password"` are not theatre: this form is
  * submitted in whatever browser the phone opened, and a token remembered by a
@@ -150,7 +158,7 @@ ${hidden}
 <input class="field" type="password" name="token" placeholder="Endpoint token" autocomplete="off" autofocus required>
 <button class="go" type="submit">Approve</button>
 </form>
-<p class="detail small">Printed by <code>lanes link outputs --show</code>.</p>`;
+<p class="detail small">Printed by <code>lanes link outputs --show --target ${escapeHtml(page.target)}</code>.</p>`;
 
   return page.retry ? shell(body, 'Authorise', 401) : shell(body, 'Authorise', 200);
 }

--- a/src/cli/commands/operate/serve.ts
+++ b/src/cli/commands/operate/serve.ts
@@ -33,8 +33,8 @@ export async function start(
         print(plan);
         print(ok(`reconciled ${ofMany ? profile : ''}`.trim()));
       },
-      tokenMinted() {
-        print(warn('minted a token — run: lanes link outputs --show'));
+      tokenMinted({ target }) {
+        print(warn(`minted a token — run: lanes link outputs --show --target ${target}`));
       },
     },
   });

--- a/src/deployments/deploy.ts
+++ b/src/deployments/deploy.ts
@@ -199,7 +199,11 @@ export async function deploy(flags: DeployFlags): Promise<void> {
 
   const url = await driver.url(deployConfig);
   if (!url) {
-    print(warn('deployed, but the platform reported no URL yet — run: lanes link outputs'));
+    print(
+      warn(
+        `deployed, but the platform reported no URL yet — run: lanes link outputs --target ${target}`,
+      ),
+    );
     return;
   }
 
@@ -207,7 +211,7 @@ export async function deploy(flags: DeployFlags): Promise<void> {
   print(`  ${url}/mcp`);
   print(await healthLine(url));
   print('');
-  print(style.dim('  Register it with: lanes link outputs'));
+  print(style.dim(`  Register it with: lanes link outputs --target ${target}`));
 
   reportUnauthorised(prepared.warnings, target);
 }

--- a/src/server/endpoint.ts
+++ b/src/server/endpoint.ts
@@ -46,7 +46,7 @@ export interface EndpointReporter {
   /** A profile whose runtime state differed from its config, and what was applied. */
   reconciled(input: { profile: string; plan: string; ofMany: boolean }): void;
   /** No profile token existed and one was minted. */
-  tokenMinted(): void;
+  tokenMinted(minted: { target: string }): void;
 }
 
 const SILENT: EndpointReporter = { reconciled() {}, tokenMinted() {} };
@@ -199,7 +199,7 @@ async function openAuthorization(
     return {
       // The issuer is somebody else's origin, so it is a constant here rather
       // than derived from the request.
-      surface: { issuer: () => declared.issuer, mcpPath: MCP_PATH },
+      surface: { issuer: () => declared.issuer, mcpPath: MCP_PATH, target: primary.target },
       authenticator: new OidcAuthenticator(verifier, profile),
     };
   }
@@ -221,7 +221,7 @@ async function openAuthorization(
   });
 
   return {
-    surface: { server, issuer: (origin) => origin, mcpPath: MCP_PATH },
+    surface: { server, issuer: (origin) => origin, mcpPath: MCP_PATH, target: primary.target },
     authenticator: new IssuedTokenAuthenticator(store, profile),
   };
 }
@@ -236,7 +236,7 @@ export async function startEndpoint(options: EndpointOptions): Promise<RunningEn
         primary.credentials,
         primary.config.auth.token_ref,
       );
-      if (created) reporter.tokenMinted();
+      if (created) reporter.tokenMinted({ target: primary.target });
     } else {
       // Deployed, the token is written by the operator's CLI into the target's
       // credential store and read back here. Refusing to start beats serving an

--- a/src/server/harness.ts
+++ b/src/server/harness.ts
@@ -229,6 +229,7 @@ export function startHarness(options: HarnessOptions): Harness {
           }),
           issuer: (origin: string) => origin,
           mcpPath: '/mcp',
+          target: 'local',
         },
         authenticator: new IssuedTokenAuthenticator(store, options.profile),
       }

--- a/src/server/oauth.test.ts
+++ b/src/server/oauth.test.ts
@@ -173,6 +173,9 @@ describe('the authorization code flow', () => {
     const html = await page.text();
     expect(html).toContain('Test Client');
     expect(html).toContain('claude.ai');
+    // And which target's store the token it asks for lives in. The endpoint
+    // knows; the shell the reader runs the command in does not.
+    expect(html).toContain('lanes link outputs --show --target local');
   });
 
   test('a client name cannot inject markup into the approval page', async () => {

--- a/src/server/oauth.ts
+++ b/src/server/oauth.ts
@@ -33,6 +33,13 @@ export interface AuthorizationSurface {
   readonly issuer: (origin: string) => string;
   /** The MCP endpoint path, so `resource` names what the client actually calls. */
   readonly mcpPath: string;
+  /**
+   * The target this endpoint runs as, so the consent page can name the store its
+   * token actually lives in. Credentials are per-target, and the reader is about
+   * to run a command in a shell that resolves a target of its own — usually
+   * `local`, which is the one store a deployed endpoint's token is never in.
+   */
+  readonly target: string;
 }
 
 /** Every path this surface answers, so the router can ask before authenticating. */
@@ -99,27 +106,35 @@ export async function handleAuthorization(
   if (!server) return new Response('Not found', { status: 404 });
 
   if (path === REGISTER_PATH && request.method === 'POST') {
-    return render(await server.register(await safeJson(request)), request);
+    return render(await server.register(await safeJson(request)), request, surface.target);
   }
 
   if (path === AUTHORIZE_PATH) {
     if (request.method === 'GET') {
-      return render(await server.authorize(url.searchParams), request);
+      return render(await server.authorize(url.searchParams), request, surface.target);
     }
     if (request.method === 'POST') {
       const form = new URLSearchParams(await request.text());
-      return render(await server.approve(requestFromForm(form), form.get('token') ?? ''), request);
+      return render(
+        await server.approve(requestFromForm(form), form.get('token') ?? ''),
+        request,
+        surface.target,
+      );
     }
   }
 
   if (path === TOKEN_PATH && request.method === 'POST') {
-    return render(await server.token(new URLSearchParams(await request.text())), request);
+    return render(
+      await server.token(new URLSearchParams(await request.text())),
+      request,
+      surface.target,
+    );
   }
 
   return new Response('Method not allowed', { status: 405 });
 }
 
-function render(result: OAuthResult, request: Request): Response {
+function render(result: OAuthResult, request: Request, target: string): Response {
   switch (result.kind) {
     case 'json':
       return json(result.body, result.status);
@@ -137,6 +152,7 @@ function render(result: OAuthResult, request: Request): Response {
         action: `${publicOrigin(request)}${AUTHORIZE_PATH}`,
         fields: formFromRequest(result.request),
         retry: result.retry,
+        target,
       });
 
     case 'error':


### PR DESCRIPTION
## What was wrong

The consent page a deployed endpoint serves ended with:

> Printed by `lanes link outputs --show`.

Run that, and `--target` resolves from `instance.default_target` — `local` on every scaffolded profile. Credentials are per-target, so the owner of a cloud endpoint was sent to a store whose token that endpoint has never seen.

It fails worse than a wrong value. `outputs` calls `ensureProfileToken`, which **mints and persists** a token when the store has none. On a cloud-only setup the local store is empty, so the command invented a fresh local token and printed it as the answer. The only symptom was "That token was not accepted" — on the screen that had just told you where to get it.

## The fix

Hardcoding `--target cloud` was rejected: `cloud` is only the name a first deploy picks by convention, and targets are user-declared. The page is served *by* the endpoint, which already knows its own target — a deployed container is baked with `LANES_LINK_TARGET`, and `Runtime` carries `target`. So `AuthorizationSurface` carries it through to the page and the hint names what is actually running.

The flag is emitted even when the target is `local`. Omitting it there is correct only for a reader whose shell resolves the same target, and `LANES_LINK_TARGET` makes that unsafe to assume.

Same fix for the other hints that name a store: `tokenMinted` gains the target it minted into so `start` can print it, both post-deploy lines in `deploy.ts` carry the target that was deployed, and the "Connecting a phone" section of the Cloud Run page is corrected. `docs/clients.md` already said `--target cloud`.

## Verified end to end

Against a scratch workspace (`LANES_LINK_HOME`), driving the real OAuth flow over HTTP:

```
running as local  →  Printed by  lanes link outputs --show --target local
running as cloud  →  Printed by  lanes link outputs --show --target cloud
```

and, pasting each token into `POST /authorize` on the endpoint running as `cloud`:

| token pasted | result |
|---|---|
| what a bare `outputs --show` prints | **401** — refused, form re-renders |
| what `--target cloud` prints | **302** — approved, code sent back |

`bun test` 1625 pass / 0 fail (baseline 1622). `bun run typecheck` clean.

## One concession to flag

`server/harness.ts` joins `KNOWN_LONG`. Adding the target to the surface took it from 399 to 400 lines with no slack. The seam is real and now named in that file's comment — `startStdioHarness` is 135 lines with two importers — but splitting it was a larger change than the one that revealed it. Per CONTRIBUTING, a genuine concession belongs in the list rather than in a raised limit. Happy to do the split here instead if preferred.

## Not fixed here

`outputs` still discards the `created` flag from `ensureProfileToken`, so a display command writes a credential without saying so. Naming the target removes the trap in practice; that is a separate defect worth its own change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)