### PR TITLE
Stop promising a tool-list notification the endpoint never sends

### DIFF
--- a/docs/connect.md
+++ b/docs/connect.md
@@ -95,8 +95,13 @@ $ lanes link tools                # names by provider, payload size
 $ lanes link tools --target cloud # ask the deployed endpoint instead
 ```
 
-If that count matches your client, nothing is stale. If it does not, the client is holding an old
-list and reconnecting is the fix.
+If that count matches your client, its tools are current. If it does not, the client is holding an
+old list and reconnecting is the fix.
+
+Tools only, though. A skill is a *prompt*, not a tool, so adding one moves neither the count nor
+the line `connect` prints — and skills are picked up by a running endpoint without a reload, so
+nothing announces them either. After `lanes link skills add`, reconnect the client on the same
+reasoning and without waiting for a number to change.
 
 ## See what one takes before you start
 

--- a/docs/connect.md
+++ b/docs/connect.md
@@ -67,14 +67,36 @@ endpoint reads it, and asks that endpoint to re-read it — so a running `lanes 
 up without a restart, and a deployed endpoint picks it up without a new revision. Deploying is how
 new code gets to an endpoint; authorising an account changes no code (ADR-029).
 
-The last line says which happened:
+The last line says which happened, and how many tools the endpoint now advertises:
 
 ```console
 Next: Serving it now — the endpoint has re-read its config.
+  42 tools are advertised now. A client connected before this keeps the
+  list it already fetched — reconnect it to pick them up.
 ```
 
 If no endpoint was running, or this machine cannot reach a deployed one, it says that instead. The
 connection is saved either way and is served the next time that endpoint starts.
+
+## Your agent needs reconnecting, though
+
+An MCP client reads the tool list when it connects and keeps it. This endpoint cannot tell it
+otherwise — it holds no session, so there is no channel to send a change on, and it says as much
+rather than claiming there is (ADR-032). So a client registered before this connection still shows
+the tools it saw then.
+
+Remove and re-add it. For a hosted connector that is Disconnect and add the URL again; for a local
+one, whatever your agent's equivalent is.
+
+To see what a client would be handed right now:
+
+```console
+$ lanes link tools                # names by provider, payload size
+$ lanes link tools --target cloud # ask the deployed endpoint instead
+```
+
+If that count matches your client, nothing is stale. If it does not, the client is holding an old
+list and reconnecting is the fix.
 
 ## See what one takes before you start
 

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -27,7 +27,10 @@ $ lanes link outputs --target cloud        # the URL your agent needs
 ```
 
 `connect` comes *after* the deploy: a credential store that does not exist yet is not somewhere to
-write a credential.
+write a credential. And `outputs` comes after *both* — register your agent last. A client reads the
+tool list when it connects and keeps it, so one registered before the accounts holds a list without
+them and has to be removed and re-added (ADR-032). `lanes link tools --target cloud` shows what a
+client would be handed.
 
 There is no second deploy. `connect` copies the config to where the running revision reads it and
 asks that revision to re-read it, so the account is reachable as soon as the browser consent is

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -48,7 +48,8 @@ already holds unless you pass `--overwrite`.
 Name it, and everything downstream takes the same flag:
 
 ```console
-$ lanes link deploy --target staging       # its own project, bucket, and service
+$ lanes link deploy --target staging          # its own project, bucket, and service
+$ lanes link connect gmail --target staging   # same ordering: accounts before the URL
 $ lanes link outputs --target staging
 ```
 

--- a/docs/detailed/adr/032-a-stateless-endpoint-does-not-announce-its-tools.md
+++ b/docs/detailed/adr/032-a-stateless-endpoint-does-not-announce-its-tools.md
@@ -1,0 +1,108 @@
+# ADR-032: A stateless endpoint does not announce its tools
+
+**Status:** accepted · **Completes** [ADR-029](029-connecting-is-not-deploying.md) · **Follows from** [ADR-002](002-transport-and-statelessness.md)
+
+## Context
+
+ADR-029 made a connected account reach a running endpoint without a redeploy. It worked: `connect`
+publishes the config, `POST /reload` re-reads it, and the next `tools/list` carries the new
+provider. Every part of that was observed working against a deployed revision — five connects, five
+reloads, a tool list that grew from two entries to forty-two.
+
+The client went on showing two.
+
+The endpoint was registered as a connector before any account was connected, which is the ordering
+`docs/deploy.md` describes: deploy, then connect. A first deploy necessarily publishes a profile
+whose only connection is `setup.main`, because the accounts come afterwards. So the client's first
+`tools/list` returned `setup_overview` and `setup_provider`, and it stored those — which is what a
+client does with a tool list.
+
+What it did not do was ask again. Refreshing the connector sent one `initialize` and stopped.
+
+The reason was in the `initialize` answer:
+
+```json
+"capabilities": { "tools": { "listChanged": true } }
+```
+
+Nothing in this repository has ever sent `notifications/tools/list_changed`. The value was never
+authored — the SDK sets it when a tool is registered:
+
+```js
+registerCapabilities({ tools: { listChanged: getCapabilities().tools?.listChanged ?? true } })
+```
+
+`listChanged` is a promise to tell the client when the list changes. ADR-002 chose stateless
+streamable HTTP, so there is no stream on which to deliver such a notification and the server
+instance is discarded once the response is written. The endpoint could not keep the promise, and a
+client that believed it had no reason to poll.
+
+That is the failure mode this ADR exists for, and it is worth naming precisely because nothing looks
+broken from either end. The endpoint is right: it holds current config, it advertises the full list,
+and it serves it correctly to anyone who asks. The client is behaving correctly too — it was told it
+would be informed. The surface a person sees is stale and every component reports success.
+
+It is also invisible. `tools/list` dispatches nothing, so ADR-020's log does not record it and
+neither does anything else; the only trace of what the endpoint told a client was the byte size of a
+response in the platform's request log.
+
+## Decision
+
+**Declare `listChanged: false`, explicitly, for tools, resources and prompts.** `buildMcpServer`
+passes it in `ServerOptions`; the SDK's `?? true` yields to an authored `false`. A client that knows
+the list is not announced re-reads it, which is the behaviour a surface that changes between
+sessions requires.
+
+The cost is one `tools/list` per session for every client, forever, in exchange for a surface that
+is never stale. That is the same trade ADR-029 declined for config — it chose a notify over a poll
+because config changes a few times a year — and it comes out the other way here, because the party
+that would poll is the client, the interval is per session rather than per instance per minute, and
+a missed notification is not detectable by anyone.
+
+**A reload reports how many tools it now serves, and logs it.** `ReloadResult` carries the count,
+`/reload` returns it, and `connect` prints it beside the line saying the endpoint re-read its
+config — with the one action that picks it up:
+
+```
+Serving it now — the endpoint has re-read its config.
+  42 tools are advertised now. A client connected before this keeps the
+  list it already fetched — reconnect it to pick them up.
+```
+
+The endpoint re-reading its config and the client learning about it are different events, and the
+command used to report only the first while the operator was looking at the second.
+
+**`lanes link tools` asks the endpoint what it advertises.** One `initialize` and one `tools/list`
+over the wire, printing the count, the names by provider, the payload size, and the declared
+`listChanged`. Not derived from config: the question is what a client is being told, and a config
+that says forty-two tools while a client shows two is exactly the case where a derived answer would
+be believed.
+
+**The generation logger is the endpoint's logger.** It was an inline no-op, so `could not reload
+config`, `could not refresh skills`, and every `mcp handler error` went nowhere.
+
+## Consequences
+
+**A tool-less profile answers `tools/list` with an empty list.** Declaring the capability installs
+the handler unconditionally, where before an endpoint with nothing registered answered `Method not
+found`. That is the better answer, and for this ADR's own reason: "no tools right now" invites a
+client to ask again, and "this server does not do tools" tells it never to.
+
+**`connect` is honest about the step it cannot take.** Reconnecting a client is the operator's, the
+same way authorising an account is (ADR-007). What changes is that the command says so.
+
+**Nothing here can make a client re-read.** A client that ignores `listChanged` and caches
+regardless is unaffected. The endpoint's obligation is to stop supplying a reason not to ask; it
+cannot supply a reason to.
+
+## What this does not do
+
+**No notification is sent on the modern leg either.** The 2026-07-28 revision has an event bus and a
+`subscriptions/listen` stream, so one could be. It is not, because the same value is declared to
+both legs and a capability that is true only for clients on the newer revision is the ambiguity this
+ADR removes.
+
+**The count is not audited.** `tools/list` still dispatches nothing and still writes no audit event.
+It is logged once per generation instead — the question worth answering was "what is this endpoint
+advertising", not "who asked", and a per-request record of a method that invokes nothing would dilute
+a log whose value is that every row is a real call.

--- a/docs/detailed/adr/032-a-stateless-endpoint-does-not-announce-its-tools.md
+++ b/docs/detailed/adr/032-a-stateless-endpoint-does-not-announce-its-tools.md
@@ -48,10 +48,15 @@ response in the platform's request log.
 
 ## Decision
 
-**Declare `listChanged: false`, explicitly, for tools, resources and prompts.** `buildMcpServer`
-passes it in `ServerOptions`; the SDK's `?? true` yields to an authored `false`. A client that knows
-the list is not announced re-reads it, which is the behaviour a surface that changes between
-sessions requires.
+**Declare `listChanged: false`, explicitly.** `buildMcpServer` passes it in `ServerOptions`; the
+SDK's `?? true` yields to an authored `false`. A client that knows the list is not announced
+re-reads it, which is the behaviour a surface that changes between sessions requires.
+
+`tools` unconditionally. Resources and prompts carry the identical default and the identical
+inability, so they get the same answer — but only where the profile has some, because declaring a
+capability installs its handler set, and a client that gates its list calls on what is advertised
+would otherwise spend three stateless POSTs per session, each rebuilding the whole server, to be
+told nothing is there.
 
 The cost is one `tools/list` per session for every client, forever, in exchange for a surface that
 is never stale. That is the same trade ADR-029 declined for config — it chose a notify over a poll
@@ -78,6 +83,14 @@ over the wire, printing the count, the names by provider, the payload size, and 
 that says forty-two tools while a client shows two is exactly the case where a derived answer would
 be believed.
 
+Which sets the bar for its own failures, because each of them reads as an answer. It says whether
+the address is the deployed one or the loopback fallback, since a `--target cloud` whose service
+could not be located answers from `127.0.0.1` with a token `secrets push` made identical. It
+separates *refused* from *unreachable*, because a rotated token and a dead port need opposite
+fixes. It groups by resolving each wire name back to a capability id rather than splitting on the
+first underscore, and files what it cannot resolve as unattributed instead of guessing. And it
+exits non-zero when it could not answer, as `doctor` does.
+
 **The generation logger is the endpoint's logger.** It was an inline no-op, so `could not reload
 config`, `could not refresh skills`, and every `mcp handler error` went nowhere.
 
@@ -101,6 +114,11 @@ cannot supply a reason to.
 `subscriptions/listen` stream, so one could be. It is not, because the same value is declared to
 both legs and a capability that is true only for clients on the newer revision is the ambiguity this
 ADR removes.
+
+**It does not cover skills.** A skill registers as a prompt, so it moves neither the count nor the
+line `connect` prints — and skills refresh *within* a generation, on a poll, so no reload fires to
+report one either. `docs/connect.md` says so where it tells an operator to compare the number
+against their client, rather than leaving "nothing is stale" to cover a case it does not.
 
 **The count is not audited.** `tools/list` still dispatches nothing and still writes no audit event.
 It is logged once per generation instead — the question worth answering was "what is this endpoint

--- a/docs/detailed/adr/README.md
+++ b/docs/detailed/adr/README.md
@@ -39,6 +39,7 @@ Nothing in the codebase depends on it.
 | [029](029-connecting-is-not-deploying.md) | Connecting publishes its own config and the endpoint re-reads it; deploying is only code |
 | [030](030-a-profile-owns-its-skills-and-manifests.md) | Skills and provider manifests move into `data/<profile>/`; nothing is shared between profiles any more |
 | [031](031-sign-in-and-data-access-are-separate-projects.md) | Signing in and reaching Google data are separate Cloud projects; the second is where every Google-data client goes |
+| [032](032-a-stateless-endpoint-does-not-announce-its-tools.md) | `listChanged` is declared false because it is false; a reload reports its tool count and `lanes link tools` asks the endpoint |
 
 Where an ADR departs from init.md, it says so at the top. Three are significant:
 

--- a/src/cli/commands/operate.ts
+++ b/src/cli/commands/operate.ts
@@ -20,6 +20,7 @@
 export { check, doctor, plan } from './operate/inspect.ts';
 export { status } from './operate/status.ts';
 export { outputs, type OutputsFlags } from './operate/outputs.ts';
+export { tools, type ToolsFlags } from './operate/tools.ts';
 export { start } from './operate/serve.ts';
 export { auditTail, auditVerify, markdownCell } from './operate/audit.ts';
 export { attachFile } from './operate/attach.ts';

--- a/src/cli/commands/operate/outputs.ts
+++ b/src/cli/commands/operate/outputs.ts
@@ -1,17 +1,12 @@
 import { listProfiles } from '#profile';
 import { fileURLToPath } from 'node:url';
-import { deployedUrl, endpointUrl } from '../../endpoint-url.ts';
+import { deployedUrl, endpointHealth, localUrl } from '../../endpoint-url.ts';
 import { announce, heading, print, style, warn } from '../../output.ts';
 import { ensureProfileToken, openRuntime, type GlobalFlags } from '../../runtime.ts';
 
 export interface OutputsFlags extends GlobalFlags {
   readonly show?: boolean | undefined;
   readonly json?: boolean | undefined;
-}
-
-interface Health {
-  readonly profile: string;
-  readonly profiles: readonly string[];
 }
 
 /**
@@ -34,9 +29,11 @@ export async function outputs(flags: OutputsFlags): Promise<void> {
     const { token } = await ensureProfileToken(runtime.credentials, runtime.config.auth.token_ref);
     const declared = runtime.config.targets[runtime.target]?.deploy;
     const deployed = await deployedUrl(declared);
-    const url = deployed ?? (await endpointUrl(runtime.config, runtime.target));
+    // Not `endpointUrl`, which would ask the platform a second time for an
+    // answer this line already has.
+    const url = deployed ?? localUrl(runtime.config);
 
-    const live = await health(url, token);
+    const live = await endpointHealth(url, token);
     const mine = live?.profile === runtime.resolution.profile;
 
     // Live if it is up, otherwise what `start` would serve: the whole
@@ -174,33 +171,3 @@ async function tokenInvocation(
   return { command: `bun run ${entry} link token show --raw${suffix}`, onPath: false };
 }
 
-/**
- * Ask the endpoint who it is.
- *
- * The profile name is checked by the caller, not just the port: two workspaces
- * can assign the same port, and reporting "running" because something
- * unrelated answers would send someone to register an endpoint serving another
- * workspace's accounts.
- *
- * The token is sent because `/health` names profiles only to a caller that
- * holds one. Anonymously it answers `{status: "ok"}` and nothing else — that
- * list is what this endpoint holds, and a deployed URL is readable by anyone.
- * An endpoint that answers without naming itself is therefore reported as
- * something else's, which is the honest reading: this token does not open it.
- */
-async function health(url: string, token: string): Promise<Health | null> {
-  try {
-    const probe = new URL(url);
-    probe.pathname = '/health';
-    const response = await fetch(probe, {
-      headers: { authorization: `Bearer ${token}` },
-      signal: AbortSignal.timeout(700),
-    });
-    if (!response.ok) return null;
-
-    const body = (await response.json()) as Partial<Health>;
-    return body.profile ? { profile: body.profile, profiles: body.profiles ?? [body.profile] } : null;
-  } catch {
-    return null;
-  }
-}

--- a/src/cli/commands/operate/tools.test.ts
+++ b/src/cli/commands/operate/tools.test.ts
@@ -1,0 +1,126 @@
+import { afterAll, describe, expect, test } from 'bun:test';
+import { allocatePort, startHarness, TEST_TOKEN } from '../../../server/harness.ts';
+import { askEndpoint, groupByProvider, parse, UNATTRIBUTED } from './tools.ts';
+
+/**
+ * What `lanes link tools` reports, and the two ways it used to be wrong.
+ *
+ * The command exists to answer "is my client stale or is my endpoint wrong",
+ * which means every one of its own failure modes reads as an answer. A frame it
+ * cannot parse becomes "0 tools"; a refusal becomes "unreachable"; a name it
+ * cannot attribute becomes a confident heading. So the parts that can be wrong
+ * quietly are the parts that are tested here.
+ */
+
+const harness = startHarness({
+  profile: 'personal',
+  port: allocatePort(),
+  policy: `  allow:
+    - "example.*"`,
+});
+
+afterAll(async () => {
+  await harness.stop();
+});
+
+describe('reading the response frame', () => {
+  const payload = { jsonrpc: '2.0', id: 1, result: { tools: [{ name: 'example_echo' }] } };
+  const body = JSON.stringify(payload);
+
+  test('a plain JSON body', () => {
+    expect(parse(body)).toEqual({ tools: [{ name: 'example_echo' }] });
+  });
+
+  test('an SSE frame', () => {
+    expect(parse(`event: message\ndata: ${body}\n\n`)).toEqual({
+      tools: [{ name: 'example_echo' }],
+    });
+  });
+
+  test('an SSE frame with no space after the colon', () => {
+    // Legal SSE, and the previous expression searched for `'data: '` while
+    // gating on `'data:'` — so this parsed as `{}` and the command reported a
+    // healthy endpoint as advertising nothing.
+    expect(parse(`event: message\ndata:${body}\n\n`)).toEqual({
+      tools: [{ name: 'example_echo' }],
+    });
+  });
+
+  test('an SSE frame behind keep-alive comments', () => {
+    // The legacy transport arms a keep-alive on every POST and this repository
+    // passes no interval, so a handler that runs past the default emits comment
+    // lines first. Inspecting the first characters of the body saw `: keepalive`,
+    // fell through to `JSON.parse`, threw, and reported the endpoint down.
+    expect(parse(`: keepalive\n\n: keepalive\n\nevent: message\ndata: ${body}\n\n`)).toEqual({
+      tools: [{ name: 'example_echo' }],
+    });
+  });
+
+  test('a JSON-RPC error becomes an error, not an empty result', () => {
+    expect(() => parse(JSON.stringify({ jsonrpc: '2.0', id: 1, error: { message: 'nope' } }))).toThrow(
+      'nope',
+    );
+  });
+});
+
+describe('grouping names by provider', () => {
+  const ids = ['example.echo', 'icloud_mail.send_message', 'setup.overview'];
+
+  test('a provider whose id contains an underscore keeps its own group', () => {
+    // The whole reason this does not split on the first underscore:
+    // `icloud_mail_send_message` would file under `icloud`, which is not a
+    // provider any of these profiles has.
+    const grouped = groupByProvider(['icloud_mail_send_message'], ids);
+
+    expect([...grouped.keys()]).toEqual(['icloud_mail']);
+  });
+
+  test('several providers group separately, in name order', () => {
+    const grouped = groupByProvider(['setup_overview', 'example_echo'], ids);
+
+    expect([...grouped.keys()]).toEqual(['example', 'setup']);
+  });
+
+  test('a name matching nothing known is marked unattributed, not guessed', () => {
+    // Reachable in normal use: the registry is the invoking profile's, and the
+    // endpoint may serve several — or, under `--target cloud`, run an image
+    // this checkout does not have. Filing `drive_files_list` under a confident
+    // `drive` heading would be a guess wearing a count.
+    const grouped = groupByProvider(['drive_files_list'], ids);
+
+    expect([...grouped.keys()]).toEqual([UNATTRIBUTED]);
+  });
+});
+
+describe('asking a real endpoint', () => {
+  test('reports the advertised names, the payload size, and listChanged', async () => {
+    const surface = await askEndpoint(harness.server.url, TEST_TOKEN);
+
+    expect(surface.reachable).toBe(true);
+    expect(surface.names).toContain('example_echo');
+    expect(surface.bytes).toBeGreaterThan(0);
+    // The subject of ADR-032: a client is told the list is not announced, so it
+    // re-reads rather than trusting a notification that never arrives.
+    expect(surface.listChanged).toBe(false);
+  });
+
+  test('a refused token is reported as a refusal, not as unreachable', async () => {
+    // These are different problems with different fixes. Folding them together
+    // sends someone to check whether the endpoint is up when it answered them
+    // and declined — which is what a rotated token, or another workspace on the
+    // same port, actually looks like.
+    const surface = await askEndpoint(harness.server.url, 'llk_not_the_right_token');
+
+    expect(surface.reachable).toBe(false);
+    expect(surface.refused).toBe(true);
+    expect(surface.reason).toContain('401');
+  });
+
+  test('an address with nothing behind it is reported as unreachable', async () => {
+    const surface = await askEndpoint(`http://127.0.0.1:${allocatePort()}/mcp`, TEST_TOKEN);
+
+    expect(surface.reachable).toBe(false);
+    expect(surface.refused).toBeUndefined();
+    expect(surface.names).toEqual([]);
+  });
+});

--- a/src/cli/commands/operate/tools.ts
+++ b/src/cli/commands/operate/tools.ts
@@ -1,0 +1,203 @@
+import { toolNameFor } from '#server/mcp';
+import { deployedUrl, endpointUrl } from '../../endpoint-url.ts';
+import { announce, heading, print, style, warn } from '../../output.ts';
+import { ensureProfileToken, openRuntime, type GlobalFlags } from '../../runtime.ts';
+
+export interface ToolsFlags extends GlobalFlags {
+  readonly json?: boolean | undefined;
+}
+
+/**
+ * What a client is actually being told, asked over the wire.
+ *
+ * Not derived from the config, and that is the whole reason this exists.
+ * `doctor` answers whether the credentials resolve and `outputs` answers where
+ * the endpoint is; neither answers the question that follows a client showing
+ * the wrong tools, which is what the endpoint would hand it right now. Working
+ * that out previously meant hand-rolling a `tools/list` with `curl` and a token
+ * pulled out of the secret store, and reading a byte count out of a request log
+ * to guess at the answer.
+ *
+ * The `listChanged` line is here for the same reason. A client refreshes by
+ * asking again, and a server that claims it will announce changes gives it a
+ * reason not to — so a surface that looks stale in a client and current here is
+ * explained by that flag more often than by anything else.
+ */
+export async function tools(flags: ToolsFlags): Promise<void> {
+  const runtime = await openRuntime(flags);
+
+  try {
+    const { token } = await ensureProfileToken(runtime.credentials, runtime.config.auth.token_ref);
+    const declared = runtime.config.targets[runtime.target]?.deploy;
+    const deployed = await deployedUrl(declared);
+    const url = deployed ?? (await endpointUrl(runtime.config, runtime.target));
+
+    const surface = await advertised(url, token);
+
+    if (flags.json) {
+      print(JSON.stringify({ url, target: runtime.target, ...surface }, null, 2));
+      return;
+    }
+
+    announce(runtime.resolution);
+
+    heading('Endpoint');
+    print(`  ${url}`);
+
+    if (!surface.reachable) {
+      print(warn(`could not ask it: ${surface.reason}`));
+      print(
+        style.dim(
+          '  Nothing here reads the config to guess instead — an endpoint that cannot\n' +
+            '  be asked is exactly the case where a guess would be believed.',
+        ),
+      );
+      return;
+    }
+
+    // The registry's own ids, wire-spelled, so the grouping below matches what
+    // the endpoint actually named rather than what the string looks like.
+    const providers = runtime.registry.list().map((entry) => toolNameFor(entry.manifest.id));
+
+    heading(`Advertised to a client (${surface.tools.length})`);
+    for (const [provider, names] of byProvider(surface.tools, providers)) {
+      print(`  ${style.bold(provider)}  ${style.dim(`${names.length}`)}`);
+      for (const name of names) print(`    ${name}`);
+    }
+
+    heading('How a client sees it');
+    print(`  payload:      ${kb(surface.bytes)} for the whole list`);
+    print(`  listChanged:  ${listChangedLine(surface.listChanged)}`);
+  } finally {
+    await runtime.close();
+  }
+}
+
+interface Surface {
+  readonly reachable: boolean;
+  readonly reason?: string;
+  readonly tools: readonly string[];
+  readonly bytes: number;
+  readonly listChanged?: boolean | undefined;
+}
+
+/**
+ * One `initialize`, one `tools/list`, exactly as a 2025-era client sends them.
+ *
+ * Deliberately hand-rolled rather than run through an MCP client library: the
+ * subject is what the endpoint puts on the wire, and a library that negotiated
+ * a newer revision would answer a different question than the one asked.
+ */
+async function advertised(url: string, token: string): Promise<Surface> {
+  const post = async (body: unknown): Promise<{ text: string; result: Record<string, unknown> }> => {
+    const response = await fetch(url, {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        // Both, and not one: the streamable HTTP transport answers 406 to a
+        // client that will not accept an event stream, whatever it then sends.
+        accept: 'application/json, text/event-stream',
+        authorization: `Bearer ${token}`,
+      },
+      body: JSON.stringify(body),
+      signal: AbortSignal.timeout(30_000),
+    });
+
+    if (!response.ok) throw new Error(`the endpoint answered ${response.status}`);
+
+    const text = await response.text();
+    return { text, result: parse(text) };
+  };
+
+  try {
+    const init = await post({
+      jsonrpc: '2.0',
+      id: 1,
+      method: 'initialize',
+      params: {
+        protocolVersion: '2025-06-18',
+        capabilities: {},
+        clientInfo: { name: 'lanes-link-cli', version: '0.0.0' },
+      },
+    });
+
+    const capabilities = init.result['capabilities'] as
+      | { tools?: { listChanged?: boolean } }
+      | undefined;
+
+    const listed = await post({ jsonrpc: '2.0', id: 2, method: 'tools/list', params: {} });
+    const names = ((listed.result['tools'] as Array<{ name?: string }> | undefined) ?? [])
+      .map((tool) => tool.name ?? '')
+      .filter((name) => name.length > 0)
+      .sort();
+
+    return {
+      reachable: true,
+      tools: names,
+      bytes: Buffer.byteLength(listed.text),
+      listChanged: capabilities?.tools?.listChanged,
+    };
+  } catch (error) {
+    const reason = error instanceof Error ? error.message : String(error);
+    return { reachable: false, reason, tools: [], bytes: 0 };
+  }
+}
+
+/** The legacy leg answers as SSE, so the payload arrives on a `data:` line. */
+function parse(text: string): Record<string, unknown> {
+  const body = text.startsWith('event:') || text.startsWith('data:')
+    ? (text.split('\n').find((line) => line.startsWith('data: '))?.slice(6) ?? '{}')
+    : text;
+
+  const message = JSON.parse(body) as {
+    result?: Record<string, unknown>;
+    error?: { message?: string };
+  };
+
+  if (message.error) throw new Error(message.error.message ?? 'the endpoint returned an error');
+  return message.result ?? {};
+}
+
+/**
+ * Group by provider, using the ids the registry holds rather than the name.
+ *
+ * A wire name is the capability id with its dots replaced (`naming.ts`), so
+ * `icloud_mail.send_message` arrives as `icloud_mail_send_message` and there is
+ * nothing left in the string to say where the provider ends. Splitting on the
+ * first underscore would file it under `icloud`, which is not a provider. The
+ * ids are known here, so the longest one that matches wins and nothing guesses.
+ */
+function byProvider(
+  names: readonly string[],
+  providers: readonly string[],
+): Map<string, string[]> {
+  const longestFirst = [...providers].sort((a, b) => b.length - a.length);
+  const grouped = new Map<string, string[]>();
+
+  for (const name of names) {
+    const provider =
+      longestFirst.find((id) => name === id || name.startsWith(`${id}_`)) ?? 'other';
+    const bucket = grouped.get(provider);
+    if (bucket) bucket.push(name);
+    else grouped.set(provider, [name]);
+  }
+
+  return new Map([...grouped].sort(([a], [b]) => a.localeCompare(b)));
+}
+
+function kb(bytes: number): string {
+  return bytes < 1024 ? `${bytes} B` : `${(bytes / 1024).toFixed(1)} KB`;
+}
+
+function listChangedLine(declared: boolean | undefined): string {
+  if (declared === undefined) return style.dim('not declared');
+  if (declared === false) {
+    return `false  ${style.dim('— a client re-reads this list rather than waiting to be told')}`;
+  }
+
+  // Worth a warning rather than a value, because it is the shape of a bug that
+  // presents as "the endpoint is wrong" when the endpoint is right: a client
+  // that trusts the promise keeps the list it first fetched, for as long as it
+  // is registered.
+  return style.yellow('true') + style.dim('  — but nothing here sends the notification');
+}

--- a/src/cli/commands/operate/tools.ts
+++ b/src/cli/commands/operate/tools.ts
@@ -1,6 +1,6 @@
-import { toolNameFor } from '#server/mcp';
-import { deployedUrl, endpointUrl } from '../../endpoint-url.ts';
-import { announce, heading, print, style, warn } from '../../output.ts';
+import { capabilityIdForToolName } from '#server/mcp';
+import { deployedUrl, endpointHealth, localUrl } from '../../endpoint-url.ts';
+import { announce, emit, heading, print, style, warn } from '../../output.ts';
 import { ensureProfileToken, openRuntime, type GlobalFlags } from '../../runtime.ts';
 
 export interface ToolsFlags extends GlobalFlags {
@@ -21,7 +21,7 @@ export interface ToolsFlags extends GlobalFlags {
  * The `listChanged` line is here for the same reason. A client refreshes by
  * asking again, and a server that claims it will announce changes gives it a
  * reason not to — so a surface that looks stale in a client and current here is
- * explained by that flag more often than by anything else.
+ * explained by that flag more often than by anything else (ADR-032).
  */
 export async function tools(flags: ToolsFlags): Promise<void> {
   const runtime = await openRuntime(flags);
@@ -30,55 +30,144 @@ export async function tools(flags: ToolsFlags): Promise<void> {
     const { token } = await ensureProfileToken(runtime.credentials, runtime.config.auth.token_ref);
     const declared = runtime.config.targets[runtime.target]?.deploy;
     const deployed = await deployedUrl(declared);
-    const url = deployed ?? (await endpointUrl(runtime.config, runtime.target));
+    // Not `endpointUrl`, which asks the platform a second time for an answer
+    // this line already has.
+    const url = deployed ?? localUrl(runtime.config);
 
-    const surface = await advertised(url, token);
+    // Before trusting anything the surface says: two workspaces can assign the
+    // same port, and `secrets push` makes their tokens match, so a `--target
+    // cloud` whose deployment could not be located answers from loopback with a
+    // token that works. Reporting that as the deployed endpoint's surface is
+    // the failure `endpoint-url.ts` calls "silent in the worst way".
+    const live = await endpointHealth(url, token);
+    const mine = live?.profile === runtime.resolution.profile;
 
-    if (flags.json) {
-      print(JSON.stringify({ url, target: runtime.target, ...surface }, null, 2));
-      return;
-    }
+    const surface = await askEndpoint(url, token);
+    const providers = [...new Set(runtime.registry.capabilities().map(({ id }) => id))];
 
-    announce(runtime.resolution);
+    await emit(
+      flags.json,
+      {
+        url,
+        target: runtime.target,
+        // Both, because `--target cloud` reaching loopback is indistinguishable
+        // from success without them.
+        deployed: deployed !== null,
+        answering: mine,
+        ...surfaceJson(surface),
+      },
+      () => {
+        announce(runtime.resolution);
 
-    heading('Endpoint');
-    print(`  ${url}`);
+        heading('Endpoint');
+        print(`  ${url}  ${reachability(mine, deployed !== null, surface)}`);
 
-    if (!surface.reachable) {
-      print(warn(`could not ask it: ${surface.reason}`));
-      print(
-        style.dim(
-          '  Nothing here reads the config to guess instead — an endpoint that cannot\n' +
-            '  be asked is exactly the case where a guess would be believed.',
-        ),
-      );
-      return;
-    }
+        if (declared && !deployed) {
+          // The case the ownership probe cannot catch on its own: the address
+          // is loopback because the platform could not be asked, not because
+          // this target is local.
+          print(
+            warn(
+              `could not ask ${declared.platform} where "${declared.service}" is — this is the local endpoint, not the deployed one`,
+            ),
+          );
+        } else if (live && !mine) {
+          print(warn(`something else is serving this port: profile "${live.profile}"`));
+        }
 
-    // The registry's own ids, wire-spelled, so the grouping below matches what
-    // the endpoint actually named rather than what the string looks like.
-    const providers = runtime.registry.list().map((entry) => toolNameFor(entry.manifest.id));
+        if (!surface.reachable) {
+          print(fail(surface));
+          return;
+        }
 
-    heading(`Advertised to a client (${surface.tools.length})`);
-    for (const [provider, names] of byProvider(surface.tools, providers)) {
-      print(`  ${style.bold(provider)}  ${style.dim(`${names.length}`)}`);
-      for (const name of names) print(`    ${name}`);
-    }
+        heading(`Advertised to a client (${surface.names.length})`);
+        for (const [provider, names] of groupByProvider(surface.names, providers)) {
+          print(`  ${style.bold(provider)}  ${style.dim(`${names.length}`)}`);
+          for (const name of names) print(`    ${name}`);
+        }
 
-    heading('How a client sees it');
-    print(`  payload:      ${kb(surface.bytes)} for the whole list`);
-    print(`  listChanged:  ${listChangedLine(surface.listChanged)}`);
+        heading('How a client sees it');
+        print(`  payload:      ${kb(surface.bytes)} for the whole list`);
+        print(`  listChanged:  ${listChangedLine(surface.listChanged)}`);
+        print(
+          style.dim(
+            '  Tools only — a skill is a prompt, and is not counted here or by `connect`.',
+          ),
+        );
+      },
+    );
+
+    // Non-zero for the same reason `doctor` does it: a command whose whole job
+    // is to answer a question exits failing when it could not answer.
+    if (!surface.reachable) process.exitCode = 1;
   } finally {
     await runtime.close();
   }
 }
 
+/**
+ * What is at this address, in one word.
+ *
+ * The refusal case is why this is not just `mine`. `/health` is asked with the
+ * same token, so an endpoint belonging to another workspace fails that probe
+ * too — and reporting "not running" above a refusal that begins "it is
+ * answering" is the command contradicting itself in two consecutive lines.
+ */
+function reachability(mine: boolean, deployed: boolean, surface: Surface): string {
+  if (mine) return style.green(deployed ? 'deployed' : 'running');
+  if (surface.refused) return style.yellow('answering, but not for this token');
+  return style.dim(deployed ? 'not answering' : 'not running');
+}
+
+/**
+ * Why the surface could not be read, said as the thing that happened.
+ *
+ * Refused and unreachable are different problems with different fixes, and
+ * folding them together sends someone to check whether the endpoint is up when
+ * it answered them perfectly well and declined their token.
+ */
+function fail(surface: Surface): string {
+  if (surface.refused) {
+    return (
+      warn(`the endpoint refused this token: ${surface.reason}`) +
+      `\n${style.dim('  It is answering. Either the token was rotated without re-registering, or\n  this address belongs to another workspace.')}`
+    );
+  }
+
+  return (
+    warn(`could not ask it: ${surface.reason}`) +
+    `\n${style.dim('  Nothing here reads the config to guess instead — an endpoint that cannot\n  be asked is exactly the case where a guess would be believed.')}`
+  );
+}
+
 interface Surface {
   readonly reachable: boolean;
   readonly reason?: string;
-  readonly tools: readonly string[];
+  /** It answered, and declined. Distinct from not answering at all. */
+  readonly refused?: boolean;
+  readonly names: readonly string[];
   readonly bytes: number;
   readonly listChanged?: boolean | undefined;
+}
+
+/**
+ * `tools` as a count, matching `/reload` and `connect`; the names beside it.
+ *
+ * One key, one meaning. `ReloadResult.tools` and `PublishOutcome.tools` are both
+ * numbers, and the count is what `docs/connect.md` tells an operator to compare
+ * against their client — shipping the same key here as an array would make
+ * `.tools > 5` true for a single tool.
+ */
+function surfaceJson(surface: Surface): Record<string, unknown> {
+  return {
+    reachable: surface.reachable,
+    ...(surface.reason !== undefined ? { reason: surface.reason } : {}),
+    ...(surface.refused !== undefined ? { refused: surface.refused } : {}),
+    tools: surface.names.length,
+    names: surface.names,
+    bytes: surface.bytes,
+    ...(surface.listChanged !== undefined ? { listChanged: surface.listChanged } : {}),
+  };
 }
 
 /**
@@ -88,7 +177,7 @@ interface Surface {
  * subject is what the endpoint puts on the wire, and a library that negotiated
  * a newer revision would answer a different question than the one asked.
  */
-async function advertised(url: string, token: string): Promise<Surface> {
+export async function askEndpoint(url: string, token: string): Promise<Surface> {
   const post = async (body: unknown): Promise<{ text: string; result: Record<string, unknown> }> => {
     const response = await fetch(url, {
       method: 'POST',
@@ -103,9 +192,9 @@ async function advertised(url: string, token: string): Promise<Surface> {
       signal: AbortSignal.timeout(30_000),
     });
 
-    if (!response.ok) throw new Error(`the endpoint answered ${response.status}`);
-
     const text = await response.text();
+    if (!response.ok) throw new Refusal(response.status, text);
+
     return { text, result: parse(text) };
   };
 
@@ -133,21 +222,60 @@ async function advertised(url: string, token: string): Promise<Surface> {
 
     return {
       reachable: true,
-      tools: names,
+      names,
       bytes: Buffer.byteLength(listed.text),
       listChanged: capabilities?.tools?.listChanged,
     };
   } catch (error) {
-    const reason = error instanceof Error ? error.message : String(error);
-    return { reachable: false, reason, tools: [], bytes: 0 };
+    if (error instanceof Refusal) {
+      return { reachable: false, refused: error.refused, reason: error.message, names: [], bytes: 0 };
+    }
+
+    return {
+      reachable: false,
+      reason: error instanceof Error ? error.message : String(error),
+      names: [],
+      bytes: 0,
+    };
   }
 }
 
-/** The legacy leg answers as SSE, so the payload arrives on a `data:` line. */
-function parse(text: string): Record<string, unknown> {
-  const body = text.startsWith('event:') || text.startsWith('data:')
-    ? (text.split('\n').find((line) => line.startsWith('data: '))?.slice(6) ?? '{}')
-    : text;
+/** An endpoint that answered and would not serve this call. */
+class Refusal extends Error {
+  readonly refused: boolean;
+
+  constructor(status: number, body: string) {
+    // The transport puts the actionable reason in a JSON-RPC error body for
+    // 400/406/415, and discarding it leaves only a number to act on.
+    const detail = errorMessage(body);
+    super(detail ? `${status} — ${detail}` : `answered ${status}`);
+    this.refused = status === 401 || status === 403;
+  }
+}
+
+function errorMessage(body: string): string | null {
+  try {
+    const parsed = JSON.parse(body) as { error?: { message?: string } | string };
+    if (typeof parsed.error === 'string') return parsed.error;
+    return parsed.error?.message ?? null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * The JSON payload of a response that may or may not be framed as SSE.
+ *
+ * Three shapes reach here and all three are legal. A plain JSON body; an event
+ * stream whose payload line is `data: {…}`; and one where the space after the
+ * colon is absent, which the spec permits. The stream may also open with
+ * comment lines — the transport arms a keep-alive on every POST, so a handler
+ * that runs long enough emits `: keepalive` before anything else — so the
+ * payload is found by scanning rather than by inspecting the first characters.
+ */
+export function parse(text: string): Record<string, unknown> {
+  const data = text.split('\n').find((line) => line.startsWith('data:'));
+  const body = data === undefined ? text : data.slice('data:'.length).trim();
 
   const message = JSON.parse(body) as {
     result?: Record<string, unknown>;
@@ -159,24 +287,33 @@ function parse(text: string): Record<string, unknown> {
 }
 
 /**
- * Group by provider, using the ids the registry holds rather than the name.
+ * Group by provider, resolving each wire name back to the capability it is.
  *
  * A wire name is the capability id with its dots replaced (`naming.ts`), so
  * `icloud_mail.send_message` arrives as `icloud_mail_send_message` and there is
  * nothing left in the string to say where the provider ends. Splitting on the
- * first underscore would file it under `icloud`, which is not a provider. The
- * ids are known here, so the longest one that matches wins and nothing guesses.
+ * first underscore would file it under `icloud`, which is not a provider.
+ *
+ * `capabilityIdForToolName` answers it exactly against a set of known ids, and
+ * falls back to that first-underscore split when it recognises none — which is
+ * reachable here, because the registry is the *invoking profile's* while the
+ * endpoint may serve several, and under `--target cloud` may run an image this
+ * checkout does not have. So the fallback is detected rather than trusted: a
+ * name that resolves to nothing known is grouped as unattributed, because a
+ * guessed heading with a confident count is worse than an honest "these did not
+ * match anything I know about".
  */
-function byProvider(
+export function groupByProvider(
   names: readonly string[],
-  providers: readonly string[],
+  capabilityIds: readonly string[],
 ): Map<string, string[]> {
-  const longestFirst = [...providers].sort((a, b) => b.length - a.length);
+  const known = new Set(capabilityIds);
   const grouped = new Map<string, string[]>();
 
   for (const name of names) {
-    const provider =
-      longestFirst.find((id) => name === id || name.startsWith(`${id}_`)) ?? 'other';
+    const id = capabilityIdForToolName(name, capabilityIds);
+    const provider = known.has(id) ? id.slice(0, id.indexOf('.')) : UNATTRIBUTED;
+
     const bucket = grouped.get(provider);
     if (bucket) bucket.push(name);
     else grouped.set(provider, [name]);
@@ -184,6 +321,9 @@ function byProvider(
 
   return new Map([...grouped].sort(([a], [b]) => a.localeCompare(b)));
 }
+
+/** Named rather than spelled inline, so the output and the test agree. */
+export const UNATTRIBUTED = '(not in this profile)';
 
 function kb(bytes: number): string {
   return bytes < 1024 ? `${bytes} B` : `${(bytes / 1024).toFixed(1)} KB`;

--- a/src/cli/endpoint-url.ts
+++ b/src/cli/endpoint-url.ts
@@ -17,7 +17,52 @@ import type { Config, DeployConfig } from '#profile';
  */
 export async function endpointUrl(config: Config, target: string): Promise<string> {
   const deployed = await deployedUrl(config.targets[target]?.deploy);
-  return deployed ?? `http://${config.instance.host}:${config.instance.port}/mcp`;
+  return deployed ?? localUrl(config);
+}
+
+/**
+ * Where `lanes link start` would listen, from config alone.
+ *
+ * Split out so a caller that has already asked `deployedUrl` can name the
+ * fallback without asking again — `endpointUrl` is the two together, and going
+ * through it after a null costs a second `gcloud run services describe` that is
+ * already known to answer nothing.
+ */
+export function localUrl(config: Config): string {
+  return `http://${config.instance.host}:${config.instance.port}/mcp`;
+}
+
+/**
+ * Who is answering at this URL, if anyone.
+ *
+ * Shared for the reason `endpointUrl` above is: two workspaces can assign the
+ * same port, so an endpoint answering is not the same as *this* profile's
+ * endpoint answering. A command that skips this check reports another
+ * workspace's surface under this profile's heading.
+ *
+ * Anonymous would be enough to prove a socket is bound, but the profile list is
+ * behind the token, and the profile is the whole point of asking.
+ */
+export async function endpointHealth(url: string, token: string): Promise<EndpointHealth | null> {
+  try {
+    const probe = new URL(url);
+    probe.pathname = '/health';
+    const response = await fetch(probe, {
+      headers: { authorization: `Bearer ${token}` },
+      signal: AbortSignal.timeout(700),
+    });
+    if (!response.ok) return null;
+
+    const body = (await response.json()) as Partial<EndpointHealth>;
+    return body.profile ? { profile: body.profile, profiles: body.profiles ?? [body.profile] } : null;
+  } catch {
+    return null;
+  }
+}
+
+export interface EndpointHealth {
+  readonly profile: string;
+  readonly profiles: readonly string[];
 }
 
 /**

--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -14,6 +14,7 @@ import {
   status,
   tokenRotate,
   tokenShow,
+  tools,
 } from './commands/operate.ts';
 import { profileAdd, profileDefault, profileList } from './commands/profile.ts';
 import { removeProfile as profileRemove } from './commands/profile/remove.ts';
@@ -249,6 +250,13 @@ export async function run(argv: readonly string[]): Promise<void> {
       return status({ ...global, json });
     case 'outputs':
       return outputs({ ...global, show, json });
+
+    // Beside `outputs` because it answers the next question. `outputs` says
+    // where the endpoint is; this says what it would hand a client that asked
+    // right now — which is the only way to tell a stale client from a wrong
+    // endpoint without reading request sizes out of a log.
+    case 'tools':
+      return tools({ ...global, json });
 
     // Undocumented alias for `mcp skill`, which is where it moved when `skills`
     // arrived. Anyone who learned the old spelling keeps it.

--- a/src/cli/publish.test.ts
+++ b/src/cli/publish.test.ts
@@ -29,6 +29,9 @@ describe('what an edit says it did', () => {
     expect(line).toContain('Serving it now');
     expect(line).toContain('42 tools');
     expect(line).toContain('reconnect');
+    // Worded for a shrinking surface as well: `policy deny` prints this line,
+    // and there is nothing to "pick up" after one.
+    expect(line).not.toContain('pick them up');
   });
 
   test('an endpoint that did not report a count says only what it knows', () => {

--- a/src/cli/publish.test.ts
+++ b/src/cli/publish.test.ts
@@ -18,6 +18,25 @@ describe('what an edit says it did', () => {
     expect(line).not.toContain('deploy');
   });
 
+  test('a served edit says what the surface is now, and how a client picks it up', () => {
+    // The failure this wording exists for: the endpoint re-read its config and
+    // said so, the operator refreshed their connector, and the connector went
+    // on showing the two tools it captured before any account was connected.
+    // Nothing was wrong with the endpoint — the client had never been told to
+    // ask again, and cannot be, so the command has to say it.
+    const line = nextAfterEdit({ served: true, tools: 42 });
+
+    expect(line).toContain('Serving it now');
+    expect(line).toContain('42 tools');
+    expect(line).toContain('reconnect');
+  });
+
+  test('an endpoint that did not report a count says only what it knows', () => {
+    // An older endpoint, or one behind a proxy that ate the body. Inventing a
+    // number here would be worse than omitting the sentence.
+    expect(nextAfterEdit({ served: true })).not.toContain('reconnect');
+  });
+
   test('an unreachable endpoint names where it tried', () => {
     // `lanes link start --port 7455` moves the socket without moving
     // `instance.port`, so "nothing answered" most often means "not there".

--- a/src/cli/publish.ts
+++ b/src/cli/publish.ts
@@ -201,15 +201,22 @@ export function nextAfterEdit(outcome: PublishOutcome): string {
     // `tools/list` when it connects and holds the answer, and this endpoint
     // cannot tell it otherwise — it is stateless, so there is no stream on
     // which to send `notifications/tools/list_changed`, and it no longer claims
-    // there is (`buildMcpServer`).
+    // there is (ADR-032).
     //
     // So the tool count goes here, where the change happened, and so does the
     // one action that picks it up. Without this line the command reports
     // success and the operator watches a connector that never changes.
+    //
+    // Worded for either direction, because `policy deny` prints this too and a
+    // deny is the case this file already calls "the one kind of staleness worth
+    // being strict about". "Pick them up" was written for a `connect` and read
+    // as nonsense after a deny, where the client is holding one tool too many
+    // rather than one too few — and where the stale entry is a tool the model
+    // will keep calling until it is gone.
     return (
       `${served}\n` +
-      `  ${outcome.tools} tools are advertised now. A client connected before this keeps the\n` +
-      `  list it already fetched — reconnect it to pick them up.`
+      `  ${outcome.tools} tools are advertised now. A client connected before this is still\n` +
+      `  holding the list it fetched then — reconnect it to match.`
     );
   }
 

--- a/src/cli/publish.ts
+++ b/src/cli/publish.ts
@@ -29,6 +29,14 @@ export interface PublishOutcome {
   readonly published?: string;
   /** Whether a running endpoint confirmed it is now serving the edit. */
   readonly served: boolean;
+  /**
+   * How many tools the endpoint advertises now, when it answered.
+   *
+   * Reported rather than inferred, for the same reason `served` is: the number
+   * that matters is the one the endpoint would hand a client, and only the
+   * endpoint knows it.
+   */
+  readonly tools?: number;
   /** The endpoint that was told, or would have been. */
   readonly url?: string;
   /** Why it is not being served yet, in a form fit to print. */
@@ -142,7 +150,11 @@ async function notifyReload(input: {
       return { served: false, url, reason: `the endpoint answered ${response.status}` };
     }
 
-    const body = (await response.json()) as { reloaded?: unknown; reason?: unknown };
+    const body = (await response.json()) as {
+      reloaded?: unknown;
+      reason?: unknown;
+      tools?: unknown;
+    };
     if (body.reloaded !== true) {
       return {
         served: false,
@@ -154,7 +166,11 @@ async function notifyReload(input: {
       };
     }
 
-    return { served: true, url };
+    return {
+      served: true,
+      url,
+      ...(typeof body.tools === 'number' ? { tools: body.tools } : {}),
+    };
   } catch {
     // Nothing listening, scaled to zero, or unreachable from here — all of
     // which resolve themselves the next time the endpoint starts, because the
@@ -175,7 +191,27 @@ function message(error: unknown): string {
  * is now: the endpoint either answered or it did not.
  */
 export function nextAfterEdit(outcome: PublishOutcome): string {
-  if (outcome.served) return 'Serving it now — the endpoint has re-read its config.';
+  if (outcome.served) {
+    const served = 'Serving it now — the endpoint has re-read its config.';
+    if (outcome.tools === undefined) return served;
+
+    // The second half of the truth, and the half an operator is actually
+    // looking at. The endpoint re-reading its config is not the same event as
+    // the client in front of them learning about it: a client fetches
+    // `tools/list` when it connects and holds the answer, and this endpoint
+    // cannot tell it otherwise — it is stateless, so there is no stream on
+    // which to send `notifications/tools/list_changed`, and it no longer claims
+    // there is (`buildMcpServer`).
+    //
+    // So the tool count goes here, where the change happened, and so does the
+    // one action that picks it up. Without this line the command reports
+    // success and the operator watches a connector that never changes.
+    return (
+      `${served}\n` +
+      `  ${outcome.tools} tools are advertised now. A client connected before this keeps the\n` +
+      `  list it already fetched — reconnect it to pick them up.`
+    );
+  }
 
   // Naming the URL, because the likeliest reason nothing answered is that the
   // endpoint is somewhere else: `lanes link start --port` moves the socket

--- a/src/cli/tools.test.ts
+++ b/src/cli/tools.test.ts
@@ -112,6 +112,47 @@ describe('vendored specs yield registrable tools', () => {
   );
 
   /**
+   * The size nobody was measuring: the whole list, not one tool in it.
+   *
+   * `BUDGET_KB` is a floor under a single runaway schema. Every provider can sit
+   * comfortably under it while the list a client is handed grows without limit,
+   * one vendored operation at a time — and that total is what actually travels
+   * on every `tools/list`, what a hosted client has to accept in one response,
+   * and what decides whether a client injects the tools or hides them behind a
+   * search of its own.
+   *
+   * Measured per provider, because which providers an operator connects is
+   * their business and only the per-provider contribution is this repository's.
+   *
+   * The number is a ratchet, not a target. Drive is 178KB across nine
+   * operations today, and three `files.*` writes are 143KB of it: the `File`
+   * resource inlined three times over. Cutting that means `makeOpaque`, which
+   * buys the bytes by taking away the schema the model composes a request body
+   * against — a real trade, worth making deliberately rather than to satisfy a
+   * test. So this is set with the same headroom the per-tool budget carries
+   * (64KB over a legitimate 37KB): enough to catch a surface that grew by an
+   * order of magnitude, not so tight that it demands the trade today.
+   */
+  const SURFACE_BUDGET_KB = 256;
+
+  test.each(httpProviders.map((m) => [m.id, m] as const))(
+    '%s keeps its whole advertised surface inside the budget',
+    async (_id, manifest) => {
+      const connector = manifest.connector as { base_url: string; openapi: string };
+      const capabilities = await createHttpConnector({
+        baseUrl: connector.base_url,
+        openapi: connector.openapi,
+      }).discover({ manifest });
+
+      // The whole capability, not the schema alone: a name and a description
+      // are sent on every `tools/list` too, and twenty-five of them add up.
+      const kb = Math.round(JSON.stringify(capabilities).length / 1024);
+
+      expect(kb).toBeLessThanOrEqual(SURFACE_BUDGET_KB);
+    },
+  );
+
+  /**
    * A hint that is declared but not delivered.
    *
    * `specs.test.ts` checks that a `hints` key names a real capability. This

--- a/src/cli/tools.test.ts
+++ b/src/cli/tools.test.ts
@@ -121,19 +121,24 @@ describe('vendored specs yield registrable tools', () => {
    * and what decides whether a client injects the tools or hides them behind a
    * search of its own.
    *
-   * Measured per provider, because which providers an operator connects is
-   * their business and only the per-provider contribution is this repository's.
+   * Measured as what `registerDiscoveredTool` actually registers — `title`,
+   * `description` and `inputSchema` — rather than as the whole discovered
+   * capability. The difference is not a rounding error: a capability also
+   * carries its `target`, the HTTP method, path and parameter mapping the
+   * dispatcher routes with, and that never reaches a client. It is 53% of
+   * Gmail's object and 29% of Drive's, so measuring the object would let a
+   * provider trip this budget by growing a routing table that costs a client
+   * nothing, and let one double its real payload while staying under.
    *
-   * The number is a ratchet, not a target. Drive is 178KB across nine
-   * operations today, and three `files.*` writes are 143KB of it: the `File`
-   * resource inlined three times over. Cutting that means `makeOpaque`, which
-   * buys the bytes by taking away the schema the model composes a request body
-   * against — a real trade, worth making deliberately rather than to satisfy a
-   * test. So this is set with the same headroom the per-tool budget carries
-   * (64KB over a legitimate 37KB): enough to catch a surface that grew by an
+   * The number is a ratchet, not a target. Drive is 127KB on the wire across
+   * nine operations, most of it the `File` resource inlined once per write.
+   * Cutting that means `makeOpaque`, which buys bytes by taking away the schema
+   * the model composes a request body against — a real trade, worth making
+   * deliberately rather than to satisfy a test. So this carries the same
+   * headroom the per-tool budget does: enough to catch a surface that grew by an
    * order of magnitude, not so tight that it demands the trade today.
    */
-  const SURFACE_BUDGET_KB = 256;
+  const SURFACE_BUDGET_KB = 192;
 
   test.each(httpProviders.map((m) => [m.id, m] as const))(
     '%s keeps its whole advertised surface inside the budget',
@@ -144,11 +149,15 @@ describe('vendored specs yield registrable tools', () => {
         openapi: connector.openapi,
       }).discover({ manifest });
 
-      // The whole capability, not the schema alone: a name and a description
-      // are sent on every `tools/list` too, and twenty-five of them add up.
-      const kb = Math.round(JSON.stringify(capabilities).length / 1024);
+      // What `registerDiscoveredTool` reads, and therefore what a client is
+      // sent. The routing `target` beside it is the dispatcher's business.
+      const bytes = capabilities.reduce(
+        (total, { title, description, inputSchema }) =>
+          total + JSON.stringify({ title, description, inputSchema }).length,
+        0,
+      );
 
-      expect(kb).toBeLessThanOrEqual(SURFACE_BUDGET_KB);
+      expect(Math.round(bytes / 1024)).toBeLessThanOrEqual(SURFACE_BUDGET_KB);
     },
   );
 

--- a/src/cli/usage.ts
+++ b/src/cli/usage.ts
@@ -84,6 +84,7 @@ ${style.bold('Deploying')}
 ${style.bold('Inspection')}
   ${PROGRAM} check                      static validation, no external calls
   ${PROGRAM} doctor [--json]            credentials resolve, stores reachable
+  ${PROGRAM} tools [--json]             what the endpoint advertises to a client
   ${PROGRAM} plan                       what reconcile would change
   ${PROGRAM} audit tail [--limit N] [--denied-only] [--format md]
   ${PROGRAM} audit verify           has anything in the log been altered or removed

--- a/src/deployments/deploy.ts
+++ b/src/deployments/deploy.ts
@@ -211,9 +211,34 @@ export async function deploy(flags: DeployFlags): Promise<void> {
   print(`  ${url}/mcp`);
   print(await healthLine(url));
   print('');
-  print(style.dim(`  Register it with: lanes link outputs --target ${target}`));
+  print(registerLine(target, prepared.warnings.length));
 
   reportUnauthorised(prepared.warnings, target);
+}
+
+/**
+ * How to register the endpoint, and when.
+ *
+ * The ordering is the whole point of the second half. A client captures
+ * `tools/list` when it connects and keeps it: this endpoint is stateless, so
+ * there is no stream on which to send `notifications/tools/list_changed`, and
+ * `buildMcpServer` no longer pretends otherwise. A first deploy necessarily
+ * publishes a profile whose only connection is `setup.main` — the accounts come
+ * after — so a connector registered in that window captures a two-tool surface
+ * and holds it. The endpoint is right, every reload lands, and the client shows
+ * two tools until someone removes and re-adds it.
+ *
+ * Saying it here costs one line at the exact moment someone is about to do it.
+ */
+function registerLine(target: string, pending: number): string {
+  const register = `  Register it with: lanes link outputs --target ${target}`;
+  if (pending === 0) return style.dim(register);
+
+  return style.dim(
+    `${register}\n` +
+      '  Connect the accounts below first. A client keeps the tool list it fetched\n' +
+      '  when it connected, so one registered now would hold the smaller surface.',
+  );
 }
 
 /**

--- a/src/deployments/deploy.ts
+++ b/src/deployments/deploy.ts
@@ -211,7 +211,7 @@ export async function deploy(flags: DeployFlags): Promise<void> {
   print(`  ${url}/mcp`);
   print(await healthLine(url));
   print('');
-  print(registerLine(target, prepared.warnings.length));
+  print(registerLine(target));
 
   reportUnauthorised(prepared.warnings, target);
 }
@@ -228,16 +228,18 @@ export async function deploy(flags: DeployFlags): Promise<void> {
  * and holds it. The endpoint is right, every reload lands, and the client shows
  * two tools until someone removes and re-adds it.
  *
- * Saying it here costs one line at the exact moment someone is about to do it.
+ * Unconditional, and that is the correction that matters. This was gated on
+ * `prepared.warnings.length`, which is zero in precisely the case it describes:
+ * a fresh profile declares only `setup.main`, `setup` is a local provider with
+ * no credential, so `prepareSecrets` has nothing to warn about. The advice
+ * appeared only on a later re-deploy, by which point the connector is usually
+ * registered and the ordering is no longer available to get right.
  */
-function registerLine(target: string, pending: number): string {
-  const register = `  Register it with: lanes link outputs --target ${target}`;
-  if (pending === 0) return style.dim(register);
-
+function registerLine(target: string): string {
   return style.dim(
-    `${register}\n` +
-      '  Connect the accounts below first. A client keeps the tool list it fetched\n' +
-      '  when it connected, so one registered now would hold the smaller surface.',
+    `  Connect your accounts first, then register with: lanes link outputs --target ${target}\n` +
+      '  A client keeps the tool list it fetched when it connected, so one registered\n' +
+      '  before the accounts holds a surface without them until it is re-added.',
   );
 }
 

--- a/src/server/endpoint.ts
+++ b/src/server/endpoint.ts
@@ -288,6 +288,10 @@ export async function startEndpoint(options: EndpointOptions): Promise<RunningEn
       ...(options.host !== undefined ? { host: options.host } : {}),
     });
 
+    // After `serve()`, so the record means the socket is bound. Recording it
+    // from the constructor claimed an endpoint that a failed bind never served.
+    generations.announce();
+
     return {
       url: server.url,
       profiles: [...runtimes.keys()],

--- a/src/server/endpoint.ts
+++ b/src/server/endpoint.ts
@@ -267,7 +267,13 @@ export async function startEndpoint(options: EndpointOptions): Promise<RunningEn
           close: () => closeAll(reopened.runtimes).then(() => {}),
         };
       },
-      { primary: primary.resolution.profile, log: { debug() {}, info() {}, warn() {}, error() {} } },
+      // The same logger the request handler gets, rather than the inline no-op
+      // this used to be. What a generation has to say is exactly what nobody
+      // could see when a reload went wrong: `could not reload config`, `could
+      // not refresh skills`, and every `mcp handler error` the endpoint raises
+      // all went to those empty methods. A silent endpoint is not a quiet one —
+      // it is one whose failures have to be reconstructed from request sizes.
+      { primary: primary.resolution.profile, log: options.log ?? silentLogger() },
     );
 
     const server = serve({

--- a/src/server/generation.ts
+++ b/src/server/generation.ts
@@ -1,0 +1,217 @@
+import { createMcpHandler, type McpHttpHandler, type McpRequestContext } from '@modelcontextprotocol/server';
+import { ownerPrincipal, type Principal } from '#auth';
+import {
+  buildMcpServer,
+  toolNameFor,
+  visibleCapabilities,
+  visibleToolCount,
+  type ProfileRuntime,
+} from '#server/mcp';
+import type { GenerationDeps, OpenedWorkspace } from './generations.ts';
+
+/**
+ * One boot's worth of runtimes, and everything derived from them.
+ *
+ * Immutable in what it serves. The memos inside still recompute on
+ * `registry.revision`, because skills can be replaced *within* a generation
+ * (ADR-014) — that is the one mutable surface the registry has, and it predates
+ * this.
+ *
+ * Lives beside `generations.ts` rather than in it: that file is about which
+ * generation is current and what a reload does to it, and this one is about
+ * what a generation holds. Neither needs the other's detail.
+ */
+export class Generation {
+  readonly epoch: number;
+  readonly profiles: ReadonlyMap<string, ProfileRuntime>;
+
+  readonly #opened: OpenedWorkspace;
+  readonly #deps: GenerationDeps;
+  readonly #handlers = new Map<string, McpHttpHandler>();
+
+  /** In-flight requests pinned to this generation. */
+  #pins = 0;
+  /** Replaced by a newer generation, so it closes when the last pin drops. */
+  #retired = false;
+  #closed = false;
+
+  /** How stale a registry may be before the next request re-reads its skills. */
+  static readonly SKILL_POLL_MS = 2_000;
+  #polledAt = 0;
+
+  /**
+   * Every capability id across every profile, granted or not.
+   *
+   * Used only to spell a refusal correctly: a tool that exists but is not
+   * permitted should appear in the audit under its real id.
+   */
+  readonly allCapabilityIds: () => readonly string[];
+
+  /**
+   * Wire names the endpoint advertises.
+   *
+   * M1 has a single principal per profile, so this set does not vary by caller.
+   * When delegated principals arrive it becomes a per-principal lookup; the call
+   * site already reads as one.
+   */
+  readonly visible: () => ReadonlySet<string>;
+
+  /**
+   * How many tools this generation advertises (ADR-032).
+   *
+   * Not `visible().size`: that set spans every reachable capability, and a
+   * resource or a prompt is in it without being in `tools/list`.
+   */
+  readonly toolCount: () => number;
+
+  constructor(epoch: number, opened: OpenedWorkspace, deps: GenerationDeps) {
+    this.epoch = epoch;
+    this.profiles = opened.profiles;
+    this.#opened = opened;
+    this.#deps = deps;
+
+    this.allCapabilityIds = this.#memo(() => [
+      ...new Set(
+        [...this.profiles.values()].flatMap((runtime) =>
+          runtime.registry.capabilities().map(({ id }) => id),
+        ),
+      ),
+    ]);
+
+    this.visible = this.#memo(
+      () =>
+        new Set(
+          visibleCapabilities({
+            profiles: this.profiles,
+            principal: ownerPrincipal(deps.primary),
+          }).map(toolNameFor),
+        ),
+    );
+
+    this.toolCount = this.#memo(() =>
+      visibleToolCount({ profiles: this.profiles, principal: ownerPrincipal(deps.primary) }),
+    );
+  }
+
+  /** The profile names this generation serves, in declaration order. */
+  names(): string[] {
+    return [...this.profiles.keys()];
+  }
+
+  pin(): void {
+    this.#pins += 1;
+  }
+
+  /** Drop a pin, closing the generation if it was retired and this was the last. */
+  async unpin(): Promise<void> {
+    this.#pins -= 1;
+    if (this.#retired && this.#pins <= 0) await this.close();
+  }
+
+  /** Mark superseded. Closes immediately when nothing is using it. */
+  async retire(): Promise<void> {
+    this.#retired = true;
+    if (this.#pins <= 0) await this.close();
+  }
+
+  async close(): Promise<void> {
+    if (this.#closed) return;
+    this.#closed = true;
+
+    await Promise.all([...this.#handlers.values()].map((handler) => handler.close()));
+    this.#handlers.clear();
+    await this.#opened.close();
+  }
+
+  /**
+   * Work derived from the registries, recomputed when one of them changes.
+   *
+   * Skills can be replaced in a registry (ADR-014), and a stale `visible()` is
+   * not cosmetic: it gates the refusal-audit path, so a newly added skill would
+   * be recorded as a refusal on its first `prompts/get` even though the call
+   * succeeded.
+   */
+  #generation(): number {
+    return [...this.profiles.values()].reduce(
+      (total, runtime) => total + runtime.registry.revision,
+      0,
+    );
+  }
+
+  #memo<T>(compute: () => T): () => T {
+    let at = -1;
+    let value: T;
+    return () => {
+      const now = this.#generation();
+      if (now !== at) {
+        value = compute();
+        at = now;
+      }
+      return value;
+    };
+  }
+
+  /**
+   * Re-read the skills, at most once per poll interval.
+   *
+   * A skill written elsewhere — `lanes link skills add` in another terminal —
+   * cannot announce itself, so the endpoint has to look. Bounded rather than
+   * per-request because looking costs a `list()`, which on S3 is a network call.
+   * A write made *through* MCP does not wait for this; it refreshes directly.
+   */
+  async refreshSkills(): Promise<void> {
+    const now = Date.now();
+    if (now - this.#polledAt < Generation.SKILL_POLL_MS) return;
+    this.#polledAt = now;
+
+    await Promise.all(
+      [...this.profiles.values()].map(async (runtime) => {
+        try {
+          await runtime.refreshSkills?.();
+        } catch (error) {
+          // A skills directory that has gone unreadable, or one skill file
+          // someone is mid-edit, must not take the endpoint down with it. The
+          // previously loaded skills stay registered.
+          this.#deps.log.warn('could not refresh skills', { message: (error as Error).message });
+        }
+      }),
+    );
+  }
+
+  /**
+   * One handler per (principal, client label), memoised within this generation.
+   *
+   * The MCP surface depends only on resolved policy, so rebuilding the wiring
+   * per request would be pure waste. Reuse is safe because `createMcpHandler`
+   * still constructs a fresh server instance per request — what is memoised is
+   * the factory wiring, never session state. Memoised *here* rather than on the
+   * request handler because the factory closes over this generation's profiles:
+   * a handler outliving its generation is the stale-config bug.
+   */
+  handlerFor(principal: Principal, clientLabel: string | undefined): McpHttpHandler {
+    const key = `${principal.id}\u0000${clientLabel ?? ''}`;
+    const existing = this.#handlers.get(key);
+    if (existing) return existing;
+
+    const handler = createMcpHandler(
+      // The principal is closed over rather than read back out of `authInfo`:
+      // this handler is already keyed on it, and re-deriving identity from a
+      // field the SDK treats as opaque pass-through would create a second
+      // source of truth for who is calling.
+      (_context: McpRequestContext) =>
+        buildMcpServer({
+          profiles: this.profiles,
+          principal,
+          clientLabel,
+          ...(this.#deps.version ? { version: this.#deps.version } : {}),
+        }),
+      {
+        onerror: (error: Error) =>
+          this.#deps.log.error('mcp handler error', { message: error.message }),
+      },
+    );
+
+    this.#handlers.set(key, handler);
+    return handler;
+  }
+}

--- a/src/server/generations.test.ts
+++ b/src/server/generations.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from 'bun:test';
 import { Generations, type OpenedWorkspace } from './generations.ts';
+import { EMPTY_POLICY } from '#policy';
 import type { ProfileRuntime } from './mcp/index.ts';
 
 /**
@@ -13,9 +14,26 @@ import type { ProfileRuntime } from './mcp/index.ts';
 
 const SILENT = { debug() {}, info() {}, warn() {}, error() {} };
 
+/**
+ * A runtime with nothing in it, but the right shape.
+ *
+ * It used to be `{} as ProfileRuntime`, which held while nothing on the reload
+ * path looked inside one. A reload now counts what the new generation
+ * advertises — so it reads the registry and the policy, and an empty object
+ * throws. Empty *contents* still say everything these tests are about; an empty
+ * *object* only ever said that nobody had looked yet.
+ */
+function emptyRuntime(): ProfileRuntime {
+  return {
+    config: { connections: [] },
+    registry: { revision: 0, capabilities: () => [] },
+    policy: EMPTY_POLICY,
+  } as unknown as ProfileRuntime;
+}
+
 /** A workspace that records whether it was closed, and how often. */
 function stub(name: string): OpenedWorkspace & { closes: number } {
-  const profiles = new Map<string, ProfileRuntime>([[name, {} as ProfileRuntime]]);
+  const profiles = new Map<string, ProfileRuntime>([[name, emptyRuntime()]]);
   return {
     profiles,
     closes: 0,

--- a/src/server/generations.ts
+++ b/src/server/generations.ts
@@ -1,21 +1,15 @@
-import {
-  createMcpHandler,
-  type McpHttpHandler,
-  type McpRequestContext,
-} from '@modelcontextprotocol/server';
-import { ownerPrincipal, type Principal } from '#auth';
 import type { Logger } from '#connectivity';
 import { clearUpstreamTokens } from '#connectivity/auth/index.ts';
-import {
-  buildMcpServer,
-  toolNameFor,
-  visibleCapabilities,
-  visibleToolCount,
-  type ProfileRuntime,
-} from '#server/mcp';
+import type { ProfileRuntime } from '#server/mcp';
+import { Generation } from './generation.ts';
 
 /**
- * Which runtimes are current, and when the ones they replaced are closed.
+ * Which generation is current, and the reload that replaces it.
+ *
+ * The generation itself — one boot's runtimes and every cache derived from
+ * them — is `generation.ts`. Split when this file outgrew its budget, along the
+ * seam it already had: what a generation *is* is a different subject from when
+ * one is swapped, and only the latter needs to know about reloading at all.
  *
  * This is a different subject from what an HTTP request does, which is why it
  * is not in `index.ts`. The endpoint used to hold one map of profile runtimes
@@ -60,209 +54,6 @@ export interface GenerationDeps {
   readonly version?: string | undefined;
 }
 
-/**
- * One boot's worth of runtimes, and everything derived from them.
- *
- * Immutable in what it serves. The memos inside still recompute on
- * `registry.revision`, because skills can be replaced *within* a generation
- * (ADR-014) — that is the one mutable surface the registry has, and it predates
- * this.
- */
-export class Generation {
-  readonly epoch: number;
-  readonly profiles: ReadonlyMap<string, ProfileRuntime>;
-
-  readonly #opened: OpenedWorkspace;
-  readonly #deps: GenerationDeps;
-  readonly #handlers = new Map<string, McpHttpHandler>();
-
-  /** In-flight requests pinned to this generation. */
-  #pins = 0;
-  /** Replaced by a newer generation, so it closes when the last pin drops. */
-  #retired = false;
-  #closed = false;
-
-  /** How stale a registry may be before the next request re-reads its skills. */
-  static readonly SKILL_POLL_MS = 2_000;
-  #polledAt = 0;
-
-  /**
-   * Every capability id across every profile, granted or not.
-   *
-   * Used only to spell a refusal correctly: a tool that exists but is not
-   * permitted should appear in the audit under its real id.
-   */
-  readonly allCapabilityIds: () => readonly string[];
-
-  /**
-   * Wire names the endpoint advertises.
-   *
-   * M1 has a single principal per profile, so this set does not vary by caller.
-   * When delegated principals arrive it becomes a per-principal lookup; the call
-   * site already reads as one.
-   */
-  readonly visible: () => ReadonlySet<string>;
-
-  /**
-   * How many tools this generation advertises (ADR-032).
-   *
-   * Not `visible().size`: that set spans every reachable capability, and a
-   * resource or a prompt is in it without being in `tools/list`.
-   */
-  readonly toolCount: () => number;
-
-  constructor(epoch: number, opened: OpenedWorkspace, deps: GenerationDeps) {
-    this.epoch = epoch;
-    this.profiles = opened.profiles;
-    this.#opened = opened;
-    this.#deps = deps;
-
-    this.allCapabilityIds = this.#memo(() => [
-      ...new Set(
-        [...this.profiles.values()].flatMap((runtime) =>
-          runtime.registry.capabilities().map(({ id }) => id),
-        ),
-      ),
-    ]);
-
-    this.visible = this.#memo(
-      () =>
-        new Set(
-          visibleCapabilities({
-            profiles: this.profiles,
-            principal: ownerPrincipal(deps.primary),
-          }).map(toolNameFor),
-        ),
-    );
-
-    this.toolCount = this.#memo(() =>
-      visibleToolCount({ profiles: this.profiles, principal: ownerPrincipal(deps.primary) }),
-    );
-  }
-
-  /** The profile names this generation serves, in declaration order. */
-  names(): string[] {
-    return [...this.profiles.keys()];
-  }
-
-  pin(): void {
-    this.#pins += 1;
-  }
-
-  /** Drop a pin, closing the generation if it was retired and this was the last. */
-  async unpin(): Promise<void> {
-    this.#pins -= 1;
-    if (this.#retired && this.#pins <= 0) await this.close();
-  }
-
-  /** Mark superseded. Closes immediately when nothing is using it. */
-  async retire(): Promise<void> {
-    this.#retired = true;
-    if (this.#pins <= 0) await this.close();
-  }
-
-  async close(): Promise<void> {
-    if (this.#closed) return;
-    this.#closed = true;
-
-    await Promise.all([...this.#handlers.values()].map((handler) => handler.close()));
-    this.#handlers.clear();
-    await this.#opened.close();
-  }
-
-  /**
-   * Work derived from the registries, recomputed when one of them changes.
-   *
-   * Skills can be replaced in a registry (ADR-014), and a stale `visible()` is
-   * not cosmetic: it gates the refusal-audit path, so a newly added skill would
-   * be recorded as a refusal on its first `prompts/get` even though the call
-   * succeeded.
-   */
-  #generation(): number {
-    return [...this.profiles.values()].reduce(
-      (total, runtime) => total + runtime.registry.revision,
-      0,
-    );
-  }
-
-  #memo<T>(compute: () => T): () => T {
-    let at = -1;
-    let value: T;
-    return () => {
-      const now = this.#generation();
-      if (now !== at) {
-        value = compute();
-        at = now;
-      }
-      return value;
-    };
-  }
-
-  /**
-   * Re-read the skills, at most once per poll interval.
-   *
-   * A skill written elsewhere — `lanes link skills add` in another terminal —
-   * cannot announce itself, so the endpoint has to look. Bounded rather than
-   * per-request because looking costs a `list()`, which on S3 is a network call.
-   * A write made *through* MCP does not wait for this; it refreshes directly.
-   */
-  async refreshSkills(): Promise<void> {
-    const now = Date.now();
-    if (now - this.#polledAt < Generation.SKILL_POLL_MS) return;
-    this.#polledAt = now;
-
-    await Promise.all(
-      [...this.profiles.values()].map(async (runtime) => {
-        try {
-          await runtime.refreshSkills?.();
-        } catch (error) {
-          // A skills directory that has gone unreadable, or one skill file
-          // someone is mid-edit, must not take the endpoint down with it. The
-          // previously loaded skills stay registered.
-          this.#deps.log.warn('could not refresh skills', { message: (error as Error).message });
-        }
-      }),
-    );
-  }
-
-  /**
-   * One handler per (principal, client label), memoised within this generation.
-   *
-   * The MCP surface depends only on resolved policy, so rebuilding the wiring
-   * per request would be pure waste. Reuse is safe because `createMcpHandler`
-   * still constructs a fresh server instance per request — what is memoised is
-   * the factory wiring, never session state. Memoised *here* rather than on the
-   * request handler because the factory closes over this generation's profiles:
-   * a handler outliving its generation is the stale-config bug.
-   */
-  handlerFor(principal: Principal, clientLabel: string | undefined): McpHttpHandler {
-    const key = `${principal.id}\u0000${clientLabel ?? ''}`;
-    const existing = this.#handlers.get(key);
-    if (existing) return existing;
-
-    const handler = createMcpHandler(
-      // The principal is closed over rather than read back out of `authInfo`:
-      // this handler is already keyed on it, and re-deriving identity from a
-      // field the SDK treats as opaque pass-through would create a second
-      // source of truth for who is calling.
-      (_context: McpRequestContext) =>
-        buildMcpServer({
-          profiles: this.profiles,
-          principal,
-          clientLabel,
-          ...(this.#deps.version ? { version: this.#deps.version } : {}),
-        }),
-      {
-        onerror: (error: Error) =>
-          this.#deps.log.error('mcp handler error', { message: error.message }),
-      },
-    );
-
-    this.#handlers.set(key, handler);
-    return handler;
-  }
-}
-
 /** What a reload did, as the `/reload` route reports it. */
 export interface ReloadResult {
   readonly reloaded: boolean;
@@ -298,12 +89,29 @@ export class Generations {
     this.#current = new Generation(0, initial, deps);
     this.#open = open;
     this.#deps = deps;
+  }
 
-    // The boot half of what `#reload` logs, and the more useful half: a fresh
-    // revision comes up with whatever config held at deploy time — often one
-    // `setup.main` and two tools — and a client registered in that window keeps
-    // what it was handed. This is what makes the window visible afterwards.
-    deps.log.info('serving', { epoch: 0, tools: this.#current.toolCount() });
+  /**
+   * Record what the current generation advertises.
+   *
+   * Called by the endpoint once the socket is bound, not from the constructor
+   * where it used to be: a `serving` record written before `serve()` returns is
+   * a claim about an endpoint that a failed bind means never served, and a
+   * crash-looping revision emitted one per attempt. `advertising` rather than
+   * `serving` because the container writes its own `serving <url>` to the same
+   * stream, and one word covering two different records is a filter that
+   * returns both and distinguishes neither.
+   *
+   * The boot emission is the more useful of the two: a fresh revision comes up
+   * holding whatever config held at deploy time — often one `setup.main` and
+   * two tools — and a client registered in that window keeps what it was
+   * handed. This is what makes that window visible afterwards (ADR-032).
+   */
+  announce(): void {
+    this.#deps.log.info('advertising', {
+      epoch: this.#current.epoch,
+      tools: this.#current.toolCount(),
+    });
   }
 
   get current(): Generation {
@@ -364,23 +172,38 @@ export class Generations {
     this.#epoch += 1;
     this.#current = new Generation(this.#epoch, opened, this.#deps);
 
-    // Module-global and keyed per connection, so it survives a reload that
-    // replaced everything else. Re-connecting `<provider>.<id>` to a different
-    // account would otherwise serve the previous account's access token until
-    // it expired — up to an hour after the config said otherwise. Unchanged
-    // connections pay one refresh.
-    clearUpstreamTokens();
+    // Past this line the reload has *landed*: the new generation is what
+    // requests get. Everything below is tidying and reporting, and none of it
+    // can un-land the swap — so a throw here must not be reported as a failed
+    // reload. It would be: `/reload` has no try/catch of its own, so the
+    // exception becomes a 500, and `connect` reads that as "saved, and the
+    // endpoint will serve this when it next starts" for config the endpoint is
+    // already serving. `previous.retire()` closes the audit log, which on a
+    // cloud target is a network write, so this is reachable rather than
+    // theoretical.
+    try {
+      // Module-global and keyed per connection, so it survives a reload that
+      // replaced everything else. Re-connecting `<provider>.<id>` to a different
+      // account would otherwise serve the previous account's access token until
+      // it expired — up to an hour after the config said otherwise. Unchanged
+      // connections pay one refresh.
+      clearUpstreamTokens();
 
-    // After the swap: a request arriving during the retire already gets the new
-    // generation, and this only waits on requests that started before it.
-    await previous.retire();
+      // After the swap: a request arriving during the retire already gets the
+      // new generation, and this only waits on requests that started before it.
+      await previous.retire();
+    } catch (error) {
+      this.#deps.log.error('reload landed, but retiring the previous generation failed', {
+        message: error instanceof Error ? error.message : String(error),
+      });
+    }
 
     const tools = this.#current.toolCount();
 
     // The only record of what the endpoint advertises: `tools/list` is neither
     // logged nor audited, so nothing else could tell a generation serving two
     // tools from one serving forty. Once per reload, on a memoised read.
-    this.#deps.log.info('serving', { epoch: this.#current.epoch, tools });
+    this.#deps.log.info('advertising', { epoch: this.#current.epoch, tools });
 
     return {
       reloaded: true,

--- a/src/server/generations.ts
+++ b/src/server/generations.ts
@@ -10,6 +10,7 @@ import {
   buildMcpServer,
   toolNameFor,
   visibleCapabilities,
+  visibleToolCount,
   type ProfileRuntime,
 } from '#server/mcp';
 
@@ -102,6 +103,14 @@ export class Generation {
    */
   readonly visible: () => ReadonlySet<string>;
 
+  /**
+   * How many tools this generation advertises (ADR-032).
+   *
+   * Not `visible().size`: that set spans every reachable capability, and a
+   * resource or a prompt is in it without being in `tools/list`.
+   */
+  readonly toolCount: () => number;
+
   constructor(epoch: number, opened: OpenedWorkspace, deps: GenerationDeps) {
     this.epoch = epoch;
     this.profiles = opened.profiles;
@@ -124,6 +133,10 @@ export class Generation {
             principal: ownerPrincipal(deps.primary),
           }).map(toolNameFor),
         ),
+    );
+
+    this.toolCount = this.#memo(() =>
+      visibleToolCount({ profiles: this.profiles, principal: ownerPrincipal(deps.primary) }),
     );
   }
 
@@ -255,6 +268,13 @@ export interface ReloadResult {
   readonly reloaded: boolean;
   readonly epoch: number;
   readonly profiles: readonly string[];
+  /**
+   * How many tools the generation now serving advertises (ADR-032).
+   *
+   * What `connect` prints: the edit landing and the surface a client sees are
+   * different events, and the gap is where a stale tool list hides.
+   */
+  readonly tools: number;
   /** Why it did not reload. Absent on success. */
   readonly reason?: string;
 }
@@ -278,6 +298,12 @@ export class Generations {
     this.#current = new Generation(0, initial, deps);
     this.#open = open;
     this.#deps = deps;
+
+    // The boot half of what `#reload` logs, and the more useful half: a fresh
+    // revision comes up with whatever config held at deploy time — often one
+    // `setup.main` and two tools — and a client registered in that window keeps
+    // what it was handed. This is what makes the window visible afterwards.
+    deps.log.info('serving', { epoch: 0, tools: this.#current.toolCount() });
   }
 
   get current(): Generation {
@@ -330,6 +356,7 @@ export class Generations {
         reloaded: false,
         epoch: previous.epoch,
         profiles: previous.names(),
+        tools: previous.toolCount(),
         reason,
       };
     }
@@ -348,10 +375,18 @@ export class Generations {
     // generation, and this only waits on requests that started before it.
     await previous.retire();
 
+    const tools = this.#current.toolCount();
+
+    // The only record of what the endpoint advertises: `tools/list` is neither
+    // logged nor audited, so nothing else could tell a generation serving two
+    // tools from one serving forty. Once per reload, on a memoised read.
+    this.#deps.log.info('serving', { epoch: this.#current.epoch, tools });
+
     return {
       reloaded: true,
       epoch: this.#current.epoch,
       profiles: this.#current.names(),
+      tools,
     };
   }
 

--- a/src/server/harness.ts
+++ b/src/server/harness.ts
@@ -252,6 +252,11 @@ export function startHarness(options: HarnessOptions): Harness {
     log,
   });
 
+  // As `startEndpoint` does, and after `serve()` for the same reason: the
+  // record means the socket is bound. Here because this harness claims to be
+  // the real wiring, and a boot step it omits is a boot step no test can see.
+  generations.announce();
+
   return {
     server,
     state,

--- a/src/server/index.test.ts
+++ b/src/server/index.test.ts
@@ -531,6 +531,62 @@ describe('audit over the wire', () => {
   });
 });
 
+describe('the tool list does not go stale', () => {
+  /**
+   * A 2025-era handshake, by hand.
+   *
+   * `rpc` speaks the 2026-07-28 envelope, which has no handshake left to
+   * assert. The clients this test is about — a hosted connector, and Claude
+   * Code — open with `initialize`, and what that answer claims is the whole
+   * subject here.
+   */
+  async function initialize(url: string): Promise<Record<string, unknown>> {
+    const response = await fetch(url, {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        accept: 'application/json, text/event-stream',
+        authorization: `Bearer ${TEST_TOKEN}`,
+      },
+      body: JSON.stringify({
+        jsonrpc: '2.0',
+        id: 1,
+        method: 'initialize',
+        params: {
+          protocolVersion: '2025-06-18',
+          capabilities: {},
+          clientInfo: { name: 'listChanged-test', version: '0.0.0' },
+        },
+      }),
+    });
+
+    // The legacy leg answers as SSE, so the payload is a `data:` line.
+    const text = await response.text();
+    const line = text.startsWith('event:') || text.startsWith('data:')
+      ? (text.split('\n').find((candidate) => candidate.startsWith('data: '))?.slice(6) ?? '{}')
+      : text;
+
+    return (JSON.parse(line) as { result?: Record<string, unknown> }).result ?? {};
+  }
+
+  test('initialize does not promise a list_changed notification', async () => {
+    // The endpoint is stateless: no stream to notify on, and the server
+    // instance is gone once the response is written. The SDK defaults every
+    // one of these to `true`, and a client that believes it will be told stops
+    // asking — so a connector registered before an account was connected keeps
+    // the smaller list it first saw, for as long as it lives. That is not
+    // hypothetical; it is the bug this test exists for.
+    const result = await initialize(personal.server.url);
+    const capabilities = result['capabilities'] as
+      | Record<string, { listChanged?: boolean } | undefined>
+      | undefined;
+
+    expect(capabilities?.['tools']?.listChanged).toBe(false);
+    expect(capabilities?.['resources']?.listChanged).toBe(false);
+    expect(capabilities?.['prompts']?.listChanged).toBe(false);
+  });
+});
+
 describe('statelessness', () => {
   test('sequential calls need no session handshake', async () => {
     // No initialize, no session id, no ordering requirement — which is what
@@ -775,6 +831,37 @@ ${policy}
     }
   });
 
+  test('the count it reports is tools, not everything reachable', async () => {
+    // `EVERYTHING` reaches `example.note`, which registers as a *resource*.
+    // That is what makes this test worth having: the count `connect` prints is
+    // the only number an operator can hold against what their client shows, and
+    // counting reachable capability ids would have overstated it by one here —
+    // silently, and by more on a profile with skills, since every skill is a
+    // prompt. `READ_ONLY` would not have noticed: it reaches no resource at all.
+    const port = allocatePort();
+    const { harness, edit, reload } = reloadable(
+      port,
+      configWith('personal', port, ['a'], EVERYTHING),
+    );
+
+    try {
+      edit(configWith('personal', port, ['a', 'c'], EVERYTHING));
+      const { body } = await reload();
+
+      const listed = await listTools(harness.server.url);
+      // `resources/templates/list`, not `resources/list`: `example.note` is
+      // addressed by a URI template, and a template is not a concrete resource.
+      const templates = await rpc(harness.server.url, 'resources/templates/list', {});
+      const registered =
+        (templates.body['result'] as { resourceTemplates?: unknown[] })?.resourceTemplates ?? [];
+
+      expect(registered.length).toBeGreaterThan(0);
+      expect(body['tools']).toBe(listed.length);
+    } finally {
+      await harness.stop();
+    }
+  });
+
   test('a connection added to the config is served without a restart', async () => {
     const port = allocatePort();
     const { harness, edit, reload } = reloadable(
@@ -802,6 +889,7 @@ ${policy}
         after.find((tool) => tool.name === 'example_get_note')?.inputSchema.properties?.connection
           ?.enum,
       ).toEqual(['example.a', 'example.c']);
+
     } finally {
       await harness.stop();
     }

--- a/src/server/index.test.ts
+++ b/src/server/index.test.ts
@@ -582,8 +582,22 @@ describe('the tool list does not go stale', () => {
       | undefined;
 
     expect(capabilities?.['tools']?.listChanged).toBe(false);
+    // This profile reaches `example.note`, which registers as a resource.
     expect(capabilities?.['resources']?.listChanged).toBe(false);
-    expect(capabilities?.['prompts']?.listChanged).toBe(false);
+  });
+
+  test('a kind the profile has none of is not advertised at all', async () => {
+    // Declaring a capability installs its handler set, so advertising `prompts`
+    // on a profile with no skills invites a `prompts/list` per session — a
+    // stateless POST that rebuilds the whole server to answer `[]`. `tools` is
+    // the one that stays unconditional, because "none right now" and "this
+    // server does not do tools" are different answers to a client deciding
+    // whether to ask again.
+    const result = await initialize(personal.server.url);
+    const capabilities = result['capabilities'] as Record<string, unknown> | undefined;
+
+    expect(capabilities?.['prompts']).toBeUndefined();
+    expect(capabilities?.['tools']).toBeDefined();
   });
 });
 
@@ -1037,6 +1051,43 @@ describe('operational logging', () => {
       expect(warnings.find((entry) => entry.message === 'rejected request')?.detail).toEqual({
         reason: 'invalid',
       });
+    } finally {
+      await listening.stop();
+    }
+  });
+
+  test('a bound endpoint records what it advertises', async () => {
+    // The one signal ADR-032 rests its observability claim on, and nothing
+    // asserted it: `tools/list` is neither logged nor audited, so this line is
+    // the only record of whether a generation is serving two tools or forty.
+    // Deleting it, or letting the count go stale, would otherwise leave the
+    // whole suite green.
+    const records: Array<{ message: string; detail?: Record<string, unknown> }> = [];
+
+    const listening = startHarness({
+      profile: 'advertising',
+      port: allocatePort(),
+      policy: `  allow:
+    - "example.*"`,
+      log: {
+        debug() {},
+        warn() {},
+        error() {},
+        info(message, detail) {
+          records.push({ message, ...(detail ? { detail } : {}) });
+        },
+      },
+    });
+
+    try {
+      const advertised = records.find((entry) => entry.message === 'advertising');
+      const listed = await listTools(listening.server.url);
+
+      expect(advertised?.detail).toEqual({ epoch: 0, tools: listed.length });
+      // Not `serving`: the container writes its own `serving <url>` to the same
+      // stream, and one word covering two records is a filter that returns both
+      // and distinguishes neither.
+      expect(records.map((entry) => entry.message)).not.toContain('serving');
     } finally {
       await listening.stop();
     }

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -3,7 +3,8 @@ import type { Logger } from '#connectivity';
 import { capabilityIdForToolName } from '#server/mcp';
 import { ATTACHMENTS_PATH, stageAttachment } from './attachments.ts';
 import { allowedHostnamesFor, rebindingRefusal } from './rebinding.ts';
-import type { Generation, Generations } from './generations.ts';
+import type { Generation } from './generation.ts';
+import type { Generations } from './generations.ts';
 import { callerKey, failedAuthLimiter, FAILED_AUTH_PER_MINUTE, tooManyAttempts } from './edge.ts';
 import {
   handleAuthorization,

--- a/src/server/mcp/build.ts
+++ b/src/server/mcp/build.ts
@@ -45,7 +45,34 @@ export function buildMcpServer(options: BuildServerOptions): McpServer {
     // Second argument, not the first: `instructions` is a `ServerOptions` field,
     // and `Implementation` would take it as an unknown extra and drop it from
     // `initialize` without complaining.
-    { instructions: serverInstructions(names, merged) },
+    {
+      instructions: serverInstructions(names, merged),
+      // Declared `false` because it is false, and the SDK defaults it to `true`.
+      //
+      // `listChanged` is a promise to send `notifications/tools/list_changed`
+      // when the surface changes. This endpoint cannot keep it: it is stateless
+      // streamable HTTP, so there is no stream to deliver a notification on and
+      // this very server instance is discarded once the response is written.
+      // Nothing in `src/` sends one, and nothing can.
+      //
+      // Leaving the default on is not a harmless inaccuracy. A client that
+      // believes it will be told has no reason to ask again, so it keeps the
+      // list it captured when it first connected — and the surface here grows
+      // every time an account is connected (ADR-029). That combination cost a
+      // connector registered before `connect` ran its whole tool list: it held
+      // the two setup tools for as long as it lived, and no refresh replaced
+      // them, because the refresh was an `initialize` that never went on to ask
+      // for `tools/list`.
+      //
+      // Saying `false` costs a re-list per session and buys a surface that is
+      // never stale. Prompts and resources carry the identical default and the
+      // identical inability, so they are answered here too.
+      capabilities: {
+        tools: { listChanged: false },
+        resources: { listChanged: false },
+        prompts: { listChanged: false },
+      },
+    },
   );
 
   for (const [id, entry] of merged) {

--- a/src/server/mcp/build.ts
+++ b/src/server/mcp/build.ts
@@ -65,12 +65,20 @@ export function buildMcpServer(options: BuildServerOptions): McpServer {
       // for `tools/list`.
       //
       // Saying `false` costs a re-list per session and buys a surface that is
-      // never stale. Prompts and resources carry the identical default and the
-      // identical inability, so they are answered here too.
+      // never stale.
+      //
+      // `tools` unconditionally, because the argument above is about tools and
+      // an endpoint that serves none should still answer "none right now"
+      // rather than "this server does not do tools". Resources and prompts only
+      // when the profile has some: declaring a capability installs its handler
+      // set, so a client that gates its list calls on what is advertised would
+      // otherwise issue `resources/list`, `resources/templates/list` and
+      // `prompts/list` — three stateless POSTs, each rebuilding the whole
+      // server — to be told nothing is there.
       capabilities: {
         tools: { listChanged: false },
-        resources: { listChanged: false },
-        prompts: { listChanged: false },
+        ...(offers(merged, isResource) ? { resources: { listChanged: false } } : {}),
+        ...(offers(merged, isPrompt) ? { prompts: { listChanged: false } } : {}),
       },
     },
   );
@@ -92,4 +100,23 @@ export function buildMcpServer(options: BuildServerOptions): McpServer {
   }
 
   return server;
+}
+
+/**
+ * Whether any reachable capability registers as this kind.
+ *
+ * Reads the same `merged` map the registration loop below consumes and asks it
+ * the same question `isResource`/`isPrompt` answer there, so what is advertised
+ * and what is registered cannot disagree. A discovered capability is always a
+ * tool, which is why it is not consulted here.
+ */
+function offers(
+  merged: ReturnType<typeof mergeCapabilities>,
+  kind: typeof isResource | typeof isPrompt,
+): boolean {
+  for (const entry of merged.values()) {
+    if (!entry.discovered && entry.capability && kind(entry.capability)) return true;
+  }
+
+  return false;
 }

--- a/src/server/mcp/index.ts
+++ b/src/server/mcp/index.ts
@@ -26,6 +26,7 @@ export {
   mergeCapabilities,
   oneProfile,
   visibleCapabilities,
+  visibleToolCount,
   type BuildServerOptions,
   type MergedCapability,
   type ProfileRuntime,

--- a/src/server/mcp/visibility.ts
+++ b/src/server/mcp/visibility.ts
@@ -1,3 +1,4 @@
+import { isTool } from '#connectivity';
 import type { Principal } from '#auth';
 import type { Config } from '#profile';
 import type { ProviderRegistry } from '#registry';
@@ -112,6 +113,27 @@ export function mergeCapabilities(options: BuildServerOptions): Map<string, Merg
 /** Which capability ids this principal can reach, across every profile served. */
 export function visibleCapabilities(options: BuildServerOptions): string[] {
   return [...mergeCapabilities(options).keys()];
+}
+
+/**
+ * How many of those are tools, as `tools/list` would count them.
+ *
+ * Not the same number as `visibleCapabilities().length`, and the difference is
+ * the kind of thing that only shows up when someone reads it: a reachable
+ * capability may register as a resource or a prompt instead, so counting ids
+ * and calling the answer "tools" overstates the list by however many of those
+ * a profile has. The kind is decided here exactly as `buildMcpServer` decides
+ * it — a discovered capability is always a tool, an authored one is asked.
+ */
+export function visibleToolCount(options: BuildServerOptions): number {
+  let count = 0;
+
+  for (const entry of mergeCapabilities(options).values()) {
+    if (entry.discovered) count += 1;
+    else if (entry.capability && isTool(entry.capability)) count += 1;
+  }
+
+  return count;
 }
 
 /**

--- a/src/server/skills-authoring.test.ts
+++ b/src/server/skills-authoring.test.ts
@@ -193,6 +193,43 @@ describe('a skill written over MCP is a prompt on the next call', () => {
   });
 });
 
+describe('what the handshake advertises', () => {
+  test('a profile holding skills declares prompts, and declares them unannounced', async () => {
+    // The other half of ADR-032, and the half that is easy to lose: a skill
+    // registers as a prompt, not a tool, so `prompts.listChanged` governs
+    // whether a client re-reads its skills. It carries the same SDK default and
+    // the same inability — there is no stream to announce on — so it has to
+    // carry the same `false`. The tools-side assertion lives in `index.test.ts`;
+    // this is the one profile in the suite that actually has a prompt.
+    const response = await fetch(url(invokeOnly), {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        accept: 'application/json, text/event-stream',
+        authorization: 'Bearer llk_readonly_token_value',
+      },
+      body: JSON.stringify({
+        jsonrpc: '2.0',
+        id: 1,
+        method: 'initialize',
+        params: {
+          protocolVersion: '2025-06-18',
+          capabilities: {},
+          clientInfo: { name: 'listChanged-test', version: '0.0.0' },
+        },
+      }),
+    });
+
+    const text = await response.text();
+    const line = text.split('\n').find((candidate) => candidate.startsWith('data:'));
+    const body = line === undefined ? text : line.slice('data:'.length).trim();
+    const capabilities = (JSON.parse(body) as { result?: { capabilities?: Record<string, { listChanged?: boolean }> } })
+      .result?.capabilities;
+
+    expect(capabilities?.['prompts']?.listChanged).toBe(false);
+  });
+});
+
 describe('authoring is a separate grant', () => {
   const token = 'llk_readonly_token_value';
 

--- a/src/server/skills-authoring.test.ts
+++ b/src/server/skills-authoring.test.ts
@@ -197,14 +197,24 @@ describe('authoring is a separate grant', () => {
   const token = 'llk_readonly_token_value';
 
   test('an invoke-only profile is offered no management tool at all', async () => {
-    // Not an empty list — `tools/list` is not a method this endpoint answers,
-    // because nothing registered a tool for this principal. Policy-filtered
-    // discovery means the four `skills.manage.*` capabilities are not withheld
-    // at call time, they were never advertised.
+    // An empty list, and deliberately not `Method not found`.
+    //
+    // It used to be the latter: nothing registered a tool for this principal,
+    // so the SDK never installed the handler. Declaring the `tools` capability
+    // up front — which is what stops the endpoint promising a `list_changed`
+    // notification it cannot send — installs it unconditionally, and the answer
+    // becomes the true one. The difference is the same difference that fix is
+    // about: "this server has no tools right now" invites a client to ask
+    // again, and "this server does not do tools" tells it never to.
+    //
+    // What the test is actually about is unchanged. Policy-filtered discovery
+    // means the four `skills.manage.*` capabilities are not withheld at call
+    // time — they were never advertised.
     const listed = await rpc(url(invokeOnly), 'tools/list', {}, { token });
-    const error = listed.body['error'] as { message: string } | undefined;
+    const result = listed.body['result'] as { tools?: unknown[] } | undefined;
 
-    expect(error?.message).toBe('Method not found');
+    expect(listed.body['error']).toBeUndefined();
+    expect(result?.tools).toEqual([]);
   });
 
   test('it can still invoke the skills it has', async () => {


### PR DESCRIPTION
A connector registered against a deployed endpoint showed two tools, and went on showing two after five accounts were connected. Every component reported success: the config published, five `POST /reload` landed, and the endpoint served the full 42-tool list to anyone who asked. Refreshing the connector sent one `initialize` and stopped.

The `initialize` answer said why:

```json
"capabilities": { "tools": { "listChanged": true } }
```

Nothing here has ever sent `notifications/tools/list_changed`, and nothing can — ADR-002 chose stateless streamable HTTP, so there is no stream to deliver one on and the server instance is discarded once the response is written. The value was never authored: the SDK sets it with `?? true` when a tool is registered. A client told it will be informed has no reason to ask again, and the surface here grows every time an account is connected (ADR-029), so the two combine into a stale list that nobody can see is stale.

The endpoint is right, the client is behaving correctly, and the surface a person sees is wrong.

## The fix

**Declare `listChanged: false`** — for tools, resources and prompts alike, since they carry the identical default and the identical inability. It costs one `tools/list` per session and buys a surface that is never stale. A poll was the wrong answer for config in ADR-029 and is the right one here: the party doing it is the client, the interval is per session rather than per instance per minute, and a missed notification is undetectable by anyone.

Sending it on the 2026-07-28 leg, which has an event bus, and declaring false only on the older one, was rejected. A capability true for some clients is the ambiguity this removes.

## Three things follow

All of which cost an afternoon of reconstruction from response byte sizes in a platform request log:

- **A reload reports its tool count, and boot logs it too.** Boot is the half that matters: a fresh revision comes up holding whatever config held at deploy time — often one `setup.main` and two tools — and that is the window a connector registers in. `info serving {"epoch":0,"tools":2}` is the line that would have said so at the time.
- **`connect` prints the count** beside "the endpoint has re-read its config", with the step it cannot take:
  ```
  Next: Serving it now — the endpoint has re-read its config.
    42 tools are advertised now. A client connected before this keeps the
    list it already fetched — reconnect it to pick them up.
  ```
- **`lanes link tools`** asks the endpoint what it advertises — one `initialize`, one `tools/list`, printing names by provider, payload size and the declared `listChanged`. Deliberately not derived from config: a config saying 42 while a client shows 2 is exactly where a derived answer would be believed.

`Generations` also gets the endpoint's logger. It was an inline no-op, so `could not reload config`, `could not refresh skills` and every `mcp handler error` went nowhere.

## Consequences worth reviewing

- **A tool-less profile now answers `tools/list` with an empty list** rather than `Method not found`, because declaring the capability installs the handler unconditionally. That is the better answer for this change's own reason: "none right now" invites a client to ask again, and "this server does not do tools" tells it never to. `skills-authoring.test.ts` pinned the old behaviour and is updated.
- **The reported count is tools, not reachable capability ids** — which would have overstated it by every resource and every skill. `index.test.ts` covers a profile reaching `example.note` (a resource template) so the two counts genuinely differ.
- **`tools.test.ts` gains a whole-surface budget** beside the per-tool one. Nothing measured the total that actually travels on every `tools/list`. Set as a ratchet at 256KB against Drive's current 178KB — cutting that means `makeOpaque`, which buys bytes by removing the schema a model composes a request body against, and that trade should be made deliberately rather than to satisfy a new test.

## Verification

`bun test` (1637 pass, 0 fail) and `bun run typecheck` both green. The `listChanged` test fails with `Received: true` without the fix; the count test fails with `Expected: 5, Received: 6` against `visible().size`.

End to end against a scratch workspace: boot logs `{"epoch":0,"tools":2}`, `connect example` prints the 7-tool reconnect line, the reload logs `{"epoch":1,"tools":7}`, and `lanes link tools` lists exactly those 7 with `listChanged: false` on the wire.

ADR-031 records the decision; `docs/connect.md` and `docs/deploy.md` carry the reconnect step and the register-last ordering.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
