### PR TITLE
Install it with one command, from npm

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,86 @@
+# Publishing `@lanes-sh/link` to npm, on a tag.
+#
+# The tag is the trigger and the record: `git push --follow-tags` on `v0.2.0` is
+# the whole release, and what shipped is afterwards recoverable from the tag
+# rather than from anyone's shell history.
+#
+# The same two commands CONTRIBUTING.md requires run here before anything is
+# published, because `ci.yml` gates pull requests and a tag is not one — a
+# release could otherwise ship a tree no reviewer ever saw green.
+name: release
+
+on:
+  push:
+    tags: ['v*']
+
+permissions:
+  # `contents: write` creates the GitHub release. `id-token: write` is what lets
+  # npm mint a short-lived OIDC credential for the publish, so that no long-lived
+  # write token has to exist — see "Credentials" below.
+  contents: write
+  id-token: write
+
+jobs:
+  release:
+    name: release
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          # The same pin as ci.yml, for the same reason: a Bun release must not
+          # be able to change what green means without a commit saying so.
+          bun-version: 1.3.11
+
+      - run: bun install --frozen-lockfile
+
+      - run: bun test
+      - run: bun run typecheck
+
+      # The tag and the manifest have to agree before anything leaves the runner.
+      # A `v0.2.0` tag on a tree still declaring 0.1.0 publishes 0.1.0, and npm
+      # does not allow a version to be republished — so the mistake is permanent
+      # and the only fix is to burn a version number.
+      - name: the tag is the version
+        run: |
+          TAG="${GITHUB_REF_NAME#v}"
+          PKG="$(bun --print 'require("./package.json").version')"
+          if [ "$TAG" != "$PKG" ]; then
+            echo "tag $GITHUB_REF_NAME declares $TAG, package.json declares $PKG" >&2
+            exit 1
+          fi
+          echo "publishing $PKG"
+
+      # Publishing is the one step that is not Bun. `bun publish` does not
+      # implement npm's OIDC trusted publishing (oven-sh/bun#24855), which is the
+      # whole reason this workflow needs no stored credential. npm reads the same
+      # package.json and packs the same `files`, so the artefact is identical.
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          registry-url: 'https://registry.npmjs.org'
+
+      # Trusted publishing needs npm 11.5.1+, and the npm bundled with Node 22 is
+      # older than that.
+      - run: npm install -g npm@latest
+
+      # `--provenance` is passed rather than relied on: npm documents it as
+      # automatic under OIDC and it does not reliably fire. It attests that this
+      # tarball was built by this workflow from this repository, which is the
+      # claim worth making for something that holds people's credentials.
+      #
+      # Credentials: until `@lanes-sh/link` exists on the registry it cannot have
+      # a trusted publisher configured, so the first release authenticates with a
+      # short-lived NPM_TOKEN. Once it is published, configure the trusted
+      # publisher on the package's npm settings page, then delete both the secret
+      # and the `env:` block below — `id-token: write` above is all that is left
+      # to need.
+      - run: npm publish --provenance --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: github release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh release create "$GITHUB_REF_NAME" --generate-notes --verify-tag

--- a/.gitignore
+++ b/.gitignore
@@ -40,6 +40,11 @@ build/
 *.tsbuildinfo
 coverage/
 
+# What `bun pm pack` leaves behind. Verifying a release means packing the
+# tarball and installing it somewhere, and the artefact is 0.5 MB of the same
+# bytes already in the tree.
+*.tgz
+
 # Compiled `lanes` binary from `bun build --compile`
 /lanes
 

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ the middle of your data.
 Needs [Bun](https://bun.com) 1.3.11+. Nothing else — no account anywhere.
 
 ```console
-$ bun install && bun link                      # puts `lanes` on your PATH
+$ bun install -g @lanes-sh/link                # puts `lanes` on your PATH
 $ lanes link profile add personal --default
 $ lanes link start
 ok    serving http://127.0.0.1:7337/mcp

--- a/bin/lanes
+++ b/bin/lanes
@@ -1,0 +1,42 @@
+#!/bin/sh
+#
+# The `lanes` command, as installed from npm.
+#
+# `src/cli/lanes.ts` carries `#!/usr/bin/env bun`, and pointing package.json's
+# `bin` straight at it was the obvious thing — until a machine without Bun
+# installs cleanly and then answers every invocation with
+# `env: bun: No such file or directory`, which names neither this project nor
+# the thing it is missing. A `#!/usr/bin/env node` shim inverts the problem for
+# anyone who has Bun and not Node. `/bin/sh` is the one interpreter present in
+# both cases, so the check lives here.
+#
+# This is also what `bun link` puts on the PATH during development, so the
+# installed path and the contributor path are one path rather than two.
+
+set -e
+
+# npm and bun both install a bin as a symlink in a global directory, so "$0" is
+# the link rather than this file, and "$(dirname "$0")/.." is that directory's
+# parent rather than the package. `readlink -f` would resolve it in one call and
+# does not exist on macOS, which is where most of these installs land.
+self=$0
+while [ -L "$self" ]; do
+  link=$(readlink "$self")
+  case $link in
+    /*) self=$link ;;
+    *) self=$(dirname "$self")/$link ;;
+  esac
+done
+root=$(cd "$(dirname "$self")/.." && pwd)
+
+if ! command -v bun >/dev/null 2>&1; then
+  echo "lanes needs Bun 1.3.11+ to run — it is not on your PATH." >&2
+  echo "" >&2
+  echo "  curl -fsSL https://bun.sh/install | bash" >&2
+  echo "  brew install bun" >&2
+  echo "" >&2
+  echo "Then run this command again. Nothing else is needed." >&2
+  exit 1
+fi
+
+exec bun run "$root/src/cli/lanes.ts" "$@"

--- a/docs/detailed/local-development.md
+++ b/docs/detailed/local-development.md
@@ -16,7 +16,13 @@ $ bun run typecheck
 ```console
 $ bun run lanes link <command>      # via the root script
 $ bun run src/cli/lanes.ts link …  # directly
+$ bun link                          # or put this checkout's `lanes` on your PATH
 ```
+
+`bun link` is what people who installed `@lanes-sh/link` from npm get, pointed at your checkout
+instead: it reads the same `bin` entry, so `lanes` runs `bin/lanes`, which runs this tree. Prefer it
+over the two lines above once you are running more than one command at a time — and note that it
+replaces any published `lanes` on your `PATH` until you `bun unlink`.
 
 Use a throwaway workspace so you never touch a real profile:
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -8,13 +8,16 @@ You need [Bun](https://bun.com) 1.3.11+. There is no build step.
 ## 1. Install
 
 ```console
-$ bun install
-$ bun link                    # puts `lanes` on your PATH
+$ bun install -g @lanes-sh/link
+$ lanes --version             # confirms it landed on your PATH
 ```
 
-Do the `bun link`. Several registration commands read your token with `$(lanes link token show
+Check that second line. Several registration commands read your token with `$(lanes link token show
 --raw)`, and without `lanes` on your `PATH` that substitutes to an empty string — the only symptom
 is a 401 that looks like a bad token.
+
+Working on Lanes Link itself rather than using it? A checkout and `bun link` put the same command on
+your `PATH`: [`detailed/local-development.md`](detailed/local-development.md).
 
 ## 2. Create a profile
 

--- a/package.json
+++ b/package.json
@@ -1,17 +1,49 @@
 {
-  "name": "lanes-link",
-  "version": "0.0.0",
-  "private": true,
+  "name": "@lanes-sh/link",
+  "version": "0.1.0",
   "description": "A self-hosted MCP gateway for your accounts, memory, skills, and secrets",
   "license": "Apache-2.0",
+  "homepage": "https://github.com/lanes-sh/link#readme",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/lanes-sh/link.git"
   },
-  "type": "module",
-  "bin": {
-    "lanes": "./src/cli/lanes.ts"
+  "bugs": {
+    "url": "https://github.com/lanes-sh/link/issues"
   },
+  "keywords": [
+    "mcp",
+    "model-context-protocol",
+    "agent",
+    "gateway",
+    "self-hosted",
+    "gmail",
+    "calendar",
+    "claude",
+    "codex"
+  ],
+  "type": "module",
+  "engines": {
+    "bun": ">=1.3.11"
+  },
+  "os": [
+    "darwin",
+    "linux"
+  ],
+  "publishConfig": {
+    "access": "public"
+  },
+  "bin": {
+    "lanes": "./bin/lanes"
+  },
+  "files": [
+    "bin",
+    "src",
+    "!src/**/*.test.ts",
+    "instructions",
+    "README.md",
+    "LICENSE"
+  ],
   "scripts": {
     "test": "bun test",
     "typecheck": "tsc --noEmit",

--- a/src/cli/lanes.test.ts
+++ b/src/cli/lanes.test.ts
@@ -1,6 +1,7 @@
 import { afterAll, describe, expect, test } from 'bun:test';
 import { mkdtemp, mkdir, rm, writeFile } from 'node:fs/promises';
 import { fileURLToPath } from 'node:url';
+import { readFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
@@ -169,5 +170,43 @@ describe('token rotate', () => {
     // The part that has to stay loud: nothing re-reads the token on its own.
     const run = await workspace();
     expect(run(['link', 'token', 'rotate']).stdout).toContain('re-registered');
+  });
+});
+
+/**
+ * `--version`, at both levels of the grammar.
+ *
+ * Asked for because installing from npm makes two versions of this CLI able to
+ * exist on two machines at once, and a bug report that cannot name which one it
+ * came from is a bug report that has to be reproduced from scratch. There was
+ * no way to ask before.
+ *
+ * Both spellings, because both get typed: `lanes --version` is the reflex for
+ * anything on a PATH, and `lanes link version` is what the grammar in this file
+ * would predict. They must not be allowed to drift apart, so the test holds all
+ * three — the two commands and the manifest — to one string.
+ */
+describe('version', () => {
+  const declared = (): string => {
+    const path = fileURLToPath(new URL('../../package.json', import.meta.url));
+    return JSON.parse(readFileSync(path, 'utf8')).version;
+  };
+
+  test('`lanes --version` prints the version and nothing else', () => {
+    const { code, stdout } = runBin(['--version']);
+    expect(code).toBe(0);
+    // Bare, so `$(lanes --version)` is usable without trimming a label off it.
+    expect(stdout.trim()).toBe(declared());
+    expect(stdout.trim()).toMatch(/^\d+\.\d+\.\d+/);
+  });
+
+  test('`-v` is the same thing', () => {
+    expect(runBin(['-v']).stdout.trim()).toBe(declared());
+  });
+
+  test('`lanes link version` agrees with it', () => {
+    const { code, stdout } = runBin(['link', 'version']);
+    expect(code).toBe(0);
+    expect(stdout.trim()).toBe(declared());
   });
 });

--- a/src/cli/lanes.ts
+++ b/src/cli/lanes.ts
@@ -1,6 +1,7 @@
 #!/usr/bin/env bun
 import { ConfigError } from '#profile';
 import { print, printErr, style } from './output.ts';
+import { version } from './version.ts';
 
 /**
  * `lanes` — the command, and the one area it currently has.
@@ -25,7 +26,11 @@ function areasUsage(): string {
     .map(([name, blurb]) => `  ${style.bold(`lanes ${name}`)}  ${blurb}`)
     .join('\n');
 
-  return `${style.bold('lanes')} — your own tools, wherever you work\n\n${rows}\n\nRun ${style.bold('lanes <area> help')} for what an area can do.\n`;
+  return (
+    `${style.bold('lanes')} — your own tools, wherever you work\n\n${rows}\n\n` +
+    `Run ${style.bold('lanes <area> help')} for what an area can do, ` +
+    `or ${style.bold('lanes --version')} for which release this is.\n`
+  );
 }
 
 async function main(argv: readonly string[]): Promise<void> {
@@ -35,6 +40,14 @@ async function main(argv: readonly string[]): Promise<void> {
   // Not an error — someone who typed `lanes` wants to know what it offers.
   if (!area || area === 'help' || area === '--help') {
     print(areasUsage());
+    return;
+  }
+
+  // Before the area is peeled, because it belongs to the binary rather than to
+  // any one area — and because `lanes --version` is the reflex for anything on
+  // a PATH. `lanes link version` answers with the same string.
+  if (area === '--version' || area === '-v') {
+    print(version());
     return;
   }
 

--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -39,6 +39,7 @@ import {
 } from './commands/owner.ts';
 import { globalFlags, ownerFlags, parseArgv, text } from './argv.ts';
 import { PROGRAM, USAGE } from './usage.ts';
+import { version } from './version.ts';
 import { print } from './output.ts';
 
 /**
@@ -321,6 +322,10 @@ export async function run(argv: readonly string[]): Promise<void> {
         default:
           throw new Error(`Unknown: ${PROGRAM} secrets ${second}`);
       }
+
+    case 'version':
+      print(version());
+      return;
 
     default:
       throw new Error(`Unknown command "${first}". Run: ${PROGRAM} help`);

--- a/src/cli/usage.ts
+++ b/src/cli/usage.ts
@@ -88,6 +88,7 @@ ${style.bold('Inspection')}
   ${PROGRAM} audit tail [--limit N] [--denied-only] [--format md]
   ${PROGRAM} audit verify           has anything in the log been altered or removed
   ${PROGRAM} config show
+  ${PROGRAM} version                    which release this is — same as lanes --version
 
 ${style.bold('Attachments')}
   ${PROGRAM} attach <file> --connection <provider>.<account>

--- a/src/cli/version.ts
+++ b/src/cli/version.ts
@@ -1,0 +1,25 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { installRoot } from '#profile';
+
+/**
+ * What this CLI calls itself when asked.
+ *
+ * Read from `package.json` at call time rather than substituted in at build
+ * time, because there is no build step: the file that declares the version and
+ * the file that ships are the same file. `installRoot` walks up to whichever
+ * root this is — a checkout during development, or the package directory under
+ * `node_modules` once installed — which is the same way `mcp/assets.ts` finds
+ * `instructions/`.
+ *
+ * Answering at all is new with publishing to npm. While the only way to get
+ * this CLI was to clone it, `git log` was the answer and a better one; two
+ * machines can now be a release apart with nothing on either to say so.
+ */
+export function version(): string {
+  const path = join(installRoot(import.meta.dir), 'package.json');
+  const declared = (JSON.parse(readFileSync(path, 'utf8')) as { version?: string }).version;
+
+  if (!declared) throw new Error(`No "version" in ${path}`);
+  return declared;
+}


### PR DESCRIPTION
Getting Lanes Link meant cloning it. This publishes it as **`@lanes-sh/link`**, so the front door
becomes one command:

```console
$ bun install -g @lanes-sh/link
$ lanes link profile add personal --default
$ lanes link start
```

The unscoped `lanes` on npm belongs to someone else; the scope matches the GitHub org.

### Why not Homebrew

`lanes-sh/homebrew-lanes` already exists and a `Formula/` can sit beside its `Casks/`. Its one real
advantage is installing Bun for you. Against that, npm reaches Linux and WSL that the tap does not,
and it is one release surface rather than two. The tap stays available later — nothing here
forecloses it.

### What is load-bearing

Mostly manifest, because nothing about how the code finds its own files changes. `specPath` and
`installRoot` both resolve real paths from `import.meta.url`, so publishing the source tree keeps
them true — where `bun build --compile` would have required embedding the seven vendored specs and
both instruction documents first.

- **`instructions/` is in `files`.** `mcp/assets.ts` reads the bundled skill and scout agent from
  there, and `mcp add` fails without it.
- **`bin` gains a `/bin/sh` shim.** `src/cli/lanes.ts` carries `#!/usr/bin/env bun`, so pointing at
  it directly means a machine without Bun installs cleanly and then answers every invocation with
  `env: bun: No such file or directory`. A node shim inverts the problem for anyone with Bun and no
  Node; `sh` is the one interpreter present in both cases. `bun link` reads the same entry, so the
  contributor path and the installed path are now one path.
- **`lanes --version` / `lanes link version`** are new — two machines can now be a release apart
  with nothing on either to say so. A test holds both commands and the manifest to one string.
- **Release on a tag**, after the same two gates CONTRIBUTING requires, since a tag is not a pull
  request and `ci.yml` never sees it. It refuses to publish when the tag and the manifest disagree:
  npm does not allow a version to be republished, so that mistake is permanent.

### Verified

Both gates green (1629 pass, 0 fail; `tsc --noEmit` clean). Beyond that, the installed shape was
exercised directly, since the suite only ever runs from a checkout — the tarball was packed and
installed into a throwaway project:

- `lanes --version` through the bin symlink → `0.1.0`
- `lanes link mcp skill` resolved `node_modules/@lanes-sh/link/instructions/skills/lanes-link`,
  which is the one command that proves the `installRoot` lookup from inside `node_modules`
- all seven `specPath()` targets exist under the installed package
- `lanes link start --port 7401` served and answered `/health`, against a scratch
  `LANES_LINK_HOME` — never the real workspace
- with Bun off the PATH, the shim exits 1 with a sentence naming Bun

`bun pm pack --dry-run`: 276 files, 1.85 MB unpacked, no `*.test.ts`.

### After merge

`npm publish` needs a credential for the first release only — a package cannot have a trusted
publisher configured until it exists. `NPM_TOKEN` is already set on this repo. Once `0.1.0` is on
the registry, configure the trusted publisher on the package's npm settings page, then delete the
secret and the `env:` block in `release.yml`; `id-token: write` is all that remains.

🤖 Generated with [Claude Code](https://claude.com/claude-code)