### PR TITLE
Add Discord, posting as an application you own

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,7 @@ One command per account. Run it again to add a second mailbox, a second calendar
 | GitHub | `lanes link connect github` |
 | Slack | `lanes link connect slack` |
 | Reddit | `lanes link connect reddit` |
+| Discord | `lanes link connect discord` |
 | Gmail (IMAP, app password) | `lanes link connect gmail_imap` |
 | Gmail (Google MCP) | `lanes link connect gmail_mcp` |
 | Drive (Google MCP) | `lanes link connect drive_mcp` |

--- a/docs/connect.md
+++ b/docs/connect.md
@@ -30,6 +30,7 @@ $ lanes link connect gmail --profile personal --target local        # again, for
 | GitHub | `lanes link connect github` | Repositories, issues, pull requests, and workflow runs |
 | Slack | `lanes link connect slack` | Search, read, and send messages, threads, files, and canvases |
 | Reddit | `lanes link connect reddit` | Read subreddits and comments, search, and post, comment, and vote as you |
+| Discord | `lanes link connect discord` | Post announcements and read channels, as a bot application you own |
 | Gmail (IMAP) | `lanes link connect gmail_imap` | The same mailbox over IMAP and SMTP, with an app password that does not expire |
 | Gmail (Google MCP) | `lanes link connect gmail_mcp` | Google's own MCP server — Developer Preview only |
 | Drive (Google MCP) | `lanes link connect drive_mcp` | Likewise; use `drive` unless you are enrolled |

--- a/docs/detailed/adr/047-a-pasted-token-carries-its-own-scheme.md
+++ b/docs/detailed/adr/047-a-pasted-token-carries-its-own-scheme.md
@@ -1,0 +1,119 @@
+# ADR-047: A pasted token may carry its own auth scheme, and a write surface may hand back a credential
+
+**Status:** accepted · **Follows** [ADR-033](033-a-pasted-token-for-an-mcp-server.md) ·
+**Builds on** [ADR-045](045-a-redirect-the-vendor-matches-exactly.md) · **Constrained by**
+[ADR-017](017-attachments-by-reference.md)
+
+## Context
+
+Discord was added to post announcements to servers the operator owns, and to read channels so an
+agent can triage them. Two things about it do not fit the shapes already here, and both are worth
+recording because the cheap answer to each is a rule this repository otherwise holds.
+
+**There is no user-account path at all.** Discord publishes no API for acting as yourself.
+Automating a user token is self-botting, which their terms forbid and which gets accounts
+terminated, and the OAuth2 user scopes cover neither posting to a channel nor reading its history.
+Everything an integration can legitimately do, it does as an *application* — and an application's
+messages carry an `APP` badge that cannot be removed. So "post as myself" is not available and
+never will be. What is available is the *name and avatar* on each message, set per message through
+a webhook, which is close enough to be worth building and not close enough to describe as the
+thing that was asked for.
+
+That also settles why this is not OAuth — and note it is *not* ADR-033's reason, which ADR-045 has
+since withdrawn. A vendor matching its callback URL exactly against a kernel-chosen port is now
+answerable with `auth.redirect_uri`, so it is no longer an argument for a pasted token anywhere.
+What holds here is narrower and not fixable on our side. A Discord OAuth2 flow with the
+`bot` scope installs an application into a server, but the credential that then calls the API is
+the application's bot token — a property of the app, not something the exchange returns. So a
+browser flow would end with the operator copying a token out of the developer portal anyway. The
+`webhook.incoming` scope *does* return a usable credential, and it is write-only to one channel: it
+cannot read, so it cannot serve the half of this that is triage.
+
+**Discord's scheme word is `Bot`, not `Bearer`.** `Authorization: Bot MTIz…`. Nothing in this
+codebase could emit that: `attachBearer` assembles `Bearer ${token}` and there is no field to say
+otherwise.
+
+## Decision
+
+**A token credential may carry its own scheme inside the stored value, rather than the manifest
+gaining a field to name one.** Discord declares `auth: { kind: 'header', header: 'Authorization' }`,
+which writes the stored value into the header verbatim, and the operator pastes `Bot MTIz…`.
+
+The alternative was one optional `scheme` field on `authTokenSchema`, defaulting to `Bearer`, read
+in `bearer/index.ts`, `credential.ts`, `resolve.ts` and `cli/identity.ts`. It is a small, additive
+change and it is the better *design*. It was not taken because it widens the shared auth surface
+for one provider, and `header` already expresses exactly this — a credential whose whole value goes
+in a named header. The provider stays inside its own folder.
+
+Two costs follow, and neither is hypothetical:
+
+- **A token pasted without the prefix fails as an opaque 401.** Mitigated where it happens rather
+  than in a comment: the prompt label is `Discord bot token, prefixed — Bot <token>`, and
+  `setup.troubleshooting` names the missing prefix as the first thing to check. `discord.test.ts`
+  asserts both, so the mitigation cannot quietly disappear.
+- **The connection cannot name itself.** `resolveAccount` sends `Authorization: Bearer <stored
+  value>`, which here is `Bearer Bot MTIz…` — a 401 and a null. So the provider declares **no
+  `identity` block at all**, rather than one that always fails after a network round trip. The
+  operator types a label. Re-running `connect` with the same label repairs the existing connection
+  instead of adding a second, because `settleIdentity` matches on it; a scripted run passes
+  `--display-name`. If a `scheme` field is ever added for another vendor, this provider should take
+  it and grow an identity block.
+
+**The webhook operations are vendored, accepting that two of them return a credential to the
+caller.** `create_webhook` and `list_channel_webhooks` include the webhook's token in their
+response, and a webhook token is standalone: anybody holding it can post to that channel with no
+other authentication. It therefore reaches the model.
+
+This is a real weakening and it is recorded as one — `provider.response-may-carry-a-credential`,
+NOT-GUARANTEED, in [`security.md`](../security.md). It is accepted because the alternative is not
+"the same thing, safely" but "no posting under the operator's own name", which was the point.
+Bounded three ways: the token only posts to the one channel it was made for, `redact` withholds
+`webhook_token` from the audit log so it is not also written down in clear, and
+`docs/detailed/setup/discord.md` says plainly that a webhook is a credential and how to revoke one.
+
+**No capability is authored.** An authored `announce` capability could find-or-create the webhook
+and post through it without ever returning the token, which would close the exposure above. It is
+not built: ADR-017 sets the bar at "the vendor's API can do something its *document* cannot
+express", and three documented calls express this fine. Recorded as the obvious follow-up if the
+exposure proves to matter more than the ~80 lines.
+
+**The vendored operation list is the security boundary, and it is pinned by a test.** `connect`
+writes one policy rule, `discord.*`, and policy has no pattern between `provider.*` and an exact
+name — so every operation in the spec is an operation an agent may call. Twenty are vendored out of
+242. `bulk_delete_messages` is excluded although it sits beside `delete_message`; so is every
+moderation, role, and guild-settings endpoint. `discord.test.ts` asserts the list is exactly those
+twenty, so a refresh that picks up a new operation fails and gets read rather than merging quietly.
+
+## Consequences
+
+Adding Discord needed no change to any shared component. What it did change is the vendoring
+pipeline, which moved from `providers/google/specs/vendor.ts` into
+`providers/shared/vendor-spec.ts`, `vendor-operations.ts` and `vendor-schemas.ts` so a second
+provider could use it — verified by re-running `bun run vendor:google` and requiring all seven
+committed specs to come back byte-identical.
+
+Three repairs were added there, each opt-in per provider, and each of them is a bug that would
+otherwise have shipped silently:
+
+- `hoistPathParameters` — Discord declares path parameters on the path item, which is legal and
+  which `mcp-from-openapi`'s validator does not read. Without it the document fails validation
+  outright and generates **zero** tools.
+- `rewriteRequestBody` — `execute_webhook`'s body is a top-level `anyOf`, so the generator emits one
+  argument literally named `body` and the connector sends `{"body":{…}}` where Discord expects
+  `{…}`. Every test in the repository passes; only a live call fails.
+- `requestContentTypes` — the `multipart/form-data` branches name fields `files[0]`, which is not a
+  legal tool property name, and one illegal name rejects the entire tools list for *every* provider
+  on the endpoint. Nothing but the generator's own content-type preference was keeping it out.
+  ADR-045 taught the transport to form-encode as well as JSON-encode, which narrows this but does
+  not close it: multipart is still unsendable, so the branch describes a request that cannot be
+  made whichever encoding the generator selects.
+
+A fourth is not a flag but a guard: the generator answers an unresolvable `$ref` by logging to the
+console and omitting that one tool, so `vendorSpec` now refuses a run where the generated tool
+count disagrees with the operation count. Pruning `components.securitySchemes` — which looks like
+11.5 KB of dead weight — silently drops three tools, including `get_my_user`, the one call an
+operator would use to check the connection.
+
+Attachments are unavailable as a result of the content-type narrowing. That is the honest state
+rather than a regression: ADR-017's machinery is the route to them, not a multipart branch nothing
+sends.

--- a/docs/detailed/adr/README.md
+++ b/docs/detailed/adr/README.md
@@ -54,6 +54,7 @@ Nothing in the codebase depends on it.
 | [044](044-a-deployment-records-where-it-lives.md) | A deployment records where it lives outside any profile, and the two copies of a workspace can be merged |
 | [045](045-a-redirect-the-vendor-matches-exactly.md) | A provider may name the loopback redirect verbatim, for a vendor that matches `redirect_uri` exactly rather than ignoring the port |
 | [046](046-an-auth-strategy-belongs-to-its-provider.md) | An auth strategy belongs to its provider, and its session is state |
+| [047](047-a-pasted-token-carries-its-own-scheme.md) | A pasted token may carry its own auth scheme in the stored value, and a vendored write surface may return a credential to the caller where the alternative is losing the capability |
 
 Where an ADR departs from init.md, it says so at the top. Three are significant:
 

--- a/docs/detailed/providers.md
+++ b/docs/detailed/providers.md
@@ -297,6 +297,89 @@ the body is often empty, so keeping it would defeat withholding the body. For a 
 `url` is the submission, so that is withheld too. What survives is where it went and how it was
 marked: `sr`, `flair_id`, `nsfw`, `spoiler`.
 
+## `discord`
+
+Twenty operations against Discord's v10 REST API. Setup:
+[`setup/discord.md`](setup/discord.md) — an application you create, whose bot token you paste, and
+which you invite to each server you want reachable.
+
+The spec at `src/providers/discord/specs/discord.v10.json` is vendored by
+`src/providers/discord/specs/vendor.ts` from the OpenAPI document Discord publishes. Vendoring
+matters more here than for Google: upstream is a public preview Discord says may change without
+notice, so the committed copy is what stops a breaking change upstream becoming a provider that
+stops working.
+
+**Discord has no API for acting as your own account.** Automating a user token is self-botting,
+which their terms forbid, and the OAuth2 user scopes cover neither posting nor reading channel
+history. So every message here is sent by an *application* and carries an `APP` badge that no
+setting removes. The name and avatar are controllable — per message, through a webhook — which is
+why the three webhook operations are vendored. ADR-047 has the whole argument.
+
+| Capability | Kind | Bundle | Why |
+|---|---|---|---|
+| `discord.get_my_user` | tool | read | Which application this token is. The cheap call that proves the `Bot ` prefix landed. |
+| `discord.list_my_guilds` | tool | read | The servers the bot was added to — not the ones you are in. An empty list means the invite was missed. |
+| `discord.get_guild` | tool | read | One server, with optional member counts. |
+| `discord.list_guild_channels` | tool | read | How a channel *name* becomes the id every other call needs. `type` says whether it can take messages. |
+| `discord.get_channel` | tool | read | One channel — name, type, topic, category. |
+| `discord.list_messages` | tool | read | The triage read, and the only one: Discord offers applications no message search. Pages on `before`/`after`. |
+| `discord.get_message` | tool | read | One message in full, with reactions and embeds. |
+| `discord.list_pins` | tool | read | What has been marked. The current endpoint, not the deprecated one. |
+| `discord.list_message_reactions_by_emoji` | tool | read | Who reacted with one emoji — a lightweight vote, read back. |
+| `discord.get_active_guild_threads` | tool | read | Every open thread in a server at once, cheaper than walking channels. |
+| `discord.create_message` | tool | write | Post as the application. `embeds` rather than `content` is what makes an announcement. |
+| `discord.update_message` | tool | write | Edit its own message. The typo fix; Discord shows an "edited" marker regardless. |
+| `discord.delete_message` | tool | write | The retraction. One message by id — there is deliberately no bulk delete. |
+| `discord.crosspost_message` | tool | write | Publish an announcement-channel post to the servers that follow it. `type: 5` channels only. |
+| `discord.add_my_message_reaction` | tool | write | Mark a message seen or triaged. Notifies nobody. |
+| `discord.create_pin` | tool | write | The heavier mark. Needs Manage Messages; 50 per channel. |
+| `discord.create_thread_from_message` | tool | write | Turn a post into a discussion without cluttering the channel. |
+| `discord.list_channel_webhooks` | tool | read | Find an existing webhook before making another. Returns tokens — see below. |
+| `discord.create_webhook` | tool | write | One per channel, once. Returns a token — see below. |
+| `discord.execute_webhook` | tool | write | Post with `username` and `avatar_url` set per message. How an announcement reads as you. |
+
+**The vendored list is the security boundary, not a convenience.** `connect` writes one rule,
+`discord.*`, and policy has nothing between a whole provider and one exact name — so twenty of
+Discord's 242 operations is the whole of what an agent can reach. `bulk_delete_messages` is
+excluded although it sits beside `delete_message`; so is every moderation, role, invite and
+guild-settings endpoint. `discord.test.ts` asserts the list is exactly those twenty, so a spec
+refresh that picks one up fails and gets read rather than merging quietly.
+
+**Two operations return a credential.** `create_webhook` and `list_channel_webhooks` include the
+webhook's token in their response, and a webhook token is standalone — anybody holding it posts to
+that channel with no other authentication. It therefore reaches the model. Recorded as
+`provider.response-may-carry-a-credential` in [`security.md`](security.md) rather than glossed
+over, and accepted because the alternative is not the same capability made safe but no posting
+under the operator's own name at all.
+
+**No scopes**, because there is no OAuth. What the token can do is chosen by the permission bits on
+the invite URL, in Discord's own console, and this endpoint cannot read them back — the same
+narrower guarantee every pasted-token provider has. The setup page prints an invite URL carrying
+exactly the bits the twenty operations need and nothing else.
+
+**Reading needs the Message Content intent**, a toggle in the developer portal that is free for an
+application under 10,000 users. Without it `list_messages` returns `200` with every `content`
+empty, and nothing in the response says why. It is called out in the walkthrough, in
+`troubleshooting`, and in the `list_messages` hint.
+
+**Every operation carries a hint**, which is unusual and not decoration: Discord describes 17 of
+its 242 operations and none of the twenty here, so `mcp-from-openapi` synthesises
+`POST /channels/{channel_id}/messages` and the hint is the entire rest of what an agent reads.
+Hinting all twenty also turns `cli/tools.test.ts` into a completeness check, since it resolves each
+hint against a generated capability by name.
+
+**Redaction** keeps ids and cursors and withholds message bodies, with two deliberate exceptions.
+`allowed_mentions` is kept everywhere something posts: it is not content but blast radius, and
+whether a post could ping `@everyone` is unrecoverable once the message is edited. `username` is
+kept on `execute_webhook`, because the post is deliberately wearing a name that is not the
+application's and *posted as "Ops" in channel 123* is the entry's whole point. `webhook_token`
+beside it is withheld, and a test asserts no capability keeps it.
+
+**Attachments are unavailable.** Discord takes files as `multipart/form-data`; the connector
+encodes JSON and form-urlencoded (ADR-045) and the multipart branches are dropped during vendoring,
+because their fields are named `files[0]` and one illegal property name rejects the entire tools
+list for every provider on the endpoint.
+
 ## iCloud — `icloud_mail`, `icloud_calendar`, `icloud_contacts`
 
 One Apple Account, three providers, one app-specific password

--- a/docs/detailed/security.md
+++ b/docs/detailed/security.md
@@ -112,6 +112,7 @@ limitation. `RESERVED` names a compatibility slot with no implementation.
 | `credentials.no-standing-grant` | **NOT-GUARANTEED for a connection authenticated with a key** | see below |
 | `credentials.plaintext-in-use` | NOT-GUARANTEED | inherent |
 | `provider.sandboxed` | NOT-GUARANTEED | provider code is trusted |
+| `provider.response-may-carry-a-credential` | NOT-GUARANTEED **for two Discord operations** | a capability's *response* is returned to the caller unread, and `discord.create_webhook` and `discord.list_channel_webhooks` include the webhook's token in theirs. A webhook token is standalone: it posts to that one channel with no other authentication. Accepted in [ADR-047](adr/047-a-pasted-token-carries-its-own-scheme.md) because the alternative is not the same capability made safe but no posting under the operator's own name at all. Bounded to one channel, withheld from the audit log by `DISCORD_REDACT` and asserted so in `src/providers/discord/discord.test.ts`, and revocable from Discord's channel settings — see [`setup/discord.md`](setup/discord.md). Distinct from `credentials.not-agent-reachable`, which is about this system's own store and still holds |
 | `egress.controlled` | NOT-GUARANTEED | follows from the above |
 | `policy.approval_required` | RESERVED | the model carries the state; no engine, and it fails closed |
 | `delegation.external-clients` | RESERVED | the principal parameter; nothing more |
@@ -243,8 +244,10 @@ The cache is keyed per connection, so two accounts never share a token, and a st
 starts cold with an empty cache.
 
 **Not every upstream credential is an OAuth token, and the ones that are not are weaker in two
-ways.** iCloud takes an app-specific password; GitHub and Slack take a token the operator generates
-and pastes, because neither vendor's MCP server will register a client for us (ADR-033). Such a
+ways.** iCloud takes an app-specific password; GitHub, Slack and Discord take a token the operator
+generates and pastes — the first two because neither vendor's MCP server will register a client
+for us (ADR-033), Discord because its bot token is a property of the application rather than
+anything an OAuth exchange returns (ADR-047). Such a
 credential is long-lived and *is* persisted — there is no refresh, so the stored value is the
 credential itself rather than a means of obtaining one. Rotation is manual: `connect --replace`,
 after revoking upstream.
@@ -254,7 +257,7 @@ is about to be granted and refuses to proceed if the scopes have widened without
 `confirmScopes` is that gate. There is no equivalent here, and there cannot be: what a pasted token
 can do is chosen in the vendor's own console, and this endpoint has no way to read it back. So the
 guarantee for these providers is narrower — the policy layer still bounds what an agent may *call*,
-but the credential's own reach is the operator's to bound, at the vendor, when they create it. Both
+but the credential's own reach is the operator's to bound, at the vendor, when they create it. All three
 setup pages say so at the point the token is generated.
 
 **A Google Cloud project left in "Testing" publishing status expires refresh tokens after seven

--- a/docs/detailed/setup/discord.md
+++ b/docs/detailed/setup/discord.md
@@ -1,0 +1,217 @@
+# Connecting Discord
+
+```console
+$ lanes link connect discord --profile <profile> --target <target>
+```
+
+It asks for one thing: a bot token, which you get from Discord's developer portal. Everything
+else is choices you make in that portal and an invite link you open once per server.
+
+## What this can and cannot do
+
+Read this part first, because it decides whether the rest is worth your time.
+
+**Discord has no API for acting as your own account.** Automating a user token is "self-botting" —
+their terms forbid it and accounts get terminated for it — and the OAuth2 user scopes cover neither
+posting to a channel nor reading its history. Every legitimate integration acts as an
+*application*, and an application's messages carry an `APP` badge next to the name. There is no
+setting, permission, or endpoint that removes it.
+
+What you *can* control is the name and the avatar. Two ways:
+
+- **As the application.** `discord_create_message` posts under the application's own name and
+  icon, which you set once in the portal. Set them to your name and photo and posts read as you,
+  with the badge.
+- **As anything, per message.** `discord_execute_webhook` takes `username` and `avatar_url` on each
+  call, so one channel can carry posts under different names. This is the closer match to "post as
+  myself" and it needs a webhook, which is a two-call setup per channel. See
+  [Posting under your own name](#posting-under-your-own-name).
+
+Reading is the other half, and it has one gate that will waste an afternoon if you miss it: the
+**Message Content intent**. Without it every message you read comes back with an empty `content`,
+the call still returns `200`, and nothing anywhere says why.
+
+## Why a token rather than OAuth
+
+Discord does have OAuth2, and it does not help. Authorising with the `bot` scope installs your
+application into a server, but the credential that then calls the API is the application's *bot
+token* — a property of the app, not something the token exchange hands back. So a browser flow
+would end with you copying a token out of the portal regardless.
+
+The one scope that returns a usable credential, `webhook.incoming`, is write-only to a single
+channel. It cannot read, so it cannot do triage.
+
+That leaves the token you generate yourself — the same conclusion GitHub reached, though for a
+reason that no longer applies: GitHub's was a callback port a vendor would not accept, which
+[ADR-045](../adr/045-a-redirect-the-vendor-matches-exactly.md) has since fixed. Discord's reason is
+about where the credential lives and is not ours to fix
+([ADR-033](../adr/033-a-pasted-token-for-an-mcp-server.md),
+[ADR-047](../adr/047-a-pasted-token-carries-its-own-scheme.md)).
+
+## The application
+
+1. Open <https://discord.com/developers/applications> and choose **New Application**. The name you
+   give it is the name on every post, so name it what you want people to read.
+2. On **General Information**, set the icon. That is the avatar on every post. Copy the
+   **Application ID** while you are here — the invite link needs it.
+3. Open the **Bot** tab. Set the username.
+4. Still on **Bot**, under **Privileged Gateway Intents**, switch on **MESSAGE CONTENT**. An
+   application in fewer than 10,000 servers can just toggle it — there is no review and no
+   verification. Leave `PRESENCE` and `SERVER MEMBERS` off; nothing here uses them.
+5. Turn **Public Bot** off, unless you want other people able to add it to their servers.
+
+## The token
+
+On the **Bot** tab, choose **Reset Token** and copy what it shows you. Discord shows it once.
+
+**Paste it with the word `Bot` and a space in front:**
+
+```
+Bot MTIzNDU2Nzg5MDEyMzQ1Njc4.GhIjKl.mNoPqRsTuVwXyZ
+```
+
+That prefix is not decoration — it is Discord's authentication scheme, the way `Bearer` is most
+other vendors'. The stored value goes into the `Authorization` header exactly as you type it, so a
+token pasted bare produces a `401` on every call with nothing in it to say what is wrong. If
+something is refusing to authenticate, check this first.
+
+The token is stored encrypted at `discord/<connection>` in the credential store, never in config.
+
+## Inviting it to a server
+
+Take the Application ID from step 2 and open:
+
+```
+https://discord.com/oauth2/authorize?client_id=<application-id>&scope=bot&permissions=309774593088
+```
+
+Pick a server you own and authorise. Repeat per server.
+
+Those permission bits are exactly what the vendored operations need, and no more:
+
+| Permission | Why |
+|---|---|
+| View Channels | see that a channel exists at all |
+| Send Messages | `create_message` |
+| Send Messages in Threads | posting into a thread |
+| Read Message History | `list_messages`, which is the whole triage read |
+| Add Reactions | `add_my_message_reaction` |
+| Manage Messages | `create_pin` — Discord puts pinning behind this |
+| Create Public Threads | `create_thread_from_message` |
+| Manage Webhooks | `create_webhook`, `list_channel_webhooks` |
+
+There is no kick, ban, timeout, role, or channel-management bit in there, and no operation vendored
+that could use one.
+
+**A private channel needs the bot added to it separately.** Server-wide permissions do not reach a
+channel the bot cannot see — add it under the channel's own permission settings.
+
+## Posting under your own name
+
+`create_message` posts as the application. To post as *you*:
+
+1. `discord_list_channel_webhooks` on the channel. If one is already there, use it — a channel
+   holds at most 15 and there is no reason to make a second.
+2. `discord_create_webhook` if not. Keep the `id` and `token` it returns.
+3. `discord_execute_webhook` with `username` and `avatar_url` set to whatever the post should wear.
+
+**A webhook token is a credential.** Anybody holding it can post to that channel with no other
+authentication, and steps 1 and 2 both return it in their response — which means it reaches the
+agent, and whatever the agent is talking to. This is recorded as a
+[NOT-GUARANTEED row in the security model](../security.md#guarantee-status) rather than glossed
+over. It is withheld from the audit log, and it is bounded: one channel, no read access, nothing
+else.
+
+To revoke one: the channel's **Integrations → Webhooks** settings, in Discord itself. Deleting the
+webhook there invalidates the token immediately.
+
+## Which tools you get
+
+Twenty, out of 242 in Discord's API. Reads: `get_my_user`, `list_my_guilds`, `get_guild`,
+`list_guild_channels`, `get_channel`, `list_messages`, `get_message`, `list_pins`,
+`list_message_reactions_by_emoji`, `get_active_guild_threads`. Writes: `create_message`,
+`update_message`, `delete_message`, `crosspost_message`, `add_my_message_reaction`, `create_pin`,
+`create_thread_from_message`. Webhooks: `list_channel_webhooks`, `create_webhook`,
+`execute_webhook`.
+
+`connect` grants `discord.*`, which is all twenty — policy has no pattern between a whole provider
+and one exact capability. So **the vendored list is the boundary**, and it deliberately excludes
+`bulk_delete_messages`, every moderation endpoint, and everything under roles, invites and guild
+settings. A test pins the list so a spec refresh cannot widen it quietly.
+
+If you want a narrower connection, deny what you do not want:
+
+```console
+$ lanes link policy deny 'discord.delete_message' --profile <profile> --target <target>
+$ lanes link policy deny 'discord.create_webhook' --profile <profile> --target <target>
+```
+
+Deny beats allow regardless of order, so this holds even though `connect` wrote `discord.*`.
+
+There is no message search: Discord does not offer one to applications. Finding something means
+paging `list_messages` per channel with `before`/`after` and filtering yourself.
+
+Attachments are not available. Discord takes files as `multipart/form-data`, which this connector
+cannot encode — it does JSON and form-urlencoded.
+
+## Non-interactive
+
+The connection is named by a label you type, because Discord's `/users/@me` cannot be probed with
+the scheme this provider uses — so a scripted run has to supply one:
+
+```console
+$ lanes link connect discord --profile <profile> --target <target> \
+    --display-name "Announcer" --non-interactive
+```
+
+The token still has to be in the credential store first:
+
+```console
+$ printf 'Bot %s' "$DISCORD_BOT_TOKEN" | \
+    lanes link secrets set discord/main --profile <profile> --target <target>
+```
+
+Re-running `connect` with the **same** `--display-name` repairs the existing connection. A
+different label makes a second one, which is how you end up with `announcer2`.
+
+## What is recorded
+
+Every call, allowed or refused. Snowflake ids are kept — which guild, channel, message, webhook —
+along with pagination cursors and limits, so the log can answer where something went.
+
+Message bodies are not. `content`, `embeds`, `components`, `attachments`, `poll` and a thread's
+`name` are withheld and appear as type markers, because a log that reproduced them would be a
+second copy of the channel.
+
+Two deliberate exceptions:
+
+- `allowed_mentions` is **kept** on everything that posts. It is not content, it is blast radius —
+  whether a post was permitted to ping `@everyone` is exactly the thing you want in the log, and it
+  is unrecoverable once the message is edited.
+- `username` is **kept** on `execute_webhook`. A webhook post is wearing a name that is not the
+  application's, and *posted as "Announcer" in channel 123* is the entry's whole point. The
+  `webhook_token` beside it is withheld.
+
+## Troubleshooting
+
+**`401` on everything, including `get_my_user`.** The prefix, nine times out of ten — the stored
+value must start with `Bot `. Otherwise: a token invalidated by a later **Reset Token**, or a
+deleted application. Reset it and re-run `lanes link connect discord --replace`.
+
+**Reads work, every `content` is empty.** The MESSAGE CONTENT intent is off. Bot tab → Privileged
+Gateway Intents. It is not a permission on the invite and no error mentions it. Content is always
+available for messages that mention the application, messages in DMs with it, and its own
+messages — which is why this can look intermittent.
+
+**`403` on one channel, fine elsewhere.** The bot is in the server but not that channel. Add it in
+the channel's own permission settings. A private channel does not inherit.
+
+**`crosspost_message` fails.** It only works on an *announcement* channel — `type: 5` from
+`list_guild_channels` — and only on a message already posted there. It is rate limited far more
+tightly than posting, and it cannot be undone.
+
+**`create_pin` fails with `403`.** Pinning needs Manage Messages, and a channel holds at most 50
+pins.
+
+**A webhook post 400s.** Check `username` is 1–80 characters and is not "Clyde" or "Discord", both
+of which Discord refuses.

--- a/package.json
+++ b/package.json
@@ -49,8 +49,9 @@
     "typecheck": "tsc --noEmit",
     "lanes": "bun run ./src/cli/lanes.ts",
     "audit": "bun pm scan",
-    "vendor:google": "bun run ./src/providers/google/specs/vendor.ts",
-    "vendor:bunq": "bun run ./src/providers/bunq/specs/vendor.ts"
+    "vendor:bunq": "bun run ./src/providers/bunq/specs/vendor.ts",
+    "vendor:discord": "bun run ./src/providers/discord/specs/vendor.ts",
+    "vendor:google": "bun run ./src/providers/google/specs/vendor.ts"
   },
   "imports": {
     "#audit": "./src/audit/index.ts",

--- a/src/architecture.test.ts
+++ b/src/architecture.test.ts
@@ -138,7 +138,7 @@ describe('dependency direction', () => {
  * worse. What must not appear is a vendor name the code *branches on* or
  * *prints*.
  */
-const VENDORS = /\b(gmail|icloud|notion|linear|apple|google|dropbox|fastmail|reddit|bunq)\b/i;
+const VENDORS = /\b(gmail|icloud|notion|linear|apple|google|dropbox|fastmail|reddit|bunq|discord)\b/i;
 
 /**
  * Where the rule bites: the machinery a request passes through.

--- a/src/architecture.test.ts
+++ b/src/architecture.test.ts
@@ -309,7 +309,6 @@ const KNOWN_LONG = new Set([
   'connectivity/transports/dav/ical.ts',
   'deployments/adapters/gcp-secret-manager.ts',
   'profile/schema.ts',
-  'providers/google/specs/vendor.ts',
   'providers/memory/provider.ts',
   'server/endpoint.ts',
   'server/harness.ts',

--- a/src/providers/discord/discord.test.ts
+++ b/src/providers/discord/discord.test.ts
@@ -1,0 +1,166 @@
+import { describe, expect, test } from 'bun:test';
+import { readFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { discord } from './index.ts';
+import { DISCORD_HINTS } from './hints.ts';
+import { DISCORD_REDACT } from './redact.ts';
+
+/**
+ * What `cli/tools.test.ts` cannot say.
+ *
+ * That file already measures the generated surface against every http provider
+ * at once: legal property names, the size budgets, that each declared hint
+ * arrives, that each `redact` key names a real argument. None of it is repeated
+ * here.
+ *
+ * What is left is the part that is a *decision* rather than a measurement — the
+ * shape of the auth block, the absence of an identity probe, and above all which
+ * operations were vendored. That last one is the security boundary: `connect`
+ * writes a single `discord.*` policy rule, so the operation list is the only
+ * thing standing between an agent and Discord's moderation endpoints. A list
+ * cannot defend itself, so it is pinned here.
+ */
+
+const spec = JSON.parse(
+  await readFile(join(import.meta.dir, 'specs', 'discord.v10.json'), 'utf8'),
+) as {
+  servers: Array<{ url: string }>;
+  paths: Record<string, Record<string, { operationId?: string }>>;
+};
+
+const METHODS = ['get', 'post', 'put', 'patch', 'delete', 'head'];
+
+const vendored = Object.values(spec.paths)
+  .flatMap((item) => Object.entries(item))
+  .filter(([method]) => METHODS.includes(method))
+  .map(([, operation]) => operation.operationId!)
+  .sort();
+
+describe('the vendored operation list', () => {
+  test('is exactly these twenty, so adding one is a visible decision', () => {
+    // Deliberately spelled out rather than derived. A refresh that picks up a
+    // new operation should fail here and be read, not merge quietly — the list
+    // *is* the policy, because `discord.*` grants whatever is in it.
+    expect(vendored).toEqual([
+      'add_my_message_reaction',
+      'create_message',
+      'create_pin',
+      'create_thread_from_message',
+      'create_webhook',
+      'crosspost_message',
+      'delete_message',
+      'execute_webhook',
+      'get_active_guild_threads',
+      'get_channel',
+      'get_guild',
+      'get_message',
+      'get_my_user',
+      'list_channel_webhooks',
+      'list_guild_channels',
+      'list_message_reactions_by_emoji',
+      'list_messages',
+      'list_my_guilds',
+      'list_pins',
+      'update_message',
+    ]);
+  });
+
+  test('excludes moderation and mass deletion, which exist upstream', () => {
+    // Every id here is real in Discord's document, so this asserts a choice
+    // rather than a typo. `bulk_delete_messages` is the one to watch: it sits
+    // beside `delete_message` in the spec and would let one call clear a channel.
+    for (const refused of [
+      'bulk_delete_messages',
+      'delete_channel',
+      'ban_user_from_guild',
+      'delete_guild_member',
+      'update_guild',
+      'update_guild_member',
+      'create_guild_role',
+      'delete_webhook',
+      'deprecated_delete_pin',
+    ]) {
+      expect(vendored).not.toContain(refused);
+    }
+  });
+
+  test('every operation carries a hint and a redaction rule', () => {
+    // Discord describes 17 of its 242 operations, none of them ours, so a hint
+    // is not decoration — it is the only description an agent gets. And an
+    // operation with no `redact` entry logs nothing but type markers.
+    expect(Object.keys(DISCORD_HINTS).sort()).toEqual(vendored);
+    expect(Object.keys(DISCORD_REDACT).sort()).toEqual(vendored);
+  });
+});
+
+describe('the manifest', () => {
+  test('reaches the host the vendored spec names', () => {
+    expect(discord.connector.kind).toBe('http');
+    const base = discord.connector.kind === 'http' ? discord.connector.base_url : '';
+    expect(base).toBe(spec.servers[0]!.url);
+  });
+
+  test('sends the credential as a raw Authorization header, not as a bearer token', () => {
+    // Discord's scheme word is `Bot`, and a bearer credential is assembled as
+    // `Bearer <token>` with no way to say otherwise. `header` writes the stored
+    // value verbatim, so the scheme travels inside the value the operator pastes.
+    expect(discord.auth.kind).toBe('header');
+    expect(discord.auth.kind === 'header' ? discord.auth.header : undefined).toBe('Authorization');
+  });
+
+  test('asks for the token once, secretly, and spells out the prefix', () => {
+    // Only the first prompt's answer is stored for a non-basic credential, so a
+    // second prompt would be collected and silently dropped.
+    const prompts = discord.setup?.prompts ?? [];
+    expect(prompts.map((prompt) => prompt.key)).toEqual(['token']);
+    expect(prompts[0]?.scope).toBe('connection');
+    expect(prompts[0]?.secret).toBe(true);
+    // The whole mitigation for a footgun: a token pasted bare 401s with nothing
+    // to read, so the label is where it gets said.
+    expect(prompts[0]?.label).toContain('Bot');
+    expect(discord.setup?.troubleshooting).toContain('Bot ');
+  });
+
+  test('declares no identity, because the probe would send the wrong scheme', () => {
+    // `resolveAccount` sends `Authorization: Bearer <stored value>`, which here
+    // would be `Bearer Bot MTIz…` — a 401 and a null after a round trip, on
+    // every connect. Naming the connection falls to the operator instead.
+    expect(discord.identity).toBeUndefined();
+  });
+
+  test('tells the operator to switch the message content intent on', () => {
+    // Reads succeed without it and return empty bodies, which is the failure
+    // nothing else reports. It has to be in the walkthrough.
+    const steps = (discord.setup?.steps ?? []).join(' ');
+    expect(steps).toContain('MESSAGE CONTENT');
+    expect(discord.setup?.troubleshooting).toContain('MESSAGE CONTENT');
+  });
+});
+
+describe('redaction', () => {
+  test('never keeps a webhook token, which is a credential in a path parameter', () => {
+    // `execute_webhook` authenticates with a token in its URL. Keeping it would
+    // write a reusable channel-posting credential into the audit log in clear.
+    for (const [capability, kept] of Object.entries(DISCORD_REDACT)) {
+      expect(kept, `${capability} keeps webhook_token`).not.toContain('webhook_token');
+    }
+  });
+
+  test('withholds message bodies while keeping where the message went', () => {
+    for (const posting of ['create_message', 'update_message', 'execute_webhook']) {
+      const kept = DISCORD_REDACT[posting]!;
+      for (const content of ['content', 'embeds', 'components', 'attachments', 'poll']) {
+        expect(kept, `${posting} keeps ${content}`).not.toContain(content);
+      }
+      // Not content, and the one fact about a post that is unrecoverable once it
+      // is edited: whether it was allowed to ping the room.
+      expect(kept).toContain('allowed_mentions');
+    }
+
+    expect(DISCORD_REDACT['create_message']).toContain('channel_id');
+    expect(DISCORD_REDACT['execute_webhook']).toContain('webhook_id');
+    // A webhook post deliberately wears a name that is not the app's, so the
+    // log is illegible without it.
+    expect(DISCORD_REDACT['execute_webhook']).toContain('username');
+  });
+});

--- a/src/providers/discord/hints.ts
+++ b/src/providers/discord/hints.ts
@@ -1,0 +1,195 @@
+/**
+ * The documentation, because Discord's spec has none.
+ *
+ * Their OpenAPI document is machine-generated and carries a `summary` or
+ * `description` on 17 of its 242 operations — none of them ours. So
+ * `mcp-from-openapi` synthesises `POST /channels/{channel_id}/messages` and that
+ * is the *entire* description an agent would otherwise read. A hint is appended
+ * to it, which here means a hint is the whole of it.
+ *
+ * Every operation therefore gets one, including the ones whose names look
+ * self-explanatory. Two reasons. The names are self-explanatory to someone who
+ * already knows Discord's model, and the model has sharp edges — a channel id is
+ * not a channel name, `list_messages` pages backwards, an announcement is only
+ * publishable from one kind of channel. And `cli/tools.test.ts` looks each hint
+ * up by capability name, so a full set is also the check that all twenty tools
+ * generated: a hint keyed to a tool that silently failed to generate fails the
+ * suite, which is the one failure the size and shape tests cannot see.
+ *
+ * Prose costs 3.4 KB of a 192 KB surface budget. It is not the constraint.
+ */
+export const DISCORD_HINTS: Record<string, string> = {
+  get_my_user: [
+    'Returns the bot application this token belongs to — its id, username, and discriminator.',
+    'Costs nothing and needs no permissions, so it is the call to make first when a connection',
+    'is misbehaving: a 401 here means the stored token is wrong or is missing its `Bot ` prefix,',
+    'and everything else will fail the same way.',
+  ].join(' '),
+
+  list_my_guilds: [
+    'The servers this bot has been added to — not the servers you are a member of.',
+    'A server the bot was never invited to is invisible here and unreachable by every other',
+    'tool, so an empty list means the invite step was missed rather than that you have no servers.',
+    'Returns id, name, and your permissions in each. Start here to turn a server name into the',
+    'id every other call wants.',
+  ].join(' '),
+
+  get_guild: [
+    'One server by id: name, description, icon, owner, and feature flags.',
+    'Pass `with_counts: true` to also get approximate member and presence counts.',
+    'Use this to confirm you have the right server before posting to it.',
+  ].join(' '),
+
+  list_guild_channels: [
+    'Every channel in a server, which is how a channel *name* becomes the `channel_id`',
+    'the posting and reading tools require. Check the `type` field before posting:',
+    '0 is a normal text channel, 5 is an announcement channel (the only kind',
+    '`crosspost_message` works on), 15 is a forum, and 2 and 13 are voice and stage,',
+    'which cannot take messages. `parent_id` is the category a channel sits under.',
+  ].join(' '),
+
+  get_channel: [
+    'One channel by id — its name, type, topic, and which category it belongs to.',
+    'Worth calling before a first post to a channel an agent has not written to before,',
+    'to confirm it is the one intended and that it takes messages at all.',
+  ].join(' '),
+
+  list_messages: [
+    'Read a channel\'s recent messages. This is the triage read, and the only one:',
+    'Discord exposes no message search to bot applications, so finding something means',
+    'paging this and filtering yourself.',
+    'Newest first by default, up to `limit: 100` per call. Page *backwards* through history',
+    'with `before` set to the oldest id you have seen; page forward for new arrivals with',
+    '`after` set to the newest. `around` centres on one message.',
+    'If every `content` comes back empty, the Message Content intent is switched off for',
+    'this application — that is a toggle in the developer portal, not a permission on the',
+    'invite, and nothing else reports it.',
+  ].join(' '),
+
+  get_message: [
+    'One message by id, with its author, timestamp, attachments, reactions, and any embeds.',
+    'Use it to re-read a single message in full after `list_messages` has narrowed things down,',
+    'or to check whether an edit or a reaction landed.',
+  ].join(' '),
+
+  list_pins: [
+    'The pinned messages in a channel. Pinning is how this integration marks something as',
+    'handled or important where a human will see it, so this is the read that shows what',
+    'has been marked. Note the path is the current one — Discord also serves a deprecated',
+    'pins endpoint that is not exposed here.',
+  ].join(' '),
+
+  list_message_reactions_by_emoji: [
+    'Who reacted to a message with one specific emoji. Pass a Unicode emoji directly',
+    '(`emoji_name: "✅"`); a custom server emoji is `name:id`.',
+    'Useful for reading a lightweight vote or acknowledgement off a message rather than',
+    'asking people to reply.',
+  ].join(' '),
+
+  get_active_guild_threads: [
+    'Every thread in a server that is not archived, across all channels at once.',
+    'Cheaper than walking channels one at a time when the question is "what conversations',
+    'are open right now", which is the usual first step of a triage pass.',
+  ].join(' '),
+
+  create_message: [
+    'Post a message to a channel, as the bot application — it will carry an APP badge',
+    'and the application\'s own name and avatar. To post under your own name instead,',
+    'use `execute_webhook`.',
+    'For a plain message, pass `content` (up to 2000 characters, Discord-flavoured markdown).',
+    'For an announcement, prefer `embeds`: an embed gives you a title, a coloured left border,',
+    'a description, and up to 25 name/value `fields`, and it is what makes a post read as',
+    'deliberate rather than typed. `color` is a decimal integer, not a hex string —',
+    '0x5865F2 is 5793266.',
+    'Set `allowed_mentions` explicitly on anything that could ping a room:',
+    '`{"parse": []}` suppresses every mention even if the text contains @everyone.',
+    'Reply to something by passing `message_reference` with the message id.',
+    'Attachments are not available here — files need a multipart request, which Discord accepts',
+    'and this connector cannot encode.',
+  ].join(' '),
+
+  update_message: [
+    'Edit a message this application posted. It cannot edit anyone else\'s, including one',
+    'posted through a webhook — that needs the webhook\'s own edit endpoint.',
+    'This is the typo fix for an announcement already out. Only the fields you pass are',
+    'changed; passing `content` alone leaves existing embeds in place, and clearing an',
+    'embed means passing `embeds: []` explicitly.',
+    'Discord shows an "edited" marker afterwards, which cannot be suppressed.',
+  ].join(' '),
+
+  delete_message: [
+    'Delete a message — the retraction, for an announcement that should not have gone out.',
+    'Irreversible, and it leaves no trace in the channel for anyone who had not already read it.',
+    'The application can always delete its own messages; deleting somebody else\'s needs',
+    'Manage Messages in that channel.',
+    'There is deliberately no bulk delete here: this removes one message named by id, so',
+    'clearing a channel is not something an agent can do in one call.',
+  ].join(' '),
+
+  crosspost_message: [
+    'Publish a message that was posted in an *announcement* channel out to every server',
+    'that follows it. This is what makes an announcement channel worth using: subscribers',
+    'see the post in their own server without joining yours.',
+    'Only works on channel `type: 5`, and only on a message already posted there — so the',
+    'sequence is `create_message` then this, with the id it returned.',
+    'Rate limited far more tightly than posting, and it cannot be undone.',
+  ].join(' '),
+
+  add_my_message_reaction: [
+    'React to a message as this application. The cheapest way to mark a message as seen,',
+    'triaged, or categorised — a ✅ or 👀 costs nothing, notifies nobody, and is visible',
+    'to everyone reading the channel.',
+    'Pass a Unicode emoji directly (`emoji_name: "✅"`); a custom server emoji is `name:id`.',
+    'Remove one with the matching delete tool, which is not exposed here.',
+  ].join(' '),
+
+  create_pin: [
+    'Pin a message to its channel, where it stays visible in the channel\'s pinned list.',
+    'The heavier alternative to a reaction for marking something important: a pin is',
+    'channel-wide and appears in the header, so it is the right weight for "this is the',
+    'announcement that matters" and the wrong weight for routine triage.',
+    'Needs Manage Messages. A channel holds at most 50 pins.',
+  ].join(' '),
+
+  create_thread_from_message: [
+    'Start a thread hanging off an existing message, which is how a post becomes a',
+    'discussion without cluttering the channel. `name` is the thread title and is required.',
+    '`auto_archive_duration` is in minutes and accepts only 60, 1440, 4320, or 10080.',
+    'Use this to route a triaged message somewhere people can talk about it, rather than',
+    'replying inline where it scrolls away.',
+  ].join(' '),
+
+  list_channel_webhooks: [
+    'The webhooks already configured on a channel, with their ids and tokens.',
+    'Check here before calling `create_webhook`: a channel accumulates a webhook per call',
+    'and there is a limit of 15, so reusing the one you made last time is the difference',
+    'between a working integration and a channel full of clutter.',
+    'Needs Manage Webhooks. The response includes each webhook\'s token, which is a',
+    'credential — see the note on `execute_webhook`.',
+  ].join(' '),
+
+  create_webhook: [
+    'Create a webhook on a channel, which is what makes posting under your own name',
+    'possible. Do this once per channel and keep the id and token; call',
+    '`list_channel_webhooks` first to find an existing one rather than making another.',
+    '`name` is a fallback label only — the name and avatar that actually appear are the',
+    'ones passed per message to `execute_webhook`. `avatar` takes a base64 data URI,',
+    'not a URL, and is optional.',
+    'Needs Manage Webhooks. The returned `token` is a standalone credential: anybody',
+    'holding it can post to this channel without any other authentication.',
+  ].join(' '),
+
+  execute_webhook: [
+    'Post through a webhook, setting the name and avatar on the message itself.',
+    'This is how an announcement appears under your own name rather than the',
+    'application\'s: pass `username` and `avatar_url` and the message wears them.',
+    'It still carries an APP badge — Discord has no way to remove that, and no API for',
+    'posting as a real user account.',
+    'Takes the same `content` and `embeds` as `create_message`. Pass `wait: true` to get',
+    'the created message back, which is the only way to learn its id.',
+    '`thread_id` posts into an existing thread in the webhook\'s channel.',
+    'Note what this cannot do: a webhook only posts. It cannot read the channel, and the',
+    'message it creates cannot be edited by `update_message` — a webhook message is',
+    'editable only through the webhook that sent it.',
+  ].join(' '),
+};

--- a/src/providers/discord/index.ts
+++ b/src/providers/discord/index.ts
@@ -1,0 +1,121 @@
+import { defineProvider } from '#connectivity';
+import { DISCORD_HINTS } from './hints.ts';
+import { DISCORD_REDACT } from './redact.ts';
+
+/**
+ * Discord asks callers to identify themselves and blocks the ones that do not.
+ *
+ * Their documented format is `DiscordBot ($url, $version)`, and a request with a
+ * generic or absent agent is refused at the edge rather than by the API — so it
+ * presents as a network failure with no JSON to read. `connector.headers` on an
+ * `http` connector is what carries it (ADR-045 added the field for the same
+ * problem at Reddit).
+ *
+ * No handle or address in it: this file is public, and `architecture.test.ts`
+ * refuses a real identifier anywhere a reader can see. A name and a URL are what
+ * the check actually looks for.
+ */
+const DISCORD_USER_AGENT = 'DiscordBot (https://lanes.sh/link, 0.3)';
+
+/** The vendored spec sits beside this file. See `specs/vendor.ts`. */
+function specPath(name: string): string {
+  return new URL(`./specs/${name}`, import.meta.url).pathname;
+}
+
+/**
+ * Discord's v10 HTTP API, reached with a bot token the operator pasted.
+ *
+ * There is no user-account path and it is not for want of looking. Discord
+ * publishes no API for acting as yourself: automating a user token is
+ * self-botting, which their terms forbid and which gets accounts terminated, and
+ * the OAuth2 user scopes cover neither posting to a channel nor reading its
+ * history. Everything an integration can legitimately do, it does as an
+ * application. So a message will always carry an APP badge — that part is not
+ * negotiable — but the *name and avatar* on it are, per message, through a
+ * webhook. `execute_webhook` is why the three webhook operations are vendored:
+ * an announcement can read as the operator while an ordinary reply reads as the
+ * integration, from the one token.
+ *
+ * Not OAuth, and for a reason of its own rather than the one ADR-033 gave. That
+ * reason — a vendor matching its callback URL exactly, against a port the kernel
+ * picks — was withdrawn by ADR-045, which added `auth.redirect_uri`; so it is no
+ * longer an argument for a pasted token anywhere. What holds here is narrower and
+ * not fixable on our side: a Discord OAuth2 flow with the `bot` scope installs an
+ * application into a server, but the credential that then calls the API is the
+ * *application's* bot token, a property of the app rather than anything the
+ * exchange returns — so a browser flow would end with the operator still copying
+ * a token out of the developer portal. The `webhook.incoming` scope does return a
+ * usable credential, and it is write-only to a single channel: it cannot read, so
+ * it cannot serve the half of this that is triage.
+ *
+ * `auth.kind` is `header` rather than `bearer` because Discord's scheme word is
+ * `Bot`, not `Bearer`, and a bearer credential is assembled as `Bearer <token>`
+ * with no way to say otherwise. `header` writes the stored value into
+ * `Authorization` verbatim, so the value the operator pastes carries its own
+ * scheme — `Bot MTIz…`. That keeps the whole provider inside this folder at the
+ * cost of a prefix somebody can forget, which is why the prompt label spells it
+ * out and `troubleshooting` names it as the first thing to check.
+ *
+ * No `identity` block, and its absence is deliberate rather than an omission.
+ * The probe sends `Authorization: Bearer <stored value>`, which for this
+ * provider would be `Bearer Bot MTIz…` — a 401 and a null, after a network round
+ * trip, every single connect. Naming the connection falls to the operator
+ * instead. Re-running `connect` with the *same* label repairs the existing
+ * connection rather than adding a second one, because `settleIdentity` matches
+ * on the label; a scripted run passes `--display-name`.
+ */
+export const discord = defineProvider({
+  id: 'discord',
+  name: 'Discord',
+  description:
+    'Post announcements, read channels, and triage messages in the servers your bot has been added to, via the Discord v10 HTTP API.',
+  connector: {
+    kind: 'http',
+    base_url: 'https://discord.com/api/v10',
+    // Vendored, not fetched, and doubly so here: upstream is a public preview
+    // Discord says may break without notice, and `connect` grants everything a
+    // provider discovers. See `specs/vendor.ts`.
+    openapi: specPath('discord.v10.json'),
+    headers: { 'User-Agent': DISCORD_USER_AGENT },
+  },
+  auth: { kind: 'header', header: 'Authorization' },
+  redact: DISCORD_REDACT,
+  hints: DISCORD_HINTS,
+  setup: {
+    summary:
+      'Discord authenticates an integration as an application, not as you. You create one in ' +
+      'their developer portal, copy its bot token, and invite it to the servers you want ' +
+      'reachable. Posts will carry an APP badge; the name and avatar on them are yours to set. ' +
+      'You are asked for the token once.',
+    docs: 'docs/detailed/setup/discord.md',
+    docs_url: 'https://discord.com/developers/applications',
+    steps: [
+      'Open https://discord.com/developers/applications and choose "New Application". Name it whatever you want the posts to read as — this is the name people will see.',
+      'On the General Information page, set the icon. That is the avatar posts will carry.',
+      'Open the Bot tab. Set the username, then under "Privileged Gateway Intents" switch on MESSAGE CONTENT — without it every message you read comes back with an empty body, and nothing else will tell you why. An app in fewer than 10,000 servers can just toggle it; there is no review.',
+      'Still on the Bot tab, choose "Reset Token" and copy what it shows you. Discord shows it once. Paste it below prefixed with the word Bot and a space, exactly as: Bot MTIzNDU2Nzg5.abcdef',
+      'Turn off "Public Bot" on the same page unless you want strangers adding it to their servers.',
+      'Now invite it. Take the Application ID from General Information and open: https://discord.com/oauth2/authorize?client_id=<application-id>&scope=bot&permissions=309774593088',
+      'Pick a server you own and authorise. Those permission bits are exactly what the vendored operations need: view channels, send messages, manage messages (for pinning), read message history, add reactions, create public threads, send in threads, and manage webhooks. Repeat per server.',
+      'A private channel needs the bot added to it as well — server-wide permissions do not reach a channel it cannot see.',
+      'To rotate: "Reset Token" in the portal, then run: lanes link connect discord --replace',
+    ],
+    troubleshooting:
+      'Discord refused the token. Check the prefix first — the stored value must begin with ' +
+      '"Bot " and a token pasted bare is the usual cause of a 401 that names nothing. ' +
+      'After that: a token invalidated by a later "Reset Token", or an application that was ' +
+      'deleted. If calls authenticate but a channel 403s, the bot is in the server but not ' +
+      'that channel, or the invite was authorised without the permissions above. If reads ' +
+      'succeed and every message body is empty, the MESSAGE CONTENT intent is off. ' +
+      'Reset the token at https://discord.com/developers/applications and re-run: ' +
+      'lanes link connect discord --replace',
+    prompts: [
+      {
+        key: 'token',
+        label: 'Discord bot token, prefixed — Bot <token>',
+        secret: true,
+        scope: 'connection' as const,
+      },
+    ],
+  },
+});

--- a/src/providers/discord/redact.ts
+++ b/src/providers/discord/redact.ts
@@ -1,0 +1,99 @@
+/**
+ * What survives into the audit log when Discord is read or posted to.
+ *
+ * The default withholds every value, which for a write log means recording that
+ * something was posted somewhere without recording where — so every operation
+ * here names its identifiers explicitly. Snowflake ids are kept throughout:
+ * which guild, which channel, which message, which webhook. Pagination cursors
+ * and limits are kept too, because "read 50 messages after this one" is the
+ * whole shape of a triage pass and none of it is anybody's content.
+ *
+ * Message bodies are withheld. `content`, `embeds`, `components`, `attachments`,
+ * `poll`, and a thread's `name` are the operator's own words, and a log that
+ * reproduces them is a second copy of the channel.
+ *
+ * Two departures worth stating.
+ *
+ * `allowed_mentions` is **kept** on every operation that posts. It is not
+ * content, it is the blast radius: whether a post was allowed to ping
+ * `@everyone` is exactly the fact an operator wants in the log, and it is
+ * unrecoverable from anywhere else once the message is edited or deleted.
+ *
+ * `username` is **kept** on `execute_webhook` and `webhook_token` is not.
+ * Keeping the username is what makes the log legible — a webhook post is
+ * deliberately wearing a name that is not the app's, and "posted as Ops in
+ * channel 123" answers the question the entry exists for. The token is a
+ * standalone credential for posting to that channel, so it is withheld by
+ * omission and appears as a type marker; `avatar_url` goes the same way for
+ * being cosmetic rather than a fact about what happened.
+ */
+export const DISCORD_REDACT: Record<string, string[]> = {
+  // Reads. Everything an argument can be here is an id, a cursor, or a count.
+  get_my_user: [],
+  list_my_guilds: ['before', 'after', 'limit', 'with_counts'],
+  get_guild: ['guild_id', 'with_counts'],
+  list_guild_channels: ['guild_id'],
+  get_channel: ['channel_id'],
+  list_messages: ['channel_id', 'around', 'before', 'after', 'limit'],
+  get_message: ['channel_id', 'message_id'],
+  list_pins: ['channel_id', 'before', 'limit'],
+  list_message_reactions_by_emoji: [
+    'channel_id',
+    'message_id',
+    'emoji_name',
+    'after',
+    'limit',
+    'type',
+  ],
+  get_active_guild_threads: ['guild_id'],
+
+  // Posting. `content`, `embeds`, `components`, `attachments`, `poll`, and
+  // `shared_client_theme` are withheld by omission.
+  create_message: [
+    'channel_id',
+    'allowed_mentions',
+    'message_reference',
+    'sticker_ids',
+    'flags',
+    'tts',
+    'nonce',
+    'enforce_nonce',
+  ],
+  update_message: [
+    'channel_id',
+    'message_id',
+    'allowed_mentions',
+    'sticker_ids',
+    'flags',
+  ],
+  delete_message: ['channel_id', 'message_id'],
+  crosspost_message: ['channel_id', 'message_id'],
+
+  // Triage marking. An emoji is a reaction, not private content, and which one
+  // was used is the entire meaning of the action.
+  add_my_message_reaction: ['channel_id', 'message_id', 'emoji_name'],
+  create_pin: ['channel_id', 'message_id'],
+  // `name` withheld: a thread title is the operator's words.
+  create_thread_from_message: [
+    'channel_id',
+    'message_id',
+    'auto_archive_duration',
+    'rate_limit_per_user',
+  ],
+
+  // Webhooks. `avatar` on creation is base64 image bytes; withholding it is the
+  // same call `gmail.send_message` makes about attachments.
+  list_channel_webhooks: ['channel_id'],
+  create_webhook: ['channel_id', 'name'],
+  execute_webhook: [
+    'webhook_id',
+    'username',
+    'thread_id',
+    'allowed_mentions',
+    'applied_tags',
+    'with_components',
+    'wait',
+    'flags',
+    'tts',
+  ],
+};

--- a/src/providers/discord/specs/discord.v10.json
+++ b/src/providers/discord/specs/discord.v10.json
@@ -1,0 +1,2333 @@
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "Discord HTTP API (Preview)",
+    "description": "Preview of the Discord v10 HTTP API specification. See https://discord.com/developers/docs for more details.",
+    "termsOfService": "https://discord.com/developers/docs/policies-and-agreements/developer-terms-of-service",
+    "license": {
+      "name": "MIT",
+      "identifier": "MIT"
+    },
+    "version": "10",
+    "x-vendored-from": "https://raw.githubusercontent.com/discord/discord-api-spec/main/specs/openapi.json",
+    "x-vendored-note": "Trimmed by src/providers/discord/specs/vendor.ts. Committed deliberately: upstream is a public preview that may change without notice, and a spec decides which paths are called with the operator bot token — so it must be reviewable rather than fetched at connect time."
+  },
+  "servers": [
+    {
+      "url": "https://discord.com/api/v10"
+    }
+  ],
+  "paths": {
+    "/channels/{channel_id}": {
+      "get": {
+        "operationId": "get_channel",
+        "responses": {
+          "200": {
+            "description": "Success. The response body is returned verbatim."
+          }
+        },
+        "security": [
+          {
+            "BotToken": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "channel_id",
+            "in": "path",
+            "schema": {
+              "$ref": "#/components/schemas/SnowflakeType"
+            },
+            "required": true
+          }
+        ]
+      }
+    },
+    "/channels/{channel_id}/messages": {
+      "get": {
+        "operationId": "list_messages",
+        "parameters": [
+          {
+            "name": "channel_id",
+            "in": "path",
+            "schema": {
+              "$ref": "#/components/schemas/SnowflakeType"
+            },
+            "required": true
+          },
+          {
+            "name": "around",
+            "in": "query",
+            "schema": {
+              "$ref": "#/components/schemas/SnowflakeType"
+            }
+          },
+          {
+            "name": "before",
+            "in": "query",
+            "schema": {
+              "$ref": "#/components/schemas/SnowflakeType"
+            }
+          },
+          {
+            "name": "after",
+            "in": "query",
+            "schema": {
+              "$ref": "#/components/schemas/SnowflakeType"
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 100
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success. The response body is returned verbatim."
+          }
+        },
+        "security": [
+          {
+            "BotToken": []
+          }
+        ]
+      },
+      "post": {
+        "operationId": "create_message",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/MessageCreateRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Success. The response body is returned verbatim."
+          }
+        },
+        "security": [
+          {
+            "BotToken": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "channel_id",
+            "in": "path",
+            "schema": {
+              "$ref": "#/components/schemas/SnowflakeType"
+            },
+            "required": true
+          }
+        ]
+      }
+    },
+    "/channels/{channel_id}/messages/pins": {
+      "get": {
+        "operationId": "list_pins",
+        "parameters": [
+          {
+            "name": "channel_id",
+            "in": "path",
+            "schema": {
+              "$ref": "#/components/schemas/SnowflakeType"
+            },
+            "required": true
+          },
+          {
+            "name": "before",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "format": "date-time"
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 50
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success. The response body is returned verbatim."
+          }
+        },
+        "security": [
+          {
+            "BotToken": []
+          }
+        ]
+      }
+    },
+    "/channels/{channel_id}/messages/pins/{message_id}": {
+      "put": {
+        "operationId": "create_pin",
+        "responses": {
+          "200": {
+            "description": "Success. The response body is returned verbatim."
+          }
+        },
+        "security": [
+          {
+            "BotToken": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "channel_id",
+            "in": "path",
+            "schema": {
+              "$ref": "#/components/schemas/SnowflakeType"
+            },
+            "required": true
+          },
+          {
+            "name": "message_id",
+            "in": "path",
+            "schema": {
+              "$ref": "#/components/schemas/SnowflakeType"
+            },
+            "required": true
+          }
+        ]
+      }
+    },
+    "/channels/{channel_id}/messages/{message_id}": {
+      "get": {
+        "operationId": "get_message",
+        "responses": {
+          "200": {
+            "description": "Success. The response body is returned verbatim."
+          }
+        },
+        "security": [
+          {
+            "BotToken": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "channel_id",
+            "in": "path",
+            "schema": {
+              "$ref": "#/components/schemas/SnowflakeType"
+            },
+            "required": true
+          },
+          {
+            "name": "message_id",
+            "in": "path",
+            "schema": {
+              "$ref": "#/components/schemas/SnowflakeType"
+            },
+            "required": true
+          }
+        ]
+      },
+      "delete": {
+        "operationId": "delete_message",
+        "responses": {
+          "200": {
+            "description": "Success. The response body is returned verbatim."
+          }
+        },
+        "security": [
+          {
+            "BotToken": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "channel_id",
+            "in": "path",
+            "schema": {
+              "$ref": "#/components/schemas/SnowflakeType"
+            },
+            "required": true
+          },
+          {
+            "name": "message_id",
+            "in": "path",
+            "schema": {
+              "$ref": "#/components/schemas/SnowflakeType"
+            },
+            "required": true
+          }
+        ]
+      },
+      "patch": {
+        "operationId": "update_message",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/MessageEditRequestPartial"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Success. The response body is returned verbatim."
+          }
+        },
+        "security": [
+          {
+            "BotToken": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "channel_id",
+            "in": "path",
+            "schema": {
+              "$ref": "#/components/schemas/SnowflakeType"
+            },
+            "required": true
+          },
+          {
+            "name": "message_id",
+            "in": "path",
+            "schema": {
+              "$ref": "#/components/schemas/SnowflakeType"
+            },
+            "required": true
+          }
+        ]
+      }
+    },
+    "/channels/{channel_id}/messages/{message_id}/crosspost": {
+      "post": {
+        "operationId": "crosspost_message",
+        "responses": {
+          "200": {
+            "description": "Success. The response body is returned verbatim."
+          }
+        },
+        "security": [
+          {
+            "BotToken": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "channel_id",
+            "in": "path",
+            "schema": {
+              "$ref": "#/components/schemas/SnowflakeType"
+            },
+            "required": true
+          },
+          {
+            "name": "message_id",
+            "in": "path",
+            "schema": {
+              "$ref": "#/components/schemas/SnowflakeType"
+            },
+            "required": true
+          }
+        ]
+      }
+    },
+    "/channels/{channel_id}/messages/{message_id}/reactions/{emoji_name}": {
+      "get": {
+        "operationId": "list_message_reactions_by_emoji",
+        "parameters": [
+          {
+            "name": "channel_id",
+            "in": "path",
+            "schema": {
+              "$ref": "#/components/schemas/SnowflakeType"
+            },
+            "required": true
+          },
+          {
+            "name": "message_id",
+            "in": "path",
+            "schema": {
+              "$ref": "#/components/schemas/SnowflakeType"
+            },
+            "required": true
+          },
+          {
+            "name": "emoji_name",
+            "in": "path",
+            "schema": {
+              "type": "string",
+              "maxLength": 152133
+            },
+            "required": true
+          },
+          {
+            "name": "after",
+            "in": "query",
+            "schema": {
+              "$ref": "#/components/schemas/SnowflakeType"
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 100
+            }
+          },
+          {
+            "name": "type",
+            "in": "query",
+            "schema": {
+              "$ref": "#/components/schemas/ReactionTypes"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success. The response body is returned verbatim."
+          }
+        },
+        "security": [
+          {
+            "BotToken": []
+          }
+        ]
+      }
+    },
+    "/channels/{channel_id}/messages/{message_id}/reactions/{emoji_name}/@me": {
+      "put": {
+        "operationId": "add_my_message_reaction",
+        "responses": {
+          "200": {
+            "description": "Success. The response body is returned verbatim."
+          }
+        },
+        "security": [
+          {
+            "BotToken": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "channel_id",
+            "in": "path",
+            "schema": {
+              "$ref": "#/components/schemas/SnowflakeType"
+            },
+            "required": true
+          },
+          {
+            "name": "message_id",
+            "in": "path",
+            "schema": {
+              "$ref": "#/components/schemas/SnowflakeType"
+            },
+            "required": true
+          },
+          {
+            "name": "emoji_name",
+            "in": "path",
+            "schema": {
+              "type": "string",
+              "maxLength": 152133
+            },
+            "required": true
+          }
+        ]
+      }
+    },
+    "/channels/{channel_id}/messages/{message_id}/threads": {
+      "post": {
+        "operationId": "create_thread_from_message",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateTextThreadWithMessageRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Success. The response body is returned verbatim."
+          }
+        },
+        "security": [
+          {
+            "BotToken": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "channel_id",
+            "in": "path",
+            "schema": {
+              "$ref": "#/components/schemas/SnowflakeType"
+            },
+            "required": true
+          },
+          {
+            "name": "message_id",
+            "in": "path",
+            "schema": {
+              "$ref": "#/components/schemas/SnowflakeType"
+            },
+            "required": true
+          }
+        ]
+      }
+    },
+    "/channels/{channel_id}/webhooks": {
+      "get": {
+        "operationId": "list_channel_webhooks",
+        "responses": {
+          "200": {
+            "description": "Success. The response body is returned verbatim."
+          }
+        },
+        "security": [
+          {
+            "BotToken": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "channel_id",
+            "in": "path",
+            "schema": {
+              "$ref": "#/components/schemas/SnowflakeType"
+            },
+            "required": true
+          }
+        ]
+      },
+      "post": {
+        "operationId": "create_webhook",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "name": {
+                    "type": "string",
+                    "minLength": 1,
+                    "maxLength": 80
+                  },
+                  "avatar": {
+                    "type": [
+                      "string",
+                      "null"
+                    ],
+                    "contentEncoding": "base64"
+                  }
+                },
+                "required": [
+                  "name"
+                ]
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Success. The response body is returned verbatim."
+          }
+        },
+        "security": [
+          {
+            "BotToken": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "channel_id",
+            "in": "path",
+            "schema": {
+              "$ref": "#/components/schemas/SnowflakeType"
+            },
+            "required": true
+          }
+        ]
+      }
+    },
+    "/guilds/{guild_id}": {
+      "get": {
+        "operationId": "get_guild",
+        "parameters": [
+          {
+            "name": "guild_id",
+            "in": "path",
+            "schema": {
+              "$ref": "#/components/schemas/SnowflakeType"
+            },
+            "required": true
+          },
+          {
+            "name": "with_counts",
+            "in": "query",
+            "schema": {
+              "type": "boolean"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success. The response body is returned verbatim."
+          }
+        },
+        "security": [
+          {
+            "BotToken": []
+          }
+        ]
+      }
+    },
+    "/guilds/{guild_id}/channels": {
+      "get": {
+        "operationId": "list_guild_channels",
+        "responses": {
+          "200": {
+            "description": "Success. The response body is returned verbatim."
+          }
+        },
+        "security": [
+          {
+            "BotToken": []
+          },
+          {
+            "OAuth2": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "guild_id",
+            "in": "path",
+            "schema": {
+              "$ref": "#/components/schemas/SnowflakeType"
+            },
+            "required": true
+          }
+        ]
+      }
+    },
+    "/guilds/{guild_id}/threads/active": {
+      "get": {
+        "operationId": "get_active_guild_threads",
+        "responses": {
+          "200": {
+            "description": "Success. The response body is returned verbatim."
+          }
+        },
+        "security": [
+          {
+            "BotToken": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "guild_id",
+            "in": "path",
+            "schema": {
+              "$ref": "#/components/schemas/SnowflakeType"
+            },
+            "required": true
+          }
+        ]
+      }
+    },
+    "/users/@me": {
+      "get": {
+        "operationId": "get_my_user",
+        "responses": {
+          "200": {
+            "description": "Success. The response body is returned verbatim."
+          }
+        },
+        "security": [
+          {
+            "BotToken": []
+          },
+          {
+            "OAuth2": [
+              "identify"
+            ]
+          }
+        ]
+      }
+    },
+    "/users/@me/guilds": {
+      "get": {
+        "operationId": "list_my_guilds",
+        "parameters": [
+          {
+            "name": "before",
+            "in": "query",
+            "schema": {
+              "$ref": "#/components/schemas/SnowflakeType"
+            }
+          },
+          {
+            "name": "after",
+            "in": "query",
+            "schema": {
+              "$ref": "#/components/schemas/SnowflakeType"
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 200
+            }
+          },
+          {
+            "name": "with_counts",
+            "in": "query",
+            "schema": {
+              "type": "boolean"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success. The response body is returned verbatim."
+          }
+        },
+        "security": [
+          {
+            "BotToken": []
+          },
+          {
+            "OAuth2": [
+              "guilds"
+            ]
+          }
+        ]
+      }
+    },
+    "/webhooks/{webhook_id}/{webhook_token}": {
+      "post": {
+        "operationId": "execute_webhook",
+        "parameters": [
+          {
+            "name": "webhook_id",
+            "in": "path",
+            "schema": {
+              "$ref": "#/components/schemas/SnowflakeType"
+            },
+            "required": true
+          },
+          {
+            "name": "webhook_token",
+            "in": "path",
+            "schema": {
+              "type": "string",
+              "maxLength": 152133
+            },
+            "required": true
+          },
+          {
+            "name": "wait",
+            "in": "query",
+            "schema": {
+              "type": "boolean"
+            }
+          },
+          {
+            "name": "thread_id",
+            "in": "query",
+            "schema": {
+              "$ref": "#/components/schemas/SnowflakeType"
+            }
+          },
+          {
+            "name": "with_components",
+            "in": "query",
+            "schema": {
+              "type": "boolean"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/IncomingWebhookRequestPartial"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Success. The response body is returned verbatim."
+          }
+        },
+        "security": [
+          {},
+          {
+            "BotToken": []
+          }
+        ]
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "ActionRowComponentForMessageRequest": {
+        "type": "object",
+        "additionalProperties": true,
+        "description": "A ActionRowComponentForMessageRequest. Structure omitted: this union inlines to hundreds of kilobytes. Pass the object as documented at https://discord.com/developers/docs/components/reference."
+      },
+      "AllowedMentionTypes": {
+        "type": "string",
+        "oneOf": [
+          {
+            "title": "USERS",
+            "description": "Controls role mentions",
+            "const": "users"
+          },
+          {
+            "title": "ROLES",
+            "description": "Controls user mentions",
+            "const": "roles"
+          },
+          {
+            "title": "EVERYONE",
+            "description": "Controls @everyone and @here mentions",
+            "const": "everyone"
+          }
+        ]
+      },
+      "ContainerComponentForMessageRequest": {
+        "type": "object",
+        "additionalProperties": true,
+        "description": "A ContainerComponentForMessageRequest. Structure omitted: this union inlines to hundreds of kilobytes. Pass the object as documented at https://discord.com/developers/docs/components/reference."
+      },
+      "CreateTextThreadWithMessageRequest": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 100
+          },
+          "auto_archive_duration": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/ThreadAutoArchiveDuration"
+              }
+            ]
+          },
+          "rate_limit_per_user": {
+            "type": [
+              "integer",
+              "null"
+            ],
+            "minimum": 0,
+            "maximum": 21600,
+            "format": "int32"
+          }
+        },
+        "required": [
+          "name"
+        ]
+      },
+      "CustomClientThemeShareRequest": {
+        "type": "object",
+        "properties": {
+          "colors": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "minLength": 6,
+              "maxLength": 6
+            },
+            "minItems": 1,
+            "maxItems": 5
+          },
+          "gradient_angle": {
+            "type": "integer",
+            "minimum": 0,
+            "maximum": 360,
+            "format": "int32"
+          },
+          "base_mix": {
+            "type": "integer",
+            "minimum": 0,
+            "maximum": 100,
+            "format": "int32"
+          },
+          "base_theme": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/MessageShareCustomUserThemeBaseTheme"
+              }
+            ]
+          }
+        },
+        "required": [
+          "colors",
+          "gradient_angle",
+          "base_mix"
+        ]
+      },
+      "FileComponentForMessageRequest": {
+        "type": "object",
+        "additionalProperties": true,
+        "description": "A FileComponentForMessageRequest. Structure omitted: this union inlines to hundreds of kilobytes. Pass the object as documented at https://discord.com/developers/docs/components/reference."
+      },
+      "IncomingWebhookRequestPartial": {
+        "type": "object",
+        "properties": {
+          "content": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "maxLength": 2000
+          },
+          "embeds": {
+            "type": [
+              "array",
+              "null"
+            ],
+            "items": {
+              "$ref": "#/components/schemas/RichEmbed"
+            },
+            "maxItems": 10
+          },
+          "allowed_mentions": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/MessageAllowedMentionsRequest"
+              }
+            ]
+          },
+          "components": {
+            "type": [
+              "array",
+              "null"
+            ],
+            "items": {
+              "oneOf": [
+                {
+                  "$ref": "#/components/schemas/ActionRowComponentForMessageRequest"
+                },
+                {
+                  "$ref": "#/components/schemas/ContainerComponentForMessageRequest"
+                },
+                {
+                  "$ref": "#/components/schemas/FileComponentForMessageRequest"
+                },
+                {
+                  "$ref": "#/components/schemas/MediaGalleryComponentForMessageRequest"
+                },
+                {
+                  "$ref": "#/components/schemas/SectionComponentForMessageRequest"
+                },
+                {
+                  "$ref": "#/components/schemas/SeparatorComponentForMessageRequest"
+                },
+                {
+                  "$ref": "#/components/schemas/TextDisplayComponentForMessageRequest"
+                }
+              ]
+            },
+            "maxItems": 40
+          },
+          "attachments": {
+            "type": [
+              "array",
+              "null"
+            ],
+            "items": {
+              "$ref": "#/components/schemas/MessageAttachmentRequest"
+            },
+            "maxItems": 10
+          },
+          "poll": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/PollCreateRequest"
+              }
+            ]
+          },
+          "tts": {
+            "type": [
+              "boolean",
+              "null"
+            ]
+          },
+          "flags": {
+            "type": [
+              "integer",
+              "null"
+            ]
+          },
+          "username": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "minLength": 1,
+            "maxLength": 80
+          },
+          "avatar_url": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "maxLength": 2048,
+            "format": "uri"
+          },
+          "thread_name": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "minLength": 0,
+            "maxLength": 100
+          },
+          "applied_tags": {
+            "type": [
+              "array",
+              "null"
+            ],
+            "items": {
+              "$ref": "#/components/schemas/SnowflakeType"
+            },
+            "maxItems": 5
+          }
+        }
+      },
+      "MediaGalleryComponentForMessageRequest": {
+        "type": "object",
+        "additionalProperties": true,
+        "description": "A MediaGalleryComponentForMessageRequest. Structure omitted: this union inlines to hundreds of kilobytes. Pass the object as documented at https://discord.com/developers/docs/components/reference."
+      },
+      "MessageAllowedMentionsRequest": {
+        "type": "object",
+        "properties": {
+          "parse": {
+            "type": [
+              "array",
+              "null"
+            ],
+            "items": {
+              "oneOf": [
+                {
+                  "type": "null"
+                },
+                {
+                  "$ref": "#/components/schemas/AllowedMentionTypes"
+                }
+              ]
+            },
+            "maxItems": 1521,
+            "uniqueItems": true
+          },
+          "users": {
+            "type": [
+              "array",
+              "null"
+            ],
+            "items": {
+              "oneOf": [
+                {
+                  "type": "null"
+                },
+                {
+                  "$ref": "#/components/schemas/SnowflakeType"
+                }
+              ]
+            },
+            "maxItems": 100,
+            "uniqueItems": true
+          },
+          "roles": {
+            "type": [
+              "array",
+              "null"
+            ],
+            "items": {
+              "oneOf": [
+                {
+                  "type": "null"
+                },
+                {
+                  "$ref": "#/components/schemas/SnowflakeType"
+                }
+              ]
+            },
+            "maxItems": 100,
+            "uniqueItems": true
+          },
+          "replied_user": {
+            "type": [
+              "boolean",
+              "null"
+            ]
+          }
+        }
+      },
+      "MessageAttachmentRequest": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "$ref": "#/components/schemas/SnowflakeType"
+          },
+          "filename": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "minLength": 1,
+            "maxLength": 1024
+          },
+          "description": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "maxLength": 1024
+          },
+          "duration_secs": {
+            "type": [
+              "number",
+              "null"
+            ],
+            "minimum": 0,
+            "maximum": 2147483647,
+            "format": "double"
+          },
+          "waveform": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "maxLength": 400
+          },
+          "title": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "maxLength": 1024
+          },
+          "is_spoiler": {
+            "type": [
+              "boolean",
+              "null"
+            ]
+          },
+          "is_remix": {
+            "type": [
+              "boolean",
+              "null"
+            ]
+          }
+        },
+        "required": [
+          "id"
+        ]
+      },
+      "MessageCreateRequest": {
+        "type": "object",
+        "properties": {
+          "content": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "maxLength": 4000
+          },
+          "embeds": {
+            "type": [
+              "array",
+              "null"
+            ],
+            "items": {
+              "$ref": "#/components/schemas/RichEmbed"
+            },
+            "maxItems": 10
+          },
+          "allowed_mentions": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/MessageAllowedMentionsRequest"
+              }
+            ]
+          },
+          "sticker_ids": {
+            "type": [
+              "array",
+              "null"
+            ],
+            "items": {
+              "$ref": "#/components/schemas/SnowflakeType"
+            },
+            "maxItems": 3
+          },
+          "components": {
+            "type": [
+              "array",
+              "null"
+            ],
+            "items": {
+              "oneOf": [
+                {
+                  "$ref": "#/components/schemas/ActionRowComponentForMessageRequest"
+                },
+                {
+                  "$ref": "#/components/schemas/ContainerComponentForMessageRequest"
+                },
+                {
+                  "$ref": "#/components/schemas/FileComponentForMessageRequest"
+                },
+                {
+                  "$ref": "#/components/schemas/MediaGalleryComponentForMessageRequest"
+                },
+                {
+                  "$ref": "#/components/schemas/SectionComponentForMessageRequest"
+                },
+                {
+                  "$ref": "#/components/schemas/SeparatorComponentForMessageRequest"
+                },
+                {
+                  "$ref": "#/components/schemas/TextDisplayComponentForMessageRequest"
+                }
+              ]
+            },
+            "maxItems": 40
+          },
+          "flags": {
+            "type": [
+              "integer",
+              "null"
+            ]
+          },
+          "attachments": {
+            "type": [
+              "array",
+              "null"
+            ],
+            "items": {
+              "$ref": "#/components/schemas/MessageAttachmentRequest"
+            },
+            "maxItems": 10
+          },
+          "poll": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/PollCreateRequest"
+              }
+            ]
+          },
+          "shared_client_theme": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/CustomClientThemeShareRequest"
+              }
+            ]
+          },
+          "message_reference": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/MessageReferenceRequest"
+              }
+            ]
+          },
+          "nonce": {
+            "oneOf": [
+              {
+                "type": "integer",
+                "minimum": -9223372036854776000,
+                "maximum": 9223372036854776000,
+                "format": "int64"
+              },
+              {
+                "type": "string",
+                "maxLength": 25,
+                "format": "nonce"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "enforce_nonce": {
+            "type": [
+              "boolean",
+              "null"
+            ]
+          },
+          "tts": {
+            "type": [
+              "boolean",
+              "null"
+            ]
+          }
+        }
+      },
+      "MessageEditRequestPartial": {
+        "type": "object",
+        "properties": {
+          "content": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "maxLength": 4000
+          },
+          "embeds": {
+            "type": [
+              "array",
+              "null"
+            ],
+            "items": {
+              "$ref": "#/components/schemas/RichEmbed"
+            },
+            "maxItems": 10
+          },
+          "flags": {
+            "type": [
+              "integer",
+              "null"
+            ]
+          },
+          "allowed_mentions": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/MessageAllowedMentionsRequest"
+              }
+            ]
+          },
+          "sticker_ids": {
+            "type": [
+              "array",
+              "null"
+            ],
+            "items": {
+              "$ref": "#/components/schemas/SnowflakeType"
+            },
+            "maxItems": 1521
+          },
+          "components": {
+            "type": [
+              "array",
+              "null"
+            ],
+            "items": {
+              "oneOf": [
+                {
+                  "$ref": "#/components/schemas/ActionRowComponentForMessageRequest"
+                },
+                {
+                  "$ref": "#/components/schemas/ContainerComponentForMessageRequest"
+                },
+                {
+                  "$ref": "#/components/schemas/FileComponentForMessageRequest"
+                },
+                {
+                  "$ref": "#/components/schemas/MediaGalleryComponentForMessageRequest"
+                },
+                {
+                  "$ref": "#/components/schemas/SectionComponentForMessageRequest"
+                },
+                {
+                  "$ref": "#/components/schemas/SeparatorComponentForMessageRequest"
+                },
+                {
+                  "$ref": "#/components/schemas/TextDisplayComponentForMessageRequest"
+                }
+              ]
+            },
+            "maxItems": 40
+          },
+          "attachments": {
+            "type": [
+              "array",
+              "null"
+            ],
+            "items": {
+              "$ref": "#/components/schemas/MessageAttachmentRequest"
+            },
+            "maxItems": 10
+          }
+        }
+      },
+      "MessageReferenceRequest": {
+        "type": "object",
+        "properties": {
+          "guild_id": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/SnowflakeType"
+              }
+            ]
+          },
+          "channel_id": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/SnowflakeType"
+              }
+            ]
+          },
+          "message_id": {
+            "$ref": "#/components/schemas/SnowflakeType"
+          },
+          "fail_if_not_exists": {
+            "type": [
+              "boolean",
+              "null"
+            ]
+          },
+          "type": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/MessageReferenceType"
+              }
+            ]
+          }
+        },
+        "required": [
+          "message_id"
+        ]
+      },
+      "MessageReferenceType": {
+        "type": "integer",
+        "oneOf": [
+          {
+            "title": "DEFAULT",
+            "description": "Reference to a message",
+            "const": 0
+          }
+        ],
+        "format": "int32"
+      },
+      "MessageShareCustomUserThemeBaseTheme": {
+        "type": "integer",
+        "oneOf": [
+          {
+            "title": "UNSET",
+            "description": "No base theme",
+            "const": 0
+          },
+          {
+            "title": "DARK",
+            "description": "Dark base theme",
+            "const": 1
+          },
+          {
+            "title": "LIGHT",
+            "description": "Light base theme",
+            "const": 2
+          },
+          {
+            "title": "DARKER",
+            "description": "Darker base theme",
+            "const": 3
+          },
+          {
+            "title": "MIDNIGHT",
+            "description": "Midnight base theme",
+            "const": 4
+          }
+        ],
+        "format": "int32"
+      },
+      "PollAnswerCreateRequest": {
+        "type": "object",
+        "properties": {
+          "poll_media": {
+            "$ref": "#/components/schemas/PollMediaCreateRequest",
+            "description": "The data of the answer"
+          }
+        },
+        "required": [
+          "poll_media"
+        ]
+      },
+      "PollCreateRequest": {
+        "type": "object",
+        "properties": {
+          "question": {
+            "$ref": "#/components/schemas/PollMedia",
+            "description": "The question of the poll. Only `text` is supported."
+          },
+          "answers": {
+            "type": "array",
+            "description": "Each of the answers available in the poll, up to 10",
+            "items": {
+              "$ref": "#/components/schemas/PollAnswerCreateRequest"
+            },
+            "minItems": 1,
+            "maxItems": 10
+          },
+          "allow_multiselect": {
+            "type": [
+              "boolean",
+              "null"
+            ],
+            "description": "Whether a user can select multiple answers"
+          },
+          "layout_type": {
+            "description": "The layout type of the poll. Defaults to... DEFAULT!",
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/PollLayoutTypes"
+              }
+            ]
+          },
+          "duration": {
+            "type": [
+              "integer",
+              "null"
+            ],
+            "description": "Number of hours the poll should be open for, up to 32 days. Defaults to 24",
+            "minimum": 1,
+            "maximum": 768,
+            "format": "int32"
+          }
+        },
+        "required": [
+          "question",
+          "answers"
+        ]
+      },
+      "PollEmoji": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "description": "The ID of the custom emoji",
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/SnowflakeType"
+              }
+            ]
+          },
+          "name": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "The name of the emoji, or the unicode emoji character",
+            "maxLength": 32
+          },
+          "animated": {
+            "type": [
+              "boolean",
+              "null"
+            ],
+            "description": "Whether the emoji is animated"
+          }
+        }
+      },
+      "PollEmojiCreateRequest": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "description": "The ID of the custom emoji",
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/SnowflakeType"
+              }
+            ]
+          },
+          "name": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "The name of the emoji, or the unicode emoji character",
+            "maxLength": 32
+          },
+          "animated": {
+            "type": [
+              "boolean",
+              "null"
+            ],
+            "description": "Whether the emoji is animated"
+          }
+        }
+      },
+      "PollLayoutTypes": {
+        "type": "integer",
+        "oneOf": [
+          {
+            "title": "DEFAULT",
+            "description": "The, uhm, default layout type.",
+            "const": 1
+          }
+        ],
+        "format": "int32"
+      },
+      "PollMedia": {
+        "type": "object",
+        "properties": {
+          "text": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "The text of the field",
+            "minLength": 1,
+            "maxLength": 300
+          },
+          "emoji": {
+            "description": "The emoji of the field",
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/PollEmoji"
+              }
+            ]
+          }
+        }
+      },
+      "PollMediaCreateRequest": {
+        "type": "object",
+        "properties": {
+          "text": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "The text of the field",
+            "minLength": 1,
+            "maxLength": 300
+          },
+          "emoji": {
+            "description": "The emoji of the field",
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/PollEmojiCreateRequest"
+              }
+            ]
+          }
+        }
+      },
+      "ReactionTypes": {
+        "type": "integer",
+        "oneOf": [
+          {
+            "title": "NORMAL",
+            "description": "Normal reaction type",
+            "const": 0
+          },
+          {
+            "title": "BURST",
+            "description": "Burst reaction type",
+            "const": 1
+          }
+        ],
+        "format": "int32"
+      },
+      "RichEmbed": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "maxLength": 152133
+          },
+          "url": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "maxLength": 2048,
+            "format": "uri"
+          },
+          "title": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "maxLength": 256
+          },
+          "color": {
+            "type": [
+              "integer",
+              "null"
+            ],
+            "minimum": 0,
+            "maximum": 16777215
+          },
+          "timestamp": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "format": "date-time"
+          },
+          "description": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "maxLength": 4096
+          },
+          "author": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/RichEmbedAuthor"
+              }
+            ]
+          },
+          "image": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/RichEmbedImage"
+              }
+            ]
+          },
+          "thumbnail": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/RichEmbedThumbnail"
+              }
+            ]
+          },
+          "footer": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/RichEmbedFooter"
+              }
+            ]
+          },
+          "fields": {
+            "type": [
+              "array",
+              "null"
+            ],
+            "items": {
+              "$ref": "#/components/schemas/RichEmbedField"
+            },
+            "maxItems": 25
+          },
+          "provider": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/RichEmbedProvider"
+              }
+            ]
+          },
+          "video": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/RichEmbedVideo"
+              }
+            ]
+          }
+        }
+      },
+      "RichEmbedAuthor": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "maxLength": 256
+          },
+          "url": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "maxLength": 2048,
+            "format": "uri"
+          },
+          "icon_url": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "maxLength": 2048,
+            "format": "uri"
+          }
+        }
+      },
+      "RichEmbedField": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string",
+            "maxLength": 256
+          },
+          "value": {
+            "type": "string",
+            "maxLength": 1024
+          },
+          "inline": {
+            "type": [
+              "boolean",
+              "null"
+            ]
+          }
+        },
+        "required": [
+          "name",
+          "value"
+        ]
+      },
+      "RichEmbedFooter": {
+        "type": "object",
+        "properties": {
+          "text": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "maxLength": 2048
+          },
+          "icon_url": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "maxLength": 2048,
+            "format": "uri"
+          }
+        }
+      },
+      "RichEmbedImage": {
+        "type": "object",
+        "properties": {
+          "url": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "maxLength": 2048,
+            "format": "uri"
+          },
+          "width": {
+            "type": [
+              "integer",
+              "null"
+            ]
+          },
+          "height": {
+            "type": [
+              "integer",
+              "null"
+            ]
+          },
+          "placeholder": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "maxLength": 64
+          },
+          "placeholder_version": {
+            "type": [
+              "integer",
+              "null"
+            ],
+            "minimum": 0,
+            "maximum": 2147483647
+          },
+          "is_animated": {
+            "type": [
+              "boolean",
+              "null"
+            ]
+          },
+          "description": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "maxLength": 4096
+          }
+        }
+      },
+      "RichEmbedProvider": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "maxLength": 256
+          },
+          "url": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "maxLength": 2048,
+            "format": "uri"
+          }
+        }
+      },
+      "RichEmbedThumbnail": {
+        "type": "object",
+        "properties": {
+          "url": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "maxLength": 2048,
+            "format": "uri"
+          },
+          "width": {
+            "type": [
+              "integer",
+              "null"
+            ]
+          },
+          "height": {
+            "type": [
+              "integer",
+              "null"
+            ]
+          },
+          "placeholder": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "maxLength": 64
+          },
+          "placeholder_version": {
+            "type": [
+              "integer",
+              "null"
+            ],
+            "minimum": 0,
+            "maximum": 2147483647
+          },
+          "is_animated": {
+            "type": [
+              "boolean",
+              "null"
+            ]
+          },
+          "description": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "maxLength": 4096
+          }
+        }
+      },
+      "RichEmbedVideo": {
+        "type": "object",
+        "properties": {
+          "url": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "maxLength": 2048,
+            "format": "uri"
+          },
+          "width": {
+            "type": [
+              "integer",
+              "null"
+            ]
+          },
+          "height": {
+            "type": [
+              "integer",
+              "null"
+            ]
+          },
+          "placeholder": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "maxLength": 64
+          },
+          "placeholder_version": {
+            "type": [
+              "integer",
+              "null"
+            ],
+            "minimum": 0,
+            "maximum": 2147483647
+          },
+          "is_animated": {
+            "type": [
+              "boolean",
+              "null"
+            ]
+          },
+          "description": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "maxLength": 4096
+          }
+        }
+      },
+      "SectionComponentForMessageRequest": {
+        "type": "object",
+        "additionalProperties": true,
+        "description": "A SectionComponentForMessageRequest. Structure omitted: this union inlines to hundreds of kilobytes. Pass the object as documented at https://discord.com/developers/docs/components/reference."
+      },
+      "SeparatorComponentForMessageRequest": {
+        "type": "object",
+        "additionalProperties": true,
+        "description": "A SeparatorComponentForMessageRequest. Structure omitted: this union inlines to hundreds of kilobytes. Pass the object as documented at https://discord.com/developers/docs/components/reference."
+      },
+      "SnowflakeType": {
+        "type": "string",
+        "pattern": "^(0|[1-9][0-9]*)$",
+        "format": "snowflake"
+      },
+      "TextDisplayComponentForMessageRequest": {
+        "type": "object",
+        "additionalProperties": true,
+        "description": "A TextDisplayComponentForMessageRequest. Structure omitted: this union inlines to hundreds of kilobytes. Pass the object as documented at https://discord.com/developers/docs/components/reference."
+      },
+      "ThreadAutoArchiveDuration": {
+        "type": "integer",
+        "oneOf": [
+          {
+            "title": "ONE_HOUR",
+            "description": "One hour",
+            "const": 60
+          },
+          {
+            "title": "ONE_DAY",
+            "description": "One day",
+            "const": 1440
+          },
+          {
+            "title": "THREE_DAY",
+            "description": "Three days",
+            "const": 4320
+          },
+          {
+            "title": "SEVEN_DAY",
+            "description": "Seven days",
+            "const": 10080
+          }
+        ],
+        "format": "int32"
+      }
+    },
+    "securitySchemes": {
+      "BotToken": {
+        "type": "apiKey",
+        "description": "Discord bot token",
+        "name": "Authorization",
+        "in": "header"
+      },
+      "OAuth2": {
+        "type": "oauth2",
+        "flows": {
+          "implicit": {
+            "authorizationUrl": "https://discord.com/api/oauth2/authorize",
+            "refreshUrl": "https://discord.com/api/oauth2/token",
+            "scopes": {
+              "activities.invites.write": "allows your app to send activity invites - requires Discord approval (NOT REQUIRED FOR GAMESDK ACTIVITY MANAGER)",
+              "activities.read": "allows your app to fetch data from a user's \"Now Playing/Recently Played\" list - requires Discord approval",
+              "activities.write": "allows your app to update a user's activity - requires Discord approval (NOT REQUIRED FOR GAMESDK ACTIVITY MANAGER)",
+              "applications.builds.read": "allows your app to read build data for a user's applications",
+              "applications.builds.upload": "allows your app to upload/update builds for a user's applications - requires Discord approval",
+              "applications.commands": "allows your app to use commands in a guild",
+              "applications.commands.permissions.update": "allows your app to update permissions for its commands in a guild a user has permissions to",
+              "applications.entitlements": "allows your app to read entitlements for a user's applications",
+              "applications.store.update": "allows your app to read and update store data (SKUs, store listings, achievements, etc.) for a user's applications",
+              "bot": "for oauth2 bots, this puts the bot in the user's selected guild by default",
+              "connections": "allows /users/@me/connections to return linked third-party accounts",
+              "dm_channels.read": "allows your app to see information about the user's DMs and group DMs - requires Discord approval",
+              "email": "enables /users/@me to return an email",
+              "gdm.join": "allows your app to join users to a group dm",
+              "guilds": "allows /users/@me/guilds to return basic information about all of a user's guilds",
+              "guilds.join": "allows /guilds/{guild.id}/members/{user.id} to be used for joining users to a guild",
+              "guilds.members.read": "allows /users/@me/guilds/{guild.id}/member to return a user's member information in a guild",
+              "identify": "allows /users/@me without email",
+              "messages.read": "for local rpc server api access, this allows you to read messages from all client channels (otherwise restricted to channels/guilds your app creates)",
+              "openid": "for OpenID Connect, this allows your app to receive user id and basic profile information",
+              "relationships.read": "allows your app to know a user's friends and implicit relationships - requires Discord approval",
+              "rpc": "for local rpc server access, this allows you to control a user's local Discord client - requires Discord approval",
+              "rpc.activities.write": "for local rpc server access, this allows you to update a user's activity - requires Discord approval",
+              "rpc.notifications.read": "for local rpc server access, this allows you to receive notifications pushed out to the user - requires Discord approval",
+              "rpc.screenshare.read": "for local rpc server access, this allows you to read a user's screenshare status- requires Discord approval",
+              "rpc.screenshare.write": "for local rpc server access, this allows you to update a user's screenshare settings- requires Discord approval",
+              "rpc.video.read": "for local rpc server access, this allows you to read a user's video status - requires Discord approval",
+              "rpc.video.write": "for local rpc server access, this allows you to update a user's video settings - requires Discord approval",
+              "rpc.voice.read": "for local rpc server access, this allows you to read a user's voice settings and listen for voice events - requires Discord approval",
+              "rpc.voice.write": "for local rpc server access, this allows you to update a user's voice settings - requires Discord approval",
+              "voice": "allows your app to connect to voice on user's behalf and see all the voice members - requires Discord approval",
+              "webhook.incoming": "this generates a webhook that is returned in the oauth token response for authorization code grants"
+            }
+          },
+          "clientCredentials": {
+            "tokenUrl": "https://discord.com/api/oauth2/token",
+            "refreshUrl": "https://discord.com/api/oauth2/token",
+            "scopes": {
+              "activities.invites.write": "allows your app to send activity invites - requires Discord approval (NOT REQUIRED FOR GAMESDK ACTIVITY MANAGER)",
+              "activities.read": "allows your app to fetch data from a user's \"Now Playing/Recently Played\" list - requires Discord approval",
+              "activities.write": "allows your app to update a user's activity - requires Discord approval (NOT REQUIRED FOR GAMESDK ACTIVITY MANAGER)",
+              "applications.builds.read": "allows your app to read build data for a user's applications",
+              "applications.builds.upload": "allows your app to upload/update builds for a user's applications - requires Discord approval",
+              "applications.commands": "allows your app to use commands in a guild",
+              "applications.commands.permissions.update": "allows your app to update permissions for its commands in a guild a user has permissions to",
+              "applications.commands.update": "allows your app to update its commands using a Bearer token - client credentials grant only",
+              "applications.entitlements": "allows your app to read entitlements for a user's applications",
+              "applications.store.update": "allows your app to read and update store data (SKUs, store listings, achievements, etc.) for a user's applications",
+              "bot": "for oauth2 bots, this puts the bot in the user's selected guild by default",
+              "connections": "allows /users/@me/connections to return linked third-party accounts",
+              "dm_channels.read": "allows your app to see information about the user's DMs and group DMs - requires Discord approval",
+              "email": "enables /users/@me to return an email",
+              "gdm.join": "allows your app to join users to a group dm",
+              "guilds": "allows /users/@me/guilds to return basic information about all of a user's guilds",
+              "guilds.join": "allows /guilds/{guild.id}/members/{user.id} to be used for joining users to a guild",
+              "guilds.members.read": "allows /users/@me/guilds/{guild.id}/member to return a user's member information in a guild",
+              "identify": "allows /users/@me without email",
+              "messages.read": "for local rpc server api access, this allows you to read messages from all client channels (otherwise restricted to channels/guilds your app creates)",
+              "openid": "for OpenID Connect, this allows your app to receive user id and basic profile information",
+              "relationships.read": "allows your app to know a user's friends and implicit relationships - requires Discord approval",
+              "rpc": "for local rpc server access, this allows you to control a user's local Discord client - requires Discord approval",
+              "rpc.activities.write": "for local rpc server access, this allows you to update a user's activity - requires Discord approval",
+              "rpc.notifications.read": "for local rpc server access, this allows you to receive notifications pushed out to the user - requires Discord approval",
+              "rpc.screenshare.read": "for local rpc server access, this allows you to read a user's screenshare status- requires Discord approval",
+              "rpc.screenshare.write": "for local rpc server access, this allows you to update a user's screenshare settings- requires Discord approval",
+              "rpc.video.read": "for local rpc server access, this allows you to read a user's video status - requires Discord approval",
+              "rpc.video.write": "for local rpc server access, this allows you to update a user's video settings - requires Discord approval",
+              "rpc.voice.read": "for local rpc server access, this allows you to read a user's voice settings and listen for voice events - requires Discord approval",
+              "rpc.voice.write": "for local rpc server access, this allows you to update a user's voice settings - requires Discord approval",
+              "voice": "allows your app to connect to voice on user's behalf and see all the voice members - requires Discord approval",
+              "webhook.incoming": "this generates a webhook that is returned in the oauth token response for authorization code grants"
+            }
+          },
+          "authorizationCode": {
+            "authorizationUrl": "https://discord.com/api/oauth2/authorize",
+            "tokenUrl": "https://discord.com/api/oauth2/token",
+            "refreshUrl": "https://discord.com/api/oauth2/token",
+            "scopes": {
+              "activities.invites.write": "allows your app to send activity invites - requires Discord approval (NOT REQUIRED FOR GAMESDK ACTIVITY MANAGER)",
+              "activities.read": "allows your app to fetch data from a user's \"Now Playing/Recently Played\" list - requires Discord approval",
+              "activities.write": "allows your app to update a user's activity - requires Discord approval (NOT REQUIRED FOR GAMESDK ACTIVITY MANAGER)",
+              "applications.builds.read": "allows your app to read build data for a user's applications",
+              "applications.builds.upload": "allows your app to upload/update builds for a user's applications - requires Discord approval",
+              "applications.commands": "allows your app to use commands in a guild",
+              "applications.commands.permissions.update": "allows your app to update permissions for its commands in a guild a user has permissions to",
+              "applications.entitlements": "allows your app to read entitlements for a user's applications",
+              "applications.store.update": "allows your app to read and update store data (SKUs, store listings, achievements, etc.) for a user's applications",
+              "bot": "for oauth2 bots, this puts the bot in the user's selected guild by default",
+              "connections": "allows /users/@me/connections to return linked third-party accounts",
+              "dm_channels.read": "allows your app to see information about the user's DMs and group DMs - requires Discord approval",
+              "email": "enables /users/@me to return an email",
+              "gdm.join": "allows your app to join users to a group dm",
+              "guilds": "allows /users/@me/guilds to return basic information about all of a user's guilds",
+              "guilds.join": "allows /guilds/{guild.id}/members/{user.id} to be used for joining users to a guild",
+              "guilds.members.read": "allows /users/@me/guilds/{guild.id}/member to return a user's member information in a guild",
+              "identify": "allows /users/@me without email",
+              "messages.read": "for local rpc server api access, this allows you to read messages from all client channels (otherwise restricted to channels/guilds your app creates)",
+              "openid": "for OpenID Connect, this allows your app to receive user id and basic profile information",
+              "relationships.read": "allows your app to know a user's friends and implicit relationships - requires Discord approval",
+              "role_connections.write": "allows your app to update a user's connection and metadata for the app",
+              "rpc": "for local rpc server access, this allows you to control a user's local Discord client - requires Discord approval",
+              "rpc.activities.write": "for local rpc server access, this allows you to update a user's activity - requires Discord approval",
+              "rpc.notifications.read": "for local rpc server access, this allows you to receive notifications pushed out to the user - requires Discord approval",
+              "rpc.screenshare.read": "for local rpc server access, this allows you to read a user's screenshare status- requires Discord approval",
+              "rpc.screenshare.write": "for local rpc server access, this allows you to update a user's screenshare settings- requires Discord approval",
+              "rpc.video.read": "for local rpc server access, this allows you to read a user's video status - requires Discord approval",
+              "rpc.video.write": "for local rpc server access, this allows you to update a user's video settings - requires Discord approval",
+              "rpc.voice.read": "for local rpc server access, this allows you to read a user's voice settings and listen for voice events - requires Discord approval",
+              "rpc.voice.write": "for local rpc server access, this allows you to update a user's voice settings - requires Discord approval",
+              "voice": "allows your app to connect to voice on user's behalf and see all the voice members - requires Discord approval",
+              "webhook.incoming": "this generates a webhook that is returned in the oauth token response for authorization code grants"
+            }
+          }
+        }
+      }
+    },
+    "responses": {
+      "ClientErrorResponse": {
+        "description": "Client error response",
+        "headers": {
+          "X-RateLimit-Limit": {
+            "$ref": "#/components/headers/X-RateLimit-Limit"
+          },
+          "X-RateLimit-Remaining": {
+            "$ref": "#/components/headers/X-RateLimit-Remaining"
+          },
+          "X-RateLimit-Reset": {
+            "$ref": "#/components/headers/X-RateLimit-Reset"
+          },
+          "X-RateLimit-Reset-After": {
+            "$ref": "#/components/headers/X-RateLimit-Reset-After"
+          },
+          "X-RateLimit-Bucket": {
+            "$ref": "#/components/headers/X-RateLimit-Bucket"
+          }
+        },
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/ErrorResponse"
+            }
+          }
+        }
+      },
+      "ClientRatelimitedResponse": {
+        "description": "Client ratelimited response",
+        "headers": {
+          "X-RateLimit-Limit": {
+            "$ref": "#/components/headers/X-RateLimit-Limit"
+          },
+          "X-RateLimit-Remaining": {
+            "$ref": "#/components/headers/X-RateLimit-Remaining"
+          },
+          "X-RateLimit-Reset": {
+            "$ref": "#/components/headers/X-RateLimit-Reset"
+          },
+          "X-RateLimit-Reset-After": {
+            "$ref": "#/components/headers/X-RateLimit-Reset-After"
+          },
+          "X-RateLimit-Bucket": {
+            "$ref": "#/components/headers/X-RateLimit-Bucket"
+          }
+        },
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/RatelimitedResponse"
+            }
+          }
+        }
+      }
+    },
+    "headers": {
+      "X-RateLimit-Limit": {
+        "schema": {
+          "type": "integer"
+        },
+        "description": "The maximum number of requests that can be made in the current ratelimit window"
+      },
+      "X-RateLimit-Remaining": {
+        "schema": {
+          "type": "integer"
+        },
+        "description": "The number of requests remaining in the current ratelimit window"
+      },
+      "X-RateLimit-Reset": {
+        "schema": {
+          "type": "number"
+        },
+        "description": "A unix timestamp in seconds at which the current ratelimit window resets"
+      },
+      "X-RateLimit-Reset-After": {
+        "schema": {
+          "type": "number"
+        },
+        "description": "The duration in seconds until the current ratelimit window resets"
+      },
+      "X-RateLimit-Bucket": {
+        "schema": {
+          "type": "string"
+        },
+        "description": "The bucket that the request belongs to"
+      }
+    }
+  }
+}

--- a/src/providers/discord/specs/vendor.ts
+++ b/src/providers/discord/specs/vendor.ts
@@ -1,0 +1,164 @@
+/**
+ * Vendor a trimmed OpenAPI spec for Discord's v10 HTTP API.
+ *
+ * Discord publishes an OpenAPI document of its own, which is unusual and
+ * welcome, but ships it as a public preview: "subject to breaking changes
+ * without advance notice, and should not be used within production
+ * environments". Vendoring is what answers that. The committed copy never moves
+ * under us, so a breaking change upstream becomes a diff in a refresh commit
+ * rather than a provider that stops working — and the surface an operator's bot
+ * token can reach stays reviewable.
+ *
+ *   bun run vendor:discord
+ *
+ * The pipeline is `src/providers/shared/vendor-spec.ts`. What stays here is what
+ * only Discord knows: which operations are worth exposing, and the three shapes
+ * in its document that the generator cannot take as written.
+ */
+
+import { vendorSpec } from '../../shared/vendor-spec.ts';
+
+const SOURCE = 'https://raw.githubusercontent.com/discord/discord-api-spec/main/specs/openapi.json';
+
+/**
+ * The operations this provider exposes, out of 242 in the document.
+ *
+ * Curated hard, and the curation is load-bearing rather than tidy: `connect`
+ * writes one policy rule, `discord.*`, so an operation vendored here is an
+ * operation an agent may call. This list *is* the boundary. Discord's own API
+ * would otherwise hand over kick, ban, timeout, role assignment, channel
+ * deletion, and guild settings against a server the operator owns.
+ *
+ * What is deliberately absent, so a later refresh does not quietly add it back:
+ * `bulk_delete_messages` (a mass action no announcement workflow needs), every
+ * `deprecated_*` pin variant (superseded paths, kept by Discord for old
+ * clients), and everything under members, roles, bans, invites, and guild
+ * settings.
+ */
+const READS = [
+  // Whose token this is. The first call worth making after connecting, and the
+  // one that proves the `Bot ` prefix survived being pasted.
+  'get_my_user',
+  // Navigation: which servers the bot was added to, what is in them, and what
+  // one channel is. An agent cannot post to a channel it cannot name.
+  'list_my_guilds',
+  'get_guild',
+  'list_guild_channels',
+  'get_channel',
+  // The triage read. Discord exposes no message search to bots, so reading a
+  // channel means paging `list_messages` with `after` and `limit`.
+  'list_messages',
+  'get_message',
+  'list_pins',
+  'list_message_reactions_by_emoji',
+  'get_active_guild_threads',
+] as const;
+
+const WRITES = [
+  // Posting, as the app.
+  'create_message',
+  // Editing and retracting one's own announcement. `update_message` is the
+  // typo fix; `delete_message` is the retraction, which is why it is here and
+  // `bulk_delete_messages` is not.
+  'update_message',
+  'delete_message',
+  // Publishing a message posted in an announcement channel out to the servers
+  // that follow it — the one operation that makes an announcement channel worth
+  // using rather than an ordinary one.
+  'crosspost_message',
+  // Triage marking: react to it, pin it, or turn it into a thread. All three
+  // are how a human reads back what the agent decided.
+  'add_my_message_reaction',
+  'create_pin',
+  'create_thread_from_message',
+] as const;
+
+/**
+ * Posting under the operator's own name rather than the app's.
+ *
+ * Discord has no API for acting as a user account — automating one violates
+ * their terms — so an integration posts as an application, and an application's
+ * messages carry an `APP` badge that cannot be removed. What *can* be set is the
+ * name and avatar, and `execute_webhook` sets them per message. So an
+ * announcement can read as the operator while an ordinary reply reads as the
+ * integration, from one bot token.
+ *
+ * The cost is stated in `docs/detailed/security.md`: `create_webhook` and
+ * `list_channel_webhooks` return the webhook's token in their response, and a
+ * webhook token is a standalone credential for posting to that channel.
+ */
+const WEBHOOKS = ['list_channel_webhooks', 'create_webhook', 'execute_webhook'] as const;
+
+/**
+ * Discord's v2 message components, collapsed to open objects.
+ *
+ * `mcp-from-openapi` inlines `$ref`s, and this union is referenced by four
+ * request schemas and again from inside two of its own members — so inlining
+ * duplicates the whole tree six times over. There is no wrapper schema to
+ * collapse instead; the union is written out inline at each site.
+ *
+ * Measured, this is the difference between a provider that ships and one that
+ * cannot: `execute_webhook` generates a 148.9 KB input schema against a 64 KB
+ * per-tool budget, `create_message` 76.2 KB, `update_message` 72.6 KB, and the
+ * whole surface 305.4 KB against a 192 KB budget. Opaque brings the worst tool to
+ * 10.4 KB and the surface to 34.1 KB.
+ *
+ * `RichEmbed` is deliberately *not* here. It costs 3.1 KB — 1.6% of the surface
+ * budget — and it is how an announcement gets a title, a colour, and fields, so
+ * it is the one rich shape worth schematising. Collapsing it instead was
+ * measured and moves the worst tool from 148.9 KB to 144.2 KB, which is to say
+ * embeds were never the problem.
+ */
+const OPAQUE = [
+  'ActionRowComponentForMessageRequest',
+  'ContainerComponentForMessageRequest',
+  'FileComponentForMessageRequest',
+  'MediaGalleryComponentForMessageRequest',
+  'SectionComponentForMessageRequest',
+  'SeparatorComponentForMessageRequest',
+  'TextDisplayComponentForMessageRequest',
+];
+
+await vendorSpec('discord', {
+  source: SOURCE,
+  outputDirectory: import.meta.dir,
+  out: 'discord.v10.json',
+  operations: [...READS, ...WRITES, ...WEBHOOKS],
+  opaque: OPAQUE,
+  opaqueNote:
+    'Structure omitted: this union inlines to hundreds of kilobytes. ' +
+    'Pass the object as documented at https://discord.com/developers/docs/components/reference.',
+  vendoredNote:
+    'Trimmed by src/providers/discord/specs/vendor.ts. Committed deliberately: upstream is a public preview that may change without notice, and a spec decides which paths are called with the operator bot token — so it must be reviewable rather than fetched at connect time.',
+
+  // Discord declares path parameters on the path item, not the operation. That
+  // is legal, and `mcp-from-openapi`'s validator does not read it: without this
+  // the document fails outright with 29 × MISSING_PATH_PARAMETER and generates
+  // no tools at all.
+  hoistPathParameters: true,
+
+  // `create_message`, `update_message` and `execute_webhook` also offer
+  // `multipart/form-data`, whose file fields are named `files[0]`. That is not a
+  // legal tool property name, and one illegal name rejects the entire tools list
+  // for every provider on the endpoint — so the only thing standing between us
+  // and that is the generator preferring JSON of its own accord.
+  //
+  // The transport can now form-encode as well as JSON-encode (ADR-045), but not
+  // multipart, so a multipart branch is unsendable regardless of which one the
+  // generator picks. Attachments are unavailable as a result, which is the honest
+  // state: ADR-017's machinery is the route to them, not a branch nothing sends.
+  requestContentTypes: ['application/json'],
+
+  // `execute_webhook`'s body is a top-level `anyOf` of two complete payload
+  // schemas. A union has no `properties` to walk, so the generator emits one
+  // argument literally named `body` and the connector then sends
+  // `{"body":{"content":"…"}}` where Discord expects `{"content":"…"}`. Nothing
+  // in the test suite can see this: the name is legal, the size is fine, the
+  // base_url matches — only a live call fails.
+  //
+  // Naming the branch that is actually wanted flattens it back to 17 real
+  // arguments. Lossless: the other branch's properties are a strict subset.
+  rewriteRequestBody: {
+    execute_webhook: { $ref: '#/components/schemas/IncomingWebhookRequestPartial' },
+  },
+});

--- a/src/providers/google/specs/vendor.ts
+++ b/src/providers/google/specs/vendor.ts
@@ -15,16 +15,13 @@
  * command rather than a hand edit.
  *
  *   bun run vendor:google
+ *
+ * The pipeline itself is `src/providers/shared/vendor-spec.ts`. What stays here
+ * is what only Google knows: which operations are worth exposing, and which of
+ * its system parameters have to go.
  */
 
-import { mkdir, writeFile } from 'node:fs/promises';
-import { join } from 'node:path';
-import { OpenAPIToolGenerator, type McpOpenAPITool } from 'mcp-from-openapi';
-import { cutCycles, referenced, type Spec } from '../../shared/openapi.ts';
-
-/** Kept in step with `BUDGET_KB` in `src/cli/tools.test.ts`, which enforces it. */
-const BUDGET_KB = 64;
-
+import { vendorSpec } from '../../shared/vendor-spec.ts';
 
 /**
  * The operations each provider exposes.
@@ -314,50 +311,6 @@ const SELECTION: Record<
   // field but `title` on it anyway.
 };
 
-
-
-/**
- * Replace a named schema with an open object.
- *
- * Same device as `cutCycles` and a different disease. That one cuts recursion;
- * this one cuts *fan-out*. `mcp-from-openapi` inlines `$ref`s, so a schema's
- * cost to us is not its size in the document but its size once every reference
- * below it has been expanded — and Sheets' `Request` is a union of some eighty
- * variants, each with its own nested grid, filter, and chart schemas, sharing
- * sub-schemas that inlining duplicates per occurrence.
- *
- * Measured: `sheets.spreadsheets.batchUpdate` generates a 2,469KB input schema,
- * against 45KB for the whole of Drive. That is unusable — it would be sent on
- * every `tools/list` — and it is also the only operation that can add a tab,
- * freeze a header, or format a cell, so dropping it is no better.
- *
- * Opaque keeps the operation and costs 3KB. The agent fills in `requests` from
- * the API it already knows, which is the same bet `raw` makes for a Gmail draft:
- * a well-known wire format is cheaper described than schematised. The pointer to
- * Google's reference is in the description because that is the only thing lost.
- *
- * Applied before `referenced`, so the schemas that were reachable only through
- * the replaced one leave the document entirely rather than lingering unused.
- */
-function makeOpaque(schemas: Record<string, unknown>, names: readonly string[]): number {
-  let replaced = 0;
-
-  for (const name of names) {
-    if (!(name in schemas)) continue;
-    const original = schemas[name] as { description?: string };
-    schemas[name] = {
-      type: 'object',
-      additionalProperties: true,
-      description:
-        `${original.description ?? `A ${name}.`} Structure omitted: it expands to megabytes ` +
-        'when inlined. Pass the object as documented at https://developers.google.com/workspace.',
-    };
-    replaced++;
-  }
-
-  return replaced;
-}
-
 /**
  * Google's system parameters, dropped from every operation.
  *
@@ -391,188 +344,33 @@ const SYSTEM_PARAMETERS = new Set([
 ]);
 
 /**
- * Strip system parameters from a path item or an operation.
- *
- * They arrive as `$ref`s into `components.parameters`, and the component *key*
- * is not the parameter name — `$.xgafv` is keyed `_.xgafv`, because a `$` is
- * awkward in a JSON pointer. Matching on the key would therefore miss exactly
- * the one that breaks everything, so the ref is resolved first.
+ * The note recorded in each spec's `info`, and the one `makeOpaque` leaves
+ * behind. Both are baked into the committed JSON, so they are passed verbatim
+ * rather than reworded.
  */
-function dropSystemParameters(
-  holder: Record<string, unknown>,
-  components: Record<string, unknown>,
-): number {
-  const parameters = holder['parameters'];
-  if (!Array.isArray(parameters)) return 0;
+const VENDORED_NOTE =
+  'Trimmed by src/providers/google/specs/vendor.ts. Committed deliberately: a spec decides which paths are called with the operator token, so it must be reviewable rather than fetched at connect time.';
 
-  const nameOf = (parameter: unknown): string | undefined => {
-    const record = parameter as { name?: string; $ref?: string };
-    if (record.name) return record.name;
-    if (!record.$ref) return undefined;
+const OPAQUE_NOTE =
+  'Structure omitted: it expands to megabytes when inlined. ' +
+  'Pass the object as documented at https://developers.google.com/workspace.';
 
-    const key = record.$ref.replace('#/components/parameters/', '');
-    return (components[key] as { name?: string } | undefined)?.name;
-  };
-
-  const kept = parameters.filter((parameter) => {
-    const name = nameOf(parameter);
-    return !(name && SYSTEM_PARAMETERS.has(name));
+for (const [id, selection] of Object.entries(SELECTION)) {
+  await vendorSpec(id, {
+    source: selection.source,
+    // `import.meta.dir` *is* the specs directory — this script lives beside what
+    // it writes. It used to be `scripts/vendor-google-specs.ts` and reached
+    // across the tree; commit 3cd03ce moved the script and the specs together
+    // but not the path arithmetic, so for a while this resolved to
+    // `src/providers/google/providers/builtin/specs`, created it, reported
+    // success, and left the committed spec untouched — making the documented
+    // "re-run the script" step a silent no-op.
+    outputDirectory: import.meta.dir,
+    out: selection.out,
+    operations: selection.operations,
+    ...(selection.opaque ? { opaque: selection.opaque } : {}),
+    opaqueNote: OPAQUE_NOTE,
+    vendoredNote: VENDORED_NOTE,
+    systemParameters: SYSTEM_PARAMETERS,
   });
-
-  holder['parameters'] = kept;
-  return parameters.length - kept.length;
 }
-
-const METHODS = ['get', 'post', 'put', 'patch', 'delete', 'head'];
-
-async function vendor(id: string): Promise<void> {
-  const { source, out, operations, opaque } = SELECTION[id]!;
-  const wanted = new Set(operations);
-
-  const response = await fetch(source);
-  if (!response.ok) throw new Error(`${source}: HTTP ${response.status}`);
-  const spec = (await response.json()) as Spec;
-
-  const paths: Spec['paths'] = {};
-  const seen = new Set<string>();
-
-  for (const [path, item] of Object.entries(spec.paths)) {
-    const kept: Record<string, unknown> = {};
-    for (const [method, operation] of Object.entries(item)) {
-      // Path-level keys are not operations and must survive: `parameters` here
-      // is where Google puts the query parameters shared by every method on the
-      // path, and `fields` is one of them — which `drive.about.get` *requires*.
-      // Dropping it produced a tool with no arguments at all and a 400 on every
-      // call.
-      if (!METHODS.includes(method)) {
-        kept[method] = operation;
-        continue;
-      }
-      const operationId = operation.operationId;
-      if (!operationId || !wanted.has(operationId)) continue;
-      kept[method] = operation;
-      seen.add(operationId);
-    }
-
-    // Only path-level keys survived, so no operation here was wanted.
-    if (!Object.keys(kept).some((key) => METHODS.includes(key))) continue;
-    if (Object.keys(kept).length > 0) paths[path] = kept as Spec['paths'][string];
-  }
-
-  const componentParameters = (spec.components?.['parameters'] ?? {}) as Record<string, unknown>;
-
-  let dropped = 0;
-  for (const item of Object.values(paths)) {
-    dropped += dropSystemParameters(item as unknown as Record<string, unknown>, componentParameters);
-    for (const [method, operation] of Object.entries(item)) {
-      if (!METHODS.includes(method)) continue;
-      dropped += dropSystemParameters(
-        operation as unknown as Record<string, unknown>,
-        componentParameters,
-      );
-    }
-  }
-
-  // Drop response schemas.
-  //
-  // Two reasons, and the second is the blocking one. Nothing reads them: the
-  // connector hands the response body back as text, because an agent wants the
-  // JSON, not a validated shape. And Gmail's response schemas are recursive —
-  // `Message.payload` is a `MessagePart`, which contains `MessagePart[]` — which
-  // sends the OpenAPI tool generator into infinite recursion and silently drops
-  // eight of Gmail's twelve operations from the tool list.
-  for (const item of Object.values(paths)) {
-    for (const [method, operation] of Object.entries(item)) {
-      if (!METHODS.includes(method)) continue;
-      (operation as { responses?: unknown }).responses = {
-        '200': { description: 'Success. The response body is returned verbatim.' },
-      };
-    }
-  }
-
-  const missing = operations.filter((operationId) => !seen.has(operationId));
-  if (missing.length > 0) {
-    // Loudly, rather than shipping a provider quietly missing capabilities: an
-    // upstream rename should fail the refresh, not shrink the tool list.
-    throw new Error(`${id}: these operations are not in the spec — ${missing.join(', ')}`);
-  }
-
-  const schemas = spec.components?.schemas ?? {};
-  const opaqued = makeOpaque(schemas, opaque ?? []);
-  const keep = referenced(paths, schemas);
-  const trimmedSchemas = Object.fromEntries(
-    Object.entries(schemas).filter(([name]) => keep.has(name)),
-  );
-  const cuts = cutCycles(trimmedSchemas);
-
-  const trimmed: Spec = {
-    openapi: spec.openapi,
-    info: {
-      ...spec.info,
-      'x-vendored-from': source,
-      'x-vendored-note':
-        'Trimmed by src/providers/google/specs/vendor.ts. Committed deliberately: a spec decides which paths are called with the operator token, so it must be reviewable rather than fetched at connect time.',
-    },
-    ...(spec.servers ? { servers: spec.servers } : {}),
-    paths,
-    components: { ...spec.components, schemas: trimmedSchemas },
-  };
-
-  // `import.meta.dir` *is* the specs directory — this script lives beside what it
-  // writes. It used to be `scripts/vendor-google-specs.ts` and reached across the
-  // tree; commit 3cd03ce moved the script and the specs together but not the path
-  // arithmetic, so for a while this resolved to
-  // `src/providers/google/providers/builtin/specs`, created it, reported success,
-  // and left the committed spec untouched — making the documented "re-run the
-  // script" step a silent no-op.
-  const directory = import.meta.dir;
-  await mkdir(directory, { recursive: true });
-  await writeFile(join(directory, out), `${JSON.stringify(trimmed, null, 2)}\n`);
-
-  const size = Math.round(JSON.stringify(trimmed).length / 1024);
-  console.log(
-    `  ${id.padEnd(6)} ${String(Object.keys(paths).length).padStart(2)} paths, ` +
-      `${seen.size} operations, ${Object.keys(trimmedSchemas).length} schemas, ` +
-      `${cuts} cycle${cuts === 1 ? '' : 's'} cut, ${opaqued} made opaque, ` +
-      `${dropped} system params dropped, ${size}KB`,
-  );
-
-  await reportLargestTools(trimmed);
-}
-
-/**
- * The number the budget is actually about.
- *
- * Everything on the line above counts the *spec*; `cli/tools.test.ts` measures
- * the **generated input schema**, and the two differ by orders of magnitude
- * because `mcp-from-openapi` inlines `$ref`s — a schema shared by ten fields is
- * ten copies once generated. Reasoning about `spreadsheets.create` from a schema
- * count put it at 122 KB when the real figure was 1,133 KB, which is the whole
- * difference between "just over" and "seventeen times over".
- *
- * Printed here so the refresh that adds an operation shows its cost, rather than
- * leaving it to a test failure to say so after the fact.
- */
-async function reportLargestTools(trimmed: Spec): Promise<void> {
-  try {
-    const generator = await OpenAPIToolGenerator.fromJSON(trimmed);
-    const measured = (await generator.generateTools())
-      .map((tool: McpOpenAPITool) => ({
-        name: tool.metadata.operationId ?? tool.name,
-        kb: JSON.stringify(tool.inputSchema).length / 1024,
-      }))
-      .sort((a, b) => b.kb - a.kb);
-
-    for (const { name, kb } of measured.slice(0, 3)) {
-      const over = kb > BUDGET_KB ? `  ✗ over the ${BUDGET_KB}KB budget` : '';
-      console.log(`         ${name.padEnd(38)} ${kb.toFixed(1).padStart(8)}KB${over}`);
-    }
-  } catch (error) {
-    // A generator failure is a real problem, but it is `tools.test.ts`'s to
-    // report against every provider at once. Refusing to finish the vendoring
-    // over it would leave the specs half-written.
-    console.log(`         (could not measure generated schemas: ${String(error)})`);
-  }
-}
-
-for (const id of Object.keys(SELECTION)) await vendor(id);

--- a/src/providers/index.ts
+++ b/src/providers/index.ts
@@ -1,6 +1,7 @@
 import type { ProviderDefinition, ProviderManifest } from '#connectivity';
 import { bunq } from './bunq/index.ts';
 import { calendar } from './google/calendar/index.ts';
+import { discord } from './discord/index.ts';
 import { contacts } from './google/contacts/index.ts';
 import { docs } from './google/docs/index.ts';
 import { github } from './github/index.ts';
@@ -56,6 +57,7 @@ export const PROVIDERS: readonly (ProviderManifest | ProviderDefinition)[] = [
   github,
   slack,
   reddit,
+  discord,
   gmail,
   drive,
   sheets,
@@ -100,6 +102,7 @@ export {
 } from './google/index.ts';
 export { icloudCalendar, icloudContacts, icloudDrive, icloudMail } from './icloud/index.ts';
 export { bunq } from './bunq/index.ts';
+export { discord } from './discord/index.ts';
 export { github } from './github/index.ts';
 export { linear } from './linear/index.ts';
 export { notion } from './notion/index.ts';

--- a/src/providers/shared/openapi.ts
+++ b/src/providers/shared/openapi.ts
@@ -14,10 +14,12 @@
  * through `RequestInquiry` and `RequestResponse`. Copying seventy lines into a
  * second script is how the two come to disagree about what a cycle is.
  *
- * Deliberately not moved: `makeOpaque`. It writes a sentence into the schema it
- * replaces, and that sentence points at the vendor's own reference
- * documentation — which makes it a Google function that happens to look
- * generic.
+ * `makeOpaque` was held back at first for a good reason: it writes a sentence
+ * into the schema it replaces, and that sentence points at the vendor's own
+ * reference documentation, which made it a Google function that happened to look
+ * generic. Taking the sentence as a parameter is what actually settles that —
+ * the surgery is generic, only the pointer was not — so it lives here now, with
+ * each caller passing its own note. Discord is the third vendor to need it.
  */
 
 /** The shape both vendoring scripts read and write. Generic OpenAPI 3.x. */
@@ -106,4 +108,48 @@ export function cutCycles(schemas: Record<string, unknown>): number {
 
   for (const [name, schema] of Object.entries(schemas)) walk(schema, new Set([name]));
   return cuts;
+}
+
+/**
+ * Replace a named schema with an open object.
+ *
+ * Same device as `cutCycles` and a different disease. That one cuts recursion;
+ * this one cuts *fan-out*. Because `$ref`s are inlined, a union of eighty
+ * variants — each with its own nested grid, filter, and chart schemas, sharing
+ * sub-schemas that inlining duplicates per occurrence — costs orders of
+ * magnitude more generated than it does on disk.
+ *
+ * Measured on the worst case in the repository: one spreadsheet operation
+ * generated a 2,469KB input schema against 45KB for a whole other API. That is
+ * unusable — it would be sent on every `tools/list` — and it was also the only
+ * operation that could add a tab, freeze a header, or format a cell, so
+ * dropping it was no better.
+ *
+ * Opaque keeps the operation for a few KB. The agent fills the field in from the
+ * API it already knows, which is the same bet `raw` makes for a mail draft: a
+ * well-known wire format is cheaper described than schematised. `note` carries
+ * the pointer to the vendor's reference, because that is the only thing lost.
+ *
+ * Apply before `referenced`, so the schemas that were reachable only through the
+ * replaced one leave the document entirely rather than lingering unused.
+ */
+export function makeOpaque(
+  schemas: Record<string, unknown>,
+  names: readonly string[],
+  note: string,
+): number {
+  let replaced = 0;
+
+  for (const name of names) {
+    if (!(name in schemas)) continue;
+    const original = schemas[name] as { description?: string };
+    schemas[name] = {
+      type: 'object',
+      additionalProperties: true,
+      description: `${original.description ?? `A ${name}.`} ${note}`,
+    };
+    replaced++;
+  }
+
+  return replaced;
 }

--- a/src/providers/shared/vendor-operations.ts
+++ b/src/providers/shared/vendor-operations.ts
@@ -1,0 +1,98 @@
+/**
+ * Document surgery on path items and operations.
+ *
+ * The other axis from `vendor-schemas.ts`: that file rewrites the schemas map,
+ * this one rewrites what an operation declares it takes — its parameters and the
+ * content types its request body offers. Both exist because the generated tool,
+ * not the document, is what has to be correct and small.
+ */
+
+export const METHODS = ['get', 'post', 'put', 'patch', 'delete', 'head'];
+
+/** The name a parameter goes by, resolving a `$ref` into `components.parameters`. */
+export function parameterName(
+  parameter: unknown,
+  components: Record<string, unknown>,
+): string | undefined {
+  const record = parameter as { name?: string; $ref?: string };
+  if (record.name) return record.name;
+  if (!record.$ref) return undefined;
+
+  // The component *key* is not the parameter name — `$.xgafv` is keyed
+  // `_.xgafv`, because a `$` is awkward in a JSON pointer. Matching on the key
+  // would therefore miss exactly the one that breaks everything.
+  const key = record.$ref.replace('#/components/parameters/', '');
+  return (components[key] as { name?: string } | undefined)?.name;
+}
+
+/** Strip vendor system parameters from a path item or an operation. */
+export function dropSystemParameters(
+  holder: Record<string, unknown>,
+  components: Record<string, unknown>,
+  system: ReadonlySet<string>,
+): number {
+  const parameters = holder['parameters'];
+  if (!Array.isArray(parameters)) return 0;
+
+  const kept = parameters.filter((parameter) => {
+    const name = parameterName(parameter, components);
+    return !(name && system.has(name));
+  });
+
+  holder['parameters'] = kept;
+  return parameters.length - kept.length;
+}
+
+/** Move a path item's shared `parameters` onto each of its operations. */
+export function hoistParameters(
+  item: Record<string, unknown>,
+  components: Record<string, unknown>,
+): number {
+  const shared = item['parameters'];
+  if (!Array.isArray(shared) || shared.length === 0) return 0;
+
+  let moved = 0;
+  for (const [method, operation] of Object.entries(item)) {
+    if (!METHODS.includes(method)) continue;
+
+    const holder = operation as Record<string, unknown>;
+    const own = Array.isArray(holder['parameters']) ? (holder['parameters'] as unknown[]) : [];
+    const taken = new Set(
+      own.map((parameter) => parameterName(parameter, components)).filter(Boolean),
+    );
+
+    // An operation that already declares the parameter keeps its own. Adding
+    // both is what produces a renamed duplicate.
+    const inherited = shared.filter(
+      (parameter) => !taken.has(parameterName(parameter, components)),
+    );
+    holder['parameters'] = [...inherited, ...own];
+    moved += inherited.length;
+  }
+
+  delete item['parameters'];
+  return moved;
+}
+
+/** Keep only the listed request body content types, refusing to empty a body. */
+export function narrowRequestBody(
+  operation: Record<string, unknown>,
+  operationId: string,
+  allowed: readonly string[],
+): number {
+  const body = operation['requestBody'] as { content?: Record<string, unknown> } | undefined;
+  if (!body?.content) return 0;
+
+  const before = Object.keys(body.content);
+  const kept = before.filter((type) => allowed.includes(type));
+  if (kept.length === 0) {
+    // Silently leaving the body alone would reintroduce whatever the filter was
+    // added to remove, so this is a refusal rather than a fallback.
+    throw new Error(
+      `${operationId}: request body offers ${before.join(', ')}, none of which is kept by requestContentTypes (${allowed.join(', ')}).`,
+    );
+  }
+
+  body.content = Object.fromEntries(kept.map((type) => [type, body.content![type]]));
+  return before.length - kept.length;
+}

--- a/src/providers/shared/vendor-spec.ts
+++ b/src/providers/shared/vendor-spec.ts
@@ -1,0 +1,309 @@
+/**
+ * Trim an upstream OpenAPI document down to a reviewable, committed spec.
+ *
+ * The output is **committed**, and that is the point. A spec decides which paths
+ * get called with the operator's token, and `connect` grants everything a
+ * provider discovers — so a spec fetched at connect time from a third party
+ * could introduce, say, a DELETE operation that lands on the vendor's own host
+ * holding a real credential. Vendoring makes the surface reviewable and the
+ * build reproducible; a per-provider script exists so refreshing it is one
+ * command rather than a hand edit.
+ *
+ * Every caller passes its own `outputDirectory`, its own note strings, and opts
+ * in to the repairs its upstream document happens to need. Nothing here knows
+ * which vendor it is trimming: a document that declares path parameters one
+ * level up is a shape, not a brand, and the flag that fixes it is set by the
+ * provider that has that shape.
+ */
+
+import { mkdir, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { OpenAPIToolGenerator, type McpOpenAPITool } from 'mcp-from-openapi';
+import { cutCycles, makeOpaque, referenced, type Spec } from './openapi.ts';
+import {
+  METHODS,
+  dropSystemParameters,
+  hoistParameters,
+  narrowRequestBody,
+} from './vendor-operations.ts';
+
+/** Kept in step with `BUDGET_KB` in `src/cli/tools.test.ts`, which enforces it. */
+export const BUDGET_KB = 64;
+
+export interface VendorSpecOptions {
+  /** The upstream document. */
+  readonly source: string;
+  /**
+   * Where to write, which is the caller's own `import.meta.dir`.
+   *
+   * A parameter rather than this module's own directory, and not a stylistic
+   * choice: resolving it here would write every provider's spec into
+   * `providers/shared/`, report success, and leave the committed file untouched.
+   * That exact no-op shipped once before — see the note in the Google script.
+   */
+  readonly outputDirectory: string;
+  readonly out: string;
+  /** The operations to keep, by `operationId`. Everything else is dropped. */
+  readonly operations: readonly string[];
+  /** Schemas to replace with an open object, before reachability is computed. */
+  readonly opaque?: readonly string[];
+  /** The sentence `makeOpaque` appends, naming where the real shape is documented. */
+  readonly opaqueNote?: string;
+  /** What `info['x-vendored-note']` records about why this file is committed. */
+  readonly vendoredNote: string;
+  /** Vendor-specific query parameters to strip from every operation. */
+  readonly systemParameters?: ReadonlySet<string>;
+  /**
+   * Move path-item `parameters` onto each operation, and delete the shared copy.
+   *
+   * Off by default, because a document that already declares its parameters per
+   * operation must not be rewritten — and a path-item `parameters` array is also
+   * where some vendors put the query parameters shared by every method on the
+   * path, which the operations genuinely need to inherit rather than own.
+   *
+   * On, it repairs a document whose path parameters live only at the path level.
+   * `mcp-from-openapi`'s validator reads `operation.parameters` and nothing else,
+   * so such a document fails validation outright with one
+   * `MISSING_PATH_PARAMETER` per parameter and generates zero tools. Deleting the
+   * shared copy is half the fix: leaving both makes the generator see the same
+   * parameter twice and rename one of them.
+   */
+  readonly hoistPathParameters?: boolean;
+  /**
+   * Request body content types to keep. Omit to keep all of them.
+   *
+   * The HTTP connector encodes a body as JSON or form-urlencoded, whichever the
+   * document declares (ADR-045). It cannot do `multipart/form-data` at all — a
+   * multipart branch would be JSON-stringified under a multipart content type —
+   * so that branch describes a request it cannot make, and carries the cost of
+   * one anyway.
+   *
+   * Worse than dead weight: multipart file fields are named `files[0]`, which is
+   * not a legal tool property name, and one illegal name rejects the *entire*
+   * tools list for every provider on the endpoint. Nothing but the generator's
+   * own content-type preference order keeps it out of the generated schema, and
+   * that is a third party's choice to change.
+   */
+  readonly requestContentTypes?: readonly string[];
+  /**
+   * Replace an operation's whole request body schema, by `operationId`.
+   *
+   * For a body the generator cannot flatten. A top-level `anyOf` has no
+   * `properties` to walk, so it emits a single argument literally named `body`
+   * and the connector then sends `{"body":{…}}` where the vendor expects
+   * `{…}` — every test in the repository passes and only a live call fails.
+   * Naming the branch that is actually wanted flattens it back out.
+   *
+   * Applied before reachability, so a branch that is no longer referenced leaves
+   * the document rather than lingering unused.
+   */
+  readonly rewriteRequestBody?: Readonly<Record<string, unknown>>;
+}
+
+export async function vendorSpec(id: string, options: VendorSpecOptions): Promise<void> {
+  const { source, operations } = options;
+  const wanted = new Set(operations);
+
+  const response = await fetch(source);
+  if (!response.ok) throw new Error(`${source}: HTTP ${response.status}`);
+  const spec = (await response.json()) as Spec;
+
+  const paths: Spec['paths'] = {};
+  const seen = new Set<string>();
+
+  for (const [path, item] of Object.entries(spec.paths)) {
+    const kept: Record<string, unknown> = {};
+    for (const [method, operation] of Object.entries(item)) {
+      // Path-level keys are not operations and must survive: `parameters` here
+      // is where some vendors put the query parameters shared by every method on
+      // the path, and one of those may be *required* by an operation. Dropping
+      // it produced a tool with no arguments at all and a 400 on every call.
+      if (!METHODS.includes(method)) {
+        kept[method] = operation;
+        continue;
+      }
+      const operationId = operation.operationId;
+      if (!operationId || !wanted.has(operationId)) continue;
+      kept[method] = operation;
+      seen.add(operationId);
+    }
+
+    // Only path-level keys survived, so no operation here was wanted.
+    if (!Object.keys(kept).some((key) => METHODS.includes(key))) continue;
+    if (Object.keys(kept).length > 0) paths[path] = kept as Spec['paths'][string];
+  }
+
+  const componentParameters = (spec.components?.['parameters'] ?? {}) as Record<string, unknown>;
+  const system = options.systemParameters ?? new Set<string>();
+
+  let hoisted = 0;
+  if (options.hoistPathParameters) {
+    for (const item of Object.values(paths)) {
+      hoisted += hoistParameters(item as unknown as Record<string, unknown>, componentParameters);
+    }
+  }
+
+  let dropped = 0;
+  for (const item of Object.values(paths)) {
+    dropped += dropSystemParameters(
+      item as unknown as Record<string, unknown>,
+      componentParameters,
+      system,
+    );
+    for (const [method, operation] of Object.entries(item)) {
+      if (!METHODS.includes(method)) continue;
+      dropped += dropSystemParameters(
+        operation as unknown as Record<string, unknown>,
+        componentParameters,
+        system,
+      );
+    }
+  }
+
+  let narrowed = 0;
+  for (const item of Object.values(paths)) {
+    for (const [method, operation] of Object.entries(item)) {
+      if (!METHODS.includes(method)) continue;
+      const holder = operation as unknown as Record<string, unknown>;
+
+      if (options.requestContentTypes) {
+        narrowed += narrowRequestBody(
+          holder,
+          operation.operationId ?? `${method} path`,
+          options.requestContentTypes,
+        );
+      }
+
+      const replacement = operation.operationId
+        ? options.rewriteRequestBody?.[operation.operationId]
+        : undefined;
+      if (replacement) {
+        const body = holder['requestBody'] as { content?: Record<string, unknown> } | undefined;
+        for (const type of Object.keys(body?.content ?? {})) {
+          (body!.content![type] as Record<string, unknown>)['schema'] = replacement;
+        }
+      }
+    }
+  }
+
+  // Drop response schemas.
+  //
+  // Two reasons, and the second is the blocking one. Nothing reads them: the
+  // connector hands the response body back as text, because an agent wants the
+  // JSON, not a validated shape. And a recursive response schema — a message
+  // whose payload is a part, which contains parts — sends the OpenAPI tool
+  // generator into infinite recursion and silently drops operations from the
+  // tool list.
+  for (const item of Object.values(paths)) {
+    for (const [method, operation] of Object.entries(item)) {
+      if (!METHODS.includes(method)) continue;
+      (operation as { responses?: unknown }).responses = {
+        '200': { description: 'Success. The response body is returned verbatim.' },
+      };
+    }
+  }
+
+  const missing = operations.filter((operationId) => !seen.has(operationId));
+  if (missing.length > 0) {
+    // Loudly, rather than shipping a provider quietly missing capabilities: an
+    // upstream rename should fail the refresh, not shrink the tool list.
+    throw new Error(`${id}: these operations are not in the spec — ${missing.join(', ')}`);
+  }
+
+  const schemas = spec.components?.schemas ?? {};
+  const opaqued = makeOpaque(schemas, options.opaque ?? [], options.opaqueNote ?? '');
+  const keep = referenced(paths, schemas);
+  const trimmedSchemas = Object.fromEntries(
+    Object.entries(schemas).filter(([name]) => keep.has(name)),
+  );
+  const cuts = cutCycles(trimmedSchemas);
+
+  const trimmed: Spec = {
+    openapi: spec.openapi,
+    info: {
+      ...spec.info,
+      'x-vendored-from': source,
+      'x-vendored-note': options.vendoredNote,
+    },
+    ...(spec.servers ? { servers: spec.servers } : {}),
+    paths,
+    components: { ...spec.components, schemas: trimmedSchemas },
+  };
+
+  await mkdir(options.outputDirectory, { recursive: true });
+  await writeFile(
+    join(options.outputDirectory, options.out),
+    `${JSON.stringify(trimmed, null, 2)}\n`,
+  );
+
+  const size = Math.round(JSON.stringify(trimmed).length / 1024);
+  const extra = [
+    options.hoistPathParameters ? `${hoisted} params hoisted` : '',
+    narrowed > 0 ? `${narrowed} body types dropped` : '',
+  ].filter(Boolean);
+  console.log(
+    `  ${id.padEnd(6)} ${String(Object.keys(paths).length).padStart(2)} paths, ` +
+      `${seen.size} operations, ${Object.keys(trimmedSchemas).length} schemas, ` +
+      `${cuts} cycle${cuts === 1 ? '' : 's'} cut, ${opaqued} made opaque, ` +
+      `${dropped} system params dropped, ${size}KB` +
+      (extra.length > 0 ? `, ${extra.join(', ')}` : ''),
+  );
+
+  await reportLargestTools(id, trimmed, seen.size);
+}
+
+/**
+ * The number the budget is actually about, and a count that proves nothing fell out.
+ *
+ * Everything on the line above counts the *spec*; `cli/tools.test.ts` measures
+ * the **generated input schema**, and the two differ by orders of magnitude
+ * because `mcp-from-openapi` inlines `$ref`s — a schema shared by ten fields is
+ * ten copies once generated. Reasoning about one operation from a schema count
+ * put it at 122 KB when the real figure was 1,133 KB, which is the whole
+ * difference between "just over" and "seventeen times over".
+ *
+ * Printed here so the refresh that adds an operation shows its cost, rather than
+ * leaving it to a test failure to say so after the fact.
+ *
+ * The count is the other half. The generator answers an unresolvable reference by
+ * logging to the console and omitting that one tool, so a document can trim
+ * cleanly, write successfully, and quietly advertise less than it selected.
+ * `tools.test.ts` only asserts the surface is non-empty, so nothing downstream
+ * would notice.
+ */
+async function reportLargestTools(id: string, trimmed: Spec, expected: number): Promise<void> {
+  let measured: Array<{ name: string; kb: number }>;
+
+  try {
+    const generator = await OpenAPIToolGenerator.fromJSON(trimmed);
+    const tools = await generator.generateTools();
+
+    if (tools.length !== expected) {
+      throw new Error(
+        `${id}: the spec holds ${expected} operations but only ${tools.length} generated. ` +
+          'The generator omits a tool it cannot resolve — check for a dangling $ref, ' +
+          'including into components this script trimmed.',
+      );
+    }
+
+    measured = tools
+      .map((tool: McpOpenAPITool) => ({
+        name: tool.metadata.operationId ?? tool.name,
+        kb: JSON.stringify(tool.inputSchema).length / 1024,
+      }))
+      .sort((a, b) => b.kb - a.kb);
+  } catch (error) {
+    // A count mismatch is this script's to report — it is the one failure
+    // `tools.test.ts` cannot see. A generator failure is not: that shows up
+    // against every provider at once, and refusing to finish over it would
+    // leave the specs half-written.
+    if (error instanceof Error && error.message.startsWith(`${id}: the spec holds`)) throw error;
+    console.log(`         (could not measure generated schemas: ${String(error)})`);
+    return;
+  }
+
+  for (const { name, kb } of measured.slice(0, 3)) {
+    const over = kb > BUDGET_KB ? `  ✗ over the ${BUDGET_KB}KB budget` : '';
+    console.log(`         ${name.padEnd(38)} ${kb.toFixed(1).padStart(8)}KB${over}`);
+  }
+}


### PR DESCRIPTION
Announcements to servers the operator owns, and channel reads an agent can triage. One manifest, one vendored spec, no authored capability. Two commits: the vendoring pipeline extraction, then the provider.

Rebased onto Reddit (#53) and bunq (#52). See [what the rebase changed](#what-landed-underneath-this) at the bottom — some of it was substantive, not mechanical.

## Read this first

**Discord has no API for acting as your own account.** Automating a user token is self-botting — their terms forbid it and accounts get terminated — and the OAuth2 user scopes cover neither posting to a channel nor reading channel history. Every legitimate integration acts as an *application*, and an application's messages carry an `APP` badge no setting removes.

What *is* controllable is the name and avatar, per message, through a webhook. So an announcement can read as the operator while an ordinary reply reads as the integration, from one bot token. That ceiling is stated at the top of `setup/discord.md`, before the instructions, because it decides whether the rest is worth someone's time.

Not OAuth, and **not** for ADR-033's reason — ADR-045 withdrew that one by adding `auth.redirect_uri`. What holds here is narrower and not ours to fix: the `bot` scope installs the application into a server, but the credential that then calls the API is the application's bot token, a property of the app rather than anything the exchange returns. `webhook.incoming` does return a usable credential and is write-only to one channel, so it cannot serve the triage half.

## Three bugs this would otherwise have shipped

Two are invisible to the test suite.

1. **Zero tools.** Discord declares path parameters on the path item. That is legal, and `mcp-from-openapi`'s validator reads only `operation.parameters` — so the document fails validation outright with 29 × `MISSING_PATH_PARAMETER` and generates nothing.
2. **`execute_webhook` sends the wrong body.** Its request body is a top-level `anyOf`, which has no `properties` to walk, so the generator emits one argument literally named `body` and the connector sends `{"body":{…}}` where Discord expects `{…}`. The name is legal, the size is fine, `base_url` matches — every test passes and only a live call fails.
3. **`files[0]` in the tools array.** The `multipart/form-data` branches name their fields that, which is not a legal tool property name, and one illegal name rejects the entire tools list for *every* provider on the endpoint.

Related trap, caught by a new guard: **do not prune `components.securitySchemes`.** It looks like 11.5 KB of dead weight and removing it silently drops three tools, including `get_my_user` — the one call you'd make to check a connection. `vendorSpec` now refuses a run where the generated tool count disagrees with the operation count.

## Budgets

| | without `opaque` | with the seven |
|---|---|---|
| worst tool (budget 64 KB) | `execute_webhook` 148.9 KB ✗ | 10.2 KB |
| advertised surface (budget 192 KB) | 305.4 KB ✗ | 33.5 KB |

The seven are all members of the v2 message-component union, written inline in four request schemas and again inside two of its own members. `RichEmbed` stays **concrete** — it costs 3.1 KB and it is how an announcement gets a title, a colour and fields. Collapsing it instead was measured and moves the worst tool from 148.9 to 144.2 KB, so embeds were never the problem.

## The operation list is the security boundary

Twenty of 242. `connect` writes one rule, `discord.*`, and policy has nothing between a whole provider and one exact name — so the vendored list is the boundary, not a convenience. `bulk_delete_messages` is excluded although it sits beside `delete_message`; so is every moderation, role, invite and guild-settings endpoint. `discord.test.ts` asserts the list is exactly those twenty, so a spec refresh that picks one up fails and gets read.

## `security.md` gains a NOT-GUARANTEED row

`create_webhook` and `list_channel_webhooks` return the webhook's token in their response, and a webhook token is standalone: it posts to that channel with no other authentication, and it reaches the model. Accepted because the alternative is not the same capability made safe but no posting under the operator's own name at all. Bounded to one channel, withheld from the audit log (asserted by a test), and revocable from Discord's channel settings. An authored capability could close it, does not meet ADR-017's bar, and is recorded in ADR-047 as the follow-up.

## Auth, and what it costs

`header` on `Authorization` rather than `bearer`, because Discord's scheme word is `Bot` and a bearer credential is assembled as `Bearer <token>`. Two alternatives were available and neither is better: an optional `scheme` field on `authTokenSchema` widens shared auth for one vendor, and the `strategy` seam ADR-046 just registered is for auth a declarative form genuinely cannot express — a static header is not that.

Two costs, both handled where they happen:

- a token pasted bare 401s with nothing to read, so the prompt label spells the prefix out and `troubleshooting` names it first;
- the identity probe hard-codes `Bearer`, so the provider declares **no `identity` block at all** rather than one that always fails after a round trip. Connections are named by a typed label; the same label on a re-run repairs rather than duplicating.

`discord.test.ts` pins all three.

## The pipeline extraction

`shared/openapi.ts` already held the schema surgery and stopped one step short. Its own docblock named the missing piece and the reason — `makeOpaque` "writes a sentence into the schema it replaces… which makes it a Google function that happens to look generic". Taking that sentence as a parameter settles it, so `makeOpaque` moves there with each caller passing its own note.

What was left duplicated is the *pipeline*, and Google's and bunq's copies had already drifted: bunq reports "protocol params dropped" where Google reports "system params dropped", the same step under two names. A third copy for Discord is how they come to disagree about what trimming means. `vendorSpec` takes it; `vendor-operations.ts` takes the operation-level surgery. Google's script drops 642 → 376 lines and comes off `KNOWN_LONG`.

**bunq's script is deliberately left alone.** It would fit, with two more opt-in repairs, but migrating a provider that landed hours ago belongs in its own commit.

**The guard:** `vendor:google` and `vendor:bunq` were run before and after — all seven Google specs and bunq's come back **byte-identical by SHA-256**. `referenced` and `cutCycles` were compared function-for-function against the copies they replace before anything was deleted.

## Verification

- `bun test` — 2260 pass, 0 fail; **2244 at commit 1 alone**, so each commit stands on its own
- `bun run typecheck` — clean
- all three vendoring scripts reproduce their committed specs byte-for-byte
- discovery through the real connector — 20 capabilities, 11 read / 9 write
- setup walkthrough rendered against a scratch workspace (`LANES_LINK_HOME`), not the real one

**Not done, deliberately:** nothing has touched a real Discord account. Creating the application, enabling the Message Content intent, and inviting a bot are changes a `git checkout` cannot undo. Live smoke sequence: `get_my_user` (proves the `Bot ` prefix landed) → `list_my_guilds` → `list_messages` (empty `content` means the intent is off) → `create_message` → `create_webhook` → `execute_webhook` with a `username` override (proves fix 2 — a `{"body":{…}}` wrapper would 400 here and nowhere else).

Also out of scope: triage logic and any Lanes coupling, gateway/websocket support, slash commands, attachments, voice, moderation, DM reading.

## What landed underneath this

Rebased twice. Not all of it was mechanical:

- **Reddit (#53) took ADR-045; bunq (#52) took ADR-046.** Mine is now **ADR-047**. Neither collision shows up as a git conflict — the filenames differ — so only `docs.test.ts` would have caught it, after the fact.
- **#53 made one of my claims false.** I had written that the HTTP connector "only ever sends `application/json`", which was the stated reason for dropping the multipart branches. It now form-encodes too. The narrowing is still right — multipart remains unsendable — but the reasoning needed rewriting in four places rather than left to mislead.
- **#53 withdrew a citation I relied on.** ADR-033's callback-port argument, which I used for "not OAuth". Replaced with Discord's own reason throughout.
- **#53 gave me a field I wanted.** `connector.headers` on `http`, so Discord gets the `User-Agent` it requires — without one Discord refuses at the edge, which surfaces as a network failure with no JSON to read.
- **#52 pre-empted half my extraction.** `shared/openapi.ts` now owns `Spec`, `referenced` and `cutCycles`. My own module duplicated them, so it is deleted and folded into theirs rather than shipped alongside.
- Added a `providers.md` section and a `VENDORS` regex entry, matching what both PRs did.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
