### PR TITLE
Connect Slack in a browser instead of asking for a Slack app

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,12 +104,12 @@ One command per account. Run it again to add a second mailbox, a second calendar
 | Drive (Google MCP) | `lanes link connect drive_mcp` |
 
 Three things worth knowing up front. `lanes link connect icloud` sets up Mail, Calendar, and
-Contacts together, because one app-specific password covers all three. Google needs no OAuth client
-of your own: `lanes link connect gmail` authorises against the one Lanes operates, so there is no
-Cloud console to visit — and where you would rather nothing expired, it also offers a service
-account key, or an app password over IMAP for a personal account. And GitHub and
-Slack take a token you paste rather than a browser sign-in, because neither will register a client
-for us; for Slack that means creating a Slack app once, which is the one console visit left here.
+Contacts together, because one app-specific password covers all three. Google and Slack need no
+OAuth client of your own: both authorise against the one Lanes operates, so there is no console to
+visit — for Google, add `--own-client` if you would rather register your own, or take a service
+account key or an app password over IMAP where you would rather nothing expired. And GitHub takes a
+token you paste rather than a browser sign-in, because it will not register a client for us; that
+is the one console visit left here.
 
 Full guide — what each one gives your agent, what it needs, and adding your own:
 **[docs/connect.md](docs/connect.md)**.

--- a/docs/connect.md
+++ b/docs/connect.md
@@ -46,15 +46,24 @@ app-specific password covers all three. iCloud Drive is separate — it holds no
 reading your sync folder through the filesystem. Full walkthrough:
 [`detailed/setup/icloud.md`](detailed/setup/icloud.md).
 
-**Only Slack asks you to register anything.** Google authorises against the client Lanes operates,
-Notion and Linear register themselves, iCloud takes an app-specific password you generate at
-appleid.apple.com, and GitHub takes a personal access token —
+**Only GitHub asks you to register anything.** Google and Slack authorise against the client Lanes
+operates, Notion and Linear register themselves, and iCloud takes an app-specific password you
+generate at appleid.apple.com. GitHub takes a personal access token you create once —
 [`detailed/setup/github.md`](detailed/setup/github.md).
 
-Slack is the exception, and not for want of trying. Slack's MCP server does not register clients
-automatically, and a client of your own needs an HTTPS callback, which a CLI listening on localhost
-cannot be. So Slack means creating a Slack app once, installing it to your workspace, and pasting
-the user token it mints: [`detailed/setup/slack.md`](detailed/setup/slack.md).
+Slack used to be on that list and no longer is. Slack does not register clients automatically and
+is not going to — it would let a client authenticate someone without an app existing, and on
+Enterprise Grid an admin approves each app first. What changed is whose app it is: Lanes registered
+one, so `lanes link connect slack` is a browser round trip like the rest.
+
+If your workspace has not approved that app — which an admin decides, not you — paste a token from
+one it already trusts instead:
+
+```console
+$ lanes link connect slack --profile personal --target local --auth pasted_token
+```
+
+[`detailed/setup/slack.md`](detailed/setup/slack.md) covers both.
 
 For Google you can still register your own, and some people have to — an organisation that forbids
 third-party clients, a Workspace app that must be "Internal", or a hosted client that has reached

--- a/docs/detailed/adr/028-a-hosted-oauth-client-is-the-default.md
+++ b/docs/detailed/adr/028-a-hosted-oauth-client-is-the-default.md
@@ -91,6 +91,9 @@ existing connections onto it — they keep refreshing where they were issued, an
 `connect` moves them. The alternative, reading the current config, would turn an unrelated-looking
 config edit into `invalid_grant` on every connection at once.
 
-**An MCP provider cannot be brokered.** The SDK owns that exchange and there is no seam to route
-it without reimplementing its auth path. `defineProvider` refuses the combination at definition
-rather than letting it fail after the operator has already approved a consent screen.
+**An MCP provider cannot be brokered.** ~~The SDK owns that exchange and there is no seam to route
+it without reimplementing its auth path.~~ **Struck by
+[ADR-040](040-an-mcp-connector-may-use-a-pre-registered-client.md):** the seam is a manifest naming
+its own `authorize_url` and `token_url`, which takes the provider off the SDK's flow and onto the
+direct one entirely. `defineProvider` now refuses only the half-declared case, where the SDK would
+run the flow and then redeem the code with a client it does not hold.

--- a/docs/detailed/adr/033-a-pasted-token-for-an-mcp-server.md
+++ b/docs/detailed/adr/033-a-pasted-token-for-an-mcp-server.md
@@ -1,6 +1,14 @@
 # ADR-033: Where a vendor will not register us as a client, the operator's own token is the credential
 
-**Status:** accepted · **Complements** [ADR-028](028-a-hosted-oauth-client-is-the-default.md)
+**Status:** accepted, **partly superseded by**
+[ADR-040](040-an-mcp-connector-may-use-a-pre-registered-client.md) · **Complements**
+[ADR-028](028-a-hosted-oauth-client-is-the-default.md)
+
+> ADR-040 revisited the middle section below and found one of its three claims false: an MCP
+> provider *can* be brokered, because the seam it says does not exist was already there. Slack
+> moved to a browser round trip. What survives here is the mechanism — a pasted token as an
+> `mcp` connector's credential — which is what GitHub uses and what Slack falls back to when a
+> workspace has not approved the Lanes app.
 
 ## Context
 
@@ -71,9 +79,9 @@ refresh token — a means of obtaining a credential, exchanged on every use, wit
 never leaving memory. Here the stored value is the credential itself. Rotation is manual:
 `connect --replace`, after revoking upstream.
 
-There is no scope-disclosure gate. `confirmScopes` shows an operator what is about to be granted and
-refuses to proceed when the set has widened without being agreed. Nothing equivalent is possible
-for a pasted token: what it can do is chosen in the vendor's console, and this endpoint has no way
+There is no scope-disclosure gate — for GitHub, and for Slack only on the pasted-token route.
+`confirmScopes` shows an operator what is about to be granted and refuses to proceed when the set
+has widened without being agreed. Nothing equivalent is possible for a pasted token: what it can do is chosen in the vendor's console, and this endpoint has no way
 to read it back. The policy layer still bounds what an agent may call; the credential's own reach is
 the operator's to bound, at the vendor, when they generate it. Both setup pages say so at the point
 the token is created.
@@ -86,10 +94,14 @@ upstream fails the way that test exists to prevent: silently, with the value wit
 reading exactly as it does when redaction is working. `doctor`'s capability drift report is the
 signal to re-read them.
 
-**Slack costs a console visit and always will.** Creating a Slack app is the only way to obtain a
-user token, so `docs/connect.md` no longer claims no provider asks you to register anything. This is
-the first time that sentence has needed an exception, and pretending otherwise would be worse than
-the exception.
+**Slack costs a console visit and always will.** ~~Creating a Slack app is the only way to obtain a
+user token, so `docs/connect.md` no longer claims no provider asks you to register anything.~~
+**Wrong, and corrected by [ADR-040](040-an-mcp-connector-may-use-a-pre-registered-client.md).** It
+is the only way to obtain a user token *of your own*; it is not the only way to obtain one. Lanes
+registered an app, and Slack accepts an `http://localhost:<port>` redirect registered against it —
+which this ADR asserts it does not, on the strength of Slack's documentation rather than its
+behaviour. Left standing rather than edited, because the shape of the mistake is the useful part:
+every individual claim here was checked, and the conclusion still did not follow.
 
 **What this is not.** It is not a retreat from ADR-028. A hosted client remains the default wherever
 one can be used, and if either vendor ships DCR the change is one field in one manifest —

--- a/docs/detailed/adr/039-a-profile-declares-who-its-owner-is.md
+++ b/docs/detailed/adr/039-a-profile-declares-who-its-owner-is.md
@@ -1,4 +1,4 @@
-# ADR-039: A profile declares who its owner is
+# ADR-040: A profile declares who its owner is
 
 **Status:** accepted · **Follows from** [ADR-019](019-describing-setup-is-not-performing-it.md) · **Extends** [ADR-007](007-control-plane-exclusions.md) · **Obeys** [ADR-037](037-a-command-names-what-it-acts-on.md)
 

--- a/docs/detailed/adr/039-cross-origin-access-is-a-deployment-only-grant.md
+++ b/docs/detailed/adr/039-cross-origin-access-is-a-deployment-only-grant.md
@@ -1,4 +1,4 @@
-# ADR-039: Cross-origin access is a deployment-only grant, and a preflight is never refused for want of a credential
+# ADR-040: Cross-origin access is a deployment-only grant, and a preflight is never refused for want of a credential
 
 **Status:** accepted · **Follows from** [ADR-018](018-the-gate-is-in-the-application.md) ·
 **Constrained by** the loopback guard in `src/server/rebinding.ts`

--- a/docs/detailed/adr/040-an-mcp-connector-may-use-a-pre-registered-client.md
+++ b/docs/detailed/adr/040-an-mcp-connector-may-use-a-pre-registered-client.md
@@ -1,0 +1,134 @@
+# ADR-040: An MCP connector may use a client somebody else registered
+
+**Status:** accepted · **Amends** [ADR-028](028-a-hosted-oauth-client-is-the-default.md) ·
+**Supersedes the Slack half of** [ADR-033](033-a-pasted-token-for-an-mcp-server.md)
+
+## Context
+
+ADR-033 ended with a sentence that has turned out to be wrong: *"Slack costs a console visit and
+always will."* The reasoning behind it was sound about Slack and wrong about this repository, which
+is the kind of mistake worth recording in full rather than quietly correcting.
+
+Three claims held it up. Two are still true:
+
+- **Slack does not support Dynamic Client Registration.** Confirmed, and it is a decision rather
+  than a gap — DCR would let a client authenticate a user without an app existing, and on
+  Enterprise Grid an admin approves each app first. Waiting for it is waiting for nothing.
+- **A confidential client is needed.** `https://mcp.slack.com/.well-known/oauth-authorization-server`
+  advertises `client_secret_post` and no `registration_endpoint`.
+
+The third does not:
+
+- **"A broker cannot be used, because the SDK owns an MCP provider's exchange and there is no seam
+  to route it."** There is a seam, and it was already load-bearing. `createMcpConnector` takes
+  `accessToken: () => Promise<string | null>` and sets a plain `Authorization: Bearer` header; at
+  serve time that token comes from `bearerToken()` through `credentialResolver`, not from the SDK.
+  The SDK owns only the *connect-time* exchange — and `authoriseDirect`, written for `http`
+  connectors that have no metadata to discover, is a complete authorization-code flow with a broker
+  hook already in it. What made an MCP provider different was discovery, and a manifest that names
+  its own endpoints has nothing left to discover.
+
+The fourth claim, about redirect URIs, is **correct**, and this ADR spent a while believing it was
+not. ADR-033 recorded that Slack requires an HTTPS redirect and that a loopback callback is
+therefore impossible. Evidence pointed the other way — Anthropic's Slack app has
+`http://localhost:3118/callback` registered and publicly distributed, confirmed by Slack's own team
+on `anthropics/claude-code#37714` — so this was built on the assumption that a registered loopback
+URL works.
+
+It does not. Tested against a real app: the Redirect URL field rejects a non-HTTPS value outright.
+Whatever exception Anthropic's app enjoys is not one available by registering an app today. The
+first shape of this change — a fixed loopback port, `auth.redirect`, and a client id shipped in the
+manifest so a public client could redeem locally — was built, tested, and then removed, because
+every part of it depended on Slack accepting a redirect Slack will not accept.
+
+The lesson is narrow and worth keeping: an observed working configuration is evidence about *that*
+configuration, not about what the console will let you create.
+
+## Decision
+
+**An `mcp` connector may declare `auth.broker` or `auth.client_id`, provided it also declares
+`authorize_url` and `token_url`.** Naming both endpoints is what takes a provider off the SDK's
+flow and onto the direct one, where the exchange is ours to route. Declaring one without the other
+is refused at definition: half-declared is the dangerous state, because the SDK would run the flow
+and then post to a token endpoint with a client it does not hold.
+
+Notion, Linear, and Google's two MCP servers name neither and are untouched.
+
+**There is no fallback, and there cannot be one here.** A shipped client id was built for the case a
+broker cannot cover — being unreachable — and removed with the loopback redirect it depended on. The
+broker is not merely where the secret lives; it is the HTTPS origin the redirect requires. A client
+with nothing behind it has nowhere for Slack to send the browser.
+
+So Slack's broker is not optional the way Google's is, and `connect slack` fails when it is down.
+Softened by Slack issuing no refresh token: an outage stops new connections and cannot interrupt one
+already made, which is the opposite of the risk ADR-028 warned a shared client carries.
+
+**Where a vendor refuses a loopback redirect, the broker receives it and bounces it down.** Slack
+sends the browser to `https://api.lanes.sh/v1/auth/link/slack/callback`; that route 302s to
+`http://127.0.0.1:<port>/callback`, and the port travels in `state` — which is opaque to the vendor,
+round-trips untouched, and is already the CSRF binding the CLI checks, so it costs no parameter and
+no state held anywhere. `runOAuthFlow` takes `relayRedirect`; the listener is unchanged and still
+binds a port the kernel picked.
+
+This does not reopen [ADR-025](025-connecting-an-account-from-a-deployed-endpoint.md). The CLI still
+starts the flow, opens the browser, receives the code, redeems it, and writes the credential
+locally. No consent moves to a server, nothing is stored between the two legs, and the broker
+already receives the authorization code at `/exchange` — seeing it one step earlier grants it
+nothing, and the PKCE verifier needed to redeem it never leaves the machine that generated it.
+
+The broker publishes that URL through `/config` rather than the manifest writing it down: the
+correct value depends on which deployment answered, and `LANES_LINK_BROKER_ORIGIN` would otherwise
+need a second override to match.
+
+**`auth.refresh_token: 'optional'` says a response without a refresh token is the success.** The
+two readings are opposite and neither is guessable from the response: Google omitting one means the
+grant already existed and the connection would die in an hour; Slack omitting one is what a
+long-lived user token looks like. The default stays `required`, and the refusal names the vendor
+from the manifest rather than saying "Google" as it used to.
+
+**A pasted token stays, as a route `--auth` selects.** A fourth entry in `method.ts`'s chooser
+rather than a flag of its own, because ADR-038 had already made "which way in" one question. Written into the same ref in the same blob shape the
+browser path writes, so nothing downstream learns there are two paths.
+
+## Consequences
+
+**The app has to be publicly distributed, and that is the step this all rests on.** A Slack app is
+created in a workspace, and by default it can only ever be installed there — every other workspace
+is refused with `invalid_team_for_non_distributed_app`. Activating public distribution decouples it:
+one app, one client id, one secret, installable by any workspace. It is self-serve and immediate,
+and it is not the same thing as an App Directory listing, which needs a review and which this does
+not want. Worth stating plainly because the mental model it displaces — "an app belongs to a
+workspace, so a shared app cannot work" — is the obvious one and is the reason this ADR looked
+impossible for longer than it was.
+
+An admin can still refuse the app for their own workspace, on Enterprise Grid especially. That is
+not a reason to register a second app; it is what the pasted-token route above exists for.
+
+**Slack's scope-disclosure gate exists now.** ADR-033 recorded its absence as permanent: what a
+pasted token can do is chosen in the vendor's console and cannot be read back. Asking for scopes in
+a browser is what makes `confirmScopes` apply, and seven of Slack's twenty are flagged broad. That
+consequence in ADR-033 now describes GitHub only.
+
+**Slack joins the `credentials.exchange-is-local: NOT-GUARANTEED` row**, on the brokered path, for
+the same reason Google is in it.
+
+**A broker outage cannot interrupt an agent here.** ADR-028 warned that a shared client "can fail in
+the middle of an agent's work rather than only at setup", because refresh runs while serving. Slack
+issues no refresh token unless token rotation is enabled on the app, so its broker is consulted at
+`connect` and never again. That is what makes the shipped-client fallback a convenience rather than
+a necessity.
+
+**`connect` is still CLI-only and the server still never participates.** No `/callback` route, no
+pending-authorization state, no consent moved to a server. [ADR-025](025-connecting-an-account-from-a-deployed-endpoint.md)
+is untouched, and so is [ADR-007](007-control-plane-exclusions.md).
+
+**`Bun.serve` does not refuse a port another listener holds.** Found while building the fixed
+callback: it binds anyway, within one process or across two, with or without `reusePort: false`, and
+the kernel then splits connections between the listeners. Recorded rather than guarded, because the
+relay removed the fixed port and with it the only way two `connect` runs could land on the same
+number. It is a live hazard for anything here that ever pins a port again.
+
+**What this is not.** It is not a claim that DCR is unnecessary. `registration: dynamic` remains the
+best case and the one that costs nothing; this is what to do when a vendor has decided against it.
+Nor does it retire the pasted token: ADR-033's mechanism is what GitHub still uses and what Slack
+falls back to.

--- a/docs/detailed/adr/README.md
+++ b/docs/detailed/adr/README.md
@@ -47,6 +47,7 @@ Nothing in the codebase depends on it.
 | [037](037-a-command-names-what-it-acts-on.md) | A command names its profile and target as flags, or it does not run; the environment variables and config defaults are parsed and no longer read |
 | [038](038-a-key-is-the-second-way-into-an-account.md) | A service account key is a second way into a Google account, for the consent nobody can give a background job |
 | [039](039-cross-origin-access-is-a-deployment-only-grant.md) | Cross-origin access is granted only by a deployment, and a preflight is answered ahead of the credential check |
+| [040](040-an-mcp-connector-may-use-a-pre-registered-client.md) | An `mcp` connector that names its own endpoints may be brokered, and a vendor that refuses a loopback redirect gets one bounced through the broker — so Slack costs a browser round trip rather than a console visit |
 
 Where an ADR departs from init.md, it says so at the top. Three are significant:
 

--- a/docs/detailed/configuration.md
+++ b/docs/detailed/configuration.md
@@ -60,7 +60,7 @@ auth:
   token_ref: profile/token
   # Browser origins allowed to call /mcp. Absent means "*", so this is only
   # worth setting to narrow it. Deployment only — a loopback endpoint refuses
-  # every cross-origin request, and this cannot widen that. ADR-039.
+  # every cross-origin request, and this cannot widen that. ADR-040.
   allowed_origins: ['*']
 
 limits:
@@ -154,7 +154,7 @@ it. `identity list` says `declared, but no agent can read it` when that is the s
 What reads it is one read-only tool, `identity_list`. Nothing on the MCP surface can write here:
 an agent able to edit this could edit the one fact that stops it signing as the wrong person, so
 editing is CLI-only under ADR-007. The endpoint's own instructions carry a pointer to the tool and
-none of the values — see [ADR-039](adr/039-a-profile-declares-who-its-owner-is.md).
+none of the values — see [ADR-040](adr/039-a-profile-declares-who-its-owner-is.md).
 
 Removing the last entry leaves the row and the rule in place, and the tool then reports that
 nothing is declared.

--- a/docs/detailed/deployment-cloudrun.md
+++ b/docs/detailed/deployment-cloudrun.md
@@ -466,7 +466,7 @@ decided by `policy`, per call, exactly as for every other client. And it does no
 `lanes link start` — a loopback endpoint refuses every cross-origin request and must keep doing so,
 because a page you happen to be visiting can otherwise reach `127.0.0.1`, including the consent form
 that asks you for your token. The field is read and discarded there. See
-[ADR-039](adr/039-cross-origin-access-is-a-deployment-only-grant.md).
+[ADR-040](adr/039-cross-origin-access-is-a-deployment-only-grant.md).
 
 ### Using an identity provider you already run
 

--- a/docs/detailed/security.md
+++ b/docs/detailed/security.md
@@ -139,8 +139,10 @@ than the right to act as a person, and the two are one prompt apart.
 
 Since [ADR-028](adr/028-a-hosted-oauth-client-is-the-default.md) a Google connection authorises,
 by default, against an OAuth client Lanes operates rather than one the operator registers. That
-removes a nine-step console walkthrough. It also moves one step off this machine, and the honest
-statement of that is worth more than the convenience:
+removes a nine-step console walkthrough. Since
+[ADR-040](adr/040-an-mcp-connector-may-use-a-pre-registered-client.md) a Slack connection does the
+same, removing a six-step one. It also moves one step off this machine, and the honest statement of
+that is worth more than the convenience:
 
 - The **authorization code** is sent to the Lanes API, because redeeming it needs the client
   secret and that secret is deliberately not here.
@@ -150,9 +152,15 @@ statement of that is worth more than the convenience:
   the flow adds for this purpose) is sent with each refresh, so the API can attribute and
   rate-limit per account. It is stored beside the tokens and never decoded here.
 
-Everything else is unchanged: the browser still talks to Google directly, the redirect still lands
-on a loopback listener this process opened, the endpoint still never participates, and the tokens
-still live in whichever credential store the config names.
+Everything else is unchanged: the browser still talks to the vendor directly, the redirect still
+lands on a loopback listener this process opened, the endpoint still never participates, and the
+tokens still live in whichever credential store the config names.
+
+Slack differs from Google in one way worth stating, and it is in Slack's favour. It issues no
+refresh token unless token rotation is enabled on the app, so only the first exchange goes through
+the Lanes API and nothing does afterwards — where a Google connection passes a refresh token
+through it for as long as the connection lives. Slack's `/config` also asks for no identity scopes,
+because there is no `openid` here to attribute a refresh with and nothing to attribute.
 
 **Nothing in this repository can verify what the Lanes API does with what it sees.** That is the
 whole of the trade, and it is why this is a row in the table rather than a paragraph in a guide.

--- a/docs/detailed/setup/slack.md
+++ b/docs/detailed/setup/slack.md
@@ -1,150 +1,98 @@
-# Connecting Slack
-
-Messages, threads, channels, files, and canvases, through the MCP server Slack
-runs.
-
-```
-lanes link connect slack
-```
-
-You are asked for one user token. Getting that token means creating a Slack app
-first, which is the one console visit left in this project — and unlike Google's,
-it cannot be removed from your side.
-
-## Why there is a console visit
-
-Every other route is closed, and each for a different reason:
-
-- **Dynamic Client Registration** — the mechanism that makes Notion and Linear
-  cost nothing to connect. Slack's documentation is explicit: *"We do not
-  support SSE-based connections or Dynamic Client Registration at this time."*
-- **An OAuth client of your own** — the fallback used for Google. Slack requires
-  redirect URIs to be **HTTPS**, and `connect` listens on `http://127.0.0.1` on
-  a port the kernel picks per run. There is no flag, tunnel, or proxy that makes
-  a loopback listener HTTPS.
-- **A broker** — a client somebody else runs and performs the exchange behind.
-  Refused at definition for an MCP provider, because the SDK owns that exchange
-  and there is no seam to route it through one.
-
-What is left is the arrangement Slack's own documentation describes for a client
-that cannot register: install an app, take the user token, send it as
-`Authorization: Bearer`. See
-[ADR-033](../adr/033-a-pasted-token-for-an-mcp-server.md).
-
-## Creating the app
-
-1. Open **[api.slack.com/apps](https://api.slack.com/apps)** → **Create New App**
-   → **From scratch**. Name it `Lanes Link` and pick your workspace.
-2. Open **OAuth & Permissions** and scroll to **Scopes**.
-3. Add the following under **User Token Scopes**. Not *Bot* Token Scopes — the
-   MCP server reads the user token, and scopes added to the wrong list produce
-   an app that installs cleanly and then refuses every call.
-
-   | | Scopes |
-   |---|---|
-   | Search | `search:read.public` `search:read.private` `search:read.im` `search:read.mpim` `search:read.users` `search:read.files` |
-   | Read messages | `channels:history` `groups:history` `im:history` `mpim:history` |
-   | Channels and people | `channels:read` `groups:read` `mpim:read` `users:read` |
-   | Send | `chat:write` |
-   | Files | `files:read` |
-
-   Optional, if you want those tools to work: `reactions:write` for reactions,
-   `canvases:read` and `canvases:write` for canvases, `emoji:read` for emoji
-   search, `channels:write` for creating channels. Slack lists every tool
-   regardless of scope and refuses at call time, so a missing scope looks like a
-   tool that exists and does not work.
-
-4. Scroll back up and choose **Install to Workspace**, then approve. A workspace
-   admin may have to approve it on your behalf.
-5. Copy the **User OAuth Token** from the same page. It begins with `xoxp-`.
-
-> The token beginning `xoxb-` on that page is the **bot** token. It is the more
-> prominent of the two and it will not work here — a bot is a different identity
-> with different visibility, and the MCP server expects yours.
-
-The token goes into the encrypted credential store at `slack/<username>`, never
-into config.
-
-## What a user token means
-
-It acts as **you**. Anything you can see in Slack — private channels you are in,
-your DMs, your group DMs — is reachable through this connection, bounded by the
-scopes above and by your Lanes Link policy, not by a separate permission model.
-That is the point of a user token rather than a bot token, and it is also the
-thing to be deliberate about.
-
-Two consequences worth stating:
-
-- **The token does not expire** unless you enable token rotation on the app.
-  There is no refresh, so nothing renews it and nothing revokes it on a
-  schedule. Revoking means uninstalling the app, or rotating it from
-  **OAuth & Permissions**.
-- **Narrowing is yours to do**, in two places. Fewer scopes at install time is
-  the coarse control. `lanes link policy deny slack.send_message slack.<you>` is
-  the fine one, and it is instant and local.
-
-After rotating or reinstalling — either mints a new token — run:
-
-```
-lanes link connect slack --replace
-```
-
-Without `--replace`, connect finds the old token already stored and reuses it.
-
-## Which account this is
-
-The connection is labelled with your Slack **username**, read from
-`auth.test`, rather than the workspace name. That matters if two people connect
-Slack on the same machine: labelled by workspace, the second connection would
-look like a reconnect of the first and overwrite their credential.
-
-A quirk to know when something goes wrong: Slack answers a bad token with HTTP
-`200` and `{"ok": false}` rather than a `401`, so a wrong token does not fail
-the identity probe cleanly — you are asked "which account is this?" instead, and
-the real error arrives a step later when discovery runs.
-
-## Non-interactive
+# Slack
 
 ```console
-$ printf %s "$SLACK_TOKEN" | lanes link secrets set slack/ada --profile personal
-$ lanes link connect slack --id ada --non-interactive --json --profile personal
+$ lanes link connect slack --profile personal --target local
 ```
 
-The credential goes in on stdin, never as a flag — an argument lands in shell
-history, in `ps` output, and in any transcript.
+A browser opens, you approve, and that is the whole of it. There is no Slack app to create, no
+scope list to transcribe, and no token to copy.
 
-## What is recorded
+## Why this used to cost a console visit
 
-Where a message went is kept; what it said is not. An audit entry for
-`send_message` records the channel, the thread, and whether it was broadcast,
-and reduces `message` to a type marker — the same line Gmail draws for mail,
-because it is the same object. `src/providers/slack/redact.ts` is the list, with
-the reasoning for each.
+Slack does not support Dynamic Client Registration, so nothing can register itself with Slack the
+way [Notion and Linear](../../connect.md) do. That is deliberate rather than missing: registering
+dynamically would let a client authenticate someone without an app existing, and on Enterprise Grid
+an admin approves each app before it can authenticate anyone.
 
-`create_canvas` keeps nothing at all, and that is deliberate rather than an
-omission: a canvas has no identifier until Slack answers with one, so its only
-arguments are the title and the document. There is nothing to keep that is not
-content.
+So a client has to be pre-registered, and the question is only whose. It used to be yours. Now it
+is one Lanes registered. What Lanes holds is the app's client secret; the browser still goes to
+Slack, the consent is between you and your workspace, and the token lands in your credential store.
 
-One caveat, the same as GitHub's. A proxied server's capabilities are discovered
-at connect time rather than declared here, so nothing in this repository can
-check those argument names — unlike an `http` provider, where
-`cli/tools.test.ts` does. They were read off the schemas Slack's server
-publishes rather than guessed, but a rename upstream fails silently, with the
-log reading exactly as it does when redaction is working. `lanes link doctor`
-reporting capability drift is the signal that the list wants re-reading.
+Slack also refuses to register a callback that is not HTTPS, and a command line cannot be HTTPS. So
+Slack returns you to `api.lanes.sh`, which immediately redirects you back down to the command
+waiting on your own machine. You will see it flicker past. Nothing is stored there — that hop
+carries the same authorization code the exchange sends a moment later anyway.
 
-## Troubleshooting
+The trade is written down in [`../security.md`](../security.md) under
+`credentials.exchange-is-local`, and it is the same one Google's connection makes — with one
+difference. A Google connection can opt out by registering your own client. A Slack one cannot: the
+hosted client is also the HTTPS address Slack returns you to, so `lanes link connect slack` needs
+it. Connections already made are unaffected if it is down, because Slack issues no refresh token and
+nothing goes back afterwards.
 
-**`Slack refused the token`** — nearly always one of three: a bot token
-(`xoxb-`) pasted where the user token (`xoxp-`) belongs, a scope added under Bot
-Token Scopes rather than User Token Scopes, or an app reinstalled since the
-token was copied. Reinstalling mints a new one.
+## What it will ask for
 
-**A tool exists but every call fails** — a missing scope. Slack lists its whole
-tool set regardless of what your token can do. Add the scope under User Token
-Scopes, reinstall, and reconnect with `--replace`.
+`connect` prints the scopes before the browser opens and stops if you do not agree to them. They
+are Slack **user-token** scopes: Slack's MCP server reads the user token, and a bot token is a
+different credential that does not work there at all.
 
-**The connection is labelled with something you typed** — the identity probe did
-not get a username back, which for Slack means the token was refused. See the
-quirk above.
+| Scope | What it means |
+| --- | --- |
+| `search:read.public`, `search:read.users`, `search:read.files` | Search public channels, people, files |
+| `search:read.private`, `search:read.im`, `search:read.mpim` | Search private channels and DMs |
+| `channels:history`, `channels:read` | Read and list public channels |
+| `groups:history`, `groups:read` | Read and list private channels |
+| `im:history`, `mpim:history`, `mpim:read` | Read direct and group direct messages |
+| `users:read` | Read people and profiles |
+| `files:read` | Read files and their contents |
+| `chat:write` | Send messages **as you** |
+| `reactions:write` | Add and remove reactions as you |
+| `canvases:read`, `canvases:write` | Read and edit canvases |
+| `channels:write` | Create and manage public channels |
+
+Seven of those are flagged broad and need an explicit yes: the four that reach private
+conversations, the two that search them, and `chat:write`. Slack draws no line between reading a
+conversation and reading a private one, so a scope that reads like routine access is usually the
+most sensitive thing in the workspace.
+
+Granting a scope is not the same as letting an agent use it. `connect` grants the read bundle and
+nothing else; `lanes link policy` is where the rest is turned on.
+
+## If your workspace has not approved the Lanes app
+
+An Enterprise Grid admin decides that, and you may not be able to change it. Use a token from an
+app your workspace already trusts:
+
+```console
+$ lanes link connect slack --profile personal --target local --auth pasted_token
+```
+
+1. Open <https://api.slack.com/apps> and choose **Create New App** → **From scratch**. Name it and
+   pick the workspace.
+2. Open **OAuth & Permissions** and add the scopes you need under **User Token Scopes** — not Bot
+   Token Scopes. The table above is the full set; a smaller set works, and the tools whose scope is
+   missing fail when they are called rather than being hidden.
+3. Choose **Install to Workspace** and approve. An admin may have to approve it for you.
+4. Copy the **User OAuth Token**. It starts with `xoxp-`. The bot token starts with `xoxb-` and
+   will not work here.
+
+The token does not expire unless you enable token rotation on the app. If you rotate or reinstall,
+the token changes:
+
+```console
+$ lanes link connect slack --profile personal --target local --auth pasted_token --replace
+```
+
+Two things are weaker on this path, and both are recorded in [`../security.md`](../security.md).
+The stored value is the credential itself rather than a means of obtaining one, so rotating it is
+manual. And there is no scope-disclosure gate: what the token can do was decided in your console
+and cannot be read back, so `connect` records what it asked for rather than what it got.
+
+## When it does not work
+
+**"Slack refused the token."** Usually a bot token (`xoxb-`) where the user token (`xoxp-`) belongs,
+a scope missing from **User Token Scopes**, or an app that has been reinstalled since — reinstalling
+mints a new token.
+
+**A tool is listed and fails when called.** Its scope was not granted. Re-run `lanes link connect
+slack` to consent again, or add the scope in your own app if you took the pasted-token route.

--- a/src/cli/commands/connect.test.ts
+++ b/src/cli/commands/connect.test.ts
@@ -127,6 +127,54 @@ describe('resolveAccount', () => {
     expect(account).toBe('me@example.com');
   });
 
+  /**
+   * Where the vendor's idea of a user is scoped to something smaller than the
+   * vendor. Slack's is: `auth.test` answers with a workspace-local handle, so
+   * the same person in two workspaces returns the same `user`, and one account
+   * string is exactly how `settleIdentity` decides a connect is a *reconnect*.
+   * Without the qualifier, connecting a second workspace matched the first and
+   * overwrote its token.
+   */
+  const slackish = (body: Record<string, string>, identity: Record<string, string>) =>
+    resolveAccount(manifest({ kind: 'http', url: 'https://slack.invalid/auth.test', ...identity }), {
+      accessToken: async () => 'tok',
+      fetch: (async () => new Response(JSON.stringify(body))) as unknown as typeof fetch,
+    });
+
+  test('a qualifier distinguishes one person in two workspaces', async () => {
+    const identity = { field: 'user', qualifier: 'team' };
+
+    const acme = await slackish({ user: 'alice', team: 'Acme' }, identity);
+    const beta = await slackish({ user: 'alice', team: 'Beta' }, identity);
+
+    expect(acme).toBe('alice (Acme)');
+    expect(beta).toBe('alice (Beta)');
+    // The property that matters: `settleIdentity` compares these strings, so
+    // two workspaces must not produce one.
+    expect(acme).not.toBe(beta);
+  });
+
+  test('and still tells two people in one workspace apart', async () => {
+    const identity = { field: 'user', qualifier: 'team' };
+
+    expect(await slackish({ user: 'alice', team: 'Acme' }, identity)).not.toBe(
+      await slackish({ user: 'bob', team: 'Acme' }, identity),
+    );
+  });
+
+  test('the qualified label slugifies whole, so the id names the workspace too', async () => {
+    // No `@` in it, so `idFromAccount` keeps both halves — `alice_acme` rather
+    // than two connections called `alice` and `alice2`.
+    expect(idFromAccount('alice (Acme)')).toBe('alice_acme');
+    expect(idFromAccount('alice (Beta)', ['alice_acme'])).toBe('alice_beta');
+  });
+
+  test('a missing qualifier degrades to the bare field rather than failing', async () => {
+    // Best-effort, like everything else here: a label is worth having and never
+    // worth failing a connect over.
+    expect(await slackish({ user: 'alice' }, { field: 'user', qualifier: 'team' })).toBe('alice');
+  });
+
   test('reads a tool identity through a JSON text block', async () => {
     const account = await resolveAccount(
       manifest({ kind: 'tool', tool: 'get_workspace', field: 'name', arguments: {} }),

--- a/src/cli/commands/connect/authorise.ts
+++ b/src/cli/commands/connect/authorise.ts
@@ -16,9 +16,14 @@ import { ensureOAuthApp } from './setup.ts';
 /**
  * Getting a token, and saying what it will be able to do first.
  *
- * Two paths, because two kinds of upstream: an MCP server publishes metadata
- * worth discovering and the SDK drives it, while a plain REST API announces
- * nothing and the manifest has to name its endpoints.
+ * Two paths, and what chooses between them is not the kind of upstream but
+ * whether the manifest names its own endpoints. Without them there is nothing
+ * to authorise against but what the server advertises, so the SDK discovers it
+ * and drives the flow. With them there is nothing left to discover, and the
+ * flow is ours — which is the only arrangement in which a client somebody else
+ * holds can redeem the code. A REST API never announces an authorization
+ * server, so it is always on the second path; an MCP server may be on either.
+ * See ADR-040.
  */
 
 /**
@@ -86,13 +91,24 @@ export async function authorise(input: {
   // announces. So the manifest names the endpoints and we run the flow
   // directly — the same loopback listener, PKCE, and exchange, minus the
   // discovery the SDK would otherwise do for us.
-  if (manifest.connector.kind !== 'mcp') {
+  //
+  // An MCP connector takes that path too when it names both endpoints, and that
+  // is the *only* thing declaring them means. The SDK's flow ends by posting to
+  // the token endpoint with whatever `clientInformation()` returned, which is
+  // fine for a client the operator holds and impossible for one held by a
+  // broker — so a provider whose client lives somewhere else opts out here
+  // rather than discovering it after consent. Nothing is lost by opting out:
+  // discovery is all the SDK was doing that this does not, and a manifest that
+  // names its endpoints has nothing left to discover. Notion, Linear, and
+  // Google's two MCP servers name neither and are untouched. See ADR-040.
+  if (
+    manifest.connector.kind !== 'mcp' ||
+    (manifest.auth.authorize_url !== undefined && manifest.auth.token_url !== undefined)
+  ) {
     await authoriseDirect(input);
     return;
   }
 
-  // An MCP provider is always bring-your-own: `defineProvider` refuses a broker
-  // on one, because the SDK owns the exchange and there is no seam to route it.
   if (manifest.auth.registration === 'manual') {
     await ensureOAuthApp(input);
   }
@@ -234,19 +250,39 @@ async function authoriseDirect(input: {
     throw new Error('Cancelled — nothing was authorised.');
   }
 
+  // What a response carrying no refresh token means, which only the manifest
+  // knows: Google omitting one is a failure worth stopping for, Slack omitting
+  // one is the ordinary success. See `RefreshTokenPolicy`.
+  const refreshToken = {
+    required: manifest.auth.refresh_token === 'required',
+    vendor: manifest.name,
+    ...(manifest.auth.revoke_url ? { revokeUrl: manifest.auth.revoke_url } : {}),
+  };
+
   let tokens;
   try {
     tokens = await runOAuthFlow({
       authorizeUrl,
-      clientId: client.kind === 'own' ? client.clientId : client.config.clientId,
-      ...(client.kind === 'own'
-        ? { tokenUrl, clientSecret: client.clientSecret }
-        : {
+      clientId: client.kind === 'brokered' ? client.config.clientId : client.clientId,
+      ...(client.kind === 'brokered'
+        ? {
             exchange: brokerExchangeVia({
               url: client.url,
+              refreshToken,
               ...(input.fetch ? { fetch: input.fetch } : {}),
             }),
+          }
+        : {
+            tokenUrl,
+            clientSecret: client.clientSecret,
           }),
+      refreshToken,
+      // Only where the broker published one, which means only where the vendor
+      // refuses a loopback redirect. The broker owns the URL because the
+      // correct value depends on which deployment answered `/config`.
+      ...(client.kind === 'brokered' && client.config.redirectUri
+        ? { relayRedirect: client.config.redirectUri }
+        : {}),
       scopes,
       connectionLabel: manifest.name,
       ...(manifest.auth.authorize_params
@@ -283,10 +319,18 @@ async function authoriseDirect(input: {
     `${manifest.id}/${connectionId}`,
     JSON.stringify({
       access_token: tokens.accessToken,
-      refresh_token: tokens.refreshToken,
+      // Both omitted rather than defaulted where the vendor issues neither.
+      //
+      // A long-lived token has no refresh token and states no lifetime, and
+      // inventing an hour for it would have `doctor` reporting a healthy
+      // connection as stale forever while telling the operator to re-run a
+      // command that changes nothing. Absent is what `upstreamAccessToken`
+      // already reads as "hand back what is stored", which is correct here.
+      ...(tokens.refreshToken ? { refresh_token: tokens.refreshToken } : {}),
       token_type: 'Bearer',
-      expires_in: tokens.expiresIn,
-      expires_at: Date.now() + tokens.expiresIn * 1000,
+      ...(tokens.expiresIn !== undefined
+        ? { expires_in: tokens.expiresIn, expires_at: Date.now() + tokens.expiresIn * 1000 }
+        : {}),
       scope: tokens.scope,
       issuer: new URL(authorizeUrl).origin,
       ...(tokens.idToken ? { id_token: tokens.idToken } : {}),

--- a/src/cli/commands/connect/client.test.ts
+++ b/src/cli/commands/connect/client.test.ts
@@ -22,7 +22,9 @@ import { brokeredScopes, hostedClientRefusal, resolveOAuthClient } from './clien
 
 const BROKER = { url: 'https://api.example.com/v1/auth/link/vendor', operator: 'Someone' };
 
-const manifest = (broker: object | null = BROKER, withPrompts = true) =>
+const SHIPPED_ID = 'shipped-client';
+
+const manifest = (broker: object | null = BROKER, withPrompts = true, shipped?: string) =>
   defineProvider({
     id: 'vendor_mail',
     name: 'Vendor Mail',
@@ -35,6 +37,7 @@ const manifest = (broker: object | null = BROKER, withPrompts = true) =>
       authorize_url: 'https://accounts.example.com/o/oauth2/v2/auth',
       token_url: 'https://oauth2.example.com/token',
       ...(broker ? { broker } : {}),
+      ...(shipped ? { client_id: shipped } : {}),
     },
     ...(withPrompts
       ? {
@@ -302,6 +305,7 @@ describe('brokeredScopes', () => {
     notice: undefined,
     docsUrl: undefined,
     capacity: undefined,
+    redirectUri: undefined,
   };
 
   test('appends the identity scopes the broker asks for', () => {
@@ -425,5 +429,74 @@ describe('what a brokered connect says out loud', () => {
     });
 
     expect(err).not.toContain('LANES_LINK_BROKER_ORIGIN');
+  });
+});
+
+/**
+ * A broker that cannot serve, for a provider that has no other way in.
+ *
+ * There was briefly a fallback here — a client id shipped in the manifest,
+ * redeemed locally with PKCE. The relay removed it: Slack will not register a
+ * loopback redirect, so the browser has to land on the broker's own HTTPS
+ * origin, and a client with no broker behind it has nowhere for the redirect to
+ * go. A refusal is the honest answer and these hold it.
+ */
+describe('a broker that cannot serve', () => {
+  const unreachable = (async () => {
+    throw new Error('connect ECONNREFUSED');
+  }) as unknown as typeof globalThis.fetch;
+
+  test('is a refusal, not a silent downgrade', async () => {
+    await expect(resolveOAuthClient(await choice({ fetch: unreachable }))).rejects.toThrow(
+      /could not be authorised/,
+    );
+  });
+
+  test('and so is one that has closed its doors', async () => {
+    const closed = brokerAnswering({
+      success: true,
+      data: { client_id: 'hosted-client', status: 'closed', notice: 'Paused.' },
+    });
+
+    await expect(resolveOAuthClient(await choice({ fetch: closed }))).rejects.toThrow(/Paused\./);
+  });
+
+  test('a profile with its own client does not need it and is unaffected', async () => {
+    const client = await resolveOAuthClient(
+      await choice({
+        credentials: memoryStore({ 'vendor/client_id': 'mine', 'vendor/client_secret': 's' }),
+        fetch: unreachable,
+      }),
+    );
+
+    expect(client.kind).toBe('own');
+    if (client.kind === 'own') expect(client.clientId).toBe('mine');
+  });
+
+  test('the relay it publishes reaches the caller', async () => {
+    // The CLI never hardcodes this: which URL is right depends on which
+    // deployment answered, so the broker that owns it says what it is.
+    const withRelay = brokerAnswering({
+      success: true,
+      data: {
+        client_id: 'hosted-client',
+        scopes_supported: ['https://api.test/auth/mail.read'],
+        status: 'open',
+        redirect_uri: 'https://api.example.com/v1/auth/link/vendor/callback',
+      },
+    });
+
+    const client = await resolveOAuthClient(await choice({ fetch: withRelay }));
+
+    expect(client.kind).toBe('brokered');
+    if (client.kind === 'brokered') {
+      expect(client.config.redirectUri).toBe('https://api.example.com/v1/auth/link/vendor/callback');
+    }
+  });
+
+  test('a broker that publishes none leaves the listener to name itself', async () => {
+    const client = await resolveOAuthClient(await choice());
+    expect(client.kind).toBe('brokered');
+    if (client.kind === 'brokered') expect(client.config.redirectUri).toBeUndefined();
   });
 });

--- a/src/cli/commands/connect/client.ts
+++ b/src/cli/commands/connect/client.ts
@@ -5,7 +5,7 @@ import {
   brokerOriginOverride,
   type BrokerConfig,
 } from '#connectivity/auth/index.ts';
-import type { ProviderManifest } from '#connectivity';
+import { hasOwnClientPath, type ProviderManifest } from '#connectivity';
 import type { SecretStore } from '#secrets';
 import { ConfigDocument } from '../../config-edit.ts';
 import { progress, style, warn } from '../../output.ts';
@@ -62,6 +62,8 @@ export async function resolveOAuthClient(input: ClientChoice): Promise<OAuthClie
 
   const { app, broker } = manifest.auth;
   const ownClient = input.client === 'own';
+  // Hoisted: four of the branches below need the answer, and it reads the store.
+  const hasOwnClient = await profileHasOwnClient(app, document, credentials);
 
   // Asked for outright, on a profile that registered a client of its own.
   //
@@ -70,10 +72,7 @@ export async function resolveOAuthClient(input: ClientChoice): Promise<OAuthClie
   // stamped on the token — so this connection refreshes against the broker
   // while every existing one keeps refreshing where it was issued. What it must
   // not be is silent, because the profile's other connections do not move.
-  const insteadOfOwn =
-    input.client === 'hosted' &&
-    broker !== undefined &&
-    (await profileHasOwnClient(app, document, credentials));
+  const insteadOfOwn = input.client === 'hosted' && broker !== undefined && hasOwnClient;
 
   if (insteadOfOwn) {
     progress(
@@ -85,11 +84,8 @@ export async function resolveOAuthClient(input: ClientChoice): Promise<OAuthClie
     );
   }
 
-  if (
-    !broker ||
-    (!insteadOfOwn && ((await profileHasOwnClient(app, document, credentials)) || ownClient))
-  ) {
-    if (ownClient && broker && !hasClientPrompts(manifest)) {
+  if (!broker || (!insteadOfOwn && (hasOwnClient || ownClient))) {
+    if (ownClient && broker && !hasOwnClientPath(manifest)) {
       // `defineProvider` permits a broker with no prompts — a provider with no
       // bring-your-own path is a legal thing to be. This is where that absence
       // becomes a sentence rather than a prompt for a value nothing collects.
@@ -149,6 +145,7 @@ export async function resolveOAuthClient(input: ClientChoice): Promise<OAuthClie
       cause: cause instanceof Error ? cause.message : String(cause),
       ...(cause instanceof BrokerError && cause.notice ? { notice: cause.notice } : {}),
       docsUrl: broker.docs_url,
+      ownClient: hasOwnClientPath(manifest),
     });
   }
 
@@ -161,6 +158,7 @@ export async function resolveOAuthClient(input: ClientChoice): Promise<OAuthClie
       cause: 'it is not accepting new connections.',
       ...(config.notice ? { notice: config.notice } : {}),
       docsUrl: config.docsUrl ?? broker.docs_url,
+      ownClient: hasOwnClientPath(manifest),
     });
   }
 
@@ -226,9 +224,6 @@ async function profileHasOwnClient(
   return Boolean(id && secret);
 }
 
-function hasClientPrompts(manifest: ProviderManifest): boolean {
-  return (manifest.setup?.prompts ?? []).some((prompt) => prompt.scope === 'shared');
-}
 
 /**
  * What is actually asked for, and what the broker cannot grant.

--- a/src/cli/commands/connect/index.ts
+++ b/src/cli/commands/connect/index.ts
@@ -9,6 +9,7 @@ import { discoverCapabilities } from './discover.ts';
 import { connectFamily, familyMembers } from './family.ts';
 import { authoriseWithKey } from './assertion.ts';
 import { authorise } from './authorise.ts';
+import { authorisePastedToken } from './pasted-token.ts';
 import { chooseAuthMethod } from './method.ts';
 import { preflight } from './requirements.ts';
 import { ALREADY, NOTHING, renderOutcome, where, type ConnectOutcome } from './outcome.ts';
@@ -213,6 +214,13 @@ async function runConnect(
         // or asking outright, is how someone says "that one again" — which is
         // what a rotated key calls for.
         replace: options.nonInteractive !== true && (options.replace === true || named !== undefined),
+        prompter,
+      });
+    } else if (method.kind === 'pasted') {
+      await authorisePastedToken({
+        manifest,
+        connectionId: provisionalId,
+        credentials: runtime.credentials,
         prompter,
       });
     } else if (manifest.auth.kind === 'oauth') {

--- a/src/cli/commands/connect/method.ts
+++ b/src/cli/commands/connect/method.ts
@@ -1,4 +1,4 @@
-import type { AuthAssertion, ProviderManifest } from '#connectivity';
+import { hasOwnClientPath, type AuthAssertion, type ProviderManifest } from '#connectivity';
 import { progress, style } from '../../output.ts';
 import { terminalPrompter, type Prompter } from '../../prompt.ts';
 
@@ -35,7 +35,17 @@ export type ChosenMethod =
    * `--own-client`, and a provider with one route — because there was no choice
    * to report. A provider that never offered two reads as it always did.
    */
-  | { readonly kind: 'oauth'; readonly id?: string; readonly client: 'own' | 'hosted' | undefined };
+  | { readonly kind: 'oauth'; readonly id?: string; readonly client: 'own' | 'hosted' | undefined }
+  /**
+   * A credential the operator already holds, for a provider that does OAuth.
+   *
+   * Offered where an OAuth manifest still declares a per-connection prompt,
+   * which is a thing to be only where the browser route can be closed by
+   * somebody who is not in the room: a Slack workspace on Enterprise Grid needs
+   * an admin to approve an app before it can authenticate anyone, and the
+   * person running `connect` may not be that admin.
+   */
+  | { readonly kind: 'pasted'; readonly id?: string };
 
 interface Option {
   /** What `--auth` accepts, and how a chosen route is named back. */
@@ -45,16 +55,6 @@ interface Option {
   readonly chosen: ChosenMethod;
 }
 
-/**
- * A provider that can be reached with a client of the operator's own.
- *
- * `defineProvider` permits a broker with no client prompts — a provider with no
- * bring-your-own path is a legal thing to be — so offering that route without
- * checking would offer a choice with nothing behind it.
- */
-function hasClientPrompts(manifest: ProviderManifest): boolean {
-  return (manifest.setup?.prompts ?? []).some((prompt) => prompt.scope === 'shared');
-}
 
 /**
  * Every route this provider actually has, in the order they are offered.
@@ -91,7 +91,7 @@ export function options(manifest: ProviderManifest): readonly Option[] {
     });
   }
 
-  if (!broker || hasClientPrompts(manifest)) {
+  if (!broker || hasOwnClientPath(manifest)) {
     found.push({
       id: 'own_client',
       label: 'Sign in through a browser, using an OAuth client you register',
@@ -103,6 +103,23 @@ export function options(manifest: ProviderManifest): readonly Option[] {
       // there is nothing to override, and forcing it would write an `oauth_apps`
       // entry for a provider whose manifest already says it is the only way.
       chosen: { kind: 'oauth', id: 'own_client', client: broker ? 'own' : undefined },
+    });
+  }
+
+  // Last, always. It is the way in when the others are refused, not one anyone
+  // should be reaching for first: what it stores is the credential itself
+  // rather than a means of obtaining one, so rotating it is manual, and nothing
+  // can show what it is allowed to do.
+  const pasted = (manifest.setup?.prompts ?? []).filter((prompt) => prompt.scope === 'connection');
+  if (pasted.length > 0) {
+    found.push({
+      id: 'pasted_token',
+      label: `Paste a ${pasted.map((prompt) => prompt.label).join(', then ')} you already hold`,
+      detail:
+        'no browser, for a workspace that has not approved this app — which an admin decides, ' +
+        'not you. The credential is stored as given, so rotating it is manual and nothing can ' +
+        'say what it is allowed to do.',
+      chosen: { kind: 'pasted', id: 'pasted_token' },
     });
   }
 

--- a/src/cli/commands/connect/pasted-token.test.ts
+++ b/src/cli/commands/connect/pasted-token.test.ts
@@ -1,0 +1,134 @@
+import { describe, expect, test } from 'bun:test';
+import { defineProvider } from '#connectivity';
+import type { SecretRef, SecretStore } from '#secrets';
+import type { Prompter } from '../../prompt.ts';
+import { authorisePastedToken } from './pasted-token.ts';
+
+/**
+ * The credential the operator already holds, for a provider that does OAuth.
+ *
+ * It exists because the browser flow can be refused by somebody who is not in
+ * the room: a Slack workspace on Enterprise Grid needs an admin to approve an
+ * app before it can authenticate anyone. What these pin is that the paste ends
+ * up indistinguishable from a browser grant everywhere downstream — same ref,
+ * same shape — because anything else would mean a second path through the
+ * dispatcher, and that is the cost this deliberately does not pay.
+ */
+const manifest = defineProvider({
+  id: 'vendor_chat',
+  name: 'Vendor Chat',
+  connector: { kind: 'mcp', endpoint: 'https://mcp.example.com/mcp' },
+  auth: {
+    kind: 'oauth',
+    registration: 'manual',
+    app: 'vendor',
+    scopes: ['chat.read', 'chat.write'],
+    authorize_url: 'https://accounts.example.com/authorize',
+    token_url: 'https://accounts.example.com/token',
+    client_id: 'shipped.1',
+    refresh_token: 'optional',
+  },
+  setup: {
+    prompts: [{ key: 'token', label: 'User token', secret: true, scope: 'connection' as const }],
+  },
+});
+
+function memoryStore(): SecretStore & { seen: Map<string, string> } {
+  const map = new Map<string, string>();
+  return {
+    seen: map,
+    get: async (ref) => map.get(ref) ?? null,
+    set: async (ref, value) => void map.set(ref, value),
+    has: async (ref) => map.has(ref),
+    delete: async (ref) => void map.delete(ref),
+    list: async (prefix) =>
+      [...map.keys()].filter((k) => !prefix || k.startsWith(prefix)) as SecretRef[],
+  };
+}
+
+const answering = (value: string): Prompter => ({
+  interactive: true,
+  ask: async () => value,
+  askSecret: async () => value,
+  confirm: async () => true,
+});
+
+describe('a pasted token for an OAuth provider', () => {
+  test('lands at the ref the browser flow writes, in the shape it writes', async () => {
+    const credentials = memoryStore();
+
+    await authorisePastedToken({
+      manifest,
+      connectionId: 'pending',
+      credentials,
+      prompter: answering('xoxp-the-token'),
+    });
+
+    const stored = JSON.parse(credentials.seen.get('vendor_chat/pending')!) as Record<
+      string,
+      unknown
+    >;
+    expect(stored['access_token']).toBe('xoxp-the-token');
+    expect(stored['token_type']).toBe('Bearer');
+    expect(stored['authorized_via']).toBe('pasted');
+  });
+
+  test('carries neither a refresh token nor an expiry, because it has neither', async () => {
+    // This is what makes it free downstream: with no refresh token
+    // `upstreamAccessToken` hands the stored value straight back, and with no
+    // `expires_at` nothing reports a healthy long-lived token as stale.
+    const credentials = memoryStore();
+
+    await authorisePastedToken({
+      manifest,
+      connectionId: 'pending',
+      credentials,
+      prompter: answering('xoxp-the-token'),
+    });
+
+    const stored = JSON.parse(credentials.seen.get('vendor_chat/pending')!) as Record<
+      string,
+      unknown
+    >;
+    expect('refresh_token' in stored).toBe(false);
+    expect('expires_at' in stored).toBe(false);
+  });
+
+  test('records what was asked for, since what was granted cannot be read back', async () => {
+    // The scope gate has nothing to show on this path: what the token can do
+    // was decided wherever it was minted. Recorded as a weaker guarantee rather
+    // than papered over with a set nobody verified.
+    const credentials = memoryStore();
+
+    await authorisePastedToken({
+      manifest,
+      connectionId: 'pending',
+      credentials,
+      prompter: answering('xoxp-the-token'),
+    });
+
+    const stored = JSON.parse(credentials.seen.get('vendor_chat/pending')!) as Record<
+      string,
+      unknown
+    >;
+    expect(stored['scope']).toBe('chat.read chat.write');
+  });
+
+  test('refuses where the manifest describes no token to ask for', async () => {
+    const noPrompts = defineProvider({
+      id: 'vendor_other',
+      name: 'Vendor Other',
+      connector: { kind: 'mcp', endpoint: 'https://mcp.example.com/mcp' },
+      auth: { kind: 'oauth', registration: 'dynamic', scopes: [] },
+    });
+
+    await expect(
+      authorisePastedToken({
+        manifest: noPrompts,
+        connectionId: 'pending',
+        credentials: memoryStore(),
+        prompter: answering('anything'),
+      }),
+    ).rejects.toThrow(/no pasted-credential path/);
+  });
+});

--- a/src/cli/commands/connect/pasted-token.ts
+++ b/src/cli/commands/connect/pasted-token.ts
@@ -1,0 +1,66 @@
+import { PASTED } from '#connectivity/auth/index.ts';
+import type { ProviderManifest } from '#connectivity';
+import type { SecretStore } from '#secrets';
+import { ok, progress } from '../../output.ts';
+import { terminalPrompter, type Prompter } from '../../prompt.ts';
+import { askForSetup } from './setup.ts';
+
+/**
+ * `--auth pasted_token`: a credential the operator already holds.
+ *
+ * The escape hatch, and it exists because the flow above can be refused by
+ * somebody who is not in the room. A Slack workspace on Enterprise Grid
+ * requires an admin to approve an app before it can authenticate anyone, so an
+ * operator whose admin has not approved the Lanes app cannot connect at all —
+ * while a user token from an app their workspace already trusts works
+ * perfectly. Removing the paste would take Slack away from exactly the people
+ * who have the least ability to do anything about it.
+ *
+ * Written in the blob shape the OAuth path writes, into the same ref, which is
+ * what makes it cost nothing downstream: no refresh token means
+ * `upstreamAccessToken` hands the stored value back untouched, and no
+ * `expires_at` means nothing calls it stale. `auth.kind` stays `oauth` because
+ * it describes what the vendor offers, not how this one connection was filled.
+ */
+export async function authorisePastedToken(input: {
+  manifest: ProviderManifest;
+  connectionId: string;
+  credentials: SecretStore;
+  prompter?: Prompter;
+}): Promise<void> {
+  const { manifest, connectionId, credentials } = input;
+  const prompter = input.prompter ?? terminalPrompter;
+  if (manifest.auth.kind !== 'oauth') return;
+
+  const prompts = (manifest.setup?.prompts ?? []).filter((prompt) => prompt.scope === 'connection');
+  if (prompts.length === 0) {
+    throw new Error(
+      `${manifest.name} has no pasted-credential path: it does not describe a token to ask you ` +
+        'for. Authorise in a browser instead — drop --auth, or pass --auth oauth.',
+    );
+  }
+
+  const ref = `${manifest.id}/${connectionId}`;
+  const answers = await askForSetup(
+    manifest,
+    prompts,
+    `Stored at ${ref}, in the credential store — never in config.`,
+    prompter,
+  );
+
+  await credentials.set(
+    ref,
+    JSON.stringify({
+      access_token: answers.get(prompts[0]!.key)!,
+      token_type: 'Bearer',
+      // What the token can do was decided wherever it was minted and cannot be
+      // read back, so this records what was asked for and no more. The scope
+      // gate the browser path runs has nothing to show here — recorded as a
+      // weaker guarantee in security.md rather than papered over.
+      scope: manifest.auth.scopes.join(' '),
+      authorized_via: PASTED,
+    }),
+  );
+
+  progress(ok('token stored'));
+}

--- a/src/cli/commands/connect/requirements.test.ts
+++ b/src/cli/commands/connect/requirements.test.ts
@@ -79,6 +79,7 @@ describe('setupRequirements', () => {
       requirements: [],
       needsId: false,
       brokered: false,
+      pastedCredential: undefined,
     });
   });
 

--- a/src/cli/commands/connect/requirements.ts
+++ b/src/cli/commands/connect/requirements.ts
@@ -86,7 +86,7 @@ export async function preflight(input: {
    * `connect --auth <key method>` would be turned away by a message describing
    * a step it does not perform.
    */
-  readonly method?: 'oauth' | 'assertion';
+  readonly method?: 'oauth' | 'assertion' | 'pasted';
 }): Promise<Blocked | null> {
   const { manifest, connectionId, profile, target, spec } = input;
   const method = input.method ?? 'oauth';
@@ -108,7 +108,10 @@ export async function preflight(input: {
         then: `${rerun} --auth ${assertion.method}`,
       };
     }
-  } else if (manifest.auth.kind === 'oauth') {
+  } else if (manifest.auth.kind === 'oauth' && method !== 'pasted') {
+    // `pasted` opens no browser, so the refusal below does not describe it. It
+    // needs a value instead, which *can* be placed ahead of time — so it falls
+    // through to the requirement check and gets the `secrets set` line.
     return {
       reason: 'needs_browser',
       message:
@@ -146,6 +149,7 @@ export async function preflight(input: {
     needs: missing,
     then:
       `${rerun}${connectionId ? ` --id ${connectionId}` : ''}` +
-      `${method === 'assertion' && assertion ? ` --auth ${assertion.method}` : ''} --non-interactive`,
+      `${method === 'assertion' && assertion ? ` --auth ${assertion.method}` : ''}` +
+      `${method === 'pasted' ? ' --auth pasted_token' : ''} --non-interactive`,
   };
 }

--- a/src/cli/commands/setup.ts
+++ b/src/cli/commands/setup.ts
@@ -143,6 +143,18 @@ function renderOne(plan: ProviderPlan, missing: ReadonlySet<string>): void {
       plan.steps.forEach((step, index) => print(`  ${index + 1}. ${step}`));
     }
   }
+
+  // The other alternative, and for the same reason it is down here: it is what
+  // to do when the line above is refused by somebody who is not the reader.
+  if (plan.tokenCommand && plan.pastedCredential) {
+    heading('Or paste a token you already hold');
+    print(`  ${plan.tokenCommand}`);
+    print(`  ${style.dim(`Asks for the ${plan.pastedCredential}.`)}`);
+    if (plan.steps.length > 0 && !plan.ownClientCommand) {
+      print();
+      plan.steps.forEach((step, index) => print(`  ${index + 1}. ${step}`));
+    }
+  }
   if (plan.browser) {
     print();
     print(

--- a/src/cli/identity.ts
+++ b/src/cli/identity.ts
@@ -58,7 +58,18 @@ export async function resolveAccount(
         headers: token ? { authorization: `Bearer ${token}` } : {},
       });
       if (!response.ok) return null;
-      return pluck(await response.json(), identity.field);
+
+      const body = await response.json();
+      const primary = pluck(body, identity.field);
+      if (!primary || !identity.qualifier) return primary;
+
+      // `alice (Acme)` rather than `alice`. The bracketed half is what makes
+      // two workspaces two accounts instead of one overwritten twice, and it
+      // survives into the connection id because `idFromAccount` slugifies the
+      // whole string when there is no `@` in it — `alice_acme`, which is a row
+      // somebody can read in `status`.
+      const qualifier = pluck(body, identity.qualifier);
+      return qualifier ? `${primary} (${qualifier})` : primary;
     }
 
     if (!probe.callTool) return null;

--- a/src/cli/oauth-callback.ts
+++ b/src/cli/oauth-callback.ts
@@ -1,0 +1,187 @@
+import { createHash, randomBytes, timingSafeEqual } from 'node:crypto';
+import { completionPage } from './callback-page.ts';
+import { OAuthError } from './oauth-error.ts';
+
+/**
+ * The loopback listener both OAuth paths come back to.
+ *
+ * Two callers want the same door and want it differently. `runOAuthFlow` drives
+ * the whole protocol and reads the code itself; `captureOAuthCallback` hands the
+ * protocol to the MCP SDK and supplies only somewhere for the browser to land.
+ * What they share is everything about the listener — that it binds loopback,
+ * serves exactly one callback, compares `state` in constant time, leaves a page
+ * a person can read, and drains before it closes — and holding that in one file
+ * is what stops the two drifting into disagreeing about it.
+ *
+ * Split out of `oauth.ts` when that file passed the size budget, along the seam
+ * the budget exists to find: the flow, and the door it knocks on.
+ */
+
+const base64url = (input: Buffer): string => input.toString('base64url');
+
+/** Compare the returned state in constant time — it is a CSRF defence. */
+export function stateMatches(expected: string, received: string): boolean {
+  const a = createHash('sha256').update(expected).digest();
+  const b = createHash('sha256').update(received).digest();
+  return timingSafeEqual(a, b);
+}
+
+/**
+ * What the browser is left looking at, in the two shapes it comes in.
+ *
+ * The label is what the caller knows and this file cannot: which provider the
+ * grant was for. Given one, the page names it under "Connected" the way the
+ * invite page names the workspace; without one it says only that the flow
+ * finished, which is what every path said before.
+ */
+export const connectedPage = (label?: string): Response =>
+  completionPage({
+    ...(label ? { label: 'Connected', heading: label } : { heading: 'Connected' }),
+    detail: 'You can close this tab and return to the terminal.',
+    ok: true,
+  });
+
+export const failedPage = (detail: string): Response =>
+  completionPage({ heading: 'Authorization failed', detail, ok: false });
+
+/**
+ * Close the listener without cutting off the response in flight.
+ *
+ * Forcing the socket shut the instant the code is read leaves the operator
+ * looking at a connection error on a flow that in fact succeeded. So: stop
+ * gracefully, wait for the in-flight callback to drain, and force only if
+ * graceful genuinely did not finish — a keep-alive connection must not be able
+ * to hold the CLI open forever either.
+ */
+export async function shutdown(server: { stop(force?: boolean): Promise<void> }): Promise<void> {
+  let drained = false;
+  const graceful = server.stop().then(() => {
+    drained = true;
+  });
+
+  await withTimeout(graceful, 2_000).catch(() => {});
+  if (!drained) await server.stop(true);
+}
+
+/**
+ * Race a promise against a deadline, and **clear the timer either way**.
+ *
+ * A bare `Promise.race` with `setTimeout` leaks: when the real promise wins,
+ * the timer is still pending, and a pending timer keeps the event loop alive
+ * for its full duration. With a five-minute OAuth deadline that turns a
+ * finished `connect` into a terminal that prints "Next: lanes link start" and
+ * then sits there for five minutes — which is exactly what it did.
+ *
+ * Rejects with `OAuthError(message)` if given one, otherwise resolves to
+ * undefined at the deadline, which is what the shutdown path wants.
+ */
+export async function withTimeout<T>(promise: Promise<T>, ms: number, message?: string): Promise<T> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+
+  try {
+    return await Promise.race([
+      promise,
+      new Promise<T>((resolve, reject) => {
+        timer = setTimeout(
+          () => (message ? reject(new OAuthError(message)) : resolve(undefined as T)),
+          ms,
+        );
+      }),
+    ]);
+  } finally {
+    if (timer) clearTimeout(timer);
+  }
+}
+
+/**
+ * Capture exactly one OAuth callback on loopback.
+ *
+ * Split out from `runOAuthFlow` so the SDK can drive the protocol — discovery,
+ * registration, PKCE, exchange — while we supply only the redirect target. The
+ * listener exists for the duration of one consent and no longer.
+ */
+export interface CallbackCapture {
+  readonly redirectUri: string;
+  /**
+   * The `state` this listener will accept, for the provider to put on the
+   * authorization URL. The SDK asks its provider for one and sends whatever it
+   * gets; nothing generates it for us.
+   */
+  readonly state: string;
+  wait(timeoutMs?: number): Promise<{ code: string; iss?: string }>;
+  close(): Promise<void>;
+}
+
+export function captureOAuthCallback(options: { label?: string } = {}): CallbackCapture {
+  const state = base64url(randomBytes(24));
+  let resolveCode: (value: { code: string; iss?: string }) => void;
+  let rejectCode: (error: Error) => void;
+
+  const received = new Promise<{ code: string; iss?: string }>((resolve, reject) => {
+    resolveCode = resolve;
+    rejectCode = reject;
+  });
+
+  const server = Bun.serve({
+    hostname: '127.0.0.1',
+    port: 0,
+    fetch(request) {
+      const url = new URL(request.url);
+      if (url.pathname !== '/callback') return new Response('Not found', { status: 404 });
+
+      const error = url.searchParams.get('error');
+      if (error) {
+        rejectCode(
+          new OAuthError(
+            error === 'access_denied'
+              ? 'Authorization was declined in the browser.'
+              : `Authorization failed: ${error}`,
+          ),
+        );
+        return failedPage('You can close this tab.');
+      }
+
+      const code = url.searchParams.get('code');
+      if (!code) {
+        rejectCode(new OAuthError('The callback carried no authorization code.'));
+        return failedPage('No code returned.');
+      }
+
+      // Checked here because nothing else checks it. The SDK's own docs say it
+      // does not validate `state`, and it only sends one if the provider hands
+      // it over — so this listener mints the value, `CredentialOAuthProvider`
+      // returns it from `state()`, and the two are compared on the way back.
+      //
+      // Without it this resolves on the first `/callback?code=` to reach the
+      // port, whoever sent it: any local process, or a page the operator has
+      // open, can sweep loopback during the five-minute window. PKCE usually
+      // turns that into a failed exchange, but a manifest is free to name an
+      // authorization server that does not enforce it, and there the code
+      // would be redeemed and the connection bound to someone else's account.
+      const returnedState = url.searchParams.get('state');
+      if (!returnedState || !stateMatches(state, returnedState)) {
+        rejectCode(new OAuthError('State mismatch — ignoring an unexpected callback.'));
+        return failedPage('Unexpected callback.');
+      }
+
+      const iss = url.searchParams.get('iss');
+      resolveCode({ code, ...(iss ? { iss } : {}) });
+      return connectedPage(options.label);
+    },
+  });
+
+  return {
+    redirectUri: `http://127.0.0.1:${server.port}/callback`,
+    state,
+
+    async wait(timeoutMs = 5 * 60_000) {
+      return withTimeout(
+        received,
+        timeoutMs,
+        `Timed out after ${Math.round(timeoutMs / 1000)}s waiting for the browser.`,
+      );
+    },
+
+    close: () => shutdown(server),
+  };
+}

--- a/src/cli/oauth-exchange.test.ts
+++ b/src/cli/oauth-exchange.test.ts
@@ -22,6 +22,20 @@ function answering(status: number, body: unknown, headers: Record<string, string
   return { fetch, calls };
 }
 
+/**
+ * The two readings of a response with no refresh token, as a manifest states them.
+ *
+ * `REQUIRED` is Google's: it means the account was already authorised and the
+ * connection would die in an hour. `OPTIONAL` is Slack's: a user token is
+ * long-lived and there is nothing to renew, so the absence is the success.
+ */
+const REQUIRED = {
+  required: true,
+  vendor: 'Vendor',
+  revokeUrl: 'https://example.com/permissions',
+} as const;
+const OPTIONAL = { required: false, vendor: 'Vendor' } as const;
+
 describe('directExchange', () => {
   test('posts the client and the verifier to the vendor', async () => {
     const { fetch, calls } = answering(200, {
@@ -35,6 +49,7 @@ describe('directExchange', () => {
       tokenUrl: 'https://oauth2.example.com/token',
       clientId: 'cid',
       clientSecret: 'secret',
+      refreshToken: REQUIRED,
       fetch,
     })(INPUT);
 
@@ -58,11 +73,69 @@ describe('directExchange', () => {
       tokenUrl: 'https://oauth2.example.com/token',
       clientId: 'cid',
       clientSecret: 'secret',
+      refreshToken: REQUIRED,
       fetch,
     })(INPUT);
 
     expect(tokens.scope).toBe('scope.a scope.b');
-    expect(tokens.expiresIn).toBe(3600);
+    // Not an invented hour. A vendor that states no lifetime gets none written,
+    // because an expiry nothing can act on has `doctor` calling a healthy
+    // connection stale and naming a command that would not change it.
+    expect(tokens.expiresIn).toBeUndefined();
+  });
+
+  test('sends no client_secret at all for a public client, rather than an empty one', async () => {
+    // `client_secret=` is not the same as no field: some authorization servers
+    // read it as a malformed confidential client and refuse for a reason that
+    // names neither the client nor the secret.
+    const { fetch, calls } = answering(200, { access_token: 'at', refresh_token: 'rt' });
+
+    await directExchange({
+      tokenUrl: 'https://oauth2.example.com/token',
+      clientId: 'cid',
+      refreshToken: REQUIRED,
+      fetch,
+    })(INPUT);
+
+    const sent = new URLSearchParams(String(calls[0]!.init!.body));
+    expect(sent.has('client_secret')).toBe(false);
+    expect(sent.get('client_id')).toBe('cid');
+    expect(sent.get('code_verifier')).toBe('the-verifier');
+  });
+
+  test('a vendor that issues no refresh token succeeds where the manifest says it will', async () => {
+    const { fetch } = answering(200, { access_token: 'xoxp-at', scope: 'chat:write' });
+
+    const tokens = await directExchange({
+      tokenUrl: 'https://vendor.example.com/token',
+      clientId: 'cid',
+      refreshToken: OPTIONAL,
+      fetch,
+    })(INPUT);
+
+    // Both absent rather than defaulted: there is nothing to renew with and no
+    // stated lifetime, and saying otherwise would be inventing both.
+    expect(tokens.accessToken).toBe('xoxp-at');
+    expect(tokens.refreshToken).toBeUndefined();
+    expect(tokens.expiresIn).toBeUndefined();
+  });
+
+  test('the refusal names the vendor that returned nothing, and where to revoke', async () => {
+    // It used to say "Google" unconditionally, on the correct-at-the-time
+    // grounds that Google was the only provider redeeming a code here.
+    const { fetch } = answering(200, { access_token: 'at' });
+
+    const error = (await directExchange({
+      tokenUrl: 'https://oauth2.example.com/token',
+      clientId: 'cid',
+      clientSecret: 'secret',
+      refreshToken: { required: true, vendor: 'Vendor Mail', revokeUrl: 'https://example.com/perms' },
+      fetch,
+    })(INPUT).catch((e) => e)) as Error;
+
+    expect(error).toBeInstanceOf(OAuthError);
+    expect(error.message).toContain('Vendor Mail returned no refresh token');
+    expect(error.message).toContain('https://example.com/perms');
   });
 
   test('surfaces an id_token when one comes back, and omits the field when not', async () => {
@@ -73,6 +146,7 @@ describe('directExchange', () => {
         tokenUrl: 'https://oauth2.example.com/token',
         clientId: 'cid',
         clientSecret: 'secret',
+        refreshToken: REQUIRED,
         fetch,
       })(INPUT);
 
@@ -88,7 +162,7 @@ describe('brokerExchangeVia', () => {
       data: { access_token: 'at', refresh_token: 'rt', id_token: 'idt', expires_in: 900 },
     });
 
-    const tokens = await brokerExchangeVia({ url: 'https://api.example.com/b', fetch })(INPUT);
+    const tokens = await brokerExchangeVia({ url: 'https://api.example.com/b', refreshToken: REQUIRED, fetch })(INPUT);
 
     expect(calls[0]!.url).toBe('https://api.example.com/b/exchange');
     expect(tokens.idToken).toBe('idt');
@@ -105,7 +179,7 @@ describe('brokerExchangeVia', () => {
       notice: 'At capacity.',
     });
 
-    const error = (await brokerExchangeVia({ url: 'https://api.example.com/b', fetch })(
+    const error = (await brokerExchangeVia({ url: 'https://api.example.com/b', refreshToken: REQUIRED, fetch })(
       INPUT,
     ).catch((e) => e)) as BrokerError;
 
@@ -118,7 +192,20 @@ describe('brokerExchangeVia', () => {
     const { fetch } = answering(200, { success: true, data: { access_token: 'at' } });
 
     await expect(
-      brokerExchangeVia({ url: 'https://api.example.com/b', fetch })(INPUT),
+      brokerExchangeVia({ url: 'https://api.example.com/b', refreshToken: REQUIRED, fetch })(INPUT),
     ).rejects.toBeInstanceOf(OAuthError);
+  });
+
+  test('unless the manifest says this vendor issues none', async () => {
+    const { fetch } = answering(200, { success: true, data: { access_token: 'at' } });
+
+    const tokens = await brokerExchangeVia({
+      url: 'https://api.example.com/b',
+      refreshToken: OPTIONAL,
+      fetch,
+    })(INPUT);
+
+    expect(tokens.accessToken).toBe('at');
+    expect(tokens.refreshToken).toBeUndefined();
   });
 });

--- a/src/cli/oauth-exchange.ts
+++ b/src/cli/oauth-exchange.ts
@@ -13,9 +13,18 @@ import { OAuthError } from './oauth-error.ts';
  */
 
 export interface OAuthTokens {
-  readonly refreshToken: string;
+  /** Absent where the vendor issues a long-lived token and never renews it. */
+  readonly refreshToken?: string;
   readonly accessToken: string;
-  readonly expiresIn: number;
+  /**
+   * Absent where the vendor states no lifetime.
+   *
+   * Not defaulted to an hour: with no refresh token there is nothing to renew
+   * with, so a made-up expiry would have `doctor` reporting a healthy
+   * connection as stale forever and would tell the operator to re-run a command
+   * that fixes nothing.
+   */
+  readonly expiresIn?: number;
   readonly scope: string;
   /**
    * An identity assertion, present when `openid` was granted.
@@ -38,11 +47,37 @@ export interface ExchangeInput {
 
 export type ExchangeCode = (input: ExchangeInput) => Promise<OAuthTokens>;
 
+/**
+ * What a response without a refresh token means for this vendor.
+ *
+ * The two readings are opposite and neither is guessable from the response.
+ * Google omitting one means the account was already authorised and the
+ * connection will die in an hour — worth stopping for. Slack omitting one is
+ * the ordinary success: a user token is long-lived unless token rotation is
+ * switched on, so demanding one would refuse every connection that worked.
+ */
+export interface RefreshTokenPolicy {
+  readonly required: boolean;
+  /** Named in the refusal, so it is not always the vendor who first needed it. */
+  readonly vendor: string;
+  /** Where the operator withdraws the existing grant, when the manifest says. */
+  readonly revokeUrl?: string | undefined;
+}
+
 /** Straight to the vendor, signed with a client this machine holds. */
 export function directExchange(options: {
   readonly tokenUrl: string;
   readonly clientId: string;
-  readonly clientSecret: string;
+  /**
+   * Absent for a public client, where PKCE is the whole of the protection.
+   *
+   * A client id shipped in a public repository has no secret to go with it, and
+   * inventing an empty one would be sent as `client_secret=` — which some
+   * authorization servers read as a malformed confidential client rather than
+   * as a public one, and refuse for a reason that names neither.
+   */
+  readonly clientSecret?: string | undefined;
+  readonly refreshToken: RefreshTokenPolicy;
   readonly fetch?: typeof globalThis.fetch | undefined;
 }): ExchangeCode {
   return async (input) => {
@@ -56,7 +91,7 @@ export function directExchange(options: {
         code: input.code,
         redirect_uri: input.redirectUri,
         client_id: options.clientId,
-        client_secret: options.clientSecret,
+        ...(options.clientSecret ? { client_secret: options.clientSecret } : {}),
         code_verifier: input.codeVerifier,
       }),
     });
@@ -71,19 +106,23 @@ export function directExchange(options: {
       error_description?: string;
     };
 
+    // Not every vendor signals failure with a status. Slack answers a refused
+    // exchange with HTTP 200 and `{ok: false, error: ...}`, so the absent token
+    // is what has to be trusted here rather than the code.
     if (!response.ok || !body.access_token) {
       throw new OAuthError(
         `Token exchange failed: ${body.error ?? response.status} ${body.error_description ?? ''}`.trim(),
       );
     }
 
-    return settle(body, input.scopes);
+    return settle(body, input.scopes, options.refreshToken);
   };
 }
 
 /** Through a broker, which holds the secret this machine does not have. */
 export function brokerExchangeVia(options: {
   readonly url: string;
+  readonly refreshToken: RefreshTokenPolicy;
   readonly fetch?: typeof globalThis.fetch | undefined;
 }): ExchangeCode {
   return async (input) => {
@@ -110,7 +149,7 @@ export function brokerExchangeVia(options: {
       throw new OAuthError('The token exchange returned no access token.');
     }
 
-    return settle(tokens, input.scopes);
+    return settle(tokens, input.scopes, options.refreshToken);
   };
 }
 
@@ -123,23 +162,26 @@ function settle(
     scope?: string | undefined;
   },
   scopes: readonly string[],
+  refreshToken: RefreshTokenPolicy,
 ): OAuthTokens {
-  if (!body.refresh_token) {
+  if (!body.refresh_token && refreshToken.required) {
     // Without one, the connection works until the access token expires and then
-    // quietly stops. Better to fail now with the actual cause. Google is named
-    // because Google is who reaches this path: every provider that redeems a
-    // code here is a Google REST one, and the others hand the exchange to the
-    // MCP SDK. Naming the page beats describing it.
+    // quietly stops. Better to fail now with the actual cause. The vendor is
+    // named rather than assumed: this used to say "Google" on the grounds that
+    // Google was the only provider redeeming a code here, and it is not any
+    // more.
     throw new OAuthError(
-      'Google returned no refresh token. This usually means the account was already authorised ' +
-        'for this app; revoke it at https://myaccount.google.com/permissions and try again.',
+      `${refreshToken.vendor} returned no refresh token. This usually means the account was ` +
+        'already authorised for this app; revoke it' +
+        (refreshToken.revokeUrl ? ` at ${refreshToken.revokeUrl}` : '') +
+        ' and try again.',
     );
   }
 
   return {
-    refreshToken: body.refresh_token,
+    ...(body.refresh_token ? { refreshToken: body.refresh_token } : {}),
     accessToken: body.access_token!,
-    expiresIn: body.expires_in ?? 3600,
+    ...(body.expires_in !== undefined ? { expiresIn: body.expires_in } : {}),
     scope: body.scope ?? scopes.join(' '),
     ...(body.id_token ? { idToken: body.id_token } : {}),
   };

--- a/src/cli/oauth.test.ts
+++ b/src/cli/oauth.test.ts
@@ -37,8 +37,30 @@ const options = (overrides: Record<string, unknown> = {}) => ({
   clientSecret: 'client-secret',
   scopes: ['scope.read'],
   timeoutMs: 5_000,
+  refreshToken: { required: true, vendor: 'Vendor', revokeUrl: 'https://example.com/permissions' },
   ...overrides,
 });
+
+/**
+ * Act as the browser coming back *through the relay*.
+ *
+ * The relay has only `state` to work from, so this reads the port out of it the
+ * same way the broker's callback route does — which is what makes this a test
+ * of the contract rather than of a value threaded through in the clear.
+ */
+function relayed(mutate?: (params: URLSearchParams) => void) {
+  return (url: string) => {
+    const authorize = new URL(url);
+    const state = authorize.searchParams.get('state')!;
+    const port = state.split('.').pop();
+
+    const back = new URL(`http://127.0.0.1:${port}/callback`);
+    back.searchParams.set('code', 'auth-code-1');
+    back.searchParams.set('state', state);
+    mutate?.(back.searchParams);
+    void fetch(back.href);
+  };
+}
 
 /** Act as the browser: follow the authorize URL back to the loopback callback. */
 function browserThatApproves(mutate?: (params: URLSearchParams) => void) {
@@ -300,80 +322,130 @@ describe('rejections', () => {
 
     expect(error).toBeInstanceOf(OAuthError);
     expect(error.message).toMatch(/no refresh token/);
-    expect(error.message).toMatch(/myaccount\.google\.com\/permissions/);
+    // The vendor and the revoke page come from the manifest now. This assertion
+    // used to name Google, which was true only while Google was the only
+    // provider that redeemed a code here.
+    expect(error.message).toMatch(/Vendor returned no refresh token/);
+    expect(error.message).toMatch(/https:\/\/example\.com\/permissions/);
+  });
+
+  test('a vendor the manifest says issues none succeeds, and stores no expiry', async () => {
+    // Slack's shape: a long-lived user token, no refresh token, no stated
+    // lifetime. Demanding one here refused every connection that worked.
+    const mock = mockTokenEndpoint({ access_token: 'xoxp-access', scope: 'chat:write' });
+
+    const tokens = await runOAuthFlow(
+      options({
+        fetch: mock.fetch,
+        openBrowser: browserThatApproves(),
+        refreshToken: { required: false, vendor: 'Vendor' },
+      }) as never,
+    );
+
+    expect(tokens.accessToken).toBe('xoxp-access');
+    expect(tokens.refreshToken).toBeUndefined();
+    expect(tokens.expiresIn).toBeUndefined();
   });
 });
 
 /**
- * The listener the SDK drives, rather than the flow we drive ourselves.
+ * A vendor that will not accept a loopback redirect at all.
  *
- * The SDK builds the authorization URL and only puts a `state` on it if its
- * provider hands one over, and it does not check the value when the callback
- * comes back. Both halves therefore live here: the listener mints the state and
- * the listener compares it. These tests are what keeps the pair together.
+ * Slack refuses to register a non-HTTPS Redirect URL, and a CLI on loopback
+ * cannot be HTTPS. So the broker's own origin is named instead, the browser
+ * lands there, and it bounces straight back down to the listener opened here.
+ * The listener does not change; only the address the vendor is told.
  */
-describe('the SDK-driven callback listener', () => {
-  test('publishes a state for the provider to send', () => {
-    const first = captureOAuthCallback();
-    const second = captureOAuthCallback();
+describe('a relayed redirect', () => {
+  const RELAY = 'https://api.example.com/v1/auth/link/vendor/callback';
 
-    try {
-      expect(first.state).toMatch(/^[A-Za-z0-9_-]{32,}$/);
-      // Per listener, not per process: two concurrent connects must not accept
-      // each other's callbacks.
-      expect(first.state).not.toBe(second.state);
-    } finally {
-      void first.close();
-      void second.close();
-    }
+  test('names the relay to the vendor, not the loopback port', async () => {
+    const mock = mockTokenEndpoint(SUCCESS);
+    let authorizeUrl = '';
+
+    await runOAuthFlow(
+      options({
+        fetch: mock.fetch,
+        relayRedirect: RELAY,
+        openBrowser: (url: string) => {
+          authorizeUrl = url;
+          relayed()(url);
+        },
+      }) as never,
+    );
+
+    expect(new URL(authorizeUrl).searchParams.get('redirect_uri')).toBe(RELAY);
   });
 
-  test('refuses a callback that carries no state', async () => {
-    const capture = captureOAuthCallback();
+  test('carries the listening port in state, because the relay has no other way home', async () => {
+    const mock = mockTokenEndpoint(SUCCESS);
+    let authorizeUrl = '';
 
-    try {
-      // The handler goes on before the request, or the rejection lands with
-      // nothing attached and Bun reports it as unhandled.
-      const refused = capture.wait(5_000).then(() => null, (error: Error) => error);
-      await fetch(`${capture.redirectUri}?code=unsolicited`).catch(() => {});
+    await runOAuthFlow(
+      options({
+        fetch: mock.fetch,
+        relayRedirect: RELAY,
+        openBrowser: (url: string) => {
+          authorizeUrl = url;
+          relayed()(url);
+        },
+      }) as never,
+    );
 
-      expect((await refused)?.message).toMatch(/State mismatch/);
-    } finally {
-      await capture.close();
-    }
+    const state = new URL(authorizeUrl).searchParams.get('state')!;
+    const port = Number(state.split('.').pop());
+    expect(state).toMatch(/^[\w-]+\.\d+$/);
+    expect(port).toBeGreaterThan(1024);
   });
 
-  test('refuses a code injected by anyone sweeping the loopback port', async () => {
-    const capture = captureOAuthCallback();
+  test('redeems against the relay, because the vendor requires the two to match', async () => {
+    const mock = mockTokenEndpoint(SUCCESS);
 
-    try {
-      const refused = capture.wait(5_000).then(() => null, (error: Error) => error);
-      // What an <img src="http://127.0.0.1:N/callback?code=..."> on any open
-      // page amounts to. PKCE would usually fail the exchange afterwards, but
-      // the code must not be redeemed at all.
-      await fetch(`${capture.redirectUri}?code=attacker&state=guessed`).catch(() => {});
+    await runOAuthFlow(
+      options({ fetch: mock.fetch, relayRedirect: RELAY, openBrowser: relayed() }) as never,
+    );
 
-      expect((await refused)?.message).toMatch(/State mismatch/);
-    } finally {
-      await capture.close();
-    }
+    expect(mock.calls[0]!.body['redirect_uri']).toBe(RELAY);
   });
 
-  test('accepts the callback it actually started', async () => {
-    const capture = captureOAuthCallback();
+  test('still refuses a callback whose state does not match', async () => {
+    // The port rides along, but the random half is unchanged and is still what
+    // binds this callback to this flow.
+    const mock = mockTokenEndpoint(SUCCESS);
 
-    try {
-      const pending = capture.wait(5_000);
-      const url = new URL(capture.redirectUri);
-      url.searchParams.set('code', 'the-real-code');
-      url.searchParams.set('state', capture.state);
-      url.searchParams.set('iss', 'https://accounts.example.test');
-      await fetch(url).catch(() => {});
+    const error = await runOAuthFlow(
+      options({
+        fetch: mock.fetch,
+        relayRedirect: RELAY,
+        timeoutMs: 1_500,
+        openBrowser: relayed((params) => params.set('state', 'someone-elses.54321')),
+      }) as never,
+    ).then(
+      () => undefined,
+      (caught: unknown) => caught as Error,
+    );
 
-      expect(await pending).toEqual({ code: 'the-real-code', iss: 'https://accounts.example.test' });
-    } finally {
-      await capture.close();
-    }
+    expect(error).toBeInstanceOf(OAuthError);
+  });
+
+  test('without one, the listener names itself as before', async () => {
+    const mock = mockTokenEndpoint(SUCCESS);
+    let authorizeUrl = '';
+
+    await runOAuthFlow(
+      options({
+        fetch: mock.fetch,
+        openBrowser: (url: string) => {
+          authorizeUrl = url;
+          browserThatApproves()(url);
+        },
+      }) as never,
+    );
+
+    const sent = new URL(authorizeUrl).searchParams;
+    expect(sent.get('redirect_uri')).toMatch(/^http:\/\/127\.0\.0\.1:\d+\/callback$/);
+    // No port appended: there is nobody to tell.
+    expect(sent.get('state')).not.toContain('.');
   });
 });
 
@@ -389,6 +461,7 @@ describe('the exchange is a seam', () => {
       authorizeUrl: 'https://accounts.example.com/authorize',
       clientId: 'cid',
       scopes: ['scope.a'],
+      refreshToken: { required: true, vendor: 'Vendor' },
       openBrowser: browserThatApproves(),
       fetch: tokenEndpoint.fetch,
       exchange: async (input) => {
@@ -410,11 +483,15 @@ describe('the exchange is a seam', () => {
     expect(redeemed?.codeVerifier).toMatch(/^[\w-]{43}$/);
   });
 
-  test('a flow with neither an exchange nor a client to redeem with refuses', async () => {
+  test('a flow with neither an exchange nor a token url to redeem at refuses', async () => {
+    // The secret is deliberately not part of this any more: a public client has
+    // none, and requiring one refused the shipped-client path before it sent
+    // anything.
     const error = await runOAuthFlow({
       authorizeUrl: 'https://accounts.example.com/authorize',
       clientId: 'cid',
       scopes: ['scope.a'],
+      refreshToken: { required: true, vendor: 'Vendor' },
       openBrowser: browserThatApproves(),
     }).then(
       () => undefined,
@@ -422,6 +499,25 @@ describe('the exchange is a seam', () => {
     );
 
     expect(error).toBeInstanceOf(OAuthError);
-    expect(error?.message).toMatch(/tokenUrl and clientSecret/);
+    expect(error?.message).toMatch(/needs a tokenUrl/);
+  });
+
+  test('a public client redeems with no secret, sending none rather than an empty one', async () => {
+    const mock = mockTokenEndpoint(SUCCESS);
+
+    await runOAuthFlow({
+      authorizeUrl: 'https://accounts.example.com/authorize',
+      tokenUrl: 'https://oauth2.example.com/token',
+      clientId: 'shipped-id',
+      scopes: ['scope.a'],
+      refreshToken: { required: true, vendor: 'Vendor' },
+      openBrowser: browserThatApproves(),
+      fetch: mock.fetch,
+    });
+
+    const sent = mock.calls[0]!.body;
+    expect(sent['client_id']).toBe('shipped-id');
+    expect('client_secret' in sent).toBe(false);
+    expect(sent['code_verifier']).toMatch(/^[\w-]{43}$/);
   });
 });

--- a/src/cli/oauth.ts
+++ b/src/cli/oauth.ts
@@ -1,7 +1,20 @@
 import { createHash, randomBytes, timingSafeEqual } from 'node:crypto';
-import { completionPage } from './callback-page.ts';
 import { OAuthError } from './oauth-error.ts';
-import { directExchange, type ExchangeCode, type OAuthTokens } from './oauth-exchange.ts';
+import {
+  captureOAuthCallback,
+  connectedPage,
+  failedPage,
+  shutdown,
+  stateMatches,
+  withTimeout,
+  type CallbackCapture,
+} from './oauth-callback.ts';
+import {
+  directExchange,
+  type ExchangeCode,
+  type OAuthTokens,
+  type RefreshTokenPolicy,
+} from './oauth-exchange.ts';
 
 /**
  * The OAuth authorization-code exchange, run entirely from the CLI.
@@ -36,7 +49,23 @@ export interface OAuthFlowOptions {
    * state check, and the browser cannot drift apart between the two paths.
    */
   readonly exchange?: ExchangeCode;
+  /** What a response carrying no refresh token means for this vendor. */
+  readonly refreshToken: RefreshTokenPolicy;
   readonly authorizeParams?: Readonly<Record<string, string>>;
+  /**
+   * An HTTPS URL to name as the redirect, for a vendor that will take no other.
+   *
+   * Absent for every vendor that accepts a loopback callback, which is all of
+   * them but Slack — there the listener names itself and this is the whole of
+   * it. Present where the vendor's redirect must be HTTPS: the browser then
+   * lands on that URL, which bounces it down to the listener opened here, and
+   * the port it needs to bounce to travels in `state`.
+   *
+   * The listener is unchanged either way. It still binds loopback on a port the
+   * kernel picked, still serves exactly one callback, and still checks `state`
+   * on the way back. What changes is only the address the vendor is told.
+   */
+  readonly relayRedirect?: string;
   /** What the completion page names as connected. A provider's display name. */
   readonly connectionLabel?: string;
   /** How long to wait for the operator to finish in the browser. */
@@ -49,7 +78,12 @@ export interface OAuthFlowOptions {
 // Re-exported so the flow stays one import for its callers even though the
 // exchange half now lives next door.
 export { OAuthError };
-export type { ExchangeCode, OAuthTokens };
+export type { ExchangeCode, OAuthTokens, RefreshTokenPolicy };
+
+// Re-exported so a caller wanting a loopback callback still has one import to
+// reach for. Which file it lives in is this module's business, not theirs.
+export { captureOAuthCallback };
+export type { CallbackCapture };
 
 const base64url = (input: Buffer): string => input.toString('base64url');
 
@@ -58,13 +92,6 @@ export function createPkcePair(): { verifier: string; challenge: string } {
   const verifier = base64url(randomBytes(32));
   const challenge = base64url(createHash('sha256').update(verifier).digest());
   return { verifier, challenge };
-}
-
-/** Compare the returned state in constant time — it is a CSRF defence. */
-function stateMatches(expected: string, received: string): boolean {
-  const a = createHash('sha256').update(expected).digest();
-  const b = createHash('sha256').update(received).digest();
-  return timingSafeEqual(a, b);
 }
 
 export function defaultOpenBrowser(url: string): void {
@@ -86,24 +113,6 @@ export function defaultOpenBrowser(url: string): void {
 }
 
 /**
- * What the browser is left looking at, in the two shapes it comes in.
- *
- * The label is what the caller knows and this file cannot: which provider the
- * grant was for. Given one, the page names it under "Connected" the way the
- * invite page names the workspace; without one it says only that the flow
- * finished, which is what every path said before.
- */
-const connectedPage = (label?: string): Response =>
-  completionPage({
-    ...(label ? { label: 'Connected', heading: label } : { heading: 'Connected' }),
-    detail: 'You can close this tab and return to the terminal.',
-    ok: true,
-  });
-
-const failedPage = (detail: string): Response =>
-  completionPage({ heading: 'Authorization failed', detail, ok: false });
-
-/**
  * Run the flow and return the tokens.
  *
  * The listener binds to 127.0.0.1 on a port the OS picks, serves exactly one
@@ -112,7 +121,6 @@ const failedPage = (detail: string): Response =>
  */
 export async function runOAuthFlow(options: OAuthFlowOptions): Promise<OAuthTokens> {
   const { verifier, challenge } = createPkcePair();
-  const state = base64url(randomBytes(24));
   const timeoutMs = options.timeoutMs ?? 5 * 60_000;
 
   let resolveCode: (code: string) => void;
@@ -124,7 +132,7 @@ export async function runOAuthFlow(options: OAuthFlowOptions): Promise<OAuthToke
 
   const server = Bun.serve({
     hostname: '127.0.0.1',
-    port: 0, // let the OS choose; Google's Desktop client type accepts any loopback port
+    port: 0, // let the OS choose; nothing outside this machine names this port
     fetch(request) {
       const url = new URL(request.url);
       if (url.pathname !== '/callback') return new Response('Not found', { status: 404 });
@@ -143,8 +151,9 @@ export async function runOAuthFlow(options: OAuthFlowOptions): Promise<OAuthToke
 
       const returnedState = url.searchParams.get('state');
       if (!returnedState || !stateMatches(state, returnedState)) {
-        // A mismatched state means this callback did not come from the request
-        // we started. Refuse it rather than redeeming whatever code it carries.
+        // A mismatched state means this callback did not come from the
+        // request we started. Refuse it rather than redeeming whatever code
+        // it carries.
         rejectCode(new OAuthError('State mismatch — ignoring an unexpected callback.'));
         return failedPage('Unexpected callback.');
       }
@@ -160,7 +169,25 @@ export async function runOAuthFlow(options: OAuthFlowOptions): Promise<OAuthToke
     },
   });
 
-  const redirectUri = `http://127.0.0.1:${server.port}/callback`;
+  // Where the vendor is told to send the browser. The relay bounces it back
+  // here; without one it comes here directly, which is every other provider.
+  const redirectUri = options.relayRedirect ?? `http://127.0.0.1:${server.port}/callback`;
+
+  /**
+   * The CSRF binding, and — behind a relay — the only way home.
+   *
+   * Built after the listener because half of it is the port the kernel just
+   * chose. The relay has nowhere else to learn that from: `state` is opaque to
+   * the vendor, round-trips untouched, and is already checked on the way back,
+   * so carrying the port in it costs no extra parameter and no state held
+   * anywhere. Without a relay it stays what it always was.
+   *
+   * Safe to declare after the handler that reads it: `Bun.serve` returns
+   * synchronously and nothing can be served until this frame yields.
+   */
+  const state = options.relayRedirect
+    ? `${base64url(randomBytes(24))}.${server.port}`
+    : base64url(randomBytes(24));
 
   try {
     const authorizeUrl = new URL(options.authorizeUrl);
@@ -196,159 +223,22 @@ export async function runOAuthFlow(options: OAuthFlowOptions): Promise<OAuthToke
   }
 }
 
-/**
- * Close the listener without cutting off the response in flight.
- *
- * Forcing the socket shut the instant the code is read leaves the operator
- * looking at a connection error on a flow that in fact succeeded. So: stop
- * gracefully, wait for the in-flight callback to drain, and force only if
- * graceful genuinely did not finish — a keep-alive connection must not be able
- * to hold the CLI open forever either.
- */
-async function shutdown(server: { stop(force?: boolean): Promise<void> }): Promise<void> {
-  let drained = false;
-  const graceful = server.stop().then(() => {
-    drained = true;
-  });
-
-  await withTimeout(graceful, 2_000).catch(() => {});
-  if (!drained) await server.stop(true);
-}
-
-/**
- * Race a promise against a deadline, and **clear the timer either way**.
- *
- * A bare `Promise.race` with `setTimeout` leaks: when the real promise wins,
- * the timer is still pending, and a pending timer keeps the event loop alive
- * for its full duration. With a five-minute OAuth deadline that turns a
- * finished `connect` into a terminal that prints "Next: lanes link start" and
- * then sits there for five minutes — which is exactly what it did.
- *
- * Rejects with `OAuthError(message)` if given one, otherwise resolves to
- * undefined at the deadline, which is what the shutdown path wants.
- */
-async function withTimeout<T>(promise: Promise<T>, ms: number, message?: string): Promise<T> {
-  let timer: ReturnType<typeof setTimeout> | undefined;
-
-  try {
-    return await Promise.race([
-      promise,
-      new Promise<T>((resolve, reject) => {
-        timer = setTimeout(
-          () => (message ? reject(new OAuthError(message)) : resolve(undefined as T)),
-          ms,
-        );
-      }),
-    ]);
-  } finally {
-    if (timer) clearTimeout(timer);
-  }
-}
-
 function defaultExchange(options: OAuthFlowOptions): ExchangeCode {
-  if (!options.tokenUrl || !options.clientSecret) {
+  // The secret is no longer part of this condition. A public client has none —
+  // its id ships in the manifest and PKCE is what protects the exchange — so
+  // requiring one here refused the shipped-client path before it sent anything.
+  if (!options.tokenUrl) {
     throw new OAuthError(
-      'runOAuthFlow needs either a tokenUrl and clientSecret to redeem the code with, or an exchange to redeem it through.',
+      'runOAuthFlow needs a tokenUrl to redeem the code at, or an exchange to redeem it through.',
     );
   }
   return directExchange({
     tokenUrl: options.tokenUrl,
     clientId: options.clientId,
-    clientSecret: options.clientSecret,
+    refreshToken: options.refreshToken,
+    ...(options.clientSecret ? { clientSecret: options.clientSecret } : {}),
     ...(options.fetch ? { fetch: options.fetch } : {}),
   });
 }
 
 
-/**
- * Capture exactly one OAuth callback on loopback.
- *
- * Split out from `runOAuthFlow` so the SDK can drive the protocol — discovery,
- * registration, PKCE, exchange — while we supply only the redirect target. The
- * listener exists for the duration of one consent and no longer.
- */
-export interface CallbackCapture {
-  readonly redirectUri: string;
-  /**
-   * The `state` this listener will accept, for the provider to put on the
-   * authorization URL. The SDK asks its provider for one and sends whatever it
-   * gets; nothing generates it for us.
-   */
-  readonly state: string;
-  wait(timeoutMs?: number): Promise<{ code: string; iss?: string }>;
-  close(): Promise<void>;
-}
-
-export function captureOAuthCallback(options: { label?: string } = {}): CallbackCapture {
-  const state = base64url(randomBytes(24));
-  let resolveCode: (value: { code: string; iss?: string }) => void;
-  let rejectCode: (error: Error) => void;
-
-  const received = new Promise<{ code: string; iss?: string }>((resolve, reject) => {
-    resolveCode = resolve;
-    rejectCode = reject;
-  });
-
-  const server = Bun.serve({
-    hostname: '127.0.0.1',
-    port: 0,
-    fetch(request) {
-      const url = new URL(request.url);
-      if (url.pathname !== '/callback') return new Response('Not found', { status: 404 });
-
-      const error = url.searchParams.get('error');
-      if (error) {
-        rejectCode(
-          new OAuthError(
-            error === 'access_denied'
-              ? 'Authorization was declined in the browser.'
-              : `Authorization failed: ${error}`,
-          ),
-        );
-        return failedPage('You can close this tab.');
-      }
-
-      const code = url.searchParams.get('code');
-      if (!code) {
-        rejectCode(new OAuthError('The callback carried no authorization code.'));
-        return failedPage('No code returned.');
-      }
-
-      // Checked here because nothing else checks it. The SDK's own docs say it
-      // does not validate `state`, and it only sends one if the provider hands
-      // it over — so this listener mints the value, `CredentialOAuthProvider`
-      // returns it from `state()`, and the two are compared on the way back.
-      //
-      // Without it this resolves on the first `/callback?code=` to reach the
-      // port, whoever sent it: any local process, or a page the operator has
-      // open, can sweep loopback during the five-minute window. PKCE usually
-      // turns that into a failed exchange, but a manifest is free to name an
-      // authorization server that does not enforce it, and there the code
-      // would be redeemed and the connection bound to someone else's account.
-      const returnedState = url.searchParams.get('state');
-      if (!returnedState || !stateMatches(state, returnedState)) {
-        rejectCode(new OAuthError('State mismatch — ignoring an unexpected callback.'));
-        return failedPage('Unexpected callback.');
-      }
-
-      const iss = url.searchParams.get('iss');
-      resolveCode({ code, ...(iss ? { iss } : {}) });
-      return connectedPage(options.label);
-    },
-  });
-
-  return {
-    redirectUri: `http://127.0.0.1:${server.port}/callback`,
-    state,
-
-    async wait(timeoutMs = 5 * 60_000) {
-      return withTimeout(
-        received,
-        timeoutMs,
-        `Timed out after ${Math.round(timeoutMs / 1000)}s waiting for the browser.`,
-      );
-    },
-
-    close: () => shutdown(server),
-  };
-}

--- a/src/cli/scopes.test.ts
+++ b/src/cli/scopes.test.ts
@@ -182,7 +182,7 @@ describe('the Google manifests stay at the documented minimum', () => {
     );
   });
 
-  test('the broad scopes are exactly the six that were argued for', () => {
+  test('the broad scopes are exactly the thirteen that were argued for', () => {
     const broad = PROVIDERS.flatMap((manifest) => {
       const scopes = manifest.auth.kind === 'oauth' ? manifest.auth.scopes : [];
       return describeScopes(scopes)
@@ -208,6 +208,25 @@ describe('the Google manifests stay at the documented minimum', () => {
         'docs https://www.googleapis.com/auth/documents',
         'calendar https://www.googleapis.com/auth/calendar.events',
         'tasks https://www.googleapis.com/auth/tasks',
+        // Slack's seven, which arrived when its scopes moved off a setup page
+        // and into the manifest. Nothing widened to put them here: this is the
+        // same grant the setup page asked the operator to transcribe, now
+        // somewhere it can be shown before consent rather than after.
+        //
+        // Six of the seven are one argument — Slack draws no line between
+        // "read a conversation" and "read a private conversation", so the
+        // history and search scopes for private channels, DMs, and group DMs
+        // each reach the most sensitive thing in a workspace while reading like
+        // routine access. `chat:write` is the seventh and the only write:
+        // messages it sends are from the person, not from an app, and there is
+        // nothing in Slack's UI that says otherwise afterwards.
+        'slack search:read.private',
+        'slack search:read.im',
+        'slack search:read.mpim',
+        'slack groups:history',
+        'slack im:history',
+        'slack mpim:history',
+        'slack chat:write',
       ].sort(),
     );
   });

--- a/src/connectivity/auth/index.ts
+++ b/src/connectivity/auth/index.ts
@@ -40,6 +40,7 @@ export { assertionKeySchema, parseAssertionKey, signAssertion, type AssertionKey
 export {
   BROKER_ORIGIN_ENV,
   BROKERED,
+  PASTED,
   BrokerError,
   brokerConfig,
   brokerExchange,

--- a/src/connectivity/auth/oauth-authcode/broker.ts
+++ b/src/connectivity/auth/oauth-authcode/broker.ts
@@ -20,6 +20,17 @@
  */
 export const BROKERED = 'broker';
 
+/**
+ * Stamped on a credential nobody here minted — the operator pasted it.
+ *
+ * The third answer, and the one that is not a client at all. It matters for the
+ * same reason as the other two and one more: a pasted token cannot be
+ * refreshed, cannot be attributed to a registration, and cannot be re-obtained
+ * by re-running a flow. `doctor` reads it to say so rather than offering a
+ * re-authorisation that would not apply.
+ */
+export const PASTED = 'pasted';
+
 /** What the broker will authorise, and whether it is currently doing so. */
 export interface BrokerConfig {
   readonly clientId: string;
@@ -27,6 +38,20 @@ export interface BrokerConfig {
   readonly scopesSupported: readonly string[];
   /** Added to every request so the exchange returns an identity assertion. */
   readonly identityScopes: readonly string[];
+  /**
+   * Where the vendor sends the browser back, when it will not send it here.
+   *
+   * Absent for a vendor that accepts a loopback redirect, which is all of them
+   * but Slack: the listener names itself and the broker is only asked to
+   * redeem. Present where the vendor demands HTTPS — then the redirect lands on
+   * the broker's own origin and is bounced down to the listener, and this is
+   * the URL both legs of the flow have to agree on.
+   *
+   * Published rather than derived, because which URL is correct depends on
+   * which deployment answered `/config` — and a broker running on loopback for
+   * a test would otherwise need a flag of its own.
+   */
+  readonly redirectUri: string | undefined;
   readonly open: boolean;
   /** Why it is closed, or near capacity. The broker's words, printed verbatim. */
   readonly notice: string | undefined;
@@ -217,6 +242,7 @@ export async function brokerConfig(
     clientId,
     scopesSupported: strings(data['scopes_supported']),
     identityScopes: strings(data['identity_scopes']),
+    redirectUri: str(data['redirect_uri']),
     open: data['status'] !== 'closed',
     notice: str(data['notice']),
     docsUrl: str(data['docs_url']),

--- a/src/connectivity/index.ts
+++ b/src/connectivity/index.ts
@@ -70,6 +70,7 @@ export {
   bundleSchema,
   credentialRefForConnection,
   rotatableCredentialRefs,
+  hasOwnClientPath,
   setupRequirements,
   UNNAMED_ID,
   RESERVED_PROVIDER_IDS,

--- a/src/connectivity/manifest/auth.ts
+++ b/src/connectivity/manifest/auth.ts
@@ -111,8 +111,10 @@ export const authOAuthSchema = z.object({
    * `dynamic` — the authorization server offers Dynamic Client Registration, so
    * we register ourselves and the operator does nothing at all (Notion, Linear).
    *
-   * `manual` — the vendor requires a pre-registered client, so the operator
-   * supplies an id and secret (Google, including for Google's own MCP servers).
+   * `manual` — the vendor requires a pre-registered client. Who supplies it is
+   * the profile's to decide and not this field's: an id and secret the operator
+   * registered (Google, if they choose to), or the client behind `broker`.
+   * `manual` says only that self-registration is not on offer.
    */
   registration: z.enum(['dynamic', 'manual']).default('dynamic'),
   /** Which `oauth_apps` entry holds the client, for `manual`. Shared across providers of a vendor. */
@@ -136,6 +138,22 @@ export const authOAuthSchema = z.object({
    * nothing about a connection that authorised in a browser.
    */
   assertion: authAssertionSchema.optional(),
+  /**
+   * Whether a token response carrying no refresh token is a failure.
+   *
+   * `required` — it is, and stopping is kinder than succeeding: the connection
+   * would work until the access token expires and then quietly stop. Google
+   * omits one when the account was already authorised for the app, which is a
+   * real and recoverable mistake.
+   *
+   * `optional` — the vendor issues a long-lived token and no refresh token is
+   * the normal, successful answer. Slack does this unless token rotation is
+   * enabled on the app, so demanding one would refuse every connection that
+   * worked.
+   */
+  refresh_token: z.enum(['required', 'optional']).default('required'),
+  /** Where the operator withdraws a grant, named in the refusal above. */
+  revoke_url: z.url().optional(),
   scopes: z.array(z.string()).default([]),
   /**
    * Usually discovered from the resource's metadata; set only to override.

--- a/src/connectivity/manifest/identity.ts
+++ b/src/connectivity/manifest/identity.ts
@@ -30,6 +30,18 @@ export const identitySchema = z.discriminatedUnion('kind', [
     url: z.url(),
     /** Dotted path into the JSON body, e.g. `emailAddress` or `user.emailAddress`. */
     field: z.string().min(1),
+    /**
+     * A second path, shown in brackets, where `field` alone is not unique.
+     *
+     * Almost no provider needs one: an address identifies a Google or iCloud
+     * account globally, and a GitHub login is unique across GitHub. Slack is
+     * the exception, because the thing it calls a user is scoped to a
+     * workspace — the same person in two workspaces answers `auth.test` with
+     * the same `user`, and one account string is how `settleIdentity` decides a
+     * connect is a *reconnect*. Without this, connecting a second workspace
+     * matches the first and overwrites its credential.
+     */
+    qualifier: z.string().min(1).optional(),
   }),
   z.object({
     kind: z.literal('tool'),

--- a/src/connectivity/manifest/index.ts
+++ b/src/connectivity/manifest/index.ts
@@ -45,4 +45,4 @@ export {
 } from './provider.ts';
 
 export type { SetupRequirement, SetupNeeds } from './requirements.ts';
-export { setupRequirements, UNNAMED_ID } from './requirements.ts';
+export { hasOwnClientPath, setupRequirements, UNNAMED_ID } from './requirements.ts';

--- a/src/connectivity/manifest/manifest.test.ts
+++ b/src/connectivity/manifest/manifest.test.ts
@@ -162,17 +162,27 @@ describe('a broker as the other answer to "where does the client come from"', ()
     expect(() => provider(oauth({ broker, authorize_url: undefined }))).toThrow(/authorize_url/);
   });
 
-  test('an mcp connector is refused, because the SDK owns its exchange', () => {
-    // Discovered at definition rather than after the operator has already
-    // approved a consent screen.
-    expect(() =>
-      defineProvider({
-        id: 'vendor_mcp',
-        name: 'Vendor',
-        connector: { kind: 'mcp', endpoint: 'https://mcp.example.com/sse' },
-        auth: oauth({ broker }),
-      }),
-    ).toThrow(/cannot route it through a broker/);
+  const mcp = (auth: Record<string, unknown>) =>
+    defineProvider({
+      id: 'vendor_mcp',
+      name: 'Vendor',
+      connector: { kind: 'mcp', endpoint: 'https://mcp.example.com/mcp' },
+      auth,
+    });
+
+  test('an mcp connector may be brokered once it names its own endpoints', () => {
+    // This used to be refused outright, on the grounds that the SDK owns an MCP
+    // provider's exchange and there is no seam to route it. The seam is naming
+    // the endpoints: that takes the provider off the SDK's flow and onto the
+    // one this repository drives, where the exchange is ours. See ADR-040.
+    expect(() => mcp(oauth({ broker }))).not.toThrow();
+  });
+
+  test('an mcp connector without a token url is refused, because the SDK would own it', () => {
+    // Half-declared is the dangerous state: the SDK would run the flow and then
+    // post to the token endpoint with a client the broker holds and it does
+    // not. Refused at definition rather than after a consent screen.
+    expect(() => mcp(oauth({ broker, token_url: undefined }))).toThrow(/auth\.token_url/);
   });
 
   test('tokens still land per provider, not under the app the broker names', () => {

--- a/src/connectivity/manifest/provider.ts
+++ b/src/connectivity/manifest/provider.ts
@@ -114,18 +114,21 @@ export function defineProvider(input: unknown): ProviderManifest {
         `Provider "${manifest.id}": a broker supplies a pre-registered client, so auth must declare registration "manual" and an "app" naming the oauth_apps entry that overrides it.`,
       );
     }
-    // An MCP provider hands the exchange to the SDK, which posts to the token
-    // endpoint with whatever `clientInformation()` returned. There is no seam
-    // to route that through a broker without reimplementing its auth path, so
-    // this is refused at definition rather than discovered after consent.
-    if (manifest.connector.kind === 'mcp') {
-      throw new Error(
-        `Provider "${manifest.id}": an mcp connector runs the exchange through the SDK, which cannot route it through a broker. Register a client (registration "manual") or use dynamic registration.`,
-      );
-    }
     if (!manifest.auth.authorize_url) {
       throw new Error(
         `Provider "${manifest.id}": a broker performs the exchange, but the browser still goes to the vendor, so auth.authorize_url is required.`,
+      );
+    }
+    // An MCP provider hands the whole flow to the SDK, which posts to the token
+    // endpoint with whatever `clientInformation()` returned and has nowhere to
+    // route an exchange somebody else performs. Declaring both endpoints is
+    // what opts it off that path and onto the direct one, where the exchange is
+    // ours — so on an mcp connector the two arrive together or the manifest is
+    // describing a flow that cannot run. Refused here rather than discovered
+    // after the operator has already approved a consent screen. See ADR-040.
+    if (manifest.connector.kind === 'mcp' && !manifest.auth.token_url) {
+      throw new Error(
+        `Provider "${manifest.id}": an mcp connector runs the exchange through the SDK, which cannot route it through a broker, unless the manifest declares its own endpoints. Add auth.token_url beside auth.authorize_url, or drop the broker and register dynamically.`,
       );
     }
   }

--- a/src/connectivity/manifest/requirements.ts
+++ b/src/connectivity/manifest/requirements.ts
@@ -55,6 +55,15 @@ export interface SetupNeeds {
    * `connect` will never ask for.
    */
   readonly brokered: boolean;
+  /**
+   * What `--auth pasted_token` would ask for, where the provider offers it.
+   *
+   * Separate from `requirements` because it is an alternative rather than a
+   * prerequisite: nothing needs it unless the browser route is closed to you.
+   * Reported only when it is *not* the chosen route, since when it is chosen it
+   * is a requirement above and naming it twice would read as two values.
+   */
+  readonly pastedCredential: string | undefined;
 }
 
 /**
@@ -123,7 +132,24 @@ function assertionRequirements(
     })),
     needsId: false,
     brokered: false,
+    pastedCredential: undefined,
   };
+}
+
+/**
+ * Whether the manifest describes an OAuth client of the operator's own.
+ *
+ * `defineProvider` permits a broker, or a shipped client id, with no client
+ * prompts — a provider with no bring-your-own path is a legal thing to be. Every
+ * surface that offers that path has to ask this first, or it offers a route with
+ * nothing behind it: the chooser, the client resolver, and the setup plan.
+ *
+ * Here rather than in any of the three because it was already written twice in
+ * two different components under two different names, and this change would
+ * have made it three.
+ */
+export function hasOwnClientPath(manifest: ProviderManifest): boolean {
+  return (manifest.setup?.prompts ?? []).some((prompt) => prompt.scope === 'shared');
 }
 
 export function setupRequirements(
@@ -142,7 +168,7 @@ export function setupRequirements(
      * because the two methods need different things and reporting the union
      * would tell someone to store a client they are not going to use.
      */
-    readonly method?: 'oauth' | 'assertion';
+    readonly method?: 'oauth' | 'assertion' | 'pasted';
   } = {},
 ): SetupNeeds {
   const assertion = manifest.auth.kind === 'oauth' ? manifest.auth.assertion : undefined;
@@ -163,7 +189,20 @@ export function setupRequirements(
     !(manifest.auth.app !== undefined && (options.ownClients ?? []).includes(manifest.auth.app));
 
   const shared = brokered ? [] : prompts.filter((prompt) => prompt.scope === 'shared');
-  const perConnection = prompts.filter((prompt) => prompt.scope === 'connection');
+
+  // An OAuth provider's per-connection prompt belongs to one route, not to the
+  // provider — it is what `--auth pasted_token` asks for, and nothing the
+  // browser route ever needs. Reporting it either way would put a
+  // mandatory-looking field in front of somebody whose whole path is a browser
+  // round trip, which is the same mistake `brokered` avoids one line above.
+  //
+  // No OAuth manifest had one of these until Slack kept its pasted token as the
+  // way past a workspace that has not approved the Lanes app.
+  const connectionPrompts = prompts.filter((prompt) => prompt.scope === 'connection');
+  const routed = manifest.auth.kind !== 'oauth' || options.method === 'pasted';
+
+  const pasted = routed ? [] : connectionPrompts;
+  const perConnection = routed ? connectionPrompts : [];
 
   const requirements: SetupRequirement[] = [];
 
@@ -204,5 +243,7 @@ export function setupRequirements(
     requirements,
     needsId: perConnection.length > 0 && connectionId === undefined,
     brokered,
+    pastedCredential:
+      pasted.length > 0 ? pasted.map((prompt) => prompt.label).join(', then ') : undefined,
   };
 }

--- a/src/profile/schema.ts
+++ b/src/profile/schema.ts
@@ -356,7 +356,7 @@ export const configSchema = z.object({
        *
        * A deployment only, and this cannot widen that: a loopback endpoint
        * refuses every cross-origin request and must keep doing so. Why the
-       * default is a wildcard is `src/server/cors.ts` and ADR-039.
+       * default is a wildcard is `src/server/cors.ts` and ADR-040.
        */
       allowed_origins: z.array(browserOrigin).optional(),
     })

--- a/src/providers/google/shared/oauth.ts
+++ b/src/providers/google/shared/oauth.ts
@@ -70,8 +70,12 @@ export const GOOGLE_OAUTH = {
   authorize_params: { access_type: 'offline', prompt: 'select_account consent' },
   // Every REST provider here spreads this block, so one line turns brokering on
   // for all seven. `gmail_mcp` and `drive_mcp` write their auth longhand and do
-  // not spread it, which is what keeps them bring-your-own — the SDK owns their
-  // exchange and `defineProvider` refuses a broker on an mcp connector.
+  // not spread it, which is what keeps them bring-your-own.
+  //
+  // That is now a choice rather than a constraint. ADR-040 made a broker legal
+  // on an mcp connector that names its own endpoints, so these two could follow
+  // Slack — what stops them is that nobody has established which client Google
+  // would have us use for its MCP servers, not that the machinery refuses.
   broker: GOOGLE_BROKER,
 } as const;
 

--- a/src/providers/scopes.ts
+++ b/src/providers/scopes.ts
@@ -1,5 +1,6 @@
 import { GOOGLE_SCOPE_MEANINGS } from './google/shared/scopes.ts';
 import { LINEAR_SCOPE_MEANINGS } from './linear/scopes.ts';
+import { SLACK_SCOPE_MEANINGS } from './slack/scopes.ts';
 
 /**
  * What a scope actually permits, contributed by the provider that requests it.
@@ -23,4 +24,5 @@ export interface ScopeMeaning {
 export const SCOPE_MEANINGS: Record<string, ScopeMeaning> = {
   ...GOOGLE_SCOPE_MEANINGS,
   ...LINEAR_SCOPE_MEANINGS,
+  ...SLACK_SCOPE_MEANINGS,
 };

--- a/src/providers/setup/plan.test.ts
+++ b/src/providers/setup/plan.test.ts
@@ -202,3 +202,89 @@ describe('the target in a command', () => {
     }
   });
 });
+
+/**
+ * A pasted credential is an alternative, not a prerequisite.
+ *
+ * Slack is the first OAuth provider with a per-connection prompt, and before
+ * this the plan rendered it beside the requirements — a mandatory-looking field
+ * in a setup whose whole point is that it has none, under a second "Values it
+ * needs" heading immediately after one saying there are none.
+ */
+describe('a provider that offers a pasted token as well as a browser', () => {
+  const withToken = defineProvider({
+    id: 'vendor_chat',
+    name: 'Vendor Chat',
+    connector: { kind: 'mcp', endpoint: 'https://mcp.example.com/mcp' },
+    auth: {
+      kind: 'oauth',
+      registration: 'manual',
+      app: 'vendor',
+      scopes: ['chat.read'],
+      authorize_url: 'https://accounts.example.com/authorize',
+      token_url: 'https://accounts.example.com/token',
+      broker: { url: 'https://api.example.com/v1/auth/link/vendor', operator: 'Someone' },
+    },
+    setup: {
+      prompts: [{ key: 'token', label: 'User token', secret: true, scope: 'connection' as const }],
+    },
+  });
+
+  const plan = planFor(withToken, { profile: 'personal', target: 'local', connections: [] });
+
+  test('does not list the token among the values it needs', () => {
+    expect(plan.requires).toEqual([]);
+    expect(plan.brokered).toBe(true);
+  });
+
+  test('does not demand an --id for a name the browser flow settles itself', () => {
+    expect(plan.needsId).toBe(false);
+    expect(plan.command).not.toContain('--id');
+  });
+
+  test('offers the token as a route --auth selects, naming what it asks for', () => {
+    expect(plan.tokenCommand).toBe(
+      'lanes link connect vendor_chat --profile personal --target local --auth pasted_token',
+    );
+    expect(plan.pastedCredential).toBe('User token');
+  });
+
+  test('does not offer --own-client, because this manifest describes no client', () => {
+    // `resolveOAuthClient` refuses the flag on exactly that ground, so printing
+    // it would be handing somebody a command that answers back with "there is
+    // no such path".
+    expect(plan.ownClientCommand).toBeUndefined();
+  });
+
+  test('a provider that does describe one still offers it', () => {
+    const withClientPrompts = defineProvider({
+      id: 'vendor_files',
+      name: 'Vendor Files',
+      connector: { kind: 'http', base_url: 'https://api.test', openapi: './t.json' },
+      auth: {
+        kind: 'oauth',
+        registration: 'manual',
+        app: 'vendor',
+        scopes: ['a'],
+        authorize_url: 'https://accounts.example.com/authorize',
+        token_url: 'https://accounts.example.com/token',
+        broker: { url: 'https://api.example.com/v1/auth/link/vendor', operator: 'Someone' },
+      },
+      setup: {
+        prompts: [
+          { key: 'client_id', label: 'Client id', credential_ref: 'vendor/client_id' },
+          {
+            key: 'client_secret',
+            label: 'Client secret',
+            secret: true,
+            credential_ref: 'vendor/client_secret',
+          },
+        ],
+      },
+    });
+
+    const plan = planFor(withClientPrompts, { profile: 'personal', target: 'local', connections: [] });
+    expect(plan.ownClientCommand).toContain('--own-client');
+    expect(plan.tokenCommand).toBeUndefined();
+  });
+});

--- a/src/providers/setup/plan.ts
+++ b/src/providers/setup/plan.ts
@@ -1,5 +1,5 @@
 import type { ProviderManifest } from '#connectivity';
-import { setupRequirements, type SetupRequirement } from '#connectivity';
+import { hasOwnClientPath, setupRequirements, type SetupRequirement } from '#connectivity';
 
 /**
  * What connecting a provider involves, assembled from its manifest.
@@ -68,6 +68,10 @@ export interface ProviderPlan {
   readonly clientOperator?: string;
   /** The line that opts out of it and registers one of your own instead. */
   readonly ownClientCommand?: string;
+  /** What `--auth pasted_token` asks for, where that is a way in. */
+  readonly pastedCredential?: string;
+  /** The line that takes that way in. */
+  readonly tokenCommand?: string;
 }
 
 export interface PlanContext {
@@ -96,7 +100,7 @@ export function planFor(
   context: PlanContext,
   connectionId?: string,
 ): ProviderPlan {
-  const { requirements, needsId, brokered } = setupRequirements(
+  const { requirements, needsId, brokered, pastedCredential } = setupRequirements(
     manifest,
     connectionId,
     { profile: context.profile, target: context.target },
@@ -128,13 +132,22 @@ export function planFor(
     needsId,
     command,
     brokered,
+    ...(pastedCredential
+      ? { pastedCredential, tokenCommand: `${command} --auth pasted_token` }
+      : {}),
     ...(brokered && manifest.auth.kind === 'oauth' && manifest.auth.broker
       ? {
           clientOperator: manifest.auth.broker.operator,
           // The steps stay in `steps` either way. A renderer decides whether to
           // show a console walkthrough for a path nobody has asked for; the
           // plan's job is to say the path exists and what opens it.
-          ownClientCommand: `${command} --own-client`,
+          //
+          // Offered only where the manifest actually describes a client to
+          // register. Slack's does not — it asks for a token, never for a
+          // client id and secret — and `resolveOAuthClient` refuses the flag on
+          // exactly that ground, so printing it here would be handing somebody
+          // a command that answers back with "there is no such path".
+          ...(hasOwnClientPath(manifest) ? { ownClientCommand: `${command} --own-client` } : {}),
         }
       : {}),
   };

--- a/src/providers/setup/provider.ts
+++ b/src/providers/setup/provider.ts
@@ -317,6 +317,21 @@ function renderProvider(plan: ProviderPlan): string {
     );
   }
 
+  // An alternative, said as one. It is not a value the command above needs, and
+  // rendering it beside the requirements — which is what it did before there
+  // was anywhere else to put it — reads as a second mandatory step in a setup
+  // whose whole selling point is that it has none.
+  if (plan.tokenCommand && plan.pastedCredential) {
+    lines.push(
+      '',
+      'If the browser path is refused — a workspace that has not approved this app, which an ' +
+        `admin decides — the same command takes --auth pasted_token and asks for the ` +
+        `${plan.pastedCredential}:`,
+      `  ${plan.tokenCommand}`,
+      '  The console steps for obtaining one are in the setup documentation above.',
+    );
+  }
+
   if (plan.browser) {
     lines.push(
       '',

--- a/src/providers/slack/index.ts
+++ b/src/providers/slack/index.ts
@@ -1,68 +1,116 @@
 import { defineProvider } from '#connectivity';
 import { SLACK_REDACT } from './redact.ts';
+import { SLACK_APP, SLACK_BROKER, SLACK_SCOPES } from './oauth.ts';
 
 /**
  * Slack, through the server Slack runs.
  *
- * The only provider here whose vendor has closed every door but one. Slack's
- * MCP server does not offer Dynamic Client Registration — their documentation
- * says so outright — and a client of your own cannot work either: Slack
- * requires an HTTPS redirect URI, and `connect` listens on `http://127.0.0.1`
- * on a port the kernel picks. There is no proxy, tunnel, or flag that makes a
- * loopback listener HTTPS. A broker would answer it and `defineProvider`
- * refuses one on an mcp connector, because the SDK owns that exchange.
+ * Slack does not offer Dynamic Client Registration and is not going to: it
+ * would let a client authenticate a user without an app existing, and on
+ * Enterprise Grid an admin approves each app first. So a client has to be
+ * pre-registered — and the question this provider used to answer wrongly is
+ * *whose*.
  *
- * What is left is the user token the Slack app mints when you install it, sent
- * as `Authorization: Bearer`. Slack supports that path deliberately; it is the
- * arrangement their own docs describe for a client that cannot register. See
- * ADR-033.
+ * It was the operator's: create an app, transcribe sixteen user-token scopes,
+ * install it, paste the `xoxp-` it mints. That was the honest shape of it only
+ * while the alternative was believed impossible. It was not. Every client that
+ * reaches Slack without a console visit does the same thing — registers one app
+ * and ships its id — and this now does too, with the secret behind the broker
+ * ADR-028 already built for Google and the redirect on a port Slack has been
+ * told about. ADR-040 records what changed and why the reasoning in ADR-033 no
+ * longer holds.
  *
- * Unlike GitHub, this does cost a console visit — creating a Slack app is the
- * only way to get a user token at all, and no amount of implementation work on
- * this side removes it. The setup block is therefore longer than any other here
- * except Google's, and that is the honest shape of it.
+ * The paste is still here, behind `--auth pasted_token`. A workspace whose admin has not
+ * approved the Lanes app cannot use the flow above, and that is not a decision
+ * the person running this command can make.
  */
 export const slack = defineProvider({
   id: 'slack',
   name: 'Slack',
   description: 'Messages, threads, channels, files, and canvases, via Slack\'s official MCP server.',
   connector: { kind: 'mcp', endpoint: 'https://mcp.slack.com/mcp' },
-  auth: { kind: 'bearer' },
   /**
-   * The person, not the workspace, and the distinction is load-bearing.
+   * An mcp connector that names its own endpoints, which is what takes it off
+   * the SDK's flow and onto the one this repository drives.
    *
-   * `settleIdentity` matches a resolved account against existing connections
-   * to decide whether this is a reconnect or a new account. Labelled by
-   * workspace, a second person's token in the same workspace would look like a
-   * reconnect of the first and overwrite their credential. `auth.test` returns
-   * both; `user` is the one that is unique per token.
+   * Not an override of discovery for its own sake — Slack publishes perfectly
+   * good metadata at `/.well-known/oauth-authorization-server` and these two
+   * values are copied from it. It is that the SDK ends its flow by posting to
+   * the token endpoint with the client *it* holds, and the client here is held
+   * by a broker. Declaring the endpoints is how a manifest says the exchange is
+   * ours to route. See `defineProvider` and ADR-040.
+   */
+  auth: {
+    kind: 'oauth',
+    registration: 'manual',
+    app: SLACK_APP,
+    authorize_url: 'https://slack.com/oauth/v2_user/authorize',
+    token_url: 'https://slack.com/api/oauth.v2.user.access',
+    scopes: [...SLACK_SCOPES],
+    broker: SLACK_BROKER,
+    /**
+     * Slack returns no refresh token, and that is the successful answer.
+     *
+     * A user token is long-lived unless token rotation is enabled on the app.
+     * Demanding one here would refuse every connection that worked — the
+     * default exists for Google, where a missing refresh token means the grant
+     * already existed and the connection would die in an hour.
+     */
+    refresh_token: 'optional',
+  },
+  /**
+   * The person *and* the workspace, because either alone collides.
+   *
+   * `settleIdentity` matches a resolved account against existing connections to
+   * decide whether this is a reconnect or a new account, so the string has to
+   * be unique per credential. Neither half of `auth.test` is:
+   *
+   *   - `team` alone — two people in one workspace look like one account, and
+   *     the second connect overwrites the first's token.
+   *   - `user` alone — Slack's "user" is a workspace-scoped handle, so one
+   *     person in two workspaces looks like a reconnect and the second
+   *     workspace overwrites the first. Connecting more than one workspace is
+   *     the ordinary case here, which made this the more likely of the two.
+   *
+   * Together they are unique, and `alice (Acme)` is a row somebody can read.
    *
    * Slack answers a bad token with HTTP 200 and `{ok: false}`, so a wrong token
    * reaches `connect`'s "which account is this?" fallback rather than a clear
    * refusal. Discovery fails loudly one step later, which is where the real
    * error is.
    */
-  identity: { kind: 'http', url: 'https://slack.com/api/auth.test', field: 'user' },
+  identity: {
+    kind: 'http',
+    url: 'https://slack.com/api/auth.test',
+    field: 'user',
+    qualifier: 'team',
+  },
   redact: SLACK_REDACT,
+  /**
+   * Read only by `--auth pasted_token`. The browser route asks for nothing.
+   *
+   * `connection` scope rather than `shared` is what makes `--own-client` refuse
+   * with "no bring-your-own client path", which is true: this asks for a token,
+   * never for a client of the operator's to register.
+   */
   setup: {
     summary:
-      'Slack needs an app of its own — there is no personal access token and no way to register ' +
-      'automatically, because Slack requires an HTTPS callback and this CLI listens on localhost. ' +
-      'You create the app once, install it to your workspace, and paste the user token it mints.',
+      'Slack normally needs nothing set up — one browser round trip against the app Lanes ' +
+      'registered. Pasting a token is the way past a workspace whose admin has not approved ' +
+      'that app, using one from an app the workspace already trusts.',
     docs: 'docs/detailed/setup/slack.md',
     docs_url: 'https://api.slack.com/apps',
     steps: [
-      'Open https://api.slack.com/apps and choose "Create New App" → "From scratch". Name it "Lanes Link" and pick the workspace.',
-      'Open "OAuth & Permissions" and scroll to "Scopes". Add these under USER TOKEN SCOPES — not Bot Token Scopes; the MCP server reads the user token: search:read.public, search:read.private, search:read.im, search:read.mpim, search:read.users, search:read.files, channels:history, groups:history, im:history, mpim:history, channels:read, groups:read, mpim:read, users:read, chat:write, files:read.',
-      'For reactions, canvases, or creating channels, add reactions:write, canvases:read, canvases:write, or channels:write as well. Those tools are listed either way and fail at call time without the scope.',
-      'Scroll up and choose "Install to Workspace", then approve. A Slack admin may have to approve it for you.',
-      'Copy the "User OAuth Token" from the same page. It starts with xoxp- — not the bot token, which starts with xoxb- and will not work here.',
-      'The token does not expire unless you enable token rotation on the app. If you rotate or reinstall, run: lanes link connect slack --replace.',
+      'Open https://api.slack.com/apps and choose "Create New App" → "From scratch". Name it and pick the workspace.',
+      'Open "OAuth & Permissions" and add the scopes you need under USER TOKEN SCOPES — not Bot Token Scopes; the MCP server reads the user token. The full set this provider asks for in the browser is listed in docs/detailed/setup/slack.md.',
+      'Choose "Install to Workspace" and approve. A Slack admin may have to approve it for you.',
+      'Copy the "User OAuth Token". It starts with xoxp- — not the bot token, which starts with xoxb- and will not work here.',
+      'The token does not expire unless you enable token rotation on the app. If you rotate or reinstall, run: lanes link connect slack --profile personal --target local --auth pasted_token --replace.',
     ],
     troubleshooting:
       'Slack refused the token. The usual causes are a bot token (xoxb-) pasted where the user token (xoxp-) belongs, ' +
       'a scope missing from USER TOKEN SCOPES, or an app that was reinstalled since — reinstalling mints a new token. ' +
-      'Copy the User OAuth Token from https://api.slack.com/apps and re-run: lanes link connect slack --replace.',
+      'Copy the User OAuth Token from https://api.slack.com/apps and re-run: lanes link connect slack --profile personal --target local --auth pasted_token --replace.',
     prompts: [
       {
         key: 'token',

--- a/src/providers/slack/oauth.test.ts
+++ b/src/providers/slack/oauth.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, test } from 'bun:test';
+import { slack } from './index.ts';
+import { SLACK_SCOPES, slackBroker } from './oauth.ts';
+
+/**
+ * What has to stay true for Slack to connect without a console visit.
+ *
+ * Each of these was a sentence in ADR-033 explaining why it could not be done,
+ * so each is worth a test rather than a comment: the reasoning that produced
+ * the old shape was sound about Slack and wrong about this repository, and
+ * nothing here should quietly drift back.
+ */
+describe('slackBroker', () => {
+  test('points at the client Lanes operates when nothing overrides it', () => {
+    expect(slackBroker({}).url).toBe('https://api.lanes.sh/v1/auth/link/slack');
+  });
+
+  test('moves the origin and keeps the path', () => {
+    expect(slackBroker({ LANES_LINK_BROKER_ORIGIN: 'http://127.0.0.1:8080' }).url).toBe(
+      'http://127.0.0.1:8080/v1/auth/link/slack',
+    );
+  });
+});
+
+describe('the manifest', () => {
+  const auth = slack.auth.kind === 'oauth' ? slack.auth : undefined;
+
+  test('names its own endpoints, which is what takes it off the SDK flow', () => {
+    // An mcp connector hands the exchange to the SDK unless it declares these,
+    // and the SDK cannot post to a token endpoint with a client a broker holds.
+    // Declaring both is the seam. See ADR-040.
+    expect(slack.connector.kind).toBe('mcp');
+    expect(auth?.authorize_url).toBe('https://slack.com/oauth/v2_user/authorize');
+    expect(auth?.token_url).toBe('https://slack.com/api/oauth.v2.user.access');
+  });
+
+  test('expects no refresh token, because a Slack user token is long-lived', () => {
+    // The default is `required`, which is Google's reading. Demanding one here
+    // would refuse every Slack connection that worked.
+    expect(auth?.refresh_token).toBe('optional');
+  });
+
+  test('names no redirect of its own, because Slack will not take a loopback one', () => {
+    // Verified against a real app: the Redirect URL field rejects a non-HTTPS
+    // value, so the listener cannot be named to Slack at all. The broker
+    // receives the callback and bounces it down, and publishes the URL through
+    // `/config` rather than the manifest writing it down twice.
+    expect(auth).not.toHaveProperty('redirect');
+    expect(auth?.broker?.url).toContain('/v1/auth/link/slack');
+  });
+
+  test('declares no client of its own, because the broker is not optional here', () => {
+    // Google's broker can be skipped by a profile that registers its own
+    // client. Slack's cannot: the broker *is* the HTTPS origin the redirect
+    // needs, so there is no arrangement that completes without it.
+    expect(auth).not.toHaveProperty('client_id');
+  });
+
+  test('asks for user-token scopes in the browser rather than on a setup page', () => {
+    // Sixteen of these used to be a numbered step telling the operator to type
+    // them into a console. Requesting them is what lets `confirmScopes` show
+    // them first — the gate ADR-033 recorded as permanently absent for Slack.
+    expect(auth?.scopes).toEqual([...SLACK_SCOPES]);
+    expect(auth?.scopes).toContain('search:read.public');
+    expect(auth?.scopes).toContain('chat:write');
+  });
+
+  test('keeps a pasted token as the way past a workspace that has not approved us', () => {
+    // Enterprise Grid requires an admin to approve an app before it can
+    // authenticate anyone, and that is not the operator's decision to make.
+    const prompts = slack.setup?.prompts ?? [];
+    expect(prompts.map((prompt) => prompt.key)).toEqual(['token']);
+    expect(prompts[0]?.scope).toBe('connection');
+    expect(prompts[0]?.secret).toBe(true);
+  });
+
+  test('has no bring-your-own-client path, and says so by asking for no client', () => {
+    // `--own-client` refuses on the absence of a `shared` prompt. Slack asks
+    // for a token, never for a client id and secret of the operator's.
+    expect(promptsOfScope('shared')).toEqual([]);
+  });
+});
+
+function promptsOfScope(scope: string): string[] {
+  return (slack.setup?.prompts ?? []).filter((p) => p.scope === scope).map((p) => p.key);
+}

--- a/src/providers/slack/oauth.ts
+++ b/src/providers/slack/oauth.ts
@@ -1,0 +1,103 @@
+import type { AuthBroker } from '#connectivity';
+import { brokerOriginOverride } from '#connectivity/auth/index.ts';
+
+/**
+ * Where Slack's client comes from, and why it cannot come from here.
+ *
+ * Slack refuses Dynamic Client Registration and says so in its documentation.
+ * That is not an omission waiting to be filled: DCR would let a client
+ * authenticate a user without an app existing, and on Enterprise Grid an admin
+ * approves each app before it can authenticate anyone. Waiting for it is
+ * waiting for something that is not coming.
+ *
+ * So somebody has to be pre-registered. Until now that somebody was the
+ * operator, once per person, in a browser tab, transcribing sixteen scopes. It
+ * is this project instead now — one app, registered once, exactly the
+ * arrangement every other client that connects to Slack without a console visit
+ * uses. See ADR-040.
+ */
+export const SLACK_APP = 'slack';
+
+const BROKER_ORIGIN = 'https://api.lanes.sh';
+const BROKER_PATH = '/v1/auth/link/slack';
+
+/**
+ * The client Lanes operates, reached at an origin an override can move.
+ *
+ * Same shape as Google's and for the same reasons — see
+ * `../google/shared/oauth.ts`. What differs is what a broker outage costs.
+ * Slack issues a long-lived user token and no refresh token unless token
+ * rotation is switched on for the app, so this is consulted at `connect` and
+ * never again: an outage here cannot interrupt an agent mid-request the way
+ * ADR-028 warned a shared dependency can. That is the whole of why the fallback
+ * below is a reasonable second answer rather than a necessary one.
+ */
+export function slackBroker(env?: Record<string, string | undefined>): AuthBroker {
+  return {
+    url: `${brokerOriginOverride(env) ?? BROKER_ORIGIN}${BROKER_PATH}`,
+    operator: 'Lanes',
+    docs_url: 'https://lanes.sh/link#slack',
+  };
+}
+
+export const SLACK_BROKER: AuthBroker = slackBroker();
+
+/**
+ * Where Slack sends the browser back — and why it is not this machine.
+ *
+ * Slack refuses to register a Redirect URL that is not HTTPS. Verified against
+ * a real app: the field rejects `http://localhost:<port>/callback` outright, so
+ * a loopback listener cannot be named to Slack at all. A CLI cannot be HTTPS
+ * either — there is no certificate for 127.0.0.1 a browser will accept.
+ *
+ * So the redirect goes to the broker, which bounces it straight down to the
+ * listener `connect` opened, carrying the port in `state`. The URL itself is
+ * not written here: `/config` publishes it, because which one is correct
+ * depends on which deployment answered, and a broker running on loopback for a
+ * test would otherwise need its own spelling of it.
+ *
+ * The cost is that Slack cannot be connected without the broker. Google's is
+ * optional — a profile may register its own client and never call it — and
+ * Slack's is not, because the broker *is* the HTTPS origin. Recorded in
+ * ADR-040, and softened by Slack issuing no refresh token: an outage stops
+ * `connect`, never a connection already made.
+ */
+
+/**
+ * What the browser grant asks for.
+ *
+ * These are user-token scopes: Slack's MCP server reads the user token, and a
+ * bot token is a different credential that does not work there at all. The list
+ * is what the setup page used to ask the operator to transcribe by hand, moved
+ * to where it can be shown before consent instead — which is what restores the
+ * scope-disclosure gate ADR-033 recorded as permanently absent for Slack.
+ *
+ * The last four are what `reactions`, `canvases`, and channel creation need.
+ * They are requested rather than left out because the tools appear in the list
+ * either way and fail at call time without them, and a tool that is visible and
+ * always fails is worse than a scope on the consent screen. What an agent may
+ * actually call is bounded by policy, where `connect` grants read and nothing
+ * else by default.
+ */
+export const SLACK_SCOPES = [
+  'search:read.public',
+  'search:read.private',
+  'search:read.im',
+  'search:read.mpim',
+  'search:read.users',
+  'search:read.files',
+  'channels:history',
+  'groups:history',
+  'im:history',
+  'mpim:history',
+  'channels:read',
+  'groups:read',
+  'mpim:read',
+  'users:read',
+  'chat:write',
+  'files:read',
+  'reactions:write',
+  'canvases:read',
+  'canvases:write',
+  'channels:write',
+] as const;

--- a/src/providers/slack/scopes.ts
+++ b/src/providers/slack/scopes.ts
@@ -1,0 +1,37 @@
+import type { ScopeMeaning } from '../scopes.ts';
+
+/**
+ * Slack's user-token scopes, said in words before the browser opens.
+ *
+ * These used to be sixteen lines of a setup page the operator transcribed into
+ * a console, where nothing described them and nothing could refuse. Asking for
+ * them in a browser is what makes `confirmScopes` apply to Slack at all — the
+ * gate ADR-033 recorded as permanently absent here.
+ *
+ * `broad` is set for the four that reach private conversations and the one that
+ * writes as the person. A grant of `search:read.private` is not "search" in the
+ * sense a reader assumes: it covers every private channel and DM the account
+ * can see, which is usually the most sensitive thing in the workspace.
+ */
+export const SLACK_SCOPE_MEANINGS: Record<string, ScopeMeaning> = {
+  'search:read.public': { meaning: 'search public channels' },
+  'search:read.private': { meaning: 'search private channels', broad: true },
+  'search:read.im': { meaning: 'search direct messages', broad: true },
+  'search:read.mpim': { meaning: 'search group direct messages', broad: true },
+  'search:read.users': { meaning: 'search people in the workspace' },
+  'search:read.files': { meaning: 'search files' },
+  'channels:history': { meaning: 'read messages in public channels' },
+  'groups:history': { meaning: 'read messages in private channels', broad: true },
+  'im:history': { meaning: 'read direct messages', broad: true },
+  'mpim:history': { meaning: 'read group direct messages', broad: true },
+  'channels:read': { meaning: 'list public channels' },
+  'groups:read': { meaning: 'list private channels' },
+  'mpim:read': { meaning: 'list group direct messages' },
+  'users:read': { meaning: 'read people and profiles' },
+  'chat:write': { meaning: 'send messages as you', broad: true },
+  'files:read': { meaning: 'read files and their contents' },
+  'reactions:write': { meaning: 'add and remove reactions as you' },
+  'canvases:read': { meaning: 'read canvases' },
+  'canvases:write': { meaning: 'create and edit canvases' },
+  'channels:write': { meaning: 'create and manage public channels' },
+};

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -371,7 +371,7 @@ export function serve(options: ServeOptions): RunningServer {
   // Cross-origin access, and its absence, are decided here for the same reason
   // `allowedHostnames` and `dashboard` are: they are all properties of what this
   // is bound to. The two are mutually exclusive and the exclusion is the
-  // decision — see `./cors.ts`, and ADR-039.
+  // decision — see `./cors.ts`, and ADR-040.
   const cors: CorsPolicy | undefined = loopback
     ? undefined
     : { allowedOrigins: primary.config.auth.allowed_origins ?? [ANY_ORIGIN] };


### PR DESCRIPTION
`lanes link connect slack` opened with six console steps and sixteen user-token scopes to transcribe into api.slack.com. It is now a browser round trip like every other provider.

Pairs with **[lanes-sh/api#8](https://github.com/lanes-sh/api/pull/8)**, which holds the client secret and serves the redirect.

## What was wrong with the old reasoning

[ADR-033](docs/detailed/adr/033-a-pasted-token-for-an-mcp-server.md) ended with "Slack costs a console visit and always will". Four claims held that up. **Three survive:** Slack refuses DCR (deliberately — it would let a client authenticate someone without an app existing, and Enterprise Grid requires an admin to approve each app); its authorization server advertises `client_secret_post` with no `registration_endpoint`; and **it will not register a callback that is not HTTPS** — tested against a real app, the Redirect URL field rejects `http://localhost:<port>/callback` outright.

The one that fails: **"an mcp connector cannot be brokered, because the SDK owns that exchange and there is no seam."** The seam was already load-bearing — `createMcpConnector` takes an `accessToken` callback and sets a plain bearer header, and at serve time that token comes from `bearerToken()`, never the SDK. The SDK owns only the connect-time exchange, and `authoriseDirect` is a complete flow with a broker hook already in it. What made an MCP provider different was *discovery*, and a manifest naming its own endpoints has nothing left to discover.

## The HTTPS-only redirect, answered with a relay

Slack sends the browser to `https://api.lanes.sh/v1/auth/link/slack/callback`, which 302s down to `http://127.0.0.1:<port>/callback`. The port travels in `state` — opaque to Slack, round-tripped untouched, and already the CSRF binding the CLI checks, so it costs no parameter and nothing remembered anywhere.

Not a reopening of [ADR-025](docs/detailed/adr/025-connecting-an-account-from-a-deployed-endpoint.md): the CLI still starts the flow, opens the browser, receives the code, redeems it, and writes the credential locally. The broker already receives that code at `/exchange` — seeing it one step earlier grants it nothing, and the PKCE verifier never leaves the machine that generated it.

> ⚠️ This makes Slack's broker **not optional** the way Google's is. It is not merely where the secret lives, it is the HTTPS origin the redirect needs. `connect slack` fails when it is down — though already-connected accounts are unaffected, because Slack issues no refresh token and nothing goes back afterwards.

## What changed

- An `mcp` connector may declare `auth.broker` **provided it declares `authorize_url` and `token_url`**. Half-declared is refused at definition. Notion, Linear, and Google's two MCP servers name neither and are untouched.
- `runOAuthFlow` takes `relayRedirect`; the listener is unchanged and still binds a kernel-chosen port.
- `auth.refresh_token: 'optional'` — a Slack user token is long-lived and carries none. `settle()` used to throw on that, naming Google unconditionally.
- `directExchange` no longer requires a client secret, and sends no field rather than an empty one.
- The pasted token becomes a fourth route in ADR-038's chooser: `--auth pasted_token`. Same ref, same blob shape, so nothing downstream learns there are two paths. It stays because an Enterprise Grid admin decides whether the Lanes app may authenticate anyone, and that is not the operator's call.

**Slack's scope gate exists now**, which ADR-033 recorded as permanently absent — the twenty scopes moved into the manifest, seven flagged broad.

## A bug this branch introduced, then found

Slack's `auth.test` calls the handle `user`, and that handle is **workspace-scoped**. The same person in two workspaces answered with the same string, and one account string is exactly how `settleIdentity` decides a connect is a *reconnect* — so connecting a second workspace matched the first and silently overwrote its credential. Connecting more than one workspace is the ordinary case here, which made it the likelier of the two collisions the original comment was reasoning about.

Fixed with `identity.qualifier`: a second dotted path, shown in brackets — `alice (Acme)` / `alice (Beta)`, ids `alice_acme` and `alice_beta`.

## Scaffolding built and then removed

A fixed loopback port, `auth.redirect`, `refusePortInUse`, and a shipped `client_id` with its own client kind were all built on the assumption that a registered loopback URL works — the evidence for which was Anthropic's Slack app, which has `http://localhost:3118/callback` registered and distributed. Whatever exception that app enjoys is not available by registering an app today. All of it is gone. The narrow lesson, recorded in the ADR: an observed working configuration is evidence about *that* configuration, not about what the console will let you create.

Recorded but no longer guarded: **`Bun.serve` does not refuse a port another listener holds** — not in one process, not across two, not with `reusePort: false`. A live hazard for anything here that pins a port again.

## Housekeeping this touched rather than chose

`hasClientPrompts` existed twice under two names in two components and this needed it a third time — now `hasOwnClientPath` in the manifest component. Two files split along the size budget's seams. The ADR index was missing its 038 row.

## Not in this PR

`/v1/auth/link/slack` on the Lanes API. Until it exists `connect slack` has no client and `--auth pasted_token` is the working route.

## Verification

`bun test` 1917 pass / 0 fail, `bun run typecheck` clean. Exercised end to end against api#8 running locally with a stand-in Slack: `/config` publishes the relay, the CLI names it as `redirect_uri` and puts its port in `state`, the relay 302s to the listener, the exchange goes through the broker with Basic auth and the PKCE verifier, and the nested scope arrives lifted to the top level with no refresh token and no expiry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)