### PR TITLE
Say how to add this to ChatGPT, and which token the approval page wants

### DIFF
--- a/docs/clients.md
+++ b/docs/clients.md
@@ -7,7 +7,7 @@ One endpoint, one token, every profile — so you register once per agent, not o
 | [Claude Code](#claude-code) | `lanes link mcp add claude` | `lanes link mcp add claude --target cloud` |
 | [Codex](#codex) | `lanes link mcp add codex` | `lanes link mcp add codex --target cloud` |
 | [Claude Desktop, Cowork](#claude-desktop-and-cowork) | by hand — see below | it cannot be given a URL |
-| [claude.ai, ChatGPT, a phone](#claudeai-chatgpt-and-your-phone) | nothing there reaches your machine | a custom connector, by URL |
+| [claude.ai](#claudeai-chatgpt-and-your-phone), [ChatGPT](#chatgpt), a phone | nothing there reaches your machine | a custom connector, by URL |
 | [Anything else](#anything-else) | `lanes link outputs` | `lanes link outputs --target cloud` |
 
 `lanes link mcp add` with no argument covers every agent it finds. It runs each one's own `mcp add`
@@ -111,6 +111,12 @@ client registers itself, a browser opens on your endpoint's own approval page, a
 target's token once — from `lanes link outputs --show --target cloud`. Same flow on a laptop and on a
 phone.
 
+**The token has to be the one that target's store holds.** Credentials are per target, and `outputs`
+mints a fresh token when the store is empty rather than saying so — so a target whose secrets were
+never pushed hands you one the deployed endpoint has never seen, and the approval page answers *"That
+token was not accepted"* with nothing pointing at why. `lanes link secrets push --from local --to
+cloud` is what fills it.
+
 If a connector reports the server as unreachable, three documents are how it learns it needs a token.
 Read them in order; the first that does not answer is the problem:
 
@@ -119,6 +125,37 @@ $ curl -i -X POST https://…run.app/mcp | head -3          # 401, with resource
 $ curl -s https://…run.app/.well-known/oauth-protected-resource | jq
 $ curl -s https://…run.app/.well-known/oauth-authorization-server | jq
 ```
+
+### ChatGPT
+
+Its connector UI is off by default and the setting is not where an older walkthrough will send you:
+Connectors was renamed Plugins, so there is no longer a Connectors → Advanced to find.
+
+1. **Settings → Security and login → Developer mode**, on. Plus, Pro, Business, Enterprise or Edu,
+   and web only — a free account cannot.
+2. **Plugins → `+` → New Plugin.** Name it; the icon and description are optional.
+3. **Connection** is **Server URL** — Tunnel is for a server on your own machine, which this is not.
+   Paste the `/mcp` address, with the path: it is what the endpoint names as the protected resource,
+   and the bare origin is a different string.
+4. **Authentication** is **OAuth**. There is nowhere to paste a bearer token, and *No authentication*
+   gets a 401.
+5. **Open Advanced OAuth settings.** Discovery runs from this panel, and leaving it unopened is
+   enough to make Create do nothing at all. Choose **dynamic client registration**, leave the client
+   id and secret empty, and take `mcp offline_access` as the scopes. Nothing has to be typed if
+   discovery filled it in.
+6. Tick the risk checkbox and **Create**, then connect. Your endpoint's own approval page opens,
+   naming `chatgpt.com` as where the code goes — worth recognising, since registration is open by
+   design and a client may call itself anything. Paste the token.
+7. Enable the plugin in the composer. Individual tools can be switched off on its own page.
+
+Nothing has to be entered by hand: `offline_access` is what keeps the connector signed in, and this
+endpoint registers clients dynamically, so there is no OAuth client to create and no redirect URI to
+register anywhere.
+
+**After `lanes link connect` adds an account, refresh the plugin.** This endpoint promises no
+`listChanged` notification — it cannot keep one, being stateless ([ADR-032](detailed/adr/032-a-stateless-endpoint-does-not-announce-its-tools.md))
+— so a client that does not ask again keeps the tool list it first saw. A connected account that
+never appears is this, not a broken deployment.
 
 ### When a working connector drops
 


### PR DESCRIPTION
`docs/clients.md` covered claude.ai, ChatGPT and a phone together, in three sentences. Accurate, and
not enough for ChatGPT — which is the client someone actually got stuck on.

Two things it did not say. **Developer mode is off by default**, and the setting is not where an older
walkthrough sends you: Connectors was renamed Plugins, so there is no longer a Connectors → Advanced
to find. And the New Plugin dialog then asks four questions with no documented answers.

The values are read off the endpoint rather than guessed:

| Field | Value | Because |
|---|---|---|
| Connection | Server URL | Tunnel is for a server on your own machine |
| Server URL | the `/mcp` address, with the path | that is what `resource` names in the protected-resource document; the bare origin is a different string |
| Authentication | OAuth | nowhere to paste a bearer string, and *No authentication* gets a 401 |
| Client setup | dynamic client registration | `registration_endpoint` is advertised |
| Client id / secret | empty | `token_endpoint_auth_methods_supported` is `["none"]` |
| Scopes | `mcp offline_access` | what both discovery documents carry |

## Two failures that each read as a broken deployment

- **Leaving Advanced OAuth settings unopened makes Create do nothing at all.** Discovery runs from
  that panel. No request reaches the endpoint, so there is nothing in its log to find and no error on
  screen — the console shows a swallowed promise rejection in ChatGPT's own bundle.
- **A connected account that never appears** is the tool list, not the connection. This endpoint
  promises no `listChanged` and cannot, being stateless (ADR-032), so a client that does not ask
  again keeps what it first saw. Refresh the plugin.

## The token note

In the parent section rather than under ChatGPT, because it is not client-specific.

ADR-037 already closed the half of this that was a missing flag — `--target` cannot be omitted now,
so nothing falls through to `local`. What it did not close is an *empty store*: `outputs` still mints
a fresh token rather than saying nothing is there, so a target whose secrets were never pushed hands
you one the endpoint has never seen, and the approval page's refusal names no cause.
`secrets push --from local --to cloud` is the fix, and is what the note points at.

## Structure

The heading and its anchor are unchanged — `deploy.md` and the table at the top of the file both link
to it — so the ChatGPT steps are a subsection, placed after the shared material rather than in the
middle of it. The table row now names both anchors, so the client someone is looking for is one click
rather than a scroll.

## Verification

- `bun test` — 1829 pass, 0 fail
- `bun run typecheck` — clean
- `src/architecture.test.ts` green over the new prose, including the reserved-domain rule

Docs only. Split out of #34, which holds the CORS change and is parked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
