### PR TITLE
Release 0.3.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lanes-sh/link",
-  "version": "0.2.2",
+  "version": "0.3.0",
   "description": "A self-hostable MCP gateway for all your connections, memory, skills, and secrets",
   "license": "Apache-2.0",
   "homepage": "https://lanes.sh/link",


### PR DESCRIPTION
A minor rather than a patch, because two of these change what a profile *is*
rather than what it can reach.

**A command names what it acts on.** `--profile` and `--target` are required;
the environment variables and `instance.default_target` are still parsed and no
longer read (ADR-037). Every command in a shell that relied on a default now
refuses instead of acting on whichever profile happened to be current, and a
flag a command does not read is refused with a suggestion rather than silently
dropped. This is the breaking change, and it is the reason for the minor.

**Memory and skills may live in a GitHub repository** (ADR-041).
`lanes link knowledge use github --repo <owner/name> --migrate` moves both, in
one commit, and reads them back before deleting anything. The credential store
and the vault are excluded structurally — there is no field that could name
them. `use local --migrate` is the same thing backwards.

Also here: Slack connects in a browser instead of asking for an app (ADR-040); a
personal Gmail mailbox is reachable with an app password over IMAP; a service
account key is a second way into a Google account (ADR-038); a profile declares
who its owner is, so an agent stops guessing; cross-origin access is a
deployment-only grant and a preflight is answered ahead of the credential check
(ADR-039); and there is a local page showing connections, profiles, and targets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)