### PR TITLE
Release 0.2.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lanes-sh/link",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "A self-hostable MCP gateway for all your connections, memory, skills, and secrets",
   "license": "Apache-2.0",
   "homepage": "https://lanes.sh/link",


### PR DESCRIPTION
Merging this publishes 0.2.2 to npm.

Since v0.2.1:

- Keep a connector signed in instead of sending its owner to a browser (#25)