### PR TITLE
Release 0.3.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lanes-sh/link",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "A self-hostable MCP gateway for all your connections, memory, skills, and secrets",
   "license": "Apache-2.0",
   "homepage": "https://lanes.sh/link",


### PR DESCRIPTION
Sets the version so that merging `develop` into `main` publishes 0.3.1 directly, rather than the workflow proposing a patch bump on a side branch afterwards — which would leave `develop` and `main` holding different trees.

Since v0.3.0: the target-scoped commands and `sync targets` (#46), the Internal-before-External OAuth audience (#45), and the command reference (#43).