### PR TITLE
Let the mark fill the icon, so a circular crop has no ring

### DIFF
--- a/src/server/index.test.ts
+++ b/src/server/index.test.ts
@@ -5,6 +5,9 @@ import { isLoopback } from './index.ts';
 import { parseConfig, type Config } from '#profile';
 import manifest from '../../package.json' with { type: 'json' };
 
+/** The stripe fill, so the two rects that are *not* stripes can be picked out. */
+const INK_ON_GROUND = '#ffffff';
+
 /**
  * End-to-end tests against a real HTTP server on a real port.
  *
@@ -253,18 +256,29 @@ describe('discovery is filtered by policy', () => {
     // to black.
     expect(svg).not.toContain('currentColor');
 
-    // The ground is painted across the whole box rather than left transparent.
-    // The published mark lets the page behind it supply the ground, which is
-    // right for a favicon on lanes.sh and wrong for an icon a client draws on
-    // a surface we know nothing about.
+    // The ground is painted rather than left transparent. The published mark
+    // lets the page behind it supply the ground, which is right for a favicon
+    // on lanes.sh and wrong for an icon a client draws on a surface we know
+    // nothing about.
     expect(svg).toContain('fill="#121214"');
 
-    // The mark is inset rather than bleeding to its own edges. Without the
-    // margin a circular avatar crop takes the silhouette and leaves anonymous
-    // diagonals. A negative viewBox origin is that margin, square on both axes.
+    // The mark fills its box rather than sitting inset in it. An inset version
+    // shipped first, on the reasoning that a circular avatar crop would take
+    // the rounded-square silhouette — what it actually produced was a dark ring
+    // inside the circle with the stripes shrunk away from it. A viewBox at the
+    // origin is what keeps the stripes running edge to edge under that crop.
     const [x, y] = (svg.match(/viewBox="(-?[\d.]+) (-?[\d.]+)/) ?? []).slice(1).map(Number);
-    expect(x).toBeLessThan(0);
-    expect(y).toBe(x);
+    expect(x).toBe(0);
+    expect(y).toBe(0);
+
+    // Ground and mask are the same rect, so the stripes stop exactly where the
+    // rounded square does — no ring of bare ground at the edge, in either
+    // direction. Two identical rects, one filled with the ground colour and one
+    // with the mask's white.
+    const rects = [...svg.matchAll(/<rect ([^>]*?) fill="([^"]+)"/g)].map((m) => m.slice(1));
+    const [ground, mask] = rects.filter(([, fill]) => fill !== INK_ON_GROUND);
+    expect(ground?.[0]).toBe(mask?.[0]);
+    expect(ground?.[1]).toBe('#121214');
   });
 
   test('server/discover leaks no capability names past the policy filter', async () => {

--- a/src/server/mcp/icon.ts
+++ b/src/server/mcp/icon.ts
@@ -19,37 +19,34 @@ import type { Icon } from '@modelcontextprotocol/server';
  * honour the field.
  */
 
-/** The published mark's own box, before the margin this file adds around it. */
-const TILE = 738;
-
 /**
- * How far the mark is inset inside the icon's box, in the mark's own units.
+ * The tile: the published mark's own geometry, used verbatim and not inset.
  *
- * The published mark bleeds to its own edges — it is a rounded square *made of*
- * the stripes, so at the edges there is nothing between the artwork and the
- * boundary. An avatar is cropped, usually to a circle, and a mark that reaches
- * its own edge loses the silhouette to the crop and reads as anonymous
- * diagonals. A tenth of the box on each side is enough for the stripes to stop
- * clear of a circular crop.
+ * These are the numbers from the published file — a 737.28 square at a
+ * sub-pixel offset inside a 738 × 739 box, with `rx="150"` corners. The tile is
+ * both the ground and the mask, which is what makes the stripes stop exactly
+ * where the rounded square does.
+ *
+ * **The mark is not inset, and that is a deliberate reversal.** An earlier
+ * version held it a tenth of the box clear of the edge, reasoning that a
+ * circular avatar crop would otherwise take the rounded-square silhouette. It
+ * does take it — but what the margin actually produced was a dark ring inside
+ * the circle with the stripes shrunk away from it, which reads as a small mark
+ * badly placed rather than as a mark whose corners were cropped. Filling the
+ * box is the better trade in both shapes: cropped to a circle the stripes run
+ * edge to edge, and left square the silhouette is there anyway.
  */
-const MARGIN = Math.round(TILE / 10);
+const TILE = { x: 0.360107, y: 0.859375, size: 737.28, radius: 150 } as const;
 
-/** The icon's outer box, and the ground the whole of it is painted on. */
-const BOX = TILE + MARGIN * 2;
+/** The box the published file declares, which the tile sits inside. */
+const WIDTH = 738;
+const HEIGHT = 739;
+
 const GROUND = '#121214';
 const INK = '#ffffff';
 
 /**
- * The corner radius, carried across from the mark rather than picked.
- *
- * The published tile is `rx="150"` on a 737.28 box. Scaling that ratio to the
- * padded box keeps the same curve rather than a tighter or looser one that
- * happens to look close at 220px and wrong at 32.
- */
-const RADIUS = Math.round((BOX * 150) / 737.28);
-
-/**
- * The icon: the published Lanes mark, inset, on its own dark ground.
+ * The icon: the published Lanes mark, filling its box, on its own dark ground.
  *
  * This is the mark lanes.sh serves as `/icon-light.svg` and `/icon-dark.svg`.
  * It is *not* the glyph beside "Any MCP client" in the README diagram: that one
@@ -70,8 +67,8 @@ const RADIUS = Math.round((BOX * 150) / 737.28);
  * right for a favicon on lanes.sh and wrong here: a client draws an icon on a
  * surface this file knows nothing about, and transparent gaps mean the mark is
  * a different thing on each one and invisible on some. Painting `#121214`
- * across the whole box — margin included — is what makes the result the same
- * icon everywhere, and it is why there is one entry below rather than two.
+ * behind the stripes is what makes the result the same icon everywhere, and it
+ * is why there is one entry below rather than two.
  *
  * The twenty-four stripes are generated rather than pasted. In the published
  * file they are an exact arithmetic progression — same step on both axes, the
@@ -90,19 +87,21 @@ function mark(): string {
     );
   }
 
+  // One rect shape, spelled once and used twice: as the ground the stripes are
+  // painted over, and as the mask that stops them at its edge. Written apart
+  // they are two places to change a corner radius and one place to forget.
+  const tile = `x="${TILE.x}" y="${TILE.y}" width="${TILE.size}" height="${TILE.size}" rx="${TILE.radius}"`;
+
   return [
-    `<svg xmlns="http://www.w3.org/2000/svg" viewBox="${-MARGIN} ${-MARGIN} ${BOX} ${BOX}"`,
-    ' role="img">',
+    `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 ${WIDTH} ${HEIGHT}" role="img">`,
     '<title>Lanes Link</title>',
-    `<rect x="${-MARGIN}" y="${-MARGIN}" width="${BOX}" height="${BOX}"`,
-    ` rx="${RADIUS}" fill="${GROUND}" />`,
+    `<rect ${tile} fill="${GROUND}" />`,
     // The rounded square is a mask rather than a drawn shape, which is what
     // makes the stripes stop where they do. Its id has to be stable but not
     // unique — the icon is its own `data:` document, so nothing else is in
-    // scope to collide with it. Its own corners never show: it is inset on a
-    // ground of the same colour, so what reads is where the stripes end.
-    '<mask id="tile" maskUnits="userSpaceOnUse" x="0" y="0" width="738" height="739">',
-    '<rect x="0.360107" y="0.859375" width="737.28" height="737.28" rx="150" fill="#fff" />',
+    // scope to collide with it.
+    `<mask id="tile" maskUnits="userSpaceOnUse" x="0" y="0" width="${WIDTH}" height="${HEIGHT}">`,
+    `<rect ${tile} fill="#fff" />`,
     '</mask>',
     `<g mask="url(#tile)">${stripes.join('')}</g>`,
     '</svg>',


### PR DESCRIPTION
Follow-up to #9.

## What was wrong

The icon shipped in #9 held the mark a tenth of its box clear of the edge. The reasoning was that an avatar is usually cropped to a circle, and a mark reaching its own edge loses the rounded-square silhouette to that crop.

The silhouette does go — but that was the wrong thing to protect. What the margin actually produces under a circular crop is a **ring of bare ground with the stripes shrunk away from it**, which reads as a small mark badly centred rather than as a mark whose corners were cropped. The ring was about 8.4% of the box on each side — some five pixels at the 64px an avatar is usually drawn at, and the first thing you see.

## What changes

The mark fills its box. Cropped to a circle the stripes now run edge to edge; left square the silhouette is there anyway, because the tile *is* a rounded square and nothing was covering it.

The ground and the mask are now one rect spelled once and used twice, rather than a padded ground behind a smaller mask. Written apart they were two places to change a corner radius and one place to forget it.

Nothing else moves. The mark is still the published Lanes mark, still carries its own painted ground rather than inheriting a transparent one, and is still a single entry with no `theme`.

## Measurements

Taken from the shipped SVG rather than by eye — the gap between the viewBox and the artwork:

| | inset | at 64px | reaches the circle's edge |
|---|---|---|---|
| before (#9) | 8.39% | ~5.4 px of bare ground | no |
| after | 0.05% | 0.03 px | yes |

The 0.05% that remains is the published file's own sub-pixel offset (`x="0.360107"`), not padding this code adds.

## Verification

- `bun test` — 1626 pass, 0 fail
- `bun run typecheck` — clean
- `bun test src/architecture.test.ts` — 6 pass
- The test's inset assertion is inverted rather than deleted: it asserted a negative viewBox origin, and now asserts an origin at zero plus that the ground and mask rects are identical. So the ring cannot come back unnoticed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)