### PR TITLE
Say that connecting again replaces the credential, and stop guessing at it

### DIFF
--- a/docs/detailed/adr/038-a-key-is-the-second-way-into-an-account.md
+++ b/docs/detailed/adr/038-a-key-is-the-second-way-into-an-account.md
@@ -78,6 +78,26 @@ right one.
 `--auth <method>` is the non-interactive answer, and deliberately the only one: a run with nobody
 to ask does not guess, because guessing picks which credential gets overwritten.
 
+**A connection authenticates one way at a time, and connecting again replaces it.** Both routes
+write to `<provider>/<connection>`, `settleIdentity` resolves a re-run of `connect` on the same
+account back to the connection that already holds it, and the credential is overwritten in place
+— so switching an account from the browser to a key, or back, is a re-run of `connect` and needs
+nothing removed first. There is one connection and one credential afterwards, and the last run
+wins.
+
+The prompt says so rather than defaulting to the route already stored. Defaulting was tried and
+was wrong twice over. Mechanically it could not work: the route was read under the *provisional*
+connection id, which is `pending` until identity is settled, so it found nothing every time and
+fell back to the browser — performing the silent swap it existed to prevent. And in principle it
+answers the operator's question by reading their credential, which puts the consequential half of
+the decision behind a default that reads as a no-op. A sentence can be read; a default cannot.
+
+Two things it does not do. It does not revoke the grant it replaced: switching a connection from
+the browser to a key overwrites the stored token and leaves the issuer holding a live
+refresh-token grant for that account, which has to be withdrawn in the vendor's console. And it
+does not remember the subject — every connect asks who the key acts as, because remembering would
+mean reading the existing connection, which is the thing that was removed.
+
 Two costs worth stating plainly. A key never expires, which is the feature and also means a
 leaked key is good until someone deletes it — there is no consent to withdraw and no token to
 age out. And domain-wide delegation is a large grant to ask an administrator for; the walkthrough
@@ -88,4 +108,5 @@ refused identically to a missing one and the refusal does not say which scope wa
 
 Nothing about a connection that authorised in a browser. The union of `auth.kind` is untouched,
 the credential ref is unchanged, and a manifest that declares no `assertion` block reads, behaves
-and prompts exactly as it did.
+and prompts exactly as it did — including the warning above, which is printed only where there is
+a choice to warn about. Connecting GitHub, Slack or iCloud asks nothing and says nothing new.

--- a/docs/detailed/setup/google.md
+++ b/docs/detailed/setup/google.md
@@ -112,6 +112,17 @@ That is why the middle row above beats the first one today: the hosted client is
 a client under review has whatever status it has. Registering your own and publishing it is the
 shortest path to connections that survive the week.
 
+**Picking wrong is not a decision you are stuck with.** An account authenticates one way at a
+time, and `connect` is how it changes: run it again, pick another route, and the new credential
+replaces the old one on the same connection. Nothing has to be disconnected or removed first, and
+you do not end up with the account listed twice. The prompt says as much each time it asks, which
+is also the warning worth reading if you are re-running `connect` only to refresh a token — the
+last route you pick is the one that account uses from then on.
+
+One thing this does not do: it does not withdraw the access you had. Moving a connection off the
+browser leaves Google still holding the consent you granted, which you remove yourself at
+[myaccount.google.com/permissions](https://myaccount.google.com/permissions).
+
 ### If you register your own
 
 **Choose External if you have a mix of personal Gmail and Workspace accounts**, which is the common

--- a/src/cli/commands/connect/index.ts
+++ b/src/cli/commands/connect/index.ts
@@ -8,7 +8,7 @@ import { discoverCapabilities } from './discover.ts';
 import { connectFamily, familyMembers } from './family.ts';
 import { authoriseWithKey } from './assertion.ts';
 import { authorise } from './authorise.ts';
-import { chooseAuthMethod, currentAuthMethod } from './method.ts';
+import { chooseAuthMethod } from './method.ts';
 import { preflight } from './requirements.ts';
 import { ALREADY, NOTHING, renderOutcome, where, type ConnectOutcome } from './outcome.ts';
 import { nextAfterEdit, publishRuntimeEdit } from '#cli/publish.ts';
@@ -179,7 +179,6 @@ async function runConnect(
       manifest,
       requested: options.auth,
       ownClient: options.ownClient === true,
-      current: await currentAuthMethod(manifest, provisionalId, runtime.credentials),
       prompter,
     });
 
@@ -307,7 +306,11 @@ async function runConnect(
         document.setIn(['connections', existingIndex, 'account'], account);
         changes.push(`connections.${connectionKey}.account = ${account}`);
       }
-      changes.push(`re-authorised ${connectionKey}`);
+      // Named where the provider offered a choice, because this is the line an
+      // operator reads to see that a re-connect swapped the route rather than
+      // refreshed it — and `--auth` reaches here having asked nothing. Unnamed
+      // for a provider with one way in, whose output is unchanged.
+      changes.push(`re-authorised ${connectionKey}${method.id ? ` with ${method.id}` : ''}`);
     }
 
     // 5. Grant it.

--- a/src/cli/commands/connect/method.test.ts
+++ b/src/cli/commands/connect/method.test.ts
@@ -1,19 +1,24 @@
 import { describe, expect, test } from 'bun:test';
 import { defineProvider, type ProviderManifest } from '#connectivity';
-import { ASSERTION_GRANT } from '#connectivity/auth/index.ts';
-import type { SecretStore } from '#secrets';
 import type { Prompter } from '../../prompt.ts';
-import { chooseAuthMethod, currentAuthMethod, methodsFor } from './method.ts';
+import { chooseAuthMethod, methodsFor } from './method.ts';
 
 /**
  * Which way in, and who decides.
  *
- * Two properties matter here and neither is about the prompt. A provider that
- * offers one method must never ask — adding a choice to Google must not put a
- * question in front of somebody connecting GitHub. And re-running `connect` on
- * an existing account must default to what that account already uses, because
- * the alternative is a repair that quietly replaces the credential it was meant
- * to repair.
+ * Two properties matter here and neither is the wording of the prompt. A
+ * provider that offers one method must never ask — adding a choice to Google
+ * must not put a question in front of somebody connecting GitHub. And the
+ * choice must be made from the flag or from the operator and from nothing
+ * else: `chooseAuthMethod` takes no credential store, which is what makes
+ * "connecting again replaces what is there" a rule rather than an accident.
+ *
+ * It used to take one, indirectly — a `current` argument read off the stored
+ * credential, meant to default a re-run to the route the account already used.
+ * It was read under the *provisional* connection id, which is `pending` until
+ * identity is settled, so it was always undefined and the default was always
+ * the browser. The prompt now says what the choice does instead of trying to
+ * guess it.
  */
 
 const ASSERTION = {
@@ -79,15 +84,25 @@ const silent: Prompter = {
   confirm: async () => false,
 };
 
-function memoryStore(seed: Record<string, string> = {}): SecretStore {
-  const map = new Map(Object.entries(seed));
-  return {
-    get: async (ref: string) => map.get(ref) ?? null,
-    set: async (ref: string, value: string) => void map.set(ref, value),
-    has: async (ref: string) => map.has(ref),
-    delete: async (ref: string) => void map.delete(ref),
-    list: async () => [...map.keys()],
-  } as unknown as SecretStore;
+/**
+ * What was printed on the way to the answer.
+ *
+ * `progress` writes to stderr, and a warning that is built and discarded type-
+ * checks and runs exactly like one that is printed — so nothing but a test
+ * reading the stream can tell them apart.
+ */
+async function captured(body: () => Promise<void>): Promise<string> {
+  const errWrite = process.stderr.write.bind(process.stderr);
+  let err = '';
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (process.stderr as any).write = (chunk: string) => ((err += chunk), true);
+  try {
+    await body();
+  } finally {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (process.stderr as any).write = errWrite;
+  }
+  return err;
 }
 
 describe('what a provider offers', () => {
@@ -116,7 +131,6 @@ describe('choosing', () => {
     const chosen = await chooseAuthMethod({
       manifest: manifest(false),
       requested: undefined,
-      current: undefined,
       prompter: terminal,
     });
 
@@ -131,7 +145,6 @@ describe('choosing', () => {
     const chosen = await chooseAuthMethod({
       manifest: manifest(false),
       requested: 'oauth',
-      current: undefined,
       prompter: prompter(),
     });
 
@@ -144,7 +157,6 @@ describe('choosing', () => {
       manifest: manifest(true, true),
       requested: undefined,
       ownClient: true,
-      current: undefined,
       prompter: terminal,
     });
 
@@ -157,19 +169,17 @@ describe('choosing', () => {
       await chooseAuthMethod({
         manifest: manifest(true, true),
         requested: undefined,
-        current: undefined,
         prompter: prompter('3'),
       }),
-    ).toEqual({ kind: 'oauth', client: 'own' });
+    ).toEqual({ kind: 'oauth', id: 'own_client', client: 'own' });
 
     expect(
       await chooseAuthMethod({
         manifest: manifest(true, true),
         requested: undefined,
-        current: undefined,
         prompter: prompter('2'),
       }),
-    ).toEqual({ kind: 'oauth', client: 'hosted' });
+    ).toEqual({ kind: 'oauth', id: 'hosted_client', client: 'hosted' });
   });
 
   test('honours --auth without asking', async () => {
@@ -177,7 +187,6 @@ describe('choosing', () => {
     const chosen = await chooseAuthMethod({
       manifest: manifest(true),
       requested: 'service_account',
-      current: undefined,
       prompter: terminal,
     });
 
@@ -190,7 +199,6 @@ describe('choosing', () => {
       chooseAuthMethod({
         manifest: manifest(true),
         requested: 'app_password',
-        current: undefined,
         prompter: prompter(),
       }),
     ).rejects.toThrow(
@@ -203,7 +211,6 @@ describe('choosing', () => {
       chooseAuthMethod({
         manifest: manifest(false),
         requested: 'service_account',
-        current: undefined,
         prompter: prompter(),
       }),
     ).rejects.toThrow(/--auth accepts: oauth, own_client/);
@@ -213,11 +220,10 @@ describe('choosing', () => {
     const chosen = await chooseAuthMethod({
       manifest: manifest(true, true),
       requested: undefined,
-      current: undefined,
       prompter: prompter(''),
     });
 
-    expect(chosen).toEqual({ kind: 'oauth', client: 'hosted' });
+    expect(chosen).toEqual({ kind: 'oauth', id: 'hosted_client', client: 'hosted' });
   });
 
   test('takes the browser by default where nobody else runs a client', async () => {
@@ -226,32 +232,16 @@ describe('choosing', () => {
     const chosen = await chooseAuthMethod({
       manifest: manifest(true),
       requested: undefined,
-      current: undefined,
       prompter: prompter(''),
     });
 
     expect(chosen.kind).toBe('oauth');
   });
 
-  test('defaults to what the connection already uses, so a re-run repairs rather than replaces', async () => {
-    // The footgun this exists to close: `connect vendor_mail.main` on a key-backed
-    // connection, Enter pressed out of habit, and the key silently swapped for a
-    // browser flow the operator did not ask for.
-    const chosen = await chooseAuthMethod({
-      manifest: manifest(true),
-      requested: undefined,
-      current: 'assertion',
-      prompter: prompter(''),
-    });
-
-    expect(chosen.kind).toBe('assertion');
-  });
-
   test('accepts the method by name as well as by number', async () => {
     const chosen = await chooseAuthMethod({
       manifest: manifest(true),
       requested: undefined,
-      current: undefined,
       prompter: prompter('service_account'),
     });
 
@@ -263,7 +253,6 @@ describe('choosing', () => {
       chooseAuthMethod({
         manifest: manifest(true),
         requested: undefined,
-        current: undefined,
         prompter: prompter('yes'),
       }),
     ).rejects.toThrow(/not one of the choices. Answer 1 to 2/);
@@ -273,43 +262,56 @@ describe('choosing', () => {
     const chosen = await chooseAuthMethod({
       manifest: manifest(true),
       requested: undefined,
-      current: undefined,
       prompter: silent,
     });
 
     expect(chosen.kind).toBe('oauth');
   });
 
-  test('keeps a key-backed connection on its key when nobody is there to ask', async () => {
-    const chosen = await chooseAuthMethod({
-      manifest: manifest(true),
+  test('names the route it chose, so a reconnect can report what it became', async () => {
+    // `connect` puts this in `changes` — it is how somebody who passed `--auth`,
+    // and was therefore never prompted, sees that the route was swapped rather
+    // than the token refreshed.
+    const key = await chooseAuthMethod({
+      manifest: manifest(true, true),
       requested: undefined,
-      current: 'assertion',
-      prompter: silent,
+      prompter: prompter('1'),
     });
 
-    expect(chosen.kind).toBe('assertion');
+    expect(key).toMatchObject({ kind: 'assertion', id: 'service_account' });
+
+    // Unset where there was no choice to report: a provider with one way in
+    // reads exactly as it did before any of this existed.
+    expect(
+      await chooseAuthMethod({ manifest: manifest(false), requested: 'oauth', prompter: silent }),
+    ).toEqual({ kind: 'oauth', client: undefined });
   });
 });
 
-describe('what a connection uses today', () => {
-  test('is nothing, for one that does not exist yet', async () => {
-    expect(await currentAuthMethod(manifest(true), 'main', memoryStore())).toBeUndefined();
-  });
-
-  test('is read off the credential, not off config', async () => {
-    const store = memoryStore({
-      'vendor_mail/main': JSON.stringify({ grant: ASSERTION_GRANT, key_ref: 'vendor/key' }),
+describe('what the prompt says out loud', () => {
+  test('warns that the choice replaces whatever the account uses now', async () => {
+    // The whole of the protection that used to be attempted by defaulting. A
+    // default cannot be read; a sentence can, and it is true on a first connect
+    // too, where there is simply nothing to replace.
+    const err = await captured(async () => {
+      await chooseAuthMethod({
+        manifest: manifest(true, true),
+        requested: undefined,
+        prompter: prompter('2'),
+      });
     });
 
-    expect(await currentAuthMethod(manifest(true), 'main', store)).toBe('assertion');
+    expect(err).toContain('becomes the only way in for this account');
+    expect(err).toContain('a connection authenticates one way at a time');
   });
 
-  test('is the browser for a stored token blob', async () => {
-    const store = memoryStore({
-      'vendor_mail/main': JSON.stringify({ access_token: 'a', refresh_token: 'r' }),
+  test('says nothing at all for a provider with one way in', async () => {
+    // The property that matters more than the warning: connecting GitHub must
+    // not acquire a paragraph because Google grew a second route.
+    const err = await captured(async () => {
+      await chooseAuthMethod({ manifest: manifest(false), requested: undefined, prompter: prompter() });
     });
 
-    expect(await currentAuthMethod(manifest(true), 'main', store)).toBe('own');
+    expect(err).toBe('');
   });
 });

--- a/src/cli/commands/connect/method.ts
+++ b/src/cli/commands/connect/method.ts
@@ -1,6 +1,4 @@
-import { credentialRefForConnection, type AuthAssertion, type ProviderManifest } from '#connectivity';
-import { BROKERED, storedAssertionFor } from '#connectivity/auth/index.ts';
-import type { SecretStore } from '#secrets';
+import type { AuthAssertion, ProviderManifest } from '#connectivity';
 import { progress, style } from '../../output.ts';
 import { terminalPrompter, type Prompter } from '../../prompt.ts';
 
@@ -15,11 +13,16 @@ import { terminalPrompter, type Prompter } from '../../prompt.ts';
  * Most providers offer exactly one route and this file is inert for them:
  * `options` returns a single entry, nothing is printed, and nothing is asked.
  * That is the property worth protecting — adding routes to Google must not put
- * a question in front of somebody connecting GitHub.
+ * a question, or a warning, in front of somebody connecting GitHub.
  */
 
 export type ChosenMethod =
-  | { readonly kind: 'assertion'; readonly assertion: AuthAssertion }
+  | {
+      readonly kind: 'assertion';
+      /** How `--auth` spells this route, for reporting what the connection became. */
+      readonly id: string;
+      readonly assertion: AuthAssertion;
+    }
   /**
    * The browser, and which client the exchange runs through.
    *
@@ -27,11 +30,12 @@ export type ChosenMethod =
    * precedence `resolveOAuthClient` has always applied: a declared `oauth_apps`
    * entry wins, otherwise the broker. It is what a provider with only one
    * browser route resolves to, so nothing about those changes.
+   *
+   * `id` is unset for exactly those synthesised cases — `--auth oauth`,
+   * `--own-client`, and a provider with one route — because there was no choice
+   * to report. A provider that never offered two reads as it always did.
    */
-  | { readonly kind: 'oauth'; readonly client: 'own' | 'hosted' | undefined };
-
-/** What this connection authenticates with today, at the granularity the prompt offers. */
-export type CurrentMethod = 'assertion' | 'own' | 'hosted';
+  | { readonly kind: 'oauth'; readonly id?: string; readonly client: 'own' | 'hosted' | undefined };
 
 interface Option {
   /** What `--auth` accepts, and how a chosen route is named back. */
@@ -39,7 +43,6 @@ interface Option {
   readonly label: string;
   readonly detail: string;
   readonly chosen: ChosenMethod;
-  readonly matches: CurrentMethod | undefined;
 }
 
 /**
@@ -73,8 +76,7 @@ export function options(manifest: ProviderManifest): readonly Option[] {
       id: assertion.method,
       label: assertion.label,
       detail: assertion.reach,
-      chosen: { kind: 'assertion', assertion },
-      matches: 'assertion',
+      chosen: { kind: 'assertion', id: assertion.method, assertion },
     });
   }
 
@@ -85,8 +87,7 @@ export function options(manifest: ProviderManifest): readonly Option[] {
       detail:
         'nothing to register and no client secret on this machine. The exchange is performed by ' +
         `${broker.operator}, and the connection is re-authorised whenever its token expires.`,
-      chosen: { kind: 'oauth', client: 'hosted' },
-      matches: 'hosted',
+      chosen: { kind: 'oauth', id: 'hosted_client', client: 'hosted' },
     });
   }
 
@@ -98,11 +99,10 @@ export function options(manifest: ProviderManifest): readonly Option[] {
         ? 'a console walkthrough once per profile, after which nothing leaves this machine but ' +
           'the browser. What an organisation that forbids third-party clients needs.'
         : 'the whole account, and the connection is re-authorised whenever its token expires.',
-      // Undefined rather than 'own' where it is the only browser route: there
-      // is nothing to override, and forcing it would write an `oauth_apps`
+      // Undefined `client` rather than 'own' where it is the only browser route:
+      // there is nothing to override, and forcing it would write an `oauth_apps`
       // entry for a provider whose manifest already says it is the only way.
-      chosen: { kind: 'oauth', client: broker ? 'own' : undefined },
-      matches: 'own',
+      chosen: { kind: 'oauth', id: 'own_client', client: broker ? 'own' : undefined },
     });
   }
 
@@ -115,47 +115,21 @@ export function methodsFor(manifest: ProviderManifest): readonly string[] {
 }
 
 /**
- * What this connection authenticates with today, or nothing if it is new.
+ * Choose, from the flag or from the operator — and from nothing else.
  *
- * Read from the credential rather than from config, because the credential is
- * where the answer lives: the routes share one ref and are told apart by what
- * is in it. Asking config instead would be a second record of the same fact,
- * free to disagree with the one that actually routes.
+ * Nothing is inferred from what this account authenticates with today, which is
+ * a decision rather than an omission. A connection authenticates one way at a
+ * time: whichever route this run picks replaces the credential the account has
+ * now, and re-running `connect` is how somebody switches. Defaulting to the
+ * stored route would mean reading a credential to answer a question that is the
+ * operator's on every run, and would hide the replacement behind a default that
+ * reads as a no-op.
  *
- * `authorized_via` is stamped at connect for the same reason it is read at
- * refresh — a refresh token minted by one client is refused by another, so
- * which client issued this is a property of the token and not of the profile.
- */
-export async function currentAuthMethod(
-  manifest: ProviderManifest,
-  connectionId: string,
-  credentials: SecretStore,
-): Promise<CurrentMethod | undefined> {
-  const ref = credentialRefForConnection(manifest, connectionId);
-  if (!ref) return undefined;
-
-  const raw = await credentials.get(ref);
-  if (!raw) return undefined;
-
-  if (await storedAssertionFor(manifest, connectionId, credentials)) return 'assertion';
-
-  try {
-    return (JSON.parse(raw) as { authorized_via?: string }).authorized_via === BROKERED
-      ? 'hosted'
-      : 'own';
-  } catch {
-    return 'own';
-  }
-}
-
-/**
- * Choose, from the flag, the operator, or the status quo — in that order.
- *
- * `current` is the default rather than a mere hint. Re-running `connect` on an
- * existing account is a repair nine times in ten, and a prompt whose default
- * silently swapped the route would turn a stale-token fix into a
- * re-authorisation nobody asked for — with the old credential overwritten by
- * the time they noticed.
+ * It used to try. The route was read from the *provisional* connection id,
+ * which is `pending` until identity is settled — so it found nothing every
+ * time, fell back to the browser, and performed the silent swap it existed to
+ * prevent on anyone who pressed Enter. Saying what the choice does is the part
+ * that was actually missing.
  */
 export async function chooseAuthMethod(input: {
   readonly manifest: ProviderManifest;
@@ -163,8 +137,6 @@ export async function chooseAuthMethod(input: {
   readonly requested: string | undefined;
   /** `--own-client`, which is the older spelling of one of these. */
   readonly ownClient?: boolean;
-  /** What this connection authenticates with today, where it already exists. */
-  readonly current: CurrentMethod | undefined;
   readonly prompter?: Prompter;
 }): Promise<ChosenMethod> {
   const { manifest, requested } = input;
@@ -192,22 +164,17 @@ export async function chooseAuthMethod(input: {
   if (available.length < 2) return { kind: 'oauth', client: undefined };
 
   // Nobody to ask. The flag above is the non-interactive answer, deliberately —
-  // guessing picks which credential gets overwritten.
-  if (!prompter.interactive) {
-    const held = available.find((option) => option.matches === input.current);
-    return held ? held.chosen : { kind: 'oauth', client: undefined };
-  }
+  // guessing picks which credential gets overwritten (ADR-038).
+  if (!prompter.interactive) return { kind: 'oauth', client: undefined };
 
-  return ask(manifest, available, input.current, prompter);
+  return ask(manifest, available, prompter);
 }
 
 async function ask(
   manifest: ProviderManifest,
   available: readonly Option[],
-  current: CurrentMethod | undefined,
   prompter: Prompter,
 ): Promise<ChosenMethod> {
-  const held = available.findIndex((option) => option.matches === current);
   // "As it works today" for anyone who has not chosen otherwise: the hosted
   // client where there is one, and otherwise the browser. Never the key — it is
   // listed first because it is the one worth knowing about, and defaulting to
@@ -216,7 +183,7 @@ async function ask(
   const hosted = available.findIndex((option) => option.id === 'hosted_client');
   const fallback =
     hosted !== -1 ? hosted : Math.max(available.findIndex((option) => option.chosen.kind === 'oauth'), 0);
-  const preferred = String((held === -1 ? fallback : held) + 1);
+  const preferred = String(fallback + 1);
 
   progress();
   progress(style.bold(`${manifest.name} can authenticate ${count(available.length)} ways`));
@@ -225,10 +192,14 @@ async function ask(
     progress(`  ${index + 1}. ${option.label}`);
     progress(style.dim(`     ${option.detail}`));
   }
-  if (held !== -1) {
-    progress();
-    progress(style.dim(`  This connection uses ${held + 1} today.`));
-  }
+  progress();
+  // Printed whether or not this account is already connected, because it is a
+  // statement about what the command does rather than a reading of what is
+  // stored — and on a first connect it is true with nothing to replace.
+  progress(style.dim('  Whichever you pick becomes the only way in for this account. It replaces'));
+  progress(
+    style.dim('  whatever is stored for it now — a connection authenticates one way at a time.'),
+  );
   progress();
 
   const answer = await prompter.ask(`  Which ${style.dim(`[${preferred}]`)}`);

--- a/src/connectivity/auth/oauth-jwt/index.ts
+++ b/src/connectivity/auth/oauth-jwt/index.ts
@@ -103,7 +103,16 @@ const minted = new Map<string, { token: string; expiresAt: number }>();
 /** Re-mint slightly early: a token that expires mid-flight fails the call it was fetched for. */
 const EXPIRY_SKEW_MS = 60_000;
 
-/** Test seam. Nothing else clears this — a process holds its tokens until it exits. */
+/**
+ * Emptied when a reload lands, and by tests.
+ *
+ * The cache key is `<provider>.<connection>` with no subject in it, so a
+ * connection re-connected to act as somebody else — or re-connected to a route
+ * that is not this one at all — would otherwise keep serving the token minted
+ * for who it used to be, for up to an hour after the config said otherwise.
+ * `server/generations.ts` clears this beside `clearUpstreamTokens`, which
+ * exists for the same reason on the other path.
+ */
 export function clearMintedTokens(): void {
   minted.clear();
 }

--- a/src/server/generations.test.ts
+++ b/src/server/generations.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, test } from 'bun:test';
 import { Generations, type OpenedWorkspace } from './generations.ts';
+import { defineProvider, type ProviderManifest } from '#connectivity';
+import { ASSERTION_GRANT, clearMintedTokens, resolveAssertionToken } from '#connectivity/auth/index.ts';
 import { EMPTY_POLICY } from '#policy';
 import type { ProfileRuntime } from './mcp/index.ts';
 
@@ -157,5 +159,112 @@ describe('a pinned generation', () => {
     // is an error that surfaces long after the work succeeded.
     await generations.release(second);
     expect(before.closes).toBe(1);
+  });
+});
+
+/**
+ * The caches that outlive a generation, and why a reload has to empty them.
+ *
+ * Both are module-global and keyed by connection, so replacing the workspace
+ * does nothing to them. That is deliberate — an unchanged connection should not
+ * pay a round trip for somebody else's edit — and it is exactly why a reload
+ * has to say otherwise: `connect` is how a connection changes hands or changes
+ * route, and it lands as a reload. A cache that survived it would serve the
+ * previous account for up to an hour after the config said otherwise.
+ *
+ * Only the minted-token half is exercised here. `clearUpstreamTokens` needs a
+ * refresh-capable OAuth provider to observe at all, and it is not the one that
+ * was missing.
+ */
+
+const KEY_REF = 'vendor/key';
+
+async function keyed(): Promise<string> {
+  const pair = await crypto.subtle.generateKey(
+    { name: 'RSASSA-PKCS1-v1_5', modulusLength: 2048, publicExponent: new Uint8Array([1, 0, 1]), hash: 'SHA-256' },
+    true,
+    ['sign', 'verify'],
+  );
+
+  const pkcs8 = await crypto.subtle.exportKey('pkcs8', pair.privateKey);
+  const body = btoa(String.fromCharCode(...new Uint8Array(pkcs8))).replace(/(.{64})/g, '$1\n');
+
+  return JSON.stringify({
+    type: 'service_account',
+    client_email: 'link@my-project.iam.gserviceaccount.example',
+    private_key: `-----BEGIN PRIVATE KEY-----\n${body}\n-----END PRIVATE KEY-----\n`,
+    token_uri: 'https://tokens.example.test/token',
+    private_key_id: 'abc123',
+  });
+}
+
+function keyedProvider(): ProviderManifest {
+  return defineProvider({
+    id: 'vendor_thing',
+    name: 'Vendor Thing',
+    connector: { kind: 'http', base_url: 'https://api.example.test', openapi: './t.json' },
+    auth: {
+      kind: 'oauth',
+      registration: 'manual',
+      app: 'vendor',
+      scopes: ['read.example'],
+      authorize_url: 'https://accounts.example.test/authorize',
+      token_url: 'https://tokens.example.test/token',
+      assertion: {
+        method: 'service_account',
+        label: 'Service account key',
+        delegation: 'optional',
+        key_ref: KEY_REF,
+        reach: 'only what is shared with it',
+        subject_label: 'Account to act as',
+        setup: {
+          steps: [],
+          prompts: [
+            { key: 'key', label: 'Key', secret: true, scope: 'shared', credential_ref: KEY_REF },
+          ],
+        },
+      },
+    },
+    setup: {
+      steps: [],
+      prompts: [
+        { key: 'client_id', label: 'Client id', scope: 'shared', credential_ref: 'vendor/client_id' },
+        { key: 'client_secret', label: 'Client secret', secret: true, scope: 'shared', credential_ref: 'vendor/client_secret' },
+      ],
+    },
+  });
+}
+
+describe('a minted token', () => {
+  test('is re-minted after a reload, because the connection may not be the same one', async () => {
+    clearMintedTokens();
+
+    const manifest = keyedProvider();
+    const key = await keyed();
+    const credentials = { get: async (ref: string) => (ref === KEY_REF ? key : null) } as never;
+    const stored = { grant: ASSERTION_GRANT, key_ref: KEY_REF } as const;
+
+    let exchanges = 0;
+    const fetch = (async () => {
+      exchanges += 1;
+      return new Response(JSON.stringify({ access_token: `token-${exchanges}`, expires_in: 3600 }), {
+        headers: { 'Content-Type': 'application/json' },
+      });
+    }) as unknown as typeof globalThis.fetch;
+
+    const mint = () =>
+      resolveAssertionToken({ manifest, connectionId: 'main', stored, credentials, fetch });
+
+    expect(await mint()).toBe('token-1');
+    // The cache doing its job — the reason it exists, and the reason clearing it
+    // has to be deliberate rather than incidental.
+    expect(await mint()).toBe('token-1');
+    expect(exchanges).toBe(1);
+
+    const generations = generationsOver(stub('before'), () => Promise.resolve(stub('after')));
+    await generations.reload();
+
+    expect(await mint()).toBe('token-2');
+    expect(exchanges).toBe(2);
   });
 });

--- a/src/server/generations.ts
+++ b/src/server/generations.ts
@@ -1,5 +1,5 @@
 import type { Logger } from '#connectivity';
-import { clearUpstreamTokens } from '#connectivity/auth/index.ts';
+import { clearMintedTokens, clearUpstreamTokens } from '#connectivity/auth/index.ts';
 import type { ProfileRuntime } from '#server/mcp';
 import { Generation } from './generation.ts';
 
@@ -184,12 +184,21 @@ export class Generations {
     // cloud target is a network write, so this is reachable rather than
     // theoretical.
     try {
-      // Module-global and keyed per connection, so it survives a reload that
+      // Module-global and keyed per connection, so they survive a reload that
       // replaced everything else. Re-connecting `<provider>.<id>` to a different
       // account would otherwise serve the previous account's access token until
       // it expired — up to an hour after the config said otherwise. Unchanged
       // connections pay one refresh.
+      //
+      // Both caches, because a connection authenticates one way at a time and
+      // re-connecting is how it changes: the route is settled by what `connect`
+      // last stored, so a reload that cleared only the authorization-code cache
+      // would keep serving a token minted from a key for a connection that no
+      // longer authenticates with one — and, worse, keep acting as the
+      // previously impersonated user, since the minted cache is keyed by
+      // connection with no subject in it.
       clearUpstreamTokens();
+      clearMintedTokens();
 
       // After the swap: a request arriving during the retire already gets the
       // new generation, and this only waits on requests that started before it.


### PR DESCRIPTION
## What this is about

`connect <provider>` on an account that is already connected **already** replaces that
connection's credential and leaves one connection behind — including when the second run picks a
different route. That is the intended rule and this branch does not change it:

- the run authorises under the provisional id `pending` (`connect/index.ts:162`);
- `settleIdentity` asks the provider whose account it is and reuses the **existing connection's
  id** when the account matches (`connect/settle.ts:127`);
- `moveCredential` copies over the old blob and deletes `pending` (`connect/index.ts:275`) —
  `SecretStore.set` overwrites, pinned by `secrets/system.test.ts:83`;
- the config row is updated in place rather than duplicated (`connect/index.ts:292`).

One connection, one credential, the last connect wins. What was missing is that nothing said so,
and two things quietly contradicted it.

## 1. The prompt tried to preserve the current route and could not

`connect/index.ts:182` asked `currentAuthMethod` about `provisionalId` — which is `pending` on
every re-connect, because `siblingAccountId` only adopts an id for the shared-password families.
So `current` was always `undefined`, and the behaviour its own doc comment described never
happened:

> a prompt whose default silently swapped the route would turn a stale-token fix into a
> re-authorisation nobody asked for — with the old credential overwritten by the time they noticed

The default was therefore always the hosted client. Pressing Enter on a re-connect of a key-backed
account silently put it back on the browser — the exact swap the mechanism existed to prevent.
Non-interactively the same lookup fell through to OAuth and the preflight refused with
`needs_browser`, a message about a step the key route does not perform.

The unit tests passed a real connection id (`method.test.ts:297`), so they were green. The wiring
was wrong.

**Removed rather than repaired.** Defaulting to the stored route answers the operator's question
by reading their credential, and hides the consequential half of the decision behind a default
that reads as a no-op. `chooseAuthMethod` now takes no credential store at all, which is what
makes "the last connect wins" a rule instead of an accident. The prompt says what the choice does
instead — real output, against a scratch workspace:

```
Google Drive can authenticate three ways

  1. Service account key
     a JSON key that never expires, and no browser. Reaches only what you share with the key's
     own address, so nothing in the account moves until you share it.
  2. Sign in through a browser, using the OAuth client Lanes operates
     nothing to register and no client secret on this machine. The exchange is performed by
     Lanes, and the connection is re-authorised whenever its token expires.
  3. Sign in through a browser, using an OAuth client you register
     a console walkthrough once per profile, after which nothing leaves this machine but the
     browser. What an organisation that forbids third-party clients needs.

  Whichever you pick becomes the only way in for this account. It replaces
  whatever is stored for it now — a connection authenticates one way at a time.
```

Printed only where there is a choice. A provider with one way in still asks nothing and says
nothing — the property that keeps Google's routes out of the way of somebody connecting GitHub,
Slack or iCloud. `ChosenMethod` gained an optional `id` so a reconnect reports which route it
became (`re-authorised gmail.main with service_account`), since `--auth` reaches that line having
asked nothing at all.

## 2. A minted token outlived the connection it was minted for

`generations.ts:192` clears the authorization-code cache on reload for the reason its own comment
gives — otherwise a re-connected `<provider>.<id>` serves the previous account's access token for
up to an hour. `clearMintedTokens` is the twin on the key path, was exported, and was never
called; its comment said "Nothing else clears this — a process holds its tokens until it exits."

Its cache key is `${manifest.id}.${connectionId}` with **no subject in it**, so a connection
switched to a different route — or to a different impersonated user — kept acting as the previous
one until the token aged out. One line beside the existing call.

## Deliberately not in scope

- **Remembering the subject.** A key-backed re-connect still asks who the key acts as, and
  `--non-interactive` still refuses with `needs_terminal`. Reading it back means reading the
  existing connection, which is the thing this branch removes.
- **Revoking the replaced grant.** Switching a connection off the browser overwrites the stored
  token and leaves Google holding a live refresh-token grant. Now said in `setup/google.md`, with
  the link to withdraw it.

## Verification

`bun test` → **1828 pass, 2 skip, 0 fail**. `bun run typecheck` → clean.

New tests:
- the prompt prints the replace sentence, read off stderr — a warning that is built and discarded
  type-checks and runs exactly like one that is printed;
- a provider with one way in prints nothing at all;
- the chosen route names itself, and is unnamed where there was no choice to report;
- **`generations.test.ts`**: mint through `resolveAssertionToken` with an injected `fetch`, assert
  the cache serves the second call, reload, assert the third call re-mints. Confirmed to fail
  without the production line (`token-1` where `token-2` is expected).

Removed: the three `currentAuthMethod` cases and the two that asserted a stored route is preserved.

End to end in a scratch workspace (`LANES_LINK_HOME` set to a temp dir, never the real one):

| Command | Result |
|---|---|
| `connect drive` | all three routes listed, warning printed |
| `connect drive --auth service_account --non-interactive` | refuses on the missing key, names `google/service_account_key`, re-run command carries `--auth service_account` |
| `connect drive --non-interactive` | refuses on the browser — a run with nobody to ask does not guess (ADR-038) |
| `connect github --non-interactive` | unchanged: no prompt, no warning |

Nothing here touches a real account.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
