### PR TITLE
Exempt profile/schema.ts from the file-size budget, so develop builds again

### DIFF
--- a/src/architecture.test.ts
+++ b/src/architecture.test.ts
@@ -261,10 +261,30 @@ const MAX_LINES = 400;
  * It crossed the line by one, adding the target an endpoint runs as to the
  * authorization surface, and splitting it was a larger change than the one
  * that revealed it. Cut there when something needs to touch this file next.
+ *
+ * `profile/schema.ts` is `server/endpoint.ts` again, and a second occurrence is
+ * what makes that a pattern rather than an accident. It was 385 lines, and two
+ * branches open at once added ten net lines each — an `identity` block on the
+ * config, and `allowed_origins` on the authorization block. Both were green,
+ * because each was measured against a base without the other, and the merge
+ * that put them together was the first thing to see 405. A budget that only one
+ * branch at a time can check will keep finding this.
+ *
+ * Exempt rather than split, and this one is not a deferral. The file holds
+ * seventeen Zod declarations and no functions at all: its length is the size of
+ * the config format, not a count of responsibilities. The seam this budget
+ * exists to point at is a second subject — what `deployments/adapters/postgres.ts`
+ * and `stores/database/conformance.ts` each turned out to be — and there is no
+ * second subject here to find. Splitting it by line count would put
+ * `targetSchema` and `configSchema` in different files to satisfy an arithmetic
+ * that is not measuring anything about them. What would earn a split is
+ * something that is not a schema appearing beside them; that is the thing to
+ * watch for, and it is visible in a diff.
  */
 const KNOWN_LONG = new Set([
   'connectivity/transports/dav/ical.ts',
   'deployments/adapters/gcp-secret-manager.ts',
+  'profile/schema.ts',
   'providers/google/specs/vendor.ts',
   'providers/memory/provider.ts',
   'server/endpoint.ts',


### PR DESCRIPTION
## develop is red on its own

```
(fail) file size > no source file is longer than the budget
+ ["profile/schema.ts is 406 lines"]
```

Verified on a clean detached checkout of `origin/develop` with nothing applied — 5 pass, 1 fail.
Every PR into develop fails on it, including ones whose own check went green before this landed.

## Neither commit that caused it was wrong

The file was 385 lines. Two branches open at once each added **ten net lines**, landing a minute
apart:

- **#36** (`884e230`) — an `identity` block on the config schema
- **#34** (`e44e516`) — `allowed_origins` on the authorization schema

Both were green, because each was measured against a base that did not contain the other. The merge
that put them together was the first thing to see 405.

This is `server/endpoint.ts` a second time. That entry on the known-long list has the same story
written next to it — 371 lines and under budget on all four branches that were open at once,
crossing at 416 only when they were integrated. A second occurrence is what makes it a pattern
rather than an accident: a budget that only one branch at a time can check will keep finding this.

## Exempt rather than split, and not as a deferral

`src/profile/schema.ts` holds **seventeen Zod declarations and no functions at all**. Its length is
the size of the config format, not a count of responsibilities.

The seam this budget exists to point at is a *second subject* — the comment above the list records
`deployments/adapters/postgres.ts` and `stores/database/conformance.ts` each turning out to be two
things, and dropping to 322 and 290 lines without being split at all. There is no second subject
here to find. Splitting by line count would put `targetSchema` and `configSchema` in different files
to satisfy an arithmetic that is not measuring anything about them.

What *would* earn a split is something that is not a schema appearing beside them. The comment says
so, so the next person to read this has a rule rather than an exemption.

## Verification

`bun test` → **1878 pass, 2 skip, 0 fail**. `bun run typecheck` → clean.

The second test in that describe block — `nothing on the known-long list has quietly disappeared` —
already guards the new entry against becoming a stale exemption if the file is ever moved or
deleted.

Worth landing before #37 and #38, both of which are otherwise green and currently inherit this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
