### PR TITLE
Offer a service account key as a second way into a Google account

### DIFF
--- a/docs/detailed/adr/037-a-key-is-the-second-way-into-an-account.md
+++ b/docs/detailed/adr/037-a-key-is-the-second-way-into-an-account.md
@@ -1,0 +1,91 @@
+# ADR-037: A key is the second way into an account
+
+**Status:** accepted · **Follows from** [ADR-028](028-a-hosted-oauth-client-is-the-default.md)
+
+## Context
+
+Every Google connection had to be re-authorised weekly, and the reason was not the one the code
+said it was. `shared/oauth.ts` claimed the hosted client escaped the seven-day refresh-token
+expiry "because that expiry is a property of a project left in 'Testing' and this one is not."
+The premise is right and the conclusion was wrong: the expiry follows the client's **publishing
+status**, which is a different setting from its verification status, and a client under review
+has whatever status it has. Meanwhile `shared/setup.ts` told operators taking the
+bring-your-own path to *leave* their own client in Testing, and closed by telling them to expect
+to re-run `connect` every week.
+
+So both routes into a Google account expired weekly, one by accident and one on purpose, and the
+document explaining verification read as though verification were the only way out.
+
+Publishing an unverified client to production is most of the fix and is not a code change — it
+is one setting, and it costs an "unverified app" screen plus a lifetime cap of 100 new users that
+cannot be reset. That is the right trade for a client one person uses and the wrong one for a
+client handed out, which is why it is a documented choice rather than a default.
+
+It also does not help at all where an organisation forbids publishing, and it does nothing about
+the deeper property: an authorization-code refresh token lives or dies by policy applied to
+somebody's consent, and that policy is not the operator's.
+
+## Decision
+
+A provider may declare a second way in, `auth.assertion` — RFC 7523, where the operator holds a
+private key, signs a short-lived JWT, and exchanges it for an access token. There is no refresh
+token, because there is nothing to refresh. `lanes link connect` offers the choice where a
+provider declares one and asks nothing where it does not.
+
+Four things about the shape, each of which had an obvious alternative that is worse:
+
+**It is not a fourth `auth.kind`.** It hangs off the `oauth` block. A `kind` is what a provider
+*is*, and these providers are not two providers — Gmail reached by a key is the same Gmail with
+the same scopes, tools, redaction and policy. Making it a `kind` would have forked
+`credentialRefForConnection`, `setupRequirements`, `rotatableCredentialRefs` and the deploy
+grants, each into two branches that must agree forever.
+
+**The stored credential's shape is the switch, not a field in config.** `credentialResolver` is
+handed a registry and a secret store and never a connection row, so a declaration in config would
+be invisible at precisely the point the decision has to be made. Both methods write to
+`<provider>/<connection>`; one blob has `access_token`, the other has `grant`. This is the same
+device `profileHasOwnClient` already uses — what is stored *is* the declaration — and it has the
+same property: there is one record of the fact, so there is nothing to disagree with.
+
+**The key is per profile and the subject is per connection.** One key covers every provider of a
+vendor. Storing it per connection would mean pasting the same file seven times and rotating seven
+copies of it. What genuinely differs per connection is who the key acts as, and that is a small
+non-secret value that rides in the pointer beside the reference to the key.
+
+**The minted token is cached in memory and never written back.** The authorization-code path
+persists its rotation because the refresh token *is* the credential. Here the credential is the
+key, which nothing at request time modifies — so persisting the access token would make this ref
+rotatable, and a deployed revision would need write access to a secret it only ever reads, to
+cache something that costs one signature and one POST to remake.
+
+## Consequences
+
+The weekly re-authorisation is escapable three ways now, in increasing order of effort: publish
+the client, register your own and publish that, or connect with a key. The first two are
+documented in `setup/google.md` and are not code.
+
+The key route reaches less, and the manifest has to say how much less. A service account is an
+identity in its own right: it has a Drive and a calendar, and no mailbox, contacts or task lists.
+So Drive, Sheets, Docs and Calendar work by sharing a resource with the key's address — which
+also means nothing in the account moves until it is shared, a real narrowing and not only a cost.
+Gmail, Contacts and Tasks work only where a Workspace administrator has granted domain-wide
+delegation, and not at all on a personal account. `delegation: 'optional' | 'required'` is that
+distinction, and it decides both the sentence printed beside the choice and whether a blank
+subject is accepted. A `required` provider refuses one, because a key acting as nobody
+authenticates perfectly and then reads every mailbox as empty — a wrong answer that looks like a
+right one.
+
+`--auth <method>` is the non-interactive answer, and deliberately the only one: a run with nobody
+to ask does not guess, because guessing picks which credential gets overwritten.
+
+Two costs worth stating plainly. A key never expires, which is the feature and also means a
+leaked key is good until someone deletes it — there is no consent to withdraw and no token to
+age out. And domain-wide delegation is a large grant to ask an administrator for; the walkthrough
+names the exact scope list rather than letting someone approximate it, because an approximation is
+refused identically to a missing one and the refusal does not say which scope was short.
+
+## What this does not change
+
+Nothing about a connection that authorised in a browser. The union of `auth.kind` is untouched,
+the credential ref is unchanged, and a manifest that declares no `assertion` block reads, behaves
+and prompts exactly as it did.

--- a/docs/detailed/adr/README.md
+++ b/docs/detailed/adr/README.md
@@ -88,3 +88,8 @@ Where an ADR departs from init.md, it says so at the top. Three are significant:
   for logging a connector out; this one removes the reason a client had for not refreshing. Both
   were needed and neither was sufficient, which is the shape worth remembering: the endpoint was
   correct and the client was correct, and the session still ended at a consent screen.
+
+- **ADR-037** follows from ADR-028 rather than amending it: the hosted client stays the default and
+  the browser stays the ordinary route. What it corrects is a claim ADR-028's implementation made
+  and could not keep — that a hosted client escapes the seven-day refresh-token expiry — and what
+  it adds is the only arrangement that genuinely does, which is a credential nobody consented to.

--- a/docs/detailed/google-verification.md
+++ b/docs/detailed/google-verification.md
@@ -17,6 +17,15 @@ Everything below is about the **hosted client** — the one Lanes operates, whic
 `lanes link connect <provider> --own-client` registers their own and needs none of this;
 [`setup/google.md`](setup/google.md) is that path.
 
+**Verification is not what makes a connection last.** The two are separate settings and it is worth
+being exact, because the confusion sends people here for a problem this page does not solve: the
+seven-day refresh-token expiry follows an OAuth client's *publishing status*, and publishing an
+unverified client removes it. What verification buys is the removal of the unverified-app screen and
+of the lifetime 100-new-user cap — which is what a client handed to other people needs, and is
+unrelated to how long any one connection survives. An operator who wants neither can authenticate
+with a service account key instead ([ADR-037](adr/037-a-key-is-the-second-way-into-an-account.md)),
+which requires no verification of any kind because nothing consents on a user's behalf.
+
 ## Where each field lives
 
 | Field | Where | What it has to contain |
@@ -308,8 +317,8 @@ last, after the scope set has stopped moving.
 
 There is no way to avoid it here. A video is required for *sensitive* scopes as well as restricted
 ones, so dropping all five restricted scopes would still leave seven that need it; the only routes
-that skip it are the ones that skip verification altogether — Internal, Testing, personal use, and
-domain-wide install — and Testing is the status [ADR-028](adr/028-a-hosted-oauth-client-is-the-default.md)
+that skip it are the ones that skip verification altogether — Internal, Testing, personal use,
+domain-wide install, and a service account key — and Testing is the status [ADR-028](adr/028-a-hosted-oauth-client-is-the-default.md)
 exists to escape.
 
 Four things are asked for, and the bar is lower than "demo video" suggests — it is a screen

--- a/docs/detailed/security.md
+++ b/docs/detailed/security.md
@@ -97,19 +97,50 @@ limitation. `RESERVED` names a compatibility slot with no implementation.
 | `audit.every-invocation` | ENFORCED **with two documented exceptions** | see below |
 | `credentials.client-secret-never-local` | ENFORCED (hosted client) | there is no client secret on the machine to hold. `resolveSecretRefs` grants no client reference at all for a connection authorised this way, asserted in `src/dispatch/context.test.ts` |
 | `credentials.exchange-is-local` | **NOT-GUARANTEED for a connection authorised against the hosted client** | see below |
+| `credentials.no-standing-grant` | **NOT-GUARANTEED for a connection authenticated with a key** | see below |
 | `credentials.plaintext-in-use` | NOT-GUARANTEED | inherent |
 | `provider.sandboxed` | NOT-GUARANTEED | provider code is trusted |
 | `egress.controlled` | NOT-GUARANTEED | follows from the above |
 | `policy.approval_required` | RESERVED | the model carries the state; no engine, and it fails closed |
 | `delegation.external-clients` | RESERVED | the principal parameter; nothing more |
 
+### What `credentials.no-standing-grant` gives up
+
+[ADR-037](adr/037-a-key-is-the-second-way-into-an-account.md) added a second way to authenticate a
+Google connection: a service account key, signed into a short-lived assertion and exchanged for an
+access token (RFC 7523). It is the only route here where nothing expires — and that is the same
+sentence read two ways.
+
+Every other credential this system holds decays or can be withdrawn from the other end. An OAuth
+refresh token can be revoked from a Google account page, is subject to the issuer's own expiry
+policy, and dies with the consent that produced it. An app-specific password dies when the account
+password changes. A key does none of that: **nobody consented, so there is no consent to withdraw,
+and a leaked key stays valid until somebody deletes it in a console.**
+
+What bounds it instead is reach, and the bound is real:
+
+- Without domain-wide delegation the key is an identity of its own, and reaches **only what has been
+  shared with its address**. Nothing in the account moves until somebody shares it — a narrower
+  standing grant than any OAuth token here, not a wider one.
+- With domain-wide delegation the key may act as any user in the domain, for the scopes an
+  administrator listed. That is the wide case, and it is granted by an administrator in their own
+  console rather than by anything in this repository.
+
+The key is stored in whichever credential store the config names, encrypted at rest under the file
+adapter like every other secret, and is never sent anywhere except to the token endpoint named
+inside the key file itself. The minted access token is held in memory for the life of the process
+and never written back — see ADR-037 for why persisting it would have widened what a deployed
+revision is granted.
+
+Prefer sharing over delegation wherever sharing will do. One shared folder is a much smaller grant
+than the right to act as a person, and the two are one prompt apart.
+
 ### What `credentials.exchange-is-local` gives up
 
 Since [ADR-028](adr/028-a-hosted-oauth-client-is-the-default.md) a Google connection authorises,
 by default, against an OAuth client Lanes operates rather than one the operator registers. That
-removes a nine-step console walkthrough and the seven-day refresh-token expiry that comes with an
-unpublished project. It also moves one step off this machine, and the honest statement of that is
-worth more than the convenience:
+removes a nine-step console walkthrough. It also moves one step off this machine, and the honest
+statement of that is worth more than the convenience:
 
 - The **authorization code** is sent to the Lanes API, because redeeming it needs the client
   secret and that secret is deliberately not here.
@@ -125,9 +156,11 @@ still live in whichever credential store the config names.
 
 **Nothing in this repository can verify what the Lanes API does with what it sees.** That is the
 whole of the trade, and it is why this is a row in the table rather than a paragraph in a guide.
-An operator who does not want to make it runs `lanes link connect <provider> --own-client` once
-per profile, which registers a client of their own and keeps the exchange between this machine and
-Google. Declaring `oauth_apps` in a profile is the same choice expressed in config, and a profile
+An operator who does not want to make it picks "an OAuth client you register" at the connect prompt
+— or `--auth own_client`, or the older `--own-client` — once per profile, which registers a client
+of their own and keeps the exchange between this machine and Google. A service account key keeps it
+local too, and for a different reason: there is no exchange to move, because there is no
+authorization code. Declaring `oauth_apps` in a profile is the same choice expressed in config, and a profile
 that declares it is never moved off it.
 
 ### Failed authentication is logged, not audited

--- a/docs/detailed/setup/google.md
+++ b/docs/detailed/setup/google.md
@@ -51,7 +51,11 @@ Everything below is that path.
 
 ---
 
-## Two ways in, and the default is the one that works
+## Two providers per product, and the default is the one that works
+
+This is a different question from which credential you use, below: it is which *API* you talk to.
+`gmail` and `gmail_mcp` are separate providers with separate tool lists and separate policy rules,
+and you connect one or the other by name.
 
 | | `gmail` / `drive` | `gmail_mcp` / `drive_mcp` |
 |---|---|---|
@@ -89,27 +93,47 @@ providers are simply unavailable to you — use `gmail` and `drive`, which have 
 
 ## Choose the right path first
 
-For a client of your own, this is the decision that determines everything else, and getting it
-wrong is what sends people into Google's verification centre. None of it applies to the hosted
-client, which is published and carries no seven-day expiry.
+`lanes link connect <provider>` asks which route you want, and prints what each one reaches before
+you pick. There are up to three:
 
-| Your accounts | User type | Verification | Refresh tokens |
+| Route | Console work | Re-authorised weekly? | Reaches |
 |---|---|---|---|
-| **A mix of personal Gmail and Workspace** | **External** | not needed, stay in Testing | **expire every 7 days** |
-| Only accounts on one Workspace domain | Internal | never needed | never expire |
+| The hosted client (default) | none | **while its verification is pending, yes** | the whole account |
+| A client of your own | ~20 minutes, once per profile | **no, if you publish it** — see below | the whole account |
+| A service account key | ~10 minutes, once per profile | **never** | see [Service account](#connecting-with-a-service-account-key) |
 
-**If you have a mix — which is the common case — choose External.** "Internal" sounds like the
-private option, but it only admits accounts on your own Workspace domain, so a personal `@gmail.com`
-account simply cannot authorise against it.
+**The seven-day expiry is a property of publishing status, not of verification.** These are two
+different settings and confusing them is what sends people into the verification centre for a
+problem a checkbox solves. A client whose publishing status is **Testing** has every refresh token
+it issues expired after exactly seven days. A client set to **In production** does not — review
+pending, review never started, it makes no difference.
 
-**Do not publish an External app.** Gmail and Drive use *restricted* scopes, and publishing those
-requires Google verification including a CASA Tier 2 security assessment — the process that asks for
-a demo video, a homepage, and scope justifications, and takes months. Staying in **Testing** needs no
-verification at all.
+That is why the middle row above beats the first one today: the hosted client is under review, and
+a client under review has whatever status it has. Registering your own and publishing it is the
+shortest path to connections that survive the week.
 
-The price of Testing is real and worth knowing up front: **Google expires refresh tokens after seven
-days**, so you will re-authorise roughly weekly. That is a Google policy setting, not a defect here,
-and `lanes link doctor` tells you which connections have gone stale.
+### If you register your own
+
+**Choose External if you have a mix of personal Gmail and Workspace accounts**, which is the common
+case. "Internal" sounds like the private option, but it only admits accounts on your own Workspace
+domain, so a personal `@gmail.com` account simply cannot authorise against it. An Internal app needs
+no verification and has no expiry, so if *every* account is on one domain it is the better choice.
+
+**Then publish it.** Publishing an unverified app is allowed and is not the same as being verified.
+What it costs:
+
+- everyone you connect sees a **"Google hasn't verified this app"** screen and has to click through
+  **Advanced → Go to \<app name\> (unsafe)**;
+- the project gains a cap of **100 new users** granted these scopes, **for the lifetime of the
+  project**, and it cannot be reset.
+
+For a client only you use, both are nothing. For a client you intend to hand out, the cap is a real
+asset to spend, and the calculation is different.
+
+**Verification itself is the other path and a much longer one.** Gmail and Drive use *restricted*
+scopes, so the review includes a CASA Tier 2 security assessment — a demo video, a homepage, scope
+justifications, and months. Worth starting, not worth waiting on: publishing removes the weekly
+re-authorisation today.
 
 ---
 
@@ -172,7 +196,10 @@ App name and a support email. Nothing here is seen by anyone but you.
 Add every Google account you intend to connect under **Test users** (up to 100), personal and
 Workspace alike. An account not listed here cannot authorise.
 
-**Leave the publishing status as "Testing".**
+**Then publish the app** — the same page, under **Publishing status → Publish app**. This is the
+setting that decides whether your connections survive the week; leaving it in Testing is what
+expires them after seven days. See [Choose the right path first](#choose-the-right-path-first) for
+what publishing unverified costs.
 
 ### 4. Data access
 
@@ -346,13 +373,78 @@ instead of the hosted client.
 
 ---
 
+## Connecting with a service account key
+
+The one route where nothing expires, because nothing consented. Pick it at the prompt, or:
+
+```console
+$ lanes link connect drive --auth service_account
+```
+
+A service account is an identity in its own right. It has a Drive and a calendar; it has no mailbox,
+no contacts and no task lists. That single fact decides everything else about this route.
+
+| Provider | Works with a key alone | Needs domain-wide delegation |
+|---|---|---|
+| `drive`, `sheets`, `docs`, `calendar` | **yes** — reaches what you share with it | only to reach the whole account |
+| `gmail`, `contacts`, `tasks` | no — there is nothing there to reach | **yes**, and Workspace only |
+| `gmail_mcp`, `drive_mcp` | not offered — Google's MCP servers take a client, not an assertion | — |
+
+### The key
+
+One key covers every Google provider on a profile, so this is done once. In the Cloud console:
+**IAM & Admin → Service Accounts → Create**, then **Keys → Add key → Create new key → JSON**. Grant
+it no project roles — that page governs Google Cloud resources, and nothing here is one.
+
+`connect` asks for the **path** to the downloaded file. It reads it once and stores the contents, so
+the file itself is not needed afterwards and can be deleted. Pasting the contents works too.
+
+### Sharing, for Drive, Sheets, Docs and Calendar
+
+The key's address ends in `.iam.gserviceaccount.com` and is printed when it is stored. Share what
+you want reachable with it, exactly as you would with a colleague — a Drive folder, one spreadsheet,
+a calendar.
+
+**Nothing else in the account is reachable, including files the same person owns.** That is the
+point of this route and it is also the answer when something appears to be missing: it has not been
+shared yet. Leave the "account to act as" prompt blank and the key acts as itself.
+
+### Delegation, for Gmail, Contacts and Tasks
+
+These need a Google Workspace administrator, and a personal Google account cannot do it at all.
+
+Copy the service account's numeric **Unique ID** from its Details tab — the client ID, not the email
+address. Then, in the Workspace Admin console: **Security → Access and data control → API controls →
+Domain-wide delegation → Add new**. Paste that ID, and paste the provider's full scope list into the
+scopes field, comma-separated, in one go.
+
+`connect` prints the exact list to paste. Paste all of it: a partial list is refused identically to a
+missing one, and the refusal does not say which scope was short. Delegation can take a few minutes to
+take effect — if the first attempt is refused with `unauthorized_client`, wait and run it again.
+Nothing was stored.
+
+Then answer the "account to act as" prompt with the address whose mail, contacts or tasks you want.
+It is required here: a key acting as nobody authenticates perfectly and then reads every mailbox as
+empty, which is a wrong answer that looks like a right one.
+
+### What it costs
+
+A key does not expire, which is the feature and also the whole of the risk: there is no consent to
+withdraw and no token to age out, so a leaked key is good until somebody deletes it in the console.
+Treat it as you would a password, and prefer sharing over delegation where sharing will do — one
+shared folder is a much smaller grant than the right to act as you.
+
+---
+
 ## The weekly re-authorisation
 
-This is a property of **your own** External app while it is in Testing. Connections made against
-the hosted client do not expire weekly, and `doctor` does not warn about their age.
+This is a property of the OAuth client's **publishing status**, and of nothing else. A client in
+Testing has every refresh token it issues expired after seven days; a client in production does
+not. It applies to a client of your own and to the hosted one identically — the hosted client is
+under review, and a client under review has whatever status it has, so connections made against it
+expire weekly too until that lands.
 
-With an External app in Testing, refresh tokens die after seven days. When one does, a call fails
-with a message naming the cause and the fix:
+When one dies, a call fails with a message naming the cause and the fix:
 
 ```
 The refresh token for gmail.work has expired or been revoked.
@@ -366,21 +458,24 @@ $ lanes link doctor
 warn  gmail.personal credential is 8 days old — Testing-status apps expire at 7. Run: lanes link connect gmail.personal
 ```
 
-If the weekly cycle becomes annoying, the escapes are:
+The escapes, cheapest first:
 
-- **Use the hosted client** — drop `--own-client`, remove the `oauth_apps` entry *and* the stored
-  `google/client_id` and `google/client_secret` (both, for the reason above), then run
-  `lanes link connect` again for each account. That client is published, so its refresh tokens do
-  not expire weekly.
+- **Register a client of your own and publish it.** `lanes link connect <provider>` and pick the
+  "OAuth client you register" route, or `--auth own_client`. Publishing is a setting, not a review;
+  it costs an unverified-app screen and a lifetime cap of 100 new users on that project. This is
+  the one most people want.
+- **Connect with a service account key instead** — `--auth service_account`. Nothing expires,
+  because nothing consented. It reaches less, and how much less depends on the product; see
+  [Service account](#connecting-with-a-service-account-key).
 - **Move those accounts to a Workspace domain** and use an Internal app — no expiry, no warning
-  screen, no verification.
+  screen, no verification, and no personal `@gmail.com` accounts either.
 - **Complete Google's verification** for your External app — weeks to months, and for restricted
   scopes it includes a paid third-party security assessment. What the review asks for, scope by
   scope, is in [`../google-verification.md`](../google-verification.md); it is written for the
   hosted client but the questions are the same for yours.
 
-There is no fourth. Anything claiming otherwise is either using non-restricted scopes or is about
-to stop working.
+Anything else claiming to avoid this is either using non-restricted scopes or is about to stop
+working.
 
 ---
 
@@ -388,7 +483,10 @@ to stop working.
 
 | Symptom | Cause |
 |---|---|
-| `invalid_grant`, roughly weekly | Expected in Testing. Re-run `lanes link connect <connection>`. |
+| `invalid_grant`, roughly weekly | The client is in Testing. Publish it, or use a key — see [The weekly re-authorisation](#the-weekly-re-authorisation). |
+| `unauthorized_client` on a service account | Domain-wide delegation is missing, or was granted with a scope list that does not match exactly. The error names the scopes to paste. |
+| `invalid_grant` on a service account | The key was deleted or disabled, or this machine's clock is off by more than a few minutes. |
+| A service account connects but everything is empty | Nothing has been shared with the key's address yet. That is the design, not a fault. |
 | `invalid_grant` immediately | The account is not in **Test users**, or the grant was revoked at <https://myaccount.google.com/permissions>. |
 | 403 "Insufficient Permission" | The API is not enabled, or the consent did not include the scope. |
 | Tools list fine but every call says **"The caller does not have permission"** | You are on `gmail_mcp` / `drive_mcp` without [Workspace Developer Preview](https://developers.google.com/workspace/preview) enrolment. Not a scope problem. Switch to `gmail` / `drive`, which use the REST API and have no gate. |

--- a/src/cli/commands/connect/assertion.test.ts
+++ b/src/cli/commands/connect/assertion.test.ts
@@ -1,0 +1,289 @@
+import { afterAll, describe, expect, test } from 'bun:test';
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { defineProvider, type ProviderManifest } from '#connectivity';
+import { ASSERTION_GRANT } from '#connectivity/auth/index.ts';
+import type { SecretStore } from '#secrets';
+import type { Prompter } from '../../prompt.ts';
+import { authoriseWithKey } from './assertion.ts';
+
+/**
+ * Collecting a key, and the two halves that have different lifetimes.
+ *
+ * The key is one file covering every provider of a vendor and is asked for once
+ * per profile; the account it acts as is per connection. Getting that wrong in
+ * either direction is a real cost — seven pastes of the same file one way, and
+ * a second connection silently inheriting the first's identity the other.
+ */
+
+const directories: string[] = [];
+afterAll(async () => {
+  for (const directory of directories) await rm(directory, { recursive: true, force: true });
+});
+
+const KEY = JSON.stringify({
+  type: 'service_account',
+  client_email: 'link@my-project.iam.gserviceaccount.example',
+  private_key: '-----BEGIN PRIVATE KEY-----\nMIIB\n-----END PRIVATE KEY-----\n',
+  token_uri: 'https://tokens.example.test/token',
+});
+
+function manifest(delegation: 'optional' | 'required' = 'optional'): ProviderManifest {
+  return defineProvider({
+    id: 'vendor_mail',
+    name: 'Vendor Mail',
+    connector: { kind: 'http', base_url: 'https://api.test', openapi: './t.json' },
+    auth: {
+      kind: 'oauth',
+      registration: 'manual',
+      app: 'vendor',
+      scopes: ['https://api.test/auth/read'],
+      authorize_url: 'https://accounts.example.com/o/oauth2/v2/auth',
+      token_url: 'https://oauth2.example.com/token',
+      assertion: {
+        method: 'service_account',
+        label: 'Service account key',
+        delegation,
+        key_ref: 'vendor/key',
+        reach: 'only what is shared with it',
+        subject_label: 'Account to act as',
+        setup: {
+          steps: ['Download the key'],
+          prompts: [
+            { key: 'key', label: 'Path to the key', secret: true, scope: 'shared', credential_ref: 'vendor/key' },
+          ],
+        },
+      },
+    },
+    setup: {
+      prompts: [{ key: 'client_id', label: 'Id', credential_ref: 'vendor/client_id' }],
+    },
+  });
+}
+
+function assertionOf(m: ProviderManifest) {
+  return (m.auth as Extract<ProviderManifest['auth'], { kind: 'oauth' }>).assertion!;
+}
+
+function memoryStore(seed: Record<string, string> = {}) {
+  const map = new Map(Object.entries(seed));
+  return {
+    store: {
+      get: async (ref: string) => map.get(ref) ?? null,
+      set: async (ref: string, value: string) => void map.set(ref, value),
+      has: async (ref: string) => map.has(ref),
+      delete: async (ref: string) => void map.delete(ref),
+      list: async () => [...map.keys()],
+    } as unknown as SecretStore,
+    map,
+  };
+}
+
+/** Answers a queue of questions, and remembers what it was asked. */
+function prompter(...answers: string[]): Prompter & { asked: string[] } {
+  const queue = [...answers];
+  const asked: string[] = [];
+  const next = (question: string): string => {
+    asked.push(question);
+    return queue.shift() ?? '';
+  };
+
+  return {
+    asked,
+    interactive: true,
+    ask: async (question) => next(question),
+    askSecret: async (question) => next(question),
+    confirm: async () => true,
+  };
+}
+
+const silent: Prompter = {
+  interactive: false,
+  ask: async () => '',
+  askSecret: async () => '',
+  confirm: async () => false,
+};
+
+async function keyFileOnDisk(): Promise<string> {
+  const directory = await mkdtemp(join(tmpdir(), 'assertion-'));
+  directories.push(directory);
+  const path = join(directory, 'key.json');
+  await writeFile(path, KEY);
+  return path;
+}
+
+const base = (overrides: Record<string, unknown> = {}) => {
+  const m = manifest();
+  return {
+    manifest: m,
+    assertion: assertionOf(m),
+    connectionId: 'main',
+    changes: [] as string[],
+    replace: false,
+    ...overrides,
+  };
+};
+
+describe('the key', () => {
+  test('is read from the path the console downloaded it to, and stored by value', async () => {
+    const { store, map } = memoryStore();
+    const path = await keyFileOnDisk();
+
+    await authoriseWithKey({ ...base(), credentials: store, prompter: prompter(path, '') });
+
+    // The contents, never the path: this credential outlives the machine, and a
+    // deployed revision has no such file to read.
+    expect(map.get('vendor/key')).toBe(KEY);
+  });
+
+  test('is taken verbatim when it was pasted instead', async () => {
+    const { store, map } = memoryStore();
+
+    await authoriseWithKey({ ...base(), credentials: store, prompter: prompter(KEY, '') });
+
+    expect(map.get('vendor/key')).toBe(KEY);
+  });
+
+  test('is rejected before anything is written when the path is wrong', async () => {
+    const { store, map } = memoryStore();
+
+    await expect(
+      authoriseWithKey({
+        ...base(),
+        credentials: store,
+        prompter: prompter('/no/such/key.json', ''),
+      }),
+    ).rejects.toThrow(/No file at/);
+
+    expect(map.size).toBe(0);
+  });
+
+  test('is rejected before anything is written when it is the wrong file', async () => {
+    const { store, map } = memoryStore();
+    const wrong = JSON.stringify({ installed: { client_id: 'x' } });
+
+    await expect(
+      authoriseWithKey({ ...base(), credentials: store, prompter: prompter(wrong, '') }),
+    ).rejects.toThrow(/client.*file, not an account key/i);
+
+    expect(map.size).toBe(0);
+  });
+
+  test('is asked for once, and found already there by the next provider', async () => {
+    const { store } = memoryStore({ 'vendor/key': KEY });
+    const terminal = prompter('');
+
+    await authoriseWithKey({
+      ...base(),
+      credentials: store,
+      prompter: terminal,
+    });
+
+    // Only the subject. Seven providers share one file, and asking again per
+    // provider would be seven pastes of the same key.
+    expect(terminal.asked).toHaveLength(1);
+    expect(terminal.asked[0]).toContain('Account to act as');
+  });
+
+  test('is asked for again when the operator says so', async () => {
+    const { store, map } = memoryStore({ 'vendor/key': 'stale' });
+
+    await authoriseWithKey({
+      ...base({ replace: true }),
+      credentials: store,
+      prompter: prompter(KEY, ''),
+    });
+
+    expect(map.get('vendor/key')).toBe(KEY);
+  });
+
+  test('is not asked for again on a first connect, because the key is not per connection', async () => {
+    // The bug this pins: `provisional` means "an earlier connect stored
+    // something no server accepted", which is true of a per-connection
+    // credential and false of a key shared by the whole profile. Testing it
+    // here made a stored key unusable — the preflight reported everything
+    // present, and the run that followed immediately asked for it.
+    const { store } = memoryStore({ 'vendor/key': KEY });
+    const terminal = prompter('');
+
+    await authoriseWithKey({ ...base(), credentials: store, prompter: terminal });
+
+    expect(terminal.asked).toHaveLength(1);
+    expect(terminal.asked[0]).toContain('Account to act as');
+  });
+});
+
+describe('the pointer a connection stores', () => {
+  test('names the key rather than copying it, so there is one thing to rotate', async () => {
+    const { store, map } = memoryStore();
+
+    await authoriseWithKey({ ...base(), credentials: store, prompter: prompter(KEY, '') });
+
+    expect(JSON.parse(map.get('vendor_mail/main')!)).toEqual({
+      grant: ASSERTION_GRANT,
+      key_ref: 'vendor/key',
+    });
+  });
+
+  test('carries the account to act as when one was given', async () => {
+    const { store, map } = memoryStore({ 'vendor/key': KEY });
+
+    await authoriseWithKey({
+      ...base(),
+      credentials: store,
+      prompter: prompter('someone@example.com'),
+    });
+
+    expect(JSON.parse(map.get('vendor_mail/main')!).subject).toBe('someone@example.com');
+  });
+
+  test('omits it entirely when the key stands for itself', async () => {
+    const { store, map } = memoryStore({ 'vendor/key': KEY });
+
+    await authoriseWithKey({ ...base(), credentials: store, prompter: prompter('') });
+
+    expect('subject' in JSON.parse(map.get('vendor_mail/main')!)).toBe(false);
+  });
+});
+
+describe('an account this can only reach by acting as someone', () => {
+  const required = () => {
+    const m = manifest('required');
+    return { manifest: m, assertion: assertionOf(m) };
+  };
+
+  test('refuses a blank answer, because the alternative reads as empty rather than as an error', async () => {
+    const { store } = memoryStore({ 'vendor/key': KEY });
+    const { manifest: m, assertion } = required();
+
+    await expect(
+      authoriseWithKey({
+        manifest: m,
+        assertion,
+        connectionId: 'main',
+        credentials: store,
+        changes: [],
+        replace: false,
+        prompter: prompter(''),
+      }),
+    ).rejects.toThrow(/would authenticate and then find every mailbox, list and calendar empty/);
+  });
+
+  test('refuses a run with nobody to ask, rather than acting as nobody', async () => {
+    const { store } = memoryStore({ 'vendor/key': KEY });
+    const { manifest: m, assertion } = required();
+
+    await expect(
+      authoriseWithKey({
+        manifest: m,
+        assertion,
+        connectionId: 'main',
+        credentials: store,
+        changes: [],
+        replace: false,
+        prompter: silent,
+      }),
+    ).rejects.toThrow(/non-interactive/);
+  });
+});

--- a/src/cli/commands/connect/assertion.ts
+++ b/src/cli/commands/connect/assertion.ts
@@ -1,0 +1,187 @@
+import { readFile } from 'node:fs/promises';
+import { homedir } from 'node:os';
+import { isAbsolute, resolve } from 'node:path';
+import { ASSERTION_GRANT, parseAssertionKey } from '#connectivity/auth/index.ts';
+import { credentialRefForConnection, type AuthAssertion, type ProviderManifest } from '#connectivity';
+import type { SecretStore } from '#secrets';
+import { ok, progress, style } from '../../output.ts';
+import { terminalPrompter, type Prompter } from '../../prompt.ts';
+import { askForSetup, printSetup } from './setup.ts';
+
+/**
+ * The counterpart to `authorise.ts`, for a provider authenticated by a key.
+ *
+ * The same conversation, minus the browser: show the console work, take what it
+ * produced, put it in the store. What differs is that there are two halves and
+ * they have different lifetimes — the key is one file covering every provider
+ * of a vendor, and the account it acts as is per connection. So the key is
+ * asked for once per profile and the subject once per account, and re-running
+ * `connect` for a second provider asks for neither.
+ */
+
+/**
+ * Take a path, or the file's contents.
+ *
+ * A key arrives as a downloaded file, and a downloaded file is a path — asking
+ * someone to open it and paste several hundred characters of PEM into a
+ * terminal is asking for a truncated key and an error two steps later. Pasting
+ * still works for anyone who would rather, which is why this looks at the shape
+ * of the answer rather than at a flag.
+ *
+ * What is *stored* is always the contents. A path is a fact about one machine
+ * and this credential outlives it: the same profile is read by a deployed
+ * revision that has no such file, and a store holding a path would fail there
+ * with an error about the filesystem rather than about the credential.
+ */
+async function contentsOf(answer: string): Promise<string> {
+  if (answer.startsWith('{')) return answer;
+
+  const expanded = answer.startsWith('~/') ? resolve(homedir(), answer.slice(2)) : answer;
+  const path = isAbsolute(expanded) ? expanded : resolve(process.cwd(), expanded);
+
+  try {
+    return await readFile(path, 'utf8');
+  } catch {
+    throw new Error(
+      `No file at ${path}. Give the path to the key the console downloaded, or paste its contents.`,
+    );
+  }
+}
+
+/**
+ * Ensure the profile holds the key, and this connection holds a pointer to it.
+ *
+ * Idempotent on the key for the same reason `ensureStaticCredential` is: seven
+ * providers share one file, and the second `connect` must find it already there
+ * and say so rather than asking again. The subject is not idempotent in the
+ * same way — it is per connection, and every connection is a first one.
+ */
+export async function authoriseWithKey(input: {
+  readonly manifest: ProviderManifest;
+  readonly assertion: AuthAssertion;
+  readonly connectionId: string;
+  readonly credentials: SecretStore;
+  readonly changes: string[];
+  /** The operator asked to be asked again — a rotated key, or the wrong account. */
+  readonly replace: boolean;
+  readonly prompter?: Prompter;
+}): Promise<void> {
+  const { manifest, assertion, connectionId, credentials, changes, replace } = input;
+  const prompter = input.prompter ?? terminalPrompter;
+
+  const keyPrompt = assertion.setup.prompts.find((prompt) => prompt.scope === 'shared');
+  if (!keyPrompt) {
+    throw new Error(
+      `Provider "${manifest.id}" declares auth.assertion with no shared prompt, so there is no key to ask for.`,
+    );
+  }
+
+  const stored = await credentials.has(assertion.key_ref);
+
+  // `stored && !replace`, and deliberately not `reuseStoredCredential` — which
+  // also asks whether the connection id is still provisional. That question is
+  // right for a per-connection credential, where a provisional id means an
+  // earlier connect stored something no server ever accepted. It is wrong here:
+  // this key is shared across the whole profile, so a *first* connect of a
+  // second provider is provisional by definition while the key it finds was
+  // stored deliberately and may already be in use. Asking again there made a
+  // stored key unusable — the preflight said it had everything it needed, and
+  // the run that followed immediately asked for it.
+  if (stored && !replace) {
+    // The walkthrough still prints. The key is shared and already held, but the
+    // *sharing* is per resource and per product: whoever connects Sheets after
+    // Drive has a key that works and a spreadsheet nobody has shared with it
+    // yet, and that failure looks exactly like a broken credential.
+    printSetup(
+      manifest,
+      `The key is already stored at ${assertion.key_ref}, so it is not asked for again — but what ` +
+        'it can reach is granted per resource, and this is the first connection of this one.',
+      assertion.setup,
+    );
+    progress(ok(`key already stored (${assertion.key_ref})`));
+    // Named because this is the only way past a key that is stored and wrong,
+    // and a well-formed key for the wrong project is refused by the token
+    // endpoint rather than here.
+    progress(style.dim(`  To replace it: lanes link connect ${manifest.id} --replace`));
+  } else {
+    if (stored) {
+      progress(
+        style.dim(
+          `Replacing ${assertion.key_ref} — what is stored is overwritten only once you have entered a new one.`,
+        ),
+      );
+    }
+
+    const answers = await askForSetup(
+      manifest,
+      [keyPrompt],
+      `Stored at ${assertion.key_ref}, in the credential store — never in config.`,
+      prompter,
+      assertion.setup,
+    );
+
+    const contents = await contentsOf(answers.get(keyPrompt.key)!);
+
+    // Parsed before it is written, so the wrong file is caught here rather than
+    // at the token endpoint. The two candidates live on adjacent pages of the
+    // same console and `parseAssertionKey` knows how to tell them apart.
+    const key = parseAssertionKey(contents, assertion.key_ref);
+
+    await credentials.set(assertion.key_ref, contents);
+    changes.push(`${assertion.key_ref} stored`);
+    progress(ok(`key stored — it acts as ${key.client_email}`));
+  }
+
+  const subject = await askForSubject(assertion, prompter);
+
+  await credentials.set(
+    credentialRefForConnection(manifest, connectionId)!,
+    JSON.stringify({
+      grant: ASSERTION_GRANT,
+      key_ref: assertion.key_ref,
+      ...(subject ? { subject } : {}),
+    }),
+  );
+
+  progress(ok(subject ? `authenticated as ${subject}` : 'authenticated'));
+}
+
+/**
+ * Who the key acts as, where it acts as anyone.
+ *
+ * Blank is a real answer when delegation is `optional` — the key is then an
+ * identity in its own right. It is refused when delegation is `required`,
+ * because the alternative is a credential that authenticates perfectly and
+ * finds nothing: there is no mailbox or contact list belonging to a key, so
+ * every call would return an empty result rather than an error, which is the
+ * worst way for this to be wrong.
+ */
+async function askForSubject(
+  assertion: AuthAssertion,
+  prompter: Prompter,
+): Promise<string | undefined> {
+  const optional = assertion.delegation === 'optional';
+
+  if (!prompter.interactive) {
+    if (optional) return undefined;
+    throw new Error(
+      `This provider can only reach an account by acting as someone, and this run is ` +
+        `non-interactive so there is nobody to ask who. Re-run in a terminal.`,
+    );
+  }
+
+  progress();
+  const answer = await prompter.ask(
+    `  ${assertion.subject_label}${optional ? style.dim(' [none]') : ''}`,
+  );
+
+  if (answer.length > 0) return answer;
+
+  if (optional) return undefined;
+
+  throw new Error(
+    `${assertion.subject_label} is required here: this provider has nothing that belongs to a ` +
+      'key, so a connection that acts as nobody would authenticate and then find every ' +
+      'mailbox, list and calendar empty.',
+  );
+}

--- a/src/cli/commands/connect/authorise.ts
+++ b/src/cli/commands/connect/authorise.ts
@@ -65,8 +65,8 @@ export async function authorise(input: {
   /** How the operator spelled the target, so a refusal names a command they typed. */
   target?: string;
   profile: string;
-  /** `--own-client`: register a client rather than using the one a broker runs. */
-  ownClient?: boolean;
+  /** Which OAuth client, when the operator chose one. `undefined` keeps today's precedence. */
+  client?: 'own' | 'hosted' | undefined;
   prompter?: Prompter;
   /** The operator has already said yes to scopes broader than the provider needs. */
   acceptBroadScopes?: boolean;
@@ -187,7 +187,7 @@ async function authoriseDirect(input: {
   firstForProvider: boolean;
   target?: string;
   profile: string;
-  ownClient?: boolean;
+  client?: 'own' | 'hosted' | undefined;
   prompter?: Prompter;
   acceptBroadScopes?: boolean;
   fetch?: typeof globalThis.fetch;
@@ -210,7 +210,7 @@ async function authoriseDirect(input: {
     document: input.document,
     changes: input.changes,
     firstForProvider: input.firstForProvider,
-    ownClient: input.ownClient === true,
+    client: input.client,
     target: input.target ?? manifest.id,
     profile: input.profile,
     ...(input.prompter ? { prompter: input.prompter } : {}),

--- a/src/cli/commands/connect/client.test.ts
+++ b/src/cli/commands/connect/client.test.ts
@@ -101,7 +101,7 @@ const choice = async (over: Partial<Parameters<typeof resolveOAuthClient>[0]> = 
   document: await document(),
   changes: [] as string[],
   firstForProvider: true,
-  ownClient: false,
+  client: undefined,
   target: 'vendor_mail',
   profile: 'personal',
   fetch: brokerAnswering(OPEN),
@@ -167,7 +167,7 @@ describe('which client a connect uses', () => {
       await choice({
         document: doc,
         changes,
-        ownClient: true,
+        client: 'own' as const,
         credentials: memoryStore({ 'vendor/client_id': 'id', 'vendor/client_secret': 'secret' }),
       }),
     );
@@ -180,9 +180,52 @@ describe('which client a connect uses', () => {
   test('--own-client on a provider that describes no client refuses, and says why', async () => {
     await expect(
       resolveOAuthClient(
-        await choice({ manifest: manifest(BROKER, false), ownClient: true }),
+        await choice({ manifest: manifest(BROKER, false), client: 'own' }),
       ),
     ).rejects.toThrow(/no bring-your-own client path/);
+  });
+});
+
+/**
+ * Asking outright, on a profile that already registered a client.
+ *
+ * The `oauth_apps` entry used to be final, and it was final for a good reason:
+ * a refresh token minted by one client is refused by another, so a profile
+ * silently moved off its own client would find every existing connection
+ * unrefreshable. What makes overriding it safe is that the *token* records
+ * which client minted it — so an override moves this connection and no other.
+ */
+describe('overriding the profile', () => {
+  const registered = () =>
+    memoryStore({ 'vendor/client_id': 'id', 'vendor/client_secret': 'secret' });
+
+  test('the hosted client is used when it is the answer given', async () => {
+    const client = await resolveOAuthClient(
+      await choice({ credentials: registered(), client: 'hosted' }),
+    );
+
+    expect(client.kind).toBe('brokered');
+  });
+
+  test('the profile keeps its own client when nothing was asked for', async () => {
+    // The precedence that has always applied, unchanged by the override above:
+    // an unanswered connect on a profile that registered a client stays on it.
+    const client = await resolveOAuthClient(await choice({ credentials: registered() }));
+
+    expect(client.kind).toBe('own');
+  });
+
+  test('overriding does not un-declare the entry the profile holds', async () => {
+    const changes: string[] = [];
+    const doc = await document();
+
+    await resolveOAuthClient(
+      await choice({ credentials: registered(), client: 'hosted', document: doc, changes }),
+    );
+
+    // The other connections still refresh against it. Removing the entry here
+    // would be an edit on their behalf that nobody asked for.
+    expect(changes).toEqual([]);
   });
 });
 

--- a/src/cli/commands/connect/client.ts
+++ b/src/cli/commands/connect/client.ts
@@ -38,8 +38,15 @@ export interface ClientChoice {
   readonly changes: string[];
   /** No connection of this provider exists yet, so its console setup is undone. */
   readonly firstForProvider: boolean;
-  /** `--own-client`: register one rather than using the client the broker runs. */
-  readonly ownClient: boolean;
+  /**
+   * Which client, when the operator said which.
+   *
+   * `undefined` is the precedence this file has always applied and is what a
+   * provider with one browser route resolves to: a declared `oauth_apps` entry
+   * wins, otherwise the broker. The two explicit values come from the choice
+   * `connect` now prints, and they override that precedence in both directions.
+   */
+  readonly client: 'own' | 'hosted' | undefined;
   /** How the operator spelled the target, so a refusal names a command they typed. */
   readonly target: string;
   readonly profile: string;
@@ -54,9 +61,35 @@ export async function resolveOAuthClient(input: ClientChoice): Promise<OAuthClie
   }
 
   const { app, broker } = manifest.auth;
+  const ownClient = input.client === 'own';
 
-  if (!broker || (await profileHasOwnClient(app, document, credentials)) || input.ownClient) {
-    if (input.ownClient && broker && !hasClientPrompts(manifest)) {
+  // Asked for outright, on a profile that registered a client of its own.
+  //
+  // Honoured rather than overruled, which is a change: the entry used to be
+  // final. It can be honoured safely because which client minted a token is
+  // stamped on the token — so this connection refreshes against the broker
+  // while every existing one keeps refreshing where it was issued. What it must
+  // not be is silent, because the profile's other connections do not move.
+  const insteadOfOwn =
+    input.client === 'hosted' &&
+    broker !== undefined &&
+    (await profileHasOwnClient(app, document, credentials));
+
+  if (insteadOfOwn) {
+    progress(
+      style.dim(
+        `This profile has an OAuth client of its own, and this connection is being authorised ` +
+          `against ${broker.operator}'s instead. Existing connections are unaffected — they keep ` +
+          `refreshing against the client that issued them.`,
+      ),
+    );
+  }
+
+  if (
+    !broker ||
+    (!insteadOfOwn && ((await profileHasOwnClient(app, document, credentials)) || ownClient))
+  ) {
+    if (ownClient && broker && !hasClientPrompts(manifest)) {
       // `defineProvider` permits a broker with no prompts — a provider with no
       // bring-your-own path is a legal thing to be. This is where that absence
       // becomes a sentence rather than a prompt for a value nothing collects.
@@ -73,7 +106,7 @@ export async function resolveOAuthClient(input: ClientChoice): Promise<OAuthClie
       firstForProvider: input.firstForProvider,
       ...(input.prompter ? { prompter: input.prompter } : {}),
     });
-    if (input.ownClient) declareOwnClient(document, manifest, input.changes);
+    if (ownClient) declareOwnClient(document, manifest, input.changes);
 
     const [clientId, clientSecret] = app
       ? await Promise.all([

--- a/src/cli/commands/connect/discover.ts
+++ b/src/cli/commands/connect/discover.ts
@@ -1,0 +1,94 @@
+import { bearerTokenAsStored } from '#connectivity/auth/index.ts';
+import type { AnyConnector, DiscoveredCapability, ProviderManifest } from '#connectivity';
+import { createMcpConnector } from '#connectivity/transports';
+import type { RegisteredProvider } from '#registry';
+import type { SecretStore } from '#secrets';
+import { progress, style } from '../../output.ts';
+
+/**
+ * Step three of `connect`: ask the upstream what it exposes.
+ *
+ * A manifest never declares capabilities for a proxied server — the server is
+ * the source of truth, and a declared list would go stale the moment the vendor
+ * ships. So this is the one part of connecting that talks to the thing being
+ * connected for a reason other than authentication.
+ *
+ * Its own file because the three cases have nothing to do with one another: an
+ * MCP server is asked over a session, an HTTP provider is read from a
+ * description on disk, and a local provider already knows. Interleaved with the
+ * config writing around them, that was three shapes wearing one `if`.
+ */
+
+/**
+ * What discovery is actually doing, per kind, so the wait is explained.
+ *
+ * They differ enough to be worth saying: reading a local OpenAPI file is
+ * instant, while signing in to an IMAP server is a TLS handshake and a LOGIN
+ * against a host that sometimes takes its time.
+ */
+const DISCOVERY_NOTE: Record<string, string> = {
+  mcp: 'Discovering capabilities…',
+  http: 'Reading the API description…',
+};
+
+export async function discoverCapabilities(input: {
+  readonly entry: RegisteredProvider;
+  readonly manifest: ProviderManifest;
+  readonly connectionId: string;
+  readonly credentials: SecretStore;
+  readonly connectorFor: (providerId: string, connectionId: string) => AnyConnector | undefined;
+  /** Called with what was found, so the caller can cache and register it. */
+  readonly remember: (discovered: DiscoveredCapability[]) => Promise<void>;
+}): Promise<DiscoveredCapability[]> {
+  const { entry, manifest, connectionId, credentials } = input;
+
+  if (manifest.connector.kind === 'local') return localCapabilities(entry, manifest);
+
+  progress(style.dim(DISCOVERY_NOTE[manifest.connector.kind] ?? 'Discovering capabilities…'));
+
+  // MCP is the one kind that does not use the runtime's connector here: it
+  // wants the token exactly as just written, without the refresh machinery that
+  // `bearerToken` wraps around it. Every other kind carries whatever credential
+  // it needs from the factory.
+  const connector =
+    manifest.connector.kind === 'mcp'
+      ? createMcpConnector({
+          endpoint: manifest.connector.endpoint,
+          ...(manifest.connector.headers ? { headers: manifest.connector.headers } : {}),
+          accessToken: () => bearerTokenAsStored(manifest, connectionId, credentials),
+        })
+      : input.connectorFor(manifest.id, connectionId);
+
+  if (!connector) return [];
+
+  // Discovery takes the manifest and nothing else. What a provider exposes is a
+  // property of the provider, not of an account — which is just as well,
+  // because the connection being created does not exist in config until the
+  // step after this one.
+  const discovered = await connector.discover({ manifest });
+  await input.remember(discovered);
+  return discovered;
+}
+
+/**
+ * Local capabilities carry their bundle from the manifest.
+ *
+ * Resources are included alongside tools: they need a policy grant too, and
+ * leaving them out would register a resource nothing is allowed to read.
+ */
+function localCapabilities(
+  entry: RegisteredProvider,
+  manifest: ProviderManifest,
+): DiscoveredCapability[] {
+  if (!entry.definition) return [];
+
+  const bundleOf = (name: string): string | undefined =>
+    manifest.bundles?.find((candidate) => candidate.capabilities.includes(name))?.name;
+
+  return entry.definition.capabilities.map((capability) => ({
+    name: capability.name,
+    description: capability.description,
+    inputSchema: {},
+    ...(bundleOf(capability.name) ? { bundle: bundleOf(capability.name)! } : {}),
+  }));
+}

--- a/src/cli/commands/connect/family.ts
+++ b/src/cli/commands/connect/family.ts
@@ -1,0 +1,67 @@
+import type { ProviderRegistry } from '#registry';
+import { progress, style } from '../../output.ts';
+import { credentialApp } from './accounts.ts';
+import { NOTHING, type ConnectOutcome } from './outcome.ts';
+
+/**
+ * `lanes link connect icloud` — an account rather than a provider.
+ *
+ * Everyone models iCloud this way: Apple's own Settings, macOS Internet
+ * Accounts, Thunderbird, DAVx⁵. One authorisation, three services. It is three
+ * *providers* underneath because mail and calendars are different protocols,
+ * and because a policy line per provider is what lets someone allow
+ * `icloud_calendar.*` while never granting mail — but nobody should have to
+ * know that to connect their account.
+ *
+ * Its own file because it is its own subject: `runConnect` is five numbered
+ * steps that add one account, and this is the fan-out that turns one name into
+ * several of those. Keeping them together made the interesting half — how a
+ * partial failure is reported — read as a preamble to be scrolled past.
+ */
+
+/** Which providers answer to this name as a shared account. Fewer than two is not a family. */
+export function familyMembers(registry: ProviderRegistry, name: string): readonly string[] {
+  return registry
+    .list()
+    .filter((candidate) => credentialApp(candidate.manifest) === name)
+    .map((candidate) => candidate.manifest.id);
+}
+
+/**
+ * Connect each member in turn, and report the account rather than the services.
+ *
+ * In sequence, and the order matters: the first settles the account id and
+ * stores the credential, and the rest find both already there.
+ *
+ * The id travels as a flag because the family members are addressed by their
+ * own names — `connect icloud.will` parses `will` off a target that is then
+ * thrown away, and recursing without it meant the command named an account and
+ * each member silently invented its own.
+ */
+export async function connectFamily<Options extends { readonly id?: string | undefined }>(input: {
+  readonly name: string;
+  readonly members: readonly string[];
+  readonly options: Options;
+  readonly namedId: string | undefined;
+  readonly connect: (provider: string, options: Options) => Promise<ConnectOutcome>;
+}): Promise<ConnectOutcome> {
+  const { name, members, options, namedId, connect } = input;
+
+  progress(style.dim(`${name} is ${members.length} services on one account: ${members.join(', ')}`));
+
+  const inherited = { ...options, id: options.id ?? namedId };
+  const outcomes: ConnectOutcome[] = [];
+  for (const member of members) outcomes.push(await connect(member, inherited));
+
+  // The whole account succeeded only if every service did. A partial result is
+  // the case worth surfacing: one member blocked on a value leaves an account
+  // half connected, which `status` shows and prose does not.
+  const firstFailure = outcomes.find((outcome) => !outcome.ok);
+
+  return {
+    ...NOTHING,
+    ok: firstFailure === undefined,
+    members: outcomes,
+    ...(firstFailure?.reason ? { reason: firstFailure.reason } : {}),
+  };
+}

--- a/src/cli/commands/connect/index.ts
+++ b/src/cli/commands/connect/index.ts
@@ -1,13 +1,14 @@
-import { createMcpConnector } from '#connectivity/transports';
-import { bearerTokenAsStored } from '#connectivity/auth/index.ts';
-import type { DiscoveredCapability } from '#connectivity';
 import { credentialRefForConnection, WRITE_BUNDLE } from '#connectivity';
 import { ConfigDocument, ensureSetupConnection, repaired } from '../../config-edit.ts';
 import { emit, print, progress, style } from '../../output.ts';
 import { nonInteractivePrompter, terminalPrompter, type Prompter } from '../../prompt.ts';
 import { openRuntime, type GlobalFlags } from '../../runtime.ts';
-import { credentialApp, matchesRule, moveCredential, siblingAccountId } from './accounts.ts';
+import { matchesRule, moveCredential, siblingAccountId } from './accounts.ts';
+import { discoverCapabilities } from './discover.ts';
+import { connectFamily, familyMembers } from './family.ts';
+import { authoriseWithKey } from './assertion.ts';
 import { authorise } from './authorise.ts';
+import { chooseAuthMethod, currentAuthMethod } from './method.ts';
 import { preflight } from './requirements.ts';
 import { ALREADY, NOTHING, renderOutcome, type ConnectOutcome } from './outcome.ts';
 import { nextAfterEdit, publishRuntimeEdit } from '#cli/publish.ts';
@@ -48,7 +49,23 @@ export interface ConnectOptions extends GlobalFlags {
    * and then forgotten, which is the right shape for a decision about a client
    * that is shared by every connection of that vendor.
    */
+  /**
+   * `--own-client`, the older spelling of one of the routes `--auth` now names.
+   *
+   * Kept because it is in scripts and in a year of documentation, and because
+   * it still says something true. It resolves to `--auth own_client`.
+   */
   readonly ownClient?: boolean | undefined;
+  /**
+   * `--auth <method>`: which way in, for a provider that offers more than one.
+   *
+   * Unset means ask, where there is somebody to ask and something to ask
+   * about. It is not sticky the way `--own-client` is: `--own-client` writes an
+   * `oauth_apps` entry that every connection of the vendor then reads, whereas
+   * this decides one connection's credential and is recorded by that credential
+   * existing. Two accounts on the same profile may honestly differ.
+   */
+  readonly auth?: string | undefined;
   /** Injected for tests. The broker is the only thing `connect` fetches. */
   readonly fetch?: typeof globalThis.fetch | undefined;
   readonly json?: boolean | undefined;
@@ -62,18 +79,6 @@ export interface ConnectOptions extends GlobalFlags {
  * credential filed under it belongs to a `connect` that did not finish.
  */
 const PROVISIONAL_ID = 'pending';
-
-/**
- * What discovery is actually doing, per kind, so the wait is explained.
- *
- * They differ enough to be worth saying: reading a local OpenAPI file is
- * instant, while signing in to an IMAP server is a TLS handshake and a LOGIN
- * against a host that sometimes takes its time.
- */
-const DISCOVERY_NOTE: Record<string, string> = {
-  mcp: 'Discovering capabilities…',
-  http: 'Reading the API description…',
-};
 
 export async function connect(target: string, options: ConnectOptions): Promise<void> {
   const outcome = await runConnect(target, options);
@@ -96,49 +101,19 @@ async function runConnect(target: string, options: ConnectOptions): Promise<Conn
     const registry = runtime.registry;
     const entry = registry.get(providerId);
 
-    // `lanes link connect icloud` — an account rather than a provider.
-    //
-    // Everyone models iCloud this way: Apple's own Settings, macOS Internet
-    // Accounts, Thunderbird, DAVx⁵. One authorisation, three services. It is
-    // three *providers* underneath because mail and calendars are different
-    // protocols, and because a policy line per provider is what lets someone
-    // allow `icloud_calendar.*` while never granting mail — but nobody should
-    // have to know that to connect their account.
+    // One name, several providers. `family.ts` says why iCloud is three.
     if (!entry) {
-      const family = registry
-        .list()
-        .filter((candidate) => credentialApp(candidate.manifest) === providerId)
-        .map((candidate) => candidate.manifest.id);
+      const members = familyMembers(registry, providerId);
 
-      if (family.length > 1) {
+      if (members.length > 1) {
         await runtime.close();
-        progress(
-          style.dim(`${providerId} is ${family.length} services on one account: ${family.join(', ')}`),
-        );
-        // In sequence, and the order matters: the first settles the account id
-        // and stores the credential, and the rest find both already there.
-        //
-        // The id travels as a flag because the family members are addressed by
-        // their own names: `connect icloud.will` parses `will` off a target
-        // that is then thrown away, and recursing with `options` alone dropped
-        // it — the command named an account and each member silently invented
-        // its own.
-        const inherited = { ...options, id: options.id ?? namedId };
-        const members: ConnectOutcome[] = [];
-        for (const member of family) members.push(await runConnect(member, inherited));
-
-        // The whole account succeeded only if every service did. A partial
-        // result is the case worth surfacing: one member blocked on a value
-        // leaves an account half connected, which `status` shows and prose does
-        // not.
-        return {
-          ...NOTHING,
-          ok: members.every((outcome) => outcome.ok),
+        return connectFamily({
+          name: providerId,
           members,
-          ...(members.find((outcome) => !outcome.ok)?.reason
-            ? { reason: members.find((outcome) => !outcome.ok)!.reason }
-            : {}),
-        };
+          options,
+          namedId,
+          connect: runConnect,
+        });
       }
     }
 
@@ -175,7 +150,27 @@ async function runConnect(target: string, options: ConnectOptions): Promise<Conn
 
     const profile = runtime.resolution.profile;
 
-    // 0. With nobody to ask, resolve everything up front or refuse saying why.
+    const prompter: Prompter =
+      options.nonInteractive === true
+        ? nonInteractivePrompter(`lanes link setup plan ${providerId} --profile ${profile}`)
+        : terminalPrompter;
+
+    // 0a. Which way in, before anything is resolved or written.
+    //
+    //     Ahead of the preflight because it changes the answer: one route needs
+    //     a browser and the other needs a key, and refusing a scripted run for
+    //     want of a browser it was never going to open is a refusal about the
+    //     wrong thing. Inert for every provider declaring one method, which is
+    //     all of them but one vendor's.
+    const method = await chooseAuthMethod({
+      manifest,
+      requested: options.auth,
+      ownClient: options.ownClient === true,
+      current: await currentAuthMethod(manifest, provisionalId, runtime.credentials),
+      prompter,
+    });
+
+    // 0b. With nobody to ask, resolve everything up front or refuse saying why.
     //
     //    Before any write, so a refusal leaves the profile exactly as it was.
     //    The whole list comes back at once: discovering a missing value a
@@ -187,17 +182,26 @@ async function runConnect(target: string, options: ConnectOptions): Promise<Conn
         profile,
         credentials: runtime.credentials,
         target,
+        method: method.kind,
       });
 
       if (blocked) return { ...NOTHING, ok: false, ...blocked };
     }
 
-    const prompter: Prompter =
-      options.nonInteractive === true
-        ? nonInteractivePrompter(`lanes link setup plan ${providerId} --profile ${profile}`)
-        : terminalPrompter;
-
-    if (manifest.auth.kind === 'oauth') {
+    if (method.kind === 'assertion') {
+      await authoriseWithKey({
+        manifest,
+        assertion: method.assertion,
+        connectionId: provisionalId,
+        credentials: runtime.credentials,
+        changes,
+        // Same reading as the static-credential arm below: naming a connection,
+        // or asking outright, is how someone says "that one again" — which is
+        // what a rotated key calls for.
+        replace: options.nonInteractive !== true && (options.replace === true || named !== undefined),
+        prompter,
+      });
+    } else if (manifest.auth.kind === 'oauth') {
       await authorise({
         manifest,
         connectionId: provisionalId,
@@ -207,7 +211,7 @@ async function runConnect(target: string, options: ConnectOptions): Promise<Conn
         firstForProvider: !runtime.config.connections.some((c) => c.provider === providerId),
         target,
         profile,
-        ownClient: options.ownClient === true,
+        client: method.client,
         prompter,
         acceptBroadScopes: options.acceptBroadScopes === true,
         ...(options.fetch ? { fetch: options.fetch } : {}),
@@ -257,52 +261,18 @@ async function runConnect(target: string, options: ConnectOptions): Promise<Conn
       if (from && to && from !== to) await moveCredential(runtime.credentials, from, to);
     }
 
-    // 3. Ask the upstream what it exposes. A manifest never declares
-    //    capabilities for a proxied server — the server is the source of truth,
-    //    and a declared list would go stale the moment the vendor ships.
-    let discovered: DiscoveredCapability[] = [];
-
-    if (manifest.connector.kind !== 'local') {
-      progress(style.dim(DISCOVERY_NOTE[manifest.connector.kind] ?? 'Discovering capabilities…'));
-
-      // MCP is the one kind that does not use the runtime's connector here: it
-      // wants the token exactly as just written, without the refresh machinery
-      // that `bearerToken` wraps around it. Every other kind carries whatever
-      // credential it needs from the factory.
-      const connector =
-        manifest.connector.kind === 'mcp'
-          ? createMcpConnector({
-              endpoint: manifest.connector.endpoint,
-              ...(manifest.connector.headers ? { headers: manifest.connector.headers } : {}),
-              accessToken: () =>
-                bearerTokenAsStored(manifest, connectionId, runtime.credentials),
-            })
-          : runtime.connectorFor(providerId, connectionId);
-
-      if (connector) {
-        // Discovery takes the manifest and nothing else. What a provider exposes
-        // is a property of the provider, not of an account — which is just as
-        // well, because the connection being created does not exist in config
-        // until step 4 below.
-        discovered = await connector.discover({ manifest });
-
-        await runtime.state.kv.set('discovery', providerId, JSON.stringify(discovered));
-        registry.setDiscovered(providerId, discovered);
-      }
-    } else if (entry.definition) {
-      // Local capabilities carry their bundle from the manifest. Resources are
-      // included alongside tools: they need a policy grant too, and leaving
-      // them out would register a resource nothing is allowed to read.
-      const bundleOf = (name: string): string | undefined =>
-        manifest.bundles?.find((candidate) => candidate.capabilities.includes(name))?.name;
-
-      discovered = entry.definition.capabilities.map((capability) => ({
-        name: capability.name,
-        description: capability.description,
-        inputSchema: {},
-        ...(bundleOf(capability.name) ? { bundle: bundleOf(capability.name)! } : {}),
-      }));
-    }
+    // 3. Ask the upstream what it exposes.
+    const discovered = await discoverCapabilities({
+      entry,
+      manifest,
+      connectionId,
+      credentials: runtime.credentials,
+      connectorFor: runtime.connectorFor.bind(runtime),
+      remember: async (found) => {
+        await runtime.state.kv.set('discovery', providerId, JSON.stringify(found));
+        registry.setDiscovered(providerId, found);
+      },
+    });
 
     // 4. Declare the connection, or update the one this account already has.
     const existingIndex = runtime.config.connections.findIndex(

--- a/src/cli/commands/connect/method.test.ts
+++ b/src/cli/commands/connect/method.test.ts
@@ -1,0 +1,315 @@
+import { describe, expect, test } from 'bun:test';
+import { defineProvider, type ProviderManifest } from '#connectivity';
+import { ASSERTION_GRANT } from '#connectivity/auth/index.ts';
+import type { SecretStore } from '#secrets';
+import type { Prompter } from '../../prompt.ts';
+import { chooseAuthMethod, currentAuthMethod, methodsFor } from './method.ts';
+
+/**
+ * Which way in, and who decides.
+ *
+ * Two properties matter here and neither is about the prompt. A provider that
+ * offers one method must never ask — adding a choice to Google must not put a
+ * question in front of somebody connecting GitHub. And re-running `connect` on
+ * an existing account must default to what that account already uses, because
+ * the alternative is a repair that quietly replaces the credential it was meant
+ * to repair.
+ */
+
+const ASSERTION = {
+  method: 'service_account',
+  label: 'Service account key',
+  delegation: 'optional',
+  key_ref: 'vendor/key',
+  reach: 'only what is shared with it',
+  subject_label: 'Account to act as',
+  setup: {
+    steps: [],
+    prompts: [
+      { key: 'key', label: 'Key', secret: true, scope: 'shared', credential_ref: 'vendor/key' },
+    ],
+  },
+} as const;
+
+const BROKER = { url: 'https://api.example.com/v1/auth/link/vendor', operator: 'Someone' };
+
+function manifest(withAssertion: boolean, withBroker = false): ProviderManifest {
+  return defineProvider({
+    id: 'vendor_mail',
+    name: 'Vendor Mail',
+    connector: { kind: 'http', base_url: 'https://api.test', openapi: './t.json' },
+    auth: {
+      kind: 'oauth',
+      registration: 'manual',
+      app: 'vendor',
+      scopes: ['https://api.test/auth/mail.read'],
+      authorize_url: 'https://accounts.example.com/o/oauth2/v2/auth',
+      token_url: 'https://oauth2.example.com/token',
+      ...(withBroker ? { broker: BROKER } : {}),
+      ...(withAssertion ? { assertion: ASSERTION } : {}),
+    },
+    setup: {
+      prompts: [
+        { key: 'client_id', label: 'Client id', credential_ref: 'vendor/client_id' },
+        { key: 'client_secret', label: 'Client secret', secret: true, credential_ref: 'vendor/client_secret' },
+      ],
+    },
+  });
+}
+
+/** A terminal that answers whatever it was handed, and records being asked. */
+function prompter(answer = ''): Prompter & { asked: string[] } {
+  const asked: string[] = [];
+  return {
+    asked,
+    interactive: true,
+    ask: async (question) => {
+      asked.push(question);
+      return answer;
+    },
+    askSecret: async () => answer,
+    confirm: async () => true,
+  };
+}
+
+const silent: Prompter = {
+  interactive: false,
+  ask: async () => '',
+  askSecret: async () => '',
+  confirm: async () => false,
+};
+
+function memoryStore(seed: Record<string, string> = {}): SecretStore {
+  const map = new Map(Object.entries(seed));
+  return {
+    get: async (ref: string) => map.get(ref) ?? null,
+    set: async (ref: string, value: string) => void map.set(ref, value),
+    has: async (ref: string) => map.has(ref),
+    delete: async (ref: string) => void map.delete(ref),
+    list: async () => [...map.keys()],
+  } as unknown as SecretStore;
+}
+
+describe('what a provider offers', () => {
+  test('is one browser route, where a client of your own is the only way in', () => {
+    expect(methodsFor(manifest(false))).toEqual(['own_client']);
+  });
+
+  test('is two browser routes, where somebody else runs a client as well', () => {
+    // `--own-client` used to be the only way to reach the second of these, which
+    // is to say it was a choice nobody discovered unless they already knew.
+    expect(methodsFor(manifest(false, true))).toEqual(['hosted_client', 'own_client']);
+  });
+
+  test('names the key first, because it is the one worth knowing about', () => {
+    expect(methodsFor(manifest(true, true))).toEqual([
+      'service_account',
+      'hosted_client',
+      'own_client',
+    ]);
+  });
+});
+
+describe('choosing', () => {
+  test('asks nothing at all when there is one way in', async () => {
+    const terminal = prompter();
+    const chosen = await chooseAuthMethod({
+      manifest: manifest(false),
+      requested: undefined,
+      current: undefined,
+      prompter: terminal,
+    });
+
+    expect(chosen).toEqual({ kind: 'oauth', client: undefined });
+    expect(terminal.asked).toEqual([]);
+  });
+
+  test('leaves the client decision to the profile when it did not ask', async () => {
+    // `client: undefined` is the precedence `resolveOAuthClient` has always
+    // applied. A provider with one browser route must resolve to it rather than
+    // to `own`, which would write an `oauth_apps` entry nobody asked for.
+    const chosen = await chooseAuthMethod({
+      manifest: manifest(false),
+      requested: 'oauth',
+      current: undefined,
+      prompter: prompter(),
+    });
+
+    expect(chosen).toEqual({ kind: 'oauth', client: undefined });
+  });
+
+  test('--own-client still says what it always said', async () => {
+    const terminal = prompter();
+    const chosen = await chooseAuthMethod({
+      manifest: manifest(true, true),
+      requested: undefined,
+      ownClient: true,
+      current: undefined,
+      prompter: terminal,
+    });
+
+    expect(chosen).toEqual({ kind: 'oauth', client: 'own' });
+    expect(terminal.asked).toEqual([]);
+  });
+
+  test('offers the hosted client and a client of your own as separate answers', async () => {
+    expect(
+      await chooseAuthMethod({
+        manifest: manifest(true, true),
+        requested: undefined,
+        current: undefined,
+        prompter: prompter('3'),
+      }),
+    ).toEqual({ kind: 'oauth', client: 'own' });
+
+    expect(
+      await chooseAuthMethod({
+        manifest: manifest(true, true),
+        requested: undefined,
+        current: undefined,
+        prompter: prompter('2'),
+      }),
+    ).toEqual({ kind: 'oauth', client: 'hosted' });
+  });
+
+  test('honours --auth without asking', async () => {
+    const terminal = prompter();
+    const chosen = await chooseAuthMethod({
+      manifest: manifest(true),
+      requested: 'service_account',
+      current: undefined,
+      prompter: terminal,
+    });
+
+    expect(chosen.kind).toBe('assertion');
+    expect(terminal.asked).toEqual([]);
+  });
+
+  test('refuses a method the provider does not have, listing the ones it does', async () => {
+    await expect(
+      chooseAuthMethod({
+        manifest: manifest(true),
+        requested: 'app_password',
+        current: undefined,
+        prompter: prompter(),
+      }),
+    ).rejects.toThrow(
+      /cannot authenticate with "app_password"[\s\S]*oauth, service_account, own_client/,
+    );
+  });
+
+  test('refuses the alternative on a provider that does not offer it', async () => {
+    await expect(
+      chooseAuthMethod({
+        manifest: manifest(false),
+        requested: 'service_account',
+        current: undefined,
+        prompter: prompter(),
+      }),
+    ).rejects.toThrow(/--auth accepts: oauth, own_client/);
+  });
+
+  test('takes the hosted client by default, which is what "as it works today" means', async () => {
+    const chosen = await chooseAuthMethod({
+      manifest: manifest(true, true),
+      requested: undefined,
+      current: undefined,
+      prompter: prompter(''),
+    });
+
+    expect(chosen).toEqual({ kind: 'oauth', client: 'hosted' });
+  });
+
+  test('takes the browser by default where nobody else runs a client', async () => {
+    // Never the key, even though it is listed first: Enter must not mean "the
+    // route with a console visit in it" for someone who was not reading.
+    const chosen = await chooseAuthMethod({
+      manifest: manifest(true),
+      requested: undefined,
+      current: undefined,
+      prompter: prompter(''),
+    });
+
+    expect(chosen.kind).toBe('oauth');
+  });
+
+  test('defaults to what the connection already uses, so a re-run repairs rather than replaces', async () => {
+    // The footgun this exists to close: `connect vendor_mail.main` on a key-backed
+    // connection, Enter pressed out of habit, and the key silently swapped for a
+    // browser flow the operator did not ask for.
+    const chosen = await chooseAuthMethod({
+      manifest: manifest(true),
+      requested: undefined,
+      current: 'assertion',
+      prompter: prompter(''),
+    });
+
+    expect(chosen.kind).toBe('assertion');
+  });
+
+  test('accepts the method by name as well as by number', async () => {
+    const chosen = await chooseAuthMethod({
+      manifest: manifest(true),
+      requested: undefined,
+      current: undefined,
+      prompter: prompter('service_account'),
+    });
+
+    expect(chosen.kind).toBe('assertion');
+  });
+
+  test('refuses an answer that is neither', async () => {
+    await expect(
+      chooseAuthMethod({
+        manifest: manifest(true),
+        requested: undefined,
+        current: undefined,
+        prompter: prompter('yes'),
+      }),
+    ).rejects.toThrow(/not one of the choices. Answer 1 to 2/);
+  });
+
+  test('does not guess for a run with nobody to ask', async () => {
+    const chosen = await chooseAuthMethod({
+      manifest: manifest(true),
+      requested: undefined,
+      current: undefined,
+      prompter: silent,
+    });
+
+    expect(chosen.kind).toBe('oauth');
+  });
+
+  test('keeps a key-backed connection on its key when nobody is there to ask', async () => {
+    const chosen = await chooseAuthMethod({
+      manifest: manifest(true),
+      requested: undefined,
+      current: 'assertion',
+      prompter: silent,
+    });
+
+    expect(chosen.kind).toBe('assertion');
+  });
+});
+
+describe('what a connection uses today', () => {
+  test('is nothing, for one that does not exist yet', async () => {
+    expect(await currentAuthMethod(manifest(true), 'main', memoryStore())).toBeUndefined();
+  });
+
+  test('is read off the credential, not off config', async () => {
+    const store = memoryStore({
+      'vendor_mail/main': JSON.stringify({ grant: ASSERTION_GRANT, key_ref: 'vendor/key' }),
+    });
+
+    expect(await currentAuthMethod(manifest(true), 'main', store)).toBe('assertion');
+  });
+
+  test('is the browser for a stored token blob', async () => {
+    const store = memoryStore({
+      'vendor_mail/main': JSON.stringify({ access_token: 'a', refresh_token: 'r' }),
+    });
+
+    expect(await currentAuthMethod(manifest(true), 'main', store)).toBe('own');
+  });
+});

--- a/src/cli/commands/connect/method.ts
+++ b/src/cli/commands/connect/method.ts
@@ -1,0 +1,249 @@
+import { credentialRefForConnection, type AuthAssertion, type ProviderManifest } from '#connectivity';
+import { BROKERED, storedAssertionFor } from '#connectivity/auth/index.ts';
+import type { SecretStore } from '#secrets';
+import { progress, style } from '../../output.ts';
+import { terminalPrompter, type Prompter } from '../../prompt.ts';
+
+/**
+ * Which way in, where a provider offers more than one.
+ *
+ * Two questions that used to be asked in two different places and are one
+ * question to the person answering: what kind of credential, and — for the
+ * browser — whose OAuth client. The second was a flag, `--own-client`, which is
+ * to say it was a choice nobody discovered unless they already knew it existed.
+ *
+ * Most providers offer exactly one route and this file is inert for them:
+ * `options` returns a single entry, nothing is printed, and nothing is asked.
+ * That is the property worth protecting — adding routes to Google must not put
+ * a question in front of somebody connecting GitHub.
+ */
+
+export type ChosenMethod =
+  | { readonly kind: 'assertion'; readonly assertion: AuthAssertion }
+  /**
+   * The browser, and which client the exchange runs through.
+   *
+   * `undefined` means "whatever this profile already decided", which is the
+   * precedence `resolveOAuthClient` has always applied: a declared `oauth_apps`
+   * entry wins, otherwise the broker. It is what a provider with only one
+   * browser route resolves to, so nothing about those changes.
+   */
+  | { readonly kind: 'oauth'; readonly client: 'own' | 'hosted' | undefined };
+
+/** What this connection authenticates with today, at the granularity the prompt offers. */
+export type CurrentMethod = 'assertion' | 'own' | 'hosted';
+
+interface Option {
+  /** What `--auth` accepts, and how a chosen route is named back. */
+  readonly id: string;
+  readonly label: string;
+  readonly detail: string;
+  readonly chosen: ChosenMethod;
+  readonly matches: CurrentMethod | undefined;
+}
+
+/**
+ * A provider that can be reached with a client of the operator's own.
+ *
+ * `defineProvider` permits a broker with no client prompts — a provider with no
+ * bring-your-own path is a legal thing to be — so offering that route without
+ * checking would offer a choice with nothing behind it.
+ */
+function hasClientPrompts(manifest: ProviderManifest): boolean {
+  return (manifest.setup?.prompts ?? []).some((prompt) => prompt.scope === 'shared');
+}
+
+/**
+ * Every route this provider actually has, in the order they are offered.
+ *
+ * The key first, because it is the one that removes a recurring chore and the
+ * one nobody would guess at. Then the hosted client, which is the default and
+ * the thing "as it works today" means. Then a client of your own, which is
+ * twenty minutes in a console and is what an organisation forbidding
+ * third-party clients needs.
+ */
+export function options(manifest: ProviderManifest): readonly Option[] {
+  if (manifest.auth.kind !== 'oauth') return [];
+
+  const { assertion, broker } = manifest.auth;
+  const found: Option[] = [];
+
+  if (assertion) {
+    found.push({
+      id: assertion.method,
+      label: assertion.label,
+      detail: assertion.reach,
+      chosen: { kind: 'assertion', assertion },
+      matches: 'assertion',
+    });
+  }
+
+  if (broker) {
+    found.push({
+      id: 'hosted_client',
+      label: `Sign in through a browser, using the OAuth client ${broker.operator} operates`,
+      detail:
+        'nothing to register and no client secret on this machine. The exchange is performed by ' +
+        `${broker.operator}, and the connection is re-authorised whenever its token expires.`,
+      chosen: { kind: 'oauth', client: 'hosted' },
+      matches: 'hosted',
+    });
+  }
+
+  if (!broker || hasClientPrompts(manifest)) {
+    found.push({
+      id: 'own_client',
+      label: 'Sign in through a browser, using an OAuth client you register',
+      detail: broker
+        ? 'a console walkthrough once per profile, after which nothing leaves this machine but ' +
+          'the browser. What an organisation that forbids third-party clients needs.'
+        : 'the whole account, and the connection is re-authorised whenever its token expires.',
+      // Undefined rather than 'own' where it is the only browser route: there
+      // is nothing to override, and forcing it would write an `oauth_apps`
+      // entry for a provider whose manifest already says it is the only way.
+      chosen: { kind: 'oauth', client: broker ? 'own' : undefined },
+      matches: 'own',
+    });
+  }
+
+  return found;
+}
+
+/** What `--auth` will accept for this provider, for a message that lists them. */
+export function methodsFor(manifest: ProviderManifest): readonly string[] {
+  return options(manifest).map((option) => option.id);
+}
+
+/**
+ * What this connection authenticates with today, or nothing if it is new.
+ *
+ * Read from the credential rather than from config, because the credential is
+ * where the answer lives: the routes share one ref and are told apart by what
+ * is in it. Asking config instead would be a second record of the same fact,
+ * free to disagree with the one that actually routes.
+ *
+ * `authorized_via` is stamped at connect for the same reason it is read at
+ * refresh — a refresh token minted by one client is refused by another, so
+ * which client issued this is a property of the token and not of the profile.
+ */
+export async function currentAuthMethod(
+  manifest: ProviderManifest,
+  connectionId: string,
+  credentials: SecretStore,
+): Promise<CurrentMethod | undefined> {
+  const ref = credentialRefForConnection(manifest, connectionId);
+  if (!ref) return undefined;
+
+  const raw = await credentials.get(ref);
+  if (!raw) return undefined;
+
+  if (await storedAssertionFor(manifest, connectionId, credentials)) return 'assertion';
+
+  try {
+    return (JSON.parse(raw) as { authorized_via?: string }).authorized_via === BROKERED
+      ? 'hosted'
+      : 'own';
+  } catch {
+    return 'own';
+  }
+}
+
+/**
+ * Choose, from the flag, the operator, or the status quo — in that order.
+ *
+ * `current` is the default rather than a mere hint. Re-running `connect` on an
+ * existing account is a repair nine times in ten, and a prompt whose default
+ * silently swapped the route would turn a stale-token fix into a
+ * re-authorisation nobody asked for — with the old credential overwritten by
+ * the time they noticed.
+ */
+export async function chooseAuthMethod(input: {
+  readonly manifest: ProviderManifest;
+  /** `--auth <method>`, if it was given. */
+  readonly requested: string | undefined;
+  /** `--own-client`, which is the older spelling of one of these. */
+  readonly ownClient?: boolean;
+  /** What this connection authenticates with today, where it already exists. */
+  readonly current: CurrentMethod | undefined;
+  readonly prompter?: Prompter;
+}): Promise<ChosenMethod> {
+  const { manifest, requested } = input;
+  const prompter = input.prompter ?? terminalPrompter;
+  const available = options(manifest);
+
+  if (requested !== undefined) {
+    // `oauth` is not an option id. It is the older, coarser spelling — "the
+    // browser, however this profile already resolves it" — and dropping it
+    // would break a scripted `--auth oauth` for no gain.
+    if (requested === 'oauth') return { kind: 'oauth', client: undefined };
+
+    const picked = available.find((option) => option.id === requested);
+    if (picked) return picked.chosen;
+
+    throw new Error(
+      `${manifest.name} cannot authenticate with "${requested}". ` +
+        `--auth accepts: ${['oauth', ...methodsFor(manifest)].join(', ')}.`,
+    );
+  }
+
+  if (input.ownClient === true) return { kind: 'oauth', client: 'own' };
+
+  // One route, or none this file knows about: decide nothing and say nothing.
+  if (available.length < 2) return { kind: 'oauth', client: undefined };
+
+  // Nobody to ask. The flag above is the non-interactive answer, deliberately —
+  // guessing picks which credential gets overwritten.
+  if (!prompter.interactive) {
+    const held = available.find((option) => option.matches === input.current);
+    return held ? held.chosen : { kind: 'oauth', client: undefined };
+  }
+
+  return ask(manifest, available, input.current, prompter);
+}
+
+async function ask(
+  manifest: ProviderManifest,
+  available: readonly Option[],
+  current: CurrentMethod | undefined,
+  prompter: Prompter,
+): Promise<ChosenMethod> {
+  const held = available.findIndex((option) => option.matches === current);
+  // "As it works today" for anyone who has not chosen otherwise: the hosted
+  // client where there is one, and otherwise the browser. Never the key — it is
+  // listed first because it is the one worth knowing about, and defaulting to
+  // the first entry would make Enter mean "the route with a console visit in
+  // it" for someone who was not reading.
+  const hosted = available.findIndex((option) => option.id === 'hosted_client');
+  const fallback =
+    hosted !== -1 ? hosted : Math.max(available.findIndex((option) => option.chosen.kind === 'oauth'), 0);
+  const preferred = String((held === -1 ? fallback : held) + 1);
+
+  progress();
+  progress(style.bold(`${manifest.name} can authenticate ${count(available.length)} ways`));
+  progress();
+  for (const [index, option] of available.entries()) {
+    progress(`  ${index + 1}. ${option.label}`);
+    progress(style.dim(`     ${option.detail}`));
+  }
+  if (held !== -1) {
+    progress();
+    progress(style.dim(`  This connection uses ${held + 1} today.`));
+  }
+  progress();
+
+  const answer = await prompter.ask(`  Which ${style.dim(`[${preferred}]`)}`);
+  const picked = answer.length === 0 ? preferred : answer;
+
+  const byNumber = available[Number(picked) - 1];
+  if (/^\d+$/.test(picked) && byNumber) return byNumber.chosen;
+
+  const byName = available.find((option) => option.id === picked);
+  if (byName) return byName.chosen;
+
+  throw new Error(
+    `"${picked}" is not one of the choices. Answer 1 to ${available.length}.`,
+  );
+}
+
+const WORDS = ['no', 'one', 'two', 'three', 'four', 'five'];
+const count = (total: number): string => WORDS[total] ?? String(total);

--- a/src/cli/commands/connect/outcome.ts
+++ b/src/cli/commands/connect/outcome.ts
@@ -101,7 +101,15 @@ export function renderOutcome(outcome: ConnectOutcome): void {
  */
 function renderBlocked(outcome: ConnectOutcome): void {
   progress();
-  print(fail(outcome.reason === 'needs_browser' ? 'a browser is needed' : 'more is needed first'));
+  print(
+    fail(
+      outcome.reason === 'needs_browser'
+        ? 'a browser is needed'
+        : outcome.reason === 'needs_terminal'
+          ? 'a terminal is needed'
+          : 'more is needed first',
+    ),
+  );
 
   for (const line of (outcome.message ?? '').split('\n')) print(`      ${line}`);
 

--- a/src/cli/commands/connect/requirements.test.ts
+++ b/src/cli/commands/connect/requirements.test.ts
@@ -184,3 +184,122 @@ describe('preflight', () => {
     ).toBeNull();
   });
 });
+
+/**
+ * The same question, asked of a provider that has two answers.
+ *
+ * The OAuth refusal is about a *browser*, and the key route opens none — so
+ * without the method in hand, a scripted `connect --auth service_account` would
+ * be turned away by a message describing a step it does not perform, naming a
+ * command that would fail the same way.
+ */
+describe('a provider offering a key as well as a browser', () => {
+  const never = { has: async () => false };
+  const always = { has: async () => true };
+
+  const withDelegation = (delegation: 'optional' | 'required') =>
+    defineProvider({
+      id: 'vendor_mail',
+      name: 'Vendor Mail',
+      connector: { kind: 'http', base_url: 'https://api.test', openapi: './t.json' },
+      auth: {
+        kind: 'oauth',
+        registration: 'manual',
+        app: 'vendor',
+        scopes: ['https://api.test/auth/read'],
+        authorize_url: 'https://accounts.example.com/o/oauth2/v2/auth',
+        token_url: 'https://oauth2.example.com/token',
+        assertion: {
+          method: 'service_account',
+          label: 'Service account key',
+          delegation,
+          key_ref: 'vendor/key',
+          reach: 'only what is shared with it',
+          subject_label: 'Account to act as',
+          setup: {
+            prompts: [
+              { key: 'key', label: 'Key', secret: true, scope: 'shared', credential_ref: 'vendor/key' },
+            ],
+          },
+        },
+      },
+      setup: {
+        prompts: [{ key: 'client_id', label: 'Id', credential_ref: 'vendor/client_id' }],
+      },
+    });
+
+  test('still needs a browser when the browser is what was chosen', async () => {
+    const blocked = await preflight({
+      manifest: withDelegation('optional'),
+      connectionId: 'main',
+      profile: 'personal',
+      credentials: never,
+      target: 'vendor_mail',
+      method: 'oauth',
+    });
+
+    expect(blocked?.reason).toBe('needs_browser');
+  });
+
+  test('asks for the key instead, and names it in the command to paste', async () => {
+    const blocked = await preflight({
+      manifest: withDelegation('optional'),
+      connectionId: 'main',
+      profile: 'personal',
+      credentials: never,
+      target: 'vendor_mail',
+      method: 'assertion',
+    });
+
+    expect(blocked?.reason).toBe('missing_credentials');
+    expect(blocked?.needs.map((need) => need.ref)).toEqual(['vendor/key']);
+    // Without this the operator stores the key, re-runs the suggested command,
+    // and lands back in the browser flow they were avoiding.
+    expect(blocked?.then).toContain('--auth service_account');
+  });
+
+  test('is not blocked at all once the key is stored', async () => {
+    expect(
+      await preflight({
+        manifest: withDelegation('optional'),
+        connectionId: 'main',
+        profile: 'personal',
+        credentials: always,
+        target: 'vendor_mail',
+        method: 'assertion',
+      }),
+    ).toBeNull();
+  });
+
+  test('needs a terminal where the key can only act as someone', async () => {
+    // The key is placeable ahead of time and who it acts as is not: that value
+    // lives inside the pointer `connect` writes, so there is no `secrets set`
+    // that would put it there.
+    const blocked = await preflight({
+      manifest: withDelegation('required'),
+      connectionId: 'main',
+      profile: 'personal',
+      credentials: always,
+      target: 'vendor_mail',
+      method: 'assertion',
+    });
+
+    expect(blocked?.reason).toBe('needs_terminal');
+    expect(blocked?.needs).toEqual([]);
+    expect(blocked?.then).toContain('--auth service_account');
+  });
+
+  test('reports the key rather than the client, so nobody stores one they will not use', () => {
+    const { requirements, needsId } = setupRequirements(
+      withDelegation('optional'),
+      undefined,
+      'personal',
+      { method: 'assertion' },
+    );
+
+    expect(requirements.map((requirement) => requirement.ref)).toEqual(['vendor/key']);
+    // The key is shared across every connection of the vendor, so no name has
+    // to be settled before it can be stored.
+    expect(needsId).toBe(false);
+  });
+});

--- a/src/cli/commands/connect/requirements.ts
+++ b/src/cli/commands/connect/requirements.ts
@@ -32,7 +32,12 @@ export async function missingRequirements(
   return missing;
 }
 
-export type BlockedReason = 'needs_id' | 'needs_browser' | 'missing_credentials';
+export type BlockedReason =
+  | 'needs_id'
+  | 'needs_browser'
+  /** A question only a person can answer, on a run with nobody to ask. */
+  | 'needs_terminal'
+  | 'missing_credentials';
 
 export interface Blocked {
   readonly reason: BlockedReason;
@@ -63,11 +68,37 @@ export async function preflight(input: {
   readonly credentials: { has(ref: string): Promise<boolean> };
   /** How the operator spelled the target — `icloud`, or `gmail.main`. */
   readonly target: string;
+  /**
+   * Which way in the operator chose, for a provider offering two.
+   *
+   * The whole reason this parameter exists is that the OAuth refusal below is
+   * about a *browser*, and the key route opens none. Without it a scripted
+   * `connect --auth <key method>` would be turned away by a message describing
+   * a step it does not perform.
+   */
+  readonly method?: 'oauth' | 'assertion';
 }): Promise<Blocked | null> {
   const { manifest, connectionId, profile, target } = input;
+  const method = input.method ?? 'oauth';
   const rerun = `lanes link connect ${target} --profile ${profile}`;
+  const assertion = manifest.auth.kind === 'oauth' ? manifest.auth.assertion : undefined;
 
-  if (manifest.auth.kind === 'oauth') {
+  if (method === 'assertion' && assertion) {
+    // The key can be placed ahead of time; who it acts as cannot. That value
+    // lives inside the pointer `connect` writes, so where it is mandatory this
+    // run has a question and nobody to ask — and refusing here is better than
+    // storing a credential that reads every mailbox as empty.
+    if (assertion.delegation === 'required') {
+      return {
+        reason: 'needs_terminal',
+        message:
+          `${manifest.name} can only reach an account by acting as someone, and who that is has ` +
+          `to be typed.\n  Nothing was written. Run this in a terminal:`,
+        needs: [],
+        then: `${rerun} --auth ${assertion.method}`,
+      };
+    }
+  } else if (manifest.auth.kind === 'oauth') {
     return {
       reason: 'needs_browser',
       message:
@@ -78,7 +109,7 @@ export async function preflight(input: {
     };
   }
 
-  const { requirements, needsId } = setupRequirements(manifest, connectionId, profile);
+  const { requirements, needsId } = setupRequirements(manifest, connectionId, profile, { method });
 
   if (needsId) {
     return {
@@ -98,6 +129,8 @@ export async function preflight(input: {
     reason: 'missing_credentials',
     message: `${manifest.name} needs ${missing.length} value(s) in the credential store first.`,
     needs: missing,
-    then: `${rerun}${connectionId ? ` --id ${connectionId}` : ''} --non-interactive`,
+    then:
+      `${rerun}${connectionId ? ` --id ${connectionId}` : ''}` +
+      `${method === 'assertion' && assertion ? ` --auth ${assertion.method}` : ''} --non-interactive`,
   };
 }

--- a/src/cli/commands/connect/setup.ts
+++ b/src/cli/commands/connect/setup.ts
@@ -1,5 +1,5 @@
 import type { SecretStore } from '#secrets';
-import type { ProviderManifest, SetupPrompt } from '#connectivity';
+import type { ProviderManifest, SetupDeclaration, SetupPrompt } from '#connectivity';
 import { credentialRefForConnection } from '#connectivity';
 import { ConfigDocument } from '../../config-edit.ts';
 import { ok, progress, style } from '../../output.ts';
@@ -27,8 +27,18 @@ import { terminalPrompter, type Prompter } from '../../prompt.ts';
  * an unregistered scope is refused at consent, and a disabled API consents
  * cleanly and then 403s on every call.
  */
-export function printSetup(manifest: ProviderManifest, note: string): void {
-  const setup = manifest.setup;
+export function printSetup(
+  manifest: ProviderManifest,
+  note: string,
+  /**
+   * Which walkthrough. Defaults to the provider's own, and is passed explicitly
+   * by a provider that has more than one way in — those steps are a different
+   * console doing a different job, and printing the browser-flow instructions
+   * to someone who chose a key would be worse than printing nothing.
+   */
+  declaration: SetupDeclaration | undefined = manifest.setup,
+): void {
+  const setup = declaration;
   if (!setup) return;
 
   progress();
@@ -55,15 +65,16 @@ export async function askForSetup(
   prompts: readonly SetupPrompt[],
   note: string,
   prompter: Prompter = terminalPrompter,
+  declaration: SetupDeclaration | undefined = manifest.setup,
 ): Promise<Map<string, string>> {
-  const setup = manifest.setup;
+  const setup = declaration;
   if (!setup) {
     throw new Error(
       `Provider "${manifest.id}" needs a credential but declares no setup, so there is no way to learn what to ask you for. Add a setup block to its manifest.`,
     );
   }
 
-  printSetup(manifest, note);
+  printSetup(manifest, note, setup);
 
   const answers = new Map<string, string>();
   for (const prompt of prompts) {

--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -85,6 +85,7 @@ export async function run(argv: readonly string[]): Promise<void> {
         nonInteractive: flags['non-interactive'] === true,
         acceptBroadScopes: flags['accept-broad-scopes'] === true,
         ownClient: flags['own-client'] === true,
+        auth: text(flags, 'auth'),
         json,
       });
 

--- a/src/cli/usage.ts
+++ b/src/cli/usage.ts
@@ -24,6 +24,7 @@ ${style.bold('Everyday')}
   ${PROGRAM} connect <provider>         add an account (run once per account)
   ${PROGRAM} connect <provider>.<id>    re-authorise one existing account
   ${PROGRAM} connect <...> --replace    ask for the stored password or key again
+  ${PROGRAM} connect <...> --auth <method>  pick how, where there is a choice
   ${PROGRAM} connect <...> --non-interactive [--json]
                                         answer nothing from a terminal: take every value
                                         from the credential store, or say what is missing
@@ -107,6 +108,9 @@ ${style.bold('Global flags')}
   --accept-broad-scopes          agree in advance to scopes broader than a provider needs
   --own-client                   register your own OAuth client instead of using the
                                  one this project operates (connect only)
+  --auth <method>                which way in, where a provider offers two (connect
+                                 only). "oauth" is the browser; the other is named
+                                 in the choice connect prints
   --port <n>                     override the configured port (start only)
 
 Every command prints the resolved profile and target before acting.

--- a/src/connectivity/auth/README.md
+++ b/src/connectivity/auth/README.md
@@ -14,6 +14,7 @@ transport asks when it has a token to send and no request to attach it to.
 | `api-key/` | `api_key` | a key, in a header or the query string |
 | `basic/` | `basic` | `username:password`, RFC 7617's own encoding |
 | `oauth-authcode/` | `oauth` | a refresh token, exchanged on every use |
+| `oauth-jwt/` | `oauth` + `assertion` | a private key, signed into an assertion per exchange |
 | `strategy/` | `strategy` | the escape hatch — per-vendor code, none registered |
 
 ## Adding one
@@ -22,13 +23,18 @@ A folder, a member of `authSchema` in `../manifest/auth.ts`, and a case in
 `resolve.ts` (plus `authorize.ts` if it touches the request). Nothing else in
 the codebase learns about it — that is the point of the split.
 
+`oauth-jwt/` is the exception that proves the shape rather than breaking it. It
+is not a `kind`, because it is a second way into a provider that already has
+one, so it hangs off the OAuth block as `auth.assertion` and is selected by the
+shape of the stored credential. Everything else about it is an ordinary folder
+here.
+
 These are named in the credential-type list this design is measured against and
 are **not built**:
 
 - `sigv4/` — AWS SigV4 request signing
 - `gcp-token/` — service account → GCP access token
 - `gcp-iap/` — service account → an IAP-signed JWT
-- `oauth-jwt/` — OAuth 2.0 JWT bearer (RFC 7523)
 - `oauth-client-creds/` — OAuth 2.0 client credentials
 - `body-param/` — the credential as a request body parameter
 

--- a/src/connectivity/auth/index.ts
+++ b/src/connectivity/auth/index.ts
@@ -7,6 +7,10 @@
  * know the whole set: `resolve.ts` and `authorize.ts` for anything HTTP-shaped,
  * and `token.ts` for a transport that takes a bare token instead of a request.
  *
+ * `oauth-jwt/` is the one folder that is not a `kind`: it is a second way into
+ * a provider that already declares `oauth`, selected by the shape of what is
+ * stored rather than by the manifest. Its own README says why.
+ *
  * This is the axis the manifest's `auth:` block selects, and it is deliberately
  * independent of `../transports/` — which is why iCloud can speak IMAP with a
  * password while Gmail speaks HTTP with OAuth, and neither costs the other any
@@ -24,6 +28,15 @@ export {
   type OAuthProviderOptions,
 } from './oauth-authcode/provider.ts';
 export { resolveUpstreamToken } from './oauth-authcode/index.ts';
+export {
+  ASSERTION_GRANT,
+  clearMintedTokens,
+  isStoredAssertion,
+  resolveAssertionToken,
+  storedAssertionFor,
+  type StoredAssertion,
+} from './oauth-jwt/index.ts';
+export { assertionKeySchema, parseAssertionKey, signAssertion, type AssertionKey } from './oauth-jwt/key.ts';
 export {
   BROKER_ORIGIN_ENV,
   BROKERED,

--- a/src/connectivity/auth/oauth-authcode/index.ts
+++ b/src/connectivity/auth/oauth-authcode/index.ts
@@ -1,6 +1,7 @@
 import { auth } from '@modelcontextprotocol/client';
 import type { ProviderManifest } from '#connectivity';
 import type { SecretStore } from '#secrets';
+import { resolveAssertionToken, storedAssertionFor } from '../oauth-jwt/index.ts';
 import { CredentialOAuthProvider, upstreamAccessToken } from './provider.ts';
 import { refreshDirectly } from './refresh.ts';
 
@@ -12,8 +13,11 @@ import { refreshDirectly } from './refresh.ts';
  * trip at connect time, a refresh on every use, and two different ways to run
  * that refresh depending on whether the provider has a metadata document.
  *
- * The other flows the credential-type list names — JWT bearer, client
- * credentials — are sibling folders that do not exist yet. See ../README.md.
+ * The other flows the credential-type list names — client credentials, SigV4 —
+ * are sibling folders that do not exist yet. See ../README.md. JWT bearer now
+ * does exist, in `../oauth-jwt/`, and is reached from here rather than from
+ * `resolve.ts`: a provider offering both declares one `auth.kind`, so the fork
+ * belongs at the point where the stored credential is first read.
  */
 
 export async function resolveUpstreamToken(
@@ -22,6 +26,16 @@ export async function resolveUpstreamToken(
   credentials: SecretStore,
 ): Promise<string | null> {
   if (manifest.auth.kind !== 'oauth') return null;
+
+  // Before anything is built, because the two arrangements share a ref and only
+  // what is stored there tells them apart. A `CredentialOAuthProvider` over an
+  // assertion pointer would find no `access_token`, conclude the connection was
+  // never authorised, and advise a browser flow the operator deliberately
+  // declined.
+  const assertion = await storedAssertionFor(manifest, connectionId, credentials);
+  if (assertion) {
+    return resolveAssertionToken({ manifest, connectionId, stored: assertion, credentials });
+  }
 
   const provider = new CredentialOAuthProvider({
     manifest,

--- a/src/connectivity/auth/oauth-jwt/README.md
+++ b/src/connectivity/auth/oauth-jwt/README.md
@@ -1,0 +1,33 @@
+# OAuth 2.0 JWT bearer (RFC 7523)
+
+A key the operator holds, signed into a short-lived assertion and exchanged for
+an access token. No browser, and **no refresh token** — there is nothing to
+refresh, because a new assertion is signed whenever the last token ages out.
+That is the point: an authorization-code refresh token lives or dies by the
+issuer's policy, and a key does not.
+
+Not a `kind` of its own. It is declared as `auth.assertion` on an existing
+`oauth` block, because it is a second arrangement for the same provider rather
+than a different provider — so `credentialRefForConnection`, `setupRequirements`
+and the deploy grants all stay as they were. Which arrangement a connection uses
+is decided by the *shape* of what is stored at `<provider>/<connection>`:
+`isStoredAssertion` is that test, and `resolve.ts` asks it before building an
+authorization-code provider.
+
+| File | What it owns |
+|---|---|
+| `key.ts` | the key file's layout, PEM to DER, and the signed claim set — no I/O |
+| `index.ts` | reading the pointer, the exchange, the process-lifetime token cache |
+
+The endpoint comes from `token_uri` **inside the key file**, never from a
+constant here, which is what keeps this folder free of any vendor. A second
+vendor offering the same grant is a manifest and no code.
+
+## What it cannot do
+
+An assertion authenticates the key, and a key is not a person. It reaches only
+what has been shared with its address — unless the identity provider is
+configured to let it act as someone, which is an administrator's grant and not
+the operator's. `auth.assertion.delegation` says which of the two a provider is,
+and `cli/commands/connect/method.ts` is where that becomes a sentence someone
+reads before choosing.

--- a/src/connectivity/auth/oauth-jwt/index.ts
+++ b/src/connectivity/auth/oauth-jwt/index.ts
@@ -1,0 +1,228 @@
+import type { ProviderManifest } from '#connectivity';
+import type { SecretStore } from '#secrets';
+import { credentialRefForConnection } from '../../manifest/credential-ref.ts';
+import { parseAssertionKey, signAssertion } from './key.ts';
+
+/**
+ * OAuth 2.0 JWT bearer (RFC 7523) — a key the operator holds, in place of a
+ * person approving a consent screen.
+ *
+ * The one property that earns this its own folder: there is no refresh token,
+ * because there is nothing to refresh. A fresh assertion is signed whenever the
+ * last access token ages out, so nothing an issuer can expire sits between the
+ * operator and their data. An authorization-code refresh token is subject to
+ * whatever policy the issuer applies to it — one such policy expires them after
+ * seven days, and re-approving a browser screen every week is the failure this
+ * folder exists to remove.
+ *
+ * What it costs is reach. An assertion authenticates the *key*, and a key is
+ * not a person: it holds only what has been shared with it, unless the identity
+ * provider has been configured to let it act as someone, which is an
+ * administrator's grant rather than the operator's. `auth.assertion.delegation`
+ * on the manifest is which of the two a provider is, and the CLI is where that
+ * becomes a sentence.
+ */
+
+/** RFC 7523's grant type, and the marker that identifies a stored credential as one. */
+export const ASSERTION_GRANT = 'urn:ietf:params:oauth:grant-type:jwt-bearer';
+
+/**
+ * What a connection stores when it authenticates this way.
+ *
+ * A pointer and not the key itself. One key covers every provider of a vendor,
+ * so it lives at a profile-shared ref and each connection records where to find
+ * it plus the one thing that genuinely differs per connection — who it acts as.
+ * Copying the key into seven connections would mean seven things to rotate.
+ */
+export interface StoredAssertion {
+  readonly grant: typeof ASSERTION_GRANT;
+  readonly key_ref: string;
+  readonly subject?: string;
+}
+
+/**
+ * Whether a stored credential is one of these.
+ *
+ * Both methods write to the same ref — `<provider>/<connection>` — and this is
+ * what tells them apart. Shape rather than a flag in config, because
+ * `credentialResolver` is handed a registry and a store and never a connection
+ * row, so a declaration in config would be invisible exactly where the decision
+ * has to be made.
+ */
+export function isStoredAssertion(value: unknown): value is StoredAssertion {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    (value as { grant?: unknown }).grant === ASSERTION_GRANT &&
+    typeof (value as { key_ref?: unknown }).key_ref === 'string'
+  );
+}
+
+/**
+ * The stored credential for this connection, if it is an assertion pointer.
+ *
+ * `null` covers both "nothing stored" and "stored, but an authorization-code
+ * blob" — the caller wants the same thing in either case, which is to carry on
+ * down the path it was already on. Asked through `credentialRefForConnection`
+ * rather than by assembling the ref here, because two files deriving that
+ * separately is exactly the disagreement that function was extracted to end.
+ */
+export async function storedAssertionFor(
+  manifest: ProviderManifest,
+  connectionId: string,
+  credentials: SecretStore,
+): Promise<StoredAssertion | null> {
+  const ref = credentialRefForConnection(manifest, connectionId);
+  if (!ref) return null;
+
+  const raw = await credentials.get(ref);
+  if (!raw) return null;
+
+  try {
+    const parsed: unknown = JSON.parse(raw);
+    return isStoredAssertion(parsed) ? parsed : null;
+  } catch {
+    // A credential that is not JSON at all is a pasted token, which is somebody
+    // else's case entirely. Not an error here.
+    return null;
+  }
+}
+
+/**
+ * Minted tokens, for as long as this process lives.
+ *
+ * In memory rather than in the store, and that is a deliberate difference from
+ * the authorization-code path. There, the refresh token is the credential and
+ * persisting the rotation is the whole point. Here the credential is the key,
+ * which nothing at request time modifies — so writing the token back would make
+ * this ref rotatable, which a deployed revision would then need write access to
+ * bind, to cache something that costs one signature and one POST to remake.
+ */
+const minted = new Map<string, { token: string; expiresAt: number }>();
+
+/** Re-mint slightly early: a token that expires mid-flight fails the call it was fetched for. */
+const EXPIRY_SKEW_MS = 60_000;
+
+/** Test seam. Nothing else clears this — a process holds its tokens until it exits. */
+export function clearMintedTokens(): void {
+  minted.clear();
+}
+
+interface TokenResponse {
+  readonly access_token?: string;
+  readonly expires_in?: number;
+  readonly error?: string;
+  readonly error_description?: string;
+}
+
+/**
+ * An access token for a connection that authenticates with a key.
+ *
+ * Reads the pointer, reads the key it names, signs, exchanges, caches. The
+ * manifest supplies the scopes and nothing else — where to exchange comes from
+ * the key file, so this stays a protocol implementation rather than a vendor's.
+ */
+export async function resolveAssertionToken(input: {
+  readonly manifest: ProviderManifest;
+  readonly connectionId: string;
+  readonly stored: StoredAssertion;
+  readonly credentials: SecretStore;
+  readonly fetch?: typeof globalThis.fetch;
+}): Promise<string> {
+  const { manifest, connectionId, stored, credentials } = input;
+  const cacheKey = `${manifest.id}.${connectionId}`;
+
+  const cached = minted.get(cacheKey);
+  if (cached && cached.expiresAt > Date.now() + EXPIRY_SKEW_MS) return cached.token;
+
+  const raw = await credentials.get(stored.key_ref);
+  if (!raw) {
+    throw new Error(
+      `No key stored at ${stored.key_ref}, which ${manifest.id}.${connectionId} authenticates with. ` +
+        `Run: lanes link connect ${manifest.id} --replace`,
+    );
+  }
+
+  const key = parseAssertionKey(raw, stored.key_ref);
+  const scopes = manifest.auth.kind === 'oauth' ? manifest.auth.scopes : [];
+
+  const assertion = await signAssertion({
+    key,
+    scopes,
+    ...(stored.subject ? { subject: stored.subject } : {}),
+  });
+
+  const response = await (input.fetch ?? globalThis.fetch)(key.token_uri, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+    body: new URLSearchParams({ grant_type: ASSERTION_GRANT, assertion }),
+  });
+
+  const body = (await response.json().catch(() => ({}))) as TokenResponse;
+
+  if (!response.ok || !body.access_token) {
+    throw new Error(refusalMessage(manifest, stored, body, response.status));
+  }
+
+  minted.set(cacheKey, {
+    token: body.access_token,
+    expiresAt: Date.now() + (body.expires_in ?? 3600) * 1000,
+  });
+
+  return body.access_token;
+}
+
+/**
+ * Why the exchange was refused, in terms of what the operator can act on.
+ *
+ * Three of these are the whole population in practice and each has a different
+ * fix in a different console, so the raw `invalid_grant` is worth translating.
+ * An operator who reads only the error code goes looking in the wrong place —
+ * most often at the key, when the actual gap is a grant an administrator has
+ * not made yet.
+ */
+function refusalMessage(
+  manifest: ProviderManifest,
+  stored: StoredAssertion,
+  body: TokenResponse,
+  status: number,
+): string {
+  const detail = body.error_description ?? body.error ?? `HTTP ${status}`;
+  const scopes = manifest.auth.kind === 'oauth' ? manifest.auth.scopes : [];
+
+  const lines = [`${manifest.name} refused the key at ${stored.key_ref}: ${detail}`];
+
+  if (body.error === 'unauthorized_client') {
+    lines.push(
+      '',
+      stored.subject
+        ? `  The key is not permitted to act as ${stored.subject}. An administrator of that` +
+            '\n  domain has to authorise this key for these scopes, all of them, exactly:'
+        : '  The key is not authorised for these scopes:',
+      ...scopes.map((scope) => `    ${scope}`),
+      '',
+      '  A partial list is refused the same way a missing one is.',
+    );
+  } else if (body.error === 'invalid_grant') {
+    // Listed rather than diagnosed. This one code covers an account that does
+    // not exist, a key that was deleted, a clock that is wrong, and a missing
+    // subject — and the description above is the only thing that distinguishes
+    // them. Asserting one of the four would send the reader to the wrong
+    // console three times in four, which is worse than naming all of them.
+    lines.push(
+      '',
+      '  The description above is the part that identifies which of these it is:',
+      '  - the account in the key no longer exists, or the key was deleted or disabled;',
+      "  - this machine's clock is wrong by more than a few minutes, and an assertion is",
+      '    signed with a timestamp;',
+      ...(stored.subject
+        ? [`  - ${stored.subject} is not an account the key may act as.`]
+        : [
+            '  - this account has to be reached by acting as someone, and this connection acts',
+            `    as nobody. Re-run and name one: lanes link connect ${manifest.id} --replace`,
+          ]),
+    );
+  }
+
+  return lines.join('\n');
+}

--- a/src/connectivity/auth/oauth-jwt/key.ts
+++ b/src/connectivity/auth/oauth-jwt/key.ts
@@ -1,0 +1,148 @@
+import { z } from 'zod';
+
+/**
+ * The key half of RFC 7523: a private key on disk, and the assertion it signs.
+ *
+ * Split from `index.ts` because it is the only part with no I/O — no store, no
+ * network — which is what makes the claim set and the signature testable
+ * against a locally generated key rather than against a live token endpoint.
+ *
+ * Nothing here knows which vendor issued the key. The layout below is the one
+ * every authorization server that accepts this grant ships, and the endpoint to
+ * present the assertion at comes from the key file itself rather than from a
+ * constant, so adding a second vendor is a manifest and no code.
+ */
+
+/**
+ * The issued key file, as the vendor's console writes it.
+ *
+ * Parsed rather than trusted: the common mistake is pasting the *client* JSON —
+ * the one with `installed` or `web` at the top level — which is a different
+ * file with a different purpose and would otherwise fail much later, at the
+ * token endpoint, as an unexplained 400.
+ */
+export const assertionKeySchema = z.object({
+  /** Who the assertion is from. Also the address a resource is shared with. */
+  client_email: z.string().min(1),
+  /** PKCS#8 PEM. */
+  private_key: z.string().min(1),
+  /** Where the assertion is exchanged. Read from the file so no vendor is named here. */
+  token_uri: z.url(),
+  /** Names which key signed it, for a server holding more than one. */
+  private_key_id: z.string().optional(),
+});
+
+export type AssertionKey = z.infer<typeof assertionKeySchema>;
+
+export function parseAssertionKey(raw: string, ref: string): AssertionKey {
+  let json: unknown;
+  try {
+    json = JSON.parse(raw);
+  } catch {
+    throw new Error(
+      `The key at ${ref} is not JSON. It should be the whole file the console downloaded, pasted verbatim.`,
+    );
+  }
+
+  const parsed = assertionKeySchema.safeParse(json);
+  if (parsed.success) return parsed.data;
+
+  // The two files are easy to confuse and the console offers both on adjacent
+  // pages, so say which one is in hand rather than listing missing fields.
+  const shape = json as Record<string, unknown> | null;
+  if (shape && (shape['installed'] !== undefined || shape['web'] !== undefined)) {
+    throw new Error(
+      `The key at ${ref} is an OAuth *client* file, not an account key. That one is for the ` +
+        'browser flow. The key needed here is downloaded from the account itself and has ' +
+        '"private_key" in it.',
+    );
+  }
+
+  throw new Error(
+    `The key at ${ref} is missing ${parsed.error.issues.map((issue) => issue.path.join('.')).join(', ')}.`,
+  );
+}
+
+/** JWT's own encoding: base64 with a URL-safe alphabet and no padding. */
+function base64url(bytes: Uint8Array | string): string {
+  const raw =
+    typeof bytes === 'string'
+      ? btoa(bytes)
+      : btoa(String.fromCharCode(...new Uint8Array(bytes)));
+  return raw.replaceAll('+', '-').replaceAll('/', '_').replaceAll('=', '');
+}
+
+/**
+ * PKCS#8 PEM to the DER bytes `importKey` wants.
+ *
+ * Tolerant of how the key arrives: a console download carries real newlines, a
+ * value pasted through an environment variable or a JSON string often carries
+ * literal `\n` instead, and both are the same key. Rejecting the second would
+ * be a failure whose cause is invisible in a terminal.
+ */
+function derFromPem(pem: string): Uint8Array {
+  const body = pem
+    .replaceAll('\\n', '\n')
+    .replace(/-----[^-]+-----/g, '')
+    .replace(/\s+/g, '');
+
+  const binary = atob(body);
+  const der = new Uint8Array(binary.length);
+  for (let index = 0; index < binary.length; index += 1) der[index] = binary.charCodeAt(index);
+  return der;
+}
+
+/** How long the assertion is good for. Kept short: it is minted per exchange. */
+const ASSERTION_LIFETIME_SECONDS = 3600;
+
+/**
+ * Sign the assertion this grant exchanges for a token.
+ *
+ * `sub` is what makes one identity act as another, and it is present only when
+ * the caller supplies one — an assertion carrying an empty `sub` is not the
+ * same request as one carrying none, and servers treat it as malformed rather
+ * than as absent.
+ */
+export async function signAssertion(input: {
+  readonly key: AssertionKey;
+  readonly scopes: readonly string[];
+  /** The account to act as, where the key is only permitted to borrow one. */
+  readonly subject?: string | undefined;
+  /** Injected by tests so the claim set is checkable. */
+  readonly now?: number;
+}): Promise<string> {
+  const issuedAt = Math.floor((input.now ?? Date.now()) / 1000);
+
+  const header = {
+    alg: 'RS256',
+    typ: 'JWT',
+    ...(input.key.private_key_id ? { kid: input.key.private_key_id } : {}),
+  };
+
+  const claims = {
+    iss: input.key.client_email,
+    scope: input.scopes.join(' '),
+    aud: input.key.token_uri,
+    iat: issuedAt,
+    exp: issuedAt + ASSERTION_LIFETIME_SECONDS,
+    ...(input.subject ? { sub: input.subject } : {}),
+  };
+
+  const signingInput = `${base64url(JSON.stringify(header))}.${base64url(JSON.stringify(claims))}`;
+
+  const privateKey = await crypto.subtle.importKey(
+    'pkcs8',
+    derFromPem(input.key.private_key) as unknown as ArrayBuffer,
+    { name: 'RSASSA-PKCS1-v1_5', hash: 'SHA-256' },
+    false,
+    ['sign'],
+  );
+
+  const signature = await crypto.subtle.sign(
+    'RSASSA-PKCS1-v1_5',
+    privateKey,
+    new TextEncoder().encode(signingInput) as unknown as ArrayBuffer,
+  );
+
+  return `${signingInput}.${base64url(new Uint8Array(signature))}`;
+}

--- a/src/connectivity/auth/oauth-jwt/oauth-jwt.test.ts
+++ b/src/connectivity/auth/oauth-jwt/oauth-jwt.test.ts
@@ -1,0 +1,353 @@
+import { describe, expect, test, beforeEach } from 'bun:test';
+import { defineProvider, type ProviderManifest } from '#connectivity';
+import { parseAssertionKey, signAssertion } from './key.ts';
+import {
+  ASSERTION_GRANT,
+  clearMintedTokens,
+  isStoredAssertion,
+  resolveAssertionToken,
+  storedAssertionFor,
+} from './index.ts';
+
+/**
+ * The protocol half of the key route, against a key generated here.
+ *
+ * Nothing in this file touches a real account or a real endpoint, which is the
+ * only way the claim set is checkable at all: an assertion is a signature over
+ * exactly what went into it, so the thing worth asserting is what went in.
+ */
+
+const TOKEN_URL = 'https://tokens.example.test/token';
+
+/** A throwaway RSA key, so the signature is real and belongs to nobody. */
+async function generateKey(): Promise<{ pem: string; publicKey: CryptoKey }> {
+  const pair = await crypto.subtle.generateKey(
+    { name: 'RSASSA-PKCS1-v1_5', modulusLength: 2048, publicExponent: new Uint8Array([1, 0, 1]), hash: 'SHA-256' },
+    true,
+    ['sign', 'verify'],
+  );
+
+  const pkcs8 = await crypto.subtle.exportKey('pkcs8', pair.privateKey);
+  const body = btoa(String.fromCharCode(...new Uint8Array(pkcs8))).replace(/(.{64})/g, '$1\n');
+
+  return {
+    pem: `-----BEGIN PRIVATE KEY-----\n${body}\n-----END PRIVATE KEY-----\n`,
+    publicKey: pair.publicKey,
+  };
+}
+
+function keyFile(pem: string): string {
+  return JSON.stringify({
+    type: 'service_account',
+    client_email: 'link@my-project.iam.gserviceaccount.example',
+    private_key: pem,
+    token_uri: TOKEN_URL,
+    private_key_id: 'abc123',
+  });
+}
+
+/** JWT's alphabet back to binary, padding restored. */
+function decodeBase64url(segment: string): string {
+  const padded = segment.replaceAll('-', '+').replaceAll('_', '/');
+  return atob(padded + '='.repeat((4 - (padded.length % 4)) % 4));
+}
+
+function decodeSegment(segment: string): Record<string, unknown> {
+  return JSON.parse(decodeBase64url(segment));
+}
+
+function manifestWith(scopes: readonly string[]): ProviderManifest {
+  return defineProvider({
+    id: 'vendor_thing',
+    name: 'Vendor Thing',
+    connector: { kind: 'http', base_url: 'https://api.example.test', openapi: './t.json' },
+    auth: {
+      kind: 'oauth',
+      registration: 'manual',
+      app: 'vendor',
+      scopes,
+      authorize_url: 'https://accounts.example.test/authorize',
+      token_url: TOKEN_URL,
+      assertion: {
+        method: 'service_account',
+        label: 'Service account key',
+        delegation: 'optional',
+        key_ref: 'vendor/key',
+        reach: 'only what is shared with it',
+        subject_label: 'Account to act as',
+        setup: {
+          steps: [],
+          prompts: [
+            { key: 'key', label: 'Key', secret: true, scope: 'shared', credential_ref: 'vendor/key' },
+          ],
+        },
+      },
+    },
+    setup: {
+      steps: [],
+      prompts: [
+        { key: 'client_id', label: 'Client id', scope: 'shared', credential_ref: 'vendor/client_id' },
+        { key: 'client_secret', label: 'Client secret', secret: true, scope: 'shared', credential_ref: 'vendor/client_secret' },
+      ],
+    },
+  });
+}
+
+/** The narrowest thing that satisfies `SecretStore` for these tests. */
+function store(entries: Record<string, string>) {
+  const held = new Map(Object.entries(entries));
+  return {
+    get: async (ref: string) => held.get(ref) ?? null,
+    set: async (ref: string, value: string) => void held.set(ref, value),
+    has: async (ref: string) => held.has(ref),
+    delete: async (ref: string) => void held.delete(ref),
+    list: async () => [...held.keys()],
+  } as never;
+}
+
+describe('the key file', () => {
+  test('is parsed when it is the account key', async () => {
+    const { pem } = await generateKey();
+    const key = parseAssertionKey(keyFile(pem), 'vendor/key');
+
+    expect(key.client_email).toBe('link@my-project.iam.gserviceaccount.example');
+    expect(key.token_uri).toBe(TOKEN_URL);
+  });
+
+  test('names the mistake when it is the OAuth client file instead', () => {
+    const client = JSON.stringify({ installed: { client_id: 'x', client_secret: 'y' } });
+
+    expect(() => parseAssertionKey(client, 'vendor/key')).toThrow(/client.*file, not an account key/i);
+  });
+
+  test('says so when it is not JSON at all', () => {
+    expect(() => parseAssertionKey('ya29.not-a-key', 'vendor/key')).toThrow(/not JSON/);
+  });
+});
+
+describe('the assertion', () => {
+  test('claims the scopes asked for, and verifies against the key that signed it', async () => {
+    const { pem, publicKey } = await generateKey();
+    const key = parseAssertionKey(keyFile(pem), 'vendor/key');
+
+    const now = 1_700_000_000_000;
+    const jwt = await signAssertion({ key, scopes: ['read.example', 'write.example'], now });
+
+    const [header, claims, signature] = jwt.split('.');
+    expect(decodeSegment(header!)).toEqual({ alg: 'RS256', typ: 'JWT', kid: 'abc123' });
+    expect(decodeSegment(claims!)).toEqual({
+      iss: 'link@my-project.iam.gserviceaccount.example',
+      scope: 'read.example write.example',
+      aud: TOKEN_URL,
+      iat: 1_700_000_000,
+      exp: 1_700_003_600,
+    });
+
+    const bytes = Uint8Array.from(decodeBase64url(signature!), (character) => character.charCodeAt(0));
+
+    expect(
+      await crypto.subtle.verify(
+        'RSASSA-PKCS1-v1_5',
+        publicKey,
+        bytes as unknown as ArrayBuffer,
+        new TextEncoder().encode(`${header}.${claims}`) as unknown as ArrayBuffer,
+      ),
+    ).toBe(true);
+  });
+
+  test('carries no sub at all when it acts as nobody', async () => {
+    const { pem } = await generateKey();
+    const key = parseAssertionKey(keyFile(pem), 'vendor/key');
+
+    const claims = decodeSegment((await signAssertion({ key, scopes: ['read.example'] })).split('.')[1]!);
+
+    // Absent, not empty: an empty `sub` is a different request and servers
+    // treat it as malformed rather than as unset.
+    expect('sub' in claims).toBe(false);
+  });
+
+  test('carries sub when it acts as someone', async () => {
+    const { pem } = await generateKey();
+    const key = parseAssertionKey(keyFile(pem), 'vendor/key');
+
+    const claims = decodeSegment(
+      (await signAssertion({ key, scopes: ['read.example'], subject: 'someone@example.com' })).split('.')[1]!,
+    );
+
+    expect(claims['sub']).toBe('someone@example.com');
+  });
+
+  test('reads a key whose newlines arrived escaped', async () => {
+    const { pem } = await generateKey();
+    const escaped = keyFile(pem.replaceAll('\n', '\\n'));
+
+    // The same key, carried through an environment variable or a JSON string.
+    // Refusing it would be a failure with no visible cause in a terminal.
+    await expect(
+      signAssertion({ key: parseAssertionKey(escaped, 'vendor/key'), scopes: ['read.example'] }),
+    ).resolves.toContain('.');
+  });
+});
+
+describe('a stored credential', () => {
+  beforeEach(() => clearMintedTokens());
+
+  test('is recognised as an assertion by its shape, and an OAuth blob is not', async () => {
+    expect(isStoredAssertion({ grant: ASSERTION_GRANT, key_ref: 'vendor/key' })).toBe(true);
+    expect(isStoredAssertion({ access_token: 'x', refresh_token: 'y' })).toBe(false);
+    expect(isStoredAssertion({ grant: ASSERTION_GRANT })).toBe(false);
+  });
+
+  test('is read back for the connection that holds one', async () => {
+    const manifest = manifestWith(['read.example']);
+    const secrets = store({
+      'vendor_thing/main': JSON.stringify({ grant: ASSERTION_GRANT, key_ref: 'vendor/key' }),
+    });
+
+    expect(await storedAssertionFor(manifest, 'main', secrets)).toMatchObject({ key_ref: 'vendor/key' });
+  });
+
+  test('is null for a connection that authorised in a browser', async () => {
+    const manifest = manifestWith(['read.example']);
+    const secrets = store({
+      'vendor_thing/main': JSON.stringify({ access_token: 'a', refresh_token: 'r' }),
+    });
+
+    expect(await storedAssertionFor(manifest, 'main', secrets)).toBeNull();
+  });
+
+  test('is null for a pasted token that is not JSON', async () => {
+    const manifest = manifestWith(['read.example']);
+    const secrets = store({ 'vendor_thing/main': 'github_pat_example' });
+
+    expect(await storedAssertionFor(manifest, 'main', secrets)).toBeNull();
+  });
+});
+
+describe('the exchange', () => {
+  beforeEach(() => clearMintedTokens());
+
+  async function fixture(scopes = ['read.example']) {
+    const { pem } = await generateKey();
+    return {
+      manifest: manifestWith(scopes),
+      secrets: store({ 'vendor/key': keyFile(pem) }),
+      stored: { grant: ASSERTION_GRANT, key_ref: 'vendor/key' } as const,
+    };
+  }
+
+  test('presents the assertion at the endpoint named in the key file', async () => {
+    const { manifest, secrets, stored } = await fixture();
+    let seen: { url: string; body: URLSearchParams } | undefined;
+
+    const token = await resolveAssertionToken({
+      manifest,
+      connectionId: 'main',
+      stored,
+      credentials: secrets,
+      fetch: (async (url: string, init: RequestInit) => {
+        seen = { url: String(url), body: init.body as URLSearchParams };
+        return Response.json({ access_token: 'minted', expires_in: 3600 });
+      }) as unknown as typeof fetch,
+    });
+
+    expect(token).toBe('minted');
+    expect(seen?.url).toBe(TOKEN_URL);
+    expect(seen?.body.get('grant_type')).toBe(ASSERTION_GRANT);
+    expect(seen?.body.get('assertion')?.split('.')).toHaveLength(3);
+  });
+
+  test('mints once and serves the same token again', async () => {
+    const { manifest, secrets, stored } = await fixture();
+    let calls = 0;
+
+    const mint = () =>
+      resolveAssertionToken({
+        manifest,
+        connectionId: 'main',
+        stored,
+        credentials: secrets,
+        fetch: (async () => {
+          calls += 1;
+          return Response.json({ access_token: `minted-${calls}`, expires_in: 3600 });
+        }) as unknown as typeof fetch,
+      });
+
+    expect(await mint()).toBe('minted-1');
+    expect(await mint()).toBe('minted-1');
+    expect(calls).toBe(1);
+  });
+
+  test('mints again once the cached token is close to expiring', async () => {
+    const { manifest, secrets, stored } = await fixture();
+    let calls = 0;
+
+    const mint = () =>
+      resolveAssertionToken({
+        manifest,
+        connectionId: 'main',
+        stored,
+        credentials: secrets,
+        fetch: (async () => {
+          calls += 1;
+          // Inside the skew, so the cache must not be trusted for the next call.
+          return Response.json({ access_token: `minted-${calls}`, expires_in: 30 });
+        }) as unknown as typeof fetch,
+      });
+
+    expect(await mint()).toBe('minted-1');
+    expect(await mint()).toBe('minted-2');
+  });
+
+  test('says which grant is missing when delegation was never authorised', async () => {
+    const { manifest, secrets } = await fixture(['read.example', 'write.example']);
+
+    const refused = resolveAssertionToken({
+      manifest,
+      connectionId: 'main',
+      stored: { grant: ASSERTION_GRANT, key_ref: 'vendor/key', subject: 'someone@example.com' },
+      credentials: secrets,
+      fetch: (async () =>
+        Response.json({ error: 'unauthorized_client' }, { status: 401 })) as unknown as typeof fetch,
+    });
+
+    // The scope list, verbatim, because a partial one is refused identically
+    // and the refusal does not say which was short.
+    await expect(refused).rejects.toThrow(/act as someone@example\.com[\s\S]*read\.example[\s\S]*write\.example/);
+  });
+
+  test('lists what invalid_grant can mean rather than asserting one of them', async () => {
+    const { manifest, secrets, stored } = await fixture();
+
+    const refused = resolveAssertionToken({
+      manifest,
+      connectionId: 'main',
+      stored,
+      credentials: secrets,
+      fetch: (async () =>
+        Response.json(
+          { error: 'invalid_grant', error_description: 'Invalid grant: account not found' },
+          { status: 400 },
+        )) as unknown as typeof fetch,
+    });
+
+    // Google returns this one code for an account that does not exist, a deleted
+    // key, a wrong clock and a missing subject. Only the description tells them
+    // apart, so it leads and the causes are listed under it.
+    await expect(refused).rejects.toThrow(/account not found[\s\S]*clock is wrong[\s\S]*acts\n    as nobody/);
+  });
+
+  test('refuses when the key it points at is gone, naming the command that fixes it', async () => {
+    const manifest = manifestWith(['read.example']);
+
+    await expect(
+      resolveAssertionToken({
+        manifest,
+        connectionId: 'main',
+        stored: { grant: ASSERTION_GRANT, key_ref: 'vendor/key' },
+        credentials: store({}),
+        fetch: (async () => Response.json({})) as unknown as typeof fetch,
+      }),
+    ).rejects.toThrow(/No key stored at vendor\/key[\s\S]*connect vendor_thing --replace/);
+  });
+});

--- a/src/connectivity/auth/token.ts
+++ b/src/connectivity/auth/token.ts
@@ -2,6 +2,7 @@ import { type ProviderManifest } from '#connectivity';
 import type { ProviderRegistry } from '#registry';
 import type { SecretStore } from '#secrets';
 import { credentialResolver } from './resolve.ts';
+import { resolveAssertionToken, storedAssertionFor } from './oauth-jwt/index.ts';
 import { CredentialOAuthProvider } from './oauth-authcode/provider.ts';
 
 /**
@@ -80,6 +81,16 @@ export async function bearerTokenAsStored(
   secrets: SecretStore,
 ): Promise<string | null> {
   if (manifest.auth.kind !== 'oauth') return bearerToken(manifest, connectionId, secrets);
+
+  // An assertion credential has no token stored to prefer — the token is minted
+  // from the key, which is what "as stored" means here. Without this branch the
+  // identity call `connect` makes immediately after writing the pointer reads
+  // `access_token` off a blob that has none, sends no Authorization header, and
+  // reports the credential rejected.
+  const assertion = await storedAssertionFor(manifest, connectionId, secrets);
+  if (assertion) {
+    return resolveAssertionToken({ manifest, connectionId, stored: assertion, credentials: secrets });
+  }
 
   const provider = new CredentialOAuthProvider({
     manifest,

--- a/src/connectivity/index.ts
+++ b/src/connectivity/index.ts
@@ -53,6 +53,7 @@ export { defineLocalProvider, defineProviderWithCapabilities } from './provider.
 export type {
   ProviderManifest,
   ConnectorConfig,
+  AuthAssertion,
   AuthBroker,
   AuthConfig,
   SetupDeclaration,

--- a/src/connectivity/manifest/auth.ts
+++ b/src/connectivity/manifest/auth.ts
@@ -1,5 +1,6 @@
 import { z } from 'zod';
 import { credentialRef, identifier } from './primitives.ts';
+import { setupSchema } from './setup.ts';
 
 /**
  * Credential types — how we prove who we are, orthogonal to how we connect.
@@ -34,6 +35,76 @@ export const authBrokerSchema = z.object({
 
 export type AuthBroker = z.infer<typeof authBrokerSchema>;
 
+/**
+ * A second way in, for an authorization server that also accepts an assertion.
+ *
+ * RFC 7523: instead of a person approving a consent screen, the operator holds
+ * a private key, signs a short-lived JWT with it, and exchanges that for an
+ * access token. There is no refresh token because there is nothing to refresh —
+ * a new assertion is signed whenever the last token ages out — which is the
+ * whole reason this exists beside `oauth`. An authorization-code refresh token
+ * can be expired by the issuer's own policy; a key the operator holds cannot.
+ *
+ * Declared *on* the OAuth block rather than as a fourth `kind`, because it is
+ * an alternative arrangement for the same provider rather than a different
+ * provider. Everything that branches on `kind` — where the credential lands,
+ * what setup requires, which refs a deployed revision may rewrite — is
+ * unchanged, and a manifest that omits this reads and behaves exactly as before.
+ *
+ * Which one a connection actually uses is not recorded here or in config. The
+ * stored credential's *shape* is the switch, the same way an `oauth_apps` entry
+ * is the switch between a broker's client and the operator's own.
+ */
+export const authAssertionSchema = z.object({
+  /**
+   * What the operator types after `--auth`, and how a chosen method is named
+   * back to them.
+   *
+   * The provider's word rather than the protocol's. "Assertion" is what this is
+   * to the authorization server and means nothing to the person holding the
+   * file; they downloaded a service account key, and that is what the prompt
+   * and the flag should say. Keeping it here is also what stops the CLI from
+   * learning a vendor's vocabulary in order to print it.
+   */
+  method: identifier,
+  /** The short name shown beside the choice — a noun, not a sentence. */
+  label: z.string().min(1),
+  /**
+   * Whether the assertion may stand for itself, or must name a user to act as.
+   *
+   * `optional` — the key is an identity in its own right, and reaches whatever
+   * has been shared with it. `required` — it can only borrow someone else's,
+   * so a connection without a subject would authenticate cleanly and then find
+   * nothing there. The CLI refuses a blank subject on `required` for that
+   * reason: the failure is otherwise a 404 on every call with no explanation.
+   */
+  delegation: z.enum(['optional', 'required']).default('optional'),
+  /**
+   * Where the profile-shared key lives.
+   *
+   * Shared, not per-connection: one key covers every provider of a vendor, and
+   * asking for it once per provider would be seven pastes of the same file.
+   * The per-connection half is the subject, which is not a secret and is small
+   * enough to sit in the pointer the connection stores.
+   */
+  key_ref: credentialRef,
+  /** One line for the choice prompt: what this method reaches, and what it does not. */
+  reach: z.string().min(1),
+  /**
+   * What to call the account this acts as, when it acts as one.
+   *
+   * Asked per connection and stored beside the pointer. Not a secret — it is an
+   * address — but it lives in the credential store rather than in config
+   * because it is half of a credential, and splitting a credential across two
+   * files is how the halves come to disagree.
+   */
+  subject_label: z.string().min(1),
+  /** The console walkthrough for this method, rendered by the same code as `setup`. */
+  setup: setupSchema,
+});
+
+export type AuthAssertion = z.infer<typeof authAssertionSchema>;
+
 export const authOAuthSchema = z.object({
   kind: z.literal('oauth'),
   /**
@@ -57,6 +128,14 @@ export const authOAuthSchema = z.object({
    * that claimed one or the other would be wrong half the time.
    */
   broker: authBrokerSchema.optional(),
+  /**
+   * The other way in, where the vendor offers one. Absent means browser or nothing.
+   *
+   * Additive and inert on its own: declaring it makes `connect` offer a choice
+   * and makes the resolver able to read an assertion credential. It changes
+   * nothing about a connection that authorised in a browser.
+   */
+  assertion: authAssertionSchema.optional(),
   scopes: z.array(z.string()).default([]),
   /**
    * Usually discovered from the resource's metadata; set only to override.

--- a/src/connectivity/manifest/index.ts
+++ b/src/connectivity/manifest/index.ts
@@ -22,11 +22,13 @@ export {
 
 export {
   authNoneSchema,
+  authAssertionSchema,
   authBrokerSchema,
   authOAuthSchema,
   authSchema,
   authStrategySchema,
   authTokenSchema,
+  type AuthAssertion,
   type AuthBroker,
   type AuthConfig,
 } from './auth.ts';

--- a/src/connectivity/manifest/manifest.test.ts
+++ b/src/connectivity/manifest/manifest.test.ts
@@ -180,3 +180,100 @@ describe('a broker as the other answer to "where does the client come from"', ()
     expect(credentialRefForConnection(gmailish, 'main')).toBe('vendor_mail/main');
   });
 });
+
+/**
+ * A second way in, declared on the block that already describes the first.
+ *
+ * `auth.assertion` is not a `kind`, which is the whole reason it needs its own
+ * guards: nothing about the discriminated union stops a manifest declaring one
+ * somewhere it cannot possibly work, so `defineProvider` has to. Each of these
+ * would otherwise be discovered by an operator, after choosing the method, with
+ * a credential already stored.
+ */
+describe('an assertion alternative', () => {
+  const assertion = {
+    method: 'service_account',
+    label: 'Service account key',
+    key_ref: 'vendor/key',
+    reach: 'only what is shared with it',
+    subject_label: 'Account to act as',
+    setup: {
+      prompts: [
+        { key: 'key', label: 'Key', secret: true, scope: 'shared', credential_ref: 'vendor/key' },
+      ],
+    },
+  };
+
+  const withAssertion = (overrides: Record<string, unknown> = {}) => ({
+    kind: 'oauth',
+    registration: 'manual',
+    app: 'vendor',
+    scopes: ['https://api.test/auth/read'],
+    authorize_url: 'https://accounts.example.com/o/oauth2/v2/auth',
+    token_url: 'https://oauth2.example.com/token',
+    setup: { prompts: [{ key: 'client_id', label: 'Id', credential_ref: 'vendor/client_id' }] },
+    assertion: { ...assertion, ...overrides },
+  });
+
+  test('is accepted beside the browser flow, and changes where nothing lands', () => {
+    const manifest = defineProvider({
+      id: 'vendor_mail',
+      name: 'Vendor Mail',
+      connector: http,
+      auth: withAssertion(),
+      setup: { prompts: [{ key: 'client_id', label: 'Id', credential_ref: 'vendor/client_id' }] },
+    });
+
+    // Still per provider, and still where the OAuth path already looks: both
+    // methods write here, and only the shape of what is stored tells them apart.
+    expect(credentialRefForConnection(manifest, 'main')).toBe('vendor_mail/main');
+  });
+
+  test('defaults to standing on its own, rather than borrowing an identity', () => {
+    const manifest = defineProvider({
+      id: 'vendor_mail',
+      name: 'Vendor Mail',
+      connector: http,
+      auth: withAssertion(),
+      setup: { prompts: [{ key: 'client_id', label: 'Id', credential_ref: 'vendor/client_id' }] },
+    });
+
+    expect(manifest.auth.kind === 'oauth' && manifest.auth.assertion?.delegation).toBe('optional');
+  });
+
+  test('is refused on an mcp connector, where there is nowhere to present it', () => {
+    expect(() =>
+      defineProvider({
+        id: 'vendor_mcp',
+        name: 'Vendor',
+        connector: { kind: 'mcp', endpoint: 'https://mcp.example.com/sse' },
+        auth: withAssertion(),
+        setup: { prompts: [{ key: 'client_id', label: 'Id', credential_ref: 'vendor/client_id' }] },
+      }),
+    ).toThrow(/cannot present a signed assertion/);
+  });
+
+  test('is refused with no scopes, because the token would be permitted nothing', () => {
+    expect(() =>
+      defineProvider({
+        id: 'vendor_mail',
+        name: 'Vendor Mail',
+        connector: http,
+        auth: { ...withAssertion(), scopes: [], broker: undefined },
+        setup: { prompts: [{ key: 'client_id', label: 'Id', credential_ref: 'vendor/client_id' }] },
+      }),
+    ).toThrow(/nothing to grant/);
+  });
+
+  test('is refused with no prompt, because there is no key to ask for', () => {
+    expect(() =>
+      defineProvider({
+        id: 'vendor_mail',
+        name: 'Vendor Mail',
+        connector: http,
+        auth: withAssertion({ setup: { prompts: [] } }),
+        setup: { prompts: [{ key: 'client_id', label: 'Id', credential_ref: 'vendor/client_id' }] },
+      }),
+    ).toThrow(/no way to learn what key to ask for/);
+  });
+});

--- a/src/connectivity/manifest/provider.ts
+++ b/src/connectivity/manifest/provider.ts
@@ -130,6 +130,32 @@ export function defineProvider(input: unknown): ProviderManifest {
     }
   }
 
+  if (manifest.auth.kind === 'oauth' && manifest.auth.assertion) {
+    // Same seam, same absence as the broker rule above. The SDK owns an mcp
+    // provider's exchange and takes a client, not a signed assertion — so the
+    // choice would be offered, accepted, and then have nowhere to go.
+    if (manifest.connector.kind === 'mcp') {
+      throw new Error(
+        `Provider "${manifest.id}": an mcp connector runs the exchange through the SDK, which cannot present a signed assertion. Remove auth.assertion.`,
+      );
+    }
+    // The assertion carries `aud` from the key file, but the *scopes* it claims
+    // come from the manifest. A provider requesting none would mint a token
+    // permitted to do nothing and only find out at the first call.
+    if (manifest.auth.scopes.length === 0) {
+      throw new Error(
+        `Provider "${manifest.id}": auth.assertion exchanges a signed assertion for a token scoped to auth.scopes, which is empty. There would be nothing to grant.`,
+      );
+    }
+    // The whole point of the alternative is that it asks for something. A block
+    // with no prompt reaches the walkthrough and then has nothing to collect.
+    if (manifest.auth.assertion.setup.prompts.length === 0) {
+      throw new Error(
+        `Provider "${manifest.id}": auth.assertion declares no setup prompts, so there is no way to learn what key to ask for.`,
+      );
+    }
+  }
+
   if (
     (manifest.auth.kind === 'bearer' ||
       manifest.auth.kind === 'api_key' ||

--- a/src/connectivity/manifest/requirements.ts
+++ b/src/connectivity/manifest/requirements.ts
@@ -80,6 +80,37 @@ function placeholderFor(prompts: readonly SetupPrompt[]): string {
   return '<value>';
 }
 
+/**
+ * What the key route needs, which is the key and nothing else.
+ *
+ * Never `needsId`, and that is the substantive difference from the block below:
+ * the key is shared across every connection of a vendor, so its ref does not
+ * derive from a connection id and nothing has to be named before it can be
+ * stored. The subject does derive per connection — but it is not a requirement
+ * because it cannot be placed ahead of time: it lives inside the pointer that
+ * `connect` itself writes, and there is no `secrets set` that would put it
+ * there.
+ */
+function assertionRequirements(
+  assertion: NonNullable<Extract<ProviderManifest['auth'], { kind: 'oauth' }>['assertion']>,
+  profile: string,
+): SetupNeeds {
+  const shared = assertion.setup.prompts.filter((prompt) => prompt.scope === 'shared');
+
+  return {
+    requirements: shared.map((prompt) => ({
+      ref: assertion.key_ref,
+      label: prompt.label,
+      secret: prompt.secret,
+      scope: 'shared' as const,
+      prompts: [prompt.key],
+      command: storeCommand(assertion.key_ref, '<value>', profile),
+    })),
+    needsId: false,
+    brokered: false,
+  };
+}
+
 export function setupRequirements(
   manifest: ProviderManifest,
   connectionId: string | undefined,
@@ -87,8 +118,24 @@ export function setupRequirements(
   options: {
     /** `oauth_apps` entries this profile declares — the clients that are its own. */
     readonly ownClients?: readonly string[];
+    /**
+     * Which way in, for a provider offering two.
+     *
+     * Defaults to the browser flow, which is every provider's only route until
+     * one declares `auth.assertion` — so an omitted value reports exactly what
+     * it always reported. Passed by `connect` once the operator has chosen,
+     * because the two methods need different things and reporting the union
+     * would tell someone to store a client they are not going to use.
+     */
+    readonly method?: 'oauth' | 'assertion';
   } = {},
 ): SetupNeeds {
+  const assertion = manifest.auth.kind === 'oauth' ? manifest.auth.assertion : undefined;
+
+  if (options.method === 'assertion' && assertion) {
+    return assertionRequirements(assertion, profile);
+  }
+
   const prompts = manifest.setup?.prompts ?? [];
 
   // A shared prompt exists to collect a client the operator registers. When a

--- a/src/providers/google/calendar/index.ts
+++ b/src/providers/google/calendar/index.ts
@@ -1,5 +1,6 @@
 import { defineProvider } from '#connectivity';
 import { CALENDAR_IDENTITY, GOOGLE_APP, GOOGLE_OAUTH, specPath } from '../shared/oauth.ts';
+import { googleServiceAccount } from '../shared/service-account.ts';
 import { googleSetup } from '../shared/setup.ts';
 import { CALENDAR_REDACT } from './redact.ts';
 
@@ -53,6 +54,7 @@ export const calendar = defineProvider({
     app: GOOGLE_APP,
     scopes: CALENDAR_SCOPES,
     ...GOOGLE_OAUTH,
+    assertion: googleServiceAccount('Calendar', CALENDAR_SCOPES, 'optional', ['calendar-json.googleapis.com']),
   },
   identity: CALENDAR_IDENTITY,
   setup: googleSetup('Calendar', CALENDAR_SCOPES, {

--- a/src/providers/google/contacts/index.ts
+++ b/src/providers/google/contacts/index.ts
@@ -1,5 +1,6 @@
 import { defineProvider } from '#connectivity';
 import { GOOGLE_APP, GOOGLE_OAUTH, PEOPLE_IDENTITY, specPath } from '../shared/oauth.ts';
+import { googleServiceAccount } from '../shared/service-account.ts';
 import { googleSetup } from '../shared/setup.ts';
 import { CONTACTS_REDACT } from './redact.ts';
 
@@ -43,6 +44,7 @@ export const contacts = defineProvider({
     app: GOOGLE_APP,
     scopes: CONTACTS_SCOPES,
     ...GOOGLE_OAUTH,
+    assertion: googleServiceAccount('Contacts', CONTACTS_SCOPES, 'required', ['people.googleapis.com']),
   },
   identity: PEOPLE_IDENTITY,
   setup: googleSetup('Contacts', CONTACTS_SCOPES, { apis: ['people.googleapis.com'] }),

--- a/src/providers/google/docs/index.ts
+++ b/src/providers/google/docs/index.ts
@@ -1,5 +1,6 @@
 import { defineProvider } from '#connectivity';
 import { DRIVE_IDENTITY, GOOGLE_APP, GOOGLE_OAUTH, specPath } from '../shared/oauth.ts';
+import { googleServiceAccount } from '../shared/service-account.ts';
 import { googleSetup } from '../shared/setup.ts';
 
 /**
@@ -32,6 +33,7 @@ export const docs = defineProvider({
     app: GOOGLE_APP,
     scopes: DOCS_SCOPES,
     ...GOOGLE_OAUTH,
+    assertion: googleServiceAccount('Docs', DOCS_SCOPES, 'optional', ['docs.googleapis.com', 'drive.googleapis.com']),
   },
   identity: DRIVE_IDENTITY,
   setup: googleSetup('Docs', DOCS_SCOPES, {

--- a/src/providers/google/drive/index.ts
+++ b/src/providers/google/drive/index.ts
@@ -1,5 +1,6 @@
 import { defineProvider } from '#connectivity';
 import { DRIVE_IDENTITY, GOOGLE_APP, GOOGLE_OAUTH, specPath } from '../shared/oauth.ts';
+import { googleServiceAccount } from '../shared/service-account.ts';
 import { googleSetup } from '../shared/setup.ts';
 import { DRIVE_HINTS } from './hints.ts';
 import { DRIVE_REDACT } from './redact.ts';
@@ -26,6 +27,7 @@ export const drive = defineProvider({
     app: GOOGLE_APP,
     scopes: DRIVE_SCOPES,
     ...GOOGLE_OAUTH,
+    assertion: googleServiceAccount('Drive', DRIVE_SCOPES, 'optional', ['drive.googleapis.com']),
   },
   identity: DRIVE_IDENTITY,
   setup: googleSetup('Drive', DRIVE_SCOPES),

--- a/src/providers/google/gmail/index.ts
+++ b/src/providers/google/gmail/index.ts
@@ -1,5 +1,6 @@
 import { defineProvider, defineProviderWithCapabilities } from '#connectivity';
 import { GMAIL_IDENTITY, GOOGLE_APP, GOOGLE_OAUTH, specPath } from '../shared/oauth.ts';
+import { googleServiceAccount } from '../shared/service-account.ts';
 import { googleSetup } from '../shared/setup.ts';
 import { GMAIL_HOST } from './api.ts';
 import { GMAIL_HINTS } from './hints.ts';
@@ -85,6 +86,7 @@ const manifest = defineProvider({
     app: GOOGLE_APP,
     scopes: GMAIL_SCOPES,
     ...GOOGLE_OAUTH,
+    assertion: googleServiceAccount('Gmail', GMAIL_SCOPES, 'required', ['gmail.googleapis.com']),
   },
   // The REST API rather than the MCP server: it answers with the address under
   // scopes we already hold, so labelling a connection costs no extra consent.

--- a/src/providers/google/shared/oauth.ts
+++ b/src/providers/google/shared/oauth.ts
@@ -24,10 +24,18 @@ export const GOOGLE_APP = 'google';
  * and there is no way to withdraw one copy of a secret.
  *
  * What this buys the operator is the whole of `setup/google.md`: no project, no
- * console, no scope list to transcribe, and no seven-day refresh-token expiry,
- * because that expiry is a property of a project left in "Testing" and this one
- * is not. What it costs is recorded in ADR-028 and in the guarantee table in
- * `docs/detailed/security.md` — chiefly that the exchange stops being local.
+ * console, and no scope list to transcribe. What it costs is recorded in
+ * ADR-028 and in the guarantee table in `docs/detailed/security.md` — chiefly
+ * that the exchange stops being local.
+ *
+ * What it does *not* buy, and used to claim to: escape from the seven-day
+ * refresh-token expiry. That expiry is a property of the client's publishing
+ * status rather than of its verification, and a client under review has the
+ * status it has — so a connection made this way is re-authorised weekly until
+ * the review lands, exactly like one made against a client of the operator's
+ * own that was left in "Testing". The way around it is not a different client.
+ * It is `auth.assertion`: a key does not expire because nothing consented, and
+ * `./service-account.ts` is that route.
  */
 const BROKER_ORIGIN = 'https://api.lanes.sh';
 const BROKER_PATH = '/v1/auth/link/google';

--- a/src/providers/google/shared/service-account.ts
+++ b/src/providers/google/shared/service-account.ts
@@ -1,0 +1,97 @@
+import { GOOGLE_APP } from './oauth.ts';
+
+/**
+ * The other way into a Google account: a key, instead of a browser.
+ *
+ * Google issues service accounts, and a service account holds a private key
+ * that does not expire. It is the answer to the one complaint the browser flow
+ * cannot fix — that a client left in "Testing" has its refresh tokens expired
+ * after seven days, so every connection has to be re-approved weekly until
+ * verification lands. A key is not subject to that, or to any other policy the
+ * issuer applies to consent, because nobody consented.
+ *
+ * What it costs is reach, and the cost is different per product, which is why
+ * `delegation` is a parameter rather than a constant. A service account is an
+ * identity in its own right: it has a Drive, and a calendar, and no mailbox and
+ * no contacts. So Drive, Sheets, Docs and Calendar work by *sharing* something
+ * with its address, and Gmail, Contacts and Tasks work only if a Workspace
+ * administrator lets the key act as a person. A personal Google account has no
+ * administrator, so for those three there is no key route at all and the
+ * walkthrough says so rather than letting someone find out later.
+ */
+
+/** Where the key lives. One file per profile, covering every Google provider. */
+export const GOOGLE_KEY_REF = `${GOOGLE_APP}/service_account_key`;
+
+const SHARE_HINT: Record<string, string> = {
+  Drive: 'a folder (Share → paste the address → Editor)',
+  Sheets: 'a spreadsheet (Share → paste the address → Editor)',
+  Docs: 'a document (Share → paste the address → Editor)',
+  Calendar:
+    'a calendar (Settings for that calendar → "Share with specific people" → paste the address)',
+};
+
+export const googleServiceAccount = (
+  product: string,
+  scopes: readonly string[],
+  delegation: 'optional' | 'required',
+  apis: readonly string[],
+) => ({
+  method: 'service_account',
+  label: 'Service account key',
+  delegation,
+  key_ref: GOOGLE_KEY_REF,
+  reach:
+    delegation === 'optional'
+      ? `a JSON key that never expires, and no browser. Reaches only what you share with the ` +
+        `key's own address, so nothing in the account moves until you share it.`
+      : `a JSON key that never expires, and no browser. ${product} has nothing that belongs to ` +
+        `a key, so this needs a Google Workspace administrator to let it act as you — a personal ` +
+        `Google account cannot do it.`,
+  subject_label:
+    delegation === 'optional'
+      ? 'Google account to act as, if an administrator has granted it'
+      : 'Google account to act as',
+  setup: {
+    summary:
+      delegation === 'optional'
+        ? `${product} can authenticate with a service account key instead of signing in. The key ` +
+          `does not expire, so this is connected once and stays connected. It reaches only what ` +
+          `is shared with it, which is the trade: you pick what it can see, one resource at a time.`
+        : `${product} can authenticate with a service account key instead of signing in. The key ` +
+          `does not expire — but a key has no mailbox, contacts or task lists of its own, so this ` +
+          `route works only where a Google Workspace administrator has authorised the key to act ` +
+          `as a user in their domain. On a personal Google account, use the browser instead.`,
+    docs: 'docs/detailed/setup/google.md',
+    docs_url: 'https://console.cloud.google.com/iam-admin/serviceaccounts',
+    steps: [
+      'Create or pick a project at https://console.cloud.google.com',
+      `Enable the APIs:\n       gcloud services enable ${apis.join(' ')} --project=YOUR_PROJECT\n       Without gcloud: APIs & Services → Library, and search for each by name.`,
+      'IAM & Admin → Service Accounts → Create service account. Name it "Lanes Link". Grant it no project roles — the roles page governs Google Cloud resources, and nothing here is one.',
+      'Open the account → Keys → Add key → Create new key → JSON. It downloads once. You are asked for the path to that file next; its contents go to the credential store and the file itself is not read again.',
+      ...(delegation === 'required'
+        ? [
+            'THIS PRODUCT NEEDS DOMAIN-WIDE DELEGATION, which only a Google Workspace administrator can grant. Copy the service account\'s numeric "Unique ID" (the client ID, not the email) from its Details tab.',
+            `In the Workspace Admin console → Security → Access and data control → API controls → Domain-wide delegation → Add new. Paste that client ID, and paste this scope list exactly:\n       ${scopes.join(',\n       ')}\n       All of them, comma-separated, in one field. A partial list is refused the same way a missing one is, and the refusal does not say which scope was short.`,
+            'Delegation can take a few minutes to take effect. If the first connect is refused with "unauthorized_client", wait and run it again — nothing was stored.',
+          ]
+        : [
+            `Share what you want reachable with the service account's email address — it ends in .iam.gserviceaccount.com and is printed once the key is stored. For ${product} that means ${SHARE_HINT[product] ?? 'the resource itself'}.`,
+            'Nothing else in the account is reachable, including files the same person owns. That is the point of this route, and it is also the thing to remember when something is "missing" — it has not been shared yet.',
+            'A Workspace administrator can instead grant domain-wide delegation, which lets the key act as a user and reach everything they can. The connect prompt asks which account to act as; leaving it blank means the key acts as itself.',
+          ]),
+    ],
+    prompts: [
+      {
+        key: 'service_account_key',
+        label: 'Path to the downloaded JSON key (or paste its contents)',
+        // Read from a path in the ordinary case, so this is not a secret typed
+        // into a terminal — but it may be pasted, and a pasted private key must
+        // not land in scrollback.
+        secret: true,
+        scope: 'shared' as const,
+        credential_ref: GOOGLE_KEY_REF,
+      },
+    ],
+  },
+});

--- a/src/providers/google/shared/setup.ts
+++ b/src/providers/google/shared/setup.ts
@@ -56,11 +56,14 @@ export const googleSetup = (
       }\n       Without gcloud: APIs & Services → Library, and search for each by name.`,
       'The rest is under Google Auth Platform — https://console.cloud.google.com/auth — in this order:',
       '  BRANDING — app name and a support email. Seen by nobody but you.',
-      '  AUDIENCE — User type: EXTERNAL (even with a Workspace domain: "Internal" admits only that one domain, so a mix of personal and Workspace accounts needs External). Add every account you will connect under "Test users". LEAVE the status as "Testing".',
+      '  AUDIENCE — User type: EXTERNAL (even with a Workspace domain: "Internal" admits only that one domain, so a mix of personal and Workspace accounts needs External). Add every account you will connect under "Test users".',
+      '  AUDIENCE, again — PUBLISH the app. This is the setting that decides whether your connections survive the week, and it is not the same thing as verification: a client left in "Testing" has every refresh token it issues expired after exactly seven days, and one set to "In production" does not, review pending or not.',
       `  DATA ACCESS — where scopes live now. Add:\n       ${scopes.join('\n       ')}\n       Note drive.file is filed under "sensitive" rather than "restricted", so it appears in a different section of that page.`,
       '  CLIENTS — Create OAuth client → type: DESKTOP APP. Google\'s docs say "Web application" with a redirect URI for Claude or Antigravity, because they assume the agent host runs the OAuth. Here the CLI does, on a loopback port — which is also why this stays Desktop even when the server runs on Cloud Run.',
       'Copy the client ID and secret — you are asked for them next.',
-      'Not publishing is deliberate: these are restricted scopes, and publishing them means Google verification with a CASA assessment taking months. Testing needs none. The cost is that refresh tokens expire after 7 days, so expect to re-run "lanes link connect" weekly — "lanes link doctor" says which are stale.',
+      'What publishing unverified costs, so it is a decision rather than a surprise: everyone you connect sees a "Google hasn\'t verified this app" screen and has to click through Advanced, and the project gains a cap of 100 new users granted these scopes. That cap is for the lifetime of the project and cannot be reset — which does not matter for a client only you use, and matters a great deal for one you intend to hand out.',
+      'Verification itself is the other path and a much longer one — restricted scopes mean a review with a security assessment measured in months. It is worth starting and not worth waiting on: publishing above removes the weekly re-authorisation today.',
+      'If none of that suits — an organisation that forbids publishing, or a client that must stay in Testing — connect with a service account key instead. It does not expire at all: lanes link connect ' + product.toLowerCase().split(' ')[0] + ' --auth service_account',
     ],
     prompts: [
       {

--- a/src/providers/google/sheets/index.ts
+++ b/src/providers/google/sheets/index.ts
@@ -1,5 +1,6 @@
 import { defineProvider } from '#connectivity';
 import { DRIVE_IDENTITY, GOOGLE_APP, GOOGLE_OAUTH, specPath } from '../shared/oauth.ts';
+import { googleServiceAccount } from '../shared/service-account.ts';
 import { googleSetup } from '../shared/setup.ts';
 import { SHEETS_HINTS } from './hints.ts';
 import { SHEETS_REDACT } from './redact.ts';
@@ -60,6 +61,7 @@ export const sheets = defineProvider({
     app: GOOGLE_APP,
     scopes: SHEETS_SCOPES,
     ...GOOGLE_OAUTH,
+    assertion: googleServiceAccount('Sheets', SHEETS_SCOPES, 'optional', ['sheets.googleapis.com', 'drive.googleapis.com']),
   },
   identity: DRIVE_IDENTITY,
   setup: googleSetup('Sheets', SHEETS_SCOPES, {

--- a/src/providers/google/tasks/index.ts
+++ b/src/providers/google/tasks/index.ts
@@ -1,5 +1,6 @@
 import { defineProvider } from '#connectivity';
 import { GOOGLE_APP, GOOGLE_OAUTH, specPath } from '../shared/oauth.ts';
+import { googleServiceAccount } from '../shared/service-account.ts';
 import { googleSetup } from '../shared/setup.ts';
 import { TASKS_REDACT } from './redact.ts';
 
@@ -47,6 +48,7 @@ export const tasks = defineProvider({
     app: GOOGLE_APP,
     scopes: TASKS_SCOPES,
     ...GOOGLE_OAUTH,
+    assertion: googleServiceAccount('Tasks', TASKS_SCOPES, 'required', ['tasks.googleapis.com']),
   },
   setup: googleSetup('Tasks', TASKS_SCOPES, { apis: ['tasks.googleapis.com'] }),
   redact: TASKS_REDACT,


### PR DESCRIPTION
## The finding this rests on

The weekly re-authorisation of every Google connection is **not** caused by pending verification.
It is caused by the OAuth client's **publishing status**, which is a separate setting. A client in
"Testing" has every refresh token it issues expired after exactly seven days; a client set to "In
production" does not — review pending or not.

Two things in this repository were wrong about that:

- `src/providers/google/shared/oauth.ts` claimed the hosted client escaped the expiry "because that
  expiry is a property of a project left in Testing and this one is not". It does not: the client
  is under review, and a client under review has whatever status it has.
- `src/providers/google/shared/setup.ts` told `--own-client` operators to *leave* their own client
  in Testing, and closed by telling them to expect to re-run `connect` weekly.

So both routes expired weekly — one by accident, one on purpose — and `google-verification.md` read
as though verification were the only way out. All three are corrected here.

**Publishing an unverified client is most of the fix and is not code**: one setting, costing an
unverified-app screen and a lifetime cap of 100 new users on that project that cannot be reset.
Right for a client one person uses, wrong for one handed out — so it is now a documented choice
rather than a default. It also does nothing where an organisation forbids publishing, and nothing
about the deeper property: an authorization-code refresh token lives or dies by policy applied to
somebody's consent, and that policy is not the operator's.

## What this adds

A provider may declare `auth.assertion` — RFC 7523, where the operator holds a private key, signs a
short-lived JWT, and exchanges it for an access token. There is no refresh token because there is
nothing to refresh.

The choice `connect` prints covers **every** route, not only the new one. `--own-client` already
existed and was a choice nobody discovered unless they already knew it was there:

```
Google Drive can authenticate three ways

  1. Service account key
     a JSON key that never expires, and no browser. Reaches only what you share
     with the key's own address, so nothing in the account moves until you share it.
  2. Sign in through a browser, using the OAuth client Lanes operates
     nothing to register and no client secret on this machine…
  3. Sign in through a browser, using an OAuth client you register
     a console walkthrough once per profile…

  Which [2]:
```

`--auth <method>` is the non-interactive answer; `--own-client` still works and resolves to
`own_client`. A provider declaring one route asks nothing, so GitHub, Slack, iCloud and Linear are
untouched.

## Coverage, which is uneven and says so

| Provider | Key alone | Needs domain-wide delegation |
|---|---|---|
| `drive`, `sheets`, `docs`, `calendar` | yes — reaches what you share with it | only to reach the whole account |
| `gmail`, `contacts`, `tasks` | no — a key has no mailbox | yes, and Workspace only |
| `gmail_mcp`, `drive_mcp` | not offered — the SDK owns their exchange | — |

`delegation: 'optional' \| 'required'` carries this. A `required` provider refuses a blank subject,
because a key acting as nobody authenticates perfectly and then reads every mailbox as empty — a
wrong answer that looks like a right one.

`gmail_mcp` is deliberately **not** in the auth prompt. It is a different provider with a different
tool surface and its own policy rules, not a credential type; choosing it there would mean
`connect gmail` creating a `gmail_mcp` connection. `setup/google.md` now states that provider choice
and credential choice are separate questions.

## Design, in four decisions

Each had an obvious alternative that is worse. [ADR-037](docs/detailed/adr/037-a-key-is-the-second-way-into-an-account.md)
is the long form.

1. **Not a fourth `auth.kind`.** Gmail reached by a key is the same Gmail with the same scopes,
   tools, redaction and policy. A `kind` would have forked `credentialRefForConnection`,
   `setupRequirements`, `rotatableCredentialRefs` and the deploy grants into branches that must
   agree forever.
2. **The stored credential's shape is the switch, not a field in config.** `credentialResolver` is
   handed a registry and a secret store and never a connection row, so a declaration in config would
   be invisible exactly where the decision is made. Both routes write to `<provider>/<connection>`;
   one blob has `access_token`, the other has `grant`. Same device `profileHasOwnClient` already
   uses.
3. **The key is per profile, the subject per connection.** One key covers seven providers. Storing
   it per connection would mean seven pastes and seven copies to rotate.
4. **The minted token is cached in memory, never written back**, so this ref does not become
   rotatable — which would make a deployed revision need write access to a secret it only ever
   reads, to cache something that costs one signature and one POST to remake.

An explicit client answer now overrides a profile's `oauth_apps` entry in both directions. That is
safe because `authorized_via` records which client minted each token, so one connection moves and no
other — and the override prints a line saying so rather than moving silently.

## Two files split, not a budget raised

`connect/index.ts` crossed the 400-line budget. Per `src/architecture.test.ts`, the fix is the seam:
the vendor-family fan-out (`family.ts`) and capability discovery (`discover.ts`) each left for their
own file. `KNOWN_LONG` is unchanged.

## Verification

`bun test` — 1761 pass, 0 fail (was 1699). `bun run typecheck` — clean.

Beyond the suite:

- **Against Google's real token endpoint**, with a locally generated throwaway key:
  `Invalid grant: account not found`. Signature, claim set, `aud` and grant type all accepted;
  rejected on identity alone, which is the only thing checkable without a real account.
- **End to end in a scratch workspace** (`LANES_LINK_HOME`, never the real one): a key-backed Drive
  connection stores one shared key plus a per-connection pointer, keeps no key material in config,
  discovers 9 capabilities, and `doctor` reports `credential resolves` with no bogus staleness
  warning — `credentialAge` already returned null for a blob with no expiry.
- That run **found a bug the unit tests missed**: `reuseStoredCredential`'s `provisional` check is
  about per-connection credentials, so a first connect re-asked for a key that was already stored,
  immediately after the preflight reported everything present. Fixed, with a regression test.
- It also showed one error message guessing wrong. Google returns `invalid_grant` for a missing
  account, a deleted key, a wrong clock *and* a missing subject; the message now leads with Google's
  own description and lists the causes instead of asserting one.

Creating a service account and its key touches a real Google account, so that part is the
operator's to run. Nothing in this branch does.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
