### PR TITLE
Keep signing in and reaching Google data in separate Cloud projects

### DIFF
--- a/docs/detailed/adr/031-sign-in-and-data-access-are-separate-projects.md
+++ b/docs/detailed/adr/031-sign-in-and-data-access-are-separate-projects.md
@@ -1,0 +1,93 @@
+# ADR-031: Signing in and reaching Google data are separate Cloud projects
+
+**Status:** accepted · **Extends** [ADR-028](028-a-hosted-oauth-client-is-the-default.md)
+
+## Context
+
+Lanes signs people in with Google, and Lanes Link reads their mail with it. Both are OAuth, both
+belong to the same company, and there is a standing temptation to register them once. Verification
+is annual, a restricted-scope review takes months and puts a third-party security assessment in
+question, and doing that twice for one company reads as obvious waste.
+
+So the question gets asked in the honest direction: why not put the client this project depends on
+into the project that already signs everyone in, so one approval covers everything Lanes will ever
+want to reach — the endpoint today, a direct connector later?
+
+The answer is that Google's unit of verification is the project, which makes the difference
+structural rather than a matter of taste.
+
+## Decision
+
+Two projects.
+
+One holds the clients that establish **identity**: the web sign-in and the desktop app's loopback
+flow. Between them they request `openid`, `email` and `profile`, and nothing else, ever. That set is
+neither sensitive nor restricted, so the project needs no verification, presents no unverified-app
+screen, and is subject to no cap. It is also the project every Lanes user passes through to reach
+anything at all.
+
+The other holds the clients that reach **Google user data**: the one ADR-028 made this endpoint's
+default, and any direct connector added later. It carries the sensitive and restricted scopes, the
+verification, and the assessment if one is required.
+
+A capability that needs Google user data gets a client in the second project. It does not get one in
+the first, and it does not get a project of its own.
+
+## Why not one project
+
+Four facts about Google's model, each sufficient alone.
+
+**Verification only ever covers sensitive and restricted scopes.** The identity project requests
+none, so it needs no approval and can receive none. Merging buys it nothing it does not already
+have: the saving it appears to offer is approval for scopes it never asks for.
+
+**The unverified-app cap is per project and permanent.** *"The user cap applies over the entire
+lifetime of the project, and it cannot be reset or changed."* Every account that consents before
+approval spends a hundredth of an allowance that never refills. Spending it on the project that
+holds sign-in would put a non-renewable resource behind the one flow that must never run out.
+
+**A submission is a submission of the whole project.** *"All OAuth Clients within a project
+requesting restricted scopes must be ready for verification once submitted. We suggest you delete
+or remove OAuth Clients that are not ready for production before submitting a verification
+request."* The identity project also holds clients its hosting platform provisions on its own,
+which nobody here wrote and nobody here controls. Merging would enter them into a restricted-scope
+review to gain nothing.
+
+**One brand per project.** The app name, logo, homepage and privacy link are project-level, so a
+merged project shows one consent screen for both purposes. The honest screen for the data client —
+naming Gmail and Drive, pointing at a page written to explain why — is not the screen anyone wants
+in front of someone who only clicked "sign in".
+
+And one fact about the reverse direction: **a merged project cannot be un-merged.** The cap is spent
+for the lifetime of the project, and ADR-028 stamps the minting client on every refresh token, so no
+live connection can be moved to a client in another project without being consented again from
+scratch.
+
+## Consequences
+
+**The second project is not this endpoint's — it is the one that holds Google data access.** That
+distinction costs nothing today and is the whole of the reuse later. A verified project holds many
+clients under one brand, so a connector shipped elsewhere in Lanes inherits the approved brand, the
+approved scope justifications, and the Letter of Assessment — the part measured in months.
+
+**The brand reads "Lanes Link" anyway, and that is deliberate.** It is what every grant against that
+project is today, and <https://lanes.sh/link> is written for the person reviewing it rather than for
+someone shopping. A later connector either accepts that name on its consent screen or triggers a
+brand re-verification, which is days. What it does not need is a second restricted-scope review or a
+second annual assessment.
+
+**A capability wanting a scope nobody has approved yet still needs a submission.** The approved
+scopes keep working while it is pending; only requests carrying the new one present the
+unverified-app screen and count against the cap. So the reuse is real but partial, and a connector
+that stays inside the thirteen already declared costs nothing at all.
+
+**Nothing in this repository can check any of this.** The projects are console state.
+`src/providers/google/specs/specs.test.ts` holds the manifests and
+[`google-verification.md`](../google-verification.md) to the same scope list, which catches a scope
+requested but not declared. It cannot catch a scope registered against the wrong project, or a
+sensitive scope quietly added to the identity one — and that second one is exactly what would put an
+unverified-app screen on sign-in. It is a step on a checklist, performed by a person, and
+`google-verification.md` is where the checklist lives.
+
+**An operator who wants none of this still runs `--own-client`.** Their client is their project,
+their cap, and their consent screen, and this decision does not reach them.

--- a/docs/detailed/adr/README.md
+++ b/docs/detailed/adr/README.md
@@ -38,6 +38,7 @@ Nothing in the codebase depends on it.
 | [028](028-a-hosted-oauth-client-is-the-default.md) | A client Lanes operates is what `connect` uses by default; `--own-client` registers your own |
 | [029](029-connecting-is-not-deploying.md) | Connecting publishes its own config and the endpoint re-reads it; deploying is only code |
 | [030](030-a-profile-owns-its-skills-and-manifests.md) | Skills and provider manifests move into `data/<profile>/`; nothing is shared between profiles any more |
+| [031](031-sign-in-and-data-access-are-separate-projects.md) | Signing in and reaching Google data are separate Cloud projects; the second is where every Google-data client goes |
 
 Where an ADR departs from init.md, it says so at the top. Three are significant:
 

--- a/docs/detailed/google-verification.md
+++ b/docs/detailed/google-verification.md
@@ -341,6 +341,32 @@ account.** The video becomes a public URL attached to the project. The rule agai
 identifiers in this repository exists because it was broken once and cost eighty-nine commits to
 undo; a video is worse, because there is no history to rewrite.
 
+## Before submitting
+
+Five checks, in the order they bite. The first is the only one that cannot be undone.
+
+**Submit the project that holds the Google-data client, not the one that signs people in.**
+[ADR-031](adr/031-sign-in-and-data-access-are-separate-projects.md) is the argument; the operational
+half is that a submission enters *every* client in that project into the review, and that the
+unverified-app cap is spent for the lifetime of a project and cannot be reset. Submitting the wrong
+one is not a mistake that gets corrected later.
+
+**Confirm the sign-in project's Data access page still lists nothing but `openid`, `email` and
+`profile`.** A sensitive scope registered there is what puts an unverified-app screen in front of
+someone who only clicked "sign in", and no test in any repository can see it. This is the check that
+keeps the two levels apart, and it is worth repeating whenever a scope is added anywhere.
+
+**Point the privacy policy field at <https://lanes.sh/privacy>, with no query string.** That page
+exists for this field, and says so in its own source: review tooling will not follow a query
+parameter into a client-side tab. A `?tab=` form resolves to the same document for a human and is a
+gratuitous chance for a reviewer to land somewhere unintended.
+
+**Fill the three fields on every sensitive and restricted scope** — justification, intended data
+usage, demo video — from the text above. The console refuses the submission until all three are
+present on all twelve; `drive.file` needs none.
+
+**Say what the broker is before anyone asks.** The next section is why.
+
 ## The security assessment, and the question that decides it
 
 The five restricted scopes are what raise it. Google's stated trigger is narrow, and it is worth


### PR DESCRIPTION
Verification is about to be submitted, and the question that comes up first is whether to submit the project that already signs everyone in instead — one approval covering the endpoint today and a direct connector later. This records why not, before it gets decided by whoever is holding the console.

Google's unit of verification is the **project**, not the client, and that makes the split structural rather than a matter of taste.

### Why not one project

| Fact | Consequence of merging |
|---|---|
| Verification only ever covers sensitive and restricted scopes | The identity project requests none, so the saving is approval for scopes it never asks for |
| The unverified-app cap is spent over a project's **entire lifetime** and cannot be reset | A non-renewable allowance sits behind the one flow that must never run out |
| A submission enters *every* client in the project into the review | Including the ones a hosting platform provisions on its own |
| One brand per project | A single consent screen for both purposes — the honest one names Gmail and Drive |

And the reason to write it down rather than decide it again later: **a merged project cannot be un-merged.** The cap is gone for good, and ADR-028 stamps the minting client on every refresh token, so no live connection could be moved back without being consented from scratch.

### What the reuse actually is

The second project is not this endpoint's — it is the one that holds Google data access. A connector shipped elsewhere in Lanes gets a client there and inherits the approved brand, the approved justifications, and the Letter of Assessment. It does not inherit approval for a scope nobody has submitted yet, so the reuse is real but partial, and that limit is stated rather than left to be discovered.

The brand stays `Lanes Link`. Generalising it early buys nothing and costs the lowest-risk submission available — a later connector either accepts the name or triggers a brand re-verification, which is days against the months a second restricted-scope review would cost.

### Also here

`google-verification.md` gains the pre-submit checklist this implies. Four of its five items are console state no test can reach, and one is the check that keeps the two levels apart: that the identity project's Data access page still lists nothing but `openid`, `email` and `profile`. `specs.test.ts` holds the manifests and that file to the same scope list — it catches a scope requested but not declared, and nothing about which project a scope is registered against.

The privacy policy field also loses its query string. That page exists for this field and says so in its own source: review tooling will not follow a query parameter into a client-side tab.

### Verification

- `bun test` — 1626 pass, 2 skip, 0 fail (identical to the pre-change baseline)
- `bun run typecheck` — clean
- Docs only. No `src/` change, and no real project id, client id or address in the new text.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
