### PR TITLE
The skill describes operating a workspace, not only calling it

### DIFF
--- a/instructions/agents/lanes-link-scout.md
+++ b/instructions/agents/lanes-link-scout.md
@@ -56,8 +56,8 @@ to every future session.
 stops a write is policy on the endpoint:
 
 ```console
-$ lanes link policy deny memory.write
-$ lanes link policy list
+$ lanes link policy deny memory.write --profile <name> --target <name>
+$ lanes link policy list --profile <name>
 ```
 
 If you are running against a profile that grants writes, that is the owner's

--- a/instructions/skills/lanes-link/SKILL.md
+++ b/instructions/skills/lanes-link/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: lanes-link
-description: Use when the user refers to their own accounts, knowledge, procedures, or secrets through Lanes Link — "check my mail", "what do I know about X", "remember this", "which profile am I in" — or asks to connect, register, or set up their Lanes Link MCP server with this agent. Also covers what to do when a Lanes Link call is refused, or when the endpoint is not running.
+description: Use when the user refers to their own accounts, knowledge, procedures, or secrets through Lanes Link — "check my mail", "what do I know about X", "remember this", "which profile am I in" — or asks to connect, register, or set up their Lanes Link MCP server with this agent. Also covers operating the workspace from a shell — adding or removing a profile, checking what a target serves, deploying an endpoint or recovering a lost deployment — and what to do when a Lanes Link call is refused, or when the endpoint is not running.
 ---
 
 # Lanes Link
@@ -24,12 +24,32 @@ is listed first.** Quietly picking one crosses the line the profile exists to
 draw. There is no "current profile" to switch — the choice is made per call, and
 `lanes link profile list` shows what exists.
 
-**Every `lanes link` command names its profile and its target.** Both are required
-flags with no default, no environment variable, and nothing in a config file
-behind them, so a command missing either refuses rather than acting somewhere
-else. When you write one out for the owner, either fill both in or leave them as
-`<name>` for them to complete — never drop them. `lanes link target list
---profile <name>` shows what a profile declares.
+**What a command must be told is never inferred — but it is not always both.**
+Nothing resolves from an environment variable or a config default, so a command
+missing what it needs refuses rather than acting somewhere else. Passing a flag a
+command does not read is refused too, which makes "add both to be safe" its own
+failure. Four levels:
+
+- **Neither.** `lanes link profile list`, `lanes link mcp list`,
+  `lanes link version`.
+- **`--profile` alone.** `lanes link check`, `lanes link config show`,
+  `lanes link policy list`, `lanes link target list --profile <name>`,
+  `lanes link identity list`. Each is target-independent — one declaration in the
+  YAML that applies wherever the profile runs.
+- **`--target`, with the profiles derived from it.** `lanes link status`,
+  `lanes link deploy` and `lanes link sync targets` act on one endpoint serving
+  every profile that declares that target. `--profile` is accepted and *narrows*
+  the answer; it does not choose the subject.
+- **Both.** Everything acting on one account: `lanes link connect`,
+  `lanes link token rotate`, `lanes link secrets set`, `lanes link policy allow`,
+  `lanes link memory list`, `lanes link mcp add`.
+
+`lanes link profile add` and `lanes link profile remove` **reject** `--profile`.
+Both name their profile positionally, so a flag naming a second one could only
+disagree with it.
+
+When you write a command out for the owner, fill in what that command needs or
+leave it as `<name>` for them to complete — never drop a required one.
 
 A `connection` names an account within that profile. One profile may hold
 several of the same kind, and naming a connection belonging to a *different*
@@ -162,8 +182,101 @@ the line.
 **Never pass `--accept-broad-scopes` yourself.** When a provider asks for more than
 it needs, print the scopes and let the owner add the flag. Deciding that is theirs.
 
-A new connection is not served until the endpoint restarts, so a `setup_overview`
-straight after connecting will still not show it. Say so rather than retrying.
+**A new connection is served at once; the tools you were handed are not.**
+Connecting publishes the config to wherever that target's endpoint reads it and
+asks the endpoint to re-read it, so a `setup_overview` straight after connecting
+*does* show the account. What has not changed is the set of tools this session
+was given when it connected — the endpoint does not announce that its tools
+changed, so a capability for a freshly connected account is not callable until
+the client reconnects. Say that, rather than reporting the connection as missing
+or asking them to connect again.
+
+One exception, and it is the one that matters here: the authenticator is built
+once at boot and is not re-read, so a `lanes link token rotate` does need the
+endpoint restarted before the new token opens anything.
+
+## Operating the workspace
+
+If you have a shell, the commands that only *read* are yours to run without
+asking: `lanes link status`, `lanes link check`, `lanes link plan`,
+`lanes link doctor`, `lanes link profile list`, `lanes link target list`,
+`lanes link target show`, `lanes link tools`, `lanes link config show` and
+`lanes link audit tail`. None writes config, opens a browser, or costs anything,
+and running one beats asking the owner to paste its output back. Give each what
+its own level requires — they are not all the same, and the four levels are at
+the top of this file.
+
+**A command that writes runs `--dry-run` first, where it has one.** Show what it
+reported and wait for an answer. `lanes link deploy`, `lanes link sync targets`,
+`lanes link profile remove`, `lanes link secrets push` and `lanes link mcp add`
+all take it. For a write with no dry run — `lanes link token rotate`,
+`lanes link policy allow`, `lanes link secrets set` — say in one sentence what it
+will change, then let them decide. Never a browser sign-in: that belongs to
+whoever owns the account, as above.
+
+**`--json` is not everywhere.** It parses on every command and is read by only
+some, so one that ignores it prints its ordinary output and gives you nothing to
+key on — do not treat the absence of JSON as a failure. `status`, `doctor`,
+`tools`, `outputs`, `sync targets`, `target list`, `target show`, `profile list`,
+`connect` and `setup plan` implement it. `deploy`, `check`, `plan`,
+`config show`, `audit tail` and every `mcp` subcommand do not.
+
+**A profile is created and removed, never switched.** `lanes link profile add
+<name>` writes a new one and takes `--target <name>`, repeated once per target it
+should declare. `lanes link profile remove <name>` takes `--dry-run` and then
+`--yes`; given a `--target` it decommissions that one target's stores and leaves
+the profile file in place. Neither reads `--profile`.
+
+There is no current profile and no default target. `lanes link profile default`
+and `lanes link target use` are gone and now refuse with an explanation — if you
+meet one of those refusals, it is not a broken install, and there is no
+replacement to find. The choice is made per command, on purpose.
+
+## Deploying, and what it decides
+
+`lanes link deploy` builds an image and rolls a revision. Its subject is a
+**target**, and the profiles behind it are every profile declaring that target,
+so one deploy serves all of them — there is no per-profile deploy to run and no
+reason to loop over them.
+
+**Always `--dry-run` first, and show what it printed.** It creates cloud
+resources that cost money, it implements no `--json` to inspect instead, and that
+plan is the only place the consequences are visible while they are still
+avoidable.
+
+Two things it refuses to guess, and both are the owner's to answer:
+
+- **Whose bearer token opens the endpoint.** One token reaches every profile
+  behind that target, so this decides who gets in. With several candidates and
+  nothing recorded, it refuses and prints the command that names one.
+- **A first deploy.** A target no profile declares yet has no set to derive from,
+  so `--profile` is required there. It may be repeated, and the first one named
+  is the primary.
+
+**Never pass `--yes`, `--non-interactive`, `--access public` or
+`--service-account` yourself.** Each settles a question about who can reach their
+accounts. Print what the flag would decide and let them add it — the same rule
+this file already applies to `--accept-broad-scopes`.
+
+Deploying is how new code reaches the endpoint. It is not how an account gets
+connected and not how a config change lands; both of those publish themselves.
+
+## When the workspace and the endpoint disagree
+
+A deployment records where it lives, and a workspace can lose that record — a new
+machine, a reinstall, a profile file restored from something older. The endpoint
+is still serving; what went missing is the config that describes it. The symptom
+is a `lanes link status` that reports nothing deployed for a target you know is
+up.
+
+`lanes link sync targets` reconciles the two. `--discover` looks for a deployment
+the workspace has no record of, `--from <location>` names one directly, and
+`--dry-run` reports what it would merge without merging it. Run the dry run and
+show it.
+
+**`--prefer local` or `--prefer remote` is their answer, not yours.** It decides
+which side wins where the two disagree, and the losing value is the one nobody
+was asked about. Report what differs and let them pick.
 
 ## Registering it, and re-registering it
 
@@ -192,7 +305,7 @@ substitution form. If you have already printed one by accident, say so and offer
 Prefer `lanes link mcp add --profile <name> --target <name>` to writing the command yourself: it checks the
 endpoint is reachable, refuses to silently shadow an existing registration, and
 cannot mistype the token. For a harness it does not know, take the command from
-`lanes link outputs` rather than writing it blind — that command checks whether
+`lanes link outputs --profile <name> --target <name>` rather than writing it blind — that command checks whether
 `lanes` resolves on this machine and prints a longer working form if it does
 not, where guessing gives you an empty substitution, a `Bearer ` header, and a
 401 that reads as a bad token.
@@ -207,9 +320,20 @@ export LANES_LINK_TOKEN="$(lanes link token show --raw --profile <name> --target
 One registration covers every profile. Do not add one per profile; they share a
 URL and a token.
 
+`lanes link mcp list` needs neither flag and reports whether the registration and
+this document are current, out of date, or absent. That is the cheap first
+question when behaviour does not match what this file describes — an out-of-date
+copy means the rules you are reading are not the ones that shipped.
+
+Claude Desktop cannot be handed a URL, so it spawns the endpoint over stdio
+instead. That one is named in the client's own config file rather than registered
+by a command, as `lanes link mcp stdio --profile <name> --target <name>`; both
+flags are required, and nothing may be written to stdout.
+
 ## When it is not running
 
-`lanes link start` runs in the foreground and serves until stopped. Tell the
+`lanes link start --profile <name> --target <name>` runs in the foreground and
+serves until stopped. Tell the
 user the command rather than backgrounding it silently on their behalf.
 Registration works while it is down — the harness simply cannot reach it yet,
 and the first symptom is a failed call much later.

--- a/src/cli/instructions.test.ts
+++ b/src/cli/instructions.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, test } from 'bun:test';
+import type { Flags } from './argv.ts';
 import { ASSETS, readAsset } from './commands/mcp/assets.ts';
+import { assertKnownFlags, requirementFor, selectionKey } from './selection.ts';
 import { PROGRAM, USAGE } from './usage.ts';
 
 /**
@@ -39,6 +41,136 @@ const documented = new Set(
     }),
 );
 
+/**
+ * Every `lanes link …` invocation a document shows, as its own argv.
+ *
+ * Two passes, because the two places a command appears break differently.
+ * Inline code spans are matched whole rather than line by line: the prose wraps
+ * at the same width as everything else, so a command inside one pair of
+ * backticks may straddle two source lines — `identity add` does — and reading
+ * lines would drop the flags onto the floor and then report them missing. A
+ * fenced block has no backticks to bound a span, so those are read a line at a
+ * time, which is how they are written anyway.
+ *
+ * `PROGRAM` is searched for inside each candidate rather than anchored at its
+ * start, so the `$(lanes link token show …)` substitutions count too. Those are
+ * the invocations most worth checking, since they are meant to be pasted.
+ */
+function invocationsIn(text: string): Invocation[] {
+  const found: Invocation[] = [];
+  const lines = text.split('\n');
+
+  const offsets: number[] = [];
+  let at = 0;
+  for (const line of lines) {
+    offsets.push(at);
+    at += line.length + 1;
+  }
+  const lineOf = (index: number) => text.slice(0, index).split('\n').length;
+
+  const candidates: Array<{ text: string; index: number }> = [];
+
+  // Fenced blocks are blanked out before the span pass, keeping every offset
+  // where it was. A fence is three backticks, so a span regex left to itself
+  // pairs the third with the first of the closing fence and swallows the block
+  // whole — reporting each command in it against the fence's own line.
+  const masked: string[] = [];
+  let fenced = false;
+
+  for (const [number, line] of lines.entries()) {
+    if (line.trimStart().startsWith('```')) {
+      fenced = !fenced;
+      masked.push(' '.repeat(line.length));
+      continue;
+    }
+
+    masked.push(fenced ? ' '.repeat(line.length) : line);
+    if (fenced) candidates.push({ text: line, index: offsets[number]! });
+  }
+
+  for (const match of masked.join('\n').matchAll(/`([^`]+)`/g)) {
+    candidates.push({ text: match[1]!, index: match.index! });
+  }
+
+  for (const candidate of candidates) {
+    let from = candidate.text.indexOf(`${PROGRAM} `);
+    while (from !== -1) {
+      const argv = tokenise(candidate.text.slice(from + PROGRAM.length));
+      if (argv.length > 0) {
+        found.push({ argv, line: lineOf(candidate.index), shown: `${PROGRAM} ${argv.join(' ')}` });
+      }
+      from = candidate.text.indexOf(`${PROGRAM} `, from + 1);
+    }
+  }
+
+  return found;
+}
+
+interface Invocation {
+  readonly argv: readonly string[];
+  /** 1-indexed, so a failure names a line the reader can open. */
+  readonly line: number;
+  readonly shown: string;
+}
+
+/**
+ * One invocation's argv, stopping where the command does.
+ *
+ * A trailing comment is dropped, and so is the punctuation a command picks up
+ * from the sentence or the shell around it — `<name>)"` closing a substitution,
+ * or a full stop ending the line it sits on.
+ */
+function tokenise(tail: string): string[] {
+  const argv: string[] = [];
+
+  for (const raw of tail.replace(/\s+/g, ' ').trim().split(' ')) {
+    if (raw === '#' || raw.startsWith('#')) break;
+    const token = raw.replace(/^[`"'(]+/, '').replace(/[`"'),.;]+$/, '');
+    if (token === '' || token === '\\') continue;
+    argv.push(token);
+  }
+
+  return argv;
+}
+
+/** The flags an invocation shows, in the shape `assertKnownFlags` reads. */
+function flagsOf(argv: readonly string[]): Flags {
+  const flags: Flags = {};
+
+  for (const [index, token] of argv.entries()) {
+    if (!token.startsWith('--')) continue;
+    const next = argv[index + 1];
+    flags[token.slice(2)] = next && !next.startsWith('-') ? next : true;
+  }
+
+  return flags;
+}
+
+/**
+ * How many tokens of an invocation are the command path itself.
+ *
+ * A bare second word is part of the path even where `SELECTION` does not spell
+ * the pair out — `memory list` inherits from `memory`, and reading `list` as an
+ * argument turned a mention of the command into a whole invocation that was
+ * then reported for missing the flags a mention has no business carrying.
+ */
+function pathLength(argv: readonly string[]): number {
+  const second = argv[1];
+  return selectionKey(argv[0]!, second).includes(' ') || /^[a-z]+$/.test(second ?? '') ? 2 : 1;
+}
+
+/**
+ * Whether this occurrence is the labelled wrong half of a comparison.
+ *
+ * Same convention the token test below relies on, and for the same reason: a
+ * document that may only show correct commands cannot teach the difference
+ * between a right and a wrong one.
+ */
+function underWrongLabel(text: string, line: number): boolean {
+  const lines = text.split('\n');
+  return `${lines[line - 2] ?? ''}\n${lines[line - 1] ?? ''}`.includes('WRONG');
+}
+
 describe.each(ASSETS.map((asset) => [asset.label, asset] as const))('the bundled %s', (_label, asset) => {
   test('names only commands this CLI actually has', async () => {
     const named = commandsNamedIn(await readAsset(asset));
@@ -53,6 +185,53 @@ describe.each(ASSETS.map((asset) => [asset.label, asset] as const))('the bundled
 
   test('names at least one, or the check above passed on an empty list', async () => {
     expect(commandsNamedIn(await readAsset(asset)).length).toBeGreaterThan(0);
+  });
+
+  test('never shows a flag its command refuses', async () => {
+    // `assertKnownFlags` is the function the CLI refuses with, so this cannot
+    // disagree with the binary about what a command accepts. It is the half of
+    // ADR-037 the earlier check missed: naming a real command is not the same as
+    // naming it correctly, and `profile add --profile` is a real command with a
+    // flag that is rejected before dispatch.
+    const text = await readAsset(asset);
+    const refused: string[] = [];
+
+    for (const shown of invocationsIn(text)) {
+      try {
+        assertKnownFlags(shown.argv[0]!, shown.argv[1], flagsOf(shown.argv));
+      } catch (error) {
+        refused.push(`line ${shown.line}: ${shown.shown} — ${(error as Error).message.split('\n')[0]}`);
+      }
+    }
+
+    expect(refused).toEqual([]);
+  });
+
+  test('shows every flag its command requires, wherever it shows a whole command', async () => {
+    // Only where something follows the command path. A bare `lanes link deploy`
+    // in a sentence names the command; `lanes link deploy --dry-run` is meant to
+    // be run, and one missing `--target` makes it a line the owner pastes and
+    // watches refuse. ADR-043 is why this cannot simply demand both everywhere:
+    // `status`, `deploy` and `sync targets` take a target and no profile.
+    const text = await readAsset(asset);
+    const incomplete: string[] = [];
+
+    for (const shown of invocationsIn(text)) {
+      if (shown.argv.length <= pathLength(shown.argv)) continue;
+      if (underWrongLabel(text, shown.line)) continue;
+
+      const needs = requirementFor(shown.argv[0]!, shown.argv[1]);
+      const flags = flagsOf(shown.argv);
+      const missing = ['profile', 'target'].filter(
+        (flag) => needs.includes(flag) && !(flag in flags),
+      );
+
+      if (missing.length > 0) {
+        incomplete.push(`line ${shown.line}: ${shown.shown} — wants ${missing.map((f) => `--${f}`).join(' ')}`);
+      }
+    }
+
+    expect(incomplete).toEqual([]);
   });
 
   test('never tells an agent to print a token', async () => {
@@ -74,5 +253,31 @@ describe('the skill and the scout agree', () => {
     for (const asset of ASSETS) {
       expect(await readAsset(asset)).toContain('separate');
     }
+  });
+});
+
+describe('the skill covers the lifecycle, not only the calls', () => {
+  test('names the commands someone runs to own a workspace', async () => {
+    // The skill described using an endpoint and registering one, and nothing in
+    // between: no deploy, no status, no way to add a profile. An agent asked to
+    // deploy read the file, found nothing, and improvised from the CLI's help.
+    // Listing them here means the operator half cannot quietly fall out again.
+    const asset = ASSETS.find((candidate) => candidate.kind === 'skill')!;
+    const named = new Set(commandsNamedIn(await readAsset(asset)));
+
+    const wanted = [
+      'deploy',
+      'status',
+      'sync targets',
+      'profile add',
+      'profile remove',
+      'profile list',
+      'target list',
+      'doctor',
+      'mcp add',
+      'mcp list',
+    ];
+
+    expect(wanted.filter((command) => !named.has(command))).toEqual([]);
   });
 });


### PR DESCRIPTION
The bundled skill described calling the endpoint and registering it, and nothing in between — no `deploy`, no `status`, no `sync targets`, no way to add or remove a profile. Its frontmatter named none of that either, so "deploy my endpoint" did not load the file at all and the agent improvised from the CLI's help.

Two claims in it had gone stale as well, and one was instructing the agent to say something false.

## The wrong instruction

The file still carried ADR-019's *"a new connection is not served until the endpoint restarts"* — the sentence [ADR-029](docs/detailed/adr/029-connecting-is-not-deploying.md) withdraws by name. `connect` publishes config and asks the endpoint to re-read it, so `setup_overview` straight afterwards *does* show the account. What stays stale is the client's tool list, because a stateless endpoint does not announce that its tools changed ([ADR-032](docs/detailed/adr/032-a-stateless-endpoint-does-not-announce-its-tools.md)).

The two halves were the wrong way round, so the skill told the agent to report a working connection as missing. The one real restart is `token rotate`, since the authenticator is built once at boot.

## The wrong rule

*"Every command names its profile and its target"* was made wrong three commands at a time by [ADR-043](docs/detailed/adr/043-a-target-scoped-command-acts-on-the-target.md). `status`, `deploy` and `sync targets` name a target and derive the profiles behind it; `profile add` and `profile remove` **reject** `--profile`. Passing both to be safe is not a safe default — it is a second way to be refused. Four levels now, named.

## What is new

Three sections: operating a workspace, deploying, and reconciling one with an endpoint that has drifted from it. The rule through all of them — a command that writes runs `--dry-run` first where it has one, shows what it reported, and waits; a write with no dry run says in one sentence what it will change. Browser sign-ins stay the owner's, as before.

`deploy` gets the most of it: it creates resources that cost money, implements no `--json` to inspect instead, and settles two questions it refuses to guess — whose bearer token opens the endpoint, and a first deploy to a target nothing declares yet.

## Why the tests missed all of it

`instructions.test.ts` checked that a command named in these documents exists. That is weaker than it looks: naming a real command is not naming it correctly, and nothing noticed the absent half at all.

It now also:

- feeds every invocation the documents show through `assertKnownFlags` — the function the CLI refuses with, so a test and the binary cannot reach different conclusions about what a command accepts;
- requires the flags a command needs wherever a whole command is written out, leaving a bare mention in a sentence alone (ADR-043 is why it cannot simply demand both everywhere);
- names the lifecycle commands, so the operator half cannot quietly fall out again.

Both new checks are mutation-tested rather than assumed:

| Mutation | Result |
|---|---|
| `profile add --profile <name>` | `line 223: … Unknown flag "--profile"` |
| `mcp stdio` minus `--target` | `line 329: … wants --target` |
| the previous version of the skill | 7 of 10 lifecycle commands missing |

Commands are read as inline code spans rather than line by line: the prose wraps and `identity add` already straddles two lines, so reading lines drops the flags on the floor and then reports them missing. Fenced blocks are masked out first — ``` is three backticks, and a span regex left to itself pairs the third with the opening of the closing fence and swallows the block whole.

The scout took two lines of the same fix; its `policy deny` and `policy list` examples carried no flags at all.

## Verification

`bun test` 2133 pass / 0 fail, `bun run typecheck` clean.

End to end against a scratch workspace (`LANES_LINK_HOME`, so the real one is untouched): `profile add`, then `mcp add claude --scope project --dry-run`, which reports it would write both assets and prints the token as `<token>`. `mcp skill --print` serves the document with all three new sections.

## Not in this change

`assertKnownFlags` rejects flags the owner commands document and read — `--show`/`--raw` on `vault get`, `--raw` on `vault key generate`, `--description` on `vault set`, `--yes` on `memory forget` and `skills remove`. `selectionKey('vault', 'get')` falls back to the bare `vault` key, whose `ACCEPTS` entry is only `['connection']`, so the flag is refused before dispatch; `vault key` has no entry at all. Same class of defect `selection.ts` was written to fix, on the commands its table does not reach. Left out rather than widening this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)