### PR TITLE
Answer a CORS preflight instead of refusing it for want of a credential

### DIFF
--- a/docs/detailed/adr/039-cross-origin-access-is-a-deployment-only-grant.md
+++ b/docs/detailed/adr/039-cross-origin-access-is-a-deployment-only-grant.md
@@ -1,0 +1,135 @@
+# ADR-039: Cross-origin access is a deployment-only grant, and a preflight is never refused for want of a credential
+
+**Status:** accepted · **Follows from** [ADR-018](018-the-gate-is-in-the-application.md) ·
+**Constrained by** the loopback guard in `src/server/rebinding.ts`
+
+## Context
+
+This endpoint had no CORS handling of any kind. No `Access-Control-*` header was ever sent and no
+`OPTIONS` was ever handled, so a preflight fell past the discovery routes to the bearer gate and was
+answered with a `401`.
+
+That is not a strict policy. It is a category error, and the reason is in the CORS specification
+rather than in anything here: a preflight is sent with credentials stripped. No `Authorization`
+header, no cookie, by construction. So gating one behind the credential check refuses every
+browser-origin client *before* it has any opportunity to present the credential the refusal is
+asking it for. There is no client behaviour that recovers from it, and nothing in the response says
+what happened — the browser reports a CORS failure, and the endpoint's log records a rejected
+request with `reason: missing`, which is exactly what it records for an ordinary unauthenticated
+call.
+
+The gap survived because nothing had asked. Every client `docs/clients.md` names connects from a
+server: `claude mcp add` and Codex are local processes, and a claude.ai or ChatGPT connector performs
+its fetches in the vendor's backend, not in the page. A browser-origin MCP client is the case nobody
+had, so the missing header was never the reason for a failure anyone reported.
+
+## Decision
+
+**Answer a preflight, and answer it before the auth gate.** `204`, carrying whatever grant applies,
+and never a `401`.
+
+**The wrapper goes at `serve()`, not in the router.** That is where the policy is decided, and the
+two belong together: cross-origin access is a property of the address this endpoint is bound to,
+exactly as `allowedHostnames` and the dashboard are. Three lines in one function, all derived from
+the same `loopback`, rather than an invariant spread across two files.
+
+It is also what makes the ordering safe. A preflight answered in the wrapper never reaches the
+rebinding guard inside the router — and does not need to, because a policy exists only off loopback,
+which is precisely where that guard is inert. Wrapping inside the router instead would have meant
+hoisting the guard out to keep it first, and a reader would then have had to hold both files at once
+to see why the order was right.
+
+**Only for a routable deployment. Never on loopback.** This is the part worth recording, because it
+looks like an omission and is a constraint.
+
+`src/server/rebinding.ts` already answers the browser question for a local endpoint, and answers it
+*no*. `rebindingRefusal` validates `Origin` as well as `Host`, and the note there states the threat
+precisely: an endpoint on `127.0.0.1` is reachable by any page its owner happens to be visiting, and
+what such a page reaches is everything that answers before authentication — `/health`, the discovery
+documents, `/register`, and the `/authorize` consent form **that asks the owner for their token**.
+
+A CORS grant and an `Origin` refusal on the same request are two answers to one question. So the
+policy is built only for a host that is not loopback, and no configuration can override that: the
+field described below is read, and then discarded, for a loopback bind. A reader who later notices
+that `lanes link start` cannot be given an allowed origin should read this paragraph rather than
+close the gap.
+
+**Within a deployment, the default grant is `*`, and there is no setup step.**
+
+| Paths | Grant | Why |
+|---|---|---|
+| the authorization surface — both discovery documents, `/register`, `/token`, `/authorize` | `*`, always | unauthenticated by design; that is what makes discovery work at all. Never narrowed, because a client that cannot read these cannot find out that it needs a token |
+| `/mcp`, `/attachments` | `*` unless `auth.allowed_origins` names origins | see below |
+| `/health`, `/reload`, the dashboard | nothing | no browser client needs them, and where the answer is not obvious the cheaper mistake is refusing |
+
+**The wildcard on the credentialed surface is the decision worth arguing, so here is the argument.**
+An allowlist there was the first design, and default deny made it feel obviously right. What it
+actually bought was a required setup step per user in exchange for narrowing a surface that was not
+exposed. Three things are true together on a deployment:
+
+1. **It is already reachable by anyone.** `access: public` is what a connector needs (ADR-018), so
+   any server on the internet can post to `/mcp` today and read the refusal. CORS never gated
+   *sending* — it gates whether a *page* may read the reply, and an attacker with a server needs no
+   page. The only thing a hostile page adds is the victim's IP address.
+2. **The credential is never ambient.** It is an `Authorization` header a page must already possess,
+   never a cookie a browser attaches on its own. So what a hostile page gains is an unauthenticated
+   request, and what it learns from reading the answer is a `401` available from anywhere.
+3. **`Access-Control-Allow-Credentials` is never sent, and with `*` cannot be** — the specification
+   refuses the combination outright. The one header that would make a wildcard dangerous is
+   unreachable from here rather than merely omitted.
+
+So the wildcard grants a browser exactly what `curl` already has. Naming origins still narrows, for
+anyone who wants it; absent means `*`, because a default nobody can skip is a default that is wrong.
+
+**None of that holds on loopback**, which is the other half of why loopback has no policy. There the
+endpoint is *not* publicly reachable, and public reachability is the premise the whole argument above
+rests on — a page reaching `127.0.0.1` is stealing exactly the thing a deployment has already given
+away.
+
+**`WWW-Authenticate` is exposed.** Without it a browser client receives the `401` and cannot read the
+`resource_metadata` pointer inside it — which is the whole discovery handshake ADR-036 exists to
+make work. A refusal a client cannot read the recovery from is the failure mode that ADR reversed,
+arriving by a different route. `Retry-After` is exposed for the same reason on the rate-limit
+refusal.
+
+**Where an allowlist *is* configured, an unlisted origin gets `204` with no grant, not a `403`.** The
+browser refuses the call on the absence of the header, which is the mechanism CORS actually uses; a
+distinct status would let a page map which paths exist without being allowed to call any of them. A
+listed origin is echoed rather than answered with `*`, so `Vary: Origin` goes with it — a shared cache
+would otherwise hand one origin's grant to another.
+
+## Consequences
+
+**Nothing changes for any client that exists today.** A caller sending no `Origin` — every local
+registration, every SDK, `curl` — gets byte-identical responses, because the grant is computed only
+when there is an origin to grant to. That is the whole of the compatibility claim: a deployment's
+`/mcp` *does* now answer a page that asks, which is the point.
+
+**An origin is not a permission.** Being allowed to *attempt* a call is all this decides; what a
+caller may do if it obtains a credential is still decided per capability, per call, by the profile's
+policy. Worth stating because "allowed origin" reads like an authorization concept and is not one —
+and because the wildcard would be alarming if it were one.
+
+**A leaked token is usable from a browser now, where before it needed a server.** That is the real
+cost of the wildcard, stated plainly. It is an amplification rather than a new capability — a token
+that has escaped is already usable from anywhere — and the alternative bought protection against it
+only for the users who completed a setup step, which is not the users who leak tokens.
+
+**The header list is fixed rather than reflected.** `Access-Control-Request-Headers` is not echoed
+back, because echoing grants whatever was asked for and this endpoint knows which headers it reads.
+The cost is that adding a header the endpoint reads means adding it in `cors.ts` too, and forgetting
+fails in the browser only — which is why the list names the envelope's `mcp-method` and `mcp-name`
+with the reason attached.
+
+**A `0.0.0.0` bind now behaves differently from `127.0.0.1`.** It always did — `allowedHostnamesFor`
+returns nothing for it, so the rebinding guard is already off — and this makes the difference wider
+by making CORS available there. That asymmetry is inherent to what the guard protects rather than new
+here, but it is now a second consequence of the same choice of bind address.
+
+## What this does not do
+
+**It does not make this endpoint usable from a browser.** It removes the reason it could not be. A
+page still needs a credential, and the only paths to one are an owner pasting a token or completing
+the authorization flow — neither of which a page can do on its own behalf.
+
+**It does not add CORS to the stdio surface**, which has no origin, no headers, and no browser.

--- a/docs/detailed/adr/README.md
+++ b/docs/detailed/adr/README.md
@@ -45,6 +45,8 @@ Nothing in the codebase depends on it.
 | [035](035-a-replayed-refresh-token-must-not-log-the-owner-out.md) | A replayed refresh token is refused on its own and recorded; the family it belongs to survives |
 | [036](036-a-client-is-told-this-endpoint-keeps-it-signed-in.md) | `offline_access` is advertised and granted, a rejected credential is told `invalid_token`, and scope is narrowed rather than echoed |
 | [037](037-a-command-names-what-it-acts-on.md) | A command names its profile and target as flags, or it does not run; the environment variables and config defaults are parsed and no longer read |
+| [038](038-a-key-is-the-second-way-into-an-account.md) | A service account key is a second way into a Google account, for the consent nobody can give a background job |
+| [039](039-cross-origin-access-is-a-deployment-only-grant.md) | Cross-origin access is granted only by a deployment, and a preflight is answered ahead of the credential check |
 
 Where an ADR departs from init.md, it says so at the top. Three are significant:
 

--- a/docs/detailed/configuration.md
+++ b/docs/detailed/configuration.md
@@ -58,6 +58,10 @@ targets:
 auth:
   mode: bearer
   token_ref: profile/token
+  # Browser origins allowed to call /mcp. Absent means "*", so this is only
+  # worth setting to narrow it. Deployment only — a loopback endpoint refuses
+  # every cross-origin request, and this cannot widen that. ADR-039.
+  allowed_origins: ['*']
 
 limits:
   requests_per_minute: 120        # per profile

--- a/docs/detailed/deployment-cloudrun.md
+++ b/docs/detailed/deployment-cloudrun.md
@@ -438,6 +438,36 @@ $ curl -s https://…run.app/.well-known/oauth-protected-resource | jq
 $ curl -s https://…run.app/.well-known/oauth-authorization-server | jq
 ```
 
+### Calling it from a browser
+
+Nothing to configure. A deployment answers a cross-origin request from any page, because there is
+nothing for an allowlist to defend: the endpoint is already reachable by anyone, the credential is an
+`Authorization` header a page must already hold rather than a cookie a browser attaches on its own,
+and `Access-Control-Allow-Credentials` is never sent.
+
+To narrow it anyway — an enterprise deployment might — name the origins:
+
+```yaml
+auth:
+  mode: bearer
+  token_ref: profile/token
+  allowed_origins:
+    - https://app.example
+```
+
+An origin exactly: scheme, host, and port, with no trailing slash and no path. A browser sends
+`Origin: https://app.example`, and a configured `https://app.example/` compares unequal and would
+refuse the origin you believed you had allowed — so the config refuses it up front rather than at
+request time. The discovery documents are never narrowed by this; a client that cannot read them
+cannot find out that it needs a token.
+
+Two things it does not do. It grants no capability: what a caller may do once it holds a credential is
+decided by `policy`, per call, exactly as for every other client. And it does nothing at all for
+`lanes link start` — a loopback endpoint refuses every cross-origin request and must keep doing so,
+because a page you happen to be visiting can otherwise reach `127.0.0.1`, including the consent form
+that asks you for your token. The field is read and discarded there. See
+[ADR-039](adr/039-cross-origin-access-is-a-deployment-only-grant.md).
+
 ### Using an identity provider you already run
 
 `mode: oidc` points the same handshake at somebody else's authorization server and reduces this

--- a/src/profile/primitives.ts
+++ b/src/profile/primitives.ts
@@ -1,7 +1,7 @@
 import { z } from 'zod';
 
 /**
- * The three string shapes the config contract is built out of.
+ * The four string shapes the config contract is built out of.
  *
  * Their own file because more than one schema module needs them, and the
  * alternative was either a circular import or a second copy of a regex that
@@ -43,3 +43,26 @@ export const capabilityPattern = z
     /^(?:\*|[a-z][a-z0-9_]*\.(?:\*|[A-Za-z0-9][A-Za-z0-9_-]*(?:\.[A-Za-z0-9][A-Za-z0-9_-]*)*(?:\.\*)?))$/,
     'must be "*", "gmail.*", "gmail.users.*", or "gmail.users.drafts.send"',
   );
+
+/**
+ * A browser origin, exactly — scheme, host, and port, with nothing after it. Or
+ * `*`, which is what an absent list means anyway and is accepted so that saying
+ * it explicitly is not an error.
+ *
+ * Checked by round trip rather than by a regex, because `URL` already knows what
+ * an origin is and the failure this catches is a trailing slash or a path that
+ * looks harmless and matches nothing: a browser sends `Origin: https://x.example`
+ * and a configured `https://x.example/` would compare unequal, silently refusing
+ * the origin its owner believed they had allowed.
+ */
+export const browserOrigin = z.string().refine(
+  (value) => {
+    if (value === '*') return true;
+    try {
+      return new URL(value).origin === value;
+    } catch {
+      return false;
+    }
+  },
+  'must be "*" or an origin with no trailing slash or path, e.g. "https://chat.example"',
+);

--- a/src/profile/schema.ts
+++ b/src/profile/schema.ts
@@ -1,5 +1,5 @@
 import { z } from 'zod';
-import { capabilityPattern, credentialRef, identifier } from './primitives.ts';
+import { browserOrigin, capabilityPattern, credentialRef, identifier } from './primitives.ts';
 import { authorizationSchema } from './authorization.ts';
 
 /**
@@ -349,6 +349,15 @@ export const configSchema = z.object({
        * get one. Omitting it leaves every existing profile behaving identically.
        */
       authorization: authorizationSchema.optional(),
+      /**
+       * Browser origins that may call a *deployment's* MCP endpoint. Absent
+       * means `*`, so naming any is a narrowing and nothing needs setting.
+       *
+       * A deployment only, and this cannot widen that: a loopback endpoint
+       * refuses every cross-origin request and must keep doing so. Why the
+       * default is a wildcard is `src/server/cors.ts` and ADR-039.
+       */
+      allowed_origins: z.array(browserOrigin).optional(),
     })
     .default({ mode: 'bearer', token_ref: 'profile/token' }),
 

--- a/src/server/cors.test.ts
+++ b/src/server/cors.test.ts
@@ -1,0 +1,228 @@
+import { afterAll, describe, expect, test } from 'bun:test';
+import { BearerAuthenticator } from '#auth';
+import { allocatePort, startHarness, wireProfiles, TEST_TOKEN } from './harness.ts';
+import { createRequestHandler, MCP_PATH } from './index.ts';
+import { ATTACHMENTS_PATH } from './attachments.ts';
+import { ANY_ORIGIN, corsAware } from './cors.ts';
+import { Generations } from './generations.ts';
+import { silentLogger } from './logging.ts';
+
+/**
+ * Who may call this endpoint from a browser.
+ *
+ * The loopback half is over real HTTP, because that is the half with a wrong
+ * answer available: an endpoint on `127.0.0.1` must refuse a cross-origin caller
+ * however the request is dressed, and the guard doing it lives in the same
+ * router as the grant.
+ *
+ * The deployed half is a handler rather than a socket, and the reason is a
+ * tradeoff worth stating. Reaching `serve`'s non-loopback branch means binding a
+ * non-loopback address, which in practice means `0.0.0.0` — a listener on every
+ * interface, and on macOS a firewall prompt, every time anyone runs `bun test`.
+ * What that would buy over the handler is the socket alone: the request, the
+ * response, the header values and the position of the preflight relative to the
+ * auth gate are all exercised below.
+ */
+
+const ORIGIN = 'https://chat.example';
+
+/** Loopback, so `serve` builds no policy at all. */
+const local = startHarness({
+  profile: 'personal',
+  port: allocatePort(),
+  policy: `  allow:\n    - "example.*"`,
+});
+
+afterAll(async () => {
+  await local.stop();
+});
+
+/**
+ * A handler wired as a deployment: no `allowedHostnames`, and a policy.
+ *
+ * Composed exactly as `serve()` composes it off loopback — the same wrapper over
+ * the same router — so what differs from a real endpoint is the socket and
+ * nothing else. `wireProfiles` is the wiring `startHarness` uses.
+ */
+function deployed(allowedOrigins: readonly string[]): (request: Request) => Promise<Response> {
+  const { profiles, credentials } = wireProfiles({
+    profile: 'personal',
+    port: allocatePort(),
+    policy: `  allow:\n    - "example.*"`,
+  });
+
+  const nothing = () => Promise.resolve();
+  const log = silentLogger();
+
+  const handler = createRequestHandler({
+    generations: new Generations(
+      { profiles, close: nothing },
+      async () => ({ profiles, close: nothing }),
+      { primary: 'personal', log },
+    ),
+    primary: 'personal',
+    authenticator: new BearerAuthenticator({
+      profile: 'personal',
+      tokenRef: 'profile/token',
+      credentials,
+    }),
+    log,
+  });
+
+  return corsAware((request) => handler.fetch(request), [MCP_PATH, ATTACHMENTS_PATH], {
+    allowedOrigins,
+  });
+}
+
+const preflight = (path: string, origin = ORIGIN): Request =>
+  new Request(`http://endpoint.example${path}`, {
+    method: 'OPTIONS',
+    headers: {
+      origin,
+      'access-control-request-method': 'POST',
+      'access-control-request-headers': 'authorization,content-type',
+    },
+  });
+
+describe('a deployment answers a preflight', () => {
+  test('without a credential, which is the only way one ever arrives', async () => {
+    const response = await deployed([ANY_ORIGIN])(preflight(MCP_PATH));
+
+    // The bug this whole file exists for: 401 here refuses every browser client
+    // before it can present the credential the refusal is asking for.
+    expect(response.status).toBe(204);
+    expect(response.headers.get('access-control-allow-origin')).toBe(ANY_ORIGIN);
+    expect(response.headers.get('www-authenticate')).toBeNull();
+  });
+
+  test('for any origin, because that is what an unset allowlist means', async () => {
+    // The default, and the reason there is no setup step: a deployment is
+    // already reachable by anyone, and the credential is never ambient.
+    const response = await deployed([ANY_ORIGIN])(preflight(MCP_PATH, 'https://unknown.example'));
+    expect(response.headers.get('access-control-allow-origin')).toBe(ANY_ORIGIN);
+  });
+
+  test('and a wildcard does not claim to vary, which would poison a cache', async () => {
+    const response = await deployed([ANY_ORIGIN])(preflight(MCP_PATH));
+    expect(response.headers.get('vary')).toBeNull();
+  });
+
+  test('naming the headers this endpoint actually reads', async () => {
+    const response = await deployed([ANY_ORIGIN])(preflight(MCP_PATH));
+    const allowed = response.headers.get('access-control-allow-headers') ?? '';
+
+    // `authorization` because the credential is one, and the envelope's two
+    // because a call carrying neither is served as a 2025-era request instead.
+    expect(allowed).toContain('authorization');
+    expect(allowed).toContain('mcp-method');
+    expect(allowed).toContain('mcp-name');
+  });
+
+  test('and never claims credentials may be attached', async () => {
+    // The one header that would make the wildcard dangerous, and with `*` the
+    // specification refuses the combination anyway.
+    const response = await deployed([ANY_ORIGIN])(preflight(MCP_PATH));
+    expect(response.headers.get('access-control-allow-credentials')).toBeNull();
+  });
+});
+
+describe('naming origins narrows it', () => {
+  test('echoing a listed one, and varying so no cache crosses them', async () => {
+    const response = await deployed([ORIGIN])(preflight(MCP_PATH));
+
+    expect(response.headers.get('access-control-allow-origin')).toBe(ORIGIN);
+    expect(response.headers.get('vary')).toBe('Origin');
+  });
+
+  test('and granting nothing to one that is not listed', async () => {
+    const response = await deployed([ORIGIN])(preflight(MCP_PATH, 'https://other.example'));
+
+    // 204 rather than 403: the browser refuses on the absent header, which is
+    // the mechanism CORS uses, and a distinct status would map which paths exist.
+    expect(response.status).toBe(204);
+    expect(response.headers.get('access-control-allow-origin')).toBeNull();
+  });
+
+  test('but never narrows discovery, which a client reads before it has anything', async () => {
+    const response = await deployed([ORIGIN])(
+      preflight('/.well-known/oauth-protected-resource', 'https://other.example'),
+    );
+
+    expect(response.headers.get('access-control-allow-origin')).toBe(ANY_ORIGIN);
+  });
+});
+
+describe('the discovery surface needs no allowlist', () => {
+  test('because it answers without a credential either way', async () => {
+    const response = await deployed([])(
+      preflight('/.well-known/oauth-protected-resource', 'https://anyone.example'),
+    );
+
+    expect(response.status).toBe(204);
+    expect(response.headers.get('access-control-allow-origin')).toBe('*');
+    // A wildcard cannot vary, and saying it does would poison a shared cache.
+    expect(response.headers.get('vary')).toBeNull();
+  });
+
+  test('and /health is in neither half, so it is granted nothing', async () => {
+    const response = await deployed([ANY_ORIGIN])(preflight('/health'));
+    expect(response.headers.get('access-control-allow-origin')).toBeNull();
+  });
+});
+
+describe('a real response carries the grant too', () => {
+  test('including the 401, whose challenge is the whole handshake', async () => {
+    const response = await deployed([ANY_ORIGIN])(
+      new Request(`http://endpoint.example${MCP_PATH}`, {
+        method: 'POST',
+        headers: { origin: ORIGIN, 'content-type': 'application/json' },
+        body: '{}',
+      }),
+    );
+
+    expect(response.status).toBe(401);
+    expect(response.headers.get('access-control-allow-origin')).toBe(ANY_ORIGIN);
+    // Without this a browser client receives the refusal and cannot read the
+    // `resource_metadata` pointer telling it what to do about it (ADR-036).
+    expect(response.headers.get('access-control-expose-headers')).toContain('WWW-Authenticate');
+  });
+
+  test('and a non-browser caller sees exactly what it saw before', async () => {
+    const response = await deployed([ANY_ORIGIN])(
+      new Request(`http://endpoint.example${MCP_PATH}`, { method: 'POST', body: '{}' }),
+    );
+
+    // No Origin, so nothing to grant and no header invented for it.
+    expect(response.headers.get('access-control-allow-origin')).toBeNull();
+    expect(response.headers.get('www-authenticate')).toContain('realm="lanes-link"');
+  });
+});
+
+describe('a loopback endpoint grants nothing, ever', () => {
+  test('refusing a cross-origin preflight rather than answering it', async () => {
+    const response = await fetch(`${local.server.url}`, {
+      method: 'OPTIONS',
+      headers: { origin: ORIGIN, 'access-control-request-method': 'POST' },
+    });
+
+    // `./rebinding.ts` has already answered this question, and answered it no:
+    // a page the owner is visiting can reach 127.0.0.1, and what it would reach
+    // includes the form that asks them for their token.
+    expect(response.headers.get('access-control-allow-origin')).toBeNull();
+    expect(response.status).toBe(403);
+  });
+
+  test('and a same-origin caller is unaffected', async () => {
+    const response = await fetch(`${local.server.url}`, {
+      method: 'POST',
+      headers: {
+        authorization: `Bearer ${TEST_TOKEN}`,
+        'content-type': 'application/json',
+        accept: 'application/json, text/event-stream',
+      },
+      body: JSON.stringify({ jsonrpc: '2.0', id: 1, method: 'tools/list', params: {} }),
+    });
+
+    expect(response.status).toBe(200);
+  });
+});

--- a/src/server/cors.ts
+++ b/src/server/cors.ts
@@ -1,0 +1,252 @@
+import { isAuthorizationPath } from './oauth.ts';
+
+/**
+ * Cross-origin access, for a routable deployment and nothing else.
+ *
+ * A preflight carries no credentials, by construction rather than by omission:
+ * the CORS specification strips them, so `OPTIONS` arrives with no
+ * `Authorization` header and no cookie. Answering it from behind the bearer gate
+ * therefore refuses every browser-origin client *before* it has any opportunity
+ * to present one — which is what this endpoint did until this file existed, and
+ * it is a category error rather than a policy.
+ *
+ * **Never on loopback.** `./rebinding.ts` already answers that question, and
+ * answers it no: a cross-origin `Origin` on a request to `127.0.0.1` is refused
+ * outright, because a page the owner happens to be visiting can otherwise reach
+ * everything that answers before authentication — including the `/authorize`
+ * form that asks them for their token. A CORS grant and an `Origin` refusal on
+ * the same request are two answers to one question. So `serve` builds a policy
+ * only for a host that is not loopback, and nothing in this file decides that:
+ * it is decided by whether a policy exists at all.
+ */
+
+/**
+ * Two halves, because what is already public and what carries the credential
+ * differ in what a grant costs.
+ *
+ * The public half is the authorization surface: readable without a credential by
+ * design, so a wildcard adds no reach a `curl` did not already have. It includes
+ * `/authorize`, which needs no grant at all — a top-level navigation, not a
+ * fetch — because `isAuthorizationPath` is one predicate that already exists and
+ * a second list of five paths would be a second thing to drift.
+ *
+ * `/health` and `/reload` are in neither half. No browser client needs them, and
+ * where the answer is not obvious default deny is the cheaper mistake.
+ */
+export type CorsSurface = 'public' | 'credentialed';
+
+export interface CorsPolicy {
+  /**
+   * Origins that may call the credentialed surface. `['*']` is the default.
+   *
+   * A wildcard, and not because narrowing was too much work — because on a
+   * deployment there is nothing left for it to defend. Three things have to be
+   * true together, and here they are:
+   *
+   * 1. **The endpoint is already reachable by anyone.** `access: public` is what
+   *    a connector needs, so any server on the internet can post to `/mcp` and
+   *    read the refusal today. CORS never gated *sending*; it gates whether a
+   *    *page* may read the reply. An attacker with a server needs no page.
+   * 2. **The credential is never ambient.** It is an `Authorization` header a
+   *    page must already possess, never a cookie a browser attaches on its own.
+   *    So the request a hostile page gains is an unauthenticated one, and what
+   *    it gains from reading the answer is a `401` it could have had from
+   *    anywhere.
+   * 3. **`Access-Control-Allow-Credentials` is never sent** — and with `*` it
+   *    cannot be: the specification refuses the combination outright. The one
+   *    header that would make a wildcard dangerous is unreachable from here.
+   *
+   * What an allowlist bought, then, was a required setup step per user in
+   * exchange for narrowing a surface that was not exposed. Naming origins is
+   * still possible and still narrows — an enterprise deployment may want it —
+   * but absent means `*`, because a default nobody can skip is a default that
+   * is wrong.
+   *
+   * None of this holds on loopback, which is why loopback has no policy at all.
+   * There the endpoint is *not* publicly reachable, and that is precisely what
+   * a page reaching `127.0.0.1` would be stealing.
+   */
+  readonly allowedOrigins: readonly string[];
+}
+
+/** The default, and what an absent `auth.allowed_origins` resolves to. */
+export const ANY_ORIGIN = '*';
+
+/**
+ * What a browser is allowed to send.
+ *
+ * The list is fixed rather than reflected from `Access-Control-Request-Headers`,
+ * because reflecting it grants whatever was asked for and the answer to "which
+ * headers does this endpoint read" is knowable here. These are they: the
+ * credential, the 2026-07-28 envelope's method and target, the client label the
+ * audit log records, and the session and resumption headers the MCP SDK sends.
+ */
+const ALLOW_HEADERS = [
+  'authorization',
+  'content-type',
+  'mcp-session-id',
+  'mcp-protocol-version',
+  'mcp-method',
+  'mcp-name',
+  'x-mcp-client',
+  'last-event-id',
+].join(', ');
+
+/**
+ * What a browser is allowed to read back.
+ *
+ * `WWW-Authenticate` is the load-bearing one: it carries `resource_metadata`,
+ * which is the whole discovery handshake (ADR-036). Without it a browser client
+ * receives the `401` and cannot see the pointer that tells it what to do next,
+ * which looks exactly like an endpoint that refuses for no reason.
+ *
+ * `Retry-After` for the same reason on the other refusal — `edge.ts` sends one
+ * with a `429` and a caller that cannot read it can only guess when to retry.
+ */
+const EXPOSE_HEADERS = ['WWW-Authenticate', 'Mcp-Session-Id', 'Retry-After'].join(', ');
+
+/**
+ * Which half a path belongs to, or neither.
+ *
+ * The authorization surface answers without a credential by design, so a
+ * wildcard there hands a page what `curl` already has. Everything else is either
+ * named by the caller as credentialed or gets nothing at all.
+ */
+function surfaceOf(pathname: string, credentialed: readonly string[]): CorsSurface | undefined {
+  if (isAuthorizationPath(pathname)) return 'public';
+  return credentialed.includes(pathname) ? 'credentialed' : undefined;
+}
+
+/** POST for calls, GET for the SSE stream, DELETE to end a session. */
+const ALLOW_METHODS = 'GET, POST, DELETE, OPTIONS';
+
+/** A day. A preflight per call is the cost of getting this wrong. */
+const MAX_AGE = '86400';
+
+/**
+ * The value for `Access-Control-Allow-Origin`, or `null` to grant nothing.
+ *
+ * A listed origin is echoed rather than answered with `*`, because a list is a
+ * narrowing and `*` would discard it. That is also why the wildcard and the echo
+ * cannot share a branch: they differ in whether the answer varies by caller, and
+ * `Vary` has to follow.
+ */
+function grantFor(request: Request, surface: CorsSurface, policy: CorsPolicy): string | null {
+  if (surface === 'public') return ANY_ORIGIN;
+  if (policy.allowedOrigins.includes(ANY_ORIGIN)) return ANY_ORIGIN;
+
+  const origin = request.headers.get('origin');
+  return origin && policy.allowedOrigins.includes(origin) ? origin : null;
+}
+
+/**
+ * The headers to add to a response, or `undefined` for nothing to add.
+ *
+ * Nothing is added when the request carries no `Origin`, which is every
+ * non-browser client: there is no origin to grant, and a header naming one
+ * would be an invention. That is also what keeps `curl` output identical to what
+ * it was.
+ */
+function corsHeaders(
+  request: Request,
+  surface: CorsSurface,
+  policy: CorsPolicy,
+): Record<string, string> | undefined {
+  const origin = request.headers.get('origin');
+  if (!origin) return undefined;
+
+  const allowed = grantFor(request, surface, policy);
+  if (!allowed) return undefined;
+
+  return {
+    'access-control-allow-origin': allowed,
+    'access-control-allow-methods': ALLOW_METHODS,
+    'access-control-allow-headers': ALLOW_HEADERS,
+    'access-control-expose-headers': EXPOSE_HEADERS,
+    'access-control-max-age': MAX_AGE,
+    // Only meaningful where the value varies, and harmful to omit there: a
+    // shared cache would otherwise hand one origin's grant to another.
+    ...(allowed === ANY_ORIGIN ? {} : { vary: 'Origin' }),
+  };
+}
+
+/**
+ * The answer to a preflight: `204`, with the grant or without it.
+ *
+ * Without it for an origin that is not allowed, rather than a `403` — the
+ * browser refuses the call on the absence of the header, which is the mechanism
+ * CORS actually uses, and a distinct status would tell a probing page which
+ * paths exist. Never a `401`: see the note at the top of this file.
+ *
+ * `Access-Control-Allow-Credentials` is absent from both, deliberately and
+ * everywhere. The credential here is a header a page cannot obtain, never a
+ * cookie a browser would attach on its own, so the wildcard above grants
+ * nothing without it — and sending it is what would turn that wildcard into a
+ * hole.
+ */
+function preflightResponse(headers: Record<string, string> | undefined): Response {
+  return new Response(null, { status: 204, headers: headers ?? {} });
+}
+
+/**
+ * The same response, carrying the grant.
+ *
+ * Rebuilt rather than mutated: a `Response` the MCP SDK returns may carry an
+ * immutable header guard, and `body` is a stream that survives being passed
+ * through. A `204` or `304` has a null body already, so this is safe for those
+ * too.
+ */
+function withCors(response: Response, headers: Record<string, string>): Response {
+  const merged = new Headers(response.headers);
+  for (const [name, value] of Object.entries(headers)) merged.set(name, value);
+
+  return new Response(response.body, {
+    status: response.status,
+    statusText: response.statusText,
+    headers: merged,
+  });
+}
+
+/**
+ * The same handler, with cross-origin requests answered.
+ *
+ * A wrapper rather than six branches in the router, for the reason `./oauth.ts`
+ * is its own file: `index.ts` gains a delegation instead of the whole of this
+ * behaviour, and it stays inside the size budget that would otherwise be the
+ * rule relaxed to fit this in.
+ *
+ * Wrapped at `serve()` rather than inside the router, which is also where the
+ * policy is decided: cross-origin access is a property of the address this is
+ * bound to, exactly as `allowedHostnames` and the dashboard are, and putting all
+ * three in one function is what makes the loopback exclusion legible instead of
+ * an invariant spread across two files.
+ *
+ * It is what makes the ordering safe, too. A preflight answered here never
+ * reaches the rebinding guard inside `inner` — and does not need to, because a
+ * policy exists only off loopback, where that guard is inert. Both facts are
+ * three lines apart in `serve()`, derived from the same `loopback`.
+ *
+ * The credentialed paths are passed rather than imported because the router owns
+ * its own path constants, and reaching back for `MCP_PATH` would make this file
+ * and that one import each other.
+ */
+export function corsAware(
+  inner: (request: Request) => Promise<Response>,
+  credentialed: readonly string[],
+  policy: CorsPolicy,
+): (request: Request) => Promise<Response> {
+  return async (request) => {
+    const surface = surfaceOf(new URL(request.url).pathname, credentialed);
+    if (!surface) return await inner(request);
+
+    const headers = corsHeaders(request, surface, policy);
+
+    // Answered here, ahead of the auth gate, because a preflight carries no
+    // credential and never will — the note at the top of this file says why that
+    // is a fact about CORS rather than a choice about this endpoint.
+    if (request.method === 'OPTIONS') return preflightResponse(headers);
+
+    const response = await inner(request);
+    return headers ? withCors(response, headers) : response;
+  };
+}

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -3,6 +3,7 @@ import type { Logger } from '#connectivity';
 import { capabilityIdForToolName } from '#server/mcp';
 import { ATTACHMENTS_PATH, stageAttachment } from './attachments.ts';
 import { allowedHostnamesFor, rebindingRefusal } from './rebinding.ts';
+import { ANY_ORIGIN, corsAware, type CorsPolicy } from './cors.ts';
 import {
   DASHBOARD_PATH,
   dashboardSessions,
@@ -366,17 +367,24 @@ export function serve(options: ServeOptions): RunningServer {
 
   const loopback = isLoopback(host);
   const allowedHostnames = options.allowedHostnames ?? allowedHostnamesFor(host, loopback);
+
+  // Cross-origin access, and its absence, are decided here for the same reason
+  // `allowedHostnames` and `dashboard` are: they are all properties of what this
+  // is bound to. The two are mutually exclusive and the exclusion is the
+  // decision — see `./cors.ts`, and ADR-039.
+  const cors: CorsPolicy | undefined = loopback
+    ? undefined
+    : { allowedOrigins: primary.config.auth.allowed_origins ?? [ANY_ORIGIN] };
   const handler = createRequestHandler({
     ...options,
     dashboard: servesDashboard(options.dashboard, loopback),
     ...(allowedHostnames ? { allowedHostnames } : {}),
   });
 
-  const server = Bun.serve({
-    hostname: host,
-    port,
-    fetch: (request: Request) => handler.fetch(request),
-  });
+  const route = (request: Request): Promise<Response> => handler.fetch(request);
+  const fetch = cors ? corsAware(route, [MCP_PATH, ATTACHMENTS_PATH], cors) : route;
+
+  const server = Bun.serve({ hostname: host, port, fetch });
 
   return {
     url: `http://${host}:${port}${MCP_PATH}`,


### PR DESCRIPTION
No CORS handling existed at all — no `Access-Control-*` header was ever sent, no `OPTIONS` was ever
handled. A preflight fell past the discovery routes to the bearer gate and was answered `401`.

That is a category error, not a strict policy. A preflight is sent with credentials stripped, by
construction: no `Authorization` header, no cookie. Gating one behind the credential check refuses
every browser-origin client *before* it can present the credential the refusal asks for. No client
behaviour recovers from it, and the log line is indistinguishable from an ordinary unauthenticated
call.

It survived because nothing had asked. Every client `docs/clients.md` names connects from a server —
the local registrations are processes, and a claude.ai or ChatGPT connector fetches from the vendor's
backend rather than from the page.

## A deployment grants any origin, and there is no setup step

The earlier revision of this PR had `auth.allowed_origins` default to empty, so a browser client did
nothing until an origin was named. That is now the wildcard, and the argument is worth stating
because it is what makes the setup step unnecessary rather than merely inconvenient. Three things
hold together on a deployment:

1. **It is already reachable by anyone.** `access: public` is what a connector needs (ADR-018), so
   any server on the internet can post to `/mcp` today and read the refusal. CORS never gated
   *sending* — it gates whether a *page* may read the reply, and an attacker with a server needs no
   page. The only thing a hostile page adds is the victim's IP address.
2. **The credential is never ambient.** It is an `Authorization` header a page must already possess,
   never a cookie a browser attaches on its own. So a hostile page gains an unauthenticated request,
   and learns a `401` available from anywhere.
3. **`Allow-Credentials` is never sent, and with `*` cannot be** — the specification refuses the
   combination outright. The one header that would make a wildcard dangerous is unreachable from
   here rather than merely omitted.

So the wildcard grants a browser exactly what `curl` already has. An allowlist bought a required step
per user in exchange for narrowing a surface that was not exposed.

**The cost, stated plainly:** a leaked token is usable from a browser now, where before it needed a
server. An amplification rather than a new capability — a token that has escaped is already usable
from anywhere — and the allowlist protected only the users who completed a setup step, which is not
the users who leak tokens.

`auth.allowed_origins` still narrows, for an enterprise deployment that wants it. Absent means `*`.

## The surface

| Paths | Grant |
|---|---|
| both discovery documents, `/register`, `/token`, `/authorize` | `*`, always — never narrowed, because a client that cannot read these cannot find out that it needs a token |
| `/mcp`, `/attachments` | `*` unless `auth.allowed_origins` names origins, in which case a listed origin is echoed with `Vary: Origin` |
| `/health`, `/reload`, the dashboard | nothing |

**None of it applies to loopback**, which gets no policy at all. `rebinding.ts` already answers the
browser question there and answers it *no*: a page the owner is visiting can otherwise reach
`127.0.0.1`, and what it reaches is everything answering before authentication — including the
consent form that asks for their token. Public reachability is the premise the wildcard rests on, and
a page reaching loopback steals exactly what a deployment already gave away. The dashboard is
withheld off loopback for the mirror-image reason.

`WWW-Authenticate` is exposed, because a browser client that cannot read the `resource_metadata`
pointer inside a `401` cannot discover what to do about it — the failure ADR-036 reversed, arriving
by another route.

Rejected: reflecting `Access-Control-Request-Headers`, which grants whatever was asked for when the
set this endpoint reads is knowable. Rejected too: a `403` for an unlisted origin where an allowlist
*is* configured — the browser refuses on the absent header, and a distinct status would let a page map
which paths exist without being allowed to call any.

## Where the seam is

The wrapper goes at `serve()`, not in the router — the same function that decides `allowedHostnames`
and the dashboard, all three being properties of the address this is bound to. That is also what
makes the ordering safe: a preflight answered in the wrapper never reaches the rebinding guard inside
the router, and does not need to, because a policy exists only off loopback, which is exactly where
that guard is inert. Three lines apart, from the same `loopback`.

## Tests, and what they do not cover

The loopback half of `cors.test.ts` is real HTTP, because that is the half with a wrong answer
available. The deployed half composes the wrapper over the router exactly as `serve()` does and
drives it as a function. Reaching `serve()`'s non-loopback branch for real means binding `0.0.0.0` —
a listener on every interface and, on macOS, a firewall prompt every time anyone runs the suite. What
that buys over the composition is the socket alone.

## Verification

- `bun test` — 1843 pass, 0 fail
- `bun run typecheck` — clean
- `index.ts`, `schema.ts` both 396 against the 400-line budget

Rebased onto `develop`; the ADR is **039**, since `develop` already has 037 and 038. The ChatGPT
instructions that were originally in this branch shipped as #35.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
