### PR TITLE
Say which target an account is going into, and where the next command runs

### DIFF
--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -36,6 +36,11 @@ There is no second deploy. `connect` copies the config to where the running revi
 asks that revision to re-read it, so the account is reachable as soon as the browser consent is
 done. Deploying is how new code gets there, and authorising an account changes no code (ADR-029).
 
+`--target cloud` is on those last two for a reason: deploying does not move `instance.default_target`,
+so a command without the flag still acts on `local` and the deployment never sees the account. The
+deploy says so when it finishes, and `connect` warns when it is about to write somewhere your
+deployment cannot read.
+
 `cloud` there is a name, not a keyword — it is what the first deploy calls the target it creates.
 `lanes link target list` shows what your profile declares and which one commands are using.
 

--- a/src/cli/commands/connect/accounts.ts
+++ b/src/cli/commands/connect/accounts.ts
@@ -92,3 +92,32 @@ export async function moveCredential(
   await credentials.set(to, value);
   await credentials.delete(from);
 }
+
+/**
+ * The providers that make up one vendor account, when a spec names the account.
+ *
+ * `lanes link connect icloud` names no provider at all. Everyone models iCloud
+ * this way: Apple's own Settings, macOS Internet Accounts, Thunderbird, DAVx⁵.
+ * One authorisation, three services. It is three *providers* underneath because
+ * mail and calendars are different protocols, and because a policy line per
+ * provider is what lets someone allow `icloud_calendar.*` while never granting
+ * mail — but nobody should have to know that to connect their account.
+ *
+ * Asked of the registry rather than matched on the id, for the reason
+ * `siblingAccountId` gives: `app` is a manifest field, and a provider is free to
+ * declare `app: icloud` under any name it likes.
+ */
+export function familyMembers(
+  providerId: string,
+  registry: { list(): readonly { readonly manifest: ProviderManifest }[] },
+): string[] {
+  return registry
+    .list()
+    .filter((candidate) => credentialApp(candidate.manifest) === providerId)
+    .map((candidate) => candidate.manifest.id);
+}
+
+/** What a spec that named an account rather than a provider turned out to mean. */
+export function familyNote(providerId: string, family: readonly string[]): string {
+  return `${providerId} is ${family.length} services on one account: ${family.join(', ')}`;
+}

--- a/src/cli/commands/connect/index.ts
+++ b/src/cli/commands/connect/index.ts
@@ -6,13 +6,14 @@ import { ConfigDocument, ensureSetupConnection, repaired } from '../../config-ed
 import { emit, print, progress, style } from '../../output.ts';
 import { nonInteractivePrompter, terminalPrompter, type Prompter } from '../../prompt.ts';
 import { openRuntime, type GlobalFlags } from '../../runtime.ts';
-import { credentialApp, matchesRule, moveCredential, siblingAccountId } from './accounts.ts';
+import { familyMembers, familyNote, matchesRule, moveCredential, siblingAccountId } from './accounts.ts';
 import { authorise } from './authorise.ts';
 import { preflight } from './requirements.ts';
-import { ALREADY, NOTHING, renderOutcome, type ConnectOutcome } from './outcome.ts';
+import { ALREADY, NOTHING, familyOutcome, renderOutcome, where, type ConnectOutcome } from './outcome.ts';
 import { nextAfterEdit, publishRuntimeEdit } from '#cli/publish.ts';
 import { ensureStaticCredential } from './setup.ts';
 import { settleIdentity } from './settle.ts';
+import { announceConnectTarget } from './target-note.ts';
 
 /**
  * `lanes link connect <provider>` — the one command that adds an account.
@@ -83,7 +84,12 @@ export async function connect(target: string, options: ConnectOptions): Promise<
   return emit(options.json, outcome, () => renderOutcome(outcome));
 }
 
-async function runConnect(target: string, options: ConnectOptions): Promise<ConnectOutcome> {
+async function runConnect(
+  target: string,
+  options: ConnectOptions,
+  /** A family member — the account this belongs to has already said where it goes. */
+  announced = false,
+): Promise<ConnectOutcome> {
   const separator = target.indexOf('.');
   const providerId = separator === -1 ? target : target.slice(0, separator);
   const namedId = separator === -1 ? undefined : target.slice(separator + 1);
@@ -93,28 +99,24 @@ async function runConnect(target: string, options: ConnectOptions): Promise<Conn
   const runtime = await openRuntime(options);
 
   try {
+    // After the runtime rather than before, like every other command that
+    // announces: the alternative is resolving the profile twice, which for a
+    // `gs://` workspace is a second network read of the same YAML. Still long
+    // before the browser opens, which is the part that matters. Inside the
+    // `try` so the `finally` closes the runtime if the rendering throws.
+    if (!announced) announceConnectTarget(runtime, target, options.json);
+
     const registry = runtime.registry;
     const entry = registry.get(providerId);
 
-    // `lanes link connect icloud` — an account rather than a provider.
-    //
-    // Everyone models iCloud this way: Apple's own Settings, macOS Internet
-    // Accounts, Thunderbird, DAVx⁵. One authorisation, three services. It is
-    // three *providers* underneath because mail and calendars are different
-    // protocols, and because a policy line per provider is what lets someone
-    // allow `icloud_calendar.*` while never granting mail — but nobody should
-    // have to know that to connect their account.
+    // `lanes link connect icloud` — an account rather than a provider. What that
+    // means, and why it is three providers underneath, is in `familyMembers`.
     if (!entry) {
-      const family = registry
-        .list()
-        .filter((candidate) => credentialApp(candidate.manifest) === providerId)
-        .map((candidate) => candidate.manifest.id);
+      const family = familyMembers(providerId, registry);
 
       if (family.length > 1) {
         await runtime.close();
-        progress(
-          style.dim(`${providerId} is ${family.length} services on one account: ${family.join(', ')}`),
-        );
+        progress(style.dim(familyNote(providerId, family)));
         // In sequence, and the order matters: the first settles the account id
         // and stores the credential, and the rest find both already there.
         //
@@ -123,22 +125,14 @@ async function runConnect(target: string, options: ConnectOptions): Promise<Conn
         // that is then thrown away, and recursing with `options` alone dropped
         // it — the command named an account and each member silently invented
         // its own.
+        //
+        // `announced` because the line naming the target belongs to the account,
+        // not to each service: three copies of it is three times nothing new.
         const inherited = { ...options, id: options.id ?? namedId };
         const members: ConnectOutcome[] = [];
-        for (const member of family) members.push(await runConnect(member, inherited));
+        for (const member of family) members.push(await runConnect(member, inherited, true));
 
-        // The whole account succeeded only if every service did. A partial
-        // result is the case worth surfacing: one member blocked on a value
-        // leaves an account half connected, which `status` shows and prose does
-        // not.
-        return {
-          ...NOTHING,
-          ok: members.every((outcome) => outcome.ok),
-          members,
-          ...(members.find((outcome) => !outcome.ok)?.reason
-            ? { reason: members.find((outcome) => !outcome.ok)!.reason }
-            : {}),
-        };
+        return familyOutcome(members);
       }
     }
 
@@ -369,6 +363,7 @@ async function runConnect(target: string, options: ConnectOptions): Promise<Conn
         ok: true,
         key: connectionKey,
         account,
+        ...where(runtime),
         discovered: discovered.length,
         next: ALREADY,
       };
@@ -384,6 +379,7 @@ async function runConnect(target: string, options: ConnectOptions): Promise<Conn
       ok: true,
       key: connectionKey,
       account,
+      ...where(runtime),
       changes,
       granted,
       ...(notes.length > 0 ? { notes } : {}),

--- a/src/cli/commands/connect/outcome.ts
+++ b/src/cli/commands/connect/outcome.ts
@@ -17,6 +17,10 @@ export interface ConnectOutcome {
   readonly ok: boolean;
   readonly key?: string;
   readonly account?: string;
+  /** The profile written to, for a caller that cannot see the announce line. */
+  readonly profile?: string;
+  /** The target written to — which credential store now holds this account. */
+  readonly target?: string;
   readonly changes: readonly string[];
   readonly granted: readonly string[];
   /**
@@ -44,6 +48,35 @@ export interface ConnectOutcome {
 export const NOTHING = { changes: [], granted: [], discovered: 0 } as const;
 
 export const ALREADY = 'Already connected — nothing changed.';
+
+/**
+ * One result for an account that turned out to be several services.
+ *
+ * The whole account succeeded only if every service did. A partial result is the
+ * case worth surfacing: one member blocked on a value leaves an account half
+ * connected, which `status` shows and prose does not.
+ */
+export function familyOutcome(members: readonly ConnectOutcome[]): ConnectOutcome {
+  const blocked = members.find((outcome) => !outcome.ok);
+
+  return {
+    ...NOTHING,
+    ok: members.every((outcome) => outcome.ok),
+    members,
+    ...(blocked?.reason ? { reason: blocked.reason } : {}),
+  };
+}
+
+/**
+ * Which store an account landed in, for the caller not reading the terminal.
+ *
+ * `announceConnectTarget` fixes the human channel. A `--json` caller had the
+ * same blindness the operator did — and an agent is exactly the reader who
+ * cannot see the line printed above it.
+ */
+export function where(runtime: { resolution: { profile: string; target: string } }) {
+  return { profile: runtime.resolution.profile, target: runtime.resolution.target };
+}
 
 /**
  * What `connect` says last.

--- a/src/cli/commands/connect/target-note.test.ts
+++ b/src/cli/commands/connect/target-note.test.ts
@@ -1,0 +1,182 @@
+import { describe, expect, test } from 'bun:test';
+import type { Config, Resolution } from '#profile';
+import { announceConnectTarget, deploymentGap } from './target-note.ts';
+
+/**
+ * Where `connect` says it is writing, and when it warns that you meant elsewhere.
+ *
+ * Testable without a runtime, a config file, or a credential store — which is
+ * the reason this wording lives beside `outcome.ts` rather than inside the five
+ * steps. The condition being pinned down here is the one that decides whether an
+ * operator ever reads the line: a warning that fires on every local `connect`
+ * gets tuned out long before the one deploy it was written for.
+ */
+
+function captured(body: () => void): { out: string; err: string } {
+  const outWrite = process.stdout.write.bind(process.stdout);
+  const errWrite = process.stderr.write.bind(process.stderr);
+  let out = '';
+  let err = '';
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (process.stdout as any).write = (chunk: string) => ((out += chunk), true);
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (process.stderr as any).write = (chunk: string) => ((err += chunk), true);
+
+  try {
+    body();
+  } finally {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (process.stdout as any).write = outWrite;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (process.stderr as any).write = errWrite;
+  }
+
+  return { out, err };
+}
+
+function targets(declared: Record<string, { deployed?: boolean }>): Config['targets'] {
+  return Object.fromEntries(
+    Object.entries(declared).map(([name, { deployed }]) => [
+      name,
+      {
+        credentials: { adapter: 'file' },
+        storage: { adapter: 'filesystem' },
+        ...(deployed
+          ? {
+              deploy: {
+                platform: 'cloudrun',
+                region: 'europe-west1',
+                service: `lanes-link-${name}`,
+                access: 'public',
+              },
+            }
+          : {}),
+      },
+    ]),
+  ) as Config['targets'];
+}
+
+function at(target: string, source: Resolution['targetSource']) {
+  return { target, targetSource: source };
+}
+
+describe('the deployment gap', () => {
+  test('is silent when the target being written to is the deployed one', () => {
+    const gap = deploymentGap(at('cloud', 'config-default'), targets({ local: {}, cloud: { deployed: true } }), 'gmail');
+
+    expect(gap).toBeNull();
+  });
+
+  test('is silent when nothing is deployed, which is most profiles', () => {
+    // The common case, and the one that decides whether this is a good idea:
+    // somebody who has never deployed must never see a word about deployments.
+    const gap = deploymentGap(at('local', 'config-default'), targets({ local: {} }), 'gmail');
+
+    expect(gap).toBeNull();
+  });
+
+  test('is silent when --target named the local one on this command line', () => {
+    // The house rule `target.ts` states for a conditional line: print it only
+    // when the two disagree. A flag is the operator saying "local" in the same
+    // breath, and the announce directly above already echoes `(flag)` back.
+    // Without this, anyone genuinely running both targets sees the warning on
+    // every local connect and stops reading it.
+    const gap = deploymentGap(at('local', 'flag'), targets({ local: {}, cloud: { deployed: true } }), 'gmail');
+
+    expect(gap).toBeNull();
+  });
+
+  test('fires for a config default, which is the case it exists for', () => {
+    const gap = deploymentGap(at('local', 'config-default'), targets({ local: {}, cloud: { deployed: true } }), 'gmail');
+
+    expect(gap).not.toBeNull();
+    expect(gap!.join('\n')).toContain('lanes link connect gmail --target cloud');
+  });
+
+  test('fires for an exported variable, the source hardest to notice', () => {
+    const gap = deploymentGap(at('local', 'environment'), targets({ local: {}, cloud: { deployed: true } }), 'gmail');
+
+    expect(gap!.join('\n')).toContain('--target cloud');
+  });
+
+  test('names both targets, so the sentence says which is which', () => {
+    const text = deploymentGap(
+      at('local', 'config-default'),
+      targets({ local: {}, cloud: { deployed: true } }),
+      'gmail',
+    )!.join('\n');
+
+    expect(text).toContain('"local" declares no deployment');
+    expect(text).toContain('"cloud"');
+  });
+
+  test('echoes the spec verbatim, so the command it prints is pasteable', () => {
+    const declared = targets({ local: {}, cloud: { deployed: true } });
+
+    // A named connection and a whole account are both legal specs, and both
+    // have to survive into the suggested command — `connect icloud` is the
+    // family case, where inventing `icloud_mail` here would be wrong.
+    expect(deploymentGap(at('local', 'config-default'), declared, 'gmail.side')!.join('\n')).toContain(
+      'lanes link connect gmail.side --target cloud',
+    );
+    expect(deploymentGap(at('local', 'config-default'), declared, 'icloud')!.join('\n')).toContain(
+      'lanes link connect icloud --target cloud',
+    );
+  });
+
+  test('refuses to pick when several targets are deployed', () => {
+    // `resolveDeployTarget` throws rather than taking whichever came first in a
+    // YAML mapping. A printed line should not be less careful than the resolver.
+    const text = deploymentGap(
+      at('local', 'config-default'),
+      targets({ local: {}, cloud: { deployed: true }, staging: { deployed: true } }),
+      'gmail',
+    )!.join('\n');
+
+    expect(text).toContain('<one of: cloud, staging>');
+    expect(text).toContain('"cloud" and "staging"');
+  });
+});
+
+describe('announcing the target', () => {
+  const resolution: Resolution = {
+    workspaceRoot: '/tmp/workspace',
+    profile: 'personal',
+    profilePath: '/tmp/workspace/profiles/personal.yaml',
+    target: 'local',
+    profileSource: 'workspace-default',
+    targetSource: 'config-default',
+  };
+
+  const config = { targets: targets({ local: {}, cloud: { deployed: true } }) };
+
+  test('writes nothing to stdout for a --json caller', () => {
+    // The assertion is the parse. `emit` guards the lines printed at the emit,
+    // and this one precedes the browser — so it carries its own guard, and a
+    // stray line here would corrupt the document a caller is parsing.
+    const { out } = captured(() => {
+      announceConnectTarget({ resolution, config }, 'gmail', true);
+      process.stdout.write(JSON.stringify({ ok: true }));
+    });
+
+    expect(() => JSON.parse(out)).not.toThrow();
+  });
+
+  test('names the profile, the target, and where each came from', () => {
+    const { out } = captured(() => announceConnectTarget({ resolution, config }, 'gmail', false));
+
+    expect(out).toContain('personal');
+    expect(out).toContain('local');
+    expect(out).toContain('config-default');
+  });
+
+  test('carries the warning on stdout beside the announce, not on stderr', () => {
+    // Splitting the pair across channels would make the warning vanish for
+    // anyone sending stdout to a file — which is when it is needed most.
+    const { out, err } = captured(() => announceConnectTarget({ resolution, config }, 'gmail', false));
+
+    expect(out).toContain('--target cloud');
+    expect(err).toBe('');
+  });
+});

--- a/src/cli/commands/connect/target-note.ts
+++ b/src/cli/commands/connect/target-note.ts
@@ -1,0 +1,97 @@
+import type { Config, Resolution } from '#profile';
+import { announce, print, style, warn } from '../../output.ts';
+
+/**
+ * The line `connect` prints before it acts, and the one case it warns about.
+ *
+ * The sibling of `outcome.ts`, split from the orchestration for the reason that
+ * file's header already gives: the five steps are about vendors and credentials,
+ * this is about what a caller is told. It buys the same thing too — neither
+ * function needs a runtime, a config file, or a credential store to be tested,
+ * which is what makes the wording checkable at all.
+ *
+ * `connect` was the only mutating command that never said which target it wrote
+ * to, and the only one that writes a credential to a real store. A profile whose
+ * `instance.default_target` is still `local` after a deploy takes the account
+ * into the local file, and the deployed endpoint goes on refusing it — with
+ * nothing printed that would let anyone notice. `docs/deploy.md` already claimed
+ * "every command prints which target it resolved and where that came from"; this
+ * is the file that makes that true.
+ */
+
+/**
+ * Say where this is going, unless the caller wants JSON.
+ *
+ * The guard is here rather than at the call site so the announce and the warning
+ * cannot drift apart on the question. `emit`'s early return only protects lines
+ * printed *at* the emit, and this one has to precede the browser — so it needs
+ * the guard `audit.ts` and `owner/shared.ts` already use, for the reason
+ * `output.ts` gives beside `emit`: a line of prose in front of a JSON document
+ * corrupts it for whatever is parsing.
+ */
+export function announceConnectTarget(
+  runtime: { readonly resolution: Resolution; readonly config: Pick<Config, 'targets'> },
+  spec: string,
+  json?: boolean | undefined,
+): void {
+  if (json === true) return;
+
+  announce(runtime.resolution);
+
+  const gap = deploymentGap(runtime.resolution, runtime.config.targets, spec);
+  if (!gap) return;
+
+  print();
+  for (const line of gap) print(line);
+}
+
+/**
+ * The warning for an account about to land somewhere the deployment cannot read.
+ *
+ * Returns lines rather than printing them: an array is something a test can
+ * assert on without capturing stdout, and it leaves the wording reusable.
+ *
+ * Three conditions, and the third is the one worth defending. `target.ts` states
+ * the house rule for a conditional line — print it only when the two disagree,
+ * because saying it every time trains people to stop reading it. `--target local`
+ * typed on this very command line is the operator saying it in the same breath,
+ * and the announce directly above already echoes `target local (flag)` back at
+ * them. What is left is exactly the two silent sources: `config-default`, which
+ * is the case this exists for, and `environment`, which `Resolution` calls the
+ * one an operator is most likely to be surprised by.
+ *
+ * "Declares a deployment", never "is deployed". Knowing a target is genuinely
+ * deployed means asking the platform — a `gcloud` subprocess on the path of
+ * every `connect`, a cost `target list` already refuses for a listing. The free
+ * signal is the `deploy` block, so the wording is held to what that proves.
+ */
+export function deploymentGap(
+  resolution: Pick<Resolution, 'target' | 'targetSource'>,
+  targets: Config['targets'],
+  spec: string,
+): readonly string[] | null {
+  if (targets[resolution.target]?.deploy !== undefined) return null;
+  if (resolution.targetSource === 'flag') return null;
+
+  const deployed = Object.entries(targets)
+    .filter(([, declared]) => declared.deploy !== undefined)
+    .map(([name]) => name);
+
+  if (deployed.length === 0) return null;
+
+  const here = resolution.target;
+  // Named rather than picked, matching `resolveDeployTarget`, which throws on
+  // this ambiguity instead of taking whichever came first in a YAML mapping. A
+  // printed line should not be less careful than the resolver.
+  const named = deployed.length === 1 ? deployed[0] : `<one of: ${deployed.join(', ')}>`;
+
+  return [
+    warn(
+      `"${here}" declares no deployment; this profile declares ` +
+        `${deployed.length === 1 ? `"${deployed[0]}"` : deployed.map((name) => `"${name}"`).join(' and ')}, which does.`,
+    ),
+    style.dim(`      The account goes into ${here}'s credential store, so the deployed endpoint`),
+    style.dim('      will not see it. To put it there instead:'),
+    style.dim(`        lanes link connect ${spec} --target ${named}`),
+  ];
+}

--- a/src/cli/commands/setup.ts
+++ b/src/cli/commands/setup.ts
@@ -1,5 +1,5 @@
 import { planAll, planFor, type ProviderPlan } from '#providers/setup/plan.ts';
-import { emit, heading, print, style, table } from '../output.ts';
+import { announce, emit, heading, print, style, table } from '../output.ts';
 import { missingRequirements } from './connect/requirements.ts';
 import { openRuntime, type GlobalFlags } from '../runtime.ts';
 
@@ -55,16 +55,19 @@ export async function setupPlan(provider: string | undefined, flags: SetupFlags)
             ),
           );
 
-      return emit(
-        flags.json,
-        { ...plan, missing: [...missing] },
-        () => renderOne(plan, missing),
-      );
+      // Inside the render callback, not before it: `emit` returns the JSON
+      // early, so this is where a line of prose is safe. `connect` needs its
+      // own guard because its announce has to precede a browser.
+      return emit(flags.json, { ...plan, missing: [...missing] }, () => {
+        announce(runtime.resolution);
+        renderOne(plan, missing);
+      });
     }
 
     const plans = planAll(manifests, context);
 
     return emit(flags.json, { profile: context.profile, providers: plans }, () => {
+      announce(runtime.resolution);
       heading(`Connected in ${style.bold(context.profile)}`);
       const done = plans.filter((plan) => plan.connected.length > 0);
       if (done.length === 0) print(style.dim('  nothing yet'));

--- a/src/deployments/deploy.test.ts
+++ b/src/deployments/deploy.test.ts
@@ -3,6 +3,7 @@ import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { rotatableRefs } from './prepare.ts';
+import { defaultTargetHandOff } from './handoff.ts';
 import {
   deployedWorkspace,
   isWorkspaceConfig,
@@ -470,5 +471,62 @@ describe('the allowlist against a real workspace listing', () => {
     const { source } = await populated();
 
     expect(await landed(source)).toContain('data/personal/credentials.enc.key');
+  });
+});
+
+/**
+ * What a deploy leaves the operator's next command pointing at.
+ *
+ * The bug this closes is silent from both ends: `deploy` picks its own target
+ * and never writes `instance.default_target`, so a bare `connect` straight
+ * afterwards goes to the local store and the revision that just rolled goes on
+ * refusing the account. Neither command says a word about it.
+ */
+describe('the hand-off after a deploy', () => {
+  test('says nothing when a bare command already lands on the deployment', () => {
+    expect(defaultTargetHandOff({ deployed: 'cloud', defaultTarget: 'cloud' })).toBeNull();
+  });
+
+  test('names the file, the deployed target, and both ways to change it', () => {
+    const text = defaultTargetHandOff({ deployed: 'cloud', defaultTarget: 'local' })!;
+
+    expect(text).toContain('instance.default_target is still "local"');
+    expect(text).toContain('lanes link connect <provider> --target cloud');
+    expect(text).toContain('lanes link target use cloud');
+  });
+
+  test('says nothing when the variable already points at the deployment', () => {
+    // The case a naive `defaultTarget !== deployed` check gets wrong: the file
+    // disagrees, and it does not matter, because the variable wins and the
+    // operator's next command lands in the right place regardless.
+    expect(
+      defaultTargetHandOff({ deployed: 'cloud', defaultTarget: 'local', fromEnv: 'cloud' }),
+    ).toBeNull();
+  });
+
+  test('names the variable rather than the file when the variable is winning', () => {
+    // Telling someone to run `target use` while a variable overrides the file is
+    // advice that changes the file and nothing else — the same trap `target use`
+    // warns about from its own end.
+    const text = defaultTargetHandOff({
+      deployed: 'cloud',
+      defaultTarget: 'local',
+      fromEnv: 'staging',
+    })!;
+
+    expect(text).toContain('LANES_LINK_TARGET="staging"');
+    expect(text).toContain('wins over the file');
+    expect(text).toContain('export LANES_LINK_TARGET=cloud');
+    expect(text).not.toContain('lanes link target use');
+  });
+
+  test('names what a bare command actually resolves to, not what the file says', () => {
+    const text = defaultTargetHandOff({
+      deployed: 'cloud',
+      defaultTarget: 'local',
+      fromEnv: 'staging',
+    })!;
+
+    expect(text).toContain('still acts on "staging"');
   });
 });

--- a/src/deployments/deploy.ts
+++ b/src/deployments/deploy.ts
@@ -1,4 +1,4 @@
-import { ConfigError, resolveDeployTarget, type DeployConfig } from '#profile';
+import { ConfigError, TARGET_ENV, resolveDeployTarget, type DeployConfig } from '#profile';
 import { announce, fail, heading, ok, print, style, warn } from '#cli/output.ts';
 import { staleNudge } from '#cli/release.ts';
 import { confirm, isInteractive } from '#cli/prompt.ts';
@@ -8,6 +8,7 @@ import { printSteps, runSteps } from './steps.ts';
 import { driverFor } from './drivers.ts';
 import { prepareSecrets, readableRefs, rotatableRefs } from './prepare.ts';
 import { deployedWorkspace, repairSetupSurface, uploadWorkspace } from './upload.ts';
+import { defaultTargetHandOff } from './handoff.ts';
 
 /**
  * `lanes link deploy` — set up what is missing, build the image, roll a revision,
@@ -211,16 +212,31 @@ export async function deploy(flags: DeployFlags): Promise<void> {
         `deployed, but the platform reported no URL yet — run: lanes link outputs --target ${target}`,
       ),
     );
-    return;
+  } else {
+    heading('Endpoint');
+    print(`  ${url}/mcp`);
+    print(await healthLine(url));
+    print('');
+    print(registerLine(target));
+
+    reportUnauthorised(prepared.warnings, target);
   }
 
-  heading('Endpoint');
-  print(`  ${url}/mcp`);
-  print(await healthLine(url));
-  print('');
-  print(registerLine(target));
-
-  reportUnauthorised(prepared.warnings, target);
+  // Last, and on the no-URL path too — that deploy still succeeded, and where
+  // the operator's next command runs is just as wrong either way. It goes after
+  // `reportUnauthorised` for the reason that function's own comment gives about
+  // going last: this one governs every subsequent command, so it has the
+  // strongest claim on the bottom of the screen. On a first deploy nothing is
+  // unauthorised yet and this is the only thing left on it.
+  const handOff = defaultTargetHandOff({
+    deployed: target,
+    defaultTarget: config.instance.default_target,
+    ...(process.env[TARGET_ENV] ? { fromEnv: process.env[TARGET_ENV] } : {}),
+  });
+  if (handOff) {
+    print('');
+    print(handOff);
+  }
 }
 
 /**

--- a/src/deployments/handoff.ts
+++ b/src/deployments/handoff.ts
@@ -1,0 +1,67 @@
+import { TARGET_ENV } from '#profile';
+import { style } from '#cli/output.ts';
+
+/**
+ * What a deploy leaves the operator's *next* command pointing at.
+ *
+ * `deploy` is the one command that works out its own target — the one declaring
+ * a `deploy` block, per `resolveDeployTarget` — and it changes nothing about
+ * where every other command runs. That is correct, and it is invisible: a
+ * profile scaffolded with `default_target: local` still resolves `local`
+ * afterwards, so the `connect` typed straight after a successful deploy writes
+ * the account into the local credential store and the revision that just rolled
+ * goes on refusing it. Nothing in either command's output disagrees.
+ *
+ * Its own file rather than a private function in `deploy.ts` because that is
+ * what makes it testable: `deploy.test.ts` does not import `deploy.ts`, and
+ * making it do so would drag the whole CLI runtime — every provider manifest —
+ * into a unit test, along with a `deployments → cli → deployments` cycle.
+ */
+
+export function defaultTargetHandOff(input: {
+  /** The target that was just deployed. */
+  readonly deployed: string;
+  /** `instance.default_target` — what the profile says. */
+  readonly defaultTarget: string;
+  /**
+   * `LANES_LINK_TARGET`, when this shell exports one.
+   *
+   * Read here, and deliberately, though `resolveDeployTarget` refuses to read it
+   * three files away. The two rules answer different questions. There it governs
+   * *what gets deployed*, where a stray export could name a Cloud Run service
+   * into existence. Here it governs *what the operator's next command will do* —
+   * and their next command genuinely does read it, so a prediction that ignored
+   * it would be wrong exactly when it matters.
+   */
+  readonly fromEnv?: string | undefined;
+}): string | null {
+  // What a bare command resolves to, not what the file says. A profile left at
+  // `local` with `LANES_LINK_TARGET` already exported as the deployed target
+  // lands there anyway, and telling that operator to fix something is noise.
+  const bare = input.fromEnv ?? input.defaultTarget;
+  if (bare === input.deployed) return null;
+
+  // Naming whichever one is actually winning. Telling someone to run
+  // `target use` while a variable overrides the file is advice that changes the
+  // file and nothing else — which is the case `target use` itself warns about
+  // from the other end.
+  const why =
+    input.fromEnv !== undefined
+      ? `${TARGET_ENV}="${input.fromEnv}" is set in this shell and wins over the file, so`
+      : `instance.default_target is still "${input.defaultTarget}" — deploying did not change it, so`;
+
+  const connect = `lanes link connect <provider> --target ${input.deployed}`;
+  const settle =
+    input.fromEnv !== undefined
+      ? `export ${TARGET_ENV}=${input.deployed}`
+      : `lanes link target use ${input.deployed}`;
+
+  const width = Math.max(connect.length, settle.length) + 3;
+
+  return style.dim(
+    `  ${why}\n` +
+      `  a command without --target still acts on "${bare}", which this deployment cannot read.\n` +
+      `    ${connect.padEnd(width)}for one account\n` +
+      `    ${settle.padEnd(width)}${input.fromEnv !== undefined ? 'for this shell' : 'for good'}`,
+  );
+}


### PR DESCRIPTION
`connect` was the only mutating command that never printed which target it resolved, and the only command that writes a credential to a real store. On a profile deployed to Cloud Run but left at `default_target: local` — which is every profile, because `deploy` does not change it — `lanes link connect gmail` put the refresh token in the local encrypted file and the deployed endpoint went on refusing the account, with nothing printed that would let anyone notice.

Three things made that hard to see rather than merely undocumented:

- `connect` had no `announce` call at all, so the one line every other command prints before acting was missing exactly where acting is irreversible.
- `deploy` resolves its target by a different rule from every other command — the one declaring a `deploy` block, per `resolveDeployTarget` — so `deploy` and then `connect` in one shell act on different targets and neither said so.
- `docs/deploy.md:57` already claimed *"Every command prints which target it resolved and where that came from, so neither can act on you silently"*, which has been false for this one since it was written.

## What changes

`connect` and `setup plan` announce their target. `connect` warns when the store it is about to write to has no deployment while the profile declares one. `deploy` ends by saying `instance.default_target` is unchanged and how to change it.

```console
$ lanes link connect example
profile personal (workspace-default)  target local (config-default)  ~/.lanes-link

warn  "local" declares no deployment; this profile declares "cloud", which does.
      The account goes into local's credential store, so the deployed endpoint
      will not see it. To put it there instead:
        lanes link connect example --target cloud
```

and after a deploy:

```
  instance.default_target is still "local" — deploying did not change it, so
  a command without --target still acts on "local", which this deployment cannot read.
    lanes link connect <provider> --target cloud   for one account
    lanes link target use cloud                    for good
```

`--json` now carries `profile` and `target` too — an agent parsing the outcome had the same blindness the operator did.

## Decisions worth reviewing

**The warning is suppressed when `--target` named the store on the same command line.** This follows the rule `target.ts` already states for a conditional line — print it only when the two disagree — because a flag is the operator saying it in the same breath, and a warning shown on every local connect is one nobody reads by the second week. What is left is the two silent sources, `config-default` and `environment`.

**It says "declares no deployment", not "is not deployed".** Knowing a target is genuinely deployed means asking the platform, which is a `gcloud` subprocess on the path of every `connect` — a cost `target list` already refuses for a mere listing. The free signal is the `deploy` block, and the wording is held to what that proves.

**`handoff.ts` reads `LANES_LINK_TARGET` although `resolveDeployTarget` is forbidden to.** The two rules answer different questions: there it governs what gets deployed, where a stray export could name a Cloud Run service into existence; here it governs what the operator's next command will do, and their next command genuinely does read it.

**`deploy --dry-run` deliberately does not print the hand-off.** That path returns before any rollout, and "deploying did not change it" would contradict `--dry-run`'s own "nothing was run" line.

**Two new files rather than private functions.** Both are testable without a runtime, a config file, or a credential store — which is what makes the wording checkable at all. `handoff.ts` additionally could not live in `deploy.ts`: `deploy.test.ts` does not import it, and making it do so would pull the whole CLI runtime into a unit test along with a `deployments → cli → deployments` cycle.

**The family fan-out moved to `accounts.ts` and `outcome.ts` first.** Not tidying — `connect/index.ts` was at 398 lines against the 400-line budget, two lines of headroom and not enough for a guarded call plus the comment explaining it. It now sits at 394.

## Verification

`bun test` 1715 pass / 0 fail (baseline 1699 — 16 new tests). `bun run typecheck` clean.

Behaviour exercised end-to-end against a scratch workspace with a `local` and a declared-but-undeployed `cloud`: the warning fires for `config-default` and `environment`, stays silent for `--target`, `--json` still parses on both `connect` and `setup plan`, and all four hand-off variants render as intended.