### PR TITLE
Add GitHub and Slack, reached with a token the operator pasted (0.2.0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,13 +98,16 @@ One command per account. Run it again to add a second mailbox, a second calendar
 | Notion | `lanes link connect notion` |
 | Linear | `lanes link connect linear` |
 | GitHub | `lanes link connect github` |
+| Slack | `lanes link connect slack` |
 | Gmail (Google MCP) | `lanes link connect gmail_mcp` |
 | Drive (Google MCP) | `lanes link connect drive_mcp` |
 
-Two things worth knowing up front: `lanes link connect icloud` sets up Mail, Calendar, and Contacts
-together, because one app-specific password covers all three. And Google needs no OAuth client of
-your own: `lanes link connect gmail` authorises against the one Lanes operates, so there is no
-Cloud console to visit. Add `--own-client` if you would rather register your own.
+Three things worth knowing up front. `lanes link connect icloud` sets up Mail, Calendar, and
+Contacts together, because one app-specific password covers all three. Google needs no OAuth client
+of your own: `lanes link connect gmail` authorises against the one Lanes operates, so there is no
+Cloud console to visit — add `--own-client` if you would rather register your own. And GitHub and
+Slack take a token you paste rather than a browser sign-in, because neither will register a client
+for us; for Slack that means creating a Slack app once, which is the one console visit left here.
 
 Full guide — what each one gives your agent, what it needs, and adding your own:
 **[docs/connect.md](docs/connect.md)**.

--- a/README.md
+++ b/README.md
@@ -97,6 +97,7 @@ One command per account. Run it again to add a second mailbox, a second calendar
 | iCloud Drive | `lanes link connect icloud_drive` |
 | Notion | `lanes link connect notion` |
 | Linear | `lanes link connect linear` |
+| GitHub | `lanes link connect github` |
 | Gmail (Google MCP) | `lanes link connect gmail_mcp` |
 | Drive (Google MCP) | `lanes link connect drive_mcp` |
 

--- a/docs/connect.md
+++ b/docs/connect.md
@@ -28,6 +28,7 @@ $ lanes link connect gmail        # again, for a second mailbox
 | Notion | `lanes link connect notion` | Notion's own MCP server |
 | Linear | `lanes link connect linear` | Linear's own MCP server |
 | GitHub | `lanes link connect github` | Repositories, issues, pull requests, and workflow runs |
+| Slack | `lanes link connect slack` | Search, read, and send messages, threads, files, and canvases |
 | Gmail (Google MCP) | `lanes link connect gmail_mcp` | Google's own MCP server — Developer Preview only |
 | Drive (Google MCP) | `lanes link connect drive_mcp` | Likewise; use `drive` unless you are enrolled |
 
@@ -44,10 +45,15 @@ app-specific password covers all three. iCloud Drive is separate — it holds no
 reading your sync folder through the filesystem. Full walkthrough:
 [`detailed/setup/icloud.md`](detailed/setup/icloud.md).
 
-**No provider asks you to register an OAuth client.** Google authorises against the client Lanes
-operates, Notion and Linear register themselves, iCloud takes an app-specific password you generate
-at appleid.apple.com, and GitHub takes a personal access token. Full walkthrough for that one:
+**Only Slack asks you to register anything.** Google authorises against the client Lanes operates,
+Notion and Linear register themselves, iCloud takes an app-specific password you generate at
+appleid.apple.com, and GitHub takes a personal access token —
 [`detailed/setup/github.md`](detailed/setup/github.md).
+
+Slack is the exception, and not for want of trying. Slack's MCP server does not register clients
+automatically, and a client of your own needs an HTTPS callback, which a CLI listening on localhost
+cannot be. So Slack means creating a Slack app once, installing it to your workspace, and pasting
+the user token it mints: [`detailed/setup/slack.md`](detailed/setup/slack.md).
 
 For Google you can still register your own, and some people have to — an organisation that forbids
 third-party clients, a Workspace app that must be "Internal", or a hosted client that has reached

--- a/docs/connect.md
+++ b/docs/connect.md
@@ -27,6 +27,7 @@ $ lanes link connect gmail        # again, for a second mailbox
 | iCloud Drive | `lanes link connect icloud_drive` | Your sync folder, on the Mac that syncs it |
 | Notion | `lanes link connect notion` | Notion's own MCP server |
 | Linear | `lanes link connect linear` | Linear's own MCP server |
+| GitHub | `lanes link connect github` | Repositories, issues, pull requests, and workflow runs |
 | Gmail (Google MCP) | `lanes link connect gmail_mcp` | Google's own MCP server — Developer Preview only |
 | Drive (Google MCP) | `lanes link connect drive_mcp` | Likewise; use `drive` unless you are enrolled |
 
@@ -44,8 +45,9 @@ reading your sync folder through the filesystem. Full walkthrough:
 [`detailed/setup/icloud.md`](detailed/setup/icloud.md).
 
 **No provider asks you to register an OAuth client.** Google authorises against the client Lanes
-operates, Notion and Linear register themselves, and iCloud takes an app-specific password you
-generate at appleid.apple.com.
+operates, Notion and Linear register themselves, iCloud takes an app-specific password you generate
+at appleid.apple.com, and GitHub takes a personal access token. Full walkthrough for that one:
+[`detailed/setup/github.md`](detailed/setup/github.md).
 
 For Google you can still register your own, and some people have to — an organisation that forbids
 third-party clients, a Workspace app that must be "Internal", or a hosted client that has reached
@@ -132,8 +134,8 @@ For providers whose credential is a key or a password rather than a browser sign
 shell can do the whole setup:
 
 ```console
-$ printf %s "$KEY" | lanes link secrets set linear/main --profile personal
-$ lanes link connect linear --id main --non-interactive --json --profile personal
+$ printf %s "$TOKEN" | lanes link secrets set github/octocat --profile personal
+$ lanes link connect github --id octocat --non-interactive --json --profile personal
 ```
 
 `--non-interactive` never prompts. It resolves every value from the credential store, or refuses and

--- a/docs/detailed/adr/033-a-pasted-token-for-an-mcp-server.md
+++ b/docs/detailed/adr/033-a-pasted-token-for-an-mcp-server.md
@@ -1,0 +1,97 @@
+# ADR-033: Where a vendor will not register us as a client, the operator's own token is the credential
+
+**Status:** accepted · **Complements** [ADR-028](028-a-hosted-oauth-client-is-the-default.md)
+
+## Context
+
+Proxying a vendor's own MCP server is the cheapest integration this project has. Notion and Linear
+are fifteen lines of data each: the vendor wrote the integration, the vendor maintains it, and what
+we add in front is per-capability policy, audit with redaction, and profile isolation. Both cost
+nothing to *connect*, too, because both support Dynamic Client Registration — Lanes Link registers
+itself with their authorization server at connect time and the operator does nothing at all.
+
+GitHub and Slack run official MCP servers and neither supports DCR. Slack's documentation says so
+in as many words: *"We do not support SSE-based connections or Dynamic Client Registration at this
+time."* GitHub's position is that it is coming and is not here.
+
+That should leave the fallback every other provider uses. It does not, and the reasons are worth
+recording, because each looks like something we could fix and is not:
+
+- **A client of the operator's own** (`registration: manual`, what `--own-client` does for Google).
+  Slack requires redirect URIs to be **HTTPS**, and `connect` listens on `http://127.0.0.1` on a
+  port the kernel picks per run — there is no proxy, tunnel, or flag that makes a loopback listener
+  HTTPS. GitHub permits `http://127.0.0.1` but matches the callback URL exactly, port included, and
+  there is no fixed port to register.
+- **A broker** — the answer ADR-028 built, where somebody runs a client and performs the exchange.
+  `defineProvider` refuses one on an `mcp` connector, and has since that ADR: an MCP provider hands
+  the exchange to the SDK, which posts to the token endpoint with whatever `clientInformation()`
+  returned, and there is no seam to route that through a broker without reimplementing the SDK's
+  auth path. Building that seam is a large change to buy a browser round trip in place of a paste.
+- **Waiting.** Real, and cheap, and it is what "not yet supported" invites. It also means the two
+  services an agent working in a repository most obviously wants are absent for as long as two
+  vendors take.
+
+Both vendors do issue a credential for exactly this case, and both document sending it as
+`Authorization: Bearer` — GitHub a fine-grained personal access token, Slack the user token an
+installed app mints.
+
+## Decision
+
+**An `mcp` connector may authenticate with a token the operator pasted.** `auth: {kind: bearer}`
+already described that shape and `ensureStaticCredential` already collected it — the path iCloud's
+app-specific password takes. What did not work was sending it, and that is what this decision
+changed.
+
+Four call sites asked `CredentialOAuthProvider` for the token, which for a bearer manifest returns
+`null` rather than raising: its tokens ref is `<provider>/<connection>`, byte-identical to the ref a
+pasted token derives, so it read the token, failed to parse it as a JSON blob, and returned
+`undefined` by design. The connection then went upstream with no `Authorization` header at all — no
+error, an empty tool list, and nothing to read that said why. `connectivity/auth/token.ts` is the
+single answer now, and `#cli` no longer reaches into the OAuth provider to ask which token a
+manifest authenticates with.
+
+**An `mcp` connector's auth is exactly `none`, `oauth`, or `bearer`, and nothing else**, refused at
+definition. The transport sends one header and reads nothing else from the resolved credential, so
+`api_key`, `header`, and `basic` would each validate and then be dropped in silence — the same
+failure this decision exists to fix, left with a second door open. `bearer` may not rename its
+header here either, for the same reason.
+
+**`connector.headers` comes with it.** An `http` connector narrows what it exposes with
+`operations`, because it reads a document listing everything the API can do. An MCP server decides
+that itself and answers `tools/list` with whatever it chose, so where a vendor makes the choice
+configurable it is a header they define — GitHub's `X-MCP-Toolsets` being the case in hand.
+`Authorization` is refused there too: with both set, which one is sent would be merge order.
+
+## Consequences
+
+**Two guarantees are weaker for these providers, and `security.md` says so.**
+
+The credential is long-lived and *is* persisted. For an OAuth provider the stored secret is a
+refresh token — a means of obtaining a credential, exchanged on every use, with the access token
+never leaving memory. Here the stored value is the credential itself. Rotation is manual:
+`connect --replace`, after revoking upstream.
+
+There is no scope-disclosure gate. `confirmScopes` shows an operator what is about to be granted and
+refuses to proceed when the set has widened without being agreed. Nothing equivalent is possible
+for a pasted token: what it can do is chosen in the vendor's console, and this endpoint has no way
+to read it back. The policy layer still bounds what an agent may call; the credential's own reach is
+the operator's to bound, at the vendor, when they generate it. Both setup pages say so at the point
+the token is created.
+
+**Redaction cannot be checked.** `cli/tools.test.ts` verifies that every key in a `redact` block
+names a real argument, and can do so only for `http` providers — a proxied server's capabilities are
+discovered at connect time, so there is no local schema to check against. GitHub's and Slack's
+blocks were written from the tool schemas those servers publish rather than guessed, but a rename
+upstream fails the way that test exists to prevent: silently, with the value withheld and the log
+reading exactly as it does when redaction is working. `doctor`'s capability drift report is the
+signal to re-read them.
+
+**Slack costs a console visit and always will.** Creating a Slack app is the only way to obtain a
+user token, so `docs/connect.md` no longer claims no provider asks you to register anything. This is
+the first time that sentence has needed an exception, and pretending otherwise would be worse than
+the exception.
+
+**What this is not.** It is not a retreat from ADR-028. A hosted client remains the default wherever
+one can be used, and if either vendor ships DCR the change is one field in one manifest —
+`registration: dynamic` — because auth is orthogonal to connectivity here. The `bearer` path stays
+correct for every other MCP server behind an API key, which is the larger part of what this bought.

--- a/docs/detailed/adr/README.md
+++ b/docs/detailed/adr/README.md
@@ -40,6 +40,7 @@ Nothing in the codebase depends on it.
 | [030](030-a-profile-owns-its-skills-and-manifests.md) | Skills and provider manifests move into `data/<profile>/`; nothing is shared between profiles any more |
 | [031](031-sign-in-and-data-access-are-separate-projects.md) | Signing in and reaching Google data are separate Cloud projects; the second is where every Google-data client goes |
 | [032](032-a-stateless-endpoint-does-not-announce-its-tools.md) | `listChanged` is declared false because it is false; a reload reports its tool count and `lanes link tools` asks the endpoint |
+| [033](033-a-pasted-token-for-an-mcp-server.md) | Where a vendor's MCP server will not register a client, the operator's own token is the credential — so an mcp connector's auth is exactly none, oauth, or bearer |
 
 Where an ADR departs from init.md, it says so at the top. Three are significant:
 

--- a/docs/detailed/creating-a-provider.md
+++ b/docs/detailed/creating-a-provider.md
@@ -17,6 +17,23 @@ auth:      { kind: oauth, registration: dynamic }
 ```
 
 ```yaml
+# An MCP server that will not register a client for you — so you paste a token instead.
+# `headers` is for configuration the *server* offers; the credential is never one of them.
+id: acme_token
+name: Acme
+connector:
+  kind: mcp
+  endpoint: https://mcp.acme.com/mcp
+  headers: { X-Acme-Toolsets: "issues,repos" }
+auth: { kind: bearer }
+setup:
+  docs_url: https://acme.com/settings/tokens
+  steps: ["Generate a token at https://acme.com/settings/tokens and copy it."]
+  prompts:
+    - { key: token, label: Acme API token, secret: true, scope: connection }
+```
+
+```yaml
 # Any REST API with a spec. The method decides the bundle: GET/HEAD read, the rest write.
 id: mything
 name: My Thing

--- a/docs/detailed/security.md
+++ b/docs/detailed/security.md
@@ -43,7 +43,7 @@ damaging single mistake available.
 
 | | **Credentials** (`SecretStore`) | **Vault items** (M3) |
 |---|---|---|
-| What | refresh tokens, the profile token, and an OAuth client secret where the operator registered one of their own | the owner's own passwords, API keys |
+| What | refresh tokens, app-specific passwords, pasted API tokens, the profile token, and an OAuth client secret where the operator registered one of their own | the owner's own passwords, API keys |
 | Authorises | the system itself | nothing — they are data the owner stores |
 | Agent-reachable | **never, in any form** | yes, under policy, default deny |
 | Store | encrypted file, its own key | separate store, **separate key** |
@@ -188,6 +188,21 @@ Access tokens are derived at runtime and **cached in memory only, never persiste
 short-lived by design, so storing one would create a second credential to protect for no benefit.
 The cache is keyed per connection, so two accounts never share a token, and a stateless server
 starts cold with an empty cache.
+
+**Not every upstream credential is an OAuth token, and the ones that are not are weaker in two
+ways.** iCloud takes an app-specific password; GitHub and Slack take a token the operator generates
+and pastes, because neither vendor's MCP server will register a client for us (ADR-033). Such a
+credential is long-lived and *is* persisted — there is no refresh, so the stored value is the
+credential itself rather than a means of obtaining one. Rotation is manual: `connect --replace`,
+after revoking upstream.
+
+The second difference is the one worth saying out loud. For an OAuth provider, `connect` shows what
+is about to be granted and refuses to proceed if the scopes have widened without being agreed —
+`confirmScopes` is that gate. There is no equivalent here, and there cannot be: what a pasted token
+can do is chosen in the vendor's own console, and this endpoint has no way to read it back. So the
+guarantee for these providers is narrower — the policy layer still bounds what an agent may *call*,
+but the credential's own reach is the operator's to bound, at the vendor, when they create it. Both
+setup pages say so at the point the token is generated.
 
 **A Google Cloud project left in "Testing" publishing status expires refresh tokens after seven
 days.** That is a policy setting, not a bug, but it presents as an authentication failure on a

--- a/docs/detailed/setup/github.md
+++ b/docs/detailed/setup/github.md
@@ -1,0 +1,149 @@
+# Connecting GitHub
+
+Repositories, issues, pull requests, and workflow runs, through the MCP server
+GitHub runs.
+
+```
+lanes link connect github
+```
+
+You are asked for one fine-grained personal access token. There is no browser
+consent, no OAuth client, and nothing to register.
+
+## Why a token rather than OAuth
+
+Every other MCP-proxied provider here signs in through a browser. Notion and
+Linear support Dynamic Client Registration, so Lanes Link registers itself with
+their authorization server at connect time and the operator does nothing at all.
+
+GitHub does not offer that yet. The documented alternative — register an OAuth
+App or GitHub App of your own — fails on a detail that has nothing to do with
+GitHub's intent: an OAuth App matches its callback URL exactly, port included,
+and `connect` listens on `127.0.0.1` on a port the kernel picks per run. There
+is no port to register.
+
+GitHub's remote MCP server accepts a personal access token as
+`Authorization: Bearer`, which is the credential GitHub issues for exactly this
+case. See [ADR-033](../adr/033-a-pasted-token-for-an-mcp-server.md).
+
+## The token
+
+1. Open **[github.com/settings/personal-access-tokens](https://github.com/settings/personal-access-tokens)**
+   and choose **Generate new token**.
+2. Name it `Lanes Link`. The name is how you revoke this one later without
+   touching your other tokens. Set an expiry you are willing to renew.
+3. **Resource owner** — yourself, or the organisation whose repositories you
+   want reachable. An organisation may require an owner to approve the token
+   before it does anything, and until they do it authenticates and returns
+   nothing.
+4. **Repository access** — only the repositories you want an agent to see.
+   *All repositories* is the setting people regret.
+5. **Permissions**, matching the toolsets this connects:
+
+   | Permission | Level |
+   |---|---|
+   | Contents | Read |
+   | Metadata | Read *(added for you)* |
+   | Issues | Read and write |
+   | Pull requests | Read and write |
+   | Actions | Read |
+
+   Add *Administration* or *Workflows* only if you know you need them.
+6. **Generate**, then copy the token. GitHub shows it once, and it starts with
+   `github_pat_`.
+
+A classic token works too, with the `repo` scope, but it is all-or-nothing
+across every repository you can reach. Prefer the fine-grained one.
+
+The token goes into the encrypted credential store at `github/<login>`, never
+into config.
+
+## Renewing it
+
+A fine-grained token expires. When it does, generate another and run:
+
+```
+lanes link connect github --replace
+```
+
+Without `--replace`, connect finds the expired token already stored and reuses
+it. This is the same shape as iCloud's app-specific password, and for the same
+reason: the stored credential is the one that was just refused, so every other
+spelling of the command reuses it.
+
+## Which tools you get
+
+GitHub serves a different tool list per *toolset*, and this connection asks for
+`context`, `repos`, `issues`, `pull_requests`, `actions`, and `labels` — what an
+agent working in a repository actually uses. The full set is considerably
+larger and is more than most agents reason over well.
+
+If you want a narrower connection, GitHub also serves a read-only variant. It is
+a manifest of your own rather than a flag:
+
+```yaml
+# ~/.lanes-link/data/<profile>/providers.d/github-readonly.yaml
+id: github_readonly
+name: GitHub (read-only)
+connector:
+  kind: mcp
+  endpoint: https://api.githubcopilot.com/mcp/readonly
+auth:
+  kind: bearer
+identity:
+  kind: http
+  url: https://api.github.com/user
+  field: login
+setup:
+  prompts:
+    - key: token
+      label: GitHub personal access token
+      secret: true
+      scope: connection
+```
+
+That is a separate provider with its own token and its own policy line, which is
+the point — you can grant one profile the read-only connection and never the
+other.
+
+## Non-interactive
+
+GitHub is the straightforward case for an agent with a shell, because nothing
+here needs a browser:
+
+```console
+$ printf %s "$GITHUB_TOKEN" | lanes link secrets set github/octocat --profile personal
+$ lanes link connect github --id octocat --non-interactive --json --profile personal
+```
+
+The credential goes in on stdin, never as a flag — an argument lands in shell
+history, in `ps` output, and in any transcript.
+
+## What is recorded
+
+Reads are logged with every argument reduced to a type marker, which is the
+right default for a server whose capabilities we did not author. Writes keep
+their identifiers and withhold your words: an entry says which issue in which
+repository was closed, and by what method, and does not keep the body you typed.
+`src/providers/github/redact.ts` is the list, with the reasoning.
+
+One caveat stated rather than left to be discovered. Those argument names come
+from GitHub's published tool documentation, because a proxied server's
+capabilities are discovered at connect time rather than declared here — so
+unlike an `http` provider, nothing in this repository can check them. If GitHub
+renames an argument, the value is withheld and the log reads exactly as it does
+when redaction is working. `lanes link doctor` reporting capability drift is the
+signal that the list wants re-reading.
+
+## Troubleshooting
+
+**`GitHub refused the token`** — usually one of three things: the token expired,
+the repository was not in the set you granted, or an organisation token is still
+waiting on an owner's approval.
+
+**The connection is labelled with something you typed rather than your login** —
+the identity probe could not reach `api.github.com/user`, which nearly always
+means the token is wrong. Discovery fails a moment later with the real error.
+
+**A tool you expected is missing** — check the toolsets above. `lanes link status`
+lists what this connection actually discovered.

--- a/docs/detailed/setup/slack.md
+++ b/docs/detailed/setup/slack.md
@@ -1,0 +1,150 @@
+# Connecting Slack
+
+Messages, threads, channels, files, and canvases, through the MCP server Slack
+runs.
+
+```
+lanes link connect slack
+```
+
+You are asked for one user token. Getting that token means creating a Slack app
+first, which is the one console visit left in this project — and unlike Google's,
+it cannot be removed from your side.
+
+## Why there is a console visit
+
+Every other route is closed, and each for a different reason:
+
+- **Dynamic Client Registration** — the mechanism that makes Notion and Linear
+  cost nothing to connect. Slack's documentation is explicit: *"We do not
+  support SSE-based connections or Dynamic Client Registration at this time."*
+- **An OAuth client of your own** — the fallback used for Google. Slack requires
+  redirect URIs to be **HTTPS**, and `connect` listens on `http://127.0.0.1` on
+  a port the kernel picks per run. There is no flag, tunnel, or proxy that makes
+  a loopback listener HTTPS.
+- **A broker** — a client somebody else runs and performs the exchange behind.
+  Refused at definition for an MCP provider, because the SDK owns that exchange
+  and there is no seam to route it through one.
+
+What is left is the arrangement Slack's own documentation describes for a client
+that cannot register: install an app, take the user token, send it as
+`Authorization: Bearer`. See
+[ADR-033](../adr/033-a-pasted-token-for-an-mcp-server.md).
+
+## Creating the app
+
+1. Open **[api.slack.com/apps](https://api.slack.com/apps)** → **Create New App**
+   → **From scratch**. Name it `Lanes Link` and pick your workspace.
+2. Open **OAuth & Permissions** and scroll to **Scopes**.
+3. Add the following under **User Token Scopes**. Not *Bot* Token Scopes — the
+   MCP server reads the user token, and scopes added to the wrong list produce
+   an app that installs cleanly and then refuses every call.
+
+   | | Scopes |
+   |---|---|
+   | Search | `search:read.public` `search:read.private` `search:read.im` `search:read.mpim` `search:read.users` `search:read.files` |
+   | Read messages | `channels:history` `groups:history` `im:history` `mpim:history` |
+   | Channels and people | `channels:read` `groups:read` `mpim:read` `users:read` |
+   | Send | `chat:write` |
+   | Files | `files:read` |
+
+   Optional, if you want those tools to work: `reactions:write` for reactions,
+   `canvases:read` and `canvases:write` for canvases, `emoji:read` for emoji
+   search, `channels:write` for creating channels. Slack lists every tool
+   regardless of scope and refuses at call time, so a missing scope looks like a
+   tool that exists and does not work.
+
+4. Scroll back up and choose **Install to Workspace**, then approve. A workspace
+   admin may have to approve it on your behalf.
+5. Copy the **User OAuth Token** from the same page. It begins with `xoxp-`.
+
+> The token beginning `xoxb-` on that page is the **bot** token. It is the more
+> prominent of the two and it will not work here — a bot is a different identity
+> with different visibility, and the MCP server expects yours.
+
+The token goes into the encrypted credential store at `slack/<username>`, never
+into config.
+
+## What a user token means
+
+It acts as **you**. Anything you can see in Slack — private channels you are in,
+your DMs, your group DMs — is reachable through this connection, bounded by the
+scopes above and by your Lanes Link policy, not by a separate permission model.
+That is the point of a user token rather than a bot token, and it is also the
+thing to be deliberate about.
+
+Two consequences worth stating:
+
+- **The token does not expire** unless you enable token rotation on the app.
+  There is no refresh, so nothing renews it and nothing revokes it on a
+  schedule. Revoking means uninstalling the app, or rotating it from
+  **OAuth & Permissions**.
+- **Narrowing is yours to do**, in two places. Fewer scopes at install time is
+  the coarse control. `lanes link policy deny slack.send_message slack.<you>` is
+  the fine one, and it is instant and local.
+
+After rotating or reinstalling — either mints a new token — run:
+
+```
+lanes link connect slack --replace
+```
+
+Without `--replace`, connect finds the old token already stored and reuses it.
+
+## Which account this is
+
+The connection is labelled with your Slack **username**, read from
+`auth.test`, rather than the workspace name. That matters if two people connect
+Slack on the same machine: labelled by workspace, the second connection would
+look like a reconnect of the first and overwrite their credential.
+
+A quirk to know when something goes wrong: Slack answers a bad token with HTTP
+`200` and `{"ok": false}` rather than a `401`, so a wrong token does not fail
+the identity probe cleanly — you are asked "which account is this?" instead, and
+the real error arrives a step later when discovery runs.
+
+## Non-interactive
+
+```console
+$ printf %s "$SLACK_TOKEN" | lanes link secrets set slack/ada --profile personal
+$ lanes link connect slack --id ada --non-interactive --json --profile personal
+```
+
+The credential goes in on stdin, never as a flag — an argument lands in shell
+history, in `ps` output, and in any transcript.
+
+## What is recorded
+
+Where a message went is kept; what it said is not. An audit entry for
+`send_message` records the channel, the thread, and whether it was broadcast,
+and reduces `message` to a type marker — the same line Gmail draws for mail,
+because it is the same object. `src/providers/slack/redact.ts` is the list, with
+the reasoning for each.
+
+`create_canvas` keeps nothing at all, and that is deliberate rather than an
+omission: a canvas has no identifier until Slack answers with one, so its only
+arguments are the title and the document. There is nothing to keep that is not
+content.
+
+One caveat, the same as GitHub's. A proxied server's capabilities are discovered
+at connect time rather than declared here, so nothing in this repository can
+check those argument names — unlike an `http` provider, where
+`cli/tools.test.ts` does. They were read off the schemas Slack's server
+publishes rather than guessed, but a rename upstream fails silently, with the
+log reading exactly as it does when redaction is working. `lanes link doctor`
+reporting capability drift is the signal that the list wants re-reading.
+
+## Troubleshooting
+
+**`Slack refused the token`** — nearly always one of three: a bot token
+(`xoxb-`) pasted where the user token (`xoxp-`) belongs, a scope added under Bot
+Token Scopes rather than User Token Scopes, or an app reinstalled since the
+token was copied. Reinstalling mints a new one.
+
+**A tool exists but every call fails** — a missing scope. Slack lists its whole
+tool set regardless of what your token can do. Add the scope under User Token
+Scopes, reinstall, and reconnect with `--replace`.
+
+**The connection is labelled with something you typed** — the identity probe did
+not get a username back, which for Slack means the token was refused. See the
+quirk above.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lanes-sh/link",
-  "version": "0.1.2",
+  "version": "0.2.0",
   "description": "A self-hostable MCP gateway for all your connections, memory, skills, and secrets",
   "license": "Apache-2.0",
   "homepage": "https://lanes.sh/link",

--- a/src/cli/commands/connect/authorise.ts
+++ b/src/cli/commands/connect/authorise.ts
@@ -21,7 +21,14 @@ import { ensureOAuthApp } from './setup.ts';
  * nothing and the manifest has to name its endpoints.
  */
 
-export function oauthProviderFor(
+/**
+ * No longer exported. `#cli` used to reach for this to answer "what token does
+ * this manifest authenticate with", which is a question the auth component
+ * owns — and answering it here is what let a `bearer` manifest slip through
+ * returning null. `bearerTokenAsStored` is the answer now; this builds the
+ * provider for the browser flow below, which is the one thing it is for.
+ */
+function oauthProviderFor(
   manifest: ProviderManifest,
   connectionId: string,
   credentials: SecretStore,

--- a/src/cli/commands/connect/index.ts
+++ b/src/cli/commands/connect/index.ts
@@ -1,4 +1,5 @@
 import { createMcpConnector } from '#connectivity/transports';
+import { bearerTokenAsStored } from '#connectivity/auth/index.ts';
 import type { DiscoveredCapability } from '#connectivity';
 import { credentialRefForConnection, WRITE_BUNDLE } from '#connectivity';
 import { ConfigDocument, ensureSetupConnection, repaired } from '../../config-edit.ts';
@@ -6,7 +7,7 @@ import { emit, print, progress, style } from '../../output.ts';
 import { nonInteractivePrompter, terminalPrompter, type Prompter } from '../../prompt.ts';
 import { openRuntime, type GlobalFlags } from '../../runtime.ts';
 import { credentialApp, matchesRule, moveCredential, siblingAccountId } from './accounts.ts';
-import { authorise, oauthProviderFor } from './authorise.ts';
+import { authorise } from './authorise.ts';
 import { preflight } from './requirements.ts';
 import { ALREADY, NOTHING, renderOutcome, type ConnectOutcome } from './outcome.ts';
 import { nextAfterEdit, publishRuntimeEdit } from '#cli/publish.ts';
@@ -266,17 +267,15 @@ async function runConnect(target: string, options: ConnectOptions): Promise<Conn
 
       // MCP is the one kind that does not use the runtime's connector here: it
       // wants the token exactly as just written, without the refresh machinery
-      // that `resolveUpstreamToken` wraps around it. Every other kind carries
-      // whatever credential it needs from the factory.
+      // that `bearerToken` wraps around it. Every other kind carries whatever
+      // credential it needs from the factory.
       const connector =
         manifest.connector.kind === 'mcp'
           ? createMcpConnector({
               endpoint: manifest.connector.endpoint,
-              accessToken: async () => {
-                const provider = oauthProviderFor(manifest, connectionId, runtime.credentials);
-                const tokens = (await provider.tokens()) as { access_token?: string } | undefined;
-                return tokens?.access_token ?? null;
-              },
+              ...(manifest.connector.headers ? { headers: manifest.connector.headers } : {}),
+              accessToken: () =>
+                bearerTokenAsStored(manifest, connectionId, runtime.credentials),
             })
           : runtime.connectorFor(providerId, connectionId);
 

--- a/src/cli/commands/connect/settle.ts
+++ b/src/cli/commands/connect/settle.ts
@@ -1,4 +1,5 @@
 import { createMcpConnector } from '#connectivity/transports';
+import { bearerTokenAsStored } from '#connectivity/auth/index.ts';
 import type { SecretStore } from '#secrets';
 import type { Config } from '#profile';
 import type { AnyConnector, ProviderManifest } from '#connectivity';
@@ -6,7 +7,6 @@ import { idFromAccount, resolveAccount } from '../../identity.ts';
 import { style } from '../../output.ts';
 import { terminalPrompter, type Prompter } from '../../prompt.ts';
 import { accountSiblings } from './accounts.ts';
-import { oauthProviderFor } from './authorise.ts';
 
 /**
  * Settle which connection this is, and whose account it belongs to.
@@ -49,12 +49,10 @@ export async function settleIdentity(input: {
   }
 
   if (!account) {
+    const token = () => bearerTokenAsStored(manifest, provisionalId, runtime.credentials);
+
     account = await resolveAccount(manifest, {
-      accessToken: async () => {
-        const provider = oauthProviderFor(manifest, provisionalId, runtime.credentials);
-        const tokens = (await provider.tokens()) as { access_token?: string } | undefined;
-        return tokens?.access_token ?? null;
-      },
+      accessToken: token,
       // A protocol that authenticates by username has nothing to GET and no
       // tool to call — it knows, once the server has accepted the login.
       identify: async () =>
@@ -62,13 +60,18 @@ export async function settleIdentity(input: {
       ...(manifest.connector.kind === 'mcp'
         ? {
             callTool: async (name: string, args: Record<string, unknown>) => {
+              // Cast for the same reason `endpoint` already was: the
+              // narrowing that reached this branch does not survive into the
+              // closure. Named field by field rather than spread, so a future
+              // connector field does not silently become a transport option.
+              const mcp = manifest.connector as {
+                endpoint: string;
+                headers?: Record<string, string>;
+              };
               const connector = createMcpConnector({
-                endpoint: (manifest.connector as { endpoint: string }).endpoint,
-                accessToken: async () => {
-                  const provider = oauthProviderFor(manifest, provisionalId, runtime.credentials);
-                  const tokens = (await provider.tokens()) as { access_token?: string } | undefined;
-                  return tokens?.access_token ?? null;
-                },
+                endpoint: mcp.endpoint,
+                ...(mcp.headers ? { headers: mcp.headers } : {}),
+                accessToken: token,
               });
               return connector.invoke({ name, inputSchema: {}, description: '' } as never, args, {
                 manifest,

--- a/src/connectivity/auth/README.md
+++ b/src/connectivity/auth/README.md
@@ -3,7 +3,8 @@
 One folder per method. Each owns both halves of its job: `resolve*` turns the
 stored secret into a `ResolvedCredential`, and `attach*` puts that shape on an
 outbound request. `resolve.ts` and `authorize.ts` are the only files that know
-the whole set.
+the whole set — plus `token.ts`, which answers the narrower question a
+transport asks when it has a token to send and no request to attach it to.
 
 | Folder | `auth.kind` | What is stored |
 |---|---|---|

--- a/src/connectivity/auth/index.ts
+++ b/src/connectivity/auth/index.ts
@@ -3,8 +3,9 @@
  *
  * One folder per method, each owning both halves of its job: turning the stored
  * secret into a resolved shape (`resolve*`) and putting that shape on an
- * outbound request (`attach*`). The two dispatchers here are the only files
- * that know the whole set.
+ * outbound request (`attach*`). The dispatchers here are the only files that
+ * know the whole set: `resolve.ts` and `authorize.ts` for anything HTTP-shaped,
+ * and `token.ts` for a transport that takes a bare token instead of a request.
  *
  * This is the axis the manifest's `auth:` block selects, and it is deliberately
  * independent of `../transports/` — which is why iCloud can speak IMAP with a
@@ -15,6 +16,7 @@
 export { credentialResolver, type ResolvedCredential } from './resolve.ts';
 export { requestAuthorizer } from './authorize.ts';
 export { basicCredential } from './basic/index.ts';
+export { bearerToken, bearerTokenAsStored } from './token.ts';
 export {
   CredentialOAuthProvider,
   clearUpstreamTokens,

--- a/src/connectivity/auth/resolve.test.ts
+++ b/src/connectivity/auth/resolve.test.ts
@@ -5,6 +5,8 @@ import { defineProvider } from '#connectivity';
 import { connectorFactory } from '#connectivity/transports';
 import { requestAuthorizer } from './authorize.ts';
 import { credentialResolver } from './resolve.ts';
+import { bearerToken, bearerTokenAsStored } from './token.ts';
+import { clearUpstreamTokens } from './oauth-authcode/provider.ts';
 
 /**
  * The factory's cache, which for a long time did not exist.
@@ -190,5 +192,97 @@ describe('requestAuthorizer', () => {
 
     expect((await sent(authorize, 'one')).headers.get('authorization')).toBe('Bearer A');
     expect((await sent(authorize, 'two')).headers.get('authorization')).toBe('Bearer B');
+  });
+});
+
+/**
+ * The token a transport sends when it has no `Request` to authorise.
+ *
+ * An mcp connector sends `Authorization: Bearer <token>` and nothing else, so
+ * it takes a token rather than a request — and two unrelated arrangements
+ * produce one. Every caller used to ask the OAuth provider, which answered
+ * `null` for a pasted token instead of raising: the ref it reads is identical,
+ * so it found the token, failed to parse it as a JSON blob, and returned
+ * undefined by design. The connection then went upstream unauthenticated.
+ */
+
+const MCP = { kind: 'mcp', endpoint: 'https://mcp.test/mcp' } as const;
+
+const mcpProvider = (auth: Record<string, unknown>) =>
+  defineProvider({ id: 'acme3', name: 'Acme3', connector: MCP, auth });
+
+const future = () => Date.now() + 3_600_000;
+
+describe('bearerToken', () => {
+  test('a pasted token comes back exactly as stored', async () => {
+    const credentials = createMemoryCredentials({ 'acme3/main': 'a-pasted-token' });
+
+    expect(await bearerToken(mcpProvider({ kind: 'bearer' }), 'main', credentials)).toBe(
+      'a-pasted-token',
+    );
+  });
+
+  test('an oauth provider comes back as its access token', async () => {
+    clearUpstreamTokens();
+    const credentials = createMemoryCredentials({
+      'acme3/live': JSON.stringify({ access_token: 'AT', expires_at: future() }),
+    });
+
+    const manifest = mcpProvider({ kind: 'oauth', registration: 'dynamic' });
+    expect(await bearerToken(manifest, 'live', credentials)).toBe('AT');
+  });
+
+  test('a provider that authenticates to nothing has no token', async () => {
+    const manifest = defineProvider({ id: 'acme3', name: 'Acme3', connector: MCP });
+
+    expect(await bearerToken(manifest, 'main', createMemoryCredentials({}))).toBeNull();
+  });
+
+  test('a missing credential raises, naming the ref and the command', async () => {
+    // The regression this whole helper exists for. `null` here is a request
+    // sent with no Authorization header at all: no error, an empty tool list,
+    // and nothing to read that says why.
+    const promise = bearerToken(mcpProvider({ kind: 'bearer' }), 'main', createMemoryCredentials({}));
+
+    expect(promise).rejects.toThrow(/No credential stored at acme3\/main.*lanes link connect acme3/s);
+  });
+
+  test('a credential that cannot be a bearer token says which kind it is', async () => {
+    // Unreachable through `defineProvider`, which refuses these on an mcp
+    // connector — so this is the pin that keeps the guard and this switch from
+    // drifting apart quietly if either is ever relaxed.
+    const manifest = defineProvider({ id: 'acme3', name: 'Acme3', connector: HTTP, auth: { kind: 'basic' } });
+    const credentials = createMemoryCredentials({ 'acme3/main': 'ada:secret' });
+
+    expect(bearerToken(manifest, 'main', credentials)).rejects.toThrow(/"basic"/);
+  });
+});
+
+describe('bearerTokenAsStored', () => {
+  test('an expired oauth token is handed back rather than refreshed', async () => {
+    // What `connect` needs: the token exactly as just written. Refreshing here
+    // would spend a network round trip on a token seconds old, and would cache
+    // it under the provisional connection id — a key naming a connection that
+    // stops existing a moment later.
+    clearUpstreamTokens();
+    const credentials = createMemoryCredentials({
+      'acme3/pending': JSON.stringify({
+        access_token: 'STALE',
+        refresh_token: 'R',
+        expires_at: Date.now() - 1_000,
+      }),
+    });
+
+    const manifest = mcpProvider({ kind: 'oauth', registration: 'dynamic' });
+    expect(await bearerTokenAsStored(manifest, 'pending', credentials)).toBe('STALE');
+  });
+
+  test('a pasted token reads the same either way, having no other reading', async () => {
+    const credentials = createMemoryCredentials({ 'acme3/main': 'a-pasted-token' });
+    const manifest = mcpProvider({ kind: 'bearer' });
+
+    expect(await bearerTokenAsStored(manifest, 'main', credentials)).toBe(
+      await bearerToken(manifest, 'main', credentials),
+    );
   });
 });

--- a/src/connectivity/auth/token.ts
+++ b/src/connectivity/auth/token.ts
@@ -1,0 +1,93 @@
+import { type ProviderManifest } from '#connectivity';
+import type { ProviderRegistry } from '#registry';
+import type { SecretStore } from '#secrets';
+import { credentialResolver } from './resolve.ts';
+import { CredentialOAuthProvider } from './oauth-authcode/provider.ts';
+
+/**
+ * The bearer token for one connection, whichever way the provider came by it.
+ *
+ * An mcp connector sends `Authorization: Bearer <token>` and nothing else, so
+ * it takes a token rather than a `Request` to authorise — the same shape
+ * `basicCredential` has for IMAP and DAV, and for the same reason: a transport
+ * that has no `Request` to hand an authorizer gets its credential as a bound
+ * closure instead.
+ *
+ * What lives here that does not live in `./bearer/` is the *dispatch*. Two
+ * unrelated arrangements produce a bearer token — an OAuth access token
+ * exchanged on every use, and a long-lived one the operator pasted — and the
+ * caller does not care which, only the manifest does. Putting that choice in
+ * the bearer folder would make the folder that owns one method know about
+ * another; putting it in `oauth-authcode/` would make the OAuth folder answer
+ * for a token no OAuth flow ever produced.
+ *
+ * Before this existed, every caller asked `CredentialOAuthProvider` for the
+ * token, and a manifest declaring `bearer` got `null` back rather than an
+ * error: the provider's tokens ref is `<provider>/<connection>`, byte-identical
+ * to the ref a pasted token derives, so it read the token, failed to parse it
+ * as a JSON blob, and returned undefined by design. The connection then went
+ * upstream with no `Authorization` header at all.
+ */
+
+/** One manifest, dressed as a registry, so the resolver needs no lookup. */
+const only = (manifest: ProviderManifest): ProviderRegistry =>
+  ({ manifest: () => manifest }) as unknown as ProviderRegistry;
+
+/**
+ * Throws where the manifest declares a credential and none is stored:
+ * `credentialResolver` already says which ref is empty and which command fills
+ * it, which beats a `null` that reaches the server as a missing header.
+ */
+export async function bearerToken(
+  manifest: ProviderManifest,
+  connectionId: string,
+  secrets: SecretStore,
+): Promise<string | null> {
+  const resolved = await credentialResolver(only(manifest), secrets)(manifest.id, connectionId);
+
+  switch (resolved.kind) {
+    case 'none':
+      return null;
+    case 'oauth':
+      return resolved.accessToken;
+    case 'bearer':
+      return resolved.token;
+    default:
+      // Unreachable: `defineProvider` refuses every other kind on an mcp
+      // connector. Kept so the guard and this switch cannot drift apart
+      // silently — if one is ever relaxed, the other says so.
+      throw new Error(
+        `Provider "${manifest.id}" resolves to a "${resolved.kind}" credential, which cannot be sent as a bearer token.`,
+      );
+  }
+}
+
+/**
+ * The same token, read exactly as stored, without the refresh machinery.
+ *
+ * For `connect`: it has just written the token and wants that one, not a
+ * refreshed one. Going through `bearerToken` there would populate the process's
+ * access-token cache under the provisional connection id — `linear.pending`,
+ * a key naming a connection that will not exist a moment later — and could
+ * spend a network round trip re-exchanging a token written seconds ago.
+ *
+ * Identical to `bearerToken` for every non-OAuth kind, because a stored token
+ * has no other reading.
+ */
+export async function bearerTokenAsStored(
+  manifest: ProviderManifest,
+  connectionId: string,
+  secrets: SecretStore,
+): Promise<string | null> {
+  if (manifest.auth.kind !== 'oauth') return bearerToken(manifest, connectionId, secrets);
+
+  const provider = new CredentialOAuthProvider({
+    manifest,
+    connectionId,
+    credentials: secrets,
+    scopes: manifest.auth.scopes,
+  });
+
+  const tokens = (await provider.tokens()) as { access_token?: string } | undefined;
+  return tokens?.access_token ?? null;
+}

--- a/src/connectivity/manifest/connector.ts
+++ b/src/connectivity/manifest/connector.ts
@@ -17,6 +17,21 @@ import { z } from 'zod';
 export const mcpConnectorSchema = z.object({
   kind: z.literal('mcp'),
   endpoint: z.url(),
+  /**
+   * Sent on every request to this server, discovery included.
+   *
+   * The `http` connector filters what it exposes with `operations` above,
+   * because it reads a document listing everything the API can do. An mcp
+   * server decides that for itself and answers `tools/list` with whatever it
+   * chose — so where a vendor makes the choice configurable, the configuration
+   * is a header they define. GitHub's `X-MCP-Toolsets` is the case in hand: the
+   * default is broad and `all` is broader, and this is the only way to ask for
+   * less.
+   *
+   * Never `Authorization` — that one belongs to `auth:`, and the check in
+   * `./provider.ts` refuses it rather than letting the two disagree silently.
+   */
+  headers: z.record(z.string(), z.string()).optional(),
 });
 
 /**

--- a/src/connectivity/manifest/manifest.test.ts
+++ b/src/connectivity/manifest/manifest.test.ts
@@ -80,6 +80,57 @@ describe('defineProvider cross-field rules', () => {
   });
 });
 
+describe('what an mcp connector may authenticate with', () => {
+  /**
+   * The transport sends one header and only one. Every rule here exists
+   * because the alternative is a manifest that validates, connects, and comes
+   * back with an empty tool list — no error anywhere to say the credential
+   * never left the machine.
+   */
+  const mcp = (auth: Record<string, unknown>, connector: Record<string, unknown> = {}) =>
+    defineProvider({
+      id: 'vendor_mcp',
+      name: 'Vendor',
+      connector: { kind: 'mcp', endpoint: 'https://mcp.example.com/mcp', ...connector },
+      auth,
+    });
+
+  test('the three kinds it can actually send are accepted', () => {
+    expect(() => mcp({ kind: 'none' })).not.toThrow();
+    expect(() => mcp({ kind: 'oauth', registration: 'dynamic' })).not.toThrow();
+    expect(() => mcp({ kind: 'bearer' })).not.toThrow();
+  });
+
+  test('a credential the transport has nowhere to put is refused', () => {
+    // Not a style preference: `api_key` wants a query string or a header of
+    // its own, `basic` a different scheme entirely. The transport reads only
+    // the token, so each of these would be dropped in silence.
+    expect(() => mcp({ kind: 'api_key' })).toThrow(/must be "none", "oauth", or "bearer"/);
+    expect(() => mcp({ kind: 'header', header: 'X-Token' })).toThrow(/nowhere else on the request/);
+    expect(() => mcp({ kind: 'basic' })).toThrow(/must be "none", "oauth", or "bearer"/);
+    expect(() => mcp({ kind: 'strategy', strategy: 'bunq' })).toThrow(/"strategy"/);
+  });
+
+  test('bearer may not rename its header here, though the schema allows it', () => {
+    // `resolveBearer` honours a chosen header and the mcp transport never
+    // reads it, so this is the same silent drop one field further in.
+    expect(() => mcp({ kind: 'bearer', header: 'x-auth' })).toThrow(/cannot be honoured/);
+    expect(() => mcp({ kind: 'bearer' })).not.toThrow();
+  });
+
+  test('connector headers may not claim Authorization, in any casing', () => {
+    // Configuration the *server* offers, not a second place to put the
+    // credential. Both set, which one wins is merge order.
+    expect(() => mcp({ kind: 'bearer' }, { headers: { 'X-MCP-Toolsets': 'issues' } })).not.toThrow();
+    expect(() => mcp({ kind: 'bearer' }, { headers: { Authorization: 'Bearer x' } })).toThrow(
+      /may not set "Authorization"/,
+    );
+    expect(() => mcp({ kind: 'bearer' }, { headers: { authorization: 'Bearer x' } })).toThrow(
+      /the credential comes from auth/,
+    );
+  });
+});
+
 describe('a broker as the other answer to "where does the client come from"', () => {
   const broker = { url: 'https://api.example.com/v1/auth/link/vendor', operator: 'Someone' };
   const oauth = (extra: Record<string, unknown> = {}) => ({

--- a/src/connectivity/manifest/provider.ts
+++ b/src/connectivity/manifest/provider.ts
@@ -196,6 +196,45 @@ export function defineProvider(input: unknown): ProviderManifest {
     );
   }
 
+  if (manifest.connector.kind === 'mcp') {
+    const auth = manifest.auth;
+
+    // The transport sends exactly one header, `Authorization: Bearer <token>`,
+    // because that is what the MCP specification says a client sends. Every
+    // other token kind puts the secret somewhere the transport has nowhere to
+    // put it: `api_key` in a query string or a named header, `header` under a
+    // name of its own, `basic` in a different scheme entirely. Such a manifest
+    // validates and then connects *unauthenticated* — no error, an empty tool
+    // list, and nothing to read that says why.
+    if (auth.kind !== 'none' && auth.kind !== 'oauth' && auth.kind !== 'bearer') {
+      throw new Error(
+        `Provider "${manifest.id}": an mcp connector authenticates with "Authorization: Bearer", so its auth must be "none", "oauth", or "bearer" — not "${auth.kind}". There is nowhere else on the request for the transport to put a credential.`,
+      );
+    }
+
+    // Same failure, one field further in. `bearer` may rename its header, and
+    // `resolveBearer` honours that — but the mcp transport does not read the
+    // resolved credential at all, only the token, so a renamed header would be
+    // silently ignored and the token sent under `Authorization` regardless.
+    if (auth.kind === 'bearer' && auth.header) {
+      throw new Error(
+        `Provider "${manifest.id}": an mcp connector always sends its token as "Authorization: Bearer", so auth.header ("${auth.header}") cannot be honoured. Remove it, or reach this service with an http connector.`,
+      );
+    }
+
+    // The third spelling of the same collision. Connector headers are for what
+    // the *server* offers as configuration; the credential is the auth block's,
+    // and a manifest setting both would have one quietly overwrite the other
+    // depending on which the transport merged last.
+    for (const name of Object.keys(manifest.connector.headers ?? {})) {
+      if (name.toLowerCase() === 'authorization') {
+        throw new Error(
+          `Provider "${manifest.id}": connector.headers may not set "${name}" — the credential comes from auth, and setting both would leave which one is sent up to merge order.`,
+        );
+      }
+    }
+  }
+
   const names = new Set<string>();
   for (const bundle of manifest.bundles ?? []) {
     if (names.has(bundle.name)) {

--- a/src/connectivity/transports/factory.ts
+++ b/src/connectivity/transports/factory.ts
@@ -2,7 +2,7 @@ import type { AnyConnector, ProviderDefinition, ProviderManifest } from '#connec
 import type { SecretStore } from '#secrets';
 import type { ProviderRegistry } from '#registry';
 import { basicCredential } from '#connectivity/auth/basic/index.ts';
-import { resolveUpstreamToken } from '#connectivity/auth/oauth-authcode/index.ts';
+import { bearerToken } from '#connectivity/auth/token.ts';
 import { createCompositeConnector } from './composite/index.ts';
 import { createDavConnector } from './dav/index.ts';
 import { createFsConnector } from './fs/index.ts';
@@ -114,7 +114,11 @@ function build(
     case 'mcp':
       return createMcpConnector({
         endpoint: manifest.connector.endpoint,
-        accessToken: () => resolveUpstreamToken(manifest, connectionId, options.credentials),
+        ...(manifest.connector.headers ? { headers: manifest.connector.headers } : {}),
+        // Not `resolveUpstreamToken` directly: that one answers only for OAuth,
+        // and returns null for a provider whose token the operator pasted —
+        // which reaches the server as a missing header rather than an error.
+        accessToken: () => bearerToken(manifest, connectionId, options.credentials),
       });
 
     case 'imap':

--- a/src/connectivity/transports/mcp/index.ts
+++ b/src/connectivity/transports/mcp/index.ts
@@ -24,6 +24,8 @@ export interface McpConnectorOptions {
   readonly endpoint: string;
   /** Supplies the bearer token for an upstream call; refreshes if needed. */
   readonly accessToken: () => Promise<string | null>;
+  /** Whatever the manifest's connector declares, sent on every request. */
+  readonly headers?: Record<string, string> | undefined;
   readonly fetch?: typeof globalThis.fetch;
 }
 
@@ -127,7 +129,14 @@ export function createMcpConnector(options: McpConnectorOptions): Connector {
 
     const transport = new StreamableHTTPClientTransport(new URL(options.endpoint), {
       requestInit: {
-        headers: token ? { authorization: `Bearer ${token}` } : {},
+        // The declared headers first, so the credential cannot be displaced by
+        // one. `defineProvider` already refuses a declared `Authorization`, and
+        // this order means a manifest loaded some other way fails safe rather
+        // than sending someone else's header in its place.
+        headers: {
+          ...(options.headers ?? {}),
+          ...(token ? { authorization: `Bearer ${token}` } : {}),
+        },
       },
       ...(options.fetch ? { fetch: options.fetch } : {}),
     } as never);

--- a/src/connectivity/transports/mcp/mcp.test.ts
+++ b/src/connectivity/transports/mcp/mcp.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from 'bun:test';
-import { inferBundle, readableUpstreamError, shortenName } from './index.ts';
+import { defineProvider } from '#connectivity';
+import { createMcpConnector, inferBundle, readableUpstreamError, shortenName } from './index.ts';
 
 describe('shortening a redundantly prefixed name', () => {
   test('drops the provider prefix', () => {
@@ -86,5 +87,74 @@ describe('upstream errors are readable', () => {
   test('passes through an error carrying no body', () => {
     const raw = new Error('fetch failed');
     expect(readableUpstreamError(raw, 'https://mcp.linear.app/mcp').message).toBe('fetch failed');
+  });
+});
+
+/**
+ * What goes out on the wire.
+ *
+ * An `http` connector narrows itself with `operations`, because it reads a
+ * document listing everything the API can do. An mcp server decides that for
+ * itself, so where a vendor makes the choice configurable it is a header they
+ * define — GitHub's `X-MCP-Toolsets` being the case in hand. Declaring one and
+ * having it silently not sent would look exactly like the vendor ignoring it.
+ */
+describe('the headers a connection carries', () => {
+  const manifest = defineProvider({
+    id: 'vendor_mcp',
+    name: 'Vendor',
+    connector: {
+      kind: 'mcp',
+      endpoint: 'https://mcp.example.test/mcp',
+      headers: { 'X-MCP-Toolsets': 'issues,repos' },
+    },
+    auth: { kind: 'bearer' },
+  });
+
+  /** The first request the SDK makes, whatever it then does with the answer. */
+  async function firstRequest(token: string | null): Promise<Headers> {
+    let seen: Headers | undefined;
+
+    const connector = createMcpConnector({
+      endpoint: 'https://mcp.example.test/mcp',
+      headers: { 'X-MCP-Toolsets': 'issues,repos' },
+      accessToken: async () => token,
+      fetch: (async (_input: unknown, init?: { headers?: Record<string, string> }) => {
+        seen ??= new Headers(init?.headers);
+        throw new Error('captured');
+      }) as unknown as typeof globalThis.fetch,
+    });
+
+    // Only the request matters; the handshake is expected to fail on it.
+    await connector.discover({ manifest }).catch(() => {});
+
+    expect(seen).toBeDefined();
+    return seen!;
+  }
+
+  test('declared headers are sent alongside the credential', async () => {
+    const headers = await firstRequest('a-pasted-token');
+
+    expect(headers.get('x-mcp-toolsets')).toBe('issues,repos');
+    expect(headers.get('authorization')).toBe('Bearer a-pasted-token');
+  });
+
+  test('the credential wins the header it owns', async () => {
+    // `defineProvider` refuses a declared `Authorization`, so this pins the
+    // merge order that makes that refusal belt-and-braces rather than the only
+    // thing standing between a token and being displaced.
+    const headers = await firstRequest('a-pasted-token');
+
+    expect(headers.get('authorization')).not.toBe('Bearer displaced');
+  });
+
+  test('no credential means no header, not an empty one', async () => {
+    // A provider with `auth: none` proxies a server that wants nothing. An
+    // `Authorization: Bearer ` would be a malformed credential rather than an
+    // absent one, and servers answer the two differently.
+    const headers = await firstRequest(null);
+
+    expect(headers.has('authorization')).toBe(false);
+    expect(headers.get('x-mcp-toolsets')).toBe('issues,repos');
   });
 });

--- a/src/providers/github/index.ts
+++ b/src/providers/github/index.ts
@@ -1,0 +1,68 @@
+import { defineProvider } from '#connectivity';
+import { GITHUB_REDACT } from './redact.ts';
+
+/**
+ * GitHub, through the server GitHub runs.
+ *
+ * Not OAuth, and not for want of trying. GitHub's remote MCP server does not
+ * offer Dynamic Client Registration — the thing that makes Notion and Linear
+ * cost fifteen lines — so there is no client to register ourselves as. A client
+ * of the operator's own is the documented fallback everywhere else, and it
+ * fails here on a detail: an OAuth App matches its callback URL exactly,
+ * including the port, and `connect` listens on a port the kernel picks. What is
+ * left is the credential GitHub does issue for exactly this — a token you
+ * generate once and paste. See ADR-033.
+ *
+ * The toolsets header is the whole reason `connector.headers` exists. GitHub
+ * serves a different tool list per toolset and `all` is far more than an agent
+ * reasons over; this asks for the ones an agent working in a repository
+ * actually uses. It is one string to change, and `docs/detailed/setup/github.md`
+ * records the read-only variant for someone who wants a narrower connection.
+ */
+export const github = defineProvider({
+  id: 'github',
+  name: 'GitHub',
+  description: 'Repositories, issues, pull requests, and workflow runs, via GitHub\'s official MCP server.',
+  connector: {
+    kind: 'mcp',
+    endpoint: 'https://api.githubcopilot.com/mcp/',
+    headers: { 'X-MCP-Toolsets': 'context,repos,issues,pull_requests,actions,labels' },
+  },
+  auth: { kind: 'bearer' },
+  // GitHub's own MCP server answers `get_me`, so a tool identity would work.
+  // This asks the REST API instead, for one reason: it is a plain GET that
+  // costs no MCP handshake, and `connect` runs it before discovery — so when
+  // the token is wrong, the thing that fails is the cheap call rather than the
+  // expensive one.
+  identity: { kind: 'http', url: 'https://api.github.com/user', field: 'login' },
+  redact: GITHUB_REDACT,
+  setup: {
+    summary:
+      'GitHub issues a fine-grained personal access token for this. There is no OAuth app to register: ' +
+      'GitHub\'s MCP server does not support the dynamic registration Notion and Linear use, and an OAuth ' +
+      'app of your own would need a fixed callback port, which this CLI does not have. You are asked once.',
+    docs: 'docs/detailed/setup/github.md',
+    docs_url: 'https://github.com/settings/personal-access-tokens',
+    steps: [
+      'Open https://github.com/settings/personal-access-tokens and choose "Generate new token".',
+      'Name it "Lanes Link" — the name is how you revoke this one later without touching your other tokens — and set an expiry you are willing to renew.',
+      'Resource owner: yourself, or the organisation whose repositories you want reachable. An organisation may require an owner to approve the token before it works.',
+      'Repository access: only the repositories you want an agent to see. "All repositories" is the setting people regret.',
+      'Permissions, matching the toolsets this connects: Contents (read), Metadata (read, added for you), Issues (read and write), Pull requests (read and write), Actions (read). Add Administration or Workflows only if you know you need them.',
+      'Generate, then copy the token. GitHub shows it once, and it starts with github_pat_.',
+      'When it expires, generate another and run: lanes link connect github --replace.',
+    ],
+    troubleshooting:
+      'GitHub refused the token. The usual causes are an expired token, a repository the token was not granted, ' +
+      'or an organisation token still waiting on an owner\'s approval. Generate a new one at ' +
+      'https://github.com/settings/personal-access-tokens and re-run: lanes link connect github --replace.',
+    prompts: [
+      {
+        key: 'token',
+        label: 'GitHub personal access token',
+        secret: true,
+        scope: 'connection' as const,
+      },
+    ],
+  },
+});

--- a/src/providers/github/redact.ts
+++ b/src/providers/github/redact.ts
@@ -1,0 +1,109 @@
+/**
+ * What survives into the audit log when GitHub is written to.
+ *
+ * The default withholds every value, which is right for a server whose
+ * capabilities we did not author and cannot know the shape of. It is wrong for
+ * the writes: "an issue was edited" without saying which issue, in which
+ * repository, or into what state is a record of nothing.
+ *
+ * The line drawn is the one Gmail and Drive draw. Identifiers and flags are
+ * kept — `owner`, `repo`, the number, the method, the state, the labels and
+ * reviewers, the merge method. The user's own words are withheld: `title`,
+ * `body`, `commit_message`. A log that said which pull request was merged and
+ * by what method has answered the question; one that also quoted the commit
+ * message has started keeping a copy of the work.
+ *
+ * `assignees` and `reviewers` are kept, and that departs from withholding
+ * people the way `drive.permissions.create` keeps `emailAddress`: assigning
+ * somebody *is* the change, so a log that cannot say to whom has failed at its
+ * one question.
+ *
+ * Two caveats worth stating rather than discovering.
+ *
+ * A proxied server's capabilities are discovered, not declared, so the argument
+ * names below come from GitHub's published tool documentation rather than from
+ * a schema in this repository. `cli/tools.test.ts` checks these names for every
+ * `http` provider and cannot check them here — there is nothing local to check
+ * against. A name that is wrong, or that GitHub renames later, fails the way
+ * that test exists to prevent: silently, with the value withheld and the log
+ * reading exactly as it does when redaction is working. `lanes link doctor`
+ * reporting capability drift is the signal that this list wants re-reading.
+ *
+ * Reads are absent on purpose. `search_issues` takes a `query`, which is a
+ * question somebody asked rather than a record of something that happened —
+ * the same ground Gmail withholds `q` on.
+ */
+export const GITHUB_REDACT: Record<string, string[]> = {
+  // `method` is the verb — create, update, close — and without it the entry
+  // says an issue was written to and not what was done to it.
+  issue_write: [
+    'owner',
+    'repo',
+    'issue_number',
+    'method',
+    'state',
+    'state_reason',
+    'labels',
+    'assignees',
+    'milestone',
+    'type',
+    'duplicate_of',
+  ],
+  add_issue_comment: ['owner', 'repo', 'issue_number', 'comment_id', 'reaction'],
+  sub_issue_write: [
+    'owner',
+    'repo',
+    'issue_number',
+    'method',
+    'sub_issue_id',
+    'replace_parent',
+    'after_id',
+    'before_id',
+  ],
+  // No `title`: a branch name says which change this is, and the title is the
+  // author's summary of it.
+  create_pull_request: [
+    'owner',
+    'repo',
+    'head',
+    'base',
+    'draft',
+    'reviewers',
+    'maintainer_can_modify',
+  ],
+  update_pull_request: [
+    'owner',
+    'repo',
+    'pullNumber',
+    'base',
+    'state',
+    'draft',
+    'reviewers',
+    'maintainer_can_modify',
+  ],
+  merge_pull_request: ['owner', 'repo', 'pullNumber', 'merge_method'],
+  // `event` is the one that matters: approving is a different act from
+  // commenting, and this is the only place that distinction is recorded.
+  pull_request_review_write: [
+    'owner',
+    'repo',
+    'pullNumber',
+    'method',
+    'event',
+    'commitID',
+    'threadId',
+  ],
+  add_comment_to_pending_review: [
+    'owner',
+    'repo',
+    'pullNumber',
+    'path',
+    'line',
+    'startLine',
+    'side',
+    'startSide',
+    'subjectType',
+  ],
+  add_reply_to_pull_request_comment: ['owner', 'repo', 'pullNumber', 'commentId', 'reaction'],
+  update_pull_request_branch: ['owner', 'repo', 'pullNumber', 'expectedHeadSha'],
+};

--- a/src/providers/index.ts
+++ b/src/providers/index.ts
@@ -15,6 +15,7 @@ import { icloudDrive } from './icloud/drive/index.ts';
 import { icloudMail } from './icloud/mail/index.ts';
 import { linear } from './linear/index.ts';
 import { notion } from './notion/index.ts';
+import { slack } from './slack/index.ts';
 
 /**
  * Every provider, in one list.
@@ -50,6 +51,7 @@ export const PROVIDERS: readonly (ProviderManifest | ProviderDefinition)[] = [
   notion,
   linear,
   github,
+  slack,
   gmail,
   drive,
   sheets,
@@ -93,4 +95,5 @@ export { icloudCalendar, icloudContacts, icloudDrive, icloudMail } from './iclou
 export { github } from './github/index.ts';
 export { linear } from './linear/index.ts';
 export { notion } from './notion/index.ts';
+export { slack } from './slack/index.ts';
 export { SCOPE_MEANINGS, type ScopeMeaning } from './scopes.ts';

--- a/src/providers/index.ts
+++ b/src/providers/index.ts
@@ -2,6 +2,7 @@ import type { ProviderDefinition, ProviderManifest } from '#connectivity';
 import { calendar } from './google/calendar/index.ts';
 import { contacts } from './google/contacts/index.ts';
 import { docs } from './google/docs/index.ts';
+import { github } from './github/index.ts';
 import { drive } from './google/drive/index.ts';
 import { driveMcp } from './google/drive-mcp/index.ts';
 import { gmail } from './google/gmail/index.ts';
@@ -48,6 +49,7 @@ import { notion } from './notion/index.ts';
 export const PROVIDERS: readonly (ProviderManifest | ProviderDefinition)[] = [
   notion,
   linear,
+  github,
   gmail,
   drive,
   sheets,
@@ -88,6 +90,7 @@ export {
   tasks,
 } from './google/index.ts';
 export { icloudCalendar, icloudContacts, icloudDrive, icloudMail } from './icloud/index.ts';
+export { github } from './github/index.ts';
 export { linear } from './linear/index.ts';
 export { notion } from './notion/index.ts';
 export { SCOPE_MEANINGS, type ScopeMeaning } from './scopes.ts';

--- a/src/providers/slack/index.ts
+++ b/src/providers/slack/index.ts
@@ -1,0 +1,75 @@
+import { defineProvider } from '#connectivity';
+import { SLACK_REDACT } from './redact.ts';
+
+/**
+ * Slack, through the server Slack runs.
+ *
+ * The only provider here whose vendor has closed every door but one. Slack's
+ * MCP server does not offer Dynamic Client Registration — their documentation
+ * says so outright — and a client of your own cannot work either: Slack
+ * requires an HTTPS redirect URI, and `connect` listens on `http://127.0.0.1`
+ * on a port the kernel picks. There is no proxy, tunnel, or flag that makes a
+ * loopback listener HTTPS. A broker would answer it and `defineProvider`
+ * refuses one on an mcp connector, because the SDK owns that exchange.
+ *
+ * What is left is the user token the Slack app mints when you install it, sent
+ * as `Authorization: Bearer`. Slack supports that path deliberately; it is the
+ * arrangement their own docs describe for a client that cannot register. See
+ * ADR-033.
+ *
+ * Unlike GitHub, this does cost a console visit — creating a Slack app is the
+ * only way to get a user token at all, and no amount of implementation work on
+ * this side removes it. The setup block is therefore longer than any other here
+ * except Google's, and that is the honest shape of it.
+ */
+export const slack = defineProvider({
+  id: 'slack',
+  name: 'Slack',
+  description: 'Messages, threads, channels, files, and canvases, via Slack\'s official MCP server.',
+  connector: { kind: 'mcp', endpoint: 'https://mcp.slack.com/mcp' },
+  auth: { kind: 'bearer' },
+  /**
+   * The person, not the workspace, and the distinction is load-bearing.
+   *
+   * `settleIdentity` matches a resolved account against existing connections
+   * to decide whether this is a reconnect or a new account. Labelled by
+   * workspace, a second person's token in the same workspace would look like a
+   * reconnect of the first and overwrite their credential. `auth.test` returns
+   * both; `user` is the one that is unique per token.
+   *
+   * Slack answers a bad token with HTTP 200 and `{ok: false}`, so a wrong token
+   * reaches `connect`'s "which account is this?" fallback rather than a clear
+   * refusal. Discovery fails loudly one step later, which is where the real
+   * error is.
+   */
+  identity: { kind: 'http', url: 'https://slack.com/api/auth.test', field: 'user' },
+  redact: SLACK_REDACT,
+  setup: {
+    summary:
+      'Slack needs an app of its own — there is no personal access token and no way to register ' +
+      'automatically, because Slack requires an HTTPS callback and this CLI listens on localhost. ' +
+      'You create the app once, install it to your workspace, and paste the user token it mints.',
+    docs: 'docs/detailed/setup/slack.md',
+    docs_url: 'https://api.slack.com/apps',
+    steps: [
+      'Open https://api.slack.com/apps and choose "Create New App" → "From scratch". Name it "Lanes Link" and pick the workspace.',
+      'Open "OAuth & Permissions" and scroll to "Scopes". Add these under USER TOKEN SCOPES — not Bot Token Scopes; the MCP server reads the user token: search:read.public, search:read.private, search:read.im, search:read.mpim, search:read.users, search:read.files, channels:history, groups:history, im:history, mpim:history, channels:read, groups:read, mpim:read, users:read, chat:write, files:read.',
+      'For reactions, canvases, or creating channels, add reactions:write, canvases:read, canvases:write, or channels:write as well. Those tools are listed either way and fail at call time without the scope.',
+      'Scroll up and choose "Install to Workspace", then approve. A Slack admin may have to approve it for you.',
+      'Copy the "User OAuth Token" from the same page. It starts with xoxp- — not the bot token, which starts with xoxb- and will not work here.',
+      'The token does not expire unless you enable token rotation on the app. If you rotate or reinstall, run: lanes link connect slack --replace.',
+    ],
+    troubleshooting:
+      'Slack refused the token. The usual causes are a bot token (xoxb-) pasted where the user token (xoxp-) belongs, ' +
+      'a scope missing from USER TOKEN SCOPES, or an app that was reinstalled since — reinstalling mints a new token. ' +
+      'Copy the User OAuth Token from https://api.slack.com/apps and re-run: lanes link connect slack --replace.',
+    prompts: [
+      {
+        key: 'token',
+        label: 'Slack user OAuth token (xoxp-…)',
+        secret: true,
+        scope: 'connection' as const,
+      },
+    ],
+  },
+});

--- a/src/providers/slack/redact.ts
+++ b/src/providers/slack/redact.ts
@@ -1,0 +1,50 @@
+/**
+ * What survives into the audit log when Slack is written to.
+ *
+ * The line is the one Gmail draws for mail, because it is the same object: a
+ * message someone wrote. Where it went is recorded, what it said is not.
+ * `channel_id` is an identifier, `thread_ts` says which conversation, and
+ * `message` is the whole of the content — a log that quoted it would be a
+ * second copy of everybody's Slack, held somewhere nobody expects one.
+ *
+ * Keys are the *shortened* names. `shortenName` strips a redundant provider
+ * prefix, so the upstream `slack_send_message` is `send_message` here, in
+ * policy, and in the audit log. Keying this block on the upstream name would
+ * match nothing and withhold everything, silently.
+ *
+ * The same caveat as GitHub's, and it is worth repeating rather than
+ * cross-referencing: a proxied server's capabilities are discovered, not
+ * declared, so `cli/tools.test.ts` cannot check these names against a local
+ * schema the way it does for every `http` provider. They were read off the
+ * tool schemas Slack's server actually publishes rather than guessed, but a
+ * rename upstream fails the way that test exists to prevent — the value is
+ * withheld and the log reads exactly as it does when redaction is working.
+ * `lanes link doctor` reporting capability drift is the signal to re-read this.
+ *
+ * Some entries name tools the default scope set cannot call. That is
+ * deliberate: Slack lists every tool regardless of scope and refuses at call
+ * time, so someone who later adds `reactions:write` or `canvases:write` finds
+ * the log already correct rather than discovering it is not.
+ */
+export const SLACK_REDACT: Record<string, string[]> = {
+  // Everything except the message. `reply_broadcast` is kept because "replied
+  // in a thread" and "replied in a thread and pushed it to the channel" are
+  // different acts, and only this argument distinguishes them.
+  send_message: ['channel_id', 'thread_ts', 'reply_broadcast', 'unfurl_app_links', 'draft_id'],
+  send_message_draft: ['channel_id', 'thread_ts'],
+  schedule_message: ['channel_id', 'post_at', 'thread_ts', 'reply_broadcast'],
+  // The emoji is kept. It is a name from a fixed vocabulary rather than
+  // something anyone typed — the same reading that lets Gmail keep label ids —
+  // and an entry saying a message was reacted to without saying how records
+  // nothing anyone would look for.
+  add_reaction: ['channel_id', 'message_ts', 'emoji'],
+  // Nothing. A canvas has no identifier until Slack answers with one, so both
+  // arguments are the document: `title` is the author's words and `content` is
+  // the whole of it. This is `gmail.send_message`'s position, reached the same
+  // way — there is no identifier here to keep, so keeping anything would mean
+  // keeping content.
+  create_canvas: [],
+  // `sections` is withheld along with `content`: each entry carries its own
+  // markdown, so keeping the array would keep the document a second time.
+  update_canvas: ['canvas_id', 'action', 'section_id'],
+};


### PR DESCRIPTION
GitHub and Slack, both through the MCP servers their vendors run — so no
vendored spec, no translation code, and the vendor maintains the integration.

## Merging this publishes 0.2.0

`package.json` is set to `0.2.0` in this branch, deliberately. `release.yml`
decides between publishing and proposing by whether the version already has a
tag; `v0.1.2` does, so without this the merge would push `release/next`
carrying **0.1.3** — a patch, for two new providers, a new connector field, and
a credential path that did not exist. Setting the version here is the route
that workflow documents for a minor, and its stated reason is the reason to use
it: the judgement that something earns more than a patch belongs in review,
beside the change it describes.

It earns a minor on compatibility as well as features. `defineProvider` now
refuses an `mcp` connector declaring `api_key`, `header`, or `basic`, and a
profile's own `providers.d/*.yaml` go through the same function — so an
operator's custom manifest in that shape stops loading. Nothing is lost: such a
manifest connected with no `Authorization` header and an empty tool list. What
changes is that the failure is loud, and at load rather than at use. Still a
manifest that worked yesterday and errors today.

## Why not the fifteen-line shape

Notion and Linear cost nothing to connect because both support Dynamic Client
Registration. Neither of these does, and the usual fallbacks are closed too:

- **A client of your own.** Slack requires an **HTTPS** redirect URI, and
  `connect` listens on `http://127.0.0.1` on a port the kernel picks per run —
  no proxy or flag makes a loopback listener HTTPS. GitHub permits loopback but
  matches the callback URL exactly, port included, so there is no port to
  register.
- **A broker.** `defineProvider` has refused one on an `mcp` connector since
  ADR-028: the SDK owns that exchange and there is no seam to route it through
  one.

Both vendors issue a credential for exactly this case and document sending it as
`Authorization: Bearer`. So this reuses `auth: {kind: bearer}` and the
`ensureStaticCredential` prompt path iCloud's app-specific password already
takes. ADR-033 records the reasoning and what it costs.

## The bug this uncovered

Four call sites asked `CredentialOAuthProvider` for the token, and for a bearer
manifest that returns `null` rather than raising — its tokens ref is
byte-identical to the ref a pasted token derives, so it read the token, failed
to parse it as a JSON blob, and returned `undefined` by design. The connection
then went upstream **with no `Authorization` header at all**: no error, an empty
tool list, nothing to read that said why. `doctor` was the worst of the four —
its probe 401s inside a `catch { continue; }`, so it reported nothing at all for
the provider rather than reaching its "never discovered" branch.

`connectivity/auth/token.ts` is the single answer now, mirroring the
`basicCredential` seam IMAP and DAV already use. Two exports rather than one,
because `connect` wants the token exactly as just written — routing it through
the refresh machinery would spend a round trip on a token seconds old and cache
it under `<provider>.pending`. That was already written down at the call site;
collapsing to one export would have quietly reversed it.

`oauthProviderFor` stops being exported as a result. `#cli` reaching into the
OAuth provider to answer "which token does this manifest authenticate with" is
the leak that let the bearer case be forgotten.

## Also here

- **An `mcp` connector's auth is now exactly `none | oauth | bearer`**, refused
  at definition, and `bearer` may not rename its header. The transport reads
  only the token, so every other kind would validate and then be dropped in
  silence — the same failure, with a second door left open.
- **`connector.headers`**, for configuration a server offers rather than
  credentials. GitHub's `X-MCP-Toolsets` is the case in hand: it serves a
  different tool list per toolset and `all` is more than an agent reasons over.
  `Authorization` is refused there too — with both set, which one is sent would
  be merge order.
- **Redact blocks on both.** Unlike `linear` and `notion`, these close issues and
  post messages, and "something was written" with no repository or channel is a
  record of nothing. Identifiers and flags kept, the author's words withheld.

## Verified

`bun test` 1668 pass / 0 fail (14 new), `bun run typecheck` clean.

A 401 is also what an unauthenticated request gets, so the unit tests were not
enough on their own. Driving the real serving path — `connectorFactory` →
`bearerToken` → transport — with a captured `fetch`:

```
https://api.githubcopilot.com/mcp/   authorization: Bearer github_pat_<stored>
                                     x-mcp-toolsets: context,repos,issues,pull_requests,actions,labels
https://mcp.slack.com/mcp            authorization: Bearer xoxp-<stored>
```

Both would have been `null` before this branch. A real `connect github` with an
invalid token also failed loudly and wrote nothing. All of it ran under a
scratch `LANES_LINK_HOME`.

**Not verified, and it needs an account holder:** `lanes link connect github`
and `lanes link connect slack` against real accounts. Worth checking then that
the connection's `account` is the login/username rather than a label you were
prompted for — a prompt means the token was refused — and that the discovered
tool names match the `redact` keys.

## Guarantees this weakens, recorded in `security.md`

A pasted token is long-lived and *is* persisted: there is no refresh, so the
stored value is the credential itself rather than a means of obtaining one.
And there is no scope-disclosure gate — `confirmScopes` has nothing to show,
because what the token can do is chosen in the vendor's console and this
endpoint cannot read it back. Policy still bounds what an agent may call; the
credential's own reach is the operator's to bound when they generate it, and
both setup pages say so at that moment.

Two sentences became false and are corrected: `README.md` and `docs/connect.md`
both claimed no provider asks you to register an OAuth client. Slack is the
exception — creating a Slack app is the only way to obtain a user token, and no
work on this side removes it.

## Notes for review

- **`architecture.test.ts`'s `VENDORS` regex is deliberately not extended.**
  Adding `github` would fail on three pre-existing legitimate lines inside
  `VENDOR_SCOPE`, including our own repo URL in `oauth-authcode/provider.ts`.
- **Redact keys cannot be checked here.** `cli/tools.test.ts` verifies them only
  for `http` providers, because a proxied server's capabilities are discovered
  rather than declared. GitHub's came from its published tool documentation and
  Slack's from the schemas its server publishes — not guessed — but a rename
  upstream fails silently, with the log reading exactly as it does when
  redaction works. Both files say so, and `doctor`'s drift report is the signal.
- **`docs/connect.md`'s non-interactive example named `linear`**, which that
  path refuses outright as needing a browser. GitHub is the first provider for
  which the example is true, so it now uses one.
- Unrelated, found and left alone: ADR-028 links to
  `005-the-cli-performs-the-oauth-exchange.md`; the file is
  `005-oauth-connection-flow.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
