### PR TITLE
Release 0.3.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lanes-sh/link",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "A self-hostable MCP gateway for all your connections, memory, skills, and secrets",
   "license": "Apache-2.0",
   "homepage": "https://lanes.sh/link",

--- a/src/deployments/sync-apply.test.ts
+++ b/src/deployments/sync-apply.test.ts
@@ -107,6 +107,55 @@ describe('pulling what the local copy has lost', () => {
     expect(recovered).not.toContain('capability: gmail.send_message');
   });
 
+  test('an account only the local copy has survives the pull', async () => {
+    // The bug this file did not catch, and it lost six real connections.
+    //
+    // Every keyed-array test here had a local array that was a subset of the
+    // remote one — the case where "replace with remote" and "merge" agree. Both
+    // sides holding something the other lacks is the case that tells them
+    // apart, and it is the ordinary state of a profile that has been used since
+    // the last deploy.
+    const conn = (provider: string, id: string): string =>
+      `  - { id: ${id}, provider: ${provider}, account: ${id}@example.com }\n`;
+    const withConns = (entries: string, rules: string): string =>
+      `${PROFILE}connections:\n${entries}policy:\n  allow: [${rules}]\n`;
+
+    const local = await workspace({
+      personal: withConns(conn('slack', 'mine'), 'slack.*'),
+    });
+    const remote = await workspace({
+      personal: withConns(conn('gmail', 'theirs'), 'gmail.*'),
+    });
+
+    const plan = await planProfile(local, remote, 'personal', undefined);
+    await applyPulls(local, remote, 'personal', plan.changes);
+
+    const recovered = await read(local, 'personal');
+    expect(recovered).toContain('provider: gmail');  // pulled
+    expect(recovered).toContain('provider: slack');  // and not lost
+    expect(recovered).toContain('gmail.*');
+    expect(recovered).toContain('slack.*');
+  });
+
+  test('a local element the remote also has is updated, not duplicated', async () => {
+    const local = await workspace({
+      personal: `${PROFILE}connections:\n  - { id: work, provider: gmail, account: old@example.com }\n  - { id: mine, provider: slack, account: m@example.com }\npolicy:\n  allow: [gmail.*, slack.*]\n`,
+    });
+    const remote = await workspace({
+      personal: `${PROFILE}connections:\n  - { id: work, provider: gmail, account: new@example.com }\npolicy:\n  allow: [gmail.*]\n`,
+    });
+
+    const plan = await planProfile(local, remote, 'personal', 'remote');
+    await applyPulls(local, remote, 'personal', resolved(plan.changes, 'remote'));
+
+    const recovered = await read(local, 'personal');
+    expect(recovered).toContain('new@example.com');
+    expect(recovered).not.toContain('old@example.com');
+    expect(recovered).toContain('provider: slack');
+    // One entry, not two.
+    expect(recovered.match(/provider: gmail/g)).toHaveLength(1);
+  });
+
   test('applying twice changes nothing the second time', async () => {
     const local = await workspace({ personal: PROFILE });
     const remote = await workspace({ personal: PROFILE + CLOUD });

--- a/src/deployments/sync-apply.ts
+++ b/src/deployments/sync-apply.ts
@@ -8,7 +8,7 @@ import {
   type Config,
 } from '#profile';
 import { ConfigDocument } from '#cli/config-edit.ts';
-import { diffConfigs, keyedArrayFor, type Change } from './sync.ts';
+import { diffConfigs, keyOfElement, keyedArrayFor, type Change } from './sync.ts';
 import { isWorkspaceConfig } from './upload.ts';
 
 /**
@@ -155,26 +155,80 @@ export async function applyPulls(
   const remote = await readRawProfile(remoteRoot, profile);
   if (remote === undefined) return 0;
 
+  const local = document.toJSON();
   const written = new Set<string>();
+
   for (const change of pulls) {
     const array = keyedArrayFor(change.path);
-    const path = array ?? change.path;
 
-    // One write per array, however many of its elements were missing.
-    const key = path.join('.');
-    if (written.has(key)) continue;
-    written.add(key);
+    if (array) {
+      // One write per array, however many of its elements were missing — and
+      // the value written is the *merge*, never the remote array.
+      //
+      // It used to be `setIn(array, remoteArray)`, which reads as "pull the
+      // connections" and means "replace the connections". A profile that had
+      // gained six accounts locally since the last deploy lost all six to a
+      // command whose entire purpose is not losing things. The tests missed it
+      // because every one of them had a local array that was a subset of the
+      // remote — the case where replacing and merging agree.
+      const key = array.join('.');
+      if (written.has(key)) continue;
+      written.add(key);
 
-    const value = valueAt(remote, path);
+      const merged = mergeKeyed(
+        array,
+        valueAt(local, array),
+        valueAt(remote, array),
+        pulls
+          .filter((one) => keyedArrayFor(one.path)?.join('.') === key)
+          .map((one) => one.path[array.length])
+          .filter((name): name is string => name !== undefined),
+      );
+      if (merged !== undefined) document.setIn([...array], merged);
+      continue;
+    }
+
+    const value = valueAt(remote, change.path);
     // Absent from the raw document means the remote side only has it as a
     // default, which the local side fills in identically. Nothing to write.
     if (value === undefined) continue;
 
-    document.setIn([...path], value);
+    document.setIn([...change.path], value);
   }
 
   await document.save();
   return written.size;
+}
+
+/**
+ * The local array, with the named elements taken from the remote one.
+ *
+ * Element order is local's, with anything new appended, so a pull reads as a
+ * diff in the file rather than as a reshuffle. An element named in `wanted` and
+ * absent from the remote array is skipped rather than removed: the diff said it
+ * was missing locally, so it cannot also be missing remotely.
+ */
+function mergeKeyed(
+  arrayPath: readonly string[],
+  local: unknown,
+  remote: unknown,
+  wanted: readonly string[],
+): unknown[] | undefined {
+  if (!Array.isArray(remote)) return undefined;
+
+  const merged = Array.isArray(local) ? [...(local as unknown[])] : [];
+  const keyOf = (item: unknown): string | undefined => keyOfElement(arrayPath, item);
+
+  for (const name of new Set(wanted)) {
+    const incoming = remote.find((item) => keyOf(item) === name);
+    if (incoming === undefined) continue;
+
+    const at = merged.findIndex((item) => keyOf(item) === name);
+    if (at >= 0) merged[at] = incoming;
+    else merged.push(incoming);
+  }
+
+  return merged;
 }
 
 /** Read a path out of the raw document, for handing to `setIn`. */

--- a/src/deployments/sync.ts
+++ b/src/deployments/sync.ts
@@ -41,11 +41,22 @@ export interface Change {
  * first entry of a kind is the one to reach for — so it is an ordered list and
  * compares as one.
  */
-const KEYED: Record<string, (item: Record<string, unknown>) => string> = {
-  connections: (item) => `${String(item['provider'])}.${String(item['id'])}`,
-  'policy.allow': (item) => String(item['capability']),
-  'policy.deny': (item) => String(item['capability']),
+const KEYED: Record<string, (item: unknown) => string | undefined> = {
+  connections: (item) =>
+    isRecord(item) ? `${String(item['provider'])}.${String(item['id'])}` : undefined,
+  // Two shapes, and both are reached. The diff runs over validated configs,
+  // where `allow: [gmail.*]` has become `[{capability: gmail.*}]`; the writer
+  // runs over the raw document, where it is still a string. A key function that
+  // knew only the validated shape found nothing to merge and silently wrote the
+  // array without it.
+  'policy.allow': capabilityOf,
+  'policy.deny': capabilityOf,
 };
+
+function capabilityOf(item: unknown): string | undefined {
+  if (typeof item === 'string') return item;
+  return isRecord(item) ? String(item['capability']) : undefined;
+}
 
 const isRecord = (value: unknown): value is Record<string, unknown> =>
   typeof value === 'object' && value !== null && !Array.isArray(value);
@@ -102,12 +113,16 @@ function walk(path: readonly string[], local: unknown, remote: unknown): Change[
  */
 function walkKeyed(
   path: readonly string[],
-  keyOf: (item: Record<string, unknown>) => string,
+  keyOf: (item: unknown) => string | undefined,
   local: readonly unknown[],
   remote: readonly unknown[],
 ): Change[] {
   const index = (items: readonly unknown[]): Map<string, unknown> =>
-    new Map(items.filter(isRecord).map((item) => [keyOf(item), item]));
+    new Map(
+      items
+        .map((item) => [keyOf(item), item] as const)
+        .filter((pair): pair is readonly [string, unknown] => pair[0] !== undefined),
+    );
 
   const here = index(local);
   const there = index(remote);
@@ -128,6 +143,19 @@ export function keyedArrayFor(path: readonly string[]): readonly string[] | unde
     if (path.slice(0, depth).join('.') in KEYED) return path.slice(0, depth);
   }
   return undefined;
+}
+
+/**
+ * How an element of a keyed array identifies itself, for the writer.
+ *
+ * The diff indexes these to compare them; applying one has to find the same
+ * element again in *both* raw documents, and it cannot re-derive the key from
+ * the path — `connections.gmail.work` is one key containing a dot, not two
+ * steps. Exported so the two halves cannot disagree about what identifies a
+ * connection.
+ */
+export function keyOfElement(arrayPath: readonly string[], item: unknown): string | undefined {
+  return KEYED[arrayPath.join('.')]?.(item);
 }
 
 /** Whether a set of changes can be applied without being told which side wins. */


### PR DESCRIPTION
Publishes 0.3.2. Version is already set and `v0.3.2` has no tag, so the release workflow publishes
and tags rather than proposing a bump — keeping `develop` and `main` on the same tree.

## Since v0.3.1

**A data-loss fix in `sync targets`** (#49), which is why this follows 0.3.1 within the hour.

Pulling a connection the local copy was missing wrote the *remote array* over the local one, so a
profile that had gained accounts since the last deploy lost every one of them. Six pulled in, six
silently dropped, and the summary reported `4 key(s) pulled`.

The tests missed it because every keyed-array case had a local array that was a **subset** of the
remote one — the case where replacing and merging agree. A second, latent half would have made the
fix partial: `policy.allow: [gmail.*]` is a string in the raw document and `{capability: gmail.*}`
after validation, and the writer read the raw shape with a key function that only knew the
validated one.

Anyone who ran `lanes link sync targets` on 0.3.1 with connections on both sides should check their
profile against the copy in their bucket.

## Verification

`bun test` (2128 pass, 0 fail) and `bun run typecheck`; `ci` green on #49. Rehearsed against copies
of a real workspace and its bucket — 14/14 connections and 13/13 policy rules against a computed
union — then applied for real, with the deployed endpoint still answering on its existing token.