### PR TITLE
An app must be separately enabled for Slack MCP access

### DIFF
--- a/docs/detailed/adr/040-an-mcp-connector-may-use-a-pre-registered-client.md
+++ b/docs/detailed/adr/040-an-mcp-connector-may-use-a-pre-registered-client.md
@@ -128,6 +128,17 @@ the kernel then splits connections between the listeners. Recorded rather than g
 relay removed the fixed port and with it the only way two `connect` runs could land on the same
 number. It is a live hazard for anything here that ever pins a port again.
 
+**Three things about Slack that no documentation states, all found by running it.** The Redirect URL
+field refuses a non-HTTPS value, which is what the relay exists for. An app must be separately
+enabled for MCP server access at `/apps/<id>/app-assistant`, or every call fails after a
+*successful* authorisation — the worst place for a switch, because the credential is real and the
+connection looks half-made. And `auth.test`'s `user` is a workspace-scoped handle, which is what
+`identity.qualifier` answers.
+
+The flow in this ADR is verified end to end against real Slack and the deployed broker: consent,
+the relay bounce to a loopback port carried in `state`, the brokered exchange, a workspace-qualified
+account (`ja (QAVE)`), and fifteen capabilities discovered and reachable.
+
 **What this is not.** It is not a claim that DCR is unnecessary. `registration: dynamic` remains the
 best case and the one that costs nothing; this is what to do when a vendor has decided against it.
 Nor does it retire the pasted token: ADR-033's mechanism is what GitHub still uses and what Slack

--- a/docs/detailed/setup/slack.md
+++ b/docs/detailed/setup/slack.md
@@ -90,6 +90,12 @@ and cannot be read back, so `connect` records what it asked for rather than what
 
 ## When it does not work
 
+**"App is not enabled for Slack MCP server access."** Connecting succeeds, a token is stored, and
+then discovery fails with this. It is a per-app switch, separate from scopes and separate from
+distribution, at `https://api.slack.com/apps/<APP_ID>/app-assistant` — the error names the URL.
+Only the owner of the app sees this: on the browser path the app is Lanes' and it is already on.
+Re-run `connect` afterwards; it settles to the same connection and nothing is orphaned.
+
 **"Slack refused the token."** Usually a bot token (`xoxb-`) where the user token (`xoxp-`) belongs,
 a scope missing from **User Token Scopes**, or an app that has been reinstalled since — reinstalling
 mints a new token.


### PR DESCRIPTION
Found by connecting Slack for real against the deployed broker.

Authorisation succeeds, a token is stored, the account resolves — and then discovery fails:

```
ok    authorised
Discovering capabilities…
error  App is not enabled for Slack MCP server access.
       Please enable it here: https://api.slack.com/apps/<APP_ID>/app-assistant
```

A per-app switch, distinct from scopes and from distribution, and in none of Slack's MCP documentation. Worth writing down twice over because it fires *after* a successful consent — the worst place for a switch, since the credential is real and the connection looks half-made rather than unconfigured.

Only the owner of an app meets it; on the browser path the app is Lanes' and is already enabled. So it goes in the troubleshooting for the pasted-token route, and in ADR-040 as an operator note alongside the other two things about Slack that no documentation states.

Also records that ADR-040's flow is now verified end to end against real Slack and the deployed broker rather than a stand-in: consent, the relay bounce to a loopback port carried in `state`, the brokered exchange, a workspace-qualified account, and fifteen capabilities discovered and reachable.

Docs only. `bun test` 1917 pass / 0 fail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)