### PR TITLE
Create the tag through the API, so a concurrent merge cannot strand a release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -176,21 +176,40 @@ jobs:
       - if: steps.mode.outputs.mode == 'publish'
         run: npm publish --provenance --access public
 
-      - name: tag it
-        if: steps.mode.outputs.mode == 'publish'
-        env:
-          VERSION: ${{ steps.mode.outputs.version }}
-        run: |
-          set -euo pipefail
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git tag -a "v$VERSION" -m "v$VERSION"
-          git push origin "v$VERSION"
-          git push --delete origin release/next 2>/dev/null || true
-
-      - name: github release
+      # The tag is created through the API, not by `git push`.
+      #
+      # Pushing it failed, after the publish had already succeeded:
+      #
+      #   refusing to allow a GitHub App to create or update workflow
+      #   `.github/workflows/release-pr.yml` without `workflows` permission
+      #
+      # A push is refused when the ref it creates carries workflow files that
+      # differ from what the remote already has, and GITHUB_TOKEN cannot be
+      # granted the permission that would allow it — there is no `workflows`
+      # key in the `permissions:` block. The tag pointed at the commit this run
+      # checked out, another merge landed while the run was publishing, and the
+      # tag therefore looked like it was re-creating a workflow file that merge
+      # had deleted. Any merge during a release run reproduces it.
+      #
+      # Creating the ref through the API pushes no objects — the commit is
+      # already on the remote — so the check never applies. `--target` makes
+      # `gh release create` do exactly that, which also collapses the tag and
+      # the release into one call that cannot half-succeed.
+      #
+      # $GITHUB_SHA rather than the branch: `main` may have moved since this run
+      # started, and the tag has to name the tree that was published.
+      - name: tag it and announce it
         if: steps.mode.outputs.mode == 'publish'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           VERSION: ${{ steps.mode.outputs.version }}
-        run: gh release create "v$VERSION" --generate-notes --verify-tag
+        run: gh release create "v$VERSION" --target "$GITHUB_SHA" --generate-notes
+
+      # Housekeeping, and never a reason to fail a release that has already
+      # reached the registry.
+      - name: tidy the release branch
+        if: steps.mode.outputs.mode == 'publish'
+        continue-on-error: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh api -X DELETE repos/${{ github.repository }}/git/refs/heads/release/next


### PR DESCRIPTION
`0.1.2` published to npm and then **failed to tag**:

```
refusing to allow a GitHub App to create or update workflow
`.github/workflows/release-pr.yml` without `workflows` permission
```

A `git push` is refused when the ref it creates carries workflow files differing from what the remote
already has — and `GITHUB_TOKEN` **cannot** be granted the permission that would allow it. There is
no `workflows` key in the `permissions:` block to add.

The tag named the commit the run checked out; #20 merged while the run was publishing and deleted
`release-pr.yml`; so the tag looked like it was re-creating that file. **Any merge landing during a
release reproduces this.**

### Why it mattered more than a red X

The publish had already succeeded. npm served `0.1.2` while the repo had no tag for it — and an
untagged version is precisely what this workflow reads as *"publish this"*. The next run would have
tried to republish a version npm will never accept again. Stranded in a state neither half could
leave on its own.

### The fix

Creating the ref through the API pushes no objects — the commit is already on the remote — so the
check never applies. `gh release create --target "$GITHUB_SHA"` does that and cuts the release in the
same call, removing a step boundary the old version could half-succeed across.

`$GITHUB_SHA` rather than the branch: `main` may have moved since the run started, and the tag has to
name the tree that was published.

Branch cleanup moved below the release and marked `continue-on-error` — housekeeping was never worth
failing a release that had already reached the registry.

### Verified

`v0.1.2`'s tag and release were created by hand using this exact API call, which is how the fix was
confirmed to work before being written into the workflow. State is now consistent: npm `0.1.2`, tag
`v0.1.2`, release published, and `package.json` tagged so the next run proposes rather than
republishes. 1654 tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)