### PR TITLE
Rewrite the verification text for the form Google actually shows now

### DIFF
--- a/docs/detailed/google-verification.md
+++ b/docs/detailed/google-verification.md
@@ -89,17 +89,17 @@ accept when it arrives unprompted and with the escape hatch attached. It is the 
 security assessment](#the-security-assessment-and-the-question-that-decides-it) section makes at
 length, compressed to one clause. Do not drop it to buy characters for something else.
 
-### Your sensitive scopes — 998 characters
+### Your sensitive scopes — 995 characters
 
-> Lanes Link is an open-source MCP endpoint the user runs on their own machine so their agent acts on their accounts. Requests go from that machine straight to Google and back: no Lanes server in that path, no copy kept, never sold, advertised against, or used to train AI. Our shared OAuth client is optional; --own-client uses the user's own.
+> Lanes Link is an open-source MCP endpoint the user runs on their own machine, so the AI agent they chose can act on their Google data when they ask. Requests go from that machine straight to Google and back: no Lanes server in that path, no copy kept, never sold, advertised against, or used to train AI. Our shared OAuth client is optional; --own-client uses their own.
 >
-> calendar.readonly: calendarList.list (which calendars exist, and the time zone new events need) and freebusy.query ("when am I free"); calendar.events grants neither.
-> calendar.events: read events and insert/patch/move them. .readonly cannot create; .owned drops shared calendars.
-> documents, spreadsheets: read and edit Docs and Sheets. The .readonly forms cannot write; Drive cannot substitute, as a whole-file replace loses formulas.
-> tasks: read and add tasks. Google publishes only tasks and tasks.readonly.
-> contacts.readonly, contacts.other.readonly: resolve a name to an address; never enumerated.
+> Calendar (calendar.readonly, calendar.events): show their schedule, answer "when am I free", and create or reschedule events they ask for. The read-only forms cannot create an event.
 >
-> Full calendar and contacts write are not requested.
+> Docs and Sheets (documents, spreadsheets): read a doc or sheet to answer a question about it and make the edits they ask for. The .readonly forms cannot write.
+>
+> Tasks (tasks): list their tasks, add one, mark one done. Google publishes no narrower write scope.
+>
+> Contacts (contacts.readonly, contacts.other.readonly): turn a name into an email address when they say "email Bob about the invoice". Read-only, and only a search they asked for.
 
 ### Your restricted scopes → Drive scopes — 994 characters
 
@@ -131,9 +131,17 @@ monitoring, compliance, anti-spam or CRM applies.
 > mail.google.com is not requested; no permanent deletion, only trash.
 
 Each was cut to fit, and what got cut is the same thing every time: the handling paragraph below
-shrank to one clause, and the per-operation lists shrank to the operations a reviewer would
-recognise. What was kept in all three is the narrower-scope argument, because that is the half a
-submission is rejected on.
+shrank to one clause, and the per-operation detail shrank to what a reviewer reads rather than what
+an implementer needs. What was kept in all three is the narrower-scope argument, one clause per
+group, because the prompt asks for it by name and it is the half a submission is rejected on.
+
+The sensitive box is deliberately the plainest of the three. It carries seven scopes across four
+products, and a reviewer meeting it has no reason to know an API method name — so it names the
+product, says what the user gets, and gives the narrower-scope answer in a clause. It also does not
+list the scopes that were *not* requested. That argument is real and it is made at length below, but
+in 1000 characters shared by seven scopes the space goes to what is being asked for. The restricted
+boxes still make it, because `drive.file` versus `drive.readonly` and the absence of
+`mail.google.com` are the questions those reviewers actually arrive with.
 
 ## The shared handling paragraph
 

--- a/docs/detailed/google-verification.md
+++ b/docs/detailed/google-verification.md
@@ -143,6 +143,25 @@ in 1000 characters shared by seven scopes the space goes to what is being asked 
 boxes still make it, because `drive.file` versus `drive.readonly` and the absence of
 `mail.google.com` are the questions those reviewers actually arrive with.
 
+### Additional info — 974 characters
+
+A fourth box, at the end of the submission after the scope justifications and the video link, and
+the only one on the form that is optional. It is where [the broker](#the-security-assessment-and-the-question-that-decides-it)
+gets stated, because there is nowhere in a scope justification that it fits and being asked is worse
+than volunteering. Google also asks outright here for "the project IDs of any other projects that
+use OAuth", which for this application is the sign-in project ADR-031 keeps separate — so answer it.
+
+`PROJECT_ID` is a placeholder: the sign-in project's id goes there when this is pasted, and does not
+get written back into this file. The measured length leaves room for it.
+
+> Two things, stated before you ask.
+>
+> 1. Where user data goes. Lanes Link is an open-source CLI the user installs and runs themselves (github.com/lanes-sh/link). Their Google data moves directly between that machine and Google: we operate no server in that path and keep no copy. What does reach a Lanes server is the OAuth authorization code and the refresh token, in transit through our token broker and not retained, plus a salted one-way hash of the account id, used to rate-limit the shared client. An installed app cannot hold a client secret, which is the only reason the broker exists. --own-client registers the user's own client and removes us from that path too.
+>
+> 2. Other OAuth projects. Sign-in and data access are deliberately separate. The sign-in client lives in project PROJECT_ID and requests only openid, email and profile: no sensitive or restricted scopes.
+>
+> To try it: bun install -g @lanes-sh/link, then lanes link connect gmail. No Lanes account needed.
+
 ## The shared handling paragraph
 
 This is the full statement of what becomes of the data, and it no longer fits in the console: the

--- a/docs/detailed/google-verification.md
+++ b/docs/detailed/google-verification.md
@@ -1,8 +1,8 @@
 # Google verification: what goes in the console
 
 Google Auth Platform → **Data access** refuses a submission until every sensitive and restricted
-scope carries three things: a **scope justification**, an **intended data usage** statement, and a
-**demo video** URL. None of them are settings. They are free text on a console form, and a
+scope is accounted for: the feature that needs it, what becomes of the data, and **why a narrower
+scope will not work**. None of them are settings. They are free text on a console form, and a
 submission is rejected on what they say.
 
 This file is that text, kept here rather than only in the form, for three reasons. Verification is
@@ -19,11 +19,22 @@ Everything below is about the **hosted client** — the one Lanes operates, whic
 
 ## Where each field lives
 
+The console used to ask three questions of each of the twelve scopes on its own form. It now
+groups them — **one box for all seven sensitive scopes together, one box per restricted API
+family** — and merges the justification and the intended-data-usage statement into a single
+question, capped at **1000 characters**.
+
 | Field | Where | What it has to contain |
 |---|---|---|
-| Scope justification | Data access → **Fix the issue** → per-scope form | The feature that needs the scope, and **why a narrower scope will not work** — an explanation naming what would break. Omitting the second half is the common rejection. |
-| Intended data usage | The same form | What happens to data obtained under this scope. |
-| Demo video | The same form | One YouTube URL, unlisted is fine, reused for every scope. |
+| How will the scopes be used? | **Your sensitive scopes** — one box, all seven | Per scope: the feature that needs it, and **why a narrower scope will not work** — an explanation naming what would break. Omitting the second half is the common rejection. |
+| How will the scopes be used? | **Your restricted scopes** → **Drive scopes** | The same for `drive.readonly`, plus what becomes of the data. |
+| How will the scopes be used? | **Your restricted scopes** → **Gmail scopes** | The same for the four Gmail scopes. |
+| What features will you use? | A multi-select above each restricted family's box | Google's own categories. Drive: **Drive productivity** alone. Gmail: **Email client** and **Email productivity**. Claiming a category the application does not have is a rejection by itself, so "Select all" is the wrong answer to a question that offers it. |
+| Demo video | **Not on this page** — the final submission step | One YouTube URL, unlisted is fine, covering every scope. |
+
+The prompt under each box asks for three things — "why you need these scopes, how you will use
+them, and why more limited scopes aren't sufficient" — which is the old justification and the old
+intended data usage in one field. Both have to come out of the same 1000 characters.
 
 `openid` and `email` are added on the brokered path at connect time rather than declared in a
 manifest, and the console does not list them. Nothing is needed for either.
@@ -63,10 +74,74 @@ deletion, and does not request unrestricted `drive`. Permanent deletion is not o
 `messages.delete`, `threads.delete` and `files.delete` are deliberately absent, and trash is the
 recoverable form of the same intent.
 
+## What goes in the console today
+
+Three boxes, three texts, each measured against the 1000-character cap and each carrying all three
+of the things the prompt asks for. This is what is pasted. Everything from [the shared handling
+paragraph](#the-shared-handling-paragraph) onward is the long-form reasoning these were condensed
+out of, kept because it is what answers a reviewer's follow-up and because it is where the argument
+for a scope is maintained when the scope changes.
+
+All three end their opening paragraph by volunteering that the hosted client is optional. That
+sentence is there deliberately: a reviewer assessing restricted scopes is deciding whether this
+application can reach user data through a third-party server, and the honest answer is easier to
+accept when it arrives unprompted and with the escape hatch attached. It is the same argument [the
+security assessment](#the-security-assessment-and-the-question-that-decides-it) section makes at
+length, compressed to one clause. Do not drop it to buy characters for something else.
+
+### Your sensitive scopes — 998 characters
+
+> Lanes Link is an open-source MCP endpoint the user runs on their own machine so their agent acts on their accounts. Requests go from that machine straight to Google and back: no Lanes server in that path, no copy kept, never sold, advertised against, or used to train AI. Our shared OAuth client is optional; --own-client uses the user's own.
+>
+> calendar.readonly: calendarList.list (which calendars exist, and the time zone new events need) and freebusy.query ("when am I free"); calendar.events grants neither.
+> calendar.events: read events and insert/patch/move them. .readonly cannot create; .owned drops shared calendars.
+> documents, spreadsheets: read and edit Docs and Sheets. The .readonly forms cannot write; Drive cannot substitute, as a whole-file replace loses formulas.
+> tasks: read and add tasks. Google publishes only tasks and tasks.readonly.
+> contacts.readonly, contacts.other.readonly: resolve a name to an address; never enumerated.
+>
+> Full calendar and contacts write are not requested.
+
+### Your restricted scopes → Drive scopes — 994 characters
+
+**What features will you use?** *Drive productivity*, and nothing else. Nothing copies Drive
+content anywhere for retention, so not *Drive backup*; nothing mirrors Drive to a local folder, so
+not *Drive sync client*.
+
+> Lanes Link is an open-source MCP endpoint the user runs on their own machine so their agent can find and read the files they name. File content goes from that machine straight to Google and back: no Lanes server in that path, no copy kept, never sold, advertised against, or used to train AI models. Our shared OAuth client is optional; --own-client uses the user's own and removes us from the credential exchange.
+>
+> drive.readonly covers files.list (search), files.get, files.export (Google-native files have no downloadable bytes), permissions.list (sharing) and about.get (quota).
+>
+> Nothing narrower works. drive.file is requested alongside it and bounds every write, but alone reaches only files this app created or the user picked in the Google Picker - and there is no picker: this is a command-line endpoint with no UI. A file is named by title in conversation, so it must be findable by search - files.list. drive.metadata.readonly returns no content. Unrestricted drive is not requested.
+
+### Your restricted scopes → Gmail scopes — 992 characters
+
+**What features will you use?** *Email client* and *Email productivity*. Reading, searching,
+drafting and sending is client behaviour; archiving, labels and filters is productivity. The scope
+set spans both, and picking one leaves the other half unexplained — client alone makes
+`settings.basic` look stray, productivity alone weakens `compose`. Nothing about backup, migration,
+monitoring, compliance, anti-spam or CRM applies.
+
+> Lanes Link is an open-source MCP endpoint the user runs on their own machine so their agent can read, write and organise their mail. Mail goes from that machine straight to Google and back: no Lanes server in that path, no copy kept, never sold, advertised against, or used to train AI models. Our shared OAuth client is optional; --own-client uses the user's own and removes us from the credential exchange.
+>
+> gmail.readonly: messages/threads.list and .get, labels, drafts, attachments.get, filters.list. gmail.metadata returns no body, so "summarise this thread" fails.
+> gmail.compose: drafting and sending. gmail.send cannot create or revise a draft, and drafting keeps the user in the loop.
+> gmail.modify: read/unread, archive, spam, folders, labels. Gmail has no narrower verb: each is messages.modify, since a folder is a label.
+> gmail.settings.basic: filters.create/delete, to block a sender. No other scope accepts it.
+>
+> mail.google.com is not requested; no permanent deletion, only trash.
+
+Each was cut to fit, and what got cut is the same thing every time: the handling paragraph below
+shrank to one clause, and the per-operation lists shrank to the operations a reviewer would
+recognise. What was kept in all three is the narrower-scope argument, because that is the half a
+submission is rejected on.
+
 ## The shared handling paragraph
 
-Every **intended data usage** field ends with this. The scope-specific sentence says what is read
-or written; this says what becomes of it, and it is the same answer for all twelve.
+This is the full statement of what becomes of the data, and it no longer fits in the console: the
+grouped boxes are 1000 characters and the narrower-scope argument has to win that space. Each of
+the three texts above carries a one-clause form of it instead, and this is what that clause
+compresses. It is kept whole because it is what to send if a reviewer asks, and because the privacy
+policy has to stay consistent with it.
 
 > Lanes Link is software the user runs on their own machine. The request goes from that machine
 > directly to Google and the response returns to it — Lanes operates no server in that path and
@@ -81,6 +156,12 @@ or written; this says what becomes of it, and it is the same answer for all twel
 > <https://lanes.sh/privacy>, section 7.
 
 ## Gmail
+
+Everything from here on is long-form: one section per scope, at the length the argument actually
+takes. None of it is pasted as-is — [What goes in the console
+today](#what-goes-in-the-console-today) is what goes in the boxes. This is where the reasoning
+lives, where a reviewer's follow-up is answered from, and what has to be edited when an operation
+is added to `SELECTION`.
 
 ### `gmail.readonly`
 
@@ -302,9 +383,11 @@ the user asked for are returned to the user's machine. *(Then the shared handlin
 
 ## The demo video
 
-**One** unlisted YouTube video, its URL pasted into every scope's field. Not one per scope — a
-single recording is required to cover all of them, which is the whole reason it is worth recording
-last, after the scope set has stopped moving.
+**One** unlisted YouTube video covering every scope. Not one per scope — a single recording is
+required to cover all of them, which is the whole reason it is worth recording last, after the
+scope set has stopped moving. The URL field is no longer on the Data access page and is not asked
+for per scope; it is collected once at the final submission step, after the boxes above are
+filled.
 
 There is no way to avoid it here. A video is required for *sensitive* scopes as well as restricted
 ones, so dropping all five restricted scopes would still leave seven that need it; the only routes
@@ -361,9 +444,10 @@ exists for this field, and says so in its own source: review tooling will not fo
 parameter into a client-side tab. A `?tab=` form resolves to the same document for a human and is a
 gratuitous chance for a reviewer to land somewhere unintended.
 
-**Fill the three fields on every sensitive and restricted scope** — justification, intended data
-usage, demo video — from the text above. The console refuses the submission until all three are
-present on all twelve; `drive.file` needs none.
+**Fill all three boxes and both feature dropdowns** from [What goes in the console
+today](#what-goes-in-the-console-today). The console refuses the submission until every sensitive
+and restricted scope is covered by the box it sits under; `drive.file` needs nothing, and the video
+URL is asked for later.
 
 **Say what the broker is before anyone asks.** The next section is why.
 

--- a/docs/detailed/google-verification.md
+++ b/docs/detailed/google-verification.md
@@ -143,24 +143,31 @@ in 1000 characters shared by seven scopes the space goes to what is being asked 
 boxes still make it, because `drive.file` versus `drive.readonly` and the absence of
 `mail.google.com` are the questions those reviewers actually arrive with.
 
-### Additional info — 974 characters
+### Additional info — 988 characters
 
 A fourth box, at the end of the submission after the scope justifications and the video link, and
-the only one on the form that is optional. It is where [the broker](#the-security-assessment-and-the-question-that-decides-it)
-gets stated, because there is nowhere in a scope justification that it fits and being asked is worse
-than volunteering. Google also asks outright here for "the project IDs of any other projects that
-use OAuth", which for this application is the sign-in project ADR-031 keeps separate — so answer it.
+the only one on the form that is optional. Three things go in it and they only just fit.
+
+[The broker](#the-security-assessment-and-the-question-that-decides-it) is the first, because there
+is nowhere in a scope justification it fits and being asked is worse than volunteering. The full
+handling statement is the second — the scope boxes carry a one-clause form, and this is the only
+place the Limited Use commitment can be made in Google's own words, which is worth the characters
+it costs. The third is that Google asks outright, in the box's own prompt, for "the project IDs of
+any other projects that use OAuth": for this application that is the sign-in project
+[ADR-031](adr/031-sign-in-and-data-access-are-separate-projects.md) keeps separate, and a question
+the form asks by name reads as an omission when it goes unanswered.
+
+What did not fit is the install command — it is one line in the README and the repository is linked
+from the first sentence.
 
 `PROJECT_ID` is a placeholder: the sign-in project's id goes there when this is pasted, and does not
-get written back into this file. The measured length leaves room for it.
+get written back into this file. The measured length leaves room for a longer one.
 
-> Two things, stated before you ask.
+> Lanes Link is open-source software the user runs on their own machine: github.com/lanes-sh/link. Requests go from that machine directly to Google and back: Lanes operates no server in that path and holds no copy. Google user data is never used for advertising, never sold or transferred, never read by a person at Lanes, and never used to develop, improve or train generalised or non-personalised AI/ML models. Full statement: lanes.sh/privacy, section 7.
 >
-> 1. Where user data goes. Lanes Link is an open-source CLI the user installs and runs themselves (github.com/lanes-sh/link). Their Google data moves directly between that machine and Google: we operate no server in that path and keep no copy. What does reach a Lanes server is the OAuth authorization code and the refresh token, in transit through our token broker and not retained, plus a salted one-way hash of the account id, used to rate-limit the shared client. An installed app cannot hold a client secret, which is the only reason the broker exists. --own-client registers the user's own client and removes us from that path too.
+> The only things reaching a Lanes server are the OAuth authorization code and refresh token, in transit through our token broker and not retained, plus a salted hash of the account identifier, used to enforce the per-account limit on the shared client. An installed app cannot hold a client secret, which is the only reason the broker exists. --own-client registers the user's own client and removes us from that path too.
 >
-> 2. Other OAuth projects. Sign-in and data access are deliberately separate. The sign-in client lives in project PROJECT_ID and requests only openid, email and profile: no sensitive or restricted scopes.
->
-> To try it: bun install -g @lanes-sh/link, then lanes link connect gmail. No Lanes account needed.
+> Other OAuth projects: sign-in is separate, in project PROJECT_ID, requesting only openid, email and profile.
 
 ## The shared handling paragraph
 

--- a/docs/detailed/google-verification.md
+++ b/docs/detailed/google-verification.md
@@ -143,31 +143,29 @@ in 1000 characters shared by seven scopes the space goes to what is being asked 
 boxes still make it, because `drive.file` versus `drive.readonly` and the absence of
 `mail.google.com` are the questions those reviewers actually arrive with.
 
-### Additional info — 988 characters
+### Additional info — 996 characters
 
 A fourth box, at the end of the submission after the scope justifications and the video link, and
 the only one on the form that is optional. Three things go in it and they only just fit.
 
 [The broker](#the-security-assessment-and-the-question-that-decides-it) is the first, because there
-is nowhere in a scope justification it fits and being asked is worse than volunteering. The full
-handling statement is the second — the scope boxes carry a one-clause form, and this is the only
-place the Limited Use commitment can be made in Google's own words, which is worth the characters
-it costs. The third is that Google asks outright, in the box's own prompt, for "the project IDs of
-any other projects that use OAuth": for this application that is the sign-in project
+is nowhere in a scope justification it fits and being asked is worse than volunteering. The handling
+statement is the second — the scope boxes carry a one-clause form, and this is where the Limited Use
+commitment gets made in Google's own words, which is worth the characters it costs. The third is
+that Google asks outright, in the box's own prompt, for "the project IDs of any other projects that
+use OAuth": for this application that is the sign-in project
 [ADR-031](adr/031-sign-in-and-data-access-are-separate-projects.md) keeps separate, and a question
 the form asks by name reads as an omission when it goes unanswered.
 
-What did not fit is the install command — it is one line in the README and the repository is linked
-from the first sentence.
+Two things did not fit and are not missed. The install command is one line in the README and the
+repository is linked in the first sentence. The privacy policy URL has a dedicated field elsewhere
+on the same submission, so the pointer here is a cross-reference rather than the link itself.
 
-`PROJECT_ID` is a placeholder: the sign-in project's id goes there when this is pasted, and does not
-get written back into this file. The measured length leaves room for a longer one.
-
-> Lanes Link is open-source software the user runs on their own machine: github.com/lanes-sh/link. Requests go from that machine directly to Google and back: Lanes operates no server in that path and holds no copy. Google user data is never used for advertising, never sold or transferred, never read by a person at Lanes, and never used to develop, improve or train generalised or non-personalised AI/ML models. Full statement: lanes.sh/privacy, section 7.
+> Lanes Link is open-source software the user runs on their own machine: github.com/lanes-sh/link. Requests go from that machine directly to Google and back: Lanes operates no server in that path and holds no copy. Google user data is never used for advertising, never sold or transferred, never read by a person at Lanes, and never used to develop, improve or train generalised or non-personalised AI/ML models. See section 7 of our privacy policy.
 >
 > The only things reaching a Lanes server are the OAuth authorization code and refresh token, in transit through our token broker and not retained, plus a salted hash of the account identifier, used to enforce the per-account limit on the shared client. An installed app cannot hold a client secret, which is the only reason the broker exists. --own-client registers the user's own client and removes us from that path too.
 >
-> Other OAuth projects: sign-in is separate, in project PROJECT_ID, requesting only openid, email and profile.
+> Other OAuth projects: sign-in (for desktop app) is separate, in project lanes-sh, requesting only openid, email and profile.
 
 ## The shared handling paragraph
 


### PR DESCRIPTION
Google Auth Platform → Data access no longer asks three questions of each of twelve scopes. It groups them into **three boxes and two dropdowns**, each box capped at **1000 characters**, with the scope justification and the intended-data-usage statement merged into one question. `docs/detailed/google-verification.md` was written against the old per-scope form, so nothing in it could be pasted — the Gmail section alone is ~2,500 characters before the shared handling paragraph is appended.

That defeats the file's stated purpose, which is that next year's re-submission starts from what was accepted this year rather than from memory.

## What changed

- **New "What goes in the console today" section** holding the three texts verbatim, each measured: sensitive 998, Drive 994, Gmail 992.
- **"Where each field lives" rewritten** for the grouped form — which box, what it must contain, and the 1000-character cap.
- **The two "What features will you use?" multi-selects recorded**: *Drive productivity* alone for Drive; *Email client* and *Email productivity* for Gmail. The categories that do **not** apply are named too, so the next person does not re-derive them — claiming a feature the app lacks is a rejection on its own.
- **Per-scope prose kept and reframed** as the long-form source rather than paste-ready copy.
- **The shared handling paragraph reframed**: it no longer fits the console, so each text carries a one-clause form and the full version is kept for a reviewer's follow-up and for privacy-policy consistency.
- **Demo video**: the URL field has left the Data access page for the final submission step, and is no longer per scope.

## Why the long-form prose was not just condensed in place

It is where the argument for a scope is maintained when the scope changes, and it is what answers a reviewer's follow-up. Cutting it down to what fits a text box would have destroyed the reasoning in order to serve the transcription. Two layers, one job each.

What survived the cut in all three texts is the **narrower-scope argument**, because that is the half a submission is rejected on. What shrank is the handling paragraph and the per-operation lists.

## The hosted-client disclosure

All three texts volunteer that the shared OAuth client is optional and that `--own-client` removes Lanes from the credential exchange. A reviewer of restricted scopes is deciding whether this application can reach user data through a third-party server, and that answer lands better unprompted and with the escape hatch attached — the same argument the security-assessment section already makes at length.

It says **"optional"** rather than "opt-in" because [ADR-028](docs/detailed/adr/028-a-hosted-oauth-client-is-the-default.md) makes the hosted client the *default*. The public docs say so and a reviewer can read them.

## Verification

- `bun test` — 1699 pass, 2 skip, 0 fail (unchanged from the baseline on `main`)
- `bun run typecheck` — clean
- The `<!-- scopes:begin -->` block is untouched, so `specs.test.ts` still holds this file to the manifests in both directions. No scope changed.
- All three character counts re-measured out of the committed file, not asserted by hand.

Docs-only, so no release bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
