### PR TITLE
Offer Internal before External, so a Workspace domain stops paying for reach it does not want

### DIFF
--- a/docs/detailed/setup/google.md
+++ b/docs/detailed/setup/google.md
@@ -99,7 +99,8 @@ you pick. There are up to three:
 | Route | Console work | Re-authorised weekly? | Reaches |
 |---|---|---|---|
 | The hosted client (default) | none | **while its verification is pending, yes** | the whole account |
-| A client of your own | ~20 minutes, once per profile | **no, if you publish it** — see below | the whole account |
+| Your own client, **Internal** — needs a Workspace org | ~10 minutes, once per profile | **never** | the whole account |
+| Your own client, **External** | ~20 minutes, once per profile | **no, if you publish it** — see below | the whole account |
 | A service account key | ~10 minutes, once per profile | **never** | see [Service account](#connecting-with-a-service-account-key) |
 
 There is a fourth that is not on this list because it is not a way of connecting `gmail` — it is a
@@ -112,9 +113,16 @@ problem a checkbox solves. A client whose publishing status is **Testing** has e
 it issues expired after exactly seven days. A client set to **In production** does not — review
 pending, review never started, it makes no difference.
 
-That is why the middle row above beats the first one today: the hosted client is under review, and
-a client under review has whatever status it has. Registering your own and publishing it is the
-shortest path to connections that survive the week.
+That is why either own-client row beats the first one today: the hosted client is under review, and
+a client under review has whatever status it has.
+
+**An Internal app has no publishing status to have**, which is why its row says *never* rather than
+*not if you publish it*. There is no toggle to get wrong and nothing to remember to switch. If the
+project sits in a Google Workspace organisation and every account you connect is on that domain,
+this is both the shortest console detour on the list and the only own-client route with nothing to
+maintain — no test users, no verification, no scope registration. Its one prerequisite is real
+though: "Internal" means "inside my Workspace organisation", not "private to me", and Google does
+not offer it on a project with no organisation behind it.
 
 **Picking wrong is not a decision you are stuck with.** An account authenticates one way at a
 time, and `connect` is how it changes: run it again, pick another route, and the new credential
@@ -129,10 +137,16 @@ browser leaves Google still holding the consent you granted, which you remove yo
 
 ### If you register your own
 
-**Choose External if you have a mix of personal Gmail and Workspace accounts**, which is the common
-case. "Internal" sounds like the private option, but it only admits accounts on your own Workspace
-domain, so a personal `@gmail.com` account simply cannot authorise against it. An Internal app needs
-no verification and has no expiry, so if *every* account is on one domain it is the better choice.
+**Choose Internal if the project sits in a Google Workspace organisation and every account you will
+connect is on that domain.** This is the short path and it is much shorter: an Internal app has no
+publishing status at all, so there is no seven-day expiry, no verification question, no
+unverified-app warning screen, no test-user list to maintain, and no scopes to register on the Data
+Access page. Set the user type and go straight to creating the client.
+
+**Choose External for a personal `@gmail.com`, or a mix of personal and Workspace accounts.**
+"Internal" is Google's word for "inside my Workspace organisation", not "private to me" — the option
+is not offered at all on a project with no organisation behind it, and where it *is* offered it
+admits only your own domain. Everything from here to the end of this section is the External path.
 
 **Then publish it.** Publishing an unverified app is allowed and is not the same as being verified.
 What it costs:
@@ -206,7 +220,9 @@ App name and a support email. Nothing here is seen by anyone but you.
 
 ### 3. Audience
 
-**User type: External.** Choose External even with a Workspace domain — see the table above.
+**User type.** On a Workspace domain with every account on it, choose **Internal** — then skip the
+rest of this page's Audience and Data Access steps and go to [Clients](#5-clients). Otherwise choose
+**External** and continue. See the table above.
 
 Add every Google account you intend to connect under **Test users** (up to 100), personal and
 Workspace alike. An account not listed here cannot authorise.
@@ -519,10 +535,15 @@ warn  gmail.personal credential is 8 days old — Testing-status apps expire at 
 
 The escapes, cheapest first:
 
-- **Register a client of your own and publish it.** `lanes link connect <provider>` and pick the
-  "OAuth client you register" route, or `--auth own_client`. Publishing is a setting, not a review;
-  it costs an unverified-app screen and a lifetime cap of 100 new users on that project. This is
-  the one most people want.
+- **Register a client of your own as Internal**, if the project sits in a Google Workspace
+  organisation and every account is on that domain. `lanes link connect <provider>` and pick the
+  "OAuth client you register" route, or `--auth own_client`. An Internal app has no publishing
+  status, so there is nothing to expire, no warning screen, and no scopes to register. This is the
+  cheapest escape when it is available at all — it is not offered without a Workspace organisation.
+- **Register a client of your own as External and publish it.** Same route, for a personal
+  `@gmail.com` or a mix of account kinds. Publishing is a setting, not a review; it costs an
+  unverified-app screen and a lifetime cap of 100 new users on that project. This is the one most
+  people want.
 - **Use an app password over IMAP**, if this is a personal account and mail is what you need —
   `lanes link connect gmail_imap`. Nothing expires and there is no console project at all. See
   [Gmail over IMAP](#gmail-over-imap-on-a-personal-account).
@@ -545,7 +566,8 @@ working.
 
 | Symptom | Cause |
 |---|---|
-| `invalid_grant`, roughly weekly | The client is in Testing. Publish it, or use a key — see [The weekly re-authorisation](#the-weekly-re-authorisation). |
+| `invalid_grant`, roughly weekly | The client is External and in Testing. Publish it, switch it to Internal if you have a Workspace domain, or use a key — see [The weekly re-authorisation](#the-weekly-re-authorisation). |
+| `invalid_grant` once, after months of working | Not an expiry — an expiry is weekly and this was not. The consent was revoked: a Workspace admin withdrawing third-party app access, a password change, or a removal at [myaccount.google.com/permissions](https://myaccount.google.com/permissions). Publishing changes nothing here; re-run `lanes link connect <provider>.<id>` and, if an admin revoked it, get the client allowlisted first. |
 | `unauthorized_client` on a service account | Domain-wide delegation is missing, or was granted with a scope list that does not match exactly. The error names the scopes to paste. |
 | `invalid_grant` on a service account | The key was deleted or disabled, or this machine's clock is off by more than a few minutes. |
 | A service account connects but everything is empty | Nothing has been shared with the key's address yet. That is the design, not a fault. |

--- a/src/providers/google/shared/setup.test.ts
+++ b/src/providers/google/shared/setup.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, test } from 'bun:test';
+import { googleSetup } from './setup.ts';
+
+const GMAIL_SCOPES = [
+  'https://www.googleapis.com/auth/gmail.readonly',
+  'https://www.googleapis.com/auth/gmail.modify',
+];
+
+const steps = (scopes: readonly string[] = GMAIL_SCOPES) =>
+  googleSetup('Gmail', scopes).steps as string[];
+
+const audience = () => steps().find((s) => s.trimStart().startsWith('AUDIENCE — User type'))!;
+
+describe('the AUDIENCE step offers Internal before External', () => {
+  // The regression this guards is a specific one: a blanket "choose EXTERNAL"
+  // sends someone with a Workspace domain through publishing, a test-user list,
+  // scope registration and the unverified-app warning to reach a client that
+  // then expires its refresh tokens weekly if they miss the publish toggle.
+  // Internal has none of those because it has no publishing status at all.
+  test('names Internal, and names it first', () => {
+    const step = audience();
+    expect(step).toContain('INTERNAL');
+    expect(step).toContain('EXTERNAL');
+    expect(step.indexOf('INTERNAL')).toBeLessThan(step.indexOf('EXTERNAL'));
+  });
+
+  test('says what Internal removes, so the short path reads as shorter', () => {
+    expect(audience()).toContain('no publishing status');
+  });
+
+  test('states the prerequisite, because Internal is absent without an organisation', () => {
+    // "Internal" is Google's word for "inside my Workspace organisation", not
+    // "private to me" — the step has to say so or a personal @gmail.com user
+    // goes looking for an option that is not on their screen.
+    const step = audience();
+    expect(step).toContain('Workspace organisation');
+    expect(step).toContain('not offered without a Workspace organisation');
+  });
+});
+
+describe('the steps only Externals need are marked as such', () => {
+  test('publishing, scope registration, and the verification cost all say EXTERNAL ONLY', () => {
+    const marked = steps().filter((s) => s.includes('EXTERNAL ONLY'));
+    // PUBLISH, DATA ACCESS, the unverified-app cost, and verification itself.
+    expect(marked).toHaveLength(4);
+  });
+
+  test('DATA ACCESS says an Internal app can leave the page empty', () => {
+    const step = steps().find((s) => s.includes('DATA ACCESS'))!;
+    expect(step).toContain('EXTERNAL ONLY');
+    expect(step).toContain('can stay empty');
+  });
+
+  test('still lists the scopes it was given, for the path that registers them', () => {
+    const step = steps().find((s) => s.includes('DATA ACCESS'))!;
+    for (const scope of GMAIL_SCOPES) expect(step).toContain(scope);
+  });
+});

--- a/src/providers/google/shared/setup.ts
+++ b/src/providers/google/shared/setup.ts
@@ -40,6 +40,21 @@ export const googleSetup = (
     summary: `${product} signs in with Google. By default it authorises against the OAuth client Lanes operates, so there is nothing to register and no client secret on this machine — the code is exchanged for a token by the Lanes API, which holds that secret. Pass --own-client to register a client of your own instead; the steps below are that path, asked once per profile and then covering every Google account you connect.`,
     docs: 'docs/detailed/setup/google.md',
     docs_url: 'https://console.cloud.google.com/auth',
+    // AUDIENCE leads with Internal, and the ordering is the point rather than a
+    // preference. The seven-day `invalid_grant` everyone hits is a property of
+    // publishing status, and an Internal app has no publishing status to have —
+    // so it also has no expiry, no verification question, no unverified-app
+    // warning, no test-user list, and no scope registration. Steering a
+    // Workspace user to External costs them every one of those, to buy reach
+    // they do not want: Internal admits only their own domain, which is the
+    // whole set of accounts they were going to connect.
+    //
+    // What it cannot be is the only path. "Internal" is Google's word for
+    // "inside my Workspace organisation", not "private to me", and the option
+    // is simply absent on a project with no organisation behind it. So a
+    // personal @gmail.com still needs External and still has to publish, and
+    // the steps say which half applies to whom rather than making everyone read
+    // both.
     steps: [
       ...(options.preview
         ? [
@@ -56,13 +71,13 @@ export const googleSetup = (
       }\n       Without gcloud: APIs & Services → Library, and search for each by name.`,
       'The rest is under Google Auth Platform — https://console.cloud.google.com/auth — in this order:',
       '  BRANDING — app name and a support email. Seen by nobody but you.',
-      '  AUDIENCE — User type: EXTERNAL (even with a Workspace domain: "Internal" admits only that one domain, so a mix of personal and Workspace accounts needs External). Add every account you will connect under "Test users".',
-      '  AUDIENCE, again — PUBLISH the app. This is the setting that decides whether your connections survive the week, and it is not the same thing as verification: a client left in "Testing" has every refresh token it issues expired after exactly seven days, and one set to "In production" does not, review pending or not.',
-      `  DATA ACCESS — where scopes live now. Add:\n       ${scopes.join('\n       ')}\n       Note drive.file is filed under "sensitive" rather than "restricted", so it appears in a different section of that page.`,
+      '  AUDIENCE — User type, and this is the step that decides how much of the rest you do.\n       INTERNAL, if the project sits in a Google Workspace organisation and every account you will connect is on that domain. An Internal app has no publishing status at all — so no seven-day expiry, no verification, no test-user list, no unverified-app warning screen, and no scopes to register. Skip to CLIENTS.\n       EXTERNAL, for a personal @gmail.com, or a mix of personal and Workspace accounts. Internal is not offered without a Workspace organisation, and admits only your own domain. Add every account you will connect under "Test users", then do the two steps below.',
+      '  AUDIENCE, again — EXTERNAL ONLY: PUBLISH the app. This is the setting that decides whether your connections survive the week, and it is not the same thing as verification: a client left in "Testing" has every refresh token it issues expired after exactly seven days, and one set to "In production" does not, review pending or not. Internal apps have no publishing status, which is why they never expire.',
+      `  DATA ACCESS — EXTERNAL ONLY. Where scopes live now. Add:\n       ${scopes.join('\n       ')}\n       Note drive.file is filed under "sensitive" rather than "restricted", so it appears in a different section of that page. An Internal app does not need this: it authorises scopes that were never registered here, so the page can stay empty.`,
       '  CLIENTS — Create OAuth client → type: DESKTOP APP. Google\'s docs say "Web application" with a redirect URI for Claude or Antigravity, because they assume the agent host runs the OAuth. Here the CLI does, on a loopback port — which is also why this stays Desktop even when the server runs on Cloud Run.',
       'Copy the client ID and secret — you are asked for them next.',
-      'What publishing unverified costs, so it is a decision rather than a surprise: everyone you connect sees a "Google hasn\'t verified this app" screen and has to click through Advanced, and the project gains a cap of 100 new users granted these scopes. That cap is for the lifetime of the project and cannot be reset — which does not matter for a client only you use, and matters a great deal for one you intend to hand out.',
-      'Verification itself is the other path and a much longer one — restricted scopes mean a review with a security assessment measured in months. It is worth starting and not worth waiting on: publishing above removes the weekly re-authorisation today.',
+      'EXTERNAL ONLY — what publishing unverified costs, so it is a decision rather than a surprise: everyone you connect sees a "Google hasn\'t verified this app" screen and has to click through Advanced, and the project gains a cap of 100 new users granted these scopes. That cap is for the lifetime of the project and cannot be reset — which does not matter for a client only you use, and matters a great deal for one you intend to hand out. None of this applies to an Internal app.',
+      'EXTERNAL ONLY — verification itself is the other path and a much longer one: restricted scopes mean a review with a security assessment measured in months. It is worth starting and not worth waiting on, since publishing above removes the weekly re-authorisation today. If you have a Workspace domain, Internal skips this question entirely.',
       'If none of that suits — an organisation that forbids publishing, or a client that must stay in Testing — connect with a service account key instead. It does not expire at all: lanes link connect ' + product.toLowerCase().split(' ')[0] + ' --auth service_account',
     ],
     prompts: [


### PR DESCRIPTION
## Why

The own-client walkthrough said **User type: EXTERNAL (even with a Workspace domain)**. The parenthetical is true as far as it goes — Internal admits only one domain, so a mix of personal and Workspace accounts really does need External — but it was stated as a blanket instruction, and for the single-domain case it is the wrong end of a real trade.

An **Internal app has no publishing status at all.** Not "In production", not "Testing" — the Audience page offers nothing but *Make external*. So it cannot have the seven-day refresh-token expiry, which is a property of that status. It also needs no verification, no test-user list, no unverified-app warning screen, and no scopes registered on Data Access.

Steering someone with a Workspace domain to External charged them all five, to buy reach they had no use for — plus a publish toggle that silently expires every refresh token weekly if they miss it.

## Confirmed against a live project

A project that has been running this way for six months: user type **Internal**, Data Access **empty**, and `https://mail.google.com/` authorising anyway. So an Internal app really does authorise scopes that were never registered on that page — which is what lets the Internal branch drop the step rather than just soften it.

## What changed

`AUDIENCE` now branches, and the four steps only External needs say `EXTERNAL ONLY`. A single-domain reader does five steps and skips to `CLIENTS`:

| Step | Internal | External |
|---|---|---|
| BRANDING | ✓ | ✓ |
| AUDIENCE — user type | ✓ | ✓ + test users |
| AUDIENCE — publish | — | ✓ |
| DATA ACCESS — scopes | — | ✓ |
| CLIENTS | ✓ | ✓ |
| unverified cost / verification | — | ✓ |

**This is not a new default.** "Internal" is Google's word for *inside my Workspace organisation*, not *private to me*, and the option is absent on a project with no organisation behind it. A personal `@gmail.com` still needs External and still has to publish — so the step states the prerequisite rather than sending someone hunting for a control that is not on their screen.

`docs/detailed/setup/google.md` gets the matching treatment: the route table splits own-client into its two audience rows, the numbered walkthrough branches, and the "escapes, cheapest first" list leads with Internal where it is available.

## A troubleshooting row that was missing

A single `invalid_grant` after months of clean runs is **not** an expiry — an expiry is weekly. That is a revocation: an admin withdrawing third-party app access, a password change, a removal at `myaccount.google.com/permissions`. The table's existing advice ("the client is in Testing, publish it") is the wrong fix for it, and would have been the wrong fix for the project above, which was already Internal.

## Verification

- `bun test` — 2058 pass, 0 fail (+6 from the new `setup.test.ts`)
- `bun run typecheck` — clean
- New test mutation-checked: **5 of its 6 assertions fail against the pre-change `setup.ts`**, so the ordering and the `EXTERNAL ONLY` marks cannot quietly regress
- Generated walkthrough rendered and read end to end
- Rebased onto `origin/develop` (`028d4d7`); no other file in `docs/` or `src/` carries the old External steer

🤖 Generated with [Claude Code](https://claude.com/claude-code)