### PR TITLE
Release 0.1.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lanes-sh/link",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "A self-hosted MCP gateway for your accounts, memory, skills, and secrets",
   "license": "Apache-2.0",
   "homepage": "https://github.com/lanes-sh/link#readme",


### PR DESCRIPTION
Version bump only. npm serves `0.1.0`, which predates
[#12](https://github.com/lanes-sh/link/pull/12) — the tool-list notification fix — so the registry
is a real behaviour change behind `main`.

Merging this and pushing `v0.1.1` publishes it.

Also the **first release to authenticate over OIDC** rather than a stored token. `v0.1.0` could not:
a package must exist on the registry before it can be given a trusted publisher, so that one went
out under a 2FA-bypassing token which is now deleted and revoked. Nothing has exercised the OIDC
path yet — a patch is the right place to find out whether it works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)