### PR TITLE
Release 0.1.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lanes-sh/link",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "A self-hostable MCP gateway for all your connections, memory, skills, and secrets",
   "license": "Apache-2.0",
   "homepage": "https://lanes.sh/link",


### PR DESCRIPTION
Bumps `package.json` to `0.1.2`. Merging this publishes it.

Since `v0.1.1`:

- Draw the diagram the way the endpoint actually reads (#18)
- Let a merge propose its own release (#17)

---

The branch and the bump were produced by `release-pr.yml`. **This pull request was opened by hand**,
because the workflow's own `gh pr create` was refused:

```
GitHub Actions is not permitted to create or approve pull requests (createPullRequest)
```

That is the repo setting `can_approve_pull_request_reviews`, off by default. Everything before it
worked — it computed `0.1.2`, committed, and pushed the branch.

GitHub does not run workflows on pull requests it opened itself, so `ci` will not report here and
this needs an admin merge. Both gates run again in `release.yml` against the exact tree being
published, which is the run that matters.