### PR TITLE
Reach a personal Gmail mailbox with an app password, over IMAP

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,13 +99,15 @@ One command per account. Run it again to add a second mailbox, a second calendar
 | Linear | `lanes link connect linear` |
 | GitHub | `lanes link connect github` |
 | Slack | `lanes link connect slack` |
+| Gmail (IMAP, app password) | `lanes link connect gmail_imap` |
 | Gmail (Google MCP) | `lanes link connect gmail_mcp` |
 | Drive (Google MCP) | `lanes link connect drive_mcp` |
 
 Three things worth knowing up front. `lanes link connect icloud` sets up Mail, Calendar, and
 Contacts together, because one app-specific password covers all three. Google needs no OAuth client
 of your own: `lanes link connect gmail` authorises against the one Lanes operates, so there is no
-Cloud console to visit — add `--own-client` if you would rather register your own. And GitHub and
+Cloud console to visit — and where you would rather nothing expired, it also offers a service
+account key, or an app password over IMAP for a personal account. And GitHub and
 Slack take a token you paste rather than a browser sign-in, because neither will register a client
 for us; for Slack that means creating a Slack app once, which is the one console visit left here.
 

--- a/docs/connect.md
+++ b/docs/connect.md
@@ -29,6 +29,7 @@ $ lanes link connect gmail --profile personal --target local        # again, for
 | Linear | `lanes link connect linear` | Linear's own MCP server |
 | GitHub | `lanes link connect github` | Repositories, issues, pull requests, and workflow runs |
 | Slack | `lanes link connect slack` | Search, read, and send messages, threads, files, and canvases |
+| Gmail (IMAP) | `lanes link connect gmail_imap` | The same mailbox over IMAP and SMTP, with an app password that does not expire |
 | Gmail (Google MCP) | `lanes link connect gmail_mcp` | Google's own MCP server — Developer Preview only |
 | Drive (Google MCP) | `lanes link connect drive_mcp` | Likewise; use `drive` unless you are enrolled |
 

--- a/docs/detailed/setup/google.md
+++ b/docs/detailed/setup/google.md
@@ -102,6 +102,10 @@ you pick. There are up to three:
 | A client of your own | ~20 minutes, once per profile | **no, if you publish it** — see below | the whole account |
 | A service account key | ~10 minutes, once per profile | **never** | see [Service account](#connecting-with-a-service-account-key) |
 
+There is a fourth that is not on this list because it is not a way of connecting `gmail` — it is a
+different provider. `gmail_imap` reaches a personal mailbox over IMAP with an app password, which
+also never expires. See [Gmail over IMAP](#gmail-over-imap-on-a-personal-account).
+
 **The seven-day expiry is a property of publishing status, not of verification.** These are two
 different settings and confusing them is what sends people into the verification centre for a
 problem a checkbox solves. A client whose publishing status is **Testing** has every refresh token
@@ -422,7 +426,9 @@ shared yet. Leave the "account to act as" prompt blank and the key acts as itsel
 
 ### Delegation, for Gmail, Contacts and Tasks
 
-These need a Google Workspace administrator, and a personal Google account cannot do it at all.
+These need a Google Workspace administrator, and a personal Google account cannot do it at all. For
+mail specifically there is another way in — see
+[Gmail over IMAP](#gmail-over-imap-on-a-personal-account). Contacts and Tasks have none.
 
 Copy the service account's numeric **Unique ID** from its Details tab — the client ID, not the email
 address. Then, in the Workspace Admin console: **Security → Access and data control → API controls →
@@ -444,6 +450,48 @@ A key does not expire, which is the feature and also the whole of the risk: ther
 withdraw and no token to age out, so a leaked key is good until somebody deletes it in the console.
 Treat it as you would a password, and prefer sharing over delegation where sharing will do — one
 shared folder is a much smaller grant than the right to act as you.
+
+---
+
+## Gmail over IMAP, on a personal account
+
+A personal `@gmail.com` cannot use a service account for mail — the section above is why: a key has
+no mailbox, so it can only reach one by acting as a person, and that grant is made in an admin
+console a personal account does not have. But Google still serves that mailbox over IMAP, and IMAP
+takes an **app password**: sixteen characters you issue to yourself, which does not expire and is not
+your account password.
+
+```console
+$ lanes link connect gmail_imap
+```
+
+That is a different provider from `gmail`, not another route into it — a manifest has one connector,
+and IMAP is not HTTPS. Practically, that means:
+
+| | `gmail` | `gmail_imap` |
+|---|---|---|
+| Credential | OAuth token, or a service account key | An app password |
+| Expires | with the client's publishing status | **never** |
+| Works on a personal account | yes, with the weekly re-auth unless you publish a client | **yes** |
+| Works on Workspace | yes | no — Google ended basic auth there in March 2025, and an admin can disable app passwords anyway |
+| Reaches | Gmail's API: labels, threads, drafts, the lot | a mailbox: search, read, flag, move, send |
+| Policy rule | `gmail.*` | `gmail_imap.*` |
+
+They are separate connections and can both exist. Nothing shares a credential between them.
+
+**Getting the password.** Two-Step Verification has to be on first — without it the app-passwords
+page reports that the setting is not available for your account rather than saying why. Then
+[myaccount.google.com/apppasswords](https://myaccount.google.com/apppasswords) → create one → name it
+"Lanes Link", which is the only way to revoke this one later without cutting off your other devices.
+Google shows the sixteen characters once, in four groups of four; the spaces are cosmetic.
+
+`connect` asks for your full address and then that password. If a login is refused, it is almost
+always the account password pasted where the app password belongs — IMAP reports both the same way.
+`lanes link connect gmail_imap --replace` is the command to fix it; a bare re-run finds the refused
+credential already stored and reuses it.
+
+IMAP itself is on by default. If a login succeeds and then mailboxes are missing, check
+**Gmail → Settings → See all settings → Forwarding and POP/IMAP → IMAP access**.
 
 ---
 
@@ -475,6 +523,9 @@ The escapes, cheapest first:
   "OAuth client you register" route, or `--auth own_client`. Publishing is a setting, not a review;
   it costs an unverified-app screen and a lifetime cap of 100 new users on that project. This is
   the one most people want.
+- **Use an app password over IMAP**, if this is a personal account and mail is what you need —
+  `lanes link connect gmail_imap`. Nothing expires and there is no console project at all. See
+  [Gmail over IMAP](#gmail-over-imap-on-a-personal-account).
 - **Connect with a service account key instead** — `--auth service_account`. Nothing expires,
   because nothing consented. It reaches less, and how much less depends on the product; see
   [Service account](#connecting-with-a-service-account-key).

--- a/src/providers/google/gmail-imap/gmail-imap.test.ts
+++ b/src/providers/google/gmail-imap/gmail-imap.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, test } from 'bun:test';
+import { credentialRefForConnection } from '#connectivity';
+import { manifestOf, PROVIDER_MANIFESTS } from '#providers/index.ts';
+import { gmail } from '../gmail/index.ts';
+import { gmailImap } from './index.ts';
+
+// `gmail` is one of the two providers that carry a capability of their own, so
+// it arrives as a definition rather than a bare manifest. Everything asked of
+// it here is a manifest question.
+const gmailManifest = manifestOf(gmail);
+
+/**
+ * The mail route for an account that cannot take either other one.
+ *
+ * Constructing the manifest at all is most of the check — `defineProvider`
+ * refuses an imap connector that is not `basic`, and refuses `basic` without
+ * exactly one username prompt and one password prompt. What is left is what a
+ * schema cannot see: that this credential is its own, that nothing of the
+ * message reaches the audit log, and that the dead end it exists to answer
+ * actually points at it.
+ */
+
+describe('the credential', () => {
+  test('is its own, and shares nothing with the OAuth providers', () => {
+    // No `auth.app`, so the ref derives from the provider id. An `app` of
+    // `google` would have filed an app password in the same namespace as the
+    // shared OAuth client and the service account key — three unrelated
+    // secrets, one of which is rotated by a completely different console.
+    expect(credentialRefForConnection(gmailImap, 'main')).toBe('gmail_imap/main');
+    expect(credentialRefForConnection(gmailManifest, 'main')).toBe('gmail/main');
+  });
+
+  test('is asked for as a username and a password, which is what basic stores', () => {
+    const fields = (gmailImap.setup?.prompts ?? []).map((prompt) => prompt.field);
+
+    expect(fields).toEqual(['username', 'password']);
+    expect(gmailImap.auth.kind).toBe('basic');
+  });
+});
+
+describe('the audit log', () => {
+  test('gets identifiers and never the message', () => {
+    const redact = gmailImap.redact ?? {};
+
+    // Empty rather than absent: absent means "withhold everything" by default
+    // and would read the same here, but `send_message` carries `attachments`,
+    // which may literally be a file. Saying it explicitly is what keeps a later
+    // edit from opting one of these back in without noticing what is in it.
+    expect(redact.send_message).toEqual([]);
+    // A query is content. "Who did I email about the diagnosis" is the whole
+    // message, so the search terms are never kept.
+    expect(redact.search_messages).not.toContain('query');
+    expect(redact.search_messages).toContain('mailbox');
+  });
+});
+
+describe('the dead end it answers', () => {
+  test('is named by Gmail, and names a provider that exists', () => {
+    // The service-account route is refused on a personal account, and the text
+    // that says so points here. A rename on either side breaks the sentence
+    // silently — it is prose, and prose compiles.
+    const assertion = gmailManifest.auth.kind === 'oauth' ? gmailManifest.auth.assertion : undefined;
+
+    expect(assertion?.reach).toContain(gmailImap.id);
+    expect(PROVIDER_MANIFESTS.map((manifest) => manifest.id)).toContain(gmailImap.id);
+  });
+});

--- a/src/providers/google/gmail-imap/index.ts
+++ b/src/providers/google/gmail-imap/index.ts
@@ -1,0 +1,125 @@
+import { defineProvider } from '#connectivity';
+
+/**
+ * Gmail over IMAP, for the account that cannot use either other route.
+ *
+ * A personal Google account has exactly one way to a mailbox that does not
+ * expire, and this is it. The two alternatives both fail for a reason that is
+ * not about effort:
+ *
+ * - The REST provider (`gmail`) authorises in a browser, and an OAuth client
+ *   left in "Testing" has every refresh token it issues expired after seven
+ *   days. Publishing the client fixes that and is the better answer where it is
+ *   available — see ADR-038 and `docs/detailed/setup/google.md`.
+ * - The key route (`auth.assertion` on `gmail`) does not apply at all. A service
+ *   account has no mailbox of its own, so it can only reach one by acting as
+ *   somebody, and that grant is domain-wide delegation — made in a Workspace
+ *   admin console that a personal account does not have.
+ *
+ * An app password has neither problem. It is issued by the account holder to
+ * themselves, it does not expire, and IMAP asks no authorization server for
+ * anything. What it costs is reach and shape: this is a mailbox over IMAP and
+ * SMTP, so it is the mail capability set rather than Gmail's API — no labels
+ * vocabulary, no threads resource, no drafts. Searching, reading, flagging,
+ * moving and sending, which is most of what a mailbox is for.
+ *
+ * The mirror image of `../shared/service-account.ts`, and deliberately so: that
+ * one covers Workspace and not personal accounts, this one covers personal
+ * accounts and not Workspace. Google turned off basic authentication for
+ * Workspace in March 2025, and an administrator can disable app passwords
+ * outright, so an account under a domain should take one of the other two.
+ *
+ * A separate manifest rather than a route on `gmail` because a manifest has one
+ * connector, and IMAP is a different protocol from HTTPS — the same reason
+ * iCloud is three providers rather than one. It also makes the policy line
+ * separable: `gmail_imap.*` can be allowed without granting the REST surface,
+ * or the other way round.
+ */
+export const gmailImap = defineProvider({
+  id: 'gmail_imap',
+  name: 'Gmail (IMAP)',
+  description:
+    'Read, search, and send mail in a personal Gmail mailbox over IMAP and SMTP, with an app password that does not expire.',
+  connector: {
+    kind: 'imap',
+    host: 'imap.gmail.com',
+    port: 993,
+    smtp: {
+      host: 'smtp.gmail.com',
+      port: 587,
+      starttls: true,
+      // Gmail's limit is 25 MB for the whole encoded message rather than the
+      // 20 MB default, and the send path derives the usable weight of the files
+      // from it. Declaring the real number is what makes an oversized message
+      // refused before dialling rather than part-way through DATA.
+      max_message_bytes: 25 * 1024 * 1024,
+    },
+  },
+  // Not a choice. `defineProvider` refuses anything else on an imap connector,
+  // because every mail host that matters issues an app password and expects it
+  // over Basic — and Gmail's OAuth path belongs to the REST provider.
+  auth: { kind: 'basic' },
+  // No `app`: this is one provider rather than a family, so the credential
+  // lands at `gmail_imap/<connection>` and is shared with nothing. An app
+  // password is issued per app rather than per account, so there would be
+  // nothing to share it with even if there were siblings.
+  identity: { kind: 'connector' },
+  setup: {
+    summary:
+      'Gmail over IMAP uses an app password — a sixteen-character password you issue to yourself, ' +
+      'which is not your Google account password and does not expire. Nothing is authorised in a ' +
+      'browser and nothing has to be re-approved later. This is the personal-account route: ' +
+      'Google turned off basic authentication for Workspace accounts in March 2025, and a Workspace ' +
+      'administrator can disable app passwords for the whole domain.',
+    docs: 'docs/detailed/setup/google.md',
+    docs_url: 'https://support.google.com/accounts/answer/185833',
+    steps: [
+      'Two-Step Verification has to be on. Without it Google does not offer app passwords at all, and the page below returns "the setting you are looking for is not available for your account" rather than saying why. Turn it on at https://myaccount.google.com/signinoptions/twosv.',
+      'Open https://myaccount.google.com/apppasswords and create one. Name it "Lanes Link" — the name is the only way to revoke this one later without cutting off your other devices.',
+      'Copy the sixteen characters. Google shows them once, in four groups of four; the spaces are cosmetic and it is accepted either way.',
+      'You are asked for your full address next, which is the one you sign in with, ending @gmail.com.',
+      'IMAP is on by default. If a login is refused with a mailbox error rather than an authentication error, check Gmail → Settings → See all settings → Forwarding and POP/IMAP → IMAP access.',
+    ],
+    // What a transport cannot say for itself, because it must not know which
+    // vendor it is talking to. The first sentence is the mistake this route
+    // actually produces: an app password looks enough like a password that the
+    // account password gets pasted instead, and IMAP reports both identically.
+    troubleshooting:
+      'For Gmail this is almost always a Google account password used where an app password belongs, ' +
+      'or an account without Two-Step Verification — app passwords do not exist without it. Generate ' +
+      'one at https://myaccount.google.com/apppasswords and re-run: lanes link connect gmail_imap --replace.',
+    prompts: [
+      {
+        key: 'username',
+        label: 'Google account (the full email address)',
+        secret: false,
+        scope: 'connection' as const,
+        field: 'username' as const,
+      },
+      {
+        key: 'password',
+        label: 'App password (sixteen characters)',
+        secret: true,
+        scope: 'connection' as const,
+        field: 'password' as const,
+      },
+    ],
+  },
+  // The mail capability set, so the same reasoning as `icloud_mail` applies
+  // verbatim: opted back in one key at a time, everything unlisted withheld.
+  redact: {
+    // Never the search terms — a query is content, and "who did I email about
+    // the diagnosis" is the whole message.
+    search_messages: ['mailbox', 'limit', 'unseen', 'flagged'],
+    get_message: ['mailbox', 'uid', 'include_body'],
+    mark_messages: ['mailbox', 'add_flags', 'remove_flags'],
+    // `destination_flag` alongside `destination`: two spellings of the same
+    // fact, and keeping only one means a junk move logs with no destination.
+    move_messages: ['mailbox', 'destination', 'destination_flag'],
+    // Nothing. The recipients and the body are the message, and `attachments`
+    // may literally contain a file. What was attached is recorded by the send
+    // path itself through `audit.annotate` — filename, size, type, SHA-256 and
+    // origin. Identifiers, not content.
+    send_message: [],
+  },
+});

--- a/src/providers/google/gmail/index.ts
+++ b/src/providers/google/gmail/index.ts
@@ -86,7 +86,7 @@ const manifest = defineProvider({
     app: GOOGLE_APP,
     scopes: GMAIL_SCOPES,
     ...GOOGLE_OAUTH,
-    assertion: googleServiceAccount('Gmail', GMAIL_SCOPES, 'required', ['gmail.googleapis.com']),
+    assertion: googleServiceAccount('Gmail', GMAIL_SCOPES, 'required', ['gmail.googleapis.com'], 'gmail_imap'),
   },
   // The REST API rather than the MCP server: it answers with the address under
   // scopes we already hold, so labelling a connection costs no extra consent.

--- a/src/providers/google/index.ts
+++ b/src/providers/google/index.ts
@@ -1,10 +1,11 @@
-/** Google's nine providers. Each folder holds all of its own vendor knowledge. */
+/** Google's ten providers. Each folder holds all of its own vendor knowledge. */
 export { calendar } from './calendar/index.ts';
 export { contacts } from './contacts/index.ts';
 export { docs } from './docs/index.ts';
 export { drive, DRIVE_SCOPES } from './drive/index.ts';
 export { driveMcp } from './drive-mcp/index.ts';
 export { gmail, GMAIL_SCOPES } from './gmail/index.ts';
+export { gmailImap } from './gmail-imap/index.ts';
 export { gmailMcp } from './gmail-mcp/index.ts';
 export { sheets } from './sheets/index.ts';
 export { tasks } from './tasks/index.ts';

--- a/src/providers/google/shared/service-account.ts
+++ b/src/providers/google/shared/service-account.ts
@@ -31,11 +31,22 @@ const SHARE_HINT: Record<string, string> = {
     'a calendar (Settings for that calendar → "Share with specific people" → paste the address)',
 };
 
+/**
+ * Where a personal account should go instead, for the products that have
+ * somewhere.
+ *
+ * Only Gmail does. A key needs delegation for mail, contacts and task lists
+ * alike, and delegation needs an administrator — but mail is the one Google
+ * still serves over a protocol that takes a password, so `gmail_imap` is a real
+ * answer rather than a consolation. Contacts and Tasks have none, and saying so
+ * plainly beats sending somebody to look.
+ */
 export const googleServiceAccount = (
   product: string,
   scopes: readonly string[],
   delegation: 'optional' | 'required',
   apis: readonly string[],
+  instead?: string,
 ) => ({
   method: 'service_account',
   label: 'Service account key',
@@ -47,7 +58,8 @@ export const googleServiceAccount = (
         `key's own address, so nothing in the account moves until you share it.`
       : `a JSON key that never expires, and no browser. ${product} has nothing that belongs to ` +
         `a key, so this needs a Google Workspace administrator to let it act as you — a personal ` +
-        `Google account cannot do it.`,
+        `Google account cannot do it` +
+        (instead ? `, and wants ${instead} instead.` : '.'),
   subject_label:
     delegation === 'optional'
       ? 'Google account to act as, if an administrator has granted it'
@@ -61,7 +73,8 @@ export const googleServiceAccount = (
         : `${product} can authenticate with a service account key instead of signing in. The key ` +
           `does not expire — but a key has no mailbox, contacts or task lists of its own, so this ` +
           `route works only where a Google Workspace administrator has authorised the key to act ` +
-          `as a user in their domain. On a personal Google account, use the browser instead.`,
+          `as a user in their domain. On a personal Google account, use the browser instead` +
+          (instead ? `, or ${instead}, which is an app password over IMAP and does not expire either.` : '.'),
     docs: 'docs/detailed/setup/google.md',
     docs_url: 'https://console.cloud.google.com/iam-admin/serviceaccounts',
     steps: [

--- a/src/providers/index.ts
+++ b/src/providers/index.ts
@@ -6,6 +6,7 @@ import { github } from './github/index.ts';
 import { drive } from './google/drive/index.ts';
 import { driveMcp } from './google/drive-mcp/index.ts';
 import { gmail } from './google/gmail/index.ts';
+import { gmailImap } from './google/gmail-imap/index.ts';
 import { gmailMcp } from './google/gmail-mcp/index.ts';
 import { sheets } from './google/sheets/index.ts';
 import { tasks } from './google/tasks/index.ts';
@@ -59,6 +60,7 @@ export const PROVIDERS: readonly (ProviderManifest | ProviderDefinition)[] = [
   calendar,
   tasks,
   contacts,
+  gmailImap,
   gmailMcp,
   driveMcp,
   icloudMail,
@@ -87,6 +89,7 @@ export {
   drive,
   driveMcp,
   gmail,
+  gmailImap,
   gmailMcp,
   sheets,
   tasks,


### PR DESCRIPTION
## The gap

A personal `@gmail.com` has no route to a mailbox that does not expire:

- **The browser route** re-authorises weekly unless the OAuth client is published to production
  (ADR-038 — the expiry follows publishing status, not verification).
- **The key route does not apply at all.** A service account has no mailbox of its own, so it can
  only reach one by acting as a person, and that grant is domain-wide delegation — made in a
  Workspace admin console a personal account does not have.

`gmail`'s own method prompt said exactly that and then stopped, which is a dead end in a list of
choices.

Google still serves that mailbox over IMAP, and IMAP takes an **app password**: the account holder
issues it to themselves, it does not expire, and no authorization server is involved. This closes
the gap the key route opened for Workspace and left open for everyone else.

The two are mirror images. Google ended basic authentication for Workspace in March 2025 and an
administrator can disable app passwords outright, so an account under a domain takes one of the
other routes and a personal account takes this one.

## Scope: mail and nothing else

An app password reaches IMAP/SMTP. Drive, Sheets, Docs and Calendar are REST APIs that take an
OAuth token or a JWT-bearer assertion — there is no username/password door into them — and
CalDAV/CardDAV now require OAuth too. So this is one provider, not a family.

| | `gmail` | `gmail_imap` |
|---|---|---|
| Credential | OAuth token, or a service account key | An app password |
| Expires | with the client's publishing status | **never** |
| Personal account | yes, with the weekly re-auth unless a client is published | **yes** |
| Workspace | yes | no |
| Reaches | Gmail's API: labels, threads, drafts | a mailbox: search, read, flag, move, send |
| Policy rule | `gmail.*` | `gmail_imap.*` |

They are separate connections and can both exist. Nothing shares a credential between them.

## Why a separate manifest

A manifest has one connector, and IMAP is not HTTPS — the same reason iCloud is three providers
rather than one. It also keeps the policy line separable: `gmail_imap.*` can be allowed without
granting the REST surface, or the other way round.

## Almost all of it was already here

- **The IMAP transport resolves special mailboxes by SPECIAL-USE flag rather than by name**, and
  its own comments cite `[Gmail]/Sent Mail` as the case that forced it
  (`transports/imap/commands.ts:345`, `operations.ts:31`). Filing a sent copy and moving to Junk
  work with no Gmail branch anywhere.
- `defineProvider` already requires `basic` on an `imap` connector, and `basic` already requires
  exactly one `username` prompt and one `password` prompt.
- `setup.troubleshooting` is already where a vendor-specific refusal sentence goes — here, the one
  about a Google account password pasted where an app password belongs, which IMAP reports
  identically.

New: one manifest, its walkthrough, and `max_message_bytes: 25 * 1024 * 1024` — Gmail's real limit
against the 20 MB iCloud default, so an oversized message is refused before dialling rather than
part-way through `DATA`.

## Two judgement calls worth a look

**No `auth.app`.** The credential is `gmail_imap/<connection>` and is shared with nothing. An `app`
of `google` would have filed an app password in the same namespace as the shared OAuth client and
the service account key — three unrelated secrets rotated in three different consoles. Pinned by a
test.

**The dead end now points somewhere.** `googleServiceAccount` takes an optional `instead`, and only
`gmail` passes one:

```
  1. Service account key
     a JSON key that never expires, and no browser. Gmail has nothing that belongs to a key, so
     this needs a Google Workspace administrator to let it act as you — a personal Google account
     cannot do it, and wants gmail_imap instead.
```

Contacts and Tasks are also `delegation: 'required'` and genuinely have no alternative, so they
still say so plainly rather than sending somebody to look. A test pins the pointer against the
registry, because it is prose and prose compiles.

## Verification

`bun test` → **1833 pass, 2 skip, 0 fail** (+4). `bun run typecheck` → clean.

New tests (`gmail-imap.test.ts`) cover what a schema cannot see:
- the credential ref is `gmail_imap/main` and not under `google/`;
- `send_message` redacts to `[]` and the search terms are never kept — `attachments` may literally
  be a file, and a query is content;
- the sentence in `gmail`'s assertion text names a provider the registry actually has.

`src/readme.test.ts` enforces a connect command per provider, so the README table is updated too.

Exercised against a scratch workspace (`LANES_LINK_HOME` set to a temp dir, never the real one):
`setup plan gmail_imap` renders the full walkthrough, and `connect gmail_imap --non-interactive`
refuses correctly, naming `gmail_imap/<id>` and the `printf %s "<username>:<password>"` command.

Nothing here touches a real account — **the login that proves Google accepts the app password is
the operator's to run.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
