### PR TITLE
Add Reddit

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,12 +110,15 @@ One command per account. Run it again to add a second mailbox, a second calendar
 | Linear | `lanes link connect linear` |
 | GitHub | `lanes link connect github` |
 | Slack | `lanes link connect slack` |
+| Reddit | `lanes link connect reddit` |
 | Gmail (IMAP, app password) | `lanes link connect gmail_imap` |
 | Gmail (Google MCP) | `lanes link connect gmail_mcp` |
 | Drive (Google MCP) | `lanes link connect drive_mcp` |
 
 Three things worth knowing up front. `lanes link connect icloud` sets up Mail, Calendar, and
-Contacts together, because one app-specific password covers all three. Google and Slack need no
+Contacts together, because one app-specific password covers all three. Reddit is the one that does
+need an app of your own — it rate-limits per client id, so a shared client would mean strangers
+spending your budget. Google and Slack need no
 OAuth client of your own: both authorise against the one Lanes operates, so there is no console to
 visit — for Google, add `--own-client` if you would rather register your own, or take a service
 account key or an app password over IMAP where you would rather nothing expired. And GitHub takes a

--- a/docs/connect.md
+++ b/docs/connect.md
@@ -29,6 +29,7 @@ $ lanes link connect gmail --profile personal --target local        # again, for
 | Linear | `lanes link connect linear` | Linear's own MCP server |
 | GitHub | `lanes link connect github` | Repositories, issues, pull requests, and workflow runs |
 | Slack | `lanes link connect slack` | Search, read, and send messages, threads, files, and canvases |
+| Reddit | `lanes link connect reddit` | Read subreddits and comments, search, and post, comment, and vote as you |
 | Gmail (IMAP) | `lanes link connect gmail_imap` | The same mailbox over IMAP and SMTP, with an app password that does not expire |
 | Gmail (Google MCP) | `lanes link connect gmail_mcp` | Google's own MCP server — Developer Preview only |
 | Drive (Google MCP) | `lanes link connect drive_mcp` | Likewise; use `drive` unless you are enrolled |

--- a/docs/detailed/adr/045-a-redirect-the-vendor-matches-exactly.md
+++ b/docs/detailed/adr/045-a-redirect-the-vendor-matches-exactly.md
@@ -1,0 +1,71 @@
+# ADR-045: A provider may name the loopback redirect the vendor matches exactly
+
+**Status:** accepted · **Relates to** [ADR-005](005-oauth-connection-flow.md) ·
+**Amends** [ADR-033](033-a-pasted-token-for-an-mcp-server.md) ·
+**Relates to** [ADR-040](040-an-mcp-connector-may-use-a-pre-registered-client.md)
+
+## Context
+
+`connect` runs the authorization code flow against a listener on `127.0.0.1`, bound to a port the
+kernel picks (ADR-005). Nothing outside the machine names that port, so letting the OS choose it
+avoids collisions for free.
+
+That works because most authorization servers treat a loopback redirect as a special case and
+match only the host and path, ignoring the port — which is what RFC 8252 §7.3 asks them to do.
+Not all of them do. Some match `redirect_uri` as a whole string against what was registered in a
+console, and for those the port chosen at runtime can never be the port registered months earlier.
+The grant fails after consent with `redirect_uri_mismatch`, which reads as a broken client rather
+than as a port that moved.
+
+This was already costing us something. ADR-033 records GitHub reaching for a pasted token rather
+than OAuth, and the reason given there is exactly this:
+
+> an OAuth App matches its callback URL exactly, including the port, and `connect` listens on a
+> port the kernel picks
+
+That was true, and it was treated as a property of the CLI rather than as a gap in it.
+
+ADR-040 solved an adjacent problem — Slack refuses a non-HTTPS redirect at all — by sending the
+browser to the broker's HTTPS origin and carrying the loopback port in `state`. That answer does
+not transfer. It requires a broker, and a broker is the wrong shape for a vendor that rate-limits
+per client id: one shared client would pool every install into one budget.
+
+## Decision
+
+An OAuth provider may declare `auth.redirect_uri`. When it does, `connect` listens on the port
+that URL names and hands the vendor that exact string.
+
+- **The whole URL, not a port.** The two must be identical strings and only one of them is ours to
+  choose. A console that accepts `localhost` but not `127.0.0.1`, or that wants a trailing path,
+  decides the spelling — a manifest that could only name a number would have to guess the rest.
+- **Mutually exclusive with `broker`.** Both answer "where does the browser come back to", and the
+  flow reads one of them. `defineProvider` refuses a manifest declaring both.
+- **A taken port is a refusal, not a crash.** With a kernel-chosen port `EADDRINUSE` cannot happen;
+  with a fixed one it is the ordinary failure. The message names the port and says why it cannot
+  simply be moved.
+
+The listener is otherwise unchanged: same PKCE, same constant-time `state` check, same single
+callback, same shutdown.
+
+## Alternatives considered
+
+**Register a range of ports and try each.** Some consoles accept several redirect URIs, so the CLI
+could register ten and use whichever is free. It multiplies what the operator types by ten, and
+the failure when all ten are busy is worse than the failure when one is.
+
+**Always use a fixed port.** Simpler, and wrong: a fixed port can collide, and every provider that
+does not need one would inherit that for nothing.
+
+**Route everything through the broker, as ADR-040 does for Slack.** It works, and it makes a
+shared client mandatory. For a vendor metering per client id that is a permanent cost paid to
+avoid a one-time console visit.
+
+## Consequences
+
+- A vendor that pins its redirect is now reachable by OAuth. Reddit is the first, and GitHub could
+  move off its pasted token on this basis — ADR-033's reasoning for that choice no longer holds,
+  though the token still works and nothing forces the change.
+- The operator types a URL into a console and it must match exactly. The provider's `setup.steps`
+  states it verbatim, and `setup.troubleshooting` names `redirect_uri_mismatch` as the symptom.
+- One more way for two manifest fields to disagree, which is why the mutual exclusion is checked
+  at `defineProvider` rather than left for the flow to resolve by precedence.

--- a/docs/detailed/adr/README.md
+++ b/docs/detailed/adr/README.md
@@ -52,6 +52,7 @@ Nothing in the codebase depends on it.
 | [042](042-a-profile-declares-who-its-owner-is.md) | A profile declares who its owner is, so an agent writing on their behalf stops guessing |
 | [043](043-a-target-scoped-command-acts-on-the-target.md) | A command whose subject is the endpoint acts on the target, and every profile declaring it |
 | [044](044-a-deployment-records-where-it-lives.md) | A deployment records where it lives outside any profile, and the two copies of a workspace can be merged |
+| [045](045-a-redirect-the-vendor-matches-exactly.md) | A provider may name the loopback redirect verbatim, for a vendor that matches `redirect_uri` exactly rather than ignoring the port |
 
 Where an ADR departs from init.md, it says so at the top. Three are significant:
 

--- a/docs/detailed/providers.md
+++ b/docs/detailed/providers.md
@@ -243,6 +243,60 @@ calendar but no calendar itself; `tasks` is the only scope Google publishes for 
 write at all. `contacts` asks for nothing broad — both of its scopes are read-only, and the write
 scope permanently deletes. None of the three grants `auth/calendar` or `contacts`.
 
+## `reddit`
+
+Fifteen operations against Reddit's REST API. Setup: [`setup/reddit.md`](setup/reddit.md) — the one
+provider that needs an OAuth client of your own, because Reddit rate-limits per client id and a
+shared one would pool every install into a single hundred-per-minute budget.
+
+The spec at `src/providers/reddit/specs/reddit.v1.json` is **hand-authored**: Reddit publishes no
+OpenAPI document, so unlike the Google specs there is no vendoring script and no upstream to
+re-sync from. It is still a document rather than code — the operations become capabilities
+mechanically, and there is no per-endpoint translation anywhere in the folder.
+
+| Capability | Kind | Bundle | Why |
+|---|---|---|---|
+| `reddit.list_posts` | tool | read | Posts from one subreddit, in a given order. The ordinary read. |
+| `reddit.get_post` | tool | read | One post with its comment tree. Takes the base36 id, not the fullname. |
+| `reddit.search` | tool | read | Full-text search within a subreddit. |
+| `reddit.get_subreddit` | tool | read | Description, subscriber count, and whether posting needs a flair. |
+| `reddit.get_rules` | tool | read | What a submission must satisfy. Most removals are rule violations, not API errors. |
+| `reddit.list_flairs` | tool | read | Flair templates and their ids — the thing `submit_post` usually needs first. |
+| `reddit.whoami` | tool | read | Which account this connection is. Also what `identity` resolves the label from. |
+| `reddit.list_my_subreddits` | tool | read | The subreddits this account subscribes to. |
+| `reddit.submit_post` | tool | write | Create a text or link post. |
+| `reddit.add_comment` | tool | write | Comment on a post, or reply to a comment. |
+| `reddit.edit_text` | tool | write | Replace the body of something this account wrote. |
+| `reddit.vote` | tool | write | Up, down, or clear. |
+| `reddit.delete_thing` | tool | write | Permanent — Reddit has no trash reachable from the API. |
+| `reddit.save_thing` | tool | write | Add to saved items. |
+| `reddit.set_flair` | tool | write | Apply a flair template to your own post. |
+
+**No moderation, no messages, no history.** Reddit publishes thirty scopes and this asks for eight.
+`privatemessages` would put the account's DMs in reach of a tool list whose subject is public
+posting; the `mod*` scopes act on other people's content in subreddits this account moderates,
+which is a different job with a different blast radius. Nothing here needs either, and a scope on
+the consent screen that no tool can spend is a grant asked for and never noticed.
+
+**Two things the tool descriptions say twice**, because an agent gets both wrong on the first
+attempt and the error does not explain either. `add_comment` takes a *fullname* — `t3_<id>` for a
+post, `t1_<id>` for a comment — and a bare id from a URL is rejected generically. And most
+subreddits reject a submission with no `flair_id` without saying that a flair was the problem,
+which is why `list_flairs` is vendored beside `submit_post`. Both are also in `hints`.
+
+**Scope:** `submit`, `edit`, and `vote` are marked broad, and for a different reason from every
+other broad scope here. The rest are broad for how far they reach into a private space; these are
+broad for acting *publicly* under the person's username. They are also the only writes in this
+repository that cannot be taken back — deleting a post leaves the deletion behind, and anything
+quoted or replied to in the meantime stays. `read` is not marked: it reaches only what the account
+can already see, and what Reddit makes readable is public to begin with.
+
+**Redaction** follows Gmail's line, with one addition worth naming: `title` is withheld along with
+the body. It looks like metadata and is not — a Reddit title is usually the whole of the post and
+the body is often empty, so keeping it would defeat withholding the body. For a link post the
+`url` is the submission, so that is withheld too. What survives is where it went and how it was
+marked: `sr`, `flair_id`, `nsfw`, `spoiler`.
+
 ## iCloud — `icloud_mail`, `icloud_calendar`, `icloud_contacts`
 
 One Apple Account, three providers, one app-specific password

--- a/docs/detailed/setup/reddit.md
+++ b/docs/detailed/setup/reddit.md
@@ -1,0 +1,89 @@
+# Reddit
+
+```console
+$ lanes link connect reddit --profile personal --target local
+```
+
+Reddit is the one provider here that needs an app of your own. It takes a couple of minutes, once.
+
+## Why there is no shared client for this one
+
+Google and Slack authorise against a client Lanes operates, so there is no console to visit.
+Reddit cannot work that way, and the reason is how it meters access: **Reddit's rate limit is a
+hundred queries a minute per OAuth client id** — not per user and not per token.
+
+A client everyone shared would pool every install of this program into one bucket. Your limit
+would be reached by strangers, and the failure would arrive as somebody else's traffic. An app of
+your own gets its own hundred, which is the whole budget for one person and nowhere near it for
+the next.
+
+## Registering the app
+
+1. Open <https://www.reddit.com/prefs/apps> and choose **create another app...**.
+2. Give it a name you will recognise later. The name is how you revoke this one without touching
+   your other apps.
+3. Choose **web app**. The other two do not fit: `script` only ever reaches your own account, and
+   `installed app` issues no secret for this to hold.
+4. Set the redirect uri to exactly:
+
+   ```
+   http://127.0.0.1:8765/callback
+   ```
+
+   Reddit matches this character for character. It is the address `connect` listens on, and a
+   different port or `localhost` in place of `127.0.0.1` will be refused after you approve the
+   consent screen rather than before.
+5. Create the app. The **client id** is the string just under the app name; the **secret** is the
+   field labelled `secret`.
+
+Then run the connect command above. You will be asked for both values once, they are stored in
+your credential store, and the browser opens.
+
+## Registering for API access
+
+Creating an app is not the same as being allowed to call the API. Reddit's
+[Responsible Builder Policy](https://support.reddithelp.com/hc/en-us/articles/42728983564564-Responsible-Builder-Policy)
+says access must be requested and approved, and the create-app page links to that separately.
+
+The quickest way to find out where you stand is to ask for an app-only token:
+
+```console
+$ curl -sS -X POST -u "<client_id>:<client_secret>" \
+    -A "lanes-link/0.3" \
+    -d "grant_type=client_credentials" \
+    -w "\nHTTP %{http_code}\n" \
+    https://www.reddit.com/api/v1/access_token
+```
+
+`200` means the gate is open. `403`, or an HTML page instead of JSON, means the app exists but
+access has not been granted yet.
+
+## What you get
+
+Reads are granted by default. Writing needs the write bundle, and the three scopes that post,
+edit, and vote are marked broad on the consent screen because they act publicly under your
+username — a post is visible to everyone who reads the subreddit, and deleting it later leaves the
+deletion behind.
+
+Two things are worth knowing before an agent posts anywhere:
+
+- **Most subreddits require a flair.** `reddit.list_flairs` returns the templates and their ids;
+  pass one as `flair_id`. A submission without one is rejected by the subreddit, not by the API.
+- **`reddit.get_rules` is cheap and worth reading first.** Most removals are rule violations rather
+  than API errors, and the API will not tell you that.
+
+## When it stops working
+
+| What you see | What it is |
+|---|---|
+| `invalid redirect_uri` in the browser | The app's redirect uri is not exactly `http://127.0.0.1:8765/callback` |
+| Connected, then every call fails an hour later | The grant was made without `duration=permanent`. Reconnect with `--replace` |
+| `403` or HTML from every call | The app exists but API access has not been approved |
+| `429` | The hundred-per-minute limit for this client id. It is per client, so nothing else is spending it |
+| `Port 8765 is already in use` | Something else holds the port. The redirect names it exactly, so it cannot be moved — free the port |
+
+If you regenerate the secret, run:
+
+```console
+$ lanes link connect reddit --profile personal --target local --replace
+```

--- a/src/architecture.test.ts
+++ b/src/architecture.test.ts
@@ -138,7 +138,7 @@ describe('dependency direction', () => {
  * worse. What must not appear is a vendor name the code *branches on* or
  * *prints*.
  */
-const VENDORS = /\b(gmail|icloud|notion|linear|apple|google|dropbox|fastmail)\b/i;
+const VENDORS = /\b(gmail|icloud|notion|linear|apple|google|dropbox|fastmail|reddit)\b/i;
 
 /**
  * Where the rule bites: the machinery a request passes through.

--- a/src/cli/commands/connect/authorise.ts
+++ b/src/cli/commands/connect/authorise.ts
@@ -283,6 +283,11 @@ async function authoriseDirect(input: {
       ...(client.kind === 'brokered' && client.config.redirectUri
         ? { relayRedirect: client.config.redirectUri }
         : {}),
+      // The other spelling of the same need, for a vendor that takes a loopback
+      // redirect but matches it exactly. The manifest owns this URL because the
+      // vendor's console does — it has to be the string registered there, and
+      // `defineProvider` refuses a manifest declaring both this and a broker.
+      ...(manifest.auth.redirect_uri ? { fixedRedirect: manifest.auth.redirect_uri } : {}),
       scopes,
       connectionLabel: manifest.name,
       ...(manifest.auth.authorize_params

--- a/src/cli/oauth.test.ts
+++ b/src/cli/oauth.test.ts
@@ -521,3 +521,87 @@ describe('the exchange is a seam', () => {
     expect(sent['code_verifier']).toMatch(/^[\w-]{43}$/);
   });
 });
+
+describe('a redirect the vendor matches exactly', () => {
+  /**
+   * The third answer to "where does the browser come back to". A kernel-chosen
+   * port cannot be registered in a console months in advance, and a vendor that
+   * matches `redirect_uri` byte for byte refuses the grant rather than the
+   * port — so the failure is `redirect_uri_mismatch` after consent, which reads
+   * as a broken client rather than as a port that moved.
+   */
+  function freePort(): number {
+    const probe = Bun.serve({ hostname: '127.0.0.1', port: 0, fetch: () => new Response('') });
+    const { port } = probe;
+    probe.stop(true);
+    if (!port) throw new Error('Bun.serve bound no port');
+    return port;
+  }
+
+  test('the declared URL is what the vendor is told, verbatim', async () => {
+    const port = freePort();
+    const fixedRedirect = `http://127.0.0.1:${port}/callback`;
+    const { fetch: tokenFetch } = mockTokenEndpoint(SUCCESS);
+    let announced: string | undefined;
+
+    await runOAuthFlow(
+      options({
+        fixedRedirect,
+        fetch: tokenFetch,
+        openBrowser: (url: string) => {
+          announced = new URL(url).searchParams.get('redirect_uri') ?? undefined;
+          browserThatApproves()(url);
+        },
+      }) as never,
+    );
+
+    expect(announced).toBe(fixedRedirect);
+  });
+
+  test('the listener binds the port the vendor was told about', async () => {
+    // The two must agree by construction. If the flow announced the fixed URL
+    // but still listened on a kernel-chosen port, the browser would come back
+    // to a closed socket and this would time out rather than resolve.
+    const port = freePort();
+    const { fetch: tokenFetch } = mockTokenEndpoint(SUCCESS);
+
+    const tokens = await runOAuthFlow(
+      options({
+        fixedRedirect: `http://127.0.0.1:${port}/callback`,
+        fetch: tokenFetch,
+        openBrowser: browserThatApproves(),
+      }) as never,
+    );
+
+    expect(tokens.accessToken).toBe('access-1');
+  });
+
+  test('a redirect naming no port is refused before the browser opens', async () => {
+    await expect(
+      runOAuthFlow(
+        options({
+          fixedRedirect: 'https://example.com/callback',
+          openBrowser: () => {},
+        }) as never,
+      ),
+    ).rejects.toThrow(/names no port/);
+  });
+
+  test('a port already in use says so, and says why it cannot be moved', async () => {
+    const port = freePort();
+    const holder = Bun.serve({ hostname: '127.0.0.1', port, fetch: () => new Response('') });
+
+    try {
+      await expect(
+        runOAuthFlow(
+          options({
+            fixedRedirect: `http://127.0.0.1:${port}/callback`,
+            openBrowser: () => {},
+          }) as never,
+        ),
+      ).rejects.toThrow(/already in use/);
+    } finally {
+      holder.stop(true);
+    }
+  });
+});

--- a/src/cli/oauth.ts
+++ b/src/cli/oauth.ts
@@ -66,6 +66,27 @@ export interface OAuthFlowOptions {
    * on the way back. What changes is only the address the vendor is told.
    */
   readonly relayRedirect?: string;
+  /**
+   * A redirect this machine listens on, named to the vendor exactly as written.
+   *
+   * The third answer to "where does the browser come back to", and the one the
+   * comment above did not anticipate. `relayRedirect` exists for a vendor that
+   * will take no loopback address at all; this is for a vendor that takes one
+   * happily but matches it *exactly*, port included — so the kernel-chosen port
+   * below can never match a URL registered in a console months earlier.
+   *
+   * That is not a rare shape. It is the reason `providers/github/index.ts`
+   * gives for using a pasted token rather than OAuth: "an OAuth App matches its
+   * callback URL exactly, including the port, and `connect` listens on a port
+   * the kernel picks."
+   *
+   * The whole URL rather than just a port, because the two must be identical
+   * strings and only one of them is ours to choose. A console that accepts
+   * `localhost` but not `127.0.0.1` — or insists on a trailing path — decides
+   * the spelling, and a manifest that could only name a number would have to
+   * guess the rest right.
+   */
+  readonly fixedRedirect?: string;
   /** What the completion page names as connected. A provider's display name. */
   readonly connectionLabel?: string;
   /** How long to wait for the operator to finish in the browser. */
@@ -130,48 +151,80 @@ export async function runOAuthFlow(options: OAuthFlowOptions): Promise<OAuthToke
     rejectCode = reject;
   });
 
-  const server = Bun.serve({
-    hostname: '127.0.0.1',
-    port: 0, // let the OS choose; nothing outside this machine names this port
-    fetch(request) {
-      const url = new URL(request.url);
-      if (url.pathname !== '/callback') return new Response('Not found', { status: 404 });
+  // A fixed redirect is only fixed if we listen where it says. Parsed rather
+  // than configured separately so the two cannot disagree: the port the vendor
+  // was told is by construction the port this binds.
+  const fixed = options.fixedRedirect ? new URL(options.fixedRedirect) : undefined;
+  const fixedPort = fixed ? Number(fixed.port) : undefined;
 
-      const error = url.searchParams.get('error');
-      if (error) {
-        rejectCode(
-          new OAuthError(
-            error === 'access_denied'
-              ? 'Authorization was declined in the browser.'
-              : `Authorization failed: ${error}`,
-          ),
+  if (fixed && !fixedPort) {
+    throw new OAuthError(
+      `The redirect "${options.fixedRedirect}" names no port, so there is nothing for this machine to listen on. Register a redirect with an explicit port, such as http://127.0.0.1:8765/callback.`,
+    );
+  }
+
+  // Bun.serve throws synchronously when a port is taken. With a kernel-chosen
+  // port that cannot happen; with a fixed one it is the ordinary failure — a
+  // previous run still holding the socket, or another program on the port the
+  // vendor was told about. The raw EADDRINUSE names neither the provider nor
+  // the redirect, so it reads as a crash rather than as something to fix.
+  const server = ((): ReturnType<typeof Bun.serve> => {
+    try {
+    return Bun.serve({
+      hostname: '127.0.0.1',
+      // Zero lets the OS choose, which is right whenever nothing outside this
+      // machine names the port. A fixed redirect is exactly the case where
+      // something does.
+      port: fixedPort ?? 0,
+      fetch(request) {
+        const url = new URL(request.url);
+        if (url.pathname !== '/callback') return new Response('Not found', { status: 404 });
+
+        const error = url.searchParams.get('error');
+        if (error) {
+          rejectCode(
+            new OAuthError(
+              error === 'access_denied'
+                ? 'Authorization was declined in the browser.'
+                : `Authorization failed: ${error}`,
+            ),
+          );
+          return failedPage('You can close this tab.');
+        }
+
+        const returnedState = url.searchParams.get('state');
+        if (!returnedState || !stateMatches(state, returnedState)) {
+          // A mismatched state means this callback did not come from the
+          // request we started. Refuse it rather than redeeming whatever code
+          // it carries.
+          rejectCode(new OAuthError('State mismatch — ignoring an unexpected callback.'));
+          return failedPage('Unexpected callback.');
+        }
+
+        const code = url.searchParams.get('code');
+        if (!code) {
+          rejectCode(new OAuthError('The callback carried no authorization code.'));
+          return failedPage('No code returned.');
+        }
+
+        resolveCode(code);
+        return connectedPage(options.connectionLabel);
+      },
+    });
+    } catch (cause) {
+      if (fixedPort) {
+        throw new OAuthError(
+          `Port ${fixedPort} is already in use, so the callback for this connection cannot be served. The redirect registered with the provider names that port exactly, so it cannot simply be moved — free the port and try again.`,
         );
-        return failedPage('You can close this tab.');
       }
-
-      const returnedState = url.searchParams.get('state');
-      if (!returnedState || !stateMatches(state, returnedState)) {
-        // A mismatched state means this callback did not come from the
-        // request we started. Refuse it rather than redeeming whatever code
-        // it carries.
-        rejectCode(new OAuthError('State mismatch — ignoring an unexpected callback.'));
-        return failedPage('Unexpected callback.');
-      }
-
-      const code = url.searchParams.get('code');
-      if (!code) {
-        rejectCode(new OAuthError('The callback carried no authorization code.'));
-        return failedPage('No code returned.');
-      }
-
-      resolveCode(code);
-      return connectedPage(options.connectionLabel);
-    },
-  });
+      throw cause;
+    }
+  })();
 
   // Where the vendor is told to send the browser. The relay bounces it back
   // here; without one it comes here directly, which is every other provider.
-  const redirectUri = options.relayRedirect ?? `http://127.0.0.1:${server.port}/callback`;
+  const redirectUri =
+    options.relayRedirect ?? options.fixedRedirect ?? `http://127.0.0.1:${server.port}/callback`;
 
   /**
    * The CSRF binding, and — behind a relay — the only way home.

--- a/src/cli/scopes.test.ts
+++ b/src/cli/scopes.test.ts
@@ -182,7 +182,7 @@ describe('the Google manifests stay at the documented minimum', () => {
     );
   });
 
-  test('the broad scopes are exactly the thirteen that were argued for', () => {
+  test('the broad scopes are exactly the sixteen that were argued for', () => {
     const broad = PROVIDERS.flatMap((manifest) => {
       const scopes = manifest.auth.kind === 'oauth' ? manifest.auth.scopes : [];
       return describeScopes(scopes)
@@ -227,6 +227,21 @@ describe('the Google manifests stay at the documented minimum', () => {
         'slack im:history',
         'slack mpim:history',
         'slack chat:write',
+        // Reddit's three, and all three for one reason: they act publicly under
+        // the person's username. Everything above is broad for how much it
+        // reaches inside a private space; these are broad for being visible
+        // outside one, which is the other way a grant can be more than it
+        // sounds.
+        //
+        // They are also the only writes here that cannot be taken back.
+        // Deleting a post leaves the deletion behind, and anything quoted,
+        // cached, or replied to in the meantime stays — so "post as you" is
+        // nearer to publishing than to writing. `read` is deliberately not on
+        // this list: it reaches only what the account can already see, and what
+        // Reddit makes readable is public to begin with.
+        'reddit submit',
+        'reddit edit',
+        'reddit vote',
       ].sort(),
     );
   });

--- a/src/connectivity/manifest/auth.ts
+++ b/src/connectivity/manifest/auth.ts
@@ -165,6 +165,25 @@ export const authOAuthSchema = z.object({
   authorize_url: z.url().optional(),
   token_url: z.url().optional(),
   /**
+   * A loopback redirect to name to the vendor verbatim, for one that matches it
+   * exactly rather than by prefix.
+   *
+   * `connect` normally listens on a port the kernel picks, which works because
+   * most authorization servers accept any loopback port. One that pins the
+   * whole URL cannot: the port it was told in a console months ago is not the
+   * port this run happens to get, and the grant is refused with
+   * `redirect_uri_mismatch`.
+   *
+   * The full URL rather than a port, because the vendor's console decides the
+   * spelling — `localhost` and `127.0.0.1` are different strings to a matcher
+   * even when they are the same host — and the two must be identical.
+   *
+   * Mutually exclusive with `broker`, which answers the same question the other
+   * way: there the redirect is the broker's HTTPS origin and the loopback port
+   * travels in `state`.
+   */
+  redirect_uri: z.url().optional(),
+  /**
    * Extra parameters on the authorization request.
    *
    * Google needs `access_type=offline` and `prompt=consent`, without which it

--- a/src/connectivity/manifest/connector.ts
+++ b/src/connectivity/manifest/connector.ts
@@ -56,6 +56,27 @@ export const httpConnectorSchema = z.object({
       exclude: z.array(z.string()).default([]),
     })
     .optional(),
+  /**
+   * Sent on every request this connector makes.
+   *
+   * The same field as `mcp`'s above and refused the same way for
+   * `Authorization` — but for the opposite reason. An mcp server chooses its
+   * own tool list and a header is the only way to ask it for less; a REST API
+   * asks for nothing, and this is for what the *vendor* requires of a client
+   * rather than what a caller wants from it.
+   *
+   * The case in hand is a `User-Agent`. Nothing else here sets one, so every
+   * install of this program looks identical to a host that rate-limits by
+   * client — and a service that asks callers to identify themselves throttles
+   * the default agent hardest, which reads as an outage rather than a refusal.
+   *
+   * Precedence is narrowest-wins: `accept` is a default this may override, a
+   * header parameter the operation itself declares overrides this, and
+   * `content-type` is derived from the document and overrides everything —
+   * a blanket header cannot silently change how one operation's body is
+   * encoded.
+   */
+  headers: z.record(z.string(), z.string()).optional(),
 });
 
 /**

--- a/src/connectivity/manifest/manifest.test.ts
+++ b/src/connectivity/manifest/manifest.test.ts
@@ -287,3 +287,88 @@ describe('an assertion alternative', () => {
     ).toThrow(/no way to learn what key to ask for/);
   });
 });
+
+describe('the two answers to "where does the browser come back to"', () => {
+  const httpProvider = (auth: Record<string, unknown>, extra: Record<string, unknown> = {}) =>
+    defineProvider({
+      id: 'vendor_api',
+      name: 'Vendor',
+      connector: { kind: 'http', base_url: 'https://api.example.com', openapi: 'specs/vendor.json' },
+      auth,
+      ...extra,
+    });
+
+  const oauth = (extra: Record<string, unknown>) => ({
+    kind: 'oauth',
+    registration: 'manual',
+    app: 'vendor',
+    authorize_url: 'https://accounts.example.com/authorize',
+    token_url: 'https://accounts.example.com/token',
+    ...extra,
+  });
+
+  test('a fixed loopback redirect is accepted on its own', () => {
+    expect(() =>
+      httpProvider(
+        oauth({ redirect_uri: 'http://127.0.0.1:8765/callback' }),
+        {
+          setup: {
+            summary: 'Register a client.',
+            prompts: [{ key: 'client_id', label: 'Client id', scope: 'shared', credential_ref: 'vendor/client_id' }],
+          },
+        },
+      ),
+    ).not.toThrow();
+  });
+
+  test('declaring a broker as well is refused', () => {
+    // Both are answers to the same question and the flow reads one of them. A
+    // brokered redirect is the broker's own origin, with the loopback port
+    // carried in `state`; a fixed redirect is this machine, named exactly.
+    expect(() =>
+      httpProvider(
+        oauth({
+          redirect_uri: 'http://127.0.0.1:8765/callback',
+          broker: { url: 'https://broker.example.com/v1/auth', operator: 'Someone' },
+        }),
+      ),
+    ).toThrow(/"broker" or "redirect_uri", not both/);
+  });
+});
+
+describe('connector headers may not carry the credential', () => {
+  // The rule was written when `mcp` was the only connector with headers, but
+  // the reasoning never had anything to do with which transport carried them:
+  // a manifest setting both leaves which one is sent up to merge order.
+  test('an http connector naming Authorization is refused', () => {
+    expect(() =>
+      defineProvider({
+        id: 'vendor_api',
+        name: 'Vendor',
+        connector: {
+          kind: 'http',
+          base_url: 'https://api.example.com',
+          openapi: 'specs/vendor.json',
+          headers: { Authorization: 'Bearer nope' },
+        },
+        auth: { kind: 'bearer' },
+      }),
+    ).toThrow(/may not set "Authorization"/);
+  });
+
+  test('any other header is fine', () => {
+    expect(() =>
+      defineProvider({
+        id: 'vendor_api',
+        name: 'Vendor',
+        connector: {
+          kind: 'http',
+          base_url: 'https://api.example.com',
+          openapi: 'specs/vendor.json',
+          headers: { 'User-Agent': 'vendor:1.0 (by someone)' },
+        },
+        auth: { kind: 'bearer' },
+      }),
+    ).not.toThrow();
+  });
+});

--- a/src/connectivity/manifest/provider.ts
+++ b/src/connectivity/manifest/provider.ts
@@ -225,6 +225,36 @@ export function defineProvider(input: unknown): ProviderManifest {
     );
   }
 
+  // Two answers to "where does the browser come back to", and a manifest
+  // naming both leaves it to whichever the flow reads first. A broker's
+  // redirect is its own HTTPS origin, with the loopback port carried in
+  // `state`; a fixed redirect is this machine, named exactly. Neither is wrong,
+  // but they cannot both be in force.
+  if (manifest.auth.kind === 'oauth' && manifest.auth.broker && manifest.auth.redirect_uri) {
+    throw new Error(
+      `Provider "${manifest.id}": auth may declare "broker" or "redirect_uri", not both — a brokered flow redirects to the broker and carries the loopback port in state, so a fixed redirect would never be used.`,
+    );
+  }
+
+  // Connector headers are for what the *server* offers as configuration; the
+  // credential is the auth block's, and a manifest setting both would have one
+  // quietly overwrite the other depending on which the transport merged last.
+  //
+  // Checked for every connector that has the field rather than for `mcp` alone.
+  // It was written when `mcp` was the only one, and the reasoning never had
+  // anything to do with which transport carried the header — an `http`
+  // connector naming `Authorization` collides with `auth` in exactly the same
+  // way, and would have validated cleanly.
+  const connectorHeaders =
+    'headers' in manifest.connector ? (manifest.connector.headers ?? {}) : {};
+  for (const name of Object.keys(connectorHeaders)) {
+    if (name.toLowerCase() === 'authorization') {
+      throw new Error(
+        `Provider "${manifest.id}": connector.headers may not set "${name}" — the credential comes from auth, and setting both would leave which one is sent up to merge order.`,
+      );
+    }
+  }
+
   if (manifest.connector.kind === 'mcp') {
     const auth = manifest.auth;
 
@@ -249,18 +279,6 @@ export function defineProvider(input: unknown): ProviderManifest {
       throw new Error(
         `Provider "${manifest.id}": an mcp connector always sends its token as "Authorization: Bearer", so auth.header ("${auth.header}") cannot be honoured. Remove it, or reach this service with an http connector.`,
       );
-    }
-
-    // The third spelling of the same collision. Connector headers are for what
-    // the *server* offers as configuration; the credential is the auth block's,
-    // and a manifest setting both would have one quietly overwrite the other
-    // depending on which the transport merged last.
-    for (const name of Object.keys(manifest.connector.headers ?? {})) {
-      if (name.toLowerCase() === 'authorization') {
-        throw new Error(
-          `Provider "${manifest.id}": connector.headers may not set "${name}" — the credential comes from auth, and setting both would leave which one is sent up to merge order.`,
-        );
-      }
     }
   }
 

--- a/src/connectivity/transports/factory.ts
+++ b/src/connectivity/transports/factory.ts
@@ -180,6 +180,7 @@ function build(
         ...(manifest.connector.operations?.exclude?.length
           ? { exclude: manifest.connector.operations.exclude }
           : {}),
+        ...(manifest.connector.headers ? { headers: manifest.connector.headers } : {}),
       });
   }
 }

--- a/src/connectivity/transports/http/http.test.ts
+++ b/src/connectivity/transports/http/http.test.ts
@@ -419,3 +419,158 @@ describe('array query parameters are repeated, not joined', () => {
     expect(url.search).not.toContain('open%2Cclosed');
   });
 });
+
+describe('a body is encoded the way the document declares', () => {
+  // A form-encoded write is not a legacy curiosity — it is what a large share
+  // of APIs that predate JSON request bodies still require. Sending JSON to one
+  // fails outright, and the error names the missing parameters rather than the
+  // encoding, so it reads as a bad request rather than a wrong content type.
+  const FORMS = {
+    openapi: '3.0.3',
+    info: { title: 'Acme', version: '1.0.0' },
+    servers: [{ url: 'https://api.acme.test/v1' }],
+    paths: {
+      '/submit': {
+        post: {
+          operationId: 'submitForm',
+          requestBody: {
+            required: true,
+            content: {
+              'application/x-www-form-urlencoded': {
+                schema: {
+                  type: 'object',
+                  properties: {
+                    title: { type: 'string' },
+                    tags: { type: 'array', items: { type: 'string' } },
+                  },
+                  required: ['title'],
+                },
+              },
+            },
+          },
+          responses: { '200': { description: 'ok' } },
+        },
+      },
+    },
+  };
+
+  async function formConnector(record: { request?: Request }) {
+    const root = await mkdtemp(join(tmpdir(), 'lanes-link-openapi-'));
+    roots.push(root);
+    const path = join(root, 'forms.json');
+    await writeFile(path, JSON.stringify(FORMS));
+    return createHttpConnector({
+      baseUrl: 'https://api.acme.test/v1',
+      openapi: path,
+      fetch: (async (request: Request) => {
+        record.request = request;
+        return new Response('{}', { status: 200 });
+      }) as unknown as typeof fetch,
+    });
+  }
+
+  test('a form-encoded operation is sent as a form, not as JSON', async () => {
+    const record: { request?: Request } = {};
+    const connector = await formConnector(record);
+    const [capability] = await connector.discover(CONTEXT);
+
+    await connector.invoke(capability!, { title: 'hello' }, contextWith(record));
+
+    expect(record.request!.headers.get('content-type')).toBe('application/x-www-form-urlencoded');
+    expect(await record.request!.text()).toBe('title=hello');
+  });
+
+  test('an array repeats, for the reason a query parameter does', async () => {
+    const record: { request?: Request } = {};
+    const connector = await formConnector(record);
+    const [capability] = await connector.discover(CONTEXT);
+
+    await connector.invoke(capability!, { title: 'hi', tags: ['a', 'b'] }, contextWith(record));
+
+    const sent = new URLSearchParams(await record.request!.text());
+    expect(sent.getAll('tags')).toEqual(['a', 'b']);
+  });
+
+  test('an operation declaring JSON is unchanged', async () => {
+    const record: { request?: Request } = {};
+    const connector = createHttpConnector({
+      baseUrl: 'https://api.acme.test/v1',
+      openapi: await specFile(),
+      fetch: (async (request: Request) => {
+        record.request = request;
+        return new Response('{}', { status: 200 });
+      }) as unknown as typeof fetch,
+    });
+
+    const capabilities = await connector.discover(CONTEXT);
+    const createPayment = capabilities.find((c) => c.name === 'createPayment')!;
+
+    await connector.invoke(createPayment, { amount: 5, to: 'someone' }, contextWith(record));
+
+    expect(record.request!.headers.get('content-type')).toBe('application/json');
+    expect(await record.request!.json()).toEqual({ amount: 5, to: 'someone' });
+  });
+});
+
+describe('headers declared on the connector', () => {
+  // Nothing else in this program sets a `User-Agent`, so every install looks
+  // identical to a host that rate-limits by client. A service that asks callers
+  // to identify themselves throttles the default agent hardest, which reads as
+  // an outage rather than as a refusal.
+  async function connectorWithHeaders(
+    record: { request?: Request },
+    headers: Record<string, string>,
+  ) {
+    return createHttpConnector({
+      baseUrl: 'https://api.acme.test/v1',
+      openapi: await specFile(),
+      headers,
+      fetch: (async (request: Request) => {
+        record.request = request;
+        return new Response('{}', { status: 200 });
+      }) as unknown as typeof fetch,
+    });
+  }
+
+  test('a declared header is sent on every request', async () => {
+    const record: { request?: Request } = {};
+    const connector = await connectorWithHeaders(record, { 'User-Agent': 'acme:1.0 (by someone)' });
+    const capabilities = await connector.discover(CONTEXT);
+    const listAccounts = capabilities.find((c) => c.name === 'listAccounts')!;
+
+    await connector.invoke(listAccounts, {}, contextWith(record));
+
+    expect(record.request!.headers.get('user-agent')).toBe('acme:1.0 (by someone)');
+  });
+
+  test('it may override `accept`, which is only a default', async () => {
+    const record: { request?: Request } = {};
+    const connector = await connectorWithHeaders(record, { accept: 'text/plain' });
+    const capabilities = await connector.discover(CONTEXT);
+
+    await connector.invoke(
+      capabilities.find((c) => c.name === 'listAccounts')!,
+      {},
+      contextWith(record),
+    );
+
+    expect(record.request!.headers.get('accept')).toBe('text/plain');
+  });
+
+  test('it may not override a content type the document derived', async () => {
+    // Which encoding an operation uses is the document's to state. A blanket
+    // header that silently changed it would be a bug nobody could see from the
+    // manifest — the request would go out well-formed and mean something else.
+    const record: { request?: Request } = {};
+    const connector = await connectorWithHeaders(record, { 'content-type': 'text/plain' });
+    const capabilities = await connector.discover(CONTEXT);
+
+    await connector.invoke(
+      capabilities.find((c) => c.name === 'createPayment')!,
+      { amount: 1, to: 'someone' },
+      contextWith(record),
+    );
+
+    expect(record.request!.headers.get('content-type')).toBe('application/json');
+  });
+});

--- a/src/connectivity/transports/http/index.ts
+++ b/src/connectivity/transports/http/index.ts
@@ -26,7 +26,68 @@ export interface HttpConnectorOptions {
   readonly openapi: string;
   readonly include?: readonly string[];
   readonly exclude?: readonly string[];
+  /** Sent on every request. Never `Authorization` — the manifest refuses it. */
+  readonly headers?: Readonly<Record<string, string>>;
   readonly fetch?: typeof globalThis.fetch;
+}
+
+/**
+ * The one body encoding that is not JSON often enough to be worth knowing about.
+ *
+ * A form-encoded write is not a legacy curiosity: it is what a large share of
+ * APIs that predate JSON request bodies still require, and one of them refusing
+ * `application/json` is not a negotiation — the request fails outright, with an
+ * error about the parameters rather than about the encoding.
+ */
+const FORM_ENCODED = 'application/x-www-form-urlencoded';
+
+/**
+ * What the *document* says the body is, rather than what we would prefer.
+ *
+ * `mcp-from-openapi` records the declared media type on each body entry of the
+ * mapper, so this needs nothing threaded through `target` — the mapper is
+ * already cached there, which is what lets a cold instance encode correctly
+ * without re-reading the spec.
+ *
+ * JSON is the default because an operation with no declared request body has no
+ * media type to read, and because it is what this connector always sent.
+ */
+function bodyContentType(mapper: readonly ParameterMapper[]): string {
+  for (const entry of mapper) {
+    if (entry.type !== 'body') continue;
+    const declared = entry.serialization?.contentType;
+    if (declared) return declared;
+  }
+
+  return 'application/json';
+}
+
+/**
+ * Arrays repeat rather than join, for the reason the query string does above.
+ *
+ * A nested object is JSON inside the field, which is the only thing a
+ * form-encoded body can do with one — there is no standard spelling of nesting
+ * here, and every API that accepts one accepts it as a string.
+ */
+function encodeBody(body: Readonly<Record<string, unknown>>, contentType: string): string {
+  if (!contentType.startsWith(FORM_ENCODED)) return JSON.stringify(body);
+
+  const form = new URLSearchParams();
+
+  for (const [key, value] of Object.entries(body)) {
+    if (value === undefined || value === null) continue;
+
+    if (Array.isArray(value)) {
+      for (const element of value) {
+        if (element !== undefined && element !== null) form.append(key, String(element));
+      }
+      continue;
+    }
+
+    form.set(key, typeof value === 'object' ? JSON.stringify(value) : String(value));
+  }
+
+  return form.toString();
 }
 
 /**
@@ -148,6 +209,12 @@ export function createHttpConnector(options: HttpConnectorOptions): Connector {
 
       const url = new URL(options.baseUrl.replace(/\/$/, '') + buildPath(template, args, mapper));
       const headers = new Headers({ accept: 'application/json' });
+
+      // After `accept`, which is a default worth overriding, and before the
+      // operation's own header parameters, which are narrower than a header
+      // declared once for the whole connector.
+      for (const [key, value] of Object.entries(options.headers ?? {})) headers.set(key, value);
+
       const body = collect(args, mapper, 'body');
 
       for (const [key, value] of Object.entries(collect(args, mapper, 'query'))) {
@@ -174,7 +241,11 @@ export function createHttpConnector(options: HttpConnectorOptions): Connector {
       }
 
       const hasBody = Object.keys(body).length > 0;
-      if (hasBody) headers.set('content-type', 'application/json');
+      const contentType = bodyContentType(mapper);
+      // Last, so it beats a connector-wide header. Which encoding an operation
+      // uses is the document's to state, and a blanket `content-type` that
+      // silently changed it would be a bug nobody could see from the manifest.
+      if (hasBody) headers.set('content-type', contentType);
 
       // Auth is attached by core, from the manifest's auth kind or its strategy.
       // A connector never sees a raw credential.
@@ -182,7 +253,7 @@ export function createHttpConnector(options: HttpConnectorOptions): Connector {
         new Request(url.href, {
           method,
           headers,
-          ...(hasBody ? { body: JSON.stringify(body) } : {}),
+          ...(hasBody ? { body: encodeBody(body, contentType) } : {}),
           signal: context.provider.signal,
         }),
       );

--- a/src/providers/index.ts
+++ b/src/providers/index.ts
@@ -16,6 +16,7 @@ import { icloudDrive } from './icloud/drive/index.ts';
 import { icloudMail } from './icloud/mail/index.ts';
 import { linear } from './linear/index.ts';
 import { notion } from './notion/index.ts';
+import { reddit } from './reddit/index.ts';
 import { slack } from './slack/index.ts';
 
 /**
@@ -53,6 +54,7 @@ export const PROVIDERS: readonly (ProviderManifest | ProviderDefinition)[] = [
   linear,
   github,
   slack,
+  reddit,
   gmail,
   drive,
   sheets,
@@ -98,5 +100,6 @@ export { icloudCalendar, icloudContacts, icloudDrive, icloudMail } from './iclou
 export { github } from './github/index.ts';
 export { linear } from './linear/index.ts';
 export { notion } from './notion/index.ts';
+export { reddit } from './reddit/index.ts';
 export { slack } from './slack/index.ts';
 export { SCOPE_MEANINGS, type ScopeMeaning } from './scopes.ts';

--- a/src/providers/reddit/index.ts
+++ b/src/providers/reddit/index.ts
@@ -1,0 +1,113 @@
+import { defineProvider } from '#connectivity';
+import {
+  REDDIT_APP,
+  REDDIT_REDIRECT_URI,
+  REDDIT_SCOPES,
+  REDDIT_USER_AGENT,
+  specPath,
+} from './oauth.ts';
+import { REDDIT_REDACT } from './redact.ts';
+
+/**
+ * Reddit, through its own REST API.
+ *
+ * No MCP server exists to proxy and no OpenAPI document is published, so the
+ * spec beside this file is hand-authored — fifteen operations chosen rather
+ * than a whole API filtered down. That is a real cost and it buys the thing
+ * ADR-008 is about: the operations still become capabilities mechanically, and
+ * there is no per-endpoint translation code anywhere in this folder.
+ *
+ * Reddit was the first provider to need three things the transports did not
+ * have — a form-encoded request body, a `User-Agent`, and an OAuth redirect on
+ * a port fixed in advance. All three are now general, because each was a gap
+ * rather than a Reddit quirk: the last one is the exact reason `../github`
+ * gives for using a pasted token instead of OAuth.
+ */
+export const reddit = defineProvider({
+  id: 'reddit',
+  name: 'Reddit',
+  description:
+    'Read subreddits, posts, comments, and search, and post, comment, vote, and edit as your account, via the Reddit API.',
+  connector: {
+    kind: 'http',
+    // Host only. Reddit puts no version in the path, and this must equal the
+    // spec's `servers[0].url` — `cli/tools.test.ts` checks that they agree.
+    base_url: 'https://oauth.reddit.com',
+    openapi: specPath('reddit.v1.json'),
+    headers: { 'User-Agent': REDDIT_USER_AGENT },
+  },
+  auth: {
+    kind: 'oauth',
+    registration: 'manual',
+    app: REDDIT_APP,
+    /**
+     * `www.reddit.com` for the grant, `oauth.reddit.com` for the API. Mixing
+     * the two 404s, and the 404 says nothing about which half was wrong.
+     */
+    authorize_url: 'https://www.reddit.com/api/v1/authorize',
+    token_url: 'https://www.reddit.com/api/v1/access_token',
+    redirect_uri: REDDIT_REDIRECT_URI,
+    scopes: [...REDDIT_SCOPES],
+    /**
+     * Without `duration=permanent` Reddit returns an access token and no
+     * refresh token. The connection then works for exactly one hour and stops,
+     * which is a miserable thing to debug an hour after a successful connect —
+     * the same failure `authorize_params` was added for, where Google needs
+     * `access_type=offline`.
+     */
+    authorize_params: { duration: 'permanent' },
+    revoke_url: 'https://www.reddit.com/api/v1/revoke_token',
+  },
+  identity: { kind: 'http', url: 'https://oauth.reddit.com/api/v1/me', field: 'name' },
+  redact: REDDIT_REDACT,
+  /**
+   * Said once here rather than left for the tool descriptions to imply.
+   *
+   * Both are things an agent gets wrong on the first attempt and cannot learn
+   * from the error: Reddit answers a bare id with a generic failure, and a
+   * subreddit that requires a flair rejects the submission without saying that
+   * a flair was what was missing.
+   */
+  hints: {
+    add_comment:
+      'thing_id must be a fullname — t3_<id> for a post, t1_<id> for a comment — not the bare id that appears in a URL.',
+    submit_post:
+      'Many subreddits reject a submission with no flair. Call list_flairs first and pass flair_id, and read get_rules when posting somewhere unfamiliar.',
+  },
+  setup: {
+    summary:
+      'Reddit needs an app of your own, which takes a couple of minutes in a browser. There is no shared ' +
+      'client for this one on purpose: Reddit rate-limits per client id, so a client everyone shared would ' +
+      'mean strangers using up your hundred requests a minute. Your own app gets its own budget.',
+    docs: 'docs/detailed/setup/reddit.md',
+    docs_url: 'https://www.reddit.com/prefs/apps',
+    steps: [
+      'Open https://www.reddit.com/prefs/apps and choose "create another app...".',
+      'Name it something you will recognise later — the name is how you revoke this one without touching your others.',
+      'Choose "web app". "script" only ever reaches your own account, and "installed app" has no secret for this to hold.',
+      `Set the redirect uri to exactly ${REDDIT_REDIRECT_URI} — Reddit matches it character for character, and this is the address this command listens on.`,
+      'Create the app. The client id is the string under the app name; the secret is the field labelled "secret".',
+      'Reddit also asks you to register for API access separately, from the link on that page. Creating the app is not the same as being allowed to call the API.',
+      'If you regenerate the secret later, run: lanes link connect reddit --replace.',
+    ],
+    troubleshooting:
+      'Reddit refused the connection. If the browser said "invalid redirect_uri", the value registered on the app ' +
+      `is not exactly ${REDDIT_REDIRECT_URI}. If the call failed after connecting, the app exists but API access ` +
+      'has not been granted — that is a separate registration, linked from https://www.reddit.com/prefs/apps. ' +
+      'A 429 means the hundred-per-minute limit for this client id was reached.',
+    prompts: [
+      {
+        key: 'client_id',
+        label: 'Reddit client ID',
+        secret: false,
+        credential_ref: `${REDDIT_APP}/client_id`,
+      },
+      {
+        key: 'client_secret',
+        label: 'Reddit client secret',
+        secret: true,
+        credential_ref: `${REDDIT_APP}/client_secret`,
+      },
+    ],
+  },
+});

--- a/src/providers/reddit/oauth.ts
+++ b/src/providers/reddit/oauth.ts
@@ -1,0 +1,77 @@
+/**
+ * The Reddit client, and why it is the operator's rather than ours.
+ *
+ * Every other pre-registered provider here reaches for the broker ADR-028
+ * built: one client Lanes operates, so nobody visits a console. That is the
+ * right default and it is the wrong answer for Reddit, for a reason particular
+ * to how Reddit meters access.
+ *
+ * Reddit's rate limit is a hundred queries a minute *per OAuth client id* —
+ * not per user, not per token. A shared client would pool every install of this
+ * program into one bucket, so the limit would be reached by strangers and the
+ * failure would arrive as somebody else's traffic. An operator registering
+ * their own gets their own hundred, which is the whole budget for one person
+ * and nowhere near it for the next.
+ *
+ * The cost is a console visit, which is what the broker exists to avoid. It is
+ * worth paying once here because the alternative degrades with every new user,
+ * and a shared limit is not a thing a later change could unpick.
+ */
+export const REDDIT_APP = 'reddit';
+
+/**
+ * How this program names itself to Reddit.
+ *
+ * Reddit asks callers to identify themselves and throttles the default agent
+ * hardest — a client that does not set one is treated as a scraper, which
+ * surfaces as sporadic 429s rather than as a refusal anybody can read. Nothing
+ * else in this repository sets a `User-Agent`, so `connector.headers` is what
+ * carries it.
+ *
+ * Reddit's documented format ends with the author's handle. That is omitted
+ * deliberately: this file is public, a handle is a real identifier, and
+ * `architecture.test.ts` refuses one anywhere a reader can see. A descriptive
+ * name and a URL satisfy what the throttle actually looks for.
+ */
+export const REDDIT_USER_AGENT = 'lanes-link/0.3 (+https://lanes.sh/link)';
+
+/**
+ * Where the browser comes back to, named to Reddit exactly as written.
+ *
+ * Reddit matches `redirect_uri` byte for byte, and `connect` normally listens
+ * on whatever port the kernel hands out — so a URL registered in the console
+ * months earlier could never match. Declaring it pins the listener to this
+ * port instead. See `cli/oauth.ts` and ADR-045.
+ *
+ * The port is high and otherwise unused, which is the only property it needs:
+ * nothing else in this program listens here, and the operator types the same
+ * string into Reddit's form.
+ */
+export const REDDIT_REDIRECT_URI = 'http://127.0.0.1:8765/callback';
+
+/**
+ * What the browser grant asks for.
+ *
+ * `identity` and `read` carry the reads; `submit` posts and comments; `edit`,
+ * `vote`, `save`, and `flair` cover what an author does to their own content
+ * afterwards. `mysubreddits` is what lists the subreddits this account follows.
+ *
+ * Absent on purpose: `privatemessages`, `history`, and every `mod*` scope.
+ * Nothing vendored needs them, and a scope on the consent screen that no tool
+ * can use is a grant asked for and never spent.
+ */
+export const REDDIT_SCOPES = [
+  'identity',
+  'read',
+  'submit',
+  'edit',
+  'vote',
+  'save',
+  'flair',
+  'mysubreddits',
+] as const;
+
+/** Resolve a vendored spec beside this folder. */
+export function specPath(name: string): string {
+  return new URL(`./specs/${name}`, import.meta.url).pathname;
+}

--- a/src/providers/reddit/redact.ts
+++ b/src/providers/reddit/redact.ts
@@ -1,0 +1,33 @@
+/**
+ * What survives into the audit log when Reddit is written to.
+ *
+ * The line is Gmail's and Slack's, because it is the same object: something a
+ * person wrote for other people to read. Where it went is recorded, what it
+ * said is not. A log that quoted the body would be a second copy of everything
+ * this account has ever posted, held somewhere nobody expects one.
+ *
+ * `title` is withheld along with the body, which is worth saying because it
+ * looks like metadata and is not — a Reddit title is usually the whole of the
+ * post, and the body is often empty. Keeping it would defeat the rest.
+ *
+ * Keys are the *shortened* names. `shortenName` strips a redundant provider
+ * prefix, so these must match what the capability is finally called — keying
+ * this block on anything else matches nothing and withholds everything,
+ * silently and with the log still looking correct.
+ */
+export const REDDIT_REDACT: Record<string, string[]> = {
+  // Everything that says where the post went and how it was marked, and nothing
+  // that says what it said. `url` is withheld with the body: for kind="link"
+  // the URL *is* the submission.
+  submit_post: ['sr', 'kind', 'flair_id', 'nsfw', 'spoiler', 'sendreplies', 'api_type'],
+  add_comment: ['thing_id', 'api_type'],
+  edit_text: ['thing_id', 'api_type'],
+  // Kept whole. Every argument is an identifier or a value from a fixed
+  // vocabulary, and an entry recording that something was voted on without
+  // recording which way records nothing anyone would look for — the reading
+  // that lets Slack keep an emoji name.
+  vote: ['id', 'dir'],
+  delete_thing: ['id'],
+  save_thing: ['id', 'category'],
+  set_flair: ['sr', 'link', 'flair_template_id', 'api_type'],
+};

--- a/src/providers/reddit/reddit.test.ts
+++ b/src/providers/reddit/reddit.test.ts
@@ -1,0 +1,189 @@
+import { describe, expect, test } from 'bun:test';
+import { createHttpConnector } from '../../connectivity/transports/http/index.ts';
+import { reddit } from './index.ts';
+import { REDDIT_REDIRECT_URI, REDDIT_SCOPES } from './oauth.ts';
+import { REDDIT_SCOPE_MEANINGS } from './scopes.ts';
+
+/**
+ * The spec beside this file is hand-authored, which is the whole reason these
+ * tests exist. A vendored Google document is wrong only if Google is wrong;
+ * this one is wrong if anybody mistyped a path, and nothing upstream would say
+ * so. `cli/tools.test.ts` already checks the budgets and the redaction keys for
+ * every `http` provider — what is here is what is particular to Reddit.
+ */
+
+const connector = reddit.connector as {
+  kind: string;
+  base_url: string;
+  openapi: string;
+  headers?: Record<string, string>;
+};
+
+async function capabilities() {
+  return createHttpConnector({
+    baseUrl: connector.base_url,
+    openapi: connector.openapi,
+    ...(connector.headers ? { headers: connector.headers } : {}),
+  }).discover({ manifest: reddit } as never);
+}
+
+describe('the vendored spec becomes the capabilities it claims to', () => {
+  test('every operation is discovered, and named without a redundant prefix', async () => {
+    const names = (await capabilities()).map((c) => c.name).sort();
+
+    expect(names).toEqual([
+      'add_comment',
+      'delete_thing',
+      'edit_text',
+      'get_post',
+      'get_rules',
+      'get_subreddit',
+      'list_flairs',
+      'list_my_subreddits',
+      'list_posts',
+      'save_thing',
+      'search',
+      'set_flair',
+      'submit_post',
+      'vote',
+      'whoami',
+    ]);
+  });
+
+  test('reads land in read and writes in write, decided by the verb alone', async () => {
+    const byBundle = new Map((await capabilities()).map((c) => [c.name, c.bundle]));
+
+    // What `connect` grants by default is the read bundle, so a write landing
+    // in it would be granted silently. The split is derived from the HTTP
+    // method rather than curated, which is what makes that safe — but only if
+    // the spec uses the right verb, and this is where a GET on /api/submit
+    // would show up.
+    expect(byBundle.get('list_posts')).toBe('read');
+    expect(byBundle.get('get_post')).toBe('read');
+    expect(byBundle.get('search')).toBe('read');
+    expect(byBundle.get('whoami')).toBe('read');
+    expect(byBundle.get('submit_post')).toBe('write');
+    expect(byBundle.get('add_comment')).toBe('write');
+    expect(byBundle.get('vote')).toBe('write');
+    expect(byBundle.get('delete_thing')).toBe('write');
+  });
+
+  test('the writes are form-encoded, because Reddit takes nothing else', async () => {
+    // A JSON body is rejected outright, and the error names the missing
+    // parameters rather than the encoding — so this failing looks like a bad
+    // request rather than a wrong content type.
+    const writes = (await capabilities()).filter((c) => c.bundle === 'write');
+    expect(writes.length).toBeGreaterThan(0);
+
+    for (const capability of writes) {
+      const mapper = capability.target?.['mapper'] as { type: string; serialization?: { contentType?: string } }[];
+      const body = mapper.filter((entry) => entry.type === 'body');
+
+      expect(body.length).toBeGreaterThan(0);
+      for (const entry of body) {
+        expect(entry.serialization?.contentType).toBe('application/x-www-form-urlencoded');
+      }
+    }
+  });
+});
+
+describe('what the manifest has to get exactly right', () => {
+  test('the base url matches the spec server, or every call 404s', async () => {
+    const spec = (await Bun.file(String(connector.openapi)).json()) as { servers: { url: string }[] };
+    const server = spec.servers[0]?.url;
+
+    expect(server).toBeTruthy();
+    expect(connector.base_url).toBe(server!);
+  });
+
+  test('the grant is at www, the API at oauth — mixing them 404s', () => {
+    const auth = reddit.auth as { authorize_url: string; token_url: string };
+    expect(new URL(auth.authorize_url).host).toBe('www.reddit.com');
+    expect(new URL(auth.token_url).host).toBe('www.reddit.com');
+    expect(new URL(connector.base_url).host).toBe('oauth.reddit.com');
+  });
+
+  test('duration=permanent is asked for, or the connection dies after an hour', () => {
+    // Reddit returns an access token and no refresh token without it. The
+    // connection then works, and stops an hour later with nothing to point at.
+    const auth = reddit.auth as { authorize_params?: Record<string, string> };
+    expect(auth.authorize_params?.['duration']).toBe('permanent');
+  });
+
+  test('a refresh token is required, unlike Slack', () => {
+    // Slack sets this to optional because a long-lived token and no refresh is
+    // its successful answer. Here a missing one is the failure above.
+    expect((reddit.auth as { refresh_token: string }).refresh_token).toBe('required');
+  });
+
+  test('the redirect names a port, since Reddit matches it exactly', () => {
+    const auth = reddit.auth as { redirect_uri: string; broker?: unknown };
+    expect(auth.redirect_uri).toBe(REDDIT_REDIRECT_URI);
+    expect(new URL(auth.redirect_uri).port).not.toBe('');
+    // Both would answer "where does the browser come back to", and the flow
+    // reads one of them. `defineProvider` refuses the pair.
+    expect(auth.broker).toBeUndefined();
+  });
+
+  test('a User-Agent is declared, because the default one is throttled hardest', () => {
+    expect(connector.headers?.['User-Agent']).toBeTruthy();
+    // Reddit's documented format ends with the author's handle. It is left out
+    // on purpose — this repository refuses a real identifier anywhere a reader
+    // can see, and the throttle looks for a descriptive name, not a person.
+    expect(connector.headers?.['User-Agent']).not.toMatch(/\/u\//);
+  });
+});
+
+describe('scopes are asked for in words, and only where something uses them', () => {
+  test('every requested scope has a meaning to show before consent', () => {
+    for (const scope of REDDIT_SCOPES) {
+      expect(REDDIT_SCOPE_MEANINGS[scope]?.meaning).toBeTruthy();
+    }
+  });
+
+  test('the three that act publicly as the person are marked broad', () => {
+    expect(REDDIT_SCOPE_MEANINGS['submit']?.broad).toBe(true);
+    expect(REDDIT_SCOPE_MEANINGS['edit']?.broad).toBe(true);
+    expect(REDDIT_SCOPE_MEANINGS['vote']?.broad).toBe(true);
+    // Not `read`: it reaches only what the account can already see, and what
+    // Reddit makes readable is public to begin with.
+    expect(REDDIT_SCOPE_MEANINGS['read']?.broad).toBeUndefined();
+  });
+
+  test('nothing is requested that no capability can spend', () => {
+    // A scope on the consent screen that no tool uses is a grant asked for and
+    // never spent, which is the thing least likely to be noticed later.
+    const declared = new Set<string>(REDDIT_SCOPES);
+    expect(declared.has('privatemessages')).toBe(false);
+    expect(declared.has('history')).toBe(false);
+    expect([...declared].some((s) => s.startsWith('mod'))).toBe(false);
+  });
+});
+
+describe('what reaches the audit log when Reddit is written to', () => {
+  test('a post records where it went and not what it said', () => {
+    const kept = reddit.redact?.['submit_post'] ?? [];
+
+    expect(kept).toContain('sr');
+    expect(kept).toContain('flair_id');
+    // A Reddit title is usually the whole of the post and the body is often
+    // empty, so keeping it would defeat withholding the body.
+    expect(kept).not.toContain('title');
+    expect(kept).not.toContain('text');
+    // For kind="link" the URL *is* the submission.
+    expect(kept).not.toContain('url');
+  });
+
+  test('a comment records which thread and not the comment', () => {
+    expect(reddit.redact?.['add_comment']).toEqual(['thing_id', 'api_type']);
+    expect(reddit.redact?.['edit_text']).toEqual(['thing_id', 'api_type']);
+  });
+
+  test('every write has a redaction entry, so none defaults to withholding all', async () => {
+    // The default withholds every value, which makes a write log useless: it
+    // records that something changed without recording what. A new write
+    // arriving with no entry is the silent version of that.
+    const writes = (await capabilities()).filter((c) => c.bundle === 'write').map((c) => c.name);
+    for (const name of writes) expect(reddit.redact?.[name]).toBeDefined();
+  });
+});

--- a/src/providers/reddit/scopes.ts
+++ b/src/providers/reddit/scopes.ts
@@ -1,0 +1,27 @@
+import type { ScopeMeaning } from '../scopes.ts';
+
+/**
+ * Reddit's scopes, in Reddit's own words.
+ *
+ * Taken verbatim from `https://www.reddit.com/api/v1/scopes`, which publishes a
+ * description per scope, rather than paraphrased. A paraphrase is where a
+ * consent screen quietly starts understating what it asks for, and the vendor's
+ * own sentence is the one that can be checked against the vendor.
+ *
+ * Three are marked broad, and all three for the same reason: they act publicly
+ * as the person. A post, a comment, a vote, and an edit are visible under their
+ * username to everyone who reads the subreddit, and unlike a private write they
+ * cannot be quietly undone — `delete` leaves the fact of the deletion behind,
+ * and anything cached or quoted stays. `read` is not marked: it reaches only
+ * what the account can already see, and Reddit's readable surface is public.
+ */
+export const REDDIT_SCOPE_MEANINGS: Record<string, ScopeMeaning> = {
+  identity: { meaning: 'read your username and signup date' },
+  read: { meaning: 'read posts and comments' },
+  submit: { meaning: 'post and comment publicly as you', broad: true },
+  edit: { meaning: 'edit and delete your posts and comments', broad: true },
+  vote: { meaning: 'vote on posts and comments as you', broad: true },
+  save: { meaning: 'save and unsave posts and comments' },
+  flair: { meaning: 'set the flair on your posts' },
+  mysubreddits: { meaning: 'list the subreddits you belong to' },
+};

--- a/src/providers/reddit/specs/reddit.v1.json
+++ b/src/providers/reddit/specs/reddit.v1.json
@@ -1,0 +1,700 @@
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "Reddit",
+    "version": "1.0.0",
+    "description": "The subset of the Reddit API this provider exposes. Hand-authored: Reddit publishes no OpenAPI document."
+  },
+  "servers": [
+    {
+      "url": "https://oauth.reddit.com"
+    }
+  ],
+  "paths": {
+    "/r/{subreddit}/{sort}": {
+      "get": {
+        "operationId": "list_posts",
+        "summary": "List posts in a subreddit",
+        "description": "Posts from one subreddit in a given order. Returns a Listing envelope: {kind, data:{after, children:[{kind, data}]}}.",
+        "tags": [
+          "read"
+        ],
+        "parameters": [
+          {
+            "name": "subreddit",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "description": "Subreddit name without the \"r/\" prefix."
+            }
+          },
+          {
+            "name": "sort",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "enum": [
+                "hot",
+                "new",
+                "top",
+                "rising"
+              ],
+              "description": "Ordering."
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "description": "How many to return, up to 100."
+            }
+          },
+          {
+            "name": "after",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "description": "Fullname to page after, from a previous \"after\"."
+            }
+          },
+          {
+            "name": "t",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "hour",
+                "day",
+                "week",
+                "month",
+                "year",
+                "all"
+              ],
+              "description": "Time window. Only meaningful when sort is \"top\"."
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    },
+    "/comments/{article}": {
+      "get": {
+        "operationId": "get_post",
+        "summary": "Read a post and its comments",
+        "description": "One post with its comment tree. `article` is the base36 id WITHOUT the t3_ prefix. Returns a two-element array: the post, then the comments.",
+        "tags": [
+          "read"
+        ],
+        "parameters": [
+          {
+            "name": "article",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "description": "Post id in base36, no t3_ prefix."
+            }
+          },
+          {
+            "name": "sort",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "confidence",
+                "top",
+                "new",
+                "controversial",
+                "old",
+                "qa"
+              ],
+              "description": "Comment ordering."
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "description": "How many comments to return."
+            }
+          },
+          {
+            "name": "depth",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "description": "How many levels of replies to descend."
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    },
+    "/r/{subreddit}/search": {
+      "get": {
+        "operationId": "search",
+        "summary": "Search within a subreddit",
+        "description": "Full-text search. Returns a Listing envelope: {kind, data:{after, children:[{kind, data}]}}.",
+        "tags": [
+          "read"
+        ],
+        "parameters": [
+          {
+            "name": "subreddit",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "description": "Subreddit name."
+            }
+          },
+          {
+            "name": "q",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "description": "Search query."
+            }
+          },
+          {
+            "name": "restrict_sr",
+            "in": "query",
+            "schema": {
+              "type": "boolean",
+              "description": "True to search only this subreddit rather than all of Reddit."
+            }
+          },
+          {
+            "name": "sort",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "relevance",
+                "hot",
+                "top",
+                "new",
+                "comments"
+              ],
+              "description": "Ordering."
+            }
+          },
+          {
+            "name": "t",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "hour",
+                "day",
+                "week",
+                "month",
+                "year",
+                "all"
+              ],
+              "description": "Time window."
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "description": "How many to return, up to 100."
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    },
+    "/r/{subreddit}/about": {
+      "get": {
+        "operationId": "get_subreddit",
+        "summary": "Read a subreddit profile",
+        "description": "Description, subscriber count, and whether posting requires a flair (`link_flair_enabled`, `submission_type`).",
+        "tags": [
+          "read"
+        ],
+        "parameters": [
+          {
+            "name": "subreddit",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "description": "Subreddit name."
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    },
+    "/r/{subreddit}/about/rules": {
+      "get": {
+        "operationId": "get_rules",
+        "summary": "Read a subreddit’s posting rules",
+        "description": "The rules a submission must satisfy. Worth reading before posting to an unfamiliar subreddit — most removals are rule violations, not API errors.",
+        "tags": [
+          "read"
+        ],
+        "parameters": [
+          {
+            "name": "subreddit",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "description": "Subreddit name."
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    },
+    "/api/v1/{subreddit}/link_flair_v2": {
+      "get": {
+        "operationId": "list_flairs",
+        "summary": "List a subreddit’s post flairs",
+        "description": "Available post flairs and their ids. Many subreddits reject a submission with no flair_id, so call this first when submitting somewhere new.",
+        "tags": [
+          "read"
+        ],
+        "parameters": [
+          {
+            "name": "subreddit",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "description": "Subreddit name."
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    },
+    "/api/v1/me": {
+      "get": {
+        "operationId": "whoami",
+        "summary": "Read the authenticated account",
+        "description": "Username, karma, and account age for the connected account.",
+        "tags": [
+          "read"
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    },
+    "/subreddits/mine/subscriber": {
+      "get": {
+        "operationId": "list_my_subreddits",
+        "summary": "List subscribed subreddits",
+        "description": "Subreddits the connected account subscribes to. Returns a Listing envelope: {kind, data:{after, children:[{kind, data}]}}.",
+        "tags": [
+          "read"
+        ],
+        "parameters": [
+          {
+            "name": "limit",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "description": "How many to return."
+            }
+          },
+          {
+            "name": "after",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "description": "Fullname to page after."
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    },
+    "/api/submit": {
+      "post": {
+        "operationId": "submit_post",
+        "summary": "Submit a post to a subreddit",
+        "description": "Create a text or link post. kind=\"self\" needs `text`; kind=\"link\" needs `url`. Check list_flairs first — many subreddits reject a post with no flair_id.",
+        "tags": [
+          "write"
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/x-www-form-urlencoded": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "sr": {
+                    "type": "string",
+                    "description": "Subreddit name without the \"r/\" prefix."
+                  },
+                  "kind": {
+                    "type": "string",
+                    "enum": [
+                      "self",
+                      "link"
+                    ],
+                    "description": "\"self\" for a text post, \"link\" for a URL post."
+                  },
+                  "title": {
+                    "type": "string",
+                    "description": "Post title, up to 300 characters."
+                  },
+                  "text": {
+                    "type": "string",
+                    "description": "Body, as markdown. Only for kind=\"self\"."
+                  },
+                  "url": {
+                    "type": "string",
+                    "description": "Target URL. Only for kind=\"link\"."
+                  },
+                  "flair_id": {
+                    "type": "string",
+                    "description": "Flair template id from list_flairs."
+                  },
+                  "nsfw": {
+                    "type": "boolean",
+                    "description": "Mark as not safe for work."
+                  },
+                  "spoiler": {
+                    "type": "boolean",
+                    "description": "Mark as a spoiler."
+                  },
+                  "sendreplies": {
+                    "type": "boolean",
+                    "description": "Send reply notifications to the account inbox."
+                  },
+                  "api_type": {
+                    "type": "string",
+                    "enum": [
+                      "json"
+                    ],
+                    "default": "json",
+                    "description": "Always \"json\". Without it the response is not JSON and errors are unreadable."
+                  }
+                },
+                "required": [
+                  "sr",
+                  "kind",
+                  "title",
+                  "api_type"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    },
+    "/api/comment": {
+      "post": {
+        "operationId": "add_comment",
+        "summary": "Comment on a post or reply to a comment",
+        "description": "thing_id is a FULLNAME, not a bare id: t3_<id> for a post, t1_<id> for a comment. A bare id is silently rejected.",
+        "tags": [
+          "write"
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/x-www-form-urlencoded": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "thing_id": {
+                    "type": "string",
+                    "description": "Fullname of the parent: t3_<id> for a post, t1_<id> for a comment."
+                  },
+                  "text": {
+                    "type": "string",
+                    "description": "Comment body, as markdown."
+                  },
+                  "api_type": {
+                    "type": "string",
+                    "enum": [
+                      "json"
+                    ],
+                    "default": "json",
+                    "description": "Always \"json\". Without it the response is not JSON and errors are unreadable."
+                  }
+                },
+                "required": [
+                  "thing_id",
+                  "text",
+                  "api_type"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    },
+    "/api/editusertext": {
+      "post": {
+        "operationId": "edit_text",
+        "summary": "Edit your own post or comment",
+        "description": "Replaces the body of something this account authored. Only works on a text post or a comment.",
+        "tags": [
+          "write"
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/x-www-form-urlencoded": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "thing_id": {
+                    "type": "string",
+                    "description": "Fullname of the item to edit: t3_<id> or t1_<id>."
+                  },
+                  "text": {
+                    "type": "string",
+                    "description": "Replacement body, as markdown."
+                  },
+                  "api_type": {
+                    "type": "string",
+                    "enum": [
+                      "json"
+                    ],
+                    "default": "json",
+                    "description": "Always \"json\". Without it the response is not JSON and errors are unreadable."
+                  }
+                },
+                "required": [
+                  "thing_id",
+                  "text",
+                  "api_type"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    },
+    "/api/vote": {
+      "post": {
+        "operationId": "vote",
+        "summary": "Vote on a post or comment",
+        "description": "dir is 1 to upvote, -1 to downvote, 0 to clear an existing vote.",
+        "tags": [
+          "write"
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/x-www-form-urlencoded": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "id": {
+                    "type": "string",
+                    "description": "Fullname of the target: t3_<id> or t1_<id>."
+                  },
+                  "dir": {
+                    "type": "integer",
+                    "enum": [
+                      1,
+                      0,
+                      -1
+                    ],
+                    "description": "1 upvote, 0 clear, -1 downvote."
+                  }
+                },
+                "required": [
+                  "id",
+                  "dir"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    },
+    "/api/del": {
+      "post": {
+        "operationId": "delete_thing",
+        "summary": "Delete your own post or comment",
+        "description": "Permanent. Reddit has no trash for this — a deleted item cannot be restored through the API.",
+        "tags": [
+          "write"
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/x-www-form-urlencoded": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "id": {
+                    "type": "string",
+                    "description": "Fullname to delete: t3_<id> or t1_<id>."
+                  }
+                },
+                "required": [
+                  "id"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    },
+    "/api/save": {
+      "post": {
+        "operationId": "save_thing",
+        "summary": "Save a post or comment",
+        "description": "Adds to the account’s saved items.",
+        "tags": [
+          "write"
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/x-www-form-urlencoded": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "id": {
+                    "type": "string",
+                    "description": "Fullname to save: t3_<id> or t1_<id>."
+                  },
+                  "category": {
+                    "type": "string",
+                    "description": "Optional saved-items category name."
+                  }
+                },
+                "required": [
+                  "id"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    },
+    "/api/selectflair": {
+      "post": {
+        "operationId": "set_flair",
+        "summary": "Set the flair on your own post",
+        "description": "Applies a flair template from list_flairs to a post this account authored.",
+        "tags": [
+          "write"
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/x-www-form-urlencoded": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "sr": {
+                    "type": "string",
+                    "description": "Subreddit name without the \"r/\" prefix."
+                  },
+                  "link": {
+                    "type": "string",
+                    "description": "Fullname of the post: t3_<id>."
+                  },
+                  "flair_template_id": {
+                    "type": "string",
+                    "description": "Flair template id from list_flairs."
+                  },
+                  "api_type": {
+                    "type": "string",
+                    "enum": [
+                      "json"
+                    ],
+                    "default": "json",
+                    "description": "Always \"json\". Without it the response is not JSON and errors are unreadable."
+                  }
+                },
+                "required": [
+                  "sr",
+                  "link",
+                  "flair_template_id",
+                  "api_type"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    }
+  }
+}

--- a/src/providers/scopes.ts
+++ b/src/providers/scopes.ts
@@ -1,5 +1,6 @@
 import { GOOGLE_SCOPE_MEANINGS } from './google/shared/scopes.ts';
 import { LINEAR_SCOPE_MEANINGS } from './linear/scopes.ts';
+import { REDDIT_SCOPE_MEANINGS } from './reddit/scopes.ts';
 import { SLACK_SCOPE_MEANINGS } from './slack/scopes.ts';
 
 /**
@@ -24,5 +25,6 @@ export interface ScopeMeaning {
 export const SCOPE_MEANINGS: Record<string, ScopeMeaning> = {
   ...GOOGLE_SCOPE_MEANINGS,
   ...LINEAR_SCOPE_MEANINGS,
+  ...REDDIT_SCOPE_MEANINGS,
   ...SLACK_SCOPE_MEANINGS,
 };


### PR DESCRIPTION
Reads subreddits, posts, comment trees, and search; posts, comments, votes, and edits as the connected account. Fifteen operations, split read/write by HTTP verb, so `connect` grants the reads by default.

Two commits: the shared-path changes Reddit needed are general and reviewable on their own, then the provider.

## Three gaps in the shared path

Found together because one provider hit all three. None is about a vendor.

**A redirect the vendor matches exactly.** `connect` binds `port: 0` and names `http://127.0.0.1:<kernel's choice>/callback`. That works because RFC 8252 §7.3 asks a server to ignore the port on a loopback redirect. A server that matches the whole string can never agree with a URL registered in a console months earlier — the grant fails *after* consent with `redirect_uri_mismatch`.

We were already paying for this. ADR-033 records GitHub using a pasted token rather than OAuth, and the reason it gives is exactly this. It was treated as a property of the CLI; it was a gap in it. `auth.redirect_uri` is the whole URL rather than a port, because the two must be identical strings and only one is ours to choose. Mutually exclusive with `broker`, which answers the same question the other way. ADR-045 records it.

**A body encoded as the document declares.** The http transport hardcoded JSON. `mcp-from-openapi` already records the media type on each body entry of the mapper, and the mapper is already cached in `target` — so this needed nothing threaded through.

**A header the connector declares.** Nothing here set a `User-Agent`, so every install looked identical to a host that rate-limits by client. The `Authorization` guard moved out of the mcp-only block while doing this: its reasoning never had anything to do with which transport carried the header.

## The provider

**The spec is hand-authored** — Reddit publishes no OpenAPI document, so there is no vendoring script and nothing to re-sync from. `reddit.test.ts` exists because of that: a vendored Google spec is wrong only if Google is wrong; this one is wrong if somebody mistyped a path.

**No shared client, deliberately.** Reddit's rate limit is 100 QPM *per client id*. A shared client would pool every install into one bucket, so an operator's limit would be spent by strangers. Their own app gets its own. That costs a console visit — what the broker exists to avoid — and it is worth paying once, because the alternative degrades with every new user.

**Eight scopes of the thirty Reddit publishes.** `privatemessages` and the `mod*` scopes are left out; nothing vendored needs them. `submit`, `edit`, and `vote` are marked broad, for a different reason from every other broad scope here — not reach into a private space, but acting *publicly* under the person's username, and they are the only writes here that cannot be taken back.

**Redaction** follows Gmail's line, with `title` withheld alongside the body: a Reddit title is usually the whole of the post.

## Verification

`bun test` → 2164 pass, 2 skip, 0 fail (baseline 2128). `bun run typecheck` → clean. Both commits are green independently.

## Two things for the reviewer

- **Not verified against a live account.** Reddit's Responsible Builder Policy now requires access to be approved separately from creating an app, so holding a client id is no longer the same as being able to call the API. `docs/detailed/setup/reddit.md` documents how to tell which side of that you are on. Everything here is checked against the spec offline.
- **`reddit` joins the vendor-name ban** in `architecture.test.ts`, guarding the shared path the first commit widened. `github` and `slack` are still absent from that list — a pre-existing gap, left alone rather than fixed in passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)