### PR TITLE
Update from the registry, and say when there is an update to get

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -36,9 +36,10 @@ call rather than filtering it out of discovery, or adding a policy operator beyo
 **Bun-specific APIs outside the two files that are allowed them** —
 `src/deployments/adapters/sqlite.ts` and `src/server/index.ts`.
 
-**Anything `src/architecture.test.ts` refuses.** It holds three rules: the
+**Anything `src/architecture.test.ts` refuses.** It holds four rules: the
 dependency direction between components, no vendor name in the code a request
-passes through, and a file-size budget. The first was enforced by thirteen
+passes through, a file-size budget, and no real address, project, or bucket
+anywhere a reader can see. The first was enforced by thirteen
 `package.json` files until they were collapsed into one; the test is what
 replaced them. If one fails, the fix is almost never to relax the rule — and
 where a concession is genuinely right, it goes in the named list in that file

--- a/docs/detailed/adr/034-updating-is-a-reinstall.md
+++ b/docs/detailed/adr/034-updating-is-a-reinstall.md
@@ -1,0 +1,83 @@
+# ADR-034: Updating is a reinstall, and only Bun performs it
+
+**Status:** accepted · **Follows from** [ADR-015](015-one-package-under-src.md)
+
+## Context
+
+Publishing to npm made two machines able to run different versions of this CLI at the same time.
+`lanes link version` answers which one is here — that is what it was added for. Nothing answered
+whether it is the current one, and nothing fetched the current one.
+
+The only upgrade affordance in the tree was a string. A config declaring a `contract` this binary
+does not implement is refused with `Upgrade lanes-link.`, which names no command, and until now
+there was no command to name.
+
+What an update *is* here is unusually simple, and worth writing down before someone assumes
+otherwise. There is no build step: `package.json` ships `src/` directly, `bin/lanes` resolves its
+own symlink chain and execs Bun on `src/cli/lanes.ts` inside the installed package, and
+`src/cli/version.ts` reads the version out of `package.json` at call time. So the code that runs is
+the code the tarball contains. Updating is replacing that directory — there is no artifact to
+rebuild, no binary to swap, no migration to run, and the symlink on the `PATH` never moves.
+
+## Decision
+
+**`lanes link update` re-runs the global install.** It compares the installed version against the
+registry's `latest`, and on a newer one runs `bun install -g @lanes-sh/link`. `--check` reports and
+exits without installing, non-zero when an update is available, so a build can gate on it.
+
+**Bun is the only installer driven.** `bun install -g @lanes-sh/link` is the only install documented,
+`engines.bun` requires Bun, and `bin/lanes` refuses to run without it. Inferring a package manager
+would be machinery serving a case nothing tells anyone to create.
+
+That leaves one case that does exist, because nothing *prevents* `npm i -g`: Bun installs into its
+own global prefix, so updating an npm-installed copy with Bun writes a second copy elsewhere and
+leaves `PATH` order to decide which answers. `update` detects that the install root is not under
+Bun's prefix and says so before installing, then reads the version back off disk afterwards and
+reports when the copy it is running from did not change. Both halves of that are the same fact seen
+from either side, and neither is a guess.
+
+**A checkout is refused rather than updated.** `bun link` puts a checkout on the same `PATH` entry a
+published install would occupy. Installing from the registry over it would leave two copies of this
+CLI with nothing to say which one ran. The discriminator is whether the install root sits under a
+`node_modules` directory; in a checkout, `update` says `git pull` is the update and runs nothing.
+
+**The registry is asked for eighteen bytes.** `registry.npmjs.org/-/package/<name>/dist-tags`
+answers `{"latest":"0.2.0"}`. The packument at `registry.npmjs.org/<name>` carries every version ever
+published with its full manifest, which is hundreds of kilobytes to answer the same question.
+
+**Nothing updates itself, and nothing blocks on asking.** `doctor`, `start`, and `deploy` each print
+one line when a newer release is out and nothing at all when the registry cannot be reached, on a
+700 ms budget — the same one `endpointHealth` gives its probe. `check` is deliberately excluded: it
+promises static validation with no external calls, and that promise is worth more than the notice.
+
+## Consequences
+
+A version check can never fail a command. Every path degrades to `unknown` and prints nothing: an
+unparseable version, an unreachable registry, an answer that is not a version. `doctor` on a plane
+reports what it always did.
+
+`update` is the one place that knows how *this* copy updates, which is why the shared stale line
+sends everyone to it rather than naming a remedy itself. In a published install the remedy is the
+command it names; in a checkout that command says `git pull`. One funnel, one answer per install
+shape.
+
+A stale install is reported by the three commands most likely to be running when it matters, and by
+no others. Nothing polls, nothing caches a check between runs, and no everyday path gains a network
+call.
+
+## What this does not do
+
+It does not update a deployed endpoint. That is `lanes link deploy` rolling a revision from an image
+tagged with a timestamp, and the revision carries no version stamp at all.
+
+It does not migrate anything. `SUPPORTED_CONTRACT` is unchanged, and the workspace layout has no
+migration machinery by design — a config declaring a contract this binary does not implement is
+still refused rather than guessed at.
+
+It does not install a chosen version, and there is no rollback flag. Revisions and the registry both
+keep every published version; nothing has needed to name one yet.
+
+It does not stop, restart, or detect a running endpoint. `start` is a foreground process with no PID
+file, and two workspaces can bind the same port, so an endpoint answering is not evidence that
+*this* profile's endpoint answered. After a successful install `update` states the fact instead — a
+running endpoint serves the old code until it is restarted — which is true without asking anything.

--- a/docs/detailed/adr/README.md
+++ b/docs/detailed/adr/README.md
@@ -41,6 +41,7 @@ Nothing in the codebase depends on it.
 | [031](031-sign-in-and-data-access-are-separate-projects.md) | Signing in and reaching Google data are separate Cloud projects; the second is where every Google-data client goes |
 | [032](032-a-stateless-endpoint-does-not-announce-its-tools.md) | `listChanged` is declared false because it is false; a reload reports its tool count and `lanes link tools` asks the endpoint |
 | [033](033-a-pasted-token-for-an-mcp-server.md) | Where a vendor's MCP server will not register a client, the operator's own token is the credential — so an mcp connector's auth is exactly none, oauth, or bearer |
+| [034](034-updating-is-a-reinstall.md) | Updating is replacing the installed package; Bun is the only installer driven, a checkout is refused, and nothing updates itself |
 
 Where an ADR departs from init.md, it says so at the top. Three are significant:
 

--- a/docs/detailed/workflow.md
+++ b/docs/detailed/workflow.md
@@ -418,7 +418,18 @@ $ lanes link audit tail --denied-only        # the interesting half
 $ lanes link config show                     # the resolved config as JSON
 $ lanes link token show --show
 $ lanes link token rotate                    # invalidates every agent on this profile
+$ lanes link version                         # which release this is
+$ lanes link update --check                  # is a newer one published (exit 1 if so)
+$ lanes link update                          # install it
 ```
+
+`update` re-runs the global install, because that is all an update is: there is no build step, so
+the `src/` inside the installed package is the code that runs. Bun is the only installer it drives.
+From a checkout it refuses and says so — `git pull` is the update there. A running endpoint keeps
+serving the old code until it is restarted.
+
+`doctor`, `start`, and `deploy` each print one line when a newer release is out, and nothing when
+the registry cannot be reached.
 
 `lanes link audit tail` shows both allowed and denied calls, with arguments redacted per the provider's
 rules:

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -19,6 +19,9 @@ is a 401 that looks like a bad token.
 Working on Lanes Link itself rather than using it? A checkout and `bun link` put the same command on
 your `PATH`: [`detailed/local-development.md`](detailed/local-development.md).
 
+Later, `lanes link update` installs a newer release, and `lanes link update --check` only says whether
+there is one.
+
 ## 2. Create a profile
 
 A profile is one set of accounts with one set of permissions. Most people start with one.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lanes-sh/link",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "A self-hostable MCP gateway for all your connections, memory, skills, and secrets",
   "license": "Apache-2.0",
   "homepage": "https://lanes.sh/link",

--- a/src/cli/commands/operate/inspect.ts
+++ b/src/cli/commands/operate/inspect.ts
@@ -10,6 +10,7 @@ import {
   toPolicyDocument,
 } from '#registry';
 import { announce, emit, fail, ok, print, warn } from '../../output.ts';
+import { staleNudge } from '../../release.ts';
 import { capabilityDiff, discoveryProbe } from '../../runtime/discovery.ts';
 import { openRuntime, resolveProfile, type GlobalFlags } from '../../runtime.ts';
 
@@ -188,6 +189,12 @@ export async function doctor(flags: DoctorFlags): Promise<void> {
           'Fix with: bun link (from the checkout)',
       });
     }
+
+    // Every finding above is about this profile; this one is about the binary
+    // reading it. Silent when the registry cannot be reached — `doctor` is
+    // expected to work on a plane, and "could not check" is not a finding.
+    const stale = await staleNudge();
+    if (stale !== null) warnings.push({ kind: 'stale_release', message: stale });
 
     await reportCapabilityDrift(runtime, (message) =>
       warnings.push({ kind: 'capability_drift', message }),

--- a/src/cli/commands/operate/serve.ts
+++ b/src/cli/commands/operate/serve.ts
@@ -1,6 +1,7 @@
 import { startEndpoint } from '#server/endpoint.ts';
 import { streamLogger } from '#server/logging.ts';
 import { announce, ok, print, style, warn } from '../../output.ts';
+import { staleNudge } from '../../release.ts';
 import { resolveProfile, type GlobalFlags } from '../../runtime.ts';
 
 /** `lanes link start` — reconcile, then serve every profile on one endpoint. */
@@ -41,6 +42,12 @@ export async function start(
 
   print(ok(`serving ${style.bold(endpoint.url)}`));
   print(style.dim(`      profiles: ${endpoint.profiles.join(', ')}`));
+
+  // Last, not first: the endpoint is what someone ran this for, and a version
+  // note in front of it would be the first thing they read and the least useful.
+  const stale = await staleNudge();
+  if (stale !== null) print(warn(stale));
+
   print(style.dim('Ctrl-C to stop.'));
 
   const shutdown = async (): Promise<void> => {

--- a/src/cli/commands/update.test.ts
+++ b/src/cli/commands/update.test.ts
@@ -1,0 +1,114 @@
+import { describe, expect, test } from 'bun:test';
+import { bunGlobalRoot, updatePlan, type UpdateInput } from './update.ts';
+
+/**
+ * What `lanes link update` decides to do, without doing any of it.
+ *
+ * The reason this decision is a separate function is that the alternative is a
+ * test which replaces the copy of this CLI on the machine running the suite.
+ * Every branch is reachable from here with no network and no subprocess.
+ *
+ * Two of the branches are the ones worth having. A checkout must be refused:
+ * `bun link` puts it on the same PATH entry a published install would occupy, so
+ * installing from the registry would leave two copies and no indication of which
+ * one answers. And an install that is not under Bun's global prefix — an
+ * `npm i -g`, which nothing documents but nothing prevents — must be reported
+ * before the install rather than discovered afterwards, because Bun will write a
+ * second copy elsewhere and leave PATH order to decide the winner.
+ */
+
+const BUN_GLOBAL = '/home/someone/.bun/install/global';
+const INSTALLED = `${BUN_GLOBAL}/node_modules/@lanes-sh/link`;
+
+function input(overrides: Partial<UpdateInput> = {}): UpdateInput {
+  return {
+    installed: '0.1.2',
+    latest: '0.2.0',
+    state: 'stale',
+    root: INSTALLED,
+    bunGlobal: BUN_GLOBAL,
+    ...overrides,
+  };
+}
+
+describe('updatePlan', () => {
+  test('a stale install under Bun’s prefix installs, with nothing to warn about', () => {
+    const decision = updatePlan(input());
+
+    expect(decision.action).toBe('install');
+    expect(decision.install).toEqual(['install', '-g', '@lanes-sh/link']);
+    expect(decision.warning).toBeNull();
+    expect(decision.message).toContain('0.2.0');
+  });
+
+  test('a current install runs nothing', () => {
+    const decision = updatePlan(input({ state: 'current', installed: '0.2.0' }));
+
+    expect(decision.action).toBe('current');
+    expect(decision.install).toBeNull();
+  });
+
+  test('an install ahead of the registry runs nothing', () => {
+    const decision = updatePlan(input({ state: 'ahead', installed: '0.3.0' }));
+
+    expect(decision.action).toBe('ahead');
+    expect(decision.install).toBeNull();
+  });
+
+  test('an unreachable registry runs nothing and says so', () => {
+    const decision = updatePlan(input({ state: 'unknown', latest: null }));
+
+    expect(decision.action).toBe('unknown');
+    expect(decision.install).toBeNull();
+    expect(decision.message).toContain('registry');
+  });
+
+  test('a checkout is refused, and told the thing that does update it', () => {
+    // `installRoot` returns the repository root here, which holds no
+    // `node_modules` segment. Installing from npm over a `bun link`ed checkout
+    // is the one outcome that leaves someone unable to tell which code ran.
+    const decision = updatePlan(input({ root: '/home/someone/dev/link' }));
+
+    expect(decision.action).toBe('checkout');
+    expect(decision.install).toBeNull();
+    expect(decision.message).toContain('git pull');
+  });
+
+  test('a checkout is refused even when it is behind', () => {
+    // The state a contributor on an old branch is in. Still a refusal: the
+    // remedy is `git pull`, and it is not this command's to run.
+    const decision = updatePlan(input({ root: '/home/someone/dev/link', state: 'stale' }));
+
+    expect(decision.action).toBe('checkout');
+  });
+
+  test('an install outside Bun’s prefix still installs, but warns first', () => {
+    const npm = '/usr/local/lib/node_modules/@lanes-sh/link';
+    const decision = updatePlan(input({ root: npm }));
+
+    expect(decision.action).toBe('install');
+    expect(decision.install).toEqual(['install', '-g', '@lanes-sh/link']);
+    expect(decision.warning).toContain(npm);
+    expect(decision.warning).toContain('second copy');
+  });
+
+  test('the prefix check is on path segments, not on a substring', () => {
+    // A sibling directory whose name starts with the prefix must not read as
+    // being inside it — `startsWith` alone would call this one current.
+    const decision = updatePlan(input({ root: `${BUN_GLOBAL}-backup/node_modules/@lanes-sh/link` }));
+
+    expect(decision.warning).not.toBeNull();
+  });
+});
+
+describe('bunGlobalRoot', () => {
+  test('honours BUN_INSTALL', () => {
+    expect(bunGlobalRoot({ BUN_INSTALL: '/opt/bun' })).toBe('/opt/bun/install/global');
+  });
+
+  test('falls back to ~/.bun when it is unset', () => {
+    // Not compared against a literal path: the home directory is whoever is
+    // running the suite, and hard-coding one is how this fails only in CI.
+    expect(bunGlobalRoot({})).toEndWith('/.bun/install/global');
+  });
+});

--- a/src/cli/commands/update.ts
+++ b/src/cli/commands/update.ts
@@ -1,0 +1,255 @@
+import { homedir } from 'node:os';
+import { join, sep } from 'node:path';
+import { installRoot } from '#profile';
+import { emit, fail, ok, print, printErr, progress, style, warn } from '../output.ts';
+import { PACKAGE, release, type ReleaseState } from '../release.ts';
+import { version } from '../version.ts';
+
+/**
+ * `lanes link update` — install the newer release, or say why it will not.
+ *
+ * There is no build step and no compiled artifact, so updating means exactly
+ * one thing: replace the installed package directory with a newer tarball from
+ * the registry. `bin/lanes` resolves its own symlink chain and execs Bun on the
+ * `src/` inside that directory, so the shipped source *is* the running code and
+ * the symlink on the PATH never has to move.
+ *
+ * Bun is the only installer this drives. `bun install -g @lanes-sh/link` is the
+ * only install documented, `engines.bun` requires it, and the shim refuses to
+ * run without it — so inferring a package manager would be machinery serving a
+ * case nobody is told to create. The case that does exist is handled below
+ * rather than ignored: an `npm i -g` install updated with Bun gets a second
+ * copy somewhere else on the PATH, which this detects and reports instead of
+ * doing quietly.
+ *
+ * Nothing here is control plane — it touches the install, not a profile — so it
+ * resolves no profile and no target, and is the second command after `version`
+ * that prints no `announce` line.
+ */
+
+export interface UpdateFlags {
+  /** Report and exit without installing anything. */
+  readonly check?: boolean | undefined;
+  readonly json?: boolean | undefined;
+}
+
+/**
+ * What `update` would do, and why.
+ *
+ * `'checkout'` is a refusal: `bun link` puts a checkout on the same PATH entry
+ * a published install would occupy, so installing from the registry there would
+ * leave two copies of this CLI and no indication of which one answers. `git
+ * pull` is the update in a checkout, and saying so is more useful than doing
+ * something surprising.
+ */
+export type UpdateAction = 'install' | 'current' | 'ahead' | 'checkout' | 'unknown';
+
+export interface UpdateDecision {
+  readonly action: UpdateAction;
+  /** The argv to run, or `null` when nothing should be run. */
+  readonly install: readonly string[] | null;
+  readonly message: string;
+  /** Something true and unwelcome about this install, if there is anything. */
+  readonly warning: string | null;
+}
+
+export interface UpdateInput {
+  readonly installed: string;
+  readonly latest: string | null;
+  readonly state: ReleaseState;
+  /** Where this CLI is installed — `installRoot()`, not the workspace. */
+  readonly root: string;
+  /** Where Bun keeps global installs, so a copy landing elsewhere is visible. */
+  readonly bunGlobal: string;
+}
+
+/**
+ * The whole decision, as a function of five strings.
+ *
+ * Split from the spawn because the alternative is a command whose only test is
+ * one that replaces the copy of this CLI on the machine running the suite. Every
+ * branch below is reachable from `update.test.ts` with no network and no
+ * subprocess — including the stale branch, which the checkout this is written in
+ * can never reach on its own, being by definition the newest thing there is.
+ */
+export function updatePlan(input: UpdateInput): UpdateDecision {
+  const { installed, latest, state, root, bunGlobal } = input;
+
+  // A published install lives under `node_modules`; a checkout does not. Cheaper
+  // and steadier than looking for `.git`, which a tarball could carry and a
+  // shallow export could lack.
+  const published = root.split(sep).includes('node_modules');
+
+  if (!published) {
+    return {
+      action: 'checkout',
+      install: null,
+      message: `${root} is a checkout, not an install — git pull is the update here`,
+      warning: null,
+    };
+  }
+
+  if (state === 'unknown') {
+    return {
+      action: 'unknown',
+      install: null,
+      message:
+        latest === null
+          ? `could not reach the registry — ${installed} is installed`
+          : `cannot compare ${installed} against ${latest}`,
+      warning: null,
+    };
+  }
+
+  if (state === 'ahead') {
+    return {
+      action: 'ahead',
+      install: null,
+      message: `${installed} is installed, ahead of the published ${latest ?? 'release'}`,
+      warning: null,
+    };
+  }
+
+  if (state === 'current') {
+    return { action: 'current', install: null, message: `${installed} is current`, warning: null };
+  }
+
+  // Installed by npm, updated by Bun: `bun install -g` writes into its own
+  // global prefix and leaves the npm copy where it is, so both are on the PATH
+  // and its order decides which one answers. Worth saying before, not after.
+  const elsewhere = !root.startsWith(bunGlobal + sep);
+
+  return {
+    action: 'install',
+    install: ['install', '-g', PACKAGE],
+    message: `${installed} installed, ${latest} available`,
+    warning: elsewhere
+      ? `this copy is at ${root}, which is not under ${bunGlobal} — ` +
+        'Bun will install a second copy there rather than replace this one, ' +
+        'and your PATH order decides which one answers'
+      : null,
+  };
+}
+
+/** Where Bun keeps global installs, honouring `BUN_INSTALL`. */
+export function bunGlobalRoot(env: Record<string, string | undefined> = process.env): string {
+  return join(env['BUN_INSTALL'] ?? join(homedir(), '.bun'), 'install', 'global');
+}
+
+export async function update(flags: UpdateFlags): Promise<void> {
+  const current = await release();
+  const root = installRoot(import.meta.dir);
+  const decision = updatePlan({
+    installed: current.installed,
+    latest: current.latest,
+    state: current.state,
+    root,
+    bunGlobal: bunGlobalRoot(),
+  });
+
+  // A gate wants a non-zero exit for the one state that needs action. An
+  // unreachable registry is not that state — failing a build because a network
+  // was down would make this the flakiest check in it.
+  if (flags.check === true && decision.action === 'install') process.exitCode = 1;
+
+  const report = {
+    installed: current.installed,
+    latest: current.latest,
+    state: current.state,
+    action: decision.action,
+    root,
+    ...(decision.install !== null ? { install: `bun ${decision.install.join(' ')}` } : {}),
+    ...(decision.warning !== null ? { warning: decision.warning } : {}),
+  };
+
+  if (flags.check === true || decision.action !== 'install') {
+    return emit(flags.json, report, () => {
+      if (decision.action === 'install') {
+        print(warn(decision.message));
+        if (decision.warning !== null) print(style.dim(`      ${decision.warning}`));
+        print(style.dim('      run: lanes link update'));
+        return;
+      }
+
+      // Green for the two states that need nothing. A refusal and an
+      // unreachable registry are neither wrong nor fine, and `ok` would claim
+      // the second of those.
+      if (decision.action === 'current' || decision.action === 'ahead') {
+        print(ok(decision.message));
+        return;
+      }
+
+      print(style.dim(decision.message));
+    });
+  }
+
+  // Stderr, both of them. What this command produces is the version change, and
+  // with `--json` that is a document — a line of prose in front of it corrupts
+  // it for whatever is parsing, which is the whole reason `emit` exists.
+  if (decision.warning !== null) progress(warn(decision.warning));
+  progress(style.dim(`bun ${decision.install!.join(' ')}`));
+
+  const installed = await runInstall(decision.install!, flags.json === true);
+  if (!installed) {
+    printErr(fail('the install did not complete — nothing was changed'));
+    process.exitCode = 1;
+    return;
+  }
+
+  // Read the version back off disk rather than trusting the exit code. `version()`
+  // reads `package.json` from the install root at call time, so this is the one
+  // question worth asking after a successful install: did *this* copy change?
+  // Unchanged after a clean install is the second-copy case above, seen from the
+  // other side.
+  const landed = version();
+
+  return emit(
+    flags.json,
+    {
+      ...report,
+      // The action was `install`; this is what came of it. Inventing a third
+      // action value would describe an outcome as a decision.
+      result: landed === current.installed ? 'unchanged' : 'installed',
+      installed: landed,
+      previous: current.installed,
+    },
+    () => {
+      if (landed === current.installed) {
+        print(warn(`bun reported success, but ${root} is still ${landed}`));
+        print(style.dim('      the copy it installed is somewhere else on your PATH'));
+        print(style.dim('      check with: which -a lanes'));
+        return;
+      }
+
+      print(ok(`${current.installed} → ${style.bold(landed)}`));
+      print(style.dim('      a running endpoint serves the old code until it is restarted'));
+    },
+  );
+}
+
+/**
+ * Hand the install to Bun and let it own the terminal.
+ *
+ * `process.execPath` rather than `Bun.which('bun')`: this process is already
+ * running under the Bun that should do the installing, and a PATH lookup can
+ * find a different one — which would resolve the dependency set with a
+ * different resolver than the one that will run the result.
+ *
+ * Output is inherited rather than captured. Bun prints its own progress and its
+ * own errors, and paraphrasing a package manager's failure is how a report ends
+ * up less useful than the thing it replaced. Its stdout is dropped under
+ * `--json` for the same reason the lines above go to stderr: the document on
+ * stdout has to be the only thing on stdout. Its stderr is kept either way,
+ * because a failure is worth reading in both modes.
+ */
+async function runInstall(argv: readonly string[], json: boolean): Promise<boolean> {
+  try {
+    const child = Bun.spawn([process.execPath, ...argv], {
+      stdout: json ? 'ignore' : 'inherit',
+      stderr: 'inherit',
+    });
+    return (await child.exited) === 0;
+  } catch {
+    return false;
+  }
+}

--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -38,6 +38,7 @@ import {
   vaultRemove,
   vaultSet,
 } from './commands/owner.ts';
+import { update } from './commands/update.ts';
 import { globalFlags, ownerFlags, parseArgv, text } from './argv.ts';
 import { PROGRAM, USAGE } from './usage.ts';
 import { version } from './version.ts';
@@ -334,6 +335,9 @@ export async function run(argv: readonly string[]): Promise<void> {
     case 'version':
       print(version());
       return;
+
+    case 'update':
+      return update({ check: flags['check'] === true, json });
 
     default:
       throw new Error(`Unknown command "${first}". Run: ${PROGRAM} help`);

--- a/src/cli/release.test.ts
+++ b/src/cli/release.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, test } from 'bun:test';
+import { releaseState, staleLine } from './release.ts';
+
+/**
+ * How the installed version is compared against the published one.
+ *
+ * Pure on purpose, and tested here rather than through `update`, because the
+ * interesting states are the ones a checkout cannot be in: this file is by
+ * definition the newest version of itself, so `stale` is unreachable without
+ * saying what the registry answered. The registry is not consulted here at all
+ * — a suite that fails on an aeroplane is a suite people learn to ignore.
+ *
+ * The comparison degrades to `unknown` rather than throwing. `Bun.semver.order`
+ * raises on anything it cannot parse, and a registry answering something
+ * unexpected must not be able to take down `doctor`, `start`, and `deploy`,
+ * which each print one line from this.
+ */
+
+describe('releaseState', () => {
+  test('equal versions are current', () => {
+    expect(releaseState('0.2.0', '0.2.0')).toBe('current');
+  });
+
+  test('a published version above the installed one is stale', () => {
+    expect(releaseState('0.1.2', '0.2.0')).toBe('stale');
+  });
+
+  test('comparison is by precedence, not by string', () => {
+    // '0.10.0' sorts below '0.9.0' as text, which is the bug a hand-rolled
+    // comparator is most likely to ship with.
+    expect(releaseState('0.9.0', '0.10.0')).toBe('stale');
+    expect(releaseState('0.10.0', '0.9.0')).toBe('ahead');
+  });
+
+  test('a checkout ahead of the registry is not reported as behind', () => {
+    // The state a contributor is in most of the time: the version bump has
+    // merged but nothing has published yet. Telling them to update would be
+    // both wrong and the message they see most often.
+    expect(releaseState('0.3.0', '0.2.0')).toBe('ahead');
+  });
+
+  test('a prerelease is below the release it precedes', () => {
+    expect(releaseState('0.2.0-rc.1', '0.2.0')).toBe('stale');
+  });
+
+  test('an unreachable registry is unknown, not current', () => {
+    // `latest` is null on any failure. Reporting that as current would make a
+    // dropped network look exactly like an up-to-date install.
+    expect(releaseState('0.2.0', null)).toBe('unknown');
+  });
+
+  test('an unparseable version is unknown rather than an exception', () => {
+    expect(releaseState('not-a-version', '0.2.0')).toBe('unknown');
+    expect(releaseState('0.2.0', 'not-a-version')).toBe('unknown');
+    expect(releaseState('', '0.2.0')).toBe('unknown');
+  });
+});
+
+describe('staleLine', () => {
+  test('names both versions and the command that acts on them', () => {
+    const line = staleLine({ installed: '0.1.2', latest: '0.2.0', state: 'stale' });
+
+    expect(line).toContain('0.1.2');
+    expect(line).toContain('0.2.0');
+    expect(line).toContain('lanes link update');
+  });
+
+  test('says nothing about any state but stale', () => {
+    // Three commands print this line. Each of them printing "you are current"
+    // on every run is noise, and printing "could not check" is worse — it is a
+    // report about the network in the middle of a report about something else.
+    for (const state of ['current', 'ahead', 'unknown'] as const) {
+      expect(staleLine({ installed: '0.2.0', latest: '0.2.0', state })).toBeNull();
+    }
+  });
+});

--- a/src/cli/release.ts
+++ b/src/cli/release.ts
@@ -1,0 +1,111 @@
+import { version } from './version.ts';
+
+/**
+ * Whether a newer release than this one has been published.
+ *
+ * `version.ts` answers which release is installed, which stopped being the
+ * whole question when this started shipping from npm: two machines can now sit
+ * a release apart with nothing on either to say so, and the only upgrade
+ * affordance in the tree was a `contract` mismatch telling someone to "Upgrade
+ * lanes-link" without naming a command.
+ *
+ * Every function here degrades to `null` or `'unknown'` rather than throwing. A
+ * version check is never the reason a command fails — `doctor`, `start`, and
+ * `deploy` each print one line from this and must all work on a plane.
+ */
+
+/** The npm package this CLI ships as, and the only thing `update` will install. */
+export const PACKAGE = '@lanes-sh/link';
+
+/**
+ * The dist-tags document, not the packument.
+ *
+ * `registry.npmjs.org/<name>` carries every version ever published with its
+ * full manifest — hundreds of kilobytes to answer a question whose answer is
+ * eighteen bytes. This endpoint returns `{"latest":"0.2.0"}` and nothing else.
+ */
+const DIST_TAGS = `https://registry.npmjs.org/-/package/${encodeURIComponent(PACKAGE)}/dist-tags`;
+
+/**
+ * The same budget `endpointHealth` gives its probe.
+ *
+ * Long enough for a warm connection, short enough that a command which only
+ * mentions staleness in passing does not appear to hang on a captive-portal
+ * network that accepts the connection and then says nothing.
+ */
+const PROBE_TIMEOUT_MS = 700;
+
+export type ReleaseState = 'current' | 'stale' | 'ahead' | 'unknown';
+
+export interface Release {
+  readonly installed: string;
+  /** `null` when the registry could not be reached, or answered something else. */
+  readonly latest: string | null;
+  readonly state: ReleaseState;
+}
+
+/**
+ * How the installed version stands against the published one.
+ *
+ * `'ahead'` is not a mistake: a contributor running from a checkout is usually
+ * a version ahead of the registry, and telling them they are behind would be
+ * both wrong and the thing they see most often.
+ *
+ * Pure, and separate from the fetch, so every branch is testable without a
+ * network — which is the only way the stale path gets covered at all, given the
+ * checkout this is written in is by definition current.
+ */
+export function releaseState(installed: string, latest: string | null): ReleaseState {
+  if (latest === null) return 'unknown';
+
+  try {
+    const order = Bun.semver.order(installed, latest);
+    return order === 0 ? 'current' : order < 0 ? 'stale' : 'ahead';
+  } catch {
+    // `Bun.semver.order` throws on anything it cannot parse rather than
+    // ordering it arbitrarily. A registry that answers with something other
+    // than a version, or a hand-edited `package.json`, is an unknown state and
+    // not a reason to claim either answer.
+    return 'unknown';
+  }
+}
+
+/** What the registry calls `latest`, or `null` if it did not say. */
+export async function latestRelease(): Promise<string | null> {
+  try {
+    const response = await fetch(DIST_TAGS, { signal: AbortSignal.timeout(PROBE_TIMEOUT_MS) });
+    if (!response.ok) return null;
+
+    const body = (await response.json()) as { latest?: unknown };
+    return typeof body.latest === 'string' ? body.latest : null;
+  } catch {
+    return null;
+  }
+}
+
+/** The installed version, the published one, and how they stand. */
+export async function release(): Promise<Release> {
+  const installed = version();
+  const latest = await latestRelease();
+
+  return { installed, latest, state: releaseState(installed, latest) };
+}
+
+/**
+ * The one line `doctor`, `start`, and `deploy` print when this install is behind.
+ *
+ * One string in one place, because three commands saying it three ways is how
+ * two of them end up naming a command that has been renamed. `null` for every
+ * state but `'stale'`: nothing is worth saying about an install that is current,
+ * and an unreachable registry is not news.
+ */
+export function staleLine(current: Release): string | null {
+  if (current.state !== 'stale') return null;
+
+  return `${current.installed} is installed, ${current.latest} is out — run: lanes link update`;
+}
+
+/** `staleLine` over a fresh probe, for a caller that has no `Release` in hand. */
+export async function staleNudge(): Promise<string | null> {
+  return staleLine(await release());
+}

--- a/src/cli/usage.ts
+++ b/src/cli/usage.ts
@@ -90,6 +90,7 @@ ${style.bold('Inspection')}
   ${PROGRAM} audit verify           has anything in the log been altered or removed
   ${PROGRAM} config show
   ${PROGRAM} version                    which release this is — same as lanes --version
+  ${PROGRAM} update [--check] [--json]  install the newer release, or say what is available
 
 ${style.bold('Attachments')}
   ${PROGRAM} attach <file> --connection <provider>.<account>

--- a/src/deployments/deploy.ts
+++ b/src/deployments/deploy.ts
@@ -1,5 +1,6 @@
 import { ConfigError, resolveDeployTarget, type DeployConfig } from '#profile';
 import { announce, fail, heading, ok, print, style, warn } from '#cli/output.ts';
+import { staleNudge } from '#cli/release.ts';
 import { confirm, isInteractive } from '#cli/prompt.ts';
 import { openSecretStoreFor, resolveProfile, type GlobalFlags } from '#cli/runtime.ts';
 import { resolveTarget, vaultEnv } from './bootstrap.ts';
@@ -56,6 +57,12 @@ export async function deploy(flags: DeployFlags): Promise<void> {
   // `check` before anything external, per the gate order: a config that will be
   // rejected on boot should be rejected here, not after a five-minute build.
   print(ok(`${resolution.profilePath} is valid`));
+
+  // The CLI planning this rollout, not the image it will build. An old one
+  // plans an old rollout, and a build is the most expensive place to find that
+  // out.
+  const stale = await staleNudge();
+  if (stale !== null) print(warn(stale));
 
   const declared = await resolveTarget({
     config,


### PR DESCRIPTION
`lanes link version` answered which release is installed, which stopped being the whole question the moment this shipped from npm: two machines can sit a release apart with nothing on either to say so. The only upgrade affordance in the tree was a contract mismatch telling someone to "Upgrade lanes-link" without naming a command.

## What this adds

```console
$ lanes link update              # install the newer release, or say there is nothing to do
$ lanes link update --check      # report only; exit 1 if stale, so a build can gate on it
$ lanes link update --check --json
```

There is nothing more to an update than a reinstall: no build step means the `src/` inside the installed package is the code that runs, so replacing the directory is the whole operation and the symlink on the `PATH` never moves.

`doctor`, `start`, and `deploy` each print one line when a newer release is out, and nothing at all when the registry cannot be reached. `check` is deliberately left out — its help line promises static validation with no external calls.

## The decisions worth reviewing

**Bun is the only installer driven.** It is the only install documented, `engines.bun` requires it, and `bin/lanes` refuses to run without it. Nothing prevents an `npm i -g` though, and Bun would write a second copy into its own prefix and leave `PATH` order to pick the winner — so that is reported before installing, and the version is read back off disk afterwards so an unchanged copy is reported too.

**A checkout is refused.** `bun link` puts one on the same `PATH` entry a published install would occupy. `git pull` is the update there.

**No dependency, and no hand-rolled semver.** `Bun.semver.order` does the comparison; a hand-rolled one's first bug is ordering `0.10.0` below `0.9.0` as text, and there is a test for exactly that.

**The registry is asked for the dist-tags document, not the packument** — eighteen bytes against hundreds of kilobytes for the same answer, on the 700 ms budget `endpointHealth` already uses.

ADR-034 records the three that will otherwise be re-litigated.

## Verified

Both gates pass: `bun test` 1687 pass / 0 fail (baseline 1668), `bun run typecheck` clean.

The decision is a pure function split from the spawn, so every branch is covered with no network and no subprocess — the alternative is a test that replaces the CLI on the machine running the suite. Each state was also exercised end to end against a staged install root:

| state | output | exit |
|---|---|---|
| stale | `warn 0.1.2 installed, 0.2.0 available` | 1 under `--check` |
| current | `ok 0.2.0 is current` | 0 |
| ahead | `ok 0.9.0 is installed, ahead of the published 0.2.0` | 0 |
| checkout | `… is a checkout, not an install — git pull is the update here` | 0, nothing spawned |
| offline | nothing at all | 0 |

`doctor` and `start` were confirmed printing the line in place. `deploy`'s is the same three lines but was not exercised — it needs a configured cloud target and `gcloud`.

The real `bun install -g` was not run: it would replace the copy on the PATH, which no `git checkout` undoes.

## Also in here

Corrects CONTRIBUTING's claim that `architecture.test.ts` holds three rules; it holds four. Separately, that file says Bun-specific APIs are allowed in two files — 21 non-test files use them today, including six `Bun.which` and four `Bun.spawnSync` under `src/cli/`. This change follows that practice rather than the sentence; narrowing or rewording the rule is a call for its owner, so it is untouched here.

## Version

`package.json` declares **0.2.1**, so the merge publishes it and cuts `v0.2.1` rather than proposing a bump on `release/next`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)