### PR TITLE
Let a merge propose its own release

### DIFF
--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -1,0 +1,101 @@
+# Proposing the next release, so the registry stops falling behind `main`.
+#
+# Releasing was a tag pushed by hand, and npm fell behind the first time anyone
+# forgot — which was immediately. This watches for merges that change what
+# people install and opens a pull request bumping the version. Merging that is
+# the release; `release.yml` does the publishing.
+#
+# **Why a pull request rather than a push.** A workflow cannot push to `main`
+# here: the branch ruleset requires a pull request, and the built-in
+# GITHUB_TOKEN cannot be added to its bypass list — GitHub refuses because the
+# Actions identity is not branch-specific, so exempting it would exempt every
+# workflow on every branch. The alternative is a GitHub App or a personal access
+# token held as a secret, which is a credential with write access to `main`,
+# and larger than the npm token this project went out of its way to delete.
+# A pull request needs no credential at all.
+#
+# The click it costs is not purely a cost. Publishing cannot be undone — npm
+# will not let a version be republished — so a human confirming which changes
+# are going out is worth something on its own.
+name: release pr
+
+on:
+  push:
+    branches: [main]
+    # What ships, and nothing else. `files` in package.json is the same list,
+    # and the two should stay in step: a merge that cannot change the tarball
+    # must not propose a version. `README.md` is deliberately absent even though
+    # it is packed — a typo fix in it rides along with the next real release
+    # rather than becoming one.
+    paths:
+      - 'src/**'
+      - 'bin/**'
+      - 'instructions/**'
+      - 'package.json'
+      - 'bun.lock'
+
+# Only the newest proposal matters; an older run would reopen the same PR with
+# a shorter list of changes.
+concurrency:
+  group: release-pr
+  cancel-in-progress: true
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  propose:
+    name: propose
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          # Tags decide whether a release is already pending, so a shallow clone
+          # would propose a bump on top of one still waiting to be merged.
+          fetch-depth: 0
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.3.11
+
+      - name: propose the next version
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          CURRENT="$(bun --print 'require("./package.json").version')"
+
+          # A version with no tag behind it is a release already proposed and
+          # not yet merged, or a minor deliberately set in review. Either way
+          # the next number is not this job's to decide.
+          if ! git rev-parse -q --verify "refs/tags/v$CURRENT" >/dev/null; then
+            echo "$CURRENT is not released yet — a release is already pending."
+            exit 0
+          fi
+
+          NEXT="$(npm version patch --no-git-tag-version | tr -d 'v')"
+          echo "proposing $NEXT"
+
+          # What is going out, for the pull request body. This is the whole
+          # reason the release is a document rather than a tag: the person
+          # merging it can see which changes they are publishing.
+          CHANGES="$(git log "v$CURRENT..HEAD" --no-merges --pretty=format:'- %s' | head -50)"
+          [ -n "$CHANGES" ] || CHANGES="- (no commits found since v$CURRENT)"
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git checkout -B release/next
+          git add package.json
+          git commit -m "Release $NEXT"
+          git push --force origin release/next
+
+          BODY="$(printf 'Bumps \140package.json\140 to \140%s\140. Merging this publishes it.\n\nSince \140v%s\140:\n\n%s\n\n---\n\nOpened by \140release-pr.yml\140. A workflow cannot push to \140main\140 here — the ruleset requires a pull request and the built-in GITHUB_TOKEN cannot be exempted from it — so the release is a pull request rather than a stored credential with write access to \140main\140.\n\nGitHub does not run workflows on pull requests it opened itself, so the required \140ci\140 check will not report and this needs an admin merge. Both gates run again in \140release.yml\140 before anything reaches the registry.\n' "$NEXT" "$CURRENT" "$CHANGES")"
+
+          if gh pr view release/next --json number >/dev/null 2>&1; then
+            gh pr edit release/next --title "Release $NEXT" --body "$BODY"
+            echo "updated the open release pull request"
+          else
+            gh pr create --base main --head release/next \
+              --title "Release $NEXT" --body "$BODY"
+          fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,23 +1,39 @@
-# Publishing `@lanes-sh/link` to npm, on a tag.
+# Publishing `@lanes-sh/link` to npm.
 #
-# The tag is the trigger and the record: `git push --follow-tags` on `v0.2.0` is
-# the whole release, and what shipped is afterwards recoverable from the tag
-# rather than from anyone's shell history.
+# Runs when `package.json` lands on `main` carrying a version no tag has been
+# cut for — which is what merging the pull request from `release-pr.yml` does.
+# A version that already has a tag has already been published, so this exits
+# without doing anything, and an ordinary merge that happens to touch
+# `package.json` (a dependency change, say) is therefore harmless.
 #
-# The same two commands CONTRIBUTING.md requires run here before anything is
-# published, because `ci.yml` gates pull requests and a tag is not one — a
-# release could otherwise ship a tree no reviewer ever saw green.
+# **The filename is load-bearing.** npm's trusted publisher for this package
+# names `release.yml`; renaming this file makes every publish fail to
+# authenticate, with an error about OIDC rather than about the rename.
+#
+# **Minor and major releases** need no separate path: set the version you want
+# in `package.json` in an ordinary pull request. It arrives here with no tag
+# behind it and is published as declared, which puts the one judgement in a
+# release — that something earns more than a patch — in review, beside the
+# change it describes.
+#
+# Nothing here is pushed to `main`. The tag is, and a tag is not covered by the
+# branch ruleset, so this needs no bypass and no stored credential.
 name: release
 
 on:
   push:
-    tags: ['v*']
+    branches: [main]
+    paths:
+      - 'package.json'
+
+concurrency:
+  group: release
+  cancel-in-progress: false
 
 permissions:
-  # `contents: write` creates the GitHub release. `id-token: write` is what lets
-  # npm mint a short-lived OIDC credential for the publish, so that no long-lived
-  # write token has to exist — see "Credentials" below.
+  # The tag and the GitHub release. Not the branch — see above.
   contents: write
+  # What npm mints a short-lived publish credential from. No token is stored.
   id-token: write
 
 jobs:
@@ -26,63 +42,82 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
+        with:
+          # Tags decide whether this version is already out, so a shallow clone
+          # would report every version as new and try to republish the last one.
+          fetch-depth: 0
+
+      - name: is there anything to publish
+        id: check
+        run: |
+          set -euo pipefail
+          VERSION="$(node --print 'require("./package.json").version')"
+          if git rev-parse -q --verify "refs/tags/v$VERSION" >/dev/null; then
+            echo "publish=false" >> "$GITHUB_OUTPUT"
+            echo "v$VERSION is already tagged — nothing to do."
+          else
+            echo "publish=true" >> "$GITHUB_OUTPUT"
+            echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+            echo "publishing $VERSION"
+          fi
 
       - uses: oven-sh/setup-bun@v2
+        if: steps.check.outputs.publish == 'true'
         with:
           # The same pin as ci.yml, for the same reason: a Bun release must not
           # be able to change what green means without a commit saying so.
           bun-version: 1.3.11
 
-      - run: bun install --frozen-lockfile
+      - if: steps.check.outputs.publish == 'true'
+        run: bun install --frozen-lockfile
 
-      - run: bun test
-      - run: bun run typecheck
+      # The release pull request cannot carry a CI run of its own — GitHub does
+      # not run workflows on pull requests it opened itself — so this is the
+      # only place both gates run against the exact tree being published, and
+      # the registry does not give a version back.
+      - if: steps.check.outputs.publish == 'true'
+        run: bun test
+      - if: steps.check.outputs.publish == 'true'
+        run: bun run typecheck
 
-      # The tag and the manifest have to agree before anything leaves the runner.
-      # A `v0.2.0` tag on a tree still declaring 0.1.0 publishes 0.1.0, and npm
-      # does not allow a version to be republished — so the mistake is permanent
-      # and the only fix is to burn a version number.
-      - name: the tag is the version
-        run: |
-          TAG="${GITHUB_REF_NAME#v}"
-          PKG="$(bun --print 'require("./package.json").version')"
-          if [ "$TAG" != "$PKG" ]; then
-            echo "tag $GITHUB_REF_NAME declares $TAG, package.json declares $PKG" >&2
-            exit 1
-          fi
-          echo "publishing $PKG"
-
-      # Publishing is the one step that is not Bun. `bun publish` does not
-      # implement npm's OIDC trusted publishing (oven-sh/bun#24855), which is the
-      # whole reason this workflow needs no stored credential. npm reads the same
-      # package.json and packs the same `files`, so the artefact is identical.
       - uses: actions/setup-node@v4
+        if: steps.check.outputs.publish == 'true'
         with:
           node-version: '22'
           registry-url: 'https://registry.npmjs.org'
 
-      # Trusted publishing needs npm 11.5.1+, and the npm bundled with Node 22 is
-      # older than that.
-      - run: npm install -g npm@latest
+      # Trusted publishing needs npm 11.5.1+, and the npm bundled with Node 22
+      # is older than that.
+      - if: steps.check.outputs.publish == 'true'
+        run: npm install -g npm@latest
 
-      # No credential. npm mints a short-lived one from the OIDC token that
-      # `id-token: write` above allows this run to request, and matches it
-      # against the trusted publisher configured on the package — this
-      # repository, this workflow file. Nothing to store, nothing to rotate, and
-      # nothing that still works if it leaks out of a log.
-      #
-      # v0.1.0 could not do this: a package must exist on the registry before it
-      # can have a trusted publisher, so that one release went out under a
-      # short-lived NPM_TOKEN with 2FA bypassed. That token is revoked, and npm
-      # is restricting the mechanism it used anyway.
+      # Before the tag, because the order decides what a failure leaves behind.
+      # Publish first and a failure leaves the repository untouched and the run
+      # repeatable. Tag first and a failed publish leaves a tag claiming a
+      # version nobody can install, which this job then reads as released and
+      # skips forever after.
       #
       # `--provenance` is passed rather than relied on: npm documents it as
       # automatic under OIDC and it does not reliably fire. It attests that this
       # tarball was built by this workflow from this repository, which is the
       # claim worth making for something that holds people's credentials.
-      - run: npm publish --provenance --access public
+      - if: steps.check.outputs.publish == 'true'
+        run: npm publish --provenance --access public
+
+      - name: tag it
+        if: steps.check.outputs.publish == 'true'
+        env:
+          VERSION: ${{ steps.check.outputs.version }}
+        run: |
+          set -euo pipefail
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git tag -a "v$VERSION" -m "v$VERSION"
+          git push origin "v$VERSION"
 
       - name: github release
+        if: steps.check.outputs.publish == 'true'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: gh release create "$GITHUB_REF_NAME" --generate-notes --verify-tag
+          VERSION: ${{ steps.check.outputs.version }}
+        run: gh release create "v$VERSION" --generate-notes --verify-tag

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -61,6 +61,28 @@ Two tests hold the layers to the code, and both should stay green rather than be
 `src/readme.test.ts` asserts the README names a working `lanes link connect` command for every
 provider, and `src/profile/docs.test.ts` parses the YAML examples out of the reference pages.
 
+## Releasing
+
+You do not tag anything. Merging a change under `src/`, `bin/`, `instructions/`, `package.json`, or
+`bun.lock` opens a **"Release x.y.z" pull request** carrying the patch bump and a list of what is
+going out. Merging that pull request publishes to npm and cuts the tag.
+
+For a **minor or major**, put the version you want in `package.json` in your own pull request. It
+arrives on `main` with no tag behind it and is published as declared — so the judgement that
+something earns more than a patch is made in review, beside the change that earns it.
+
+Two things will look wrong and are not:
+
+- **The release pull request shows `ci` as never reporting.** GitHub does not run workflows on pull
+  requests it opened itself, so it needs an admin merge. Both gates run again in `release.yml`
+  against the exact tree being published, which is the run that matters — the registry does not give
+  a version back.
+- **Nothing is pushed to `main` by CI, ever.** A workflow cannot: the ruleset requires a pull
+  request, and the built-in `GITHUB_TOKEN` cannot be added to its bypass list. Doing it anyway would
+  mean storing a GitHub App key or a personal access token with write access to `main` — a larger
+  credential than the npm token this project deliberately does not have. Publishing authenticates
+  over OIDC instead, so there is no publish credential either.
+
 ## Commit messages
 
 Say what changed and why the approach was chosen — especially where a simpler option was rejected.


### PR DESCRIPTION
npm fell behind `main` the first time a merge didn't get tagged — which was the first merge after
`v0.1.0`. Tagging by hand isn't a process, it's a thing to forget.

**Now:** merging a change under `src/`, `bin/`, `instructions/`, `package.json`, or `bun.lock` opens
a **"Release x.y.z"** PR with the patch bump and the list of commits going out. Merging that
publishes and cuts the tag. For a minor or major, set the version in `package.json` in your own PR —
it lands with no tag behind it and is published as declared.

### Why not just have CI push the bump to main

That was the plan, and it can't work here. The ruleset requires a pull request, and the built-in
`GITHUB_TOKEN` **cannot be added to a bypass list** — GitHub refuses because the Actions identity
isn't branch-specific, so exempting it would exempt every workflow on every branch
([community #25305](https://github.com/orgs/community/discussions/25305)).

What's left is a GitHub App key or a PAT stored as a secret — a credential with **write access to
`main`**, strictly larger than the npm token deleted earlier today, guarding a smaller thing. A pull
request needs no credential, and the tag it produces isn't covered by a branch ruleset either. So
nothing here stores anything, and `gh secret list` stays empty.

### Two things that will look wrong and aren't

- **Release PRs show `ci` as never reporting.** GitHub doesn't run workflows on PRs it opened
  itself, so merging one takes an admin. Both gates run again in `release.yml` against the exact
  tree being published — the run that was load-bearing anyway.
- **`release.yml` keeps its name.** npm's trusted publisher names that file; renaming it fails every
  publish with an error about OIDC rather than about the rename.

### Verified

Both gates green (1654 pass, 0 fail; `tsc --noEmit` clean), both workflows parse, and the version
logic was exercised against the real tag list:

| state | expected | got |
|---|---|---|
| `0.1.1`, `v0.1.1` exists | skip | skip |
| `0.1.2`, untagged | publish `0.1.2` | publish `0.1.2` |
| `0.2.0` set in review | publish `0.2.0` | publish `0.2.0` |

Grepped for branch pushes: none. Only `secrets.GITHUB_TOKEN` is referenced, which Actions injects.

**Merging this is also its own first test** — it touches `.github/**` only, so it should trigger
neither workflow. The next `src/` merge is what should produce a release PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)