### PR TITLE
Let a profile declare who its owner is, so an agent stops guessing

### DIFF
--- a/docs/detailed/adr/039-a-profile-declares-who-its-owner-is.md
+++ b/docs/detailed/adr/039-a-profile-declares-who-its-owner-is.md
@@ -1,0 +1,112 @@
+# ADR-039: A profile declares who its owner is
+
+**Status:** accepted · **Follows from** [ADR-019](019-describing-setup-is-not-performing-it.md) · **Extends** [ADR-007](007-control-plane-exclusions.md) · **Obeys** [ADR-037](037-a-command-names-what-it-acts-on.md)
+
+## Context
+
+A profile says what is reachable — connections, credentials, what policy permits — and said
+nothing about whose accounts those are. The account label on a connection is the closest thing,
+and it answers a different question: it is the identity a *provider* reports, resolved at connect
+time, so it says which mailbox this is rather than what to sign a message from it with.
+
+So an agent writing as the owner had to infer. Composing an email, opening a pull request,
+choosing a display name, signing off — every one of those needs a name or an address, and the
+only source was whatever happened to be in the conversation. The observed failure is not a wrong
+guess in isolation; it is a guess that crosses profiles. Two profiles exist precisely because the
+same person is two people to two sets of accounts, and an agent with no declaration reaches for
+whichever name it saw most recently.
+
+The information is knowable. Nobody had written it down, because there was nowhere to write it.
+
+## Decision
+
+**A profile may declare an `identity` block: a flat list of `{kind, value, note}`.** `kind` is any
+identifier, `value` is the name or address, `note` is prose saying when that one applies.
+
+```yaml
+identity:
+  - { kind: name,   value: Ada,             note: use for open-source work }
+  - { kind: name,   value: A. Lovelace,     note: use on anything published }
+  - { kind: email,  value: ada@example.com }
+  - { kind: github, value: octocat }
+```
+
+**A list rather than a map, because the note is the point.** `names: [Ada, A. Lovelace]` cannot
+say which to use when, and an owner with two names has two for a reason. Declaration order is
+preserved and meaningful: the first of a kind is the default, and the surface says so, because a
+model handed two with no ranking picks by position anyway and may as well be told that position
+is what it means.
+
+**`kind` is free-form.** Shipping an enum would mean a release every time someone wants
+`linkedin`, `pronouns`, or `signature`, and there is nothing the schema could do with the
+knowledge that a value is an address that would be worth that cost.
+
+**`note` is prose, not a reference.** Binding an entry to a connection was the obvious
+alternative and is a trap: it would put a cross-reference into `assertReferentialIntegrity`, and
+renaming a connection would then break config *load* — a profile that stops opening because a
+name in a signature moved. An agent reading "use with the personal mailbox" gets it right and
+costs nothing the day that mailbox is renamed.
+
+**It lives in the profile YAML, so editing it is CLI-only.** ADR-007 keeps configuration mutation
+off the MCP surface because it authorises future agent behaviour. That argument is sharper here
+than anywhere it has been applied: an agent able to edit this could edit the one fact that stops
+it signing as the wrong person. A store would have made an `identity_write` tool the obvious next
+step, and it is exactly the tool that must not exist.
+
+**It is read through its own provider, `identity`, with one read capability.** Reporting it
+authorises nothing — the ADR-019 argument — and the disclosure is already made: a caller holding a
+grant on a mail connection has the owner's address from the first message it reads. Withholding it
+here while serving the mailbox would be theatre, and the point of reading it here is not having
+to guess.
+
+Its own provider rather than a third section of `setup_overview`, because `identity.*` is then a
+grant an owner can give or withhold on its own. An endpoint can describe what is connected
+without naming its owner, or name its owner without describing what is connected. Folding it into
+`setup` would have made those one decision, and they are not one decision.
+
+**The MCP instructions carry a pointer, not the data.** One fixed paragraph, conditional on the
+surface being reachable, telling the agent to call `identity_list`. Inlining the declaration was
+tried on paper and is wrong twice over: `MAX_INSTRUCTIONS` is a fixed ceiling, so the workspace
+with the most identities to keep apart is the one whose list would be summarised away first — and
+it would send every profile's names to a client that asked about none of them. A pointer costs
+the same at one profile as at twenty, and the tool has room for the notes, which are the half
+that actually prevents the mistake.
+
+**`identity add` provisions the surface on first use.** An `identity` block alone is inert:
+`allowedConnections` returns nothing for a provider with no connection row before it consults
+policy, so the surface is absent from `tools/list` with nothing saying why. The command therefore
+writes the entry, the connection row, and the `identity.*` allow rule in one `save()` — one save
+because `validateConfig` refuses an allow rule naming a provider with no connection, so a
+half-applied run would leave a profile that no longer loads. This is the same repair `setup`
+already needed, generalised rather than copied.
+
+## Consequences
+
+The ceiling on the instructions rose from 2300 to 2500. That is the second raise, and it was
+argued the same way as the first: the paragraph must reach a client holding no skills directory,
+and an agent signing as the wrong person has already sent the message — a skill loaded only when
+relevant is not loaded at the moment it happens. The measured worst case is 2474, so the number
+is a measurement plus a little.
+
+A fresh profile gets nothing. `newProfileTemplate` is untouched, so no connection row, no grant,
+and no instruction paragraph until something is declared — the cost is paid only by a profile
+that has an identity to keep straight.
+
+Removing the last entry leaves the connection and the grant in place. The surface then reports
+that nothing is declared, which is honest and visible; revoking it would mean the next
+`identity add` silently re-widened policy, and a command that quietly narrows what an agent may
+read is worse than a surface reporting nothing.
+
+The block is the first place a profile holds the owner's own prose, which puts it under
+`secret-detection.ts` like every other value. A note cannot trip the entropy rule — `OPAQUE_TOKEN`
+admits no spaces — and a credential pasted into a value is refused, which is the check working
+rather than a false positive to route around.
+
+## What this does not do
+
+It does not bind an identity to a connection, an account, or a provider. It does not let an agent
+write, edit, or reorder one. It does not validate a value against its kind — an `email` entry
+holding something that is not an address is the owner's to notice. It does not reconcile with the
+`account` label on a connection, which answers a different question and stays where it is. And it
+does not put any of it in the instructions, so what a client learns without asking is that the
+declaration exists.

--- a/docs/detailed/configuration.md
+++ b/docs/detailed/configuration.md
@@ -97,6 +97,16 @@ connections:
 policy:
   allow: ['*']
   deny:  [gmail.users.drafts.send]
+
+# Optional. Who the owner is, for anything written as them — a name to sign
+# with, an address to send from, a handle to attribute to. Order is the
+# ranking: the first of a kind is the default, and the note says when to
+# prefer another.
+identity:
+  - { kind: name,   value: Ada,         note: use for open-source work }
+  - { kind: name,   value: A. Lovelace, note: use on anything published }
+  - { kind: email,  value: ada.lovelace@example.com }
+  - { kind: github, value: octocat }
 ```
 
 There is no `providers` block: declaring a connection is what enables a provider, and a second
@@ -116,6 +126,34 @@ This value looked like a credential:
 ```
 
 There is deliberately no suppression flag.
+
+## Identity
+
+`kind` is any lowercase identifier, so `name`, `email` and `github` are conventions rather than a
+list this project ships — `linkedin`, `phone`, `pronouns` and `signature` need no code change.
+`value` is the name or address. `note` is prose, read by whatever is writing as you.
+
+Declare one through the CLI rather than by hand, because the block on its own is inert:
+
+```console
+$ lanes link identity add name "A. Lovelace" --note "use on anything published" --profile personal --target local
+$ lanes link identity add email ada.lovelace@example.com --profile personal --target local
+$ lanes link identity list --profile personal
+```
+
+The first of those writes three things: the entry, a `connections` row for the `identity`
+provider, and an `identity.*` allow rule. All three are needed before anything can read it — a
+provider with no connection row is filtered out before policy is consulted, so an `identity`
+block by itself is a file that says exactly what you meant and an agent that cannot see a word of
+it. `identity list` says `declared, but no agent can read it` when that is the state.
+
+What reads it is one read-only tool, `identity_list`. Nothing on the MCP surface can write here:
+an agent able to edit this could edit the one fact that stops it signing as the wrong person, so
+editing is CLI-only under ADR-007. The endpoint's own instructions carry a pointer to the tool and
+none of the values — see [ADR-039](adr/039-a-profile-declares-who-its-owner-is.md).
+
+Removing the last entry leaves the row and the rule in place, and the tool then reports that
+nothing is declared.
 
 ## A profile that uses the hosted OAuth client
 

--- a/docs/detailed/workflow.md
+++ b/docs/detailed/workflow.md
@@ -326,6 +326,49 @@ $ lanes link start --profile personal --target local                            
 That is deliberate — a write cannot hand itself a read, so granting access to a new secret is
 something you do between two runs rather than something an agent does mid-session.
 
+## Who you are
+
+Names, addresses and handles to write as you, per profile. Optional — nothing needs them until
+something writes as you and gets it wrong.
+
+```console
+$ lanes link identity add name "A. Lovelace" --note "use on anything published" --profile personal --target local
+$ lanes link identity add name Ada --note "use for open-source work" --profile personal --target local
+$ lanes link identity add email ada.lovelace@example.com --profile personal --target local
+$ lanes link identity add github octocat --profile personal --target local
+$ lanes link identity list --profile personal
+$ lanes link identity remove name Ada --profile personal --target local
+```
+
+`identity list` takes no `--target`, for the reason `policy list` does not: the block is declared
+once in the YAML and applies to every target the profile has. `add` and `remove` publish the edit,
+so they name both.
+
+`kind` is the first argument and is yours to choose: `name`, `email` and `github` are conventions,
+not a list this project ships, so `linkedin`, `phone` or `pronouns` work with no code change. The
+note is what makes several of a kind usable — it is read by whatever is deciding which one to use.
+Order is the ranking, so the first of a kind is the default.
+
+Unlike memory, skills and the vault, there is no `lanes link connect identity` to run: the first
+`identity add` writes the connection row and the `identity.*` grant for you, and says so.
+
+```console
+$ lanes link identity add name "A. Lovelace" --profile personal --target local
+ok    name A. Lovelace
+      connections += identity.main
+      policy.allow += identity.*
+      an agent can now read this profile’s identity
+```
+
+Both of those are needed before anything can read the block — a provider with no connection row is
+filtered out before policy is consulted — so `identity list` warns when a hand-edited profile has
+the entries and not the grant. Editing is CLI-only, deliberately: an agent able to change this
+could change the one fact that stops it signing as the wrong person. What it gets is one read-only
+tool, `identity_list`, and an instruction to call it rather than infer.
+
+Nothing here belongs to a connection. An entry says *when* it applies in prose rather than naming
+an account, so renaming a mailbox cannot break a profile.
+
 ## Gate order
 
 Failures surface in the cheapest place first:

--- a/instructions/skills/lanes-link/SKILL.md
+++ b/instructions/skills/lanes-link/SKILL.md
@@ -62,6 +62,27 @@ Use one to do the thing that needs it. Never quote it back, summarise it, echo
 it into a file, or paste it into a command whose output you will show. If a
 value has been printed by accident, say so.
 
+## Who you are writing as is declared, not inferred
+
+A profile may declare the names, addresses and handles its owner wants used when
+something is written as them. Call `identity_list` for the profile in play
+before signing a message, choosing an address to send from, or attributing work
+to a handle — **do not** read a name off the conversation, off a previous
+message's signature, or off the account label on a connection. That label is the
+identity a provider reports for a mailbox; it is not necessarily what they sign
+with.
+
+A profile may declare several of a kind on purpose. The first is the default and
+each carries a note saying when to prefer it, so read the notes rather than
+picking the first unconditionally. If none of them fits what you are doing, ask
+— do not combine two, and do not carry one profile's name into another. That
+crossing is the specific mistake this exists to prevent.
+
+If the tool is not there, the profile has declared nothing. Ask rather than
+inventing something; they add one with `lanes link identity add <kind> <value> --profile <profile>
+--target <target>` — both flags, because neither has a fallback.
+Nothing you can call writes here, deliberately.
+
 ## Attachments are named, not carried
 
 Where a tool takes `attachments`, each entry names **one** source and the endpoint

--- a/src/cli/commands/connect/index.ts
+++ b/src/cli/commands/connect/index.ts
@@ -1,5 +1,6 @@
 import { credentialRefForConnection, WRITE_BUNDLE } from '#connectivity';
-import { ConfigDocument, ensureSetupConnection, repaired } from '../../config-edit.ts';
+import { ConfigDocument } from '../../config-edit.ts';
+import { ensureSetupConnection, repaired } from '../../config-repair.ts';
 import { emit, print } from '../../output.ts';
 import { nonInteractivePrompter, terminalPrompter, type Prompter } from '../../prompt.ts';
 import { openRuntime, type GlobalFlags } from '../../runtime.ts';

--- a/src/cli/commands/identity.test.ts
+++ b/src/cli/commands/identity.test.ts
@@ -1,0 +1,204 @@
+import { afterAll, describe, expect, test } from 'bun:test';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { parseConfig } from '#profile';
+import { createProfile } from './profile.ts';
+import { addIdentity, identityList, readIdentity, removeIdentity } from './identity.ts';
+
+/**
+ * `lanes link identity`.
+ *
+ * The property under test is not the wording, it is that declaring an identity
+ * *makes it readable*. An `identity` block alone is inert:
+ * `allowedConnections` returns nothing for a provider with no connection row
+ * before it ever consults policy, so the surface is absent from `tools/list`
+ * with nothing saying why. An operator would be looking at a file that says
+ * exactly what they meant and an agent that cannot see a word of it — which is
+ * the failure `setup` already had once, and the reason `add` provisions.
+ *
+ * The other half is that the three edits are one save. `validateConfig` refuses
+ * an allow rule naming a provider with no connection, so a run that wrote the
+ * rule and stopped would leave a profile that no longer loads at all.
+ */
+
+/**
+ * Named on every call, because nothing falls back any more (ADR-037).
+ *
+ * `identity list` needs only the profile and `identity add` needs both, but the
+ * commands take a flag bag either way — so one constant here rather than two
+ * that would drift.
+ */
+const WHERE = { profile: 'personal', target: 'local' } as const;
+
+const roots: string[] = [];
+const previousHome = process.env['LANES_LINK_HOME'];
+
+async function workspace(): Promise<string> {
+  const root = await mkdtemp(join(tmpdir(), 'lanes-link-identity-'));
+  roots.push(root);
+  process.env['LANES_LINK_HOME'] = root;
+  await createProfile('personal', { targets: ['local'] });
+  return root;
+}
+
+afterAll(async () => {
+  if (previousHome === undefined) delete process.env['LANES_LINK_HOME'];
+  else process.env['LANES_LINK_HOME'] = previousHome;
+  await Promise.all(roots.map((root) => rm(root, { recursive: true, force: true })));
+});
+
+/** The profile as it is on disk, parsed the way the endpoint parses it. */
+async function onDisk(root: string): Promise<ReturnType<typeof parseConfig>['config']> {
+  const text = await Bun.file(join(root, 'profiles', 'personal.yaml')).text();
+  return parseConfig(text).config;
+}
+
+/** Everything written to stdout while `body` runs. */
+async function captureStdout(body: () => Promise<void>): Promise<string> {
+  const original = process.stdout.write.bind(process.stdout);
+  let captured = '';
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (process.stdout as any).write = (chunk: string | Uint8Array): boolean => {
+    captured += typeof chunk === 'string' ? chunk : new TextDecoder().decode(chunk);
+    return true;
+  };
+
+  try {
+    await body();
+  } finally {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (process.stdout as any).write = original;
+  }
+
+  return captured;
+}
+
+describe('declaring an identity makes it readable', () => {
+  test('the first entry provisions the connection and the grant', async () => {
+    const root = await workspace();
+
+    const { added } = await addIdentity('name', 'Ada', { ...WHERE, note: 'for papers' });
+
+    expect(added.provisioned).toEqual(['connections += identity.main', 'policy.allow += identity.*']);
+
+    const config = await onDisk(root);
+    expect(config.identity).toEqual([{ kind: 'name', value: 'Ada', note: 'for papers' }]);
+    expect(config.connections.some((row) => row.provider === 'identity')).toBe(true);
+    expect(config.policy.allow.some((rule) => rule.capability === 'identity.*')).toBe(true);
+  });
+
+  test('a second entry provisions nothing, because there is nothing left to do', async () => {
+    await workspace();
+    await addIdentity('name', 'Ada', WHERE);
+
+    const { added } = await addIdentity('email', 'ada@example.com', WHERE);
+
+    expect(added.provisioned).toEqual([]);
+    expect(added.total).toBe(2);
+  });
+
+  test('what lands on disk still loads', async () => {
+    // The reason the three edits are one save. An allow rule naming a provider
+    // with no connection is refused by `validateConfig`, so a half-applied run
+    // would leave a file the endpoint cannot open — and `parseConfig` here is
+    // the same call that would then fail.
+    const root = await workspace();
+    await addIdentity('name', 'Ada', { ...WHERE, note: 'for papers' });
+
+    expect(async () => await onDisk(root)).not.toThrow();
+  });
+
+  test('the profile reports itself readable once both halves are there', async () => {
+    await workspace();
+
+    expect((await readIdentity(WHERE)).listing.reachable).toBe(false);
+    await addIdentity('name', 'Ada', WHERE);
+    expect((await readIdentity(WHERE)).listing.reachable).toBe(true);
+  });
+});
+
+describe('what it refuses', () => {
+  test('the same kind and value twice, before writing anything', async () => {
+    const root = await workspace();
+    await addIdentity('name', 'Ada', { ...WHERE, note: 'for papers' });
+
+    await expect(addIdentity('name', 'Ada', { ...WHERE, note: 'for code' })).rejects.toThrow(
+      /already declares name "Ada"/,
+    );
+
+    // The note that was already there survived the refusal.
+    expect((await onDisk(root)).identity).toEqual([
+      { kind: 'name', value: 'Ada', note: 'for papers' },
+    ]);
+  });
+
+  test('removing something that was never declared', async () => {
+    await workspace();
+
+    await expect(removeIdentity('name', 'Nobody', WHERE)).rejects.toThrow(/does not declare name/);
+  });
+});
+
+describe('removing an entry', () => {
+  test('takes out the named one and leaves the rest in order', async () => {
+    const root = await workspace();
+    await addIdentity('name', 'Ada', WHERE);
+    await addIdentity('name', 'A. Lovelace', WHERE);
+    await addIdentity('email', 'ada@example.com', WHERE);
+
+    const { removed, remaining } = await removeIdentity('name', 'Ada', WHERE);
+
+    expect(removed.value).toBe('Ada');
+    expect(remaining).toBe(2);
+    expect((await onDisk(root)).identity.map((entry) => entry.value)).toEqual([
+      'A. Lovelace',
+      'ada@example.com',
+    ]);
+  });
+
+  test('leaves the grant behind when the last entry goes', async () => {
+    // Revoking it here would mean the next `identity add` silently re-widens
+    // policy. A surface reporting "nothing declared" is the honest state, and
+    // it is the one an operator can see.
+    const root = await workspace();
+    await addIdentity('name', 'Ada', WHERE);
+
+    await removeIdentity('name', 'Ada', WHERE);
+
+    const config = await onDisk(root);
+    expect(config.identity).toEqual([]);
+    expect(config.connections.some((row) => row.provider === 'identity')).toBe(true);
+    expect(config.policy.allow.some((rule) => rule.capability === 'identity.*')).toBe(true);
+  });
+});
+
+describe('identity list --json', () => {
+  test('puts nothing but JSON on stdout', async () => {
+    await workspace();
+    await addIdentity('name', 'Ada', { ...WHERE, note: 'for papers' });
+
+    const written = await captureStdout(() => identityList({ ...WHERE, json: true }));
+
+    // The assertion is the parse: `announce` runs first on every command,
+    // deliberately, and that line in front of a document is the difference
+    // between a parser and a crash.
+    const parsed = JSON.parse(written) as {
+      profile: string;
+      reachable: boolean;
+      entries: { kind: string; value: string; note?: string }[];
+    };
+    expect(parsed.profile).toBe('personal');
+    expect(parsed.reachable).toBe(true);
+    expect(parsed.entries).toEqual([{ kind: 'name', value: 'Ada', note: 'for papers' }]);
+  });
+
+  test('a profile declaring nothing still emits a document rather than prose', async () => {
+    await workspace();
+
+    const written = await captureStdout(() => identityList({ ...WHERE, json: true }));
+
+    expect(JSON.parse(written)).toMatchObject({ entries: [], reachable: false });
+  });
+});

--- a/src/cli/commands/identity.ts
+++ b/src/cli/commands/identity.ts
@@ -1,0 +1,258 @@
+import type { IdentityEntry, ProfileSelection, Resolution } from '#profile';
+import { ConfigDocument } from '../config-edit.ts';
+import { ensureIdentityConnection, repairLines, repaired } from '../config-repair.ts';
+import { announce, announceProfile, emit, ok, print, style, table, warn } from '../output.ts';
+import { resolveProfile, resolveProfileOnly, type GlobalFlags } from '../runtime.ts';
+import { nextAfterEdit, publishProfileEdit } from '../publish.ts';
+
+/**
+ * `lanes link identity` — who this profile's owner is, for anything written as them.
+ *
+ * A control-plane command under ADR-007, and the reason is sharper here than for
+ * most of them: an agent able to edit this could edit the one fact that stops it
+ * signing as the wrong person. So the surface it feeds is read-only and the
+ * editing is here.
+ *
+ * Not to be confused with `src/cli/identity.ts`, which is about a *connection's*
+ * identity — which account it is, as the provider reports it at connect time.
+ * This is the owner's, as they declare it.
+ *
+ * Each command is a data function plus a printing wrapper, for the reason given
+ * in `commands/profile.ts`: `--json` needs the facts without the rendering.
+ */
+
+/** What `add` did, including anything it provisioned to make it readable. */
+export interface IdentityAdded {
+  readonly profile: string;
+  readonly entry: IdentityEntry;
+  /** Config edits made so the surface is reachable at all. Usually empty. */
+  readonly provisioned: readonly string[];
+  readonly total: number;
+}
+
+export interface IdentityListing {
+  readonly profile: string;
+  readonly entries: readonly IdentityEntry[];
+  /** Whether an agent can read them, or only the file can. */
+  readonly reachable: boolean;
+}
+
+/** Whether a rule list puts `identity.*` in force, in either spelling. */
+function covers(rules: ReadonlyArray<{ capability: string }>): boolean {
+  return rules.some((rule) => rule.capability === '*' || rule.capability === 'identity.*');
+}
+
+/**
+ * Whether anything but the file can read this profile's identity.
+ *
+ * Reported rather than assumed, because a profile hand-edited to hold an
+ * `identity` block and nothing else is a real state and a likely one — and
+ * listing the entries without saying they are unreachable would be the most
+ * misleading thing this command could print.
+ */
+function readable(config: {
+  connections: ReadonlyArray<{ provider: string }>;
+  policy: { allow: ReadonlyArray<{ capability: string }>; deny: ReadonlyArray<{ capability: string }> };
+}): boolean {
+  return (
+    config.connections.some((connection) => connection.provider === 'identity') &&
+    covers(config.policy.allow) &&
+    !covers(config.policy.deny)
+  );
+}
+
+/**
+ * Declare one entry, and make sure something can read it.
+ *
+ * The provisioning is the part worth understanding. An `identity` block on its
+ * own is inert: `allowedConnections` finds no connection row for the provider
+ * and returns nothing *before* it consults policy, so the surface is absent from
+ * `tools/list` with nothing saying why — the same silent failure
+ * `ensureIdentityConnection` closes for `setup`. Writing the entry without it
+ * would leave an operator looking at a file that says exactly what they meant
+ * and an agent that cannot see a word of it.
+ *
+ * All three edits land in one `save()`, and that is not tidiness:
+ * `validateConfig` refuses a `policy.allow` rule naming a provider with no
+ * connection, so a run that wrote the rule and failed before the row would
+ * leave a profile that no longer loads. One save has no such middle.
+ */
+export async function addIdentity(
+  kind: string,
+  value: string,
+  options: { note?: string | undefined } & GlobalFlags,
+): Promise<{ resolution: Resolution; added: IdentityAdded; published: string }> {
+  const { resolution, config, target } = await resolveProfile(options);
+
+  if (config.identity.some((entry) => entry.kind === kind && entry.value === value)) {
+    throw new Error(
+      `Profile "${resolution.profile}" already declares ${kind} "${value}".\n` +
+        `  To change its note: lanes link identity remove ${kind} ${value}, then add it again.`,
+    );
+  }
+
+  const document = await ConfigDocument.open(resolution.workspaceRoot, resolution.profile);
+
+  const entry: IdentityEntry = { kind, value, ...(options.note ? { note: options.note } : {}) };
+  document.addTo(['identity'], entry, { inline: true });
+
+  const repair = ensureIdentityConnection(document);
+  await document.save();
+
+  return {
+    resolution,
+    added: {
+      profile: resolution.profile,
+      entry,
+      provisioned: repaired(repair) ? repairLines(repair) : [],
+      total: config.identity.length + 1,
+    },
+    published: nextAfterEdit(await publishProfileEdit({ resolution, config, target })),
+  };
+}
+
+/**
+ * Read the block, without opening a target.
+ *
+ * `resolveProfileOnly`, deliberately: this reads one field of a YAML file that
+ * is declared once and applies to every target the profile has, so demanding
+ * `--target` would be the ceremony ADR-037 warns is how a required flag stops
+ * being a guard. `SELECTION` files it as `profile`, and this is the call that
+ * makes that true rather than merely stated.
+ */
+export async function readIdentity(
+  flags: GlobalFlags,
+): Promise<{ selection: ProfileSelection; listing: IdentityListing }> {
+  const { selection, config } = await resolveProfileOnly(flags);
+
+  return {
+    selection,
+    listing: {
+      profile: selection.profile,
+      entries: config.identity,
+      reachable: readable(config),
+    },
+  };
+}
+
+/**
+ * Drop one entry, leaving the connection row and the grant behind.
+ *
+ * Deliberately: removing the last entry would otherwise silently revoke the
+ * surface, and the next `identity add` would have to widen policy again. A
+ * command that quietly narrows what an agent may read, and a later one that
+ * quietly re-widens it, is worse than a surface that reports nothing declared.
+ */
+export async function removeIdentity(
+  kind: string,
+  value: string,
+  flags: GlobalFlags,
+): Promise<{
+  resolution: Resolution;
+  removed: IdentityEntry;
+  remaining: number;
+  published: string;
+}> {
+  const { resolution, config, target } = await resolveProfile(flags);
+
+  const index = config.identity.findIndex((entry) => entry.kind === kind && entry.value === value);
+  if (index === -1) {
+    throw new Error(
+      `Profile "${resolution.profile}" does not declare ${kind} "${value}".\n` +
+        `  Run: lanes link identity list`,
+    );
+  }
+
+  const document = await ConfigDocument.open(resolution.workspaceRoot, resolution.profile);
+  document.removeFrom(['identity'], index);
+  await document.save();
+
+  return {
+    resolution,
+    removed: config.identity[index] as IdentityEntry,
+    remaining: config.identity.length - 1,
+    published: nextAfterEdit(await publishProfileEdit({ resolution, config, target })),
+  };
+}
+
+export async function identityAdd(
+  kind: string,
+  value: string,
+  options: { note?: string | undefined; json?: boolean } & GlobalFlags,
+): Promise<void> {
+  const { resolution, added, published } = await addIdentity(kind, value, options);
+
+  return emit(options.json, added, () => {
+    announce(resolution);
+    print(ok(`${added.entry.kind} ${style.bold(added.entry.value)}`));
+    if (added.entry.note) print(`      note    ${added.entry.note}`);
+
+    // Named rather than folded into the success line: this widened what an
+    // agent may read, and a command that broadens a grant says which grant.
+    for (const line of added.provisioned) print(`      ${style.dim(line)}`);
+    if (added.provisioned.length > 0) {
+      print(style.dim('      an agent can now read this profile’s identity'));
+    }
+
+    print(style.dim(`  ${published}`));
+  });
+}
+
+export async function identityList(options: { json?: boolean } & GlobalFlags): Promise<void> {
+  const { selection, listing } = await readIdentity(options);
+
+  return emit(options.json, listing, () => {
+    announceProfile(selection);
+
+    if (listing.entries.length === 0) {
+      print(style.dim('This profile declares no identity.'));
+      print(
+        style.dim('Declare one with: lanes link identity add name "Your Name" --note "when to use it"'),
+      );
+      return;
+    }
+
+    // Grouped by kind for the same reason the provider groups them: the mistake
+    // this exists to prevent is a name used where an address was wanted.
+    const kinds = [...new Set(listing.entries.map((entry) => entry.kind))];
+    const ordered = kinds.flatMap((kind) =>
+      listing.entries.filter((entry) => entry.kind === kind),
+    );
+
+    table(
+      ordered.map((entry) => [
+        `  ${style.dim(entry.kind)}`,
+        style.bold(entry.value),
+        entry.note ? style.dim(entry.note) : '',
+      ]),
+    );
+
+    if (!listing.reachable) {
+      print('');
+      print(warn('declared, but no agent can read it'));
+      print(
+        style.dim(
+          '      the identity surface needs a connection row and an identity.* allow rule;',
+        ),
+      );
+      print(style.dim('      adding an entry with this command writes both.'));
+    }
+  });
+}
+
+export async function identityRemove(
+  kind: string,
+  value: string,
+  options: { json?: boolean } & GlobalFlags,
+): Promise<void> {
+  const { resolution, removed, remaining, published } = await removeIdentity(kind, value, options);
+
+  return emit(options.json, { removed, remaining }, () => {
+    announce(resolution);
+    print(ok(`removed ${removed.kind} ${style.bold(removed.value)}`));
+    if (remaining === 0) {
+      print(style.dim('      the surface stays granted, and now reports nothing declared'));
+    }
+    print(style.dim(`  ${published}`));
+  });
+}

--- a/src/cli/config-edit.test.ts
+++ b/src/cli/config-edit.test.ts
@@ -4,7 +4,8 @@ import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
 import { readdir } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { ConfigDocument, ensureSetupConnection, newProfileTemplate, repairLines } from './config-edit.ts';
+import { ConfigDocument, newProfileTemplate } from './config-edit.ts';
+import { ensureSetupConnection, repairLines } from './config-repair.ts';
 
 /**
  * The config file is the source of truth, and an operator is meant to be able

--- a/src/cli/config-edit.ts
+++ b/src/cli/config-edit.ts
@@ -122,6 +122,22 @@ export class ConfigDocument {
   }
 
   /**
+   * Drop one item out of a sequence, by position.
+   *
+   * By index rather than by value because the items this is used on are
+   * mappings: matching one by value would mean deciding which fields count as
+   * its identity, and the caller has already decided that by finding it. The
+   * index is therefore the caller's to compute against the *validated* config,
+   * whose order this file preserves.
+   *
+   * `save` re-validates, so removing an item that something else references
+   * fails there rather than landing a config that no longer loads.
+   */
+  removeFrom(path: readonly (string | number)[], index: number): void {
+    this.#document.deleteIn([...path, index] as (string | number)[]);
+  }
+
+  /**
    * Force a collection we just grew onto multiple lines.
    *
    * A template starts with `connections: []`, and the YAML library keeps that
@@ -176,138 +192,6 @@ export class ConfigDocument {
   }
 }
 
-/** The reserved provider id the setup surface registers under. */
-const SETUP_PROVIDER_ID = 'setup';
-
-/**
- * What a repair did, split by what a caller does with each half.
- *
- * `connect` reports config edits under `changes` and policy under `granted`,
- * and both are serialised verbatim by `--json` — so an audit asking what a
- * command widened reads only the second, and one blended list of sentences
- * filed the grant as an edit and left prose in a field meant for matching.
- */
-export interface SetupRepair {
-  /** Config edits made, spelled for display. Empty when none were needed. */
-  readonly changes: readonly string[];
-  /** Allow rules added — patterns, not prose, so a caller can act on them. */
-  readonly granted: readonly string[];
-}
-
-/**
- * Give a profile the `setup` surface if it does not already have it.
- *
- * A profile written before the surface existed has neither the connection row
- * nor the allow rule, and the failure is silent in the worst way:
- * `allowedConnections` returns nothing for a provider with no connection row
- * *before* it consults policy, so `setup_overview` and `setup_provider` are
- * simply absent from `tools/list` with nothing saying why. An agent asked what
- * is connected then has nothing to read and invents a command — which is the
- * bug this exists to close, not a hypothetical.
- *
- * Both halves or neither: a connection row without `setup.*` is as inert as the
- * rule without the row, so adding one alone would look like a fix and change
- * nothing.
- *
- * CLI-side by construction. ADR-007 keeps configuration mutation off the served
- * surface, and a deployed revision holds `objectViewer` on `profiles/`
- * (ADR-023) so it could not write this even if the code let it.
- */
-export function ensureSetupConnection(document: ConfigDocument): SetupRepair {
-  // Raw YAML, so nothing here has been through a schema: this runs over sibling
-  // profiles that were never validated, and every field is whatever was typed.
-  const config = document.toJSON() as {
-    connections?: unknown;
-    policy?: { allow?: unknown; deny?: unknown };
-  } | null;
-
-  const rule = `${SETUP_PROVIDER_ID}.*`;
-  const covers = (pattern: string): boolean => pattern === '*' || pattern === rule;
-
-  // Denied on purpose, and a deny beats an allow — so writing the rule would
-  // widen nothing while announcing that an agent "can now see what is connected
-  // here", which would be false. Deleting the two lines no longer removes the
-  // surface, because the next `connect` or `deploy` puts them back; a deny is
-  // the way it stays off, so it is the one thing this must not undo.
-  //
-  // Only a rule covering the whole surface counts. `deny: [setup.provider]` is
-  // an operator narrowing it, not switching it off, and that narrowing survives
-  // the repair untouched — which is the point of denying one capability.
-  if (patternsIn(config?.policy?.deny).some(covers)) return { changes: [], granted: [] };
-
-  const changes: string[] = [];
-  const granted: string[] = [];
-
-  const connections = Array.isArray(config?.connections) ? config.connections : [];
-  const isSetup = (row: unknown): boolean =>
-    (row as { provider?: unknown } | null)?.provider === SETUP_PROVIDER_ID;
-
-  if (!connections.some(isSetup)) {
-    // Inline, and `main` for the id, so a repaired profile is spelled exactly
-    // like `newProfileTemplate` writes a fresh one. Two spellings of one row is
-    // how a template and its repair drift apart.
-    document.addTo(
-      ['connections'],
-      { id: 'main', provider: SETUP_PROVIDER_ID, account: 'Setup' },
-      { inline: true },
-    );
-    changes.push(`connections += ${SETUP_PROVIDER_ID}.main`);
-  }
-
-  // `*` already covers it. Re-stating the rule under a blanket allow would be
-  // noise in the file and a diff the operator did not ask for.
-  if (!patternsIn(config?.policy?.allow).some(covers)) {
-    document.addTo(['policy', 'allow'], rule, { inline: true });
-    granted.push(rule);
-  }
-
-  return { changes, granted };
-}
-
-/** Whether a repair did anything, without a caller adding up two lists. */
-export function repaired(repair: SetupRepair): boolean {
-  return repair.changes.length > 0 || repair.granted.length > 0;
-}
-
-/** The repair as display lines, in the order the two halves are applied. */
-export function repairLines(repair: SetupRepair): string[] {
-  return [...repair.changes, ...repair.granted.map((rule) => `policy.allow += ${rule}`)];
-}
-
-/**
- * The patterns a raw policy list puts *in force*, in either spelling.
- *
- * `policyRuleSchema` takes a bare pattern or `{ capability, expires_at }` and
- * both parse to the same thing, so reading only the string form would re-add a
- * rule the operator had already written with an expiry. Anything that is
- * neither is dropped rather than guessed at: this reads unvalidated YAML, and a
- * malformed rule is for `validateConfig` to report, not for this to interpret.
- *
- * **Expiry is part of the reading.** `evaluate` holds a rule to
- * `expiresAt === undefined || expiresAt > now` (`#policy`), so a lapsed rule
- * grants and denies nothing — and reading the capability alone got both
- * directions wrong. A lapsed *allow* read as live, so the repair wrote the row,
- * skipped the rule, and announced success: the inert half-state this exists to
- * prevent. A lapsed *deny* blocked the repair for good and printed nothing,
- * because having nothing to add is how "already had it" looks.
- *
- * An unparseable date reads as lapsed, which is the safe direction — it adds a
- * working rule rather than trusting a broken one, and the `save` that follows
- * hands the malformed value to `validateConfig`, whose job it is to complain.
- */
-function patternsIn(rules: unknown, now = Date.now()): string[] {
-  if (!Array.isArray(rules)) return [];
-
-  return rules
-    .filter((rule) => {
-      const expiry = (rule as { expires_at?: unknown } | null)?.expires_at;
-      return typeof expiry !== 'string' || Date.parse(expiry) > now;
-    })
-    .map((rule) =>
-      typeof rule === 'string' ? rule : (rule as { capability?: unknown } | null)?.capability,
-    )
-    .filter((pattern): pattern is string => typeof pattern === 'string');
-}
 
 /**
  * A fresh profile config.

--- a/src/cli/config-repair.ts
+++ b/src/cli/config-repair.ts
@@ -1,0 +1,186 @@
+import type { ConfigDocument } from './config-edit.ts';
+
+/**
+ * Giving a profile a reserved provider it is missing, without undoing a choice.
+ *
+ * Its own file, apart from `ConfigDocument`, because there are now two callers
+ * of the same repair and generalising it in place would have pushed
+ * `config-edit.ts` past the file-size budget. The split is along the seam that
+ * was already there: that file knows how to *edit* YAML safely, and this one
+ * knows what a reserved provider needs to be reachable at all.
+ *
+ * Two providers hold no account and are therefore invisible without a
+ * connection row nobody would think to write: `setup`, which describes what is
+ * connected, and `identity`, which says who the owner is. Both are repaired the
+ * same way and the rules below are subtle enough that a second copy would drift
+ * — which is the whole reason this is one function taking a provider id rather
+ * than two that look alike.
+ */
+
+/** The reserved provider ids that hold no account, and the label each row carries. */
+const RESERVED_SURFACES = {
+  setup: 'Setup',
+  identity: 'Identity',
+} as const;
+
+type ReservedSurface = keyof typeof RESERVED_SURFACES;
+
+/**
+ * What a repair did, split by what a caller does with each half.
+ *
+ * `connect` reports config edits under `changes` and policy under `granted`,
+ * and both are serialised verbatim by `--json` — so an audit asking what a
+ * command widened reads only the second, and one blended list of sentences
+ * filed the grant as an edit and left prose in a field meant for matching.
+ */
+export interface SurfaceRepair {
+  /** Config edits made, spelled for display. Empty when none were needed. */
+  readonly changes: readonly string[];
+  /** Allow rules added — patterns, not prose, so a caller can act on them. */
+  readonly granted: readonly string[];
+}
+
+/**
+ * Give a profile one of those surfaces if it does not already have it.
+ *
+ * A profile that never had the surface has neither the connection row nor the
+ * allow rule, and the failure is silent in the worst way: `allowedConnections`
+ * returns nothing for a provider with no connection row *before* it consults
+ * policy, so the tools are simply absent from `tools/list` with nothing saying
+ * why. It is not a hypothetical in either direction — asked what was connected,
+ * an agent with no `setup` surface invented a command; and an `identity` block
+ * written without the row is a file saying exactly what its owner meant to an
+ * agent that cannot see a word of it.
+ *
+ * Both halves or neither: a connection row without the matching `<provider>.*`
+ * rule is as inert as the rule without the row, so adding one alone would look
+ * like a fix and change nothing.
+ *
+ * CLI-side by construction. ADR-007 keeps configuration mutation off the served
+ * surface, and a deployed revision holds `objectViewer` on `profiles/`
+ * (ADR-023) so it could not write this even if the code let it.
+ */
+export function ensureReservedConnection(
+  document: ConfigDocument,
+  provider: ReservedSurface,
+): SurfaceRepair {
+  // Raw YAML, so nothing here has been through a schema: this runs over sibling
+  // profiles that were never validated, and every field is whatever was typed.
+  const config = document.toJSON() as {
+    connections?: unknown;
+    policy?: { allow?: unknown; deny?: unknown };
+  } | null;
+
+  const rule = `${provider}.*`;
+  const covers = (pattern: string): boolean => pattern === '*' || pattern === rule;
+
+  // Denied on purpose, and a deny beats an allow — so writing the rule would
+  // widen nothing while announcing that an agent can now read the surface,
+  // which would be false. For `setup`, deleting the two lines no longer removes
+  // it either, because the next `connect` or `deploy` puts them back; a deny is
+  // the way it stays off, so it is the one thing this must not undo. The same
+  // holds for `identity`, where the next `identity add` is what would put them
+  // back.
+  //
+  // Only a rule covering the whole surface counts. `deny: [setup.provider]` is
+  // an operator narrowing it, not switching it off, and that narrowing survives
+  // the repair untouched — which is the point of denying one capability.
+  if (patternsIn(config?.policy?.deny).some(covers)) return { changes: [], granted: [] };
+
+  const changes: string[] = [];
+  const granted: string[] = [];
+
+  const connections = Array.isArray(config?.connections) ? config.connections : [];
+  const declared = (row: unknown): boolean =>
+    (row as { provider?: unknown } | null)?.provider === provider;
+
+  if (!connections.some(declared)) {
+    // Inline, and `main` for the id, so a repaired profile is spelled exactly
+    // like `newProfileTemplate` writes a fresh one. Two spellings of one row is
+    // how a template and its repair drift apart.
+    document.addTo(
+      ['connections'],
+      { id: 'main', provider, account: RESERVED_SURFACES[provider] },
+      { inline: true },
+    );
+    changes.push(`connections += ${provider}.main`);
+  }
+
+  // `*` already covers it. Re-stating the rule under a blanket allow would be
+  // noise in the file and a diff the operator did not ask for.
+  if (!patternsIn(config?.policy?.allow).some(covers)) {
+    document.addTo(['policy', 'allow'], rule, { inline: true });
+    granted.push(rule);
+  }
+
+  return { changes, granted };
+}
+
+/** Whether a repair did anything, without a caller adding up two lists. */
+export function repaired(repair: SurfaceRepair): boolean {
+  return repair.changes.length > 0 || repair.granted.length > 0;
+}
+
+/** The repair as display lines, in the order the two halves are applied. */
+export function repairLines(repair: SurfaceRepair): string[] {
+  return [...repair.changes, ...repair.granted.map((rule) => `policy.allow += ${rule}`)];
+}
+
+/**
+ * The patterns a raw policy list puts *in force*, in either spelling.
+ *
+ * `policyRuleSchema` takes a bare pattern or `{ capability, expires_at }` and
+ * both parse to the same thing, so reading only the string form would re-add a
+ * rule the operator had already written with an expiry. Anything that is
+ * neither is dropped rather than guessed at: this reads unvalidated YAML, and a
+ * malformed rule is for `validateConfig` to report, not for this to interpret.
+ *
+ * **Expiry is part of the reading.** `evaluate` holds a rule to
+ * `expiresAt === undefined || expiresAt > now` (`#policy`), so a lapsed rule
+ * grants and denies nothing — and reading the capability alone got both
+ * directions wrong. A lapsed *allow* read as live, so the repair wrote the row,
+ * skipped the rule, and announced success: the inert half-state this exists to
+ * prevent. A lapsed *deny* blocked the repair for good and printed nothing,
+ * because having nothing to add is how "already had it" looks.
+ *
+ * An unparseable date reads as lapsed, which is the safe direction — it adds a
+ * working rule rather than trusting a broken one, and the `save` that follows
+ * hands the malformed value to `validateConfig`, whose job it is to complain.
+ */
+function patternsIn(rules: unknown, now = Date.now()): string[] {
+  if (!Array.isArray(rules)) return [];
+
+  return rules
+    .filter((rule) => {
+      const expiry = (rule as { expires_at?: unknown } | null)?.expires_at;
+      return typeof expiry !== 'string' || Date.parse(expiry) > now;
+    })
+    .map((rule) =>
+      typeof rule === 'string' ? rule : (rule as { capability?: unknown } | null)?.capability,
+    )
+    .filter((pattern): pattern is string => typeof pattern === 'string');
+}
+
+/**
+ * The `setup` surface, which every profile is expected to have.
+ *
+ * A named wrapper rather than a call site passing `'setup'`, because three
+ * callers say it and reading `ensureReservedConnection(document, 'setup')` at
+ * each of them says less than the name did.
+ */
+export function ensureSetupConnection(document: ConfigDocument): SurfaceRepair {
+  return ensureReservedConnection(document, 'setup');
+}
+
+/**
+ * The `identity` surface, which only a profile that declares an identity gets.
+ *
+ * Unlike `setup`, this is *not* repaired by `connect` or `deploy` — a profile
+ * with no identity block has nothing for the surface to report, and registering
+ * a tool that answers "nothing declared" on every fresh install would spend a
+ * paragraph of the instructions budget to say so. `identity add` is the only
+ * caller, so the grant arrives exactly when there is something behind it.
+ */
+export function ensureIdentityConnection(document: ConfigDocument): SurfaceRepair {
+  return ensureReservedConnection(document, 'identity');
+}

--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -20,6 +20,7 @@ import {
 import { profileAdd, profileDefault, profileList } from './commands/profile.ts';
 import { removeProfile as profileRemove } from './commands/profile/remove.ts';
 import { targetList, targetShow, targetUse } from './commands/target.ts';
+import { identityAdd, identityList, identityRemove } from './commands/identity.ts';
 import { setupPlan } from './commands/setup.ts';
 import { mcpAdd, mcpList, mcpStdio, skillDocument } from './commands/mcp.ts';
 import { deploy } from '#deployments/deploy.ts';
@@ -154,6 +155,28 @@ export async function run(argv: readonly string[]): Promise<void> {
         default:
           throw new Error(`Unknown: ${PROGRAM} target ${second}`);
       }
+
+    case 'identity': {
+      // Both subcommands take the same two positionals, so the usage line is
+      // built once rather than written twice with one of them going stale.
+      const [kind, value] = rest;
+      const usage = (form: string): string =>
+        `Usage: ${PROGRAM} identity ${form}\n  e.g. ${PROGRAM} identity add name "Your Name" --note "for open-source work"`;
+
+      switch (second) {
+        case 'add':
+          if (!kind || !value) throw new Error(usage('add <kind> <value> [--note text]'));
+          return identityAdd(kind, value, { ...global, note: text(flags, 'note'), json });
+        case 'list':
+        case undefined:
+          return identityList({ ...global, json });
+        case 'remove':
+          if (!kind || !value) throw new Error(usage('remove <kind> <value>'));
+          return identityRemove(kind, value, { ...global, json });
+        default:
+          throw new Error(`Unknown: ${PROGRAM} identity ${second}`);
+      }
+    }
 
     case 'policy':
       switch (second) {

--- a/src/cli/output.ts
+++ b/src/cli/output.ts
@@ -111,6 +111,21 @@ export async function waiting<T>(label: string, work: () => Promise<T>): Promise
  * so the parenthetical would say `(flag)` twice on every line forever — which
  * `target.ts` already argues is how a line stops being read.
  */
+/**
+ * The same line for a command that opens no target.
+ *
+ * `identity list` reads a block declared once in the YAML, so it takes no
+ * `--target` (ADR-037) and there is none to name. Printing `target undefined`
+ * or omitting the line entirely were the alternatives; the first is a lie and
+ * the second loses the guard that this line exists to be.
+ */
+export function announceProfile(selection: {
+  readonly profile: string;
+  readonly workspaceRoot: string;
+}): void {
+  print(style.dim(`profile ${style.bold(selection.profile)}  ${selection.workspaceRoot}`));
+}
+
 export function announce(resolution: Resolution): void {
   print(
     style.dim(

--- a/src/cli/runtime.ts
+++ b/src/cli/runtime.ts
@@ -22,6 +22,7 @@ export {
   openSecretStoreFor,
   ownerPrincipal,
   resolveProfile,
+  resolveProfileOnly,
   type GlobalFlags,
 } from './runtime/select.ts';
 

--- a/src/cli/runtime/open.ts
+++ b/src/cli/runtime/open.ts
@@ -240,6 +240,11 @@ export async function openRuntime(flags: GlobalFlags): Promise<Runtime> {
       ownClients: Object.keys(config.oauth_apps),
       reachable,
     },
+    // Straight off the config: unlike `reachable`, nothing has to be filtered
+    // through policy first. Whether the surface is reachable at all is still
+    // policy's answer, given once by `mergeCapabilities` — this only decides
+    // what it says when it is.
+    identity: { profile: config.instance.profile, target, entries: config.identity },
   });
   // Seeded from the build that just happened, so the first refresh compares
   // against what is registered rather than rebuilding once to find out.

--- a/src/cli/runtime/registry.ts
+++ b/src/cli/runtime/registry.ts
@@ -6,11 +6,13 @@ import { loadProfileProviders } from '#providers/custom/index.ts';
 import { loadProfileSkills, type LoadedSkill } from '#providers/skills/store.ts';
 import { exampleProvider } from '#providers/example/provider.ts';
 import {
+  createIdentityProvider,
   createMemoryVaultStore,
   createSetupProvider,
   createSkillsProvider,
   createVaultProvider,
   memoryProvider,
+  type IdentityProviderOptions,
   type SetupProviderOptions,
   type VaultStore,
 } from '#providers/owner.ts';
@@ -64,6 +66,15 @@ export interface OwnerLayerOptions {
    * two capabilities that would report an empty profile as the truth.
    */
   readonly setup?: SetupProviderOptions;
+  /**
+   * Who the profile says its owner is.
+   *
+   * Absent for a registry built to read manifests, which has no config to read
+   * it from. The provider still registers — it reports an empty declaration
+   * rather than vanishing, so the difference between "nothing declared" and
+   * "this build has no such surface" stays visible.
+   */
+  readonly identity?: IdentityProviderOptions;
 }
 
 /**
@@ -72,7 +83,8 @@ export interface OwnerLayerOptions {
  * Statically imported for now; the registry does not care where a manifest came
  * from, which is what lets workspace YAML register alongside these.
  *
- * `allowReserved` is what admits `memory`, `skills`, and `vault`. The guard
+ * `allowReserved` is what admits `memory`, `skills`, `vault`, `setup`, and
+ * `identity`. The guard
  * stays rather than being retired: it exists so a *third-party* provider cannot
  * claim a namespace whose policy rules would then silently mean something else,
  * and that reason survives the owner layer shipping. Only this one construction
@@ -98,6 +110,8 @@ export function buildRegistry(owner: OwnerLayerOptions = {}): ProviderRegistry {
       owner.setup ?? { profile: '', target: '', catalogue: PROVIDER_MANIFESTS },
     ),
   );
+
+  registry.register(createIdentityProvider(owner.identity ?? { profile: '' }));
 
   for (const manifest of PROVIDERS) registry.register(manifest);
   return registry;

--- a/src/cli/selection.ts
+++ b/src/cli/selection.ts
@@ -84,6 +84,10 @@ export const SELECTION: Record<string, Requires> = {
   'target show': 'profile',
   'secrets push': 'profile',
   'profile remove': 'profile',
+  // Target-independent for the same reason `policy list` is: the block is
+  // declared once in the YAML and applies to every target the profile has.
+  identity: 'profile',
+  'identity list': 'profile',
 
   connect: 'profile+target',
   setup: 'profile+target',
@@ -103,6 +107,11 @@ export const SELECTION: Record<string, Requires> = {
   deploy: 'profile+target',
   'policy allow': 'profile+target',
   'policy deny': 'profile+target',
+  // Both, unlike `identity list`, and for the same reason the policy edits are:
+  // each publishes the edit, which opens the target's credential store and
+  // reaches that target's endpoint.
+  'identity add': 'profile+target',
+  'identity remove': 'profile+target',
   'token show': 'profile+target',
   'token rotate': 'profile+target',
   'audit tail': 'profile+target',
@@ -130,6 +139,7 @@ const SUBCOMMANDS: Record<string, readonly string[]> = {
   profile: ['add', 'list', 'default', 'remove'],
   target: ['list', 'use', 'show'],
   policy: ['list', 'allow', 'deny'],
+  identity: ['add', 'list', 'remove'],
   token: ['show', 'rotate'],
   audit: ['tail', 'verify'],
   config: ['show'],
@@ -261,6 +271,7 @@ const ACCEPTS: Record<string, readonly string[]> = {
   deploy: ['dry-run', 'iam', 'access', 'service-account', 'tag', 'yes', 'non-interactive'],
   'secrets push': ['from', 'to', 'overwrite', 'dry-run'],
   update: ['check'],
+  'identity add': ['note'],
   memory: ['connection', 'title', 'description', 'file'],
   skills: ['connection', 'title', 'description', 'file'],
   vault: ['connection'],

--- a/src/cli/usage.ts
+++ b/src/cli/usage.ts
@@ -50,6 +50,12 @@ ${style.bold('Targets')}
   ${PROGRAM} target list [--urls]      where this profile can run
   ${PROGRAM} target show <name>        one target's adapters, and the address it answers on
 
+${style.bold('Who you are')}
+  ${PROGRAM} identity add <kind> <value> [--note text] [--json]
+                                 e.g. name, email, github — any kind you like
+  ${PROGRAM} identity list [--json]
+  ${PROGRAM} identity remove <kind> <value> [--json]
+
 ${style.bold('Permissions')}
   ${PROGRAM} policy list
   ${PROGRAM} policy allow <capability>  e.g. gmail.* or gmail.send_message

--- a/src/connectivity/manifest/provider.ts
+++ b/src/connectivity/manifest/provider.ts
@@ -65,7 +65,7 @@ export const providerManifestSchema = z.object({
 export type ProviderManifest = z.infer<typeof providerManifestSchema>;
 
 /** Provider ids reserved for the owner layer. */
-export const RESERVED_PROVIDER_IDS: readonly string[] = ['memory', 'skills', 'vault', 'setup'];
+export const RESERVED_PROVIDER_IDS: readonly string[] = ['memory', 'skills', 'vault', 'setup', 'identity'];
 
 /**
  * Validate a manifest, with the cross-field rules the schema alone cannot

--- a/src/deployments/upload.ts
+++ b/src/deployments/upload.ts
@@ -7,7 +7,8 @@ import {
   type Config,
   type TargetConfig,
 } from '#profile';
-import { ConfigDocument, ensureSetupConnection, repairLines, repaired } from '#cli/config-edit.ts';
+import { ConfigDocument } from '#cli/config-edit.ts';
+import { ensureSetupConnection, repairLines, repaired } from '#cli/config-repair.ts';
 import { ok, print, style, warn } from '#cli/output.ts';
 
 /**

--- a/src/dispatch/control-plane.test.ts
+++ b/src/dispatch/control-plane.test.ts
@@ -5,6 +5,7 @@ import { createMemoryBlobStore } from '#stores/blobs/testing.ts';
 import { defineLocalProvider, type ProviderContext } from '#connectivity';
 import { exampleProvider } from '#providers/example/provider.ts';
 import {
+  createIdentityProvider,
   createMemoryVaultStore,
   createSetupProvider,
   createSkillsProvider,
@@ -62,6 +63,14 @@ function registryWithBuiltins(): ProviderRegistry {
   // built with no items — a provider id in the catalogue is data, and what is
   // asserted here is the surface we author.
   registry.register(createSetupProvider({ profile: 'personal', target: 'local' }));
+  // Read-only for the same reason, and built with no entries for the same
+  // reason the vault is built with no items: an entry's `kind` is a word the
+  // *owner* chose, so a profile declaring `kind: api_token` would trip the
+  // token pattern below over their own data rather than over a surface we
+  // authored. What is asserted here is the surface we authored.
+  registry.register(
+    createIdentityProvider({ profile: 'personal', target: 'local', entries: [] }),
+  );
 
   return registry;
 }

--- a/src/profile/identity.test.ts
+++ b/src/profile/identity.test.ts
@@ -1,0 +1,151 @@
+import { describe, expect, test } from 'bun:test';
+import { identityEntrySchema } from './identity.ts';
+import { parseConfig } from './load.ts';
+
+/**
+ * The `identity` block.
+ *
+ * Most of this file is about one risk that is not obvious from the schema: this
+ * is the first block in a profile that holds the owner's own prose, and every
+ * value in a profile is walked by `secret-detection.ts` before the shape is even
+ * checked. A note that tripped it would fail `parseConfig` — and there is
+ * deliberately no suppression flag — so the profile would stop loading over a
+ * sentence someone wrote about which name to use. The cases below pin both
+ * directions: prose passes, and a credential pasted into a value does not.
+ */
+
+const PROFILE = `contract: 1
+instance:
+  profile: personal
+  default_target: local
+targets:
+  local:
+    credentials: { adapter: file, path: ./data/personal/credentials.enc }
+    storage: { adapter: filesystem, path: ./data/personal }
+connections:
+  - { id: main, provider: identity, account: Identity }
+policy:
+  allow: [identity.*]
+  deny: []
+`;
+
+/** The profile above, with an `identity` block appended. */
+function withIdentity(block: string): string {
+  return `${PROFILE}identity:\n${block}`;
+}
+
+describe('an entry', () => {
+  test('takes any kind the owner cares to invent', () => {
+    // An enum would mean a release every time someone wants `pronouns` or
+    // `linkedin`, and there is nothing this schema could do with the knowledge
+    // that a value is an email that would be worth that.
+    for (const kind of ['name', 'email', 'github', 'pronouns', 'signing_key_id']) {
+      expect(identityEntrySchema.safeParse({ kind, value: 'x' }).success).toBe(true);
+    }
+  });
+
+  test('holds the kind to the identifier shape, so it can be read as one word', () => {
+    for (const kind of ['Name', 'my kind', 'e-mail', '2fa', '']) {
+      expect(identityEntrySchema.safeParse({ kind, value: 'x' }).success).toBe(false);
+    }
+  });
+
+  test('needs a value, and a note is optional', () => {
+    expect(identityEntrySchema.safeParse({ kind: 'name', value: '' }).success).toBe(false);
+    expect(identityEntrySchema.safeParse({ kind: 'name', value: 'Ada' }).success).toBe(true);
+    expect(
+      identityEntrySchema.safeParse({ kind: 'name', value: 'Ada', note: 'for papers' }).success,
+    ).toBe(true);
+  });
+
+  test('refuses an empty note rather than storing one', () => {
+    // `note: ""` renders as a dangling em dash in every surface that shows it,
+    // and means the same as leaving it out.
+    expect(identityEntrySchema.safeParse({ kind: 'name', value: 'Ada', note: '' }).success).toBe(
+      false,
+    );
+  });
+});
+
+describe('the block in a profile', () => {
+  test('is optional, and absent means an empty list rather than undefined', () => {
+    // Every reader of `config.identity` would otherwise need a guard, and the
+    // one that forgot would throw on the common case: a profile that predates
+    // this block entirely.
+    expect(parseConfig(PROFILE).config.identity).toEqual([]);
+  });
+
+  test('keeps declaration order, because that order is the owner’s ranking', () => {
+    const { config } = parseConfig(
+      withIdentity(
+        '  - { kind: name, value: Ada }\n' +
+          '  - { kind: name, value: A. Lovelace }\n' +
+          '  - { kind: email, value: ada@example.com }\n',
+      ),
+    );
+
+    expect(config.identity.map((entry) => entry.value)).toEqual([
+      'Ada',
+      'A. Lovelace',
+      'ada@example.com',
+    ]);
+  });
+
+  test('refuses the same kind and value twice', () => {
+    // The two would usually differ only in their note, so the entry that loses
+    // is precisely the guidance someone wrote down to stop an agent picking
+    // wrong — and losing it silently is how that guidance stops working.
+    expect(() =>
+      parseConfig(
+        withIdentity(
+          '  - { kind: name, value: Ada, note: for papers }\n' +
+            '  - { kind: name, value: Ada, note: for code }\n',
+        ),
+      ),
+    ).toThrow(/duplicate entry "name: Ada"/);
+  });
+
+  test('allows the same value under two kinds', () => {
+    // A handle and a display name are routinely the same string, and they are
+    // not the same fact.
+    const { config } = parseConfig(
+      withIdentity('  - { kind: name, value: octocat }\n  - { kind: github, value: octocat }\n'),
+    );
+
+    expect(config.identity).toHaveLength(2);
+  });
+});
+
+describe('prose survives the secret scanner', () => {
+  test('a long note about when to use a name parses', () => {
+    // `looksHighEntropy` cannot fire on this: `OPAQUE_TOKEN` admits no spaces.
+    // That is the property doing the work, so it gets a test rather than a
+    // comment — a future tightening of that regex would break every profile
+    // whose owner explained themselves at length, and this is what would say so.
+    const note =
+      'Use this one on anything published under the foundation, including talks, ' +
+      'papers and release notes, but not on internal review threads where the ' +
+      'shorter form reads better and everyone already knows who you are';
+
+    const { config } = parseConfig(withIdentity(`  - { kind: name, value: Ada, note: "${note}" }\n`));
+
+    expect(config.identity[0]?.note).toBe(note);
+  });
+
+  test('an address with a plus tag and dots parses', () => {
+    const { config } = parseConfig(
+      withIdentity('  - { kind: email, value: ada.lovelace+lanes@example.com }\n'),
+    );
+
+    expect(config.identity[0]?.value).toBe('ada.lovelace+lanes@example.com');
+  });
+
+  test('a credential pasted in as a value is still refused', () => {
+    // Not a false positive to work around — the check working. Someone reaching
+    // for `identity add github <token>` has misunderstood what this block is
+    // for, and the config file is the last place that token should land.
+    expect(() =>
+      parseConfig(withIdentity('  - { kind: github, value: ghp_000000000000000000000000000000000000 }\n')),
+    ).toThrow(/ghp_/);
+  });
+});

--- a/src/profile/identity.ts
+++ b/src/profile/identity.ts
@@ -1,0 +1,60 @@
+import { z } from 'zod';
+import { identifier } from './primitives.ts';
+
+/**
+ * Who the owner is, in this profile — the names, addresses, and handles they
+ * want used when something is written as them.
+ *
+ * A profile already says what is *reachable*: connections, credentials, what
+ * policy permits. It said nothing about *whose* they are. So an agent composing
+ * a message, opening a pull request, or signing off had to infer a name from
+ * whatever happened to be in the conversation, and it mixed them across
+ * profiles — the work signature on a personal mailbox, the wrong handle in a
+ * commit trailer. The information was knowable and simply not written down.
+ *
+ * Three shapes were possible and only this one is right:
+ *
+ * - **A list, not a map.** `names: [John, Semin]` cannot say *when* to use
+ *   which, and the note is the whole point — an owner with two names has them
+ *   for a reason. A flat list of `{kind, value, note}` mirrors `connections`,
+ *   which is the other list in this file whose order a reader relies on.
+ * - **`kind` is free-form**, any `identifier`. Shipping an enum would mean a
+ *   release every time someone wants `linkedin`, `pronouns`, or `signature`,
+ *   and there is nothing this file could do with the knowledge that a value is
+ *   an email that would be worth that. Rendering is generic and stays generic.
+ * - **`note` is prose, not a reference.** Binding an entry to a connection was
+ *   the obvious alternative and is a trap: it puts a cross-reference into
+ *   `assertReferentialIntegrity`, and then renaming a connection breaks config
+ *   *load* — the profile stops opening because a name in a signature moved.
+ *   The agent reading "use with the personal mailbox" gets it right without
+ *   costing anything the day that mailbox is renamed.
+ *
+ * Declaration order is meaningful and preserved: the first entry of a kind is
+ * the one to reach for absent a reason, and the reader of the YAML sees the same
+ * order the agent is told.
+ *
+ * Not a secret, and worth being explicit about why, because this is the first
+ * block in a profile that holds the owner's own data rather than a pointer to
+ * it. A name and an address are disclosed by the first message of any mailbox
+ * this endpoint serves; withholding them here while serving the mailbox would
+ * be theatre. What is refused is a *credential* pasted into a value — a token
+ * beginning `ghp_` in a `github` entry trips `secret-detection.ts` like anything
+ * else in this file, which is that check working rather than getting in the way.
+ */
+export const identityEntrySchema = z.object({
+  /** `name`, `email`, `github` — or anything else the owner finds useful. */
+  kind: identifier,
+  value: z.string().min(1),
+  /**
+   * When this one applies, in the owner's words.
+   *
+   * Optional, and usually absent on the only entry of its kind: a profile with
+   * one address needs no note explaining which address to use. It earns its
+   * place the moment there are two.
+   */
+  note: z.string().min(1).optional(),
+});
+
+export const identitySchema = z.array(identityEntrySchema);
+
+export type IdentityEntry = z.infer<typeof identityEntrySchema>;

--- a/src/profile/index.ts
+++ b/src/profile/index.ts
@@ -19,6 +19,7 @@ export {
   type Config,
   type ConnectionConfig,
   type DeployConfig,
+  type IdentityEntry,
   type PolicyRuleConfig,
   type TargetConfig,
   type WorkspaceConfig,

--- a/src/profile/load.ts
+++ b/src/profile/load.ts
@@ -144,6 +144,20 @@ function assertReferentialIntegrity(config: Config, source: string): void {
     connectionKeys.add(key);
   });
 
+  // Same reason as a duplicate connection: two entries with the same kind and
+  // value cannot both be meant, and the one that loses is invisible. It matters
+  // more here than it looks, because the two would usually differ only in their
+  // `note` — so the discarded one is precisely the guidance someone wrote down
+  // to stop an agent picking wrong.
+  const identityKeys = new Set<string>();
+  config.identity.forEach((entry, index) => {
+    const key = `${entry.kind}=${entry.value}`;
+    if (identityKeys.has(key)) {
+      problems.push(`identity[${index}]: duplicate entry "${entry.kind}: ${entry.value}"`);
+    }
+    identityKeys.add(key);
+  });
+
   const checkRules = (rules: readonly PolicyRuleConfig[], field: 'allow' | 'deny'): void => {
     rules.forEach((rule, index) => {
       const where = `policy.${field}[${index}]`;

--- a/src/profile/schema.ts
+++ b/src/profile/schema.ts
@@ -1,6 +1,7 @@
 import { z } from 'zod';
 import { capabilityPattern, credentialRef, identifier } from './primitives.ts';
 import { authorizationSchema } from './authorization.ts';
+import { identitySchema } from './identity.ts';
 
 /**
  * Configuration is declarative desired state. This file is the source of truth
@@ -368,6 +369,13 @@ export const configSchema = z.object({
    */
   connections: z.array(connectionSchema).default([]),
   policy: policySchema.default({ allow: [], deny: [] }),
+
+  /**
+   * Who the owner is, for anything written as them. Optional and additive, so
+   * every profile written before it keeps loading unchanged — the same reasoning
+   * as `auth.authorization` above, and the reason `contract` does not move.
+   */
+  identity: identitySchema.default([]),
 });
 
 export type Config = z.infer<typeof configSchema>;
@@ -376,7 +384,8 @@ export type PolicyRuleConfig = z.infer<typeof policyRuleSchema>;
 export type TargetConfig = z.infer<typeof targetSchema>;
 export type DeployConfig = z.infer<typeof deployTargetSchema>;
 export type AuthorizationConfig = z.infer<typeof authorizationSchema>;
-export { authorizationSchema };
+export { authorizationSchema, identitySchema };
+export type { IdentityEntry } from './identity.ts';
 
 /** The workspace file: `lanes-link.yaml`, alongside a `profiles/` directory. */
 export const workspaceSchema = z.object({

--- a/src/providers/identity/provider.test.ts
+++ b/src/providers/identity/provider.test.ts
@@ -1,0 +1,145 @@
+import { describe, expect, test } from 'bun:test';
+import { type Capability, type ProviderContext } from '#connectivity';
+import type { IdentityEntry } from '#profile';
+import { createIdentityProvider } from './provider.ts';
+
+/**
+ * The read-only identity surface.
+ *
+ * Two properties carry the design and both are structural:
+ *
+ * - Nothing here writes. This block is configuration, and an agent able to edit
+ *   it could edit the one fact that stops it signing as the wrong person — so
+ *   the capability list holding exactly one read is the claim, and it is
+ *   asserted rather than left to review.
+ * - It says enough to be *acted on*. A list of names with no ranking and no
+ *   notes is a list a model picks from at random, which is the behaviour this
+ *   whole feature exists to replace. So the rendering is tested for the parts
+ *   that make a choice possible, not for wording.
+ */
+
+function capabilities(entries: readonly IdentityEntry[]): Capability[] {
+  return [...createIdentityProvider({ profile: 'personal', entries }).capabilities];
+}
+
+/** Nothing on the context is read by this handler; it is required, not used. */
+const context = { connection: { key: 'identity.main', id: 'main', provider: 'identity' } } as
+  unknown as ProviderContext;
+
+async function textOf(entries: readonly IdentityEntry[]): Promise<string> {
+  const found = capabilities(entries).find((capability) => capability.name === 'list');
+  if (!found) throw new Error('no capability "list"');
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const result = (await (found as any).handler({}, context)) as { content: { text: string }[] };
+  return result.content.map((part) => part.text).join('\n');
+}
+
+const DECLARED: readonly IdentityEntry[] = [
+  { kind: 'name', value: 'Ada', note: 'use for open-source work' },
+  { kind: 'email', value: 'ada@example.com' },
+  { kind: 'name', value: 'A. Lovelace', note: 'use on anything published' },
+  { kind: 'github', value: 'octocat' },
+];
+
+describe('the surface is read-only', () => {
+  test('offers exactly one capability, and it is a read', () => {
+    const offered = capabilities([]);
+
+    expect(offered.map((capability) => capability.name)).toEqual(['list']);
+    expect(offered[0]?.kind).toBe('tool');
+  });
+
+  test('offers no write bundle', () => {
+    const bundles = createIdentityProvider({ profile: 'personal' }).manifest.bundles ?? [];
+
+    expect(bundles.map((bundle) => bundle.name)).toEqual(['read']);
+    // A scope list would mean a third party had to consent to something. This
+    // reads a local file.
+    expect(bundles[0]?.oauth_scopes).toEqual([]);
+  });
+});
+
+describe('what it reports', () => {
+  test('names the profile it is reporting for', async () => {
+    // The handler cannot learn this — the routing arguments are stripped before
+    // dispatch — so it is stamped at construction, and a report that did not
+    // say which profile it described would be unusable on an endpoint serving
+    // more than one.
+    expect(await textOf(DECLARED)).toContain('profile "personal"');
+  });
+
+  test('keeps each entry with its note', async () => {
+    const text = await textOf(DECLARED);
+
+    expect(text).toContain('use for open-source work');
+    expect(text).toContain('use on anything published');
+    expect(text).toContain('ada@example.com');
+    expect(text).toContain('octocat');
+  });
+
+  test('groups the kinds, so a name cannot be read as an address', async () => {
+    const lines = (await textOf(DECLARED)).split('\n').filter((line) => line.startsWith('  '));
+    const kinds = lines.map((line) => line.trim().split(/\s+/)[0]);
+
+    // Declaration order interleaves the two names with an email between them.
+    // Adjacency is most of what stops the wrong one being picked, so the
+    // grouping is the assertion — not the order the file happened to hold.
+    expect(kinds).toEqual(['name', 'name', 'email', 'github']);
+  });
+
+  test('keeps declaration order within a kind, because that is the ranking', async () => {
+    const text = await textOf(DECLARED);
+
+    expect(text.indexOf('Ada')).toBeLessThan(text.indexOf('A. Lovelace'));
+  });
+
+  test('says that the first of several is the default', async () => {
+    // Without this a model handed two names picks by position anyway. Being
+    // told that position is what it means is the difference between a guess and
+    // an instruction.
+    expect(await textOf(DECLARED)).toContain('the first is the default');
+  });
+
+  test('does not offer a ranking when there is nothing to rank', async () => {
+    const text = await textOf([{ kind: 'name', value: 'Ada' }]);
+
+    expect(text).not.toContain('the first is the default');
+    expect(text).toContain('Use these as written');
+  });
+});
+
+describe('a profile that declares nothing', () => {
+  test('is a listing, not a failure', async () => {
+    const text = await textOf([]);
+
+    expect(text).toContain('declares no identity');
+  });
+
+  test('tells the caller to ask rather than to invent one', async () => {
+    // The failure mode is unchanged by there being nothing here: a model that
+    // needs a name and finds none will compose one. This is the only place that
+    // can say not to.
+    expect(await textOf([])).toContain('do not invent one');
+  });
+
+  test('names the command that would declare one', async () => {
+    // The owner runs it, not the agent — but an agent that can quote the exact
+    // line is the difference between a useful answer and "ask your admin".
+    expect(await textOf([])).toContain('lanes link identity add');
+  });
+});
+
+describe('kinds are the owner’s to choose', () => {
+  test('reports a kind this project has never heard of', async () => {
+    // The schema takes any identifier deliberately: shipping an enum would mean
+    // a release every time someone wants a kind we did not think of.
+    const text = await textOf([
+      { kind: 'pronouns', value: 'they/them' },
+      { kind: 'linkedin', value: 'in/example' },
+    ]);
+
+    expect(text).toContain('pronouns');
+    expect(text).toContain('they/them');
+    expect(text).toContain('linkedin');
+  });
+});

--- a/src/providers/identity/provider.ts
+++ b/src/providers/identity/provider.ts
@@ -1,0 +1,166 @@
+import { z } from 'zod';
+import { defineLocalProvider, type ProviderDefinition } from '#connectivity';
+import type { IdentityEntry } from '#profile';
+
+/**
+ * `identity` — who the owner is, for anything written as them.
+ *
+ * **Read-only by construction, for the same reason `setup` is.** ADR-007 keeps
+ * configuration mutation off the MCP surface, and this block *is* configuration:
+ * an agent that could rewrite whose name it signs with would be rewriting the
+ * one fact that stops it signing wrong. Declaring it is the owner's, in a
+ * terminal. So there is one capability, it is a read, and `provider.test.ts`
+ * asserts the capability list holds nothing else.
+ *
+ * Reporting it authorises nothing, which is the ADR-019 argument again. A name
+ * and an address are disclosed by the first message of any mailbox this endpoint
+ * serves — a caller holding a grant on a mail connection already has them —
+ * so withholding them here while serving the mailbox would be theatre. The
+ * difference is that reading them *here* means not having to guess, and a guess
+ * is what this exists to replace.
+ *
+ * Why it is its own provider rather than a third section of `setup_overview`:
+ * policy. `identity.*` is a grant an owner can give or withhold on its own, so
+ * an endpoint can describe what is connected without naming its owner, or name
+ * its owner without describing what is connected. Folding it into `setup` would
+ * have made those one decision, and they are not.
+ *
+ * `identity.list` is clean against the seven patterns in
+ * `dispatch/control-plane.test.ts`. So is `identity` as a prefix. Neither is a
+ * cosmetic name.
+ */
+
+export interface IdentityProviderOptions {
+  /**
+   * Which profile this instance serves.
+   *
+   * Stamped at construction for the reason recorded on `SetupProviderOptions`:
+   * `makeHandler` strips `profile` off the arguments before dispatch and
+   * `ProviderContext` does not carry it, so a handler cannot learn it. One
+   * registry is built per profile, so each instance gets its own.
+   */
+  readonly profile: string;
+  /**
+   * Which target it is serving, for the command in the empty case.
+   *
+   * Needed for the same reason `setup`'s plans need it: `--profile` and
+   * `--target` are required flags (ADR-037), and a command handed to an agent
+   * without both is a paste that refuses. An agent pastes what it is given.
+   */
+  readonly target?: string;
+  /**
+   * What that profile declares, in declaration order.
+   *
+   * A snapshot rather than a function, unlike `setup`'s `reachable`. That one
+   * has to be re-evaluated per call because policy is; this is config, and the
+   * registry holding it is rebuilt whenever config is re-read — so an entry
+   * added by the CLI is served after the next reload, exactly as a new
+   * connection is, and a function here would only imply a freshness it could
+   * not deliver.
+   */
+  readonly entries?: readonly IdentityEntry[];
+}
+
+export function createIdentityProvider(options: IdentityProviderOptions): ProviderDefinition {
+  const entries = options.entries ?? [];
+
+  return defineLocalProvider({
+    id: 'identity',
+    name: 'Identity',
+    version: '1.0.0',
+    description:
+      'The names, addresses, and handles this profile declares for its owner, and a note on ' +
+      'when each applies. Read-only: what is declared is set in the CLI, because an agent able ' +
+      'to change whose name it signs with could change the one fact that stops it signing wrong.',
+
+    configSchema: z.object({}),
+    connectionSchema: z.object({}),
+
+    bundles: [
+      {
+        name: 'read',
+        description: 'Read the declared identity. There is no write bundle, by design.',
+        oauth_scopes: [],
+        capabilities: ['list'],
+        default: true,
+      },
+    ],
+
+    capabilities: [
+      {
+        kind: 'tool',
+        name: 'list',
+        title: 'Who the owner is, in this profile',
+        description:
+          'The names, addresses, and handles this profile declares for its owner, each with a ' +
+          'note on when it applies. Call this before writing as them — signing a message, ' +
+          'addressing one, choosing an account to act as — rather than inferring one from ' +
+          'the conversation. A profile may declare several of a kind deliberately.',
+        inputSchema: z.object({}),
+        // No arguments to redact.
+        async handler(_input, _handlerContext) {
+          return {
+            content: [{ type: 'text', text: render(options.profile, options.target, entries) }],
+          };
+        },
+      },
+    ],
+  });
+}
+
+/**
+ * Grouped by kind, in order of first appearance, and self-describing per line.
+ *
+ * Grouped because the failure this exists to prevent is a name used where an
+ * address was wanted, and adjacency is most of what stops that. The kind is
+ * repeated on every line anyway rather than written once as a heading: a line
+ * lifted out of this block on its own then still says what it is, and a model
+ * quoting one line is exactly what happens next.
+ *
+ * Order within a kind is declaration order, which is the owner's ranking.
+ */
+function render(
+  profile: string,
+  target: string | undefined,
+  entries: readonly IdentityEntry[],
+): string {
+  if (entries.length === 0) {
+    // Both flags, spelled out. They are required (ADR-037), so a command
+    // missing either is one the owner pastes and watches refuse — and this is
+    // handed to an agent, which relays it verbatim.
+    const where = `--profile ${profile}${target ? ` --target ${target}` : ''}`;
+    return (
+      `Profile "${profile}" declares no identity.\n\n` +
+      'Nothing here says what name or address to use, so do not invent one — ask. ' +
+      `The owner declares them with \`lanes link identity add <kind> <value> ${where}\`.`
+    );
+  }
+
+  const kinds = [...new Set(entries.map((entry) => entry.kind))];
+  const ordered = kinds.flatMap((kind) => entries.filter((entry) => entry.kind === kind));
+
+  const kindWidth = Math.max(...ordered.map((entry) => entry.kind.length));
+  const valueWidth = Math.max(...ordered.map((entry) => entry.value.length));
+
+  const lines = ordered.map((entry) => {
+    const head = `  ${entry.kind.padEnd(kindWidth)}  ${entry.value}`;
+    return entry.note ? `${head.padEnd(kindWidth + valueWidth + 4)}  — ${entry.note}` : head;
+  });
+
+  // Said here rather than left to the reader because "several names" is
+  // otherwise ambiguous in the one direction that matters: a model handed two
+  // with no ranking picks by position anyway, and may as well be told that
+  // position is what it means.
+  const several = kinds.some((kind) => entries.filter((entry) => entry.kind === kind).length > 1);
+
+  return [
+    `Identity for profile "${profile}".`,
+    '',
+    ...lines,
+    '',
+    several
+      ? 'Where a kind holds more than one, the first is the default and the notes say when to ' +
+        'prefer another. If none of them fits what you are doing, ask rather than combining them.'
+      : 'Use these as written. If what you need is not here, ask rather than inferring it.',
+  ].join('\n');
+}

--- a/src/providers/owner.ts
+++ b/src/providers/owner.ts
@@ -1,5 +1,5 @@
 /**
- * The owner layer — memory, skills, vault.
+ * The owner layer — memory, skills, vault, setup, identity.
  *
  * Three providers that hold no third-party account: no OAuth, no vendor API, no
  * rate limit anyone else imposes. They are ordinary `defineLocalProvider`
@@ -19,7 +19,14 @@
  * read-only by construction — see ADR-019 for why describing setup is not one
  * of ADR-007's control-plane exclusions.
  *
- * The ids `memory`, `skills`, `vault`, and `setup` are reserved (`RESERVED_PROVIDER_IDS`)
+ * `identity` is the fifth and holds no account either. It says who the owner is
+ * — the names and addresses to write as them — and is read-only for the reason
+ * `setup` is: what it reports is configuration, and configuration is changed in
+ * the CLI. It is a provider of its own rather than a section of `setup` so that
+ * naming the owner and describing what is connected are two policy decisions
+ * instead of one.
+ *
+ * The ids `memory`, `skills`, `vault`, `setup`, and `identity` are reserved (`RESERVED_PROVIDER_IDS`)
  * and still refused by default — the registry has to be built with
  * `allowReserved` to hold them, so a third-party provider cannot claim a
  * namespace whose policy rules would then mean something else.
@@ -29,6 +36,7 @@ export { memoryProvider, memoryStorage, assertEntryId, type MemoryEntry } from '
 export { createSkillsProvider, type SkillsProviderOptions } from './skills/provider.ts';
 export { createVaultProvider, type VaultProviderOptions } from './vault/provider.ts';
 export { createSetupProvider, type SetupProviderOptions } from './setup/provider.ts';
+export { createIdentityProvider, type IdentityProviderOptions } from './identity/provider.ts';
 export { planAll, planFor, type PlanContext, type ProviderPlan } from './setup/plan.ts';
 // The vault's *store* is not here: it is `#secrets`, beside the system
 // credential store it must never become. What lives in `./vault/` is the

--- a/src/server/mcp/instructions.test.ts
+++ b/src/server/mcp/instructions.test.ts
@@ -189,6 +189,40 @@ describe('the habits it teaches', () => {
     expect(granted).toContain('inventing it is not');
   });
 
+  /**
+   * The paragraph that must not carry what it points at.
+   *
+   * Inlining the declaration was the obvious shape and is the wrong one: the
+   * ceiling is fixed, so the workspace with the most identities to keep apart
+   * is the one whose list would be summarised away first — and it would leak
+   * every profile's names to a client that had asked about none of them. A
+   * pointer costs the same at any size, so this asserts both halves: the
+   * pointer is there, and no name came with it.
+   */
+  test('points at the declared identity without reciting it', () => {
+    const granted = serverInstructions(
+      ['personal'],
+      new Map([
+        ['gmail.send', reaching({ personal: ['gmail.a'] })],
+        ['identity.list', reaching({ personal: ['identity.main'] })],
+      ]),
+    );
+
+    expect(granted).toContain('identity_list');
+    expect(granted).toContain('Identity is declared, not inferred');
+    // The instruction is to fetch, so the fetchable part must not be here.
+    expect(granted).not.toContain('note on when it applies.\n  ');
+  });
+
+  test('says nothing about identity for a profile that declares none', () => {
+    // A profile with no identity block gets no `identity` connection, so the
+    // capability is unreachable and the paragraph is unspent. Telling a client
+    // to call a tool it cannot see is the contradiction the test above this one
+    // exists to prevent.
+    expect(text).not.toContain('identity_list');
+    expect(text).not.toContain('Identity is declared');
+  });
+
   test('says nothing about setup when there is no surface to point at', () => {
     expect(text).not.toContain('setup_overview');
   });
@@ -237,6 +271,13 @@ describe('the habits it teaches', () => {
     // back over — and the prose is now assembled per principal, so the worst
     // case is every owner-layer provider granted at the same time. Both at once
     // is the case that has to hold.
+    //
+    // `remoteClients` is passed for the same reason. It was omitted here while
+    // `AVAILABILITY` was the paragraph the ceiling had last been raised for — so
+    // the case this test called the worst was ~180 characters short of one an
+    // endpoint actually serves, and the ceiling it certified was the wrong
+    // number to certify. Every paragraph that can be spent at once is spent
+    // here, or the budget is guarded against a case that does not happen.
     const profiles = Array.from({ length: 20 }, (_, i) => `a-fairly-long-profile-name-${i}`);
     const reachable = new Map(
       profiles.map((profile) => [
@@ -254,7 +295,9 @@ describe('the habits it teaches', () => {
         ['skills.manage.list', reaching({ [first]: ['skills.owner'] })],
         ['vault.put', reaching({ [first]: ['vault.owner'] })],
         ['setup.overview', reaching({ [first]: ['setup.main'] })],
+        ['identity.list', reaching({ [first]: ['identity.main'] })],
       ]),
+      true,
     );
 
     expect(worst.length).toBeLessThan(MAX_INSTRUCTIONS);
@@ -274,7 +317,7 @@ describe('the habits it teaches', () => {
   /**
    * The budget must not spend itself on prose and leave nothing for the facts.
    *
-   * A fully set-up workspace grants all four owner-layer providers, so its prose
+   * A fully set-up workspace grants all five owner-layer providers, so its prose
    * is the longest there is — and a reserve guessed in advance meant the listing
    * could not fit behind it *at any workspace size*. A single profile with two
    * mailboxes was told "1 profiles" with a hundred characters of the ceiling

--- a/src/server/mcp/instructions.ts
+++ b/src/server/mcp/instructions.ts
@@ -87,6 +87,23 @@ const SETUP = `**What is set up is answerable.** Before saying something cannot 
 that an account must be added, call \`setup_overview\` — then \`setup_provider\`
 for the exact command. Running it is the owner's to do; inventing it is not.`;
 
+/**
+ * The one about not signing as the wrong person.
+ *
+ * It carries no names, and that is deliberate rather than thrift. Inlining the
+ * declaration would put a per-profile list into a string with a fixed ceiling —
+ * so the workspace with the most identities to keep straight is exactly the one
+ * whose list would be summarised away first. A pointer costs the same for one
+ * profile as for twenty, and `identity_list` has room to say when each applies,
+ * which is the half that actually prevents the mistake.
+ *
+ * Conditional like the rest: a profile that declares nothing has no `identity`
+ * connection, so the capability is unreachable and this paragraph is unspent.
+ */
+const IDENTITY = `**Identity is declared, not inferred.** Where a name, address or handle of the
+owner's is needed, call \`identity_list\`: a profile may hold several, each with a
+note on when it applies.`;
+
 const FILES = `**Files are named, not carried.** Where a tool takes attachments, give a path, an
 HTTPS URL, or an attachment already on another message; the endpoint reads the
 bytes. Never encode a file into a call — that is the thing this replaces.`;
@@ -122,6 +139,7 @@ const OWNER_HABITS: Record<string, string> = {
   skills: SKILLS,
   vault: VAULT,
   setup: SETUP,
+  identity: IDENTITY,
 };
 
 /**
@@ -137,6 +155,15 @@ const OWNER_HABITS: Record<string, string> = {
  * precisely the one that holds no skills directory, so the skill is not a place
  * it can go. Only an endpoint serving remote clients spends it.
  *
+ * Raised a second time, to 2500, for `IDENTITY`, and the same answer for the
+ * same reason: an agent signing as the wrong person has already sent the
+ * message, and a skill loaded only when relevant is not loaded at the moment
+ * that happens. The measured worst case — twenty profiles, twenty connections
+ * each, every owner provider reachable, remote clients — is 2474, so this is
+ * the measurement plus a little, not a round number picked first. Two things
+ * hold it there: the paragraph names no identity, and it is spent only by a
+ * profile that declared one.
+ *
  * Exported because the test asserted `2000` as a literal while the code
  * reserved room against a second, differently-derived number — so the two could
  * disagree, and did. There is no separate listing allowance any more: `spent`
@@ -144,7 +171,7 @@ const OWNER_HABITS: Record<string, string> = {
  * exactly the final length, because `join` adds the same two characters the
  * reduce already counted.
  */
-export const MAX_INSTRUCTIONS = 2300;
+export const MAX_INSTRUCTIONS = 2500;
 
 /** Which of the owner-layer providers this principal can actually reach. */
 function ownerProviders(merged: ReadonlyMap<string, MergedCapability>): string[] {


### PR DESCRIPTION
A profile said what was reachable and nothing about *whose* it was. The closest thing is the `account` label on a connection, which answers a different question — that is the identity a provider reports at connect time, so it says which mailbox this is rather than what to sign a message from it with.

So an agent writing as the owner inferred. The failure that matters is not a wrong guess in isolation, it is a guess that **crosses profiles**: two profiles exist because the same person is two people to two sets of accounts, and an agent with no declaration reaches for whichever name it saw most recently.

```yaml
identity:
  - { kind: name,   value: Ada,             note: use for open-source work }
  - { kind: name,   value: A. Lovelace,     note: use on anything published }
  - { kind: email,  value: ada@example.com }
  - { kind: github, value: octocat }
```

```console
$ lanes link identity add name Ada --note "use for open-source work" --profile personal --target local
ok    name Ada
      note    use for open-source work
      connections += identity.main
      policy.allow += identity.*
      an agent can now read this profile's identity
```

[ADR-039](https://github.com/lanes-sh/link/blob/profile-identity/docs/detailed/adr/039-a-profile-declares-who-its-owner-is.md) has the argument. Four decisions are the ones worth reviewing:

- **A list, not a map.** `names: [Ada, A. Lovelace]` cannot say which to use when. Declaration order is the ranking and the surface says so — a model handed two with no ranking picks by position anyway.
- **`kind` is free-form.** An enum means a release every time someone wants `linkedin` or `pronouns`.
- **`note` is prose, not a reference.** Binding an entry to a connection puts a cross-reference into `assertReferentialIntegrity`, so renaming a connection would break config *load*.
- **The instructions point at the tool and carry none of the data.** Inlining is wrong twice over: the ceiling is fixed, so the workspace with the most identities to keep apart is the one whose list gets summarised away first — and it would send every profile's names to a client that asked about none of them.

Editing is CLI-only under ADR-007, and the reason is sharper than where that ADR has been applied before: an agent able to edit this could edit the one fact that stops it signing as the wrong person. It is its own provider rather than a third section of `setup_overview` so that naming the owner and describing what is connected stay two policy decisions instead of one.

`identity add` provisions the surface on first use, in one `save()`. An `identity` block alone is inert — `allowedConnections` returns nothing for a provider with no connection row *before* it consults policy — and one save because `validateConfig` refuses an allow rule naming a provider with no connection, so a half-applied run would leave a profile that no longer loads.

## Three things here that are not the feature

**`ensureSetupConnection` is generalised, not copied.** Its rules are subtle enough that a second copy would drift — a deliberate `deny` must survive the repair, `*` already covers, and rule expiry is read in both directions. That meant moving the repair helpers to `config-repair.ts`, because `config-edit.ts` was at 397 of the 400-line budget. `SetupRepair` → `SurfaceRepair`; nothing imported it by name.

**The instructions budget test was certifying the wrong number.** It never passed `remoteClients`, so the case it called the worst was ~180 characters short of one an endpoint actually serves. It now spends every paragraph that can be spent at once. `MAX_INSTRUCTIONS` moves 2300 → 2500 for the new paragraph; measured worst case is 2474.

**Small additions:** `ConfigDocument.removeFrom`, and `output.ts` gains `announceProfile` for a command that opens no target.

## Found while rebasing, not fixed here

`resolveProfileOnly` was added for ADR-037 and **is not called by anything** on `develop`, so `check`, `config show` and `policy list` still demand `--target` despite `SELECTION` filing all three as `profile`-only:

```console
$ lanes link policy list --profile personal
error  --target is required. This command opens a target's stores, and nothing else selects one.
```

`identity list` uses `resolveProfileOnly`, so it behaves as its table entry says. The other three are someone else's just-landed work and belong in their own change — `selection.test.ts` checks the table is *complete*, not that runtime behaviour matches it, which is the hole that let this through.

## Verification

`bun test` 1864 pass / 0 fail, `bun run typecheck` clean. Checked end to end over stdio against a scratch workspace: the `initialize` instructions carry the pointer and no names, `identity_list` returns the entries with their notes. Negative control also holds — with the `identity.*` rule deleted by hand the tool leaves `tools/list`, the paragraph leaves the instructions, and `identity list` reports `declared, but no agent can read it`.

## What this does not do

Bind an identity to a connection, account or provider. Let an agent write or reorder one. Validate a value against its kind. Reconcile with the `account` label on a connection, which answers a different question and stays where it is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
