### PR TITLE
Release 0.4.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,7 @@ One command per account. Run it again to add a second mailbox, a second calendar
 | GitHub | `lanes link connect github` |
 | Slack | `lanes link connect slack` |
 | Reddit | `lanes link connect reddit` |
+| Discord | `lanes link connect discord` |
 | Gmail (IMAP, app password) | `lanes link connect gmail_imap` |
 | Gmail (Google MCP) | `lanes link connect gmail_mcp` |
 | Drive (Google MCP) | `lanes link connect drive_mcp` |

--- a/README.md
+++ b/README.md
@@ -110,12 +110,15 @@ One command per account. Run it again to add a second mailbox, a second calendar
 | Linear | `lanes link connect linear` |
 | GitHub | `lanes link connect github` |
 | Slack | `lanes link connect slack` |
+| Reddit | `lanes link connect reddit` |
 | Gmail (IMAP, app password) | `lanes link connect gmail_imap` |
 | Gmail (Google MCP) | `lanes link connect gmail_mcp` |
 | Drive (Google MCP) | `lanes link connect drive_mcp` |
 
 Three things worth knowing up front. `lanes link connect icloud` sets up Mail, Calendar, and
-Contacts together, because one app-specific password covers all three. Google and Slack need no
+Contacts together, because one app-specific password covers all three. Reddit is the one that does
+need an app of your own — it rate-limits per client id, so a shared client would mean strangers
+spending your budget. Google and Slack need no
 OAuth client of your own: both authorise against the one Lanes operates, so there is no console to
 visit — for Google, add `--own-client` if you would rather register your own, or take a service
 account key or an app password over IMAP where you would rather nothing expired. And GitHub takes a

--- a/README.md
+++ b/README.md
@@ -114,6 +114,7 @@ One command per account. Run it again to add a second mailbox, a second calendar
 | Gmail (IMAP, app password) | `lanes link connect gmail_imap` |
 | Gmail (Google MCP) | `lanes link connect gmail_mcp` |
 | Drive (Google MCP) | `lanes link connect drive_mcp` |
+| bunq | `lanes link connect bunq` |
 
 Three things worth knowing up front. `lanes link connect icloud` sets up Mail, Calendar, and
 Contacts together, because one app-specific password covers all three. Reddit is the one that does
@@ -122,8 +123,11 @@ spending your budget. Google and Slack need no
 OAuth client of your own: both authorise against the one Lanes operates, so there is no console to
 visit — for Google, add `--own-client` if you would rather register your own, or take a service
 account key or an app password over IMAP where you would rather nothing expired. And GitHub takes a
-token you paste rather than a browser sign-in, because it will not register a client for us; that
-is the one console visit left here.
+token you paste rather than a browser sign-in, because it will not register a client for us. And
+bunq — which wants a key from inside its app rather than a console at all — is the one that can move
+money, and it says so: its payment tool executes immediately and is not reversible. Set a spending
+limit on the API key while you are in there, and read
+[docs/detailed/setup/bunq.md](docs/detailed/setup/bunq.md) before connecting it.
 
 Full guide — what each one gives your agent, what it needs, and adding your own:
 **[docs/connect.md](docs/connect.md)**.

--- a/docs/README.md
+++ b/docs/README.md
@@ -27,6 +27,7 @@ each decision was made, not just what to type.
 | [`google-verification.md`](detailed/google-verification.md) | The scope justifications Google's review asks for, and why each scope is the narrowest that works |
 | [`setup/icloud.md`](detailed/setup/icloud.md) | One app-specific password for Mail, Calendar, and Contacts |
 | [`creating-a-provider.md`](detailed/creating-a-provider.md) | Add your own integration |
+| [`connectivity-coverage.md`](detailed/connectivity-coverage.md) | Which connectivity and credential types compose, which are closed, and what none of them covers |
 | [`local-development.md`](detailed/local-development.md) | Working on Lanes Link itself |
 | [`adr/`](detailed/adr/) | Architecture decision records |
 | [`init.md`](detailed/init.md) | The original specification, amended to match what was built |

--- a/docs/connect.md
+++ b/docs/connect.md
@@ -33,8 +33,9 @@ $ lanes link connect gmail --profile personal --target local        # again, for
 | Gmail (IMAP) | `lanes link connect gmail_imap` | The same mailbox over IMAP and SMTP, with an app password that does not expire |
 | Gmail (Google MCP) | `lanes link connect gmail_mcp` | Google's own MCP server — Developer Preview only |
 | Drive (Google MCP) | `lanes link connect drive_mcp` | Likewise; use `drive` unless you are enrolled |
+| bunq | `lanes link connect bunq` | Accounts, balances, transaction history, and payments |
 
-## Three things the table does not show
+## Four things the table does not show
 
 **Each Google product is its own connection.** Connecting Gmail does not imply Drive, Sheets, Docs,
 Calendar, Tasks, or Contacts — each holds its own token under its own scopes. One OAuth client
@@ -47,10 +48,21 @@ app-specific password covers all three. iCloud Drive is separate — it holds no
 reading your sync folder through the filesystem. Full walkthrough:
 [`detailed/setup/icloud.md`](detailed/setup/icloud.md).
 
-**Only GitHub asks you to register anything.** Google and Slack authorise against the client Lanes
-operates, Notion and Linear register themselves, and iCloud takes an app-specific password you
-generate at appleid.apple.com. GitHub takes a personal access token you create once —
-[`detailed/setup/github.md`](detailed/setup/github.md).
+**bunq can move money, and nothing asks you to confirm.** Its payment tool executes immediately
+and is not reversible — there is no approval step in the bunq app or anywhere else. Set a spending
+limit on the API key, and if you want an agent to prepare payments rather than make them, deny the
+two payment tools **and** `UPDATE_DraftPayment` — accepting a draft is itself how a draft is spent,
+so leaving that one allowed lets an agent approve its own. Read
+[`detailed/setup/bunq.md`](detailed/setup/bunq.md) before connecting it; it is the only page here
+that is mostly about what not to do.
+
+**GitHub, Reddit, and bunq ask you to register something.** Google and Slack authorise against the
+client Lanes operates, Notion and Linear register themselves, and iCloud takes an app-specific
+password you generate at appleid.apple.com. The other three each want one thing you make yourself:
+GitHub a personal access token — [`detailed/setup/github.md`](detailed/setup/github.md) — Reddit an
+OAuth client at reddit.com/prefs/apps, because it matches the loopback redirect exactly
+([`detailed/setup/reddit.md`](detailed/setup/reddit.md)), and bunq an API key from inside the bunq
+app, which is also where you set its spending limit.
 
 Slack used to be on that list and no longer is. Slack does not register clients automatically and
 is not going to — it would let a client authenticate someone without an app existing, and on

--- a/docs/connect.md
+++ b/docs/connect.md
@@ -177,9 +177,23 @@ output, and in any transcript.
 
 ## Add your own
 
-Any MCP server, any REST API with an OpenAPI spec, any IMAP mailbox, any CalDAV or CardDAV server.
-Most are a fifteen-line YAML manifest in `~/.lanes-link/data/<profile>/providers.d/` and no code at all. See
-[`detailed/creating-a-provider.md`](detailed/creating-a-provider.md).
+Any MCP server, any REST API with an OpenAPI spec, any IMAP mailbox, any CalDAV or CardDAV server,
+any folder on this machine. One command:
+
+```console
+$ lanes link connect custom thing --connector http --auth api-key --auth-header X-Api-Key \
+    --base-url https://api.example.com/v1 --openapi https://api.example.com/openapi.json \
+    --profile personal --target local
+```
+
+`--connector` is `mcp`, `http`, `imap`, `dav` or `fs`; `--auth` is `none`, `bearer`, `api-key`,
+`header`, `basic`, `oauth` or `strategy`. Leave out a value it needs and it asks. What it writes is a
+fifteen-line YAML manifest in `~/.lanes-link/data/<profile>/providers.d/` — the same declaration a
+built-in is, and yours to edit from there.
+
+See [`detailed/creating-a-provider.md`](detailed/creating-a-provider.md) to write one by hand, and
+[`detailed/connectivity-coverage.md`](detailed/connectivity-coverage.md) for which combinations
+work, which are closed on purpose, and what none of them covers yet.
 
 ---
 

--- a/docs/connect.md
+++ b/docs/connect.md
@@ -30,6 +30,7 @@ $ lanes link connect gmail --profile personal --target local        # again, for
 | GitHub | `lanes link connect github` | Repositories, issues, pull requests, and workflow runs |
 | Slack | `lanes link connect slack` | Search, read, and send messages, threads, files, and canvases |
 | Reddit | `lanes link connect reddit` | Read subreddits and comments, search, and post, comment, and vote as you |
+| Discord | `lanes link connect discord` | Post announcements and read channels, as a bot application you own |
 | Gmail (IMAP) | `lanes link connect gmail_imap` | The same mailbox over IMAP and SMTP, with an app password that does not expire |
 | Gmail (Google MCP) | `lanes link connect gmail_mcp` | Google's own MCP server — Developer Preview only |
 | Drive (Google MCP) | `lanes link connect drive_mcp` | Likewise; use `drive` unless you are enrolled |

--- a/docs/connect.md
+++ b/docs/connect.md
@@ -29,6 +29,7 @@ $ lanes link connect gmail --profile personal --target local        # again, for
 | Linear | `lanes link connect linear` | Linear's own MCP server |
 | GitHub | `lanes link connect github` | Repositories, issues, pull requests, and workflow runs |
 | Slack | `lanes link connect slack` | Search, read, and send messages, threads, files, and canvases |
+| Reddit | `lanes link connect reddit` | Read subreddits and comments, search, and post, comment, and vote as you |
 | Gmail (IMAP) | `lanes link connect gmail_imap` | The same mailbox over IMAP and SMTP, with an app password that does not expire |
 | Gmail (Google MCP) | `lanes link connect gmail_mcp` | Google's own MCP server — Developer Preview only |
 | Drive (Google MCP) | `lanes link connect drive_mcp` | Likewise; use `drive` unless you are enrolled |

--- a/docs/detailed/adr/045-a-redirect-the-vendor-matches-exactly.md
+++ b/docs/detailed/adr/045-a-redirect-the-vendor-matches-exactly.md
@@ -1,0 +1,71 @@
+# ADR-045: A provider may name the loopback redirect the vendor matches exactly
+
+**Status:** accepted · **Relates to** [ADR-005](005-oauth-connection-flow.md) ·
+**Amends** [ADR-033](033-a-pasted-token-for-an-mcp-server.md) ·
+**Relates to** [ADR-040](040-an-mcp-connector-may-use-a-pre-registered-client.md)
+
+## Context
+
+`connect` runs the authorization code flow against a listener on `127.0.0.1`, bound to a port the
+kernel picks (ADR-005). Nothing outside the machine names that port, so letting the OS choose it
+avoids collisions for free.
+
+That works because most authorization servers treat a loopback redirect as a special case and
+match only the host and path, ignoring the port — which is what RFC 8252 §7.3 asks them to do.
+Not all of them do. Some match `redirect_uri` as a whole string against what was registered in a
+console, and for those the port chosen at runtime can never be the port registered months earlier.
+The grant fails after consent with `redirect_uri_mismatch`, which reads as a broken client rather
+than as a port that moved.
+
+This was already costing us something. ADR-033 records GitHub reaching for a pasted token rather
+than OAuth, and the reason given there is exactly this:
+
+> an OAuth App matches its callback URL exactly, including the port, and `connect` listens on a
+> port the kernel picks
+
+That was true, and it was treated as a property of the CLI rather than as a gap in it.
+
+ADR-040 solved an adjacent problem — Slack refuses a non-HTTPS redirect at all — by sending the
+browser to the broker's HTTPS origin and carrying the loopback port in `state`. That answer does
+not transfer. It requires a broker, and a broker is the wrong shape for a vendor that rate-limits
+per client id: one shared client would pool every install into one budget.
+
+## Decision
+
+An OAuth provider may declare `auth.redirect_uri`. When it does, `connect` listens on the port
+that URL names and hands the vendor that exact string.
+
+- **The whole URL, not a port.** The two must be identical strings and only one of them is ours to
+  choose. A console that accepts `localhost` but not `127.0.0.1`, or that wants a trailing path,
+  decides the spelling — a manifest that could only name a number would have to guess the rest.
+- **Mutually exclusive with `broker`.** Both answer "where does the browser come back to", and the
+  flow reads one of them. `defineProvider` refuses a manifest declaring both.
+- **A taken port is a refusal, not a crash.** With a kernel-chosen port `EADDRINUSE` cannot happen;
+  with a fixed one it is the ordinary failure. The message names the port and says why it cannot
+  simply be moved.
+
+The listener is otherwise unchanged: same PKCE, same constant-time `state` check, same single
+callback, same shutdown.
+
+## Alternatives considered
+
+**Register a range of ports and try each.** Some consoles accept several redirect URIs, so the CLI
+could register ten and use whichever is free. It multiplies what the operator types by ten, and
+the failure when all ten are busy is worse than the failure when one is.
+
+**Always use a fixed port.** Simpler, and wrong: a fixed port can collide, and every provider that
+does not need one would inherit that for nothing.
+
+**Route everything through the broker, as ADR-040 does for Slack.** It works, and it makes a
+shared client mandatory. For a vendor metering per client id that is a permanent cost paid to
+avoid a one-time console visit.
+
+## Consequences
+
+- A vendor that pins its redirect is now reachable by OAuth. Reddit is the first, and GitHub could
+  move off its pasted token on this basis — ADR-033's reasoning for that choice no longer holds,
+  though the token still works and nothing forces the change.
+- The operator types a URL into a console and it must match exactly. The provider's `setup.steps`
+  states it verbatim, and `setup.troubleshooting` names `redirect_uri_mismatch` as the symptom.
+- One more way for two manifest fields to disagree, which is why the mutual exclusion is checked
+  at `defineProvider` rather than left for the flow to resolve by precedence.

--- a/docs/detailed/adr/046-an-auth-strategy-belongs-to-its-provider.md
+++ b/docs/detailed/adr/046-an-auth-strategy-belongs-to-its-provider.md
@@ -1,0 +1,74 @@
+# ADR-046: An auth strategy belongs to its provider, and its session is state
+
+**Status:** accepted · **Milestone:** M6
+
+[ADR-008](008-connectors.md) reserved one place for per-vendor code — `AuthStrategy`, auth only,
+roughly 150 lines — and named bunq as the case that would need it. The seam was typed and left
+throwing. bunq is now built, and building it settled two questions the seam had left open.
+
+## Where the code lives
+
+**A strategy is carried by the `ProviderDefinition` that needs it, not registered in a table the
+runtime searches.**
+
+The alternative was a registry under `connectivity/auth/strategy/`, one folder per vendor,
+populated at startup. It reads naturally — the auth README's own table lists `strategy/` beside
+`bearer/` and `oauth-authcode/`, so a folder there looks like where the code goes.
+
+It is the wrong place, and `architecture.test.ts` says why. The rule that no vendor name appears in
+the code a request passes through covers `connectivity/`, and a folder of vendor implementations
+inside it would be a standing exception to the rule that component exists to keep. The rule is now
+enforced for bunq too — `bunq` was added to the `VENDORS` pattern in the same change, which is what
+makes the placement checked rather than merely intended. One error message had to give up naming a
+vendor to make that pass, which is the rule doing its job.
+
+So `connectivity` keeps the seam and learns nothing: `strategyFor` resolves the strategy a manifest
+declares from the definition beside it, and refuses when the two disagree. The implementation is
+`providers/bunq/strategy/`, where every other thing about bunq already is. Adding a provider stays
+what ADR-008 made it — a folder and a line in `providers/index.ts` — even when the provider needs
+code.
+
+## Where the session lives
+
+**Durable credentials go to the credential store during `setup`. The session token goes to
+`state`.**
+
+This looks like a weakening and is not a choice. `AuthStrategyContext.write` is absent outside
+`setup` by design, and `rotatableCredentialRefs` grants a deployed revision write access on nothing
+for a non-OAuth provider — so a per-request handshake *cannot* write a credential, on the target
+where it would matter. Two independent parts of the system already said no.
+
+`state` is where it belongs anyway. `stores/state/index.ts` describes its contents as "connection
+status, token expiry, cursors, provider state", all of it rebuildable, and a bunq session is
+exactly that: reconstructible from the API key, revocable from the app, and expiring within a week
+regardless.
+
+What forces it to be *shared* state rather than per-instance memory is a rate limit. bunq allows
+**one `/session-server` call per thirty seconds**. A deployed endpoint that opened a session per
+cold start would spend a burst of instances being refused, so the token has to survive in a place
+every instance can read.
+
+The honest cost: on a deployed target `state` is the blob store, which is weaker than the Secret
+Manager the durable half sits in. It is accepted because of what the two halves are. The private
+key and installation token are the durable identity of this client and cannot be reissued without
+the operator; the session is a week-long bearer token that any instance can mint again from a
+credential it already holds.
+
+## Consequences
+
+**A strategy reads its host from the manifest, not from an option.** bunq's sandbox is a different
+host, and the first attempt made that a `sandbox: true` option with `authorize` rewriting the
+request origin to match. That is a second source of truth for something `base_url` already states,
+and the two can disagree — a manifest pointed at the sandbox but missing the flag would have spent
+against production. Deriving both the handshake host and the request from `base_url` makes the
+disagreement impossible instead of documented. `auth.options` remains on the seam for a strategy
+that needs configuration `base_url` cannot express; bunq turned out not to be one.
+
+**`verify` earns its place.** It was declared for bunq's response signatures and is used for two
+things: checking them, and noticing a 401. The second is what lets a session that expired early
+recover without anybody intervening, because nothing else on the seam sees a response.
+
+**A strategy provider skips the credential resolver entirely.** `dispatch` branches before
+`authorizeRequest`, because a strategy has no static `ResolvedCredential` to produce. `resolve.ts`
+keeps refusing strategies, which is correct for the non-HTTP transports that take a resolved
+credential directly and could not use one.

--- a/docs/detailed/adr/047-a-pasted-token-carries-its-own-scheme.md
+++ b/docs/detailed/adr/047-a-pasted-token-carries-its-own-scheme.md
@@ -1,0 +1,119 @@
+# ADR-047: A pasted token may carry its own auth scheme, and a write surface may hand back a credential
+
+**Status:** accepted · **Follows** [ADR-033](033-a-pasted-token-for-an-mcp-server.md) ·
+**Builds on** [ADR-045](045-a-redirect-the-vendor-matches-exactly.md) · **Constrained by**
+[ADR-017](017-attachments-by-reference.md)
+
+## Context
+
+Discord was added to post announcements to servers the operator owns, and to read channels so an
+agent can triage them. Two things about it do not fit the shapes already here, and both are worth
+recording because the cheap answer to each is a rule this repository otherwise holds.
+
+**There is no user-account path at all.** Discord publishes no API for acting as yourself.
+Automating a user token is self-botting, which their terms forbid and which gets accounts
+terminated, and the OAuth2 user scopes cover neither posting to a channel nor reading its history.
+Everything an integration can legitimately do, it does as an *application* — and an application's
+messages carry an `APP` badge that cannot be removed. So "post as myself" is not available and
+never will be. What is available is the *name and avatar* on each message, set per message through
+a webhook, which is close enough to be worth building and not close enough to describe as the
+thing that was asked for.
+
+That also settles why this is not OAuth — and note it is *not* ADR-033's reason, which ADR-045 has
+since withdrawn. A vendor matching its callback URL exactly against a kernel-chosen port is now
+answerable with `auth.redirect_uri`, so it is no longer an argument for a pasted token anywhere.
+What holds here is narrower and not fixable on our side. A Discord OAuth2 flow with the
+`bot` scope installs an application into a server, but the credential that then calls the API is
+the application's bot token — a property of the app, not something the exchange returns. So a
+browser flow would end with the operator copying a token out of the developer portal anyway. The
+`webhook.incoming` scope *does* return a usable credential, and it is write-only to one channel: it
+cannot read, so it cannot serve the half of this that is triage.
+
+**Discord's scheme word is `Bot`, not `Bearer`.** `Authorization: Bot MTIz…`. Nothing in this
+codebase could emit that: `attachBearer` assembles `Bearer ${token}` and there is no field to say
+otherwise.
+
+## Decision
+
+**A token credential may carry its own scheme inside the stored value, rather than the manifest
+gaining a field to name one.** Discord declares `auth: { kind: 'header', header: 'Authorization' }`,
+which writes the stored value into the header verbatim, and the operator pastes `Bot MTIz…`.
+
+The alternative was one optional `scheme` field on `authTokenSchema`, defaulting to `Bearer`, read
+in `bearer/index.ts`, `credential.ts`, `resolve.ts` and `cli/identity.ts`. It is a small, additive
+change and it is the better *design*. It was not taken because it widens the shared auth surface
+for one provider, and `header` already expresses exactly this — a credential whose whole value goes
+in a named header. The provider stays inside its own folder.
+
+Two costs follow, and neither is hypothetical:
+
+- **A token pasted without the prefix fails as an opaque 401.** Mitigated where it happens rather
+  than in a comment: the prompt label is `Discord bot token, prefixed — Bot <token>`, and
+  `setup.troubleshooting` names the missing prefix as the first thing to check. `discord.test.ts`
+  asserts both, so the mitigation cannot quietly disappear.
+- **The connection cannot name itself.** `resolveAccount` sends `Authorization: Bearer <stored
+  value>`, which here is `Bearer Bot MTIz…` — a 401 and a null. So the provider declares **no
+  `identity` block at all**, rather than one that always fails after a network round trip. The
+  operator types a label. Re-running `connect` with the same label repairs the existing connection
+  instead of adding a second, because `settleIdentity` matches on it; a scripted run passes
+  `--display-name`. If a `scheme` field is ever added for another vendor, this provider should take
+  it and grow an identity block.
+
+**The webhook operations are vendored, accepting that two of them return a credential to the
+caller.** `create_webhook` and `list_channel_webhooks` include the webhook's token in their
+response, and a webhook token is standalone: anybody holding it can post to that channel with no
+other authentication. It therefore reaches the model.
+
+This is a real weakening and it is recorded as one — `provider.response-may-carry-a-credential`,
+NOT-GUARANTEED, in [`security.md`](../security.md). It is accepted because the alternative is not
+"the same thing, safely" but "no posting under the operator's own name", which was the point.
+Bounded three ways: the token only posts to the one channel it was made for, `redact` withholds
+`webhook_token` from the audit log so it is not also written down in clear, and
+`docs/detailed/setup/discord.md` says plainly that a webhook is a credential and how to revoke one.
+
+**No capability is authored.** An authored `announce` capability could find-or-create the webhook
+and post through it without ever returning the token, which would close the exposure above. It is
+not built: ADR-017 sets the bar at "the vendor's API can do something its *document* cannot
+express", and three documented calls express this fine. Recorded as the obvious follow-up if the
+exposure proves to matter more than the ~80 lines.
+
+**The vendored operation list is the security boundary, and it is pinned by a test.** `connect`
+writes one policy rule, `discord.*`, and policy has no pattern between `provider.*` and an exact
+name — so every operation in the spec is an operation an agent may call. Twenty are vendored out of
+242. `bulk_delete_messages` is excluded although it sits beside `delete_message`; so is every
+moderation, role, and guild-settings endpoint. `discord.test.ts` asserts the list is exactly those
+twenty, so a refresh that picks up a new operation fails and gets read rather than merging quietly.
+
+## Consequences
+
+Adding Discord needed no change to any shared component. What it did change is the vendoring
+pipeline, which moved from `providers/google/specs/vendor.ts` into
+`providers/shared/vendor-spec.ts`, `vendor-operations.ts` and `vendor-schemas.ts` so a second
+provider could use it — verified by re-running `bun run vendor:google` and requiring all seven
+committed specs to come back byte-identical.
+
+Three repairs were added there, each opt-in per provider, and each of them is a bug that would
+otherwise have shipped silently:
+
+- `hoistPathParameters` — Discord declares path parameters on the path item, which is legal and
+  which `mcp-from-openapi`'s validator does not read. Without it the document fails validation
+  outright and generates **zero** tools.
+- `rewriteRequestBody` — `execute_webhook`'s body is a top-level `anyOf`, so the generator emits one
+  argument literally named `body` and the connector sends `{"body":{…}}` where Discord expects
+  `{…}`. Every test in the repository passes; only a live call fails.
+- `requestContentTypes` — the `multipart/form-data` branches name fields `files[0]`, which is not a
+  legal tool property name, and one illegal name rejects the entire tools list for *every* provider
+  on the endpoint. Nothing but the generator's own content-type preference was keeping it out.
+  ADR-045 taught the transport to form-encode as well as JSON-encode, which narrows this but does
+  not close it: multipart is still unsendable, so the branch describes a request that cannot be
+  made whichever encoding the generator selects.
+
+A fourth is not a flag but a guard: the generator answers an unresolvable `$ref` by logging to the
+console and omitting that one tool, so `vendorSpec` now refuses a run where the generated tool
+count disagrees with the operation count. Pruning `components.securitySchemes` — which looks like
+11.5 KB of dead weight — silently drops three tools, including `get_my_user`, the one call an
+operator would use to check the connection.
+
+Attachments are unavailable as a result of the content-type narrowing. That is the honest state
+rather than a regression: ADR-017's machinery is the route to them, not a multipart branch nothing
+sends.

--- a/docs/detailed/adr/048-declaring-a-provider-from-the-fixed-lists.md
+++ b/docs/detailed/adr/048-declaring-a-provider-from-the-fixed-lists.md
@@ -1,0 +1,166 @@
+# ADR-048: A provider is declared by composing the two fixed lists
+
+**Status:** accepted · **Follows from** [ADR-008](008-connectors.md) ·
+**Relates to** [ADR-030](030-a-profile-owns-its-skills-and-manifests.md) ·
+**Relates to** [ADR-007](007-control-plane-exclusions.md)
+
+## Context
+
+ADR-008 made a provider a declaration rather than a package, and said what that was for:
+
+> The manifest schema is the same whether it arrives as a typed module in `providers/builtin` or
+> as YAML in `<workspace>/providers/*.yaml`. That is the point: a service we have never heard of
+> is a file, not a pull request.
+
+The mechanism has been true since. `loadProfileProviders` reads
+`data/<profile>/providers.d/*.yaml`, runs it through the same `defineProvider` a built-in calls at
+import, and registers it into the same registry with `origin: 'workspace'`. `connect` says so out
+loud in a comment — *a custom provider must be as connectable as a built-in* — and it is.
+
+What was missing was the way in. To reach that mechanism an operator had to know a directory no
+command names, write YAML against a schema they would read in the source, and satisfy fourteen
+cross-field rules that only announce themselves by refusing. Two commands were promised in
+docstrings and never existed: `lanes link provider new`, named as the writer of the scaffold in
+`providers/custom/load.ts`, and `lanes link provider list`, named in `registry.ts` as the reason
+`origin` is recorded at all. And the one message that would have pointed somebody at the
+directory named `<workspace>/providers/`, which nothing has ever read.
+
+So the gap was never the design. It was that the most scalable thing in the system was the least
+reachable.
+
+## Decision
+
+**`lanes link connect custom <id> --connector <kind> --auth <method>` declares a provider by
+composing the two closed unions a provider is made of, writes the manifest, and connects it.**
+
+Those unions are the whole surface: five connectivity types an operator can declare (`mcp`,
+`http`, `imap`, `dav`, `fs`) and seven credential types (`none`, `bearer`, `api_key`, `header`,
+`basic`, `oauth`, `strategy`). Thirteen of the thirty-five pairs are legal; `defineProvider` closes
+the rest, each for a stated reason. Nothing is bolted on here for a service that fits no pair — that
+is a member missing from one of the lists, which is a folder and a schema entry away, and
+[`connectivity-coverage.md`](../connectivity-coverage.md) is the standing account of which.
+
+`strategy` is offered rather than withheld, and it is the one that most needed deciding. A strategy
+names code that travels on a provider's definition rather than in a global registry
+([ADR-046](046-an-auth-strategy-belongs-to-its-provider.md)), so a declaration-only manifest reaches
+one *by name* — and doing that is the only way to point a connection at a vendor's sandbox, because
+a built-in manifest's `options` are not the operator's to edit. Whether the name resolves is the
+registry's question and not this command's: it has no registry to ask, `strategyFor` looks at the
+manifest's own definition and then at every registered provider's, and `refuseStrategy` is what says
+a name reaches nothing. So `--strategy <name>` is passed through and the answer arrives from the
+place that has it.
+
+Four things follow from it, and each is the decision rather than an implementation detail.
+
+**The flags are a projection of the two schemas, not a mirror of them.** `defineProvider` requires
+fields nobody should have to type. `setup.prompts` is mandatory for every credential type that is
+*asked for* rather than granted — without one `ensureStaticCredential` throws, so a manifest with
+no prompt is a provider that cannot be connected at all. `identity` decides whether a connection
+can be labelled with the account it belongs to. And a manual OAuth client needs two prompt keys
+and two credential refs whose exact spelling is read back by literal string in `declareOwnClient`
+and `resolveOAuthClient`; misspell one and the manifest validates, two secrets are collected and
+stored, and *then* it refuses — after the operator has been through a vendor console. All three
+are derived, and the test asserts the OAuth keys against `declareOwnClient`'s own output rather
+than against a second copy of the strings.
+
+**No flag carries a credential.** The repository already decided this for `secrets set`, which
+reads stdin because an argument is in shell history, in `ps` output while the command runs, and in
+any transcript of the session. The consequence here is better than a rule: the command's job is to
+write a manifest whose prompts declare what to ask for, and the existing connect path asks. So it
+handles no secrets, and there is no second implementation of anything about them.
+
+**A combination that validates and cannot run is refused before the write.** Four of these are
+invisible to the schema. A `strategy` on anything but an `http` connector — it signs or negotiates an
+HTTP request and the other four connectors make none it could sign, which no rule in `defineProvider`
+states because each of them already refuses `strategy` for its own reason. And three about OAuth: an `http` connector with dynamic registration (a REST API publishes no
+registration endpoint, so there is no client to authorise with), half a pair of OAuth endpoint URLs
+(`authorise` takes the direct path only when both are present, so one alone is ignored on `mcp` and
+fatal on `http`), and dynamic registration alongside both URLs (declaring them takes an `mcp`
+connector off the SDK's own flow and onto ours, and ours needs a client to present — ADR-040). This
+is the class worth the most care, because "the manifest is valid" and "the tests pass" are both
+true right up until somebody uses it.
+
+**Refusals name the alternative, not the rule.** `defineProvider` says a `dav` connector must
+declare `auth: basic`; this says `--auth basic`. The check runs regardless a moment later, so the
+duplication buys nothing except the sentence — which is the part somebody acts on.
+
+## The manifest is written before the connect, and survives a failed one
+
+`runConnect` opens the runtime on its first line, and the registry that opening builds is what
+reads `providers.d/`. So the file has to exist first; there is no ordering in which the command
+declares and connects in one pass and the connect sees a manifest written afterwards.
+
+That means a failed connect leaves a manifest and no connection. This is correct state, not a leak.
+It is the documented normal state of a hand-written manifest, `status` reports it, and a re-run is
+genuinely a repair — the manifest is registered, the stored credential is found, and the second run
+reaches the config write. Rolling it back would delete the operator's authored file because a
+browser consent was cancelled, or because a spec URL 404'd, which are the two failures the file
+itself is the fix for. So the outcome carries the manifest in `changes` either way, and the retry
+line is plain `connect <id>`: the file exists now.
+
+The one thing that must not survive is a *malformed* manifest. `loadProfileProviders` throws for
+the whole directory on one bad file, which breaks `connect`, `doctor`, `plan`, `status`, `start`
+and `deploy` for that profile — and `check`, whose job is catching exactly this, does not read the
+directory at all. So the composed text goes through `parseManifest` — the loader's own gate,
+entropy check included — before anything is written, and the write is a temp file and a rename.
+
+## Rendering the declaration, not the validated manifest
+
+Writing what `defineProvider` returns would have been the obvious thing, and it does not work.
+
+`defineProvider` applies every schema default. Writing those back freezes them: a manifest saying
+`port: 993` stops following the default if it ever changes, and a re-run diffs against a file full
+of values nobody chose. Worse, the file would not load. `auth.refresh_token` defaults to
+`required`, which puts a key ending in `_token` into the document — and the entropy check guarding
+a manifest refuses any such key that is not a `_ref`. The command would have written a file
+rejected the next time anything read it.
+
+So the command renders the *declaration* — only the fields the answers settle, plus what the
+derivation must add — and validates it separately. The round-trip test is what found this, and it
+is the assertion the design rests on: the text written is re-read by the exact code the loader
+runs and comes back the same manifest.
+
+It also records a real limit, in [`connectivity-coverage.md`](../connectivity-coverage.md): a YAML
+manifest cannot currently set `refresh_token: optional`, which a vendor issuing long-lived tokens
+without a refresh token needs. Nothing here works around it.
+
+## `custom` cannot be a provider id
+
+It is the second word of this command's own grammar, so such a provider could be declared,
+registered, and then never connected — `lanes link connect custom` would always mean the command.
+
+Refused in the command, and again in `buildRegistryWithWorkspace` so a file written by hand says
+why rather than being quietly unreachable. Deliberately *not* through
+`RESERVED_PROVIDER_IDS`: that list is the owner layer's, it is surfaced to an agent as the owner
+providers present in a profile, and the CLI registry passes `allowReserved: true` — so it would
+not have fired here anyway.
+
+## Alternatives considered
+
+**`lanes link provider new`, then `connect`.** The spelling the docstrings promised, and the
+cleaner separation — a manifest is config, a connection is a credential, and ADR-007 keeps those
+apart. Rejected because the separation is ours and the cost is the operator's: two commands to
+learn and two to type for one intention, where the second is fully determined by the first. The
+seam still exists in the code, `runConnect` is exported for it, and `provider list` remains worth
+building for a different reason — reading what a profile has, which nothing does today.
+
+**Reusing `manifestTemplate` as the writer.** It is teaching material: it names a plausible vendor,
+fills every field with an example, and explains each in a comment. Substituting values into it
+would leave the comments describing a different provider than the values beside them, and every
+optional field the operator declined sitting in the file as a value that now *is* declared. It
+stays exactly as it is, for the hand-write path.
+
+**A generic `--field key=value` escape hatch.** Rejected as the thing this ADR exists to avoid. A
+field that no connectivity type declares is not a gap in this command; it is a gap in a schema, and
+routing around it would make the fixed lists advisory.
+
+## Consequences
+
+A service reachable by one of the five protocols and one of the six credential types is now one
+command. What that command cannot express is exactly what the two unions cannot express, which is
+the property worth having — the coverage page is the list, and each entry there names its cost.
+
+The command is also the reason two things adjacent to it had to be fixed first: manifests were not
+read at all on a deployed endpoint (ADR-049), and `identity: { kind: http }` could never work for
+the commonest custom shape there is. Both were pre-existing and neither was visible until something
+made declaring a provider easy.

--- a/docs/detailed/adr/049-manifests-are-read-through-the-workspace-store.md
+++ b/docs/detailed/adr/049-manifests-are-read-through-the-workspace-store.md
@@ -1,0 +1,105 @@
+# ADR-049: A profile's manifests are read through its store, not through the filesystem
+
+**Status:** accepted · **Amends** [ADR-030](030-a-profile-owns-its-skills-and-manifests.md) ·
+**Follows from** [ADR-014](014-owner-layer-is-managed.md) ·
+**Relates to** [ADR-008](008-connectors.md)
+
+## Context
+
+A custom provider did not exist on a deployed endpoint. Not "worked partially", not "needed a
+step" — the manifest was uploaded, the read grant covered it, and the loader never looked.
+
+`loadProfileProviders` read the directory with `node:fs`:
+
+```ts
+const directory = join(workspaceRoot, layout.providers(profile));
+entries = await readdir(directory);
+```
+
+A deployed revision is handed `LANES_LINK_HOME=gs://<bucket>` at rollout, and
+`resolveWorkspaceRoot` returns it unmodified because that is exactly what it is for.
+`path.join('gs://bucket', 'data/personal/providers.d')` is `gs:/bucket/data/personal/providers.d` —
+one slash, a relative path, nothing there. `readdir` threw `ENOENT`, and the catch beside it
+reported the empty list it reports for a workspace that has no manifests:
+
+```ts
+} catch {
+  return []; // No custom providers is the normal case.
+}
+```
+
+That comment is true and it is why nothing was ever reported. Every other part of the path worked:
+`upload.ts` carries `providers.d/` to the bucket because `authoredAreaOwner` matches the directory
+segment; `deployment-cloudrun.md` documents the `objectViewer` grant over "each `providers.d/`";
+`grants.test.ts` evaluates the shipped IAM expression to prove the write exclusion. A file arrived,
+was granted, and was not read.
+
+ADR-014 had already met this exact problem and answered it, for skills:
+
+> a path is baked into a container image at build time and an object key is not
+
+Skills are read through a `BlobStore`. Manifests were not, and the divergence was invisible because
+the failure mode of a filesystem read against a bucket URL is silence.
+
+## Decision
+
+**`loadProfileProviders` reads through `workspaceFiles(root)` — the same `BlobStore` seam every
+other workspace-owned document goes through.**
+
+`workspaceFiles` already returns a filesystem store for a path and a GCS store for
+`gs://<bucket>[/prefix]`, and `#providers` may already import `#profile`. So the change is a `list`
+and a `get` where a `readdir` and a `readFile` were, and a manifest is addressed by *key* either
+way. Everything else about the loader holds: the `.yaml`/`.yml` filter, the `*.example.yaml` skip,
+the sort, and the missing-directory case that really is normal.
+
+Two smaller decisions fall out of it.
+
+**A manifest is a file in that directory, not below it.** Listing a prefix returns everything under
+it, and a relative `openapi:` points at a sibling that `upload.ts` carries into the same prefix — so
+a key with a `/` left in it after the directory is stripped is a spec, or a folder of them, and not
+a declaration. `readdir` gave this for free and `list` does not.
+
+**A relative `openapi:` is refused on a bucket workspace rather than resolved into nothing.** The
+generator wants a filesystem path or a URL, and there is no third thing a bucket key can become.
+Resolving it with `path.resolve` produced a path that does not exist, which surfaces as a discovery
+failure the runtime swallows so that startup survives an unreachable provider — leaving a provider
+registered with zero capabilities and nothing anywhere saying why. Refused at load, naming the fix:
+publish the spec at a URL.
+
+**Writing stays local.** `connect custom` refuses a `gs://` workspace outright. This is not a
+limitation of the loader but ADR-007 holding: a deployed revision never rewrites its own config, so
+a declaration is authored where the operator is and carried up by the publish that follows a
+connect, or by `deploy`.
+
+## Alternatives considered
+
+**Materialise a bucket-hosted spec to a temp file.** It would make a relative `openapi:` work
+everywhere, and it is more machinery than this needs — a cache with a lifetime, an invalidation
+question, and a temp directory in a container that may be read-only. A URL already works and is one
+line of YAML. Recorded as the follow-up if somebody hits it.
+
+**Bake manifests into the image.** Rejected for the reason ADR-014 rejected it for skills: it would
+make declaring a provider a rebuild, which is the whole thing ADR-008 exists to avoid.
+
+**Leave it, and document that custom providers are local-only.** Rejected because the failure is
+silent. A deployed endpoint reports healthy and the provider's tools are simply absent, which is
+indistinguishable from a policy problem, a discovery problem, or a client problem — and every
+existing doc claim to the contrary would have had to be walked back rather than made true.
+
+## Consequences
+
+A manifest written locally serves from a deployed endpoint once it reaches the bucket, which it
+already did.
+
+`check` still does not read `providers.d/`, so a malformed manifest is not caught by the one command
+whose job is static validation — it surfaces as every *other* command failing for that profile,
+because the loader throws for the whole directory on one bad file. `connect custom` validates
+before it writes, which closes the path that would create one; a hand-written file still has no
+gate. That is worth fixing separately.
+
+`sync targets` also does not carry manifests, despite a docstring and a heading that say it does:
+`planBlobs` excludes every `.yaml`, which was almost certainly meant to keep `profiles/*.yaml` out
+of the byte-comparison path and is over-broad. The test that looks like it covers this passes
+vacuously, asserting no changes for two identical files — which is also what the exclusion
+produces. Left alone here because the intent is not clear from the code, and guessing at it would
+change what a recovery command copies.

--- a/docs/detailed/adr/README.md
+++ b/docs/detailed/adr/README.md
@@ -55,6 +55,8 @@ Nothing in the codebase depends on it.
 | [045](045-a-redirect-the-vendor-matches-exactly.md) | A provider may name the loopback redirect verbatim, for a vendor that matches `redirect_uri` exactly rather than ignoring the port |
 | [046](046-an-auth-strategy-belongs-to-its-provider.md) | An auth strategy belongs to its provider, and its session is state |
 | [047](047-a-pasted-token-carries-its-own-scheme.md) | A pasted token may carry its own auth scheme in the stored value, and a vendored write surface may return a credential to the caller where the alternative is losing the capability |
+| [048](048-declaring-a-provider-from-the-fixed-lists.md) | A provider is declared by composing the two fixed lists — one connectivity type, one credential type — and connected in the same command |
+| [049](049-manifests-are-read-through-the-workspace-store.md) | A profile's manifests are read through its store, so a custom provider serves from a deployed endpoint |
 
 Where an ADR departs from init.md, it says so at the top. Three are significant:
 
@@ -117,3 +119,16 @@ Where an ADR departs from init.md, it says so at the top. Three are significant:
   the owner wrote are kept. What it may hold is fixed by having no field for anything else: the
   credential store and the vault cannot be named by it, by a flag, or by an example somebody copies.
   It also settles the one cost ADR-030 wrote down and declined to pay.
+
+- **ADR-048** finishes ADR-008 rather than amending it. That decision made a provider a
+  declaration and said a service nobody has integrated should be a file rather than a pull
+  request; the mechanism has been true since and the way in did not exist. What it adds is a
+  command, and one constraint on it worth reading as part of the decision: the flags are a
+  projection of the two unions, so what cannot be declared is exactly what those unions cannot
+  express — never a field this command invents to route around them.
+
+- **ADR-049** amends ADR-030 on one point. That decision moved manifests into the profile and
+  named the path; it did not say how the path is read, and the filesystem read it inherited meant
+  a deployed revision — whose workspace is a bucket URL — silently loaded none of them. ADR-014
+  had already answered the same question for skills, and this applies that answer to the other
+  directory ADR-030 created.

--- a/docs/detailed/adr/README.md
+++ b/docs/detailed/adr/README.md
@@ -52,6 +52,7 @@ Nothing in the codebase depends on it.
 | [042](042-a-profile-declares-who-its-owner-is.md) | A profile declares who its owner is, so an agent writing on their behalf stops guessing |
 | [043](043-a-target-scoped-command-acts-on-the-target.md) | A command whose subject is the endpoint acts on the target, and every profile declaring it |
 | [044](044-a-deployment-records-where-it-lives.md) | A deployment records where it lives outside any profile, and the two copies of a workspace can be merged |
+| [045](045-a-redirect-the-vendor-matches-exactly.md) | A provider may name the loopback redirect verbatim, for a vendor that matches `redirect_uri` exactly rather than ignoring the port |
 
 Where an ADR departs from init.md, it says so at the top. Three are significant:
 

--- a/docs/detailed/adr/README.md
+++ b/docs/detailed/adr/README.md
@@ -54,6 +54,7 @@ Nothing in the codebase depends on it.
 | [044](044-a-deployment-records-where-it-lives.md) | A deployment records where it lives outside any profile, and the two copies of a workspace can be merged |
 | [045](045-a-redirect-the-vendor-matches-exactly.md) | A provider may name the loopback redirect verbatim, for a vendor that matches `redirect_uri` exactly rather than ignoring the port |
 | [046](046-an-auth-strategy-belongs-to-its-provider.md) | An auth strategy belongs to its provider, and its session is state |
+| [047](047-a-pasted-token-carries-its-own-scheme.md) | A pasted token may carry its own auth scheme in the stored value, and a vendored write surface may return a credential to the caller where the alternative is losing the capability |
 
 Where an ADR departs from init.md, it says so at the top. Three are significant:
 

--- a/docs/detailed/adr/README.md
+++ b/docs/detailed/adr/README.md
@@ -53,6 +53,7 @@ Nothing in the codebase depends on it.
 | [043](043-a-target-scoped-command-acts-on-the-target.md) | A command whose subject is the endpoint acts on the target, and every profile declaring it |
 | [044](044-a-deployment-records-where-it-lives.md) | A deployment records where it lives outside any profile, and the two copies of a workspace can be merged |
 | [045](045-a-redirect-the-vendor-matches-exactly.md) | A provider may name the loopback redirect verbatim, for a vendor that matches `redirect_uri` exactly rather than ignoring the port |
+| [046](046-an-auth-strategy-belongs-to-its-provider.md) | An auth strategy belongs to its provider, and its session is state |
 
 Where an ADR departs from init.md, it says so at the top. Three are significant:
 

--- a/docs/detailed/commands.md
+++ b/docs/detailed/commands.md
@@ -59,6 +59,78 @@ $ lanes link connect gmail --profile personal --target local --id work
 `--target` never points at a running endpoint: `connect --target cloud` runs consent locally and
 writes the token into the deployment's store.
 
+### `lanes link connect custom <id>`
+
+Declare a service that is not built in, and connect it. The provider is composed from two fixed
+lists — one connectivity type and one credential type — written to
+`data/<profile>/providers.d/<id>.yaml`, and then connected exactly as a built-in is. The manifest is
+yours to edit afterwards; `lanes link connect <id>` re-reads it every time.
+
+Omit a required value and it is asked for. `--non-interactive` names every missing one at once
+instead, with the command to re-run.
+
+| | |
+|---|---|
+| `--connector <kind>` | `mcp`, `http`, `imap`, `dav`, `fs` |
+| `--auth <method>` | `none`, `bearer`, `api-key`, `header`, `basic`, `oauth`, `strategy` |
+| `--name <text>`, `--description <text>` | how the provider is labelled; the name defaults to the id read as words |
+| `--endpoint <url>` | `mcp`: the URL the server speaks Streamable HTTP on |
+| `--base-url <url>` | `http` and `dav` |
+| `--openapi <url\|path>` | `http`: a URL, or a path resolved against the manifest's own directory |
+| `--operations <globs>` | `http`: which operations to expose, by operationId, path or tag |
+| `--service <kind>` | `dav`: `caldav` or `carddav` |
+| `--host`, `--port` | `imap` |
+| `--smtp-host`, `--smtp-port` | `imap`: omit the host and the mailbox is read-only, with no send capability |
+| `--root <path>`, `--exclude <names>` | `fs` |
+| `--header 'Name: value'` | sent on every request, repeatable; `mcp` and `http` only. Never `Authorization` |
+| `--auth-header <name>` | the header the credential is sent in |
+| `--auth-query <param>` | `api-key` only: the query parameter instead of a header |
+| `--scopes <list>` | `oauth` |
+| `--authorize-url`, `--token-url` | `oauth`: together or not at all; required on `http` |
+| `--client-app <name>` | which `oauth_apps` entry holds the client; defaults to the id |
+| `--registration <kind>` | `dynamic` or `manual`; `mcp` defaults to `dynamic`, everything else to `manual` |
+| `--authorize-param k=v` | `oauth`: extra parameters on the authorization request, repeatable. Some vendors issue no refresh token without one |
+| `--redirect-uri <url>` | only for a vendor that matches the whole redirect URL (ADR-045) |
+| `--strategy <name>` | `strategy`: the name a provider in this build supplies, e.g. `bunq`. `http` only |
+| `--strategy-option k=v` | `strategy`: repeatable, read by the strategy itself — a sandbox host, say |
+| `--identity-url`, `--identity-field` | `http`: one GET that names the account, and which field to read |
+| `--setup-docs <url\|text>` | where the credential comes from. A URL becomes a link, a sentence a step |
+| `--replace-manifest` | rewrite a declaration that exists and differs. `--replace` is about the credential |
+
+It also takes `--id`, `--display-name`, `--replace`, `--accept-broad-scopes` and
+`--non-interactive`, which are forwarded to the connect that follows.
+
+```console
+$ lanes link connect custom docs_server --connector mcp --auth oauth \
+    --endpoint https://mcp.example.com/mcp --profile personal --target local
+
+$ lanes link connect custom thing --connector http --auth api-key --auth-header X-Api-Key \
+    --base-url https://api.example.com/v1 --openapi https://api.example.com/openapi.json \
+    --profile personal --target local
+
+$ lanes link connect custom mailbox --connector imap --auth basic \
+    --host imap.example.com --smtp-host smtp.example.com --smtp-port 465 \
+    --profile personal --target local
+```
+
+`--auth strategy` names code a provider in this build carries, which a manifest of your own can
+borrow — the only way to point a connection at a vendor's sandbox, since a built-in manifest's
+`options` are not yours to edit ([ADR-046](adr/046-an-auth-strategy-belongs-to-its-provider.md)).
+
+Thirteen of the thirty-five possible pairs are legal, and the rest are refused with the alternative named —
+an `mcp` connector has nowhere to put an API key, an `imap` one authenticates with a password, an
+`fs` one holds no account at all.
+[`connectivity-coverage.md`](connectivity-coverage.md) is the whole matrix, including what no pair
+covers yet.
+
+No flag carries a credential. The manifest declares what to ask for and the ordinary connect path
+asks — the same reason `secrets set` reads stdin rather than an argument.
+
+Two limits worth knowing. A declaration is written to the local filesystem, so this refuses a
+workspace that is a bucket: declare it where you deploy from, and `lanes link deploy` carries it up.
+And a failed connect leaves the manifest in place — that is the normal state of a hand-written one,
+`status` reports it, and the retry is plain `lanes link connect <id>`.
+
 ### `lanes link start`
 
 Reconcile, then serve every profile in the workspace on one endpoint.

--- a/docs/detailed/connectivity-coverage.md
+++ b/docs/detailed/connectivity-coverage.md
@@ -1,0 +1,325 @@
+# Connectivity coverage
+
+A provider is two choices: how a service is reached, and how we prove who we are. Both are closed
+discriminated unions — `connector.kind` in
+[`connector.ts`](../../src/connectivity/manifest/connector.ts) and `auth.kind` in
+[`auth.ts`](../../src/connectivity/manifest/auth.ts) — and everything else about a provider is data
+hung off the pair. `lanes link connect custom` exists to compose them, so this page is the honest
+account of what that composition reaches.
+
+It is written to be read in two directions. If you are declaring a provider, the matrix says
+whether your pair works. If you are deciding what to build next, the second half says what no pair
+covers and what each gap would cost.
+
+## How to read this
+
+Four states, not two:
+
+| | |
+|---|---|
+| **works** | Expressible in a manifest today. **Proven by** names a built-in that exercises it; blank means legal and unexercised — nothing refuses it, and the first operator to declare it is the test. |
+| **closed** | `defineProvider` refuses it, on purpose. The rule is in [Why a cell is closed](#why-a-cell-is-closed). |
+| **not built** | Nothing refuses it in principle. No code exists. No cell is in this state today — it is what the gaps in the second half are. |
+| **n/a** | Not a combination to build. |
+
+One thing the union's shape hides: **`auth.assertion` is not a `kind`.** RFC 7523 — sign a JWT with
+a key you hold and exchange it for a token — hangs off the OAuth block instead, and the reasoning is
+the rule this whole page is measured against:
+
+> Declared *on* the OAuth block rather than as a fourth `kind`, because it is an alternative
+> arrangement for the same provider rather than a different provider.
+
+So it is a column here, not a row. Which arrangement a connection actually uses is decided by the
+*shape of the stored credential*, not by config.
+
+## The matrix
+
+| connector | none | oauth | bearer | api_key | header | basic | strategy | oauth + assertion |
+|---|---|---|---|---|---|---|---|---|
+| **mcp** | works | works — `notion`, `linear`, `slack`, `gmail_mcp`, `drive_mcp` | works — `github` | closed **R7** | closed **R7** | closed **R7** | closed **R7** | closed **R4** |
+| **http** | works | works — `gmail`, `drive`, `sheets`, `docs`, `calendar`, `tasks`, `contacts`, `reddit` | works | works | works — `discord` | works | works — `bunq` | works — the seven Google providers, via a service-account key |
+| **imap** | closed **R5** | closed **R5** | closed **R5** | closed **R5** | closed **R5** | works — `icloud_mail`, `gmail_imap` | closed **R5** | n/a |
+| **dav** | closed **R5** | closed **R5** | closed **R5** | closed **R5** | closed **R5** | works — `icloud_calendar`, `icloud_contacts` | closed **R5** | n/a |
+| **fs** | works — `icloud_drive` | closed **R6** | closed **R6** | closed **R6** | closed **R6** | closed **R6** | closed **R6** | n/a |
+| **local** | works — the owner layer, `example` | closed **R6** | closed **R6** | closed **R6** | closed **R6** | closed **R6** | closed **R6** | n/a |
+
+Three readings worth stating plainly.
+
+**`http` is the row where the open cells are.** All eight of them are open, and it is where every
+custom provider that is not an MCP server or a mailbox will land. Four are unexercised, which is a
+gap in *evidence* rather than in the schema — and the one `connect custom` starts closing, which is
+why the round-trip test over every legal pair matters more than it looks.
+
+**`strategy` is only open on `http`, and that follows from what a strategy is.** It signs or
+negotiates an HTTP request, so it needs a request to sign: `mcp` sends exactly one header and
+permits only three credential types (R7), `imap` and `dav` authenticate with a password (R5), and
+`fs` makes no request at all (R6). `connect custom` refuses the other four by name.
+
+**R5 is the only closure with an expiry date.** Its stated reason is that OAuth for mail and DAV is
+partner-gated with no published scopes. That is a fact about 2025, not about IMAP. When a vendor
+publishes scopes, R5 becomes wrong and two cells open.
+
+`local` is in the matrix for completeness and cannot be declared: it means the capability code is
+ours, compiled into this build. `connect custom` refuses it by name.
+
+## Why a cell is closed
+
+Every rule is in [`defineProvider`](../../src/connectivity/manifest/provider.ts), and each exists
+because the alternative validates and then does not work.
+
+| | Rule | What it closes |
+|---|---|---|
+| **R2** | `oauth` + `registration: manual` needs an `app`, and needs either a `broker` or setup prompts | a manual client with nowhere to come from. "Otherwise there is no way to learn what to provide." |
+| **R3** | a `broker` needs `manual`, an `app`, and an `authorize_url` — plus a `token_url` on `mcp`, and never a `redirect_uri` | an exchange with nowhere to route. On `mcp` the SDK owns the flow and "has nowhere to route an exchange somebody else performs" (ADR-040). |
+| **R4** | `mcp` + `assertion` is refused | the assertion column for `mcp`. "The SDK owns an mcp provider's exchange and takes a client, not a signed assertion — so the choice would be offered, accepted, and then have nowhere to go." |
+| **R5** | `imap` and `dav` must declare `basic` | 10 cells. "Every mail and DAV host that matters issues an app password and expects it over Basic. OAuth for these exists — Apple shipped one in Oct 2025 — but is partner-gated with no published scopes, so declaring it would be a manifest that validates and then cannot authenticate." |
+| **R6** | `fs` and `local` must declare `none` | 10 cells. "Nothing to authenticate to. The permission is the operating system's, held against the process, and there is no credential to store or to leak." |
+| **R7** | `mcp` auth must be `none`, `oauth` or `bearer`, may not rename its header, and `connector.headers` may not set `Authorization` | 3 cells. "The transport sends exactly one header, `Authorization: Bearer <token>`, because that is what the MCP specification says a client sends… Such a manifest validates and then connects *unauthenticated* — no error, an empty tool list, and nothing to read that says why." |
+| **R8** | an assertion needs non-empty `scopes` and its own prompts | a token "permitted to do nothing" that only reports at the first call. |
+| **R9** | a token credential may not declare both `app` and `credential_ref` | one secret per account across a vendor versus one across every account. "Pick the one that is true." |
+| **R10** | a `shared` prompt must name a ref; a `connection` prompt must not | a ref that "would name a connection that does not exist yet". |
+| **R11** | `basic` needs exactly one `username` prompt and one `password` | `basic` stores `username:password` and cannot be assembled from anything else. |
+
+There is no rule refusing `strategy` itself, and there was briefly one here that should not have
+been. A strategy names code, and whether a name reaches any is the *registry's* question rather than
+the schema's — `strategyFor` looks at the manifest's own definition and then at every other
+registered provider's, and `refuseStrategy` is what says a name reaches nothing. That indirection is
+the point: it is what lets a declaration-only manifest in `providers.d/` borrow a registered
+strategy by name, which is the only way to point a connection at a vendor's sandbox, since a
+built-in manifest's `options` are not the operator's to edit
+([ADR-046](adr/046-an-auth-strategy-belongs-to-its-provider.md)).
+
+`connect custom` refuses R4–R7 in its own words before writing anything, naming the alternative
+rather than the rule. The rule fires regardless a moment later; the sentence is the part somebody
+acts on.
+
+## What a capability *is* depends on the connector
+
+This decides what a custom provider can do, which is a different question from whether it connects.
+
+| connector | capabilities come from |
+|---|---|
+| `http` | **discovered** — the OpenAPI document, through `mcp-from-openapi`, filtered by `operations` |
+| `mcp` | **discovered** — the upstream server's `tools/list` |
+| `imap` | **fixed** — `imap/capabilities.ts`, conditioned on whether SMTP was declared and whether the server supports `MOVE` |
+| `dav` | **fixed** — `dav/capabilities.ts`, conditioned on `caldav` or `carddav` |
+| `fs` | **fixed** — "a folder is a folder" |
+| `local` | **authored** — Zod schemas in our own code |
+
+So a manifest adds *capabilities* only on the two discovered rows. On `imap`, `dav` and `fs` it
+chooses a host and some limits and gets whatever the protocol's fixed set is. That is the right
+trade and it is deliberate — as `connector.ts` puts it, "the capability set belongs to the connector
+rather than to the manifest", because IMAP describes its extensions and never its operations.
+
+## What no cell covers
+
+Each gap ends with a cost, in one of four sizes: **schema only** · **a folder, a schema member and a
+resolve case** (the unit `connectivity/auth/README.md` claims for itself) · **a change to a
+transport or to dispatch** · **a whole transport**.
+
+One thing to read the auth gaps against first. Now that the strategy seam is real, several of them
+have a *second* answer that costs nothing here: a folder under `providers/` and a line in that
+provider's index. `sigv4` is the clearest case — request signing over a keypair the operator holds is
+exactly the shape `providers/bunq/strategy/` already is. A strategy is the right home when the
+arrangement belongs to *one vendor*, and a `kind` is the right home when it is a standard several
+vendors implement the same way, because only then does a shared implementation have anything to
+share. Client credentials below is a standard; SigV4 is one vendor's.
+
+### OAuth 2.0 client credentials
+
+The commonest machine-to-machine arrangement — a client id and secret, no browser, no person — and
+there is no path to it. The only grant types in the tree are `refresh_token`,
+`authorization_code`, and `urn:ietf:params:oauth:grant-type:jwt-bearer`. The absence is recorded in
+the code: "The other flows the credential-type list names — client credentials, SigV4 — are sibling
+folders that do not exist yet."
+
+**Cost: a folder, a schema member and a resolve case — plus two CLI touch points the README does not
+count.** `connect` needs a `ChosenMethod` member and an arm beside the assertion and pasted-token
+routes, because there is no browser to open and no static prompt to fill.
+
+One shape decision is worth settling in advance. As a new `auth.kind`, `rotatableCredentialRefs`
+returns nothing for it — so a deployed revision caching an access token gets no write binding and
+starts refusing about an hour after reporting healthy. Hung off the OAuth block as
+`auth.client_credentials`, following the assertion precedent, refs and grants are unchanged. The
+second shape is the right one, and it can cache in process memory and persist nothing at all, which
+is what the assertion path already does.
+
+### A REST API with no OpenAPI document
+
+`openapi` is required on an `http` connector and there is no path around it: the transport hands the
+string straight to the generator, and discovery is entirely that generator's output.
+
+**There is already a zero-code answer, and it should be documented rather than built:** write a
+five-operation OpenAPI document by hand and put it beside the manifest. A relative `openapi:`
+resolves against the manifest's own directory, and `upload.ts` carries a `.json` in `providers.d/`
+to a deployed bucket along with the manifest. For a service where you want six calls and not six
+hundred, hand-writing the six is less work than reading a vendor's spec anyway.
+
+**Cost if built: schema only, plus a synthesiser.** An `operations: [{ id, method, path, parameters
+}]` block and a function that emits an OpenAPI document from it, leaving the transport and the
+discovery path untouched. A second declaration format is the thing to avoid; a second *front end*
+onto the same one is fine.
+
+### GraphQL
+
+No transport handles it, and there is no cell for it. Linear rides `mcp` — which is the answer for
+any vendor operating an MCP server over their own GraphQL API, and increasingly they do.
+
+An `http` connector can technically reach `POST /graphql` if a spec describes it with a free-form
+body, and that is worse than nothing: the query becomes a string the model composes against a schema
+nothing validated, and `operations.include` — the filter that keeps a tool list reasonable — has
+exactly one operation to choose from.
+
+**Cost: a whole transport**, including introspection-driven discovery as the analogue of reading a
+spec. Out of scope, and the reason is not the cost: the set of services reachable by GraphQL and not
+by MCP is small and shrinking.
+
+### Pagination, cursors, rate limits, retries
+
+None of it is expressible. The `http` transport is one `fetch` and one response: no retry, no
+backoff, no `429` handling, no `Retry-After`, no cursor following. The rate limiting that exists is
+inbound — token buckets protecting the endpoint, not the vendor.
+
+So it is the model's problem, mediated by the spec: a `pageToken` parameter becomes a tool argument,
+the next cursor comes back in the response body, and the model passes it again. A `429` is returned
+as an error result carrying the vendor's status line, and whether anything retries is up to the
+agent.
+
+**Cost: a change to a transport** — and worth flagging as a *different kind* of cost from everything
+in the auth README, whose whole claim is that its gaps touch no transport, no provider and no
+dispatch path. This one touches a transport. It is also the likeliest first surprise for somebody
+pointing a custom provider at a paginated list endpoint.
+
+### `refresh_token: optional` cannot be written in YAML
+
+A vendor that issues a long-lived token and no refresh token needs `refresh_token: optional`, or
+`connect` treats the successful response as a failure. Slack is exactly this case, and declares it —
+but Slack is a built-in, and a built-in calls `defineProvider` directly.
+
+A YAML manifest cannot. The entropy check that guards a manifest refuses any key matching
+`_token` that is not a `_ref`, on the raw document before the schema sees it — and `refresh_token`
+matches. The check is right about the general case and wrong about this key.
+
+**Cost: schema only, in the sense that no behaviour changes** — but the fix is in
+`secret-detection.ts`, which guards every config file in the system, so it wants care rather than
+volume. An exact-name exemption for `auth.refresh_token`, or a rule that a value inside a known enum
+is not a credential.
+
+### `redact` on a provider nobody authored
+
+A manifest without a `redact` block gets `redactAllValues`, which reduces every argument to a type
+marker. So the audit log records that something happened and nothing about what.
+
+**This is the right default and the page should not hedge about it.** The alternative is a default
+that leaks, chosen on behalf of an operator who has not yet seen the capability list — and as
+`provider.ts` says, it "is the only safe default when we did not author the capability and cannot
+know what is sensitive". It is also not a custom-provider problem: `notion` and `linear` declare no
+`redact` either. The built-ins that have one have it because somebody sat down and wrote it, and
+`tasks/redact.ts` records how easy it is to get wrong — "a wrong key here fails silently — the
+lookup misses, every value is withheld, and it reads exactly like working redaction."
+
+There is a real option here, recorded and not recommended. By the time `connect` finishes it holds
+every discovered capability name and input schema, so it could write a commented `redact:` skeleton
+back into the manifest — one key per capability, empty array — giving the operator somewhere to opt
+keys in that they will otherwise never find. **Cost: no schema change and no dispatch change**, but
+it introduces a class of write nothing in this codebase does: rewriting a manifest.
+
+### Webhooks, server-push, and the protocols that are not here
+
+Out of scope with a reason rather than a shrug. The endpoint is stateless by design, so there is no
+stream on which to send a notification and no durable subscription to hold — and server-push also
+needs an inbound public URL. The decision is already applied once: Google Calendar's `watch`
+operations are excluded from the vendored spec because "the `watch` operations push to a webhook this
+endpoint does not have".
+
+SFTP, S3 and gRPC are each **a whole transport**, and each would follow the `imap`/`dav`/`fs` shape
+rather than `http`'s — a fixed capability set in the transport, because none of them has a document
+describing its operations.
+
+SQL should be refused outright, and it is worth saying why here rather than discovering it later:
+the policy layer's unit is a capability name, and the honest capability for a SQL transport is
+"execute an arbitrary query" — one name covering everything, so one grant covering everything.
+Default deny would still be on and would still mean nothing.
+
+## Keeping this page honest
+
+The examples below are held to the same standard as
+[`creating-a-provider.md`](creating-a-provider.md): `src/profile/docs.test.ts` parses every fenced
+YAML block on this page that declares an `id` and a `connector`, through the same `parseManifest`
+the loader runs. A matrix is more dangerous than a how-to, because its examples are exactly the edge
+cells nobody has run.
+
+One of each open row, so every cell claimed above has something behind it:
+
+```yaml
+id: docs_server
+name: Docs Server
+connector:
+  kind: mcp
+  endpoint: https://mcp.example.com/mcp
+auth:
+  kind: none
+```
+
+```yaml
+id: thing
+name: Thing
+connector:
+  kind: http
+  base_url: https://api.example.com/v1
+  openapi: https://api.example.com/openapi.json
+  headers:
+    User-Agent: thing:1.0 (by someone)
+auth:
+  kind: api_key
+  header: X-Api-Key
+setup:
+  prompts:
+    - key: api_key
+      label: Thing API key
+      secret: true
+      scope: connection
+```
+
+```yaml
+id: mailbox
+name: Mailbox
+connector:
+  kind: imap
+  host: imap.example.com
+  smtp:
+    host: smtp.example.com
+    port: 465
+    starttls: false
+auth:
+  kind: basic
+identity:
+  kind: connector
+setup:
+  prompts:
+    - key: username
+      label: Username
+      scope: connection
+      field: username
+    - key: password
+      label: App password
+      secret: true
+      scope: connection
+      field: password
+```
+
+```yaml
+id: notes
+name: Notes
+connector:
+  kind: fs
+  root: ~/Notes
+auth:
+  kind: none
+identity:
+  kind: connector
+```
+
+Every one of these is what `lanes link connect custom` writes for the corresponding pair — the
+command's own tests derive all twelve legal pairs and assert each survives being read back by the
+loader, so this page and that command cannot disagree for long.

--- a/docs/detailed/creating-a-provider.md
+++ b/docs/detailed/creating-a-provider.md
@@ -86,8 +86,63 @@ setup:
     - { key: password, label: App password, secret: true, scope: connection, field: password }
 ```
 
+```yaml
+# A vendor whose authentication is a protocol rather than a value. The strategy
+# is code and lives with the provider that owns it, so this names one that is
+# already registered rather than supplying it — which is also how you point a
+# connection at a vendor's sandbox. Copy the vendored spec in beside this file:
+# a relative `openapi` resolves against the manifest's own directory.
+id: bunq_sandbox
+name: bunq (sandbox)
+connector:
+  kind: http
+  base_url: https://public-api.sandbox.bunq.com/v1
+  openapi: ./bunq.v1.json
+auth:
+  kind: strategy
+  strategy: bunq
+```
+
 Then `lanes link connect mything`. The same schema validates a built-in, so the list in
 `src/providers/index.ts` is a convenience and never a boundary.
+
+### When the credential is a handshake
+
+`auth: { kind: strategy }` is the escape hatch, and it is the **only** place per-vendor code is
+allowed outside a `local` provider ([ADR-008](adr/008-connectors.md),
+[ADR-046](adr/046-an-auth-strategy-belongs-to-its-provider.md)). Reach for it when a vendor wants
+something no field can describe — bunq generates a keypair, runs a three-step handshake, signs every
+request body, and signs its replies back.
+
+A strategy is three optional methods on the provider's definition:
+
+```ts
+export const acme = defineProviderWithStrategy({
+  manifest,                       // auth: { kind: 'strategy', strategy: 'acme' }
+  strategy: {
+    id: 'acme',
+    async setup(context) { /* once, at connect. The only place `context.write` exists. */ },
+    async authorize(request, context) { /* per request: sign it, add headers, renew a session */ },
+    async verify(response, context) { /* optional: check a signed reply, notice a 401 */ },
+  },
+});
+```
+
+Three things about it are not negotiable:
+
+**Keep it to auth.** It takes a request, not an operation. The moment a strategy branches on which
+endpoint is being called, the per-endpoint translation ADR-008 removed has come back.
+
+**`write` is setup-only.** A handshake persists what it produces; per-request code must not. The
+restriction is the absence of the key rather than a rule to remember — and it is not only a
+convention, because a deployed revision is granted write access on nothing for a non-OAuth provider.
+Anything a request needs to save goes in `context.state`, which is namespaced to the connection and
+shared across instances.
+
+**It lives in `src/providers/<id>/strategy/`, never under `connectivity/`.** That component is held
+free of vendor names by `src/architecture.test.ts`, and the seam there resolves a strategy without
+knowing which one it is. A YAML manifest may name any strategy a registered provider supplies, which
+is what the sandbox example above does.
 
 ### Where the credential goes
 

--- a/docs/detailed/creating-a-provider.md
+++ b/docs/detailed/creating-a-provider.md
@@ -6,6 +6,11 @@ A provider declares *how to reach a vendor*, not *what the vendor can do*
 ([ADR-008](adr/008-connectors.md)). Capabilities are discovered — from the vendor's own MCP server,
 or from an OpenAPI document — so there is nothing per-endpoint to write.
 
+`lanes link connect custom <id> --connector <kind> --auth <method>` writes one of these for you and
+connects it in the same command, asking for anything it needs
+([ADR-048](adr/048-declaring-a-provider-from-the-fixed-lists.md)). This page is what it writes, and
+what to edit afterwards.
+
 Drop one of these in `<workspace>/data/<profile>/providers.d/*.yaml` and it registers with no code and no rebuild — for that profile, which is the only one that can reach it ([ADR-030](adr/030-a-profile-owns-its-skills-and-manifests.md)):
 
 ```yaml

--- a/docs/detailed/init.md
+++ b/docs/detailed/init.md
@@ -683,7 +683,7 @@ Run nor the owner layer got built against a shape that was about to be replaced.
 | M3 | Cloud Run | ✅ done |
 | M4 | the owner layer — memory, skills, vault | ✅ done |
 | M5 | managing the owner layer — a CLI, a skill write path, one storage shape ([ADR-014](adr/014-owner-layer-is-managed.md)) | ✅ done |
-| M6 | expanding — more providers, and the bunq `AuthStrategy` | |
+| M6 | expanding — more providers, and the bunq `AuthStrategy` | bunq shipped |
 
 M5 was not on this list. It is here because M4 shipped three providers and no way to manage any of
 them: the two stores holding the owner's own data were reachable only by an agent, and the one thing
@@ -865,10 +865,22 @@ target, and a memory entry became one Markdown file rather than an index row bes
 
 Not before M3 is done. Two strands.
 
-**The `AuthStrategy` seam and bunq.** The seam exists and fails loudly; the RSA keygen, three-step
-handshake, per-request signing, and response verification are unwritten. Sandbox first — it touches
-a bank account — and local target only until the permitted-IP and session constraints are designed
-against M3.
+**The `AuthStrategy` seam and bunq.** Built. The keypair, three-step handshake, per-request body
+signing, and response verification are in `providers/bunq/strategy/` — not in `connectivity/`,
+which keeps the seam and no vendor name; [ADR-046](adr/046-an-auth-strategy-belongs-to-its-provider.md)
+records why, and `bunq` is in the `VENDORS` pattern so the placement is checked rather than
+intended.
+
+Two constraints this milestone said would need designing, and what they turned out to be. The
+**permitted-IP** problem is not ours to solve: bunq refuses to set the wildcard over the API, on
+purpose, so a deployed endpoint needs a key the operator marked wildcard in the app and the honest
+answer is a documented setup step. The **session** constraint decided its own storage — one
+`/session-server` call per thirty seconds means a token that must be shared between instances, so
+it lives in `state` rather than per-instance memory or the credential store, which cannot be
+written on the dispatch path anyway.
+
+Sandbox first still stands, and is a manifest in `providers.d/` naming the sandbox `base_url` —
+the strategy reads its host from there — rather than a second provider or a flag beside it.
 
 **More accounts.** Owner's target stack:
 

--- a/docs/detailed/providers.md
+++ b/docs/detailed/providers.md
@@ -243,6 +243,60 @@ calendar but no calendar itself; `tasks` is the only scope Google publishes for 
 write at all. `contacts` asks for nothing broad — both of its scopes are read-only, and the write
 scope permanently deletes. None of the three grants `auth/calendar` or `contacts`.
 
+## `reddit`
+
+Fifteen operations against Reddit's REST API. Setup: [`setup/reddit.md`](setup/reddit.md) — the one
+provider that needs an OAuth client of your own, because Reddit rate-limits per client id and a
+shared one would pool every install into a single hundred-per-minute budget.
+
+The spec at `src/providers/reddit/specs/reddit.v1.json` is **hand-authored**: Reddit publishes no
+OpenAPI document, so unlike the Google specs there is no vendoring script and no upstream to
+re-sync from. It is still a document rather than code — the operations become capabilities
+mechanically, and there is no per-endpoint translation anywhere in the folder.
+
+| Capability | Kind | Bundle | Why |
+|---|---|---|---|
+| `reddit.list_posts` | tool | read | Posts from one subreddit, in a given order. The ordinary read. |
+| `reddit.get_post` | tool | read | One post with its comment tree. Takes the base36 id, not the fullname. |
+| `reddit.search` | tool | read | Full-text search within a subreddit. |
+| `reddit.get_subreddit` | tool | read | Description, subscriber count, and whether posting needs a flair. |
+| `reddit.get_rules` | tool | read | What a submission must satisfy. Most removals are rule violations, not API errors. |
+| `reddit.list_flairs` | tool | read | Flair templates and their ids — the thing `submit_post` usually needs first. |
+| `reddit.whoami` | tool | read | Which account this connection is. Also what `identity` resolves the label from. |
+| `reddit.list_my_subreddits` | tool | read | The subreddits this account subscribes to. |
+| `reddit.submit_post` | tool | write | Create a text or link post. |
+| `reddit.add_comment` | tool | write | Comment on a post, or reply to a comment. |
+| `reddit.edit_text` | tool | write | Replace the body of something this account wrote. |
+| `reddit.vote` | tool | write | Up, down, or clear. |
+| `reddit.delete_thing` | tool | write | Permanent — Reddit has no trash reachable from the API. |
+| `reddit.save_thing` | tool | write | Add to saved items. |
+| `reddit.set_flair` | tool | write | Apply a flair template to your own post. |
+
+**No moderation, no messages, no history.** Reddit publishes thirty scopes and this asks for eight.
+`privatemessages` would put the account's DMs in reach of a tool list whose subject is public
+posting; the `mod*` scopes act on other people's content in subreddits this account moderates,
+which is a different job with a different blast radius. Nothing here needs either, and a scope on
+the consent screen that no tool can spend is a grant asked for and never noticed.
+
+**Two things the tool descriptions say twice**, because an agent gets both wrong on the first
+attempt and the error does not explain either. `add_comment` takes a *fullname* — `t3_<id>` for a
+post, `t1_<id>` for a comment — and a bare id from a URL is rejected generically. And most
+subreddits reject a submission with no `flair_id` without saying that a flair was the problem,
+which is why `list_flairs` is vendored beside `submit_post`. Both are also in `hints`.
+
+**Scope:** `submit`, `edit`, and `vote` are marked broad, and for a different reason from every
+other broad scope here. The rest are broad for how far they reach into a private space; these are
+broad for acting *publicly* under the person's username. They are also the only writes in this
+repository that cannot be taken back — deleting a post leaves the deletion behind, and anything
+quoted or replied to in the meantime stays. `read` is not marked: it reaches only what the account
+can already see, and what Reddit makes readable is public to begin with.
+
+**Redaction** follows Gmail's line, with one addition worth naming: `title` is withheld along with
+the body. It looks like metadata and is not — a Reddit title is usually the whole of the post and
+the body is often empty, so keeping it would defeat withholding the body. For a link post the
+`url` is the submission, so that is withheld too. What survives is where it went and how it was
+marked: `sr`, `flair_id`, `nsfw`, `spoiler`.
+
 ## iCloud — `icloud_mail`, `icloud_calendar`, `icloud_contacts`
 
 One Apple Account, three providers, one app-specific password

--- a/docs/detailed/providers.md
+++ b/docs/detailed/providers.md
@@ -297,6 +297,89 @@ the body is often empty, so keeping it would defeat withholding the body. For a 
 `url` is the submission, so that is withheld too. What survives is where it went and how it was
 marked: `sr`, `flair_id`, `nsfw`, `spoiler`.
 
+## `discord`
+
+Twenty operations against Discord's v10 REST API. Setup:
+[`setup/discord.md`](setup/discord.md) — an application you create, whose bot token you paste, and
+which you invite to each server you want reachable.
+
+The spec at `src/providers/discord/specs/discord.v10.json` is vendored by
+`src/providers/discord/specs/vendor.ts` from the OpenAPI document Discord publishes. Vendoring
+matters more here than for Google: upstream is a public preview Discord says may change without
+notice, so the committed copy is what stops a breaking change upstream becoming a provider that
+stops working.
+
+**Discord has no API for acting as your own account.** Automating a user token is self-botting,
+which their terms forbid, and the OAuth2 user scopes cover neither posting nor reading channel
+history. So every message here is sent by an *application* and carries an `APP` badge that no
+setting removes. The name and avatar are controllable — per message, through a webhook — which is
+why the three webhook operations are vendored. ADR-047 has the whole argument.
+
+| Capability | Kind | Bundle | Why |
+|---|---|---|---|
+| `discord.get_my_user` | tool | read | Which application this token is. The cheap call that proves the `Bot ` prefix landed. |
+| `discord.list_my_guilds` | tool | read | The servers the bot was added to — not the ones you are in. An empty list means the invite was missed. |
+| `discord.get_guild` | tool | read | One server, with optional member counts. |
+| `discord.list_guild_channels` | tool | read | How a channel *name* becomes the id every other call needs. `type` says whether it can take messages. |
+| `discord.get_channel` | tool | read | One channel — name, type, topic, category. |
+| `discord.list_messages` | tool | read | The triage read, and the only one: Discord offers applications no message search. Pages on `before`/`after`. |
+| `discord.get_message` | tool | read | One message in full, with reactions and embeds. |
+| `discord.list_pins` | tool | read | What has been marked. The current endpoint, not the deprecated one. |
+| `discord.list_message_reactions_by_emoji` | tool | read | Who reacted with one emoji — a lightweight vote, read back. |
+| `discord.get_active_guild_threads` | tool | read | Every open thread in a server at once, cheaper than walking channels. |
+| `discord.create_message` | tool | write | Post as the application. `embeds` rather than `content` is what makes an announcement. |
+| `discord.update_message` | tool | write | Edit its own message. The typo fix; Discord shows an "edited" marker regardless. |
+| `discord.delete_message` | tool | write | The retraction. One message by id — there is deliberately no bulk delete. |
+| `discord.crosspost_message` | tool | write | Publish an announcement-channel post to the servers that follow it. `type: 5` channels only. |
+| `discord.add_my_message_reaction` | tool | write | Mark a message seen or triaged. Notifies nobody. |
+| `discord.create_pin` | tool | write | The heavier mark. Needs Manage Messages; 50 per channel. |
+| `discord.create_thread_from_message` | tool | write | Turn a post into a discussion without cluttering the channel. |
+| `discord.list_channel_webhooks` | tool | read | Find an existing webhook before making another. Returns tokens — see below. |
+| `discord.create_webhook` | tool | write | One per channel, once. Returns a token — see below. |
+| `discord.execute_webhook` | tool | write | Post with `username` and `avatar_url` set per message. How an announcement reads as you. |
+
+**The vendored list is the security boundary, not a convenience.** `connect` writes one rule,
+`discord.*`, and policy has nothing between a whole provider and one exact name — so twenty of
+Discord's 242 operations is the whole of what an agent can reach. `bulk_delete_messages` is
+excluded although it sits beside `delete_message`; so is every moderation, role, invite and
+guild-settings endpoint. `discord.test.ts` asserts the list is exactly those twenty, so a spec
+refresh that picks one up fails and gets read rather than merging quietly.
+
+**Two operations return a credential.** `create_webhook` and `list_channel_webhooks` include the
+webhook's token in their response, and a webhook token is standalone — anybody holding it posts to
+that channel with no other authentication. It therefore reaches the model. Recorded as
+`provider.response-may-carry-a-credential` in [`security.md`](security.md) rather than glossed
+over, and accepted because the alternative is not the same capability made safe but no posting
+under the operator's own name at all.
+
+**No scopes**, because there is no OAuth. What the token can do is chosen by the permission bits on
+the invite URL, in Discord's own console, and this endpoint cannot read them back — the same
+narrower guarantee every pasted-token provider has. The setup page prints an invite URL carrying
+exactly the bits the twenty operations need and nothing else.
+
+**Reading needs the Message Content intent**, a toggle in the developer portal that is free for an
+application under 10,000 users. Without it `list_messages` returns `200` with every `content`
+empty, and nothing in the response says why. It is called out in the walkthrough, in
+`troubleshooting`, and in the `list_messages` hint.
+
+**Every operation carries a hint**, which is unusual and not decoration: Discord describes 17 of
+its 242 operations and none of the twenty here, so `mcp-from-openapi` synthesises
+`POST /channels/{channel_id}/messages` and the hint is the entire rest of what an agent reads.
+Hinting all twenty also turns `cli/tools.test.ts` into a completeness check, since it resolves each
+hint against a generated capability by name.
+
+**Redaction** keeps ids and cursors and withholds message bodies, with two deliberate exceptions.
+`allowed_mentions` is kept everywhere something posts: it is not content but blast radius, and
+whether a post could ping `@everyone` is unrecoverable once the message is edited. `username` is
+kept on `execute_webhook`, because the post is deliberately wearing a name that is not the
+application's and *posted as "Ops" in channel 123* is the entry's whole point. `webhook_token`
+beside it is withheld, and a test asserts no capability keeps it.
+
+**Attachments are unavailable.** Discord takes files as `multipart/form-data`; the connector
+encodes JSON and form-urlencoded (ADR-045) and the multipart branches are dropped during vendoring,
+because their fields are named `files[0]` and one illegal property name rejects the entire tools
+list for every provider on the endpoint.
+
 ## iCloud — `icloud_mail`, `icloud_calendar`, `icloud_contacts`
 
 One Apple Account, three providers, one app-specific password

--- a/docs/detailed/security.md
+++ b/docs/detailed/security.md
@@ -48,6 +48,17 @@ damaging single mistake available.
 | Agent-reachable | **never, in any form** | yes, under policy, default deny |
 | Store | encrypted file, its own key | separate store, **separate key** |
 
+**One thing is a credential and does not live in that store**, and it is worth naming rather than
+leaving to be discovered. An `auth: { kind: strategy }` provider may hold a vendor-issued *session*,
+and bunq's lives in scoped runtime state — the blob store on a deployed target — not in
+`SecretStore`. That is not a preference: `AuthStrategyContext.write` exists only during `connect`,
+and a deployed revision is granted write access on nothing for a non-OAuth provider, so per-request
+code cannot put one there. It is acceptable because of what such a token is — short-lived, revocable
+by the owner from the vendor's own app, and reconstructible from the durable credential, which does
+sit in `SecretStore`. It is still a bearer token in a weaker store than the material beside it, and
+[ADR-046](adr/046-an-auth-strategy-belongs-to-its-provider.md) argues the trade in full. It is not
+agent-reachable either way.
+
 If an agent could read the Gmail refresh token it would simply call Google directly, and the entire
 policy layer would become decorative. That is why the infrastructure interface is called
 `SecretStore` rather than "secrets", why `Vault` will be a separate provider over a separate

--- a/docs/detailed/security.md
+++ b/docs/detailed/security.md
@@ -112,6 +112,7 @@ limitation. `RESERVED` names a compatibility slot with no implementation.
 | `credentials.no-standing-grant` | **NOT-GUARANTEED for a connection authenticated with a key** | see below |
 | `credentials.plaintext-in-use` | NOT-GUARANTEED | inherent |
 | `provider.sandboxed` | NOT-GUARANTEED | provider code is trusted |
+| `provider.response-may-carry-a-credential` | NOT-GUARANTEED **for two Discord operations** | a capability's *response* is returned to the caller unread, and `discord.create_webhook` and `discord.list_channel_webhooks` include the webhook's token in theirs. A webhook token is standalone: it posts to that one channel with no other authentication. Accepted in [ADR-047](adr/047-a-pasted-token-carries-its-own-scheme.md) because the alternative is not the same capability made safe but no posting under the operator's own name at all. Bounded to one channel, withheld from the audit log by `DISCORD_REDACT` and asserted so in `src/providers/discord/discord.test.ts`, and revocable from Discord's channel settings — see [`setup/discord.md`](setup/discord.md). Distinct from `credentials.not-agent-reachable`, which is about this system's own store and still holds |
 | `egress.controlled` | NOT-GUARANTEED | follows from the above |
 | `policy.approval_required` | RESERVED | the model carries the state; no engine, and it fails closed |
 | `delegation.external-clients` | RESERVED | the principal parameter; nothing more |
@@ -243,8 +244,10 @@ The cache is keyed per connection, so two accounts never share a token, and a st
 starts cold with an empty cache.
 
 **Not every upstream credential is an OAuth token, and the ones that are not are weaker in two
-ways.** iCloud takes an app-specific password; GitHub and Slack take a token the operator generates
-and pastes, because neither vendor's MCP server will register a client for us (ADR-033). Such a
+ways.** iCloud takes an app-specific password; GitHub, Slack and Discord take a token the operator
+generates and pastes — the first two because neither vendor's MCP server will register a client
+for us (ADR-033), Discord because its bot token is a property of the application rather than
+anything an OAuth exchange returns (ADR-047). Such a
 credential is long-lived and *is* persisted — there is no refresh, so the stored value is the
 credential itself rather than a means of obtaining one. Rotation is manual: `connect --replace`,
 after revoking upstream.
@@ -254,7 +257,7 @@ is about to be granted and refuses to proceed if the scopes have widened without
 `confirmScopes` is that gate. There is no equivalent here, and there cannot be: what a pasted token
 can do is chosen in the vendor's own console, and this endpoint has no way to read it back. So the
 guarantee for these providers is narrower — the policy layer still bounds what an agent may *call*,
-but the credential's own reach is the operator's to bound, at the vendor, when they create it. Both
+but the credential's own reach is the operator's to bound, at the vendor, when they create it. All three
 setup pages say so at the point the token is generated.
 
 **A Google Cloud project left in "Testing" publishing status expires refresh tokens after seven

--- a/docs/detailed/setup/bunq.md
+++ b/docs/detailed/setup/bunq.md
@@ -1,0 +1,183 @@
+# Connecting bunq
+
+Bank accounts, balances, transaction history, and payments.
+
+```
+lanes link connect bunq
+```
+
+You are asked for one API key, generated inside the bunq app. There is no web
+console, no OAuth client, and no browser consent — bunq does not offer one for
+your own account.
+
+**Read the next section before you connect this one.** It is the only provider
+here that can move money.
+
+## What an agent can do with this
+
+Eleven operations, and three of them spend:
+
+| | |
+|---|---|
+| `bunq.List_all_User` | The user id every other call is addressed under |
+| `bunq.List_all_MonetaryAccount_for_User` | Accounts and balances |
+| `bunq.List_all_Payment_for_User_MonetaryAccount` | Transaction history |
+| `bunq.READ_Payment_for_User_MonetaryAccount` | One transaction |
+| `bunq.List_all_DraftPayment_for_User_MonetaryAccount` | Drafts awaiting approval |
+| `bunq.READ_DraftPayment_for_User_MonetaryAccount` | One draft |
+| `bunq.List_all_PaymentBatch_for_User_MonetaryAccount` | Batches |
+| **`bunq.CREATE_Payment_for_User_MonetaryAccount`** | **Pays. Immediately, and irreversibly.** |
+| **`bunq.CREATE_PaymentBatch_for_User_MonetaryAccount`** | **Pays up to 350 recipients at once** |
+| `bunq.CREATE_DraftPayment_for_User_MonetaryAccount` | Prepares a payment for you to approve in the app |
+| `bunq.UPDATE_DraftPayment_for_User_MonetaryAccount` | Accepts or rejects a draft |
+
+A direct payment has no confirmation step anywhere — not in the app, not by
+email, not here. bunq accepts the call and the money is gone. A *draft* payment
+is the same call with a human in the middle: it appears in the bunq app and does
+nothing until you approve it.
+
+### Three bounds, and only one of them is ours
+
+**A spending limit on the API key**, set in the bunq app. This is the one that
+does not depend on any software here being correct — not the policy engine, not
+the tool list, not this document. Set it, and set it low.
+
+**Policy.** `connect` writes allow lines for what it discovered, and for an HTTP
+provider every `POST` lands in the `write` bundle — so connecting with write
+grants the payment tool. To keep an agent to drafts only:
+
+```
+lanes link policy deny 'bunq.CREATE_Payment_for_User_MonetaryAccount'
+lanes link policy deny 'bunq.CREATE_PaymentBatch_for_User_MonetaryAccount'
+lanes link policy deny 'bunq.UPDATE_DraftPayment_for_User_MonetaryAccount'
+```
+
+**All three.** The first two are the obvious ones. The third is the one that
+makes the other two mean anything: `UPDATE_DraftPayment` with
+`status: ACCEPTED` *is* how a draft becomes a payment, so an agent left holding
+it can create a draft and approve its own draft, and the human checkpoint the
+first two lines were bought for does not exist. Denying it costs you nothing an
+agent should have — accepting, rejecting and cancelling a draft are all things
+to do in the bunq app, which is the entire point of a draft.
+
+That leaves reading and draft-*making* intact, and every payment then waits for
+you in the app.
+
+**The vendored spec.** Nothing outside the eleven operations above exists as a
+tool, so no rule can allow it. Standing orders, opening and closing accounts,
+and ordering cards are all reachable in bunq's API and deliberately absent here.
+
+## Try it against the sandbox first
+
+bunq runs a public sandbox that needs no bank account. Everything below works
+against it, and nothing that happens there is real.
+
+Copy the vendored spec next to a manifest of your own, in
+`<workspace>/data/<profile>/providers.d/`. A relative `openapi:` resolves
+against the manifest's own directory, so keeping the two together is what makes
+the path work wherever the workspace is:
+
+```console
+$ cd <workspace>/data/<profile>/providers.d
+$ cp "$(dirname "$(readlink -f "$(which lanes)")")"/../src/providers/bunq/specs/bunq.v1.json .
+```
+
+```yaml
+id: bunq_sandbox
+name: bunq (sandbox)
+connector:
+  kind: http
+  base_url: https://public-api.sandbox.bunq.com/v1
+  openapi: ./bunq.v1.json
+auth:
+  kind: strategy
+  strategy: bunq
+```
+
+There is no sandbox flag. The strategy reads its host from `base_url`, so this
+manifest handshakes and pays against the sandbox and the built-in `bunq` does
+neither. That is deliberate: a flag beside `base_url` is a second thing to keep
+true, and getting it wrong would open a session against the sandbox and spend it
+against production — which authenticates cleanly and then answers about an
+account that does not exist.
+
+`strategy: bunq` names code the built-in provider carries; borrowing it is not
+borrowing the credential, since this manifest's own id derives
+`bunq_sandbox/<connection>`.
+
+A sandbox key comes from bunq's tinker flow; see
+[doc.bunq.com](https://doc.bunq.com/).
+
+## The API key
+
+1. In the bunq app: **Profile → Security & Settings → Developers → API keys →
+   Add API key**.
+2. Name it `Lanes Link`, so you can revoke this one later without touching your
+   others.
+3. **Set a spending limit on the key.** See above.
+4. **If this endpoint will ever run anywhere but this machine**, mark the key as
+   a *wildcard* key in the same screen. bunq binds a key to the addresses it has
+   been used from, and Cloud Run's egress address is not stable. The wildcard
+   setting cannot be enabled over the API — deliberately, so it cannot be turned
+   on by something that is not a person — so this step is yours and nothing can
+   do it for you.
+5. Copy the key and run `lanes link connect bunq`.
+
+You are then asked what to call the connection. bunq publishes no endpoint that
+reports whose account a key belongs to, so unlike Gmail or GitHub the label is
+yours to choose rather than something we can read.
+
+## What connect actually does
+
+More than store a value, which is why this provider needs code where every other
+one needs a manifest. On `connect`:
+
+1. A 2048-bit RSA keypair is generated on this machine. The private half never
+   leaves it.
+2. `POST /installation` hands bunq the public half and gets back an installation
+   token and bunq's own public key.
+3. `POST /device-server` registers the key against your account, using the API
+   key you pasted. **This is the step that rejects a wrong key**, so a bad
+   paste fails here — with bunq's message — before anything is written to your
+   config.
+4. The API key, the private key, the installation token and bunq's public key
+   are stored together under one reference, `bunq/<connection>`.
+
+No session is opened yet. The first real call opens one and keeps it in state
+for six days; see [ADR-046](../adr/046-an-auth-strategy-belongs-to-its-provider.md)
+for why it lives there rather than beside the credentials.
+
+Every request after that is signed: bunq requires an RSA signature over the
+request **body** in `X-Bunq-Client-Signature`, and replies with a signature of
+its own that this checks.
+
+## When it stops working
+
+**`bunq refused the session`, or a 401 on one call and success on the next.**
+Working as intended. A bunq session lasts as long as your account's auto-logout
+setting — a week by default — and if yours is shorter, the first call after it
+elapses fails and drops the session. The call after that opens a new one.
+
+**Every call is refused after a deploy or an ISP change.** The key is bound to
+addresses it has been used from. Mark it as a wildcard key in the app.
+
+**`answered 429`.** bunq rate-limits, and `/session-server` hardest: one call
+per thirty seconds. Ordinary calls are 3 GETs and 5 POSTs per three seconds.
+
+**Anything else.** Generate a new key in the app and run
+`lanes link connect bunq --replace`.
+
+## Refreshing the vendored spec
+
+```
+bun run vendor:bunq
+```
+
+bunq's published document cannot be used as it stands: generating tools from it
+fails on 55 operations, every payment endpoint among them, because `Payment`
+recurses through `RequestInquiry` and `RequestResponse`. The script cuts those
+cycles, drops the protocol headers bunq declares on every operation — including
+`X-Bunq-Client-Authentication`, which must never be an argument a model can
+fill in — and strips the response-only fields bunq's request bodies inherit from
+pointing at whole resources. The result is committed, so what an operator's
+credential can be pointed at is reviewable in a diff.

--- a/docs/detailed/setup/discord.md
+++ b/docs/detailed/setup/discord.md
@@ -1,0 +1,217 @@
+# Connecting Discord
+
+```console
+$ lanes link connect discord --profile <profile> --target <target>
+```
+
+It asks for one thing: a bot token, which you get from Discord's developer portal. Everything
+else is choices you make in that portal and an invite link you open once per server.
+
+## What this can and cannot do
+
+Read this part first, because it decides whether the rest is worth your time.
+
+**Discord has no API for acting as your own account.** Automating a user token is "self-botting" —
+their terms forbid it and accounts get terminated for it — and the OAuth2 user scopes cover neither
+posting to a channel nor reading its history. Every legitimate integration acts as an
+*application*, and an application's messages carry an `APP` badge next to the name. There is no
+setting, permission, or endpoint that removes it.
+
+What you *can* control is the name and the avatar. Two ways:
+
+- **As the application.** `discord_create_message` posts under the application's own name and
+  icon, which you set once in the portal. Set them to your name and photo and posts read as you,
+  with the badge.
+- **As anything, per message.** `discord_execute_webhook` takes `username` and `avatar_url` on each
+  call, so one channel can carry posts under different names. This is the closer match to "post as
+  myself" and it needs a webhook, which is a two-call setup per channel. See
+  [Posting under your own name](#posting-under-your-own-name).
+
+Reading is the other half, and it has one gate that will waste an afternoon if you miss it: the
+**Message Content intent**. Without it every message you read comes back with an empty `content`,
+the call still returns `200`, and nothing anywhere says why.
+
+## Why a token rather than OAuth
+
+Discord does have OAuth2, and it does not help. Authorising with the `bot` scope installs your
+application into a server, but the credential that then calls the API is the application's *bot
+token* — a property of the app, not something the token exchange hands back. So a browser flow
+would end with you copying a token out of the portal regardless.
+
+The one scope that returns a usable credential, `webhook.incoming`, is write-only to a single
+channel. It cannot read, so it cannot do triage.
+
+That leaves the token you generate yourself — the same conclusion GitHub reached, though for a
+reason that no longer applies: GitHub's was a callback port a vendor would not accept, which
+[ADR-045](../adr/045-a-redirect-the-vendor-matches-exactly.md) has since fixed. Discord's reason is
+about where the credential lives and is not ours to fix
+([ADR-033](../adr/033-a-pasted-token-for-an-mcp-server.md),
+[ADR-047](../adr/047-a-pasted-token-carries-its-own-scheme.md)).
+
+## The application
+
+1. Open <https://discord.com/developers/applications> and choose **New Application**. The name you
+   give it is the name on every post, so name it what you want people to read.
+2. On **General Information**, set the icon. That is the avatar on every post. Copy the
+   **Application ID** while you are here — the invite link needs it.
+3. Open the **Bot** tab. Set the username.
+4. Still on **Bot**, under **Privileged Gateway Intents**, switch on **MESSAGE CONTENT**. An
+   application in fewer than 10,000 servers can just toggle it — there is no review and no
+   verification. Leave `PRESENCE` and `SERVER MEMBERS` off; nothing here uses them.
+5. Turn **Public Bot** off, unless you want other people able to add it to their servers.
+
+## The token
+
+On the **Bot** tab, choose **Reset Token** and copy what it shows you. Discord shows it once.
+
+**Paste it with the word `Bot` and a space in front:**
+
+```
+Bot MTIzNDU2Nzg5MDEyMzQ1Njc4.GhIjKl.mNoPqRsTuVwXyZ
+```
+
+That prefix is not decoration — it is Discord's authentication scheme, the way `Bearer` is most
+other vendors'. The stored value goes into the `Authorization` header exactly as you type it, so a
+token pasted bare produces a `401` on every call with nothing in it to say what is wrong. If
+something is refusing to authenticate, check this first.
+
+The token is stored encrypted at `discord/<connection>` in the credential store, never in config.
+
+## Inviting it to a server
+
+Take the Application ID from step 2 and open:
+
+```
+https://discord.com/oauth2/authorize?client_id=<application-id>&scope=bot&permissions=309774593088
+```
+
+Pick a server you own and authorise. Repeat per server.
+
+Those permission bits are exactly what the vendored operations need, and no more:
+
+| Permission | Why |
+|---|---|
+| View Channels | see that a channel exists at all |
+| Send Messages | `create_message` |
+| Send Messages in Threads | posting into a thread |
+| Read Message History | `list_messages`, which is the whole triage read |
+| Add Reactions | `add_my_message_reaction` |
+| Manage Messages | `create_pin` — Discord puts pinning behind this |
+| Create Public Threads | `create_thread_from_message` |
+| Manage Webhooks | `create_webhook`, `list_channel_webhooks` |
+
+There is no kick, ban, timeout, role, or channel-management bit in there, and no operation vendored
+that could use one.
+
+**A private channel needs the bot added to it separately.** Server-wide permissions do not reach a
+channel the bot cannot see — add it under the channel's own permission settings.
+
+## Posting under your own name
+
+`create_message` posts as the application. To post as *you*:
+
+1. `discord_list_channel_webhooks` on the channel. If one is already there, use it — a channel
+   holds at most 15 and there is no reason to make a second.
+2. `discord_create_webhook` if not. Keep the `id` and `token` it returns.
+3. `discord_execute_webhook` with `username` and `avatar_url` set to whatever the post should wear.
+
+**A webhook token is a credential.** Anybody holding it can post to that channel with no other
+authentication, and steps 1 and 2 both return it in their response — which means it reaches the
+agent, and whatever the agent is talking to. This is recorded as a
+[NOT-GUARANTEED row in the security model](../security.md#guarantee-status) rather than glossed
+over. It is withheld from the audit log, and it is bounded: one channel, no read access, nothing
+else.
+
+To revoke one: the channel's **Integrations → Webhooks** settings, in Discord itself. Deleting the
+webhook there invalidates the token immediately.
+
+## Which tools you get
+
+Twenty, out of 242 in Discord's API. Reads: `get_my_user`, `list_my_guilds`, `get_guild`,
+`list_guild_channels`, `get_channel`, `list_messages`, `get_message`, `list_pins`,
+`list_message_reactions_by_emoji`, `get_active_guild_threads`. Writes: `create_message`,
+`update_message`, `delete_message`, `crosspost_message`, `add_my_message_reaction`, `create_pin`,
+`create_thread_from_message`. Webhooks: `list_channel_webhooks`, `create_webhook`,
+`execute_webhook`.
+
+`connect` grants `discord.*`, which is all twenty — policy has no pattern between a whole provider
+and one exact capability. So **the vendored list is the boundary**, and it deliberately excludes
+`bulk_delete_messages`, every moderation endpoint, and everything under roles, invites and guild
+settings. A test pins the list so a spec refresh cannot widen it quietly.
+
+If you want a narrower connection, deny what you do not want:
+
+```console
+$ lanes link policy deny 'discord.delete_message' --profile <profile> --target <target>
+$ lanes link policy deny 'discord.create_webhook' --profile <profile> --target <target>
+```
+
+Deny beats allow regardless of order, so this holds even though `connect` wrote `discord.*`.
+
+There is no message search: Discord does not offer one to applications. Finding something means
+paging `list_messages` per channel with `before`/`after` and filtering yourself.
+
+Attachments are not available. Discord takes files as `multipart/form-data`, which this connector
+cannot encode — it does JSON and form-urlencoded.
+
+## Non-interactive
+
+The connection is named by a label you type, because Discord's `/users/@me` cannot be probed with
+the scheme this provider uses — so a scripted run has to supply one:
+
+```console
+$ lanes link connect discord --profile <profile> --target <target> \
+    --display-name "Announcer" --non-interactive
+```
+
+The token still has to be in the credential store first:
+
+```console
+$ printf 'Bot %s' "$DISCORD_BOT_TOKEN" | \
+    lanes link secrets set discord/main --profile <profile> --target <target>
+```
+
+Re-running `connect` with the **same** `--display-name` repairs the existing connection. A
+different label makes a second one, which is how you end up with `announcer2`.
+
+## What is recorded
+
+Every call, allowed or refused. Snowflake ids are kept — which guild, channel, message, webhook —
+along with pagination cursors and limits, so the log can answer where something went.
+
+Message bodies are not. `content`, `embeds`, `components`, `attachments`, `poll` and a thread's
+`name` are withheld and appear as type markers, because a log that reproduced them would be a
+second copy of the channel.
+
+Two deliberate exceptions:
+
+- `allowed_mentions` is **kept** on everything that posts. It is not content, it is blast radius —
+  whether a post was permitted to ping `@everyone` is exactly the thing you want in the log, and it
+  is unrecoverable once the message is edited.
+- `username` is **kept** on `execute_webhook`. A webhook post is wearing a name that is not the
+  application's, and *posted as "Announcer" in channel 123* is the entry's whole point. The
+  `webhook_token` beside it is withheld.
+
+## Troubleshooting
+
+**`401` on everything, including `get_my_user`.** The prefix, nine times out of ten — the stored
+value must start with `Bot `. Otherwise: a token invalidated by a later **Reset Token**, or a
+deleted application. Reset it and re-run `lanes link connect discord --replace`.
+
+**Reads work, every `content` is empty.** The MESSAGE CONTENT intent is off. Bot tab → Privileged
+Gateway Intents. It is not a permission on the invite and no error mentions it. Content is always
+available for messages that mention the application, messages in DMs with it, and its own
+messages — which is why this can look intermittent.
+
+**`403` on one channel, fine elsewhere.** The bot is in the server but not that channel. Add it in
+the channel's own permission settings. A private channel does not inherit.
+
+**`crosspost_message` fails.** It only works on an *announcement* channel — `type: 5` from
+`list_guild_channels` — and only on a message already posted there. It is rate limited far more
+tightly than posting, and it cannot be undone.
+
+**`create_pin` fails with `403`.** Pinning needs Manage Messages, and a channel holds at most 50
+pins.
+
+**A webhook post 400s.** Check `username` is 1–80 characters and is not "Clyde" or "Discord", both
+of which Discord refuses.

--- a/docs/detailed/setup/reddit.md
+++ b/docs/detailed/setup/reddit.md
@@ -1,0 +1,89 @@
+# Reddit
+
+```console
+$ lanes link connect reddit --profile personal --target local
+```
+
+Reddit is the one provider here that needs an app of your own. It takes a couple of minutes, once.
+
+## Why there is no shared client for this one
+
+Google and Slack authorise against a client Lanes operates, so there is no console to visit.
+Reddit cannot work that way, and the reason is how it meters access: **Reddit's rate limit is a
+hundred queries a minute per OAuth client id** — not per user and not per token.
+
+A client everyone shared would pool every install of this program into one bucket. Your limit
+would be reached by strangers, and the failure would arrive as somebody else's traffic. An app of
+your own gets its own hundred, which is the whole budget for one person and nowhere near it for
+the next.
+
+## Registering the app
+
+1. Open <https://www.reddit.com/prefs/apps> and choose **create another app...**.
+2. Give it a name you will recognise later. The name is how you revoke this one without touching
+   your other apps.
+3. Choose **web app**. The other two do not fit: `script` only ever reaches your own account, and
+   `installed app` issues no secret for this to hold.
+4. Set the redirect uri to exactly:
+
+   ```
+   http://127.0.0.1:8765/callback
+   ```
+
+   Reddit matches this character for character. It is the address `connect` listens on, and a
+   different port or `localhost` in place of `127.0.0.1` will be refused after you approve the
+   consent screen rather than before.
+5. Create the app. The **client id** is the string just under the app name; the **secret** is the
+   field labelled `secret`.
+
+Then run the connect command above. You will be asked for both values once, they are stored in
+your credential store, and the browser opens.
+
+## Registering for API access
+
+Creating an app is not the same as being allowed to call the API. Reddit's
+[Responsible Builder Policy](https://support.reddithelp.com/hc/en-us/articles/42728983564564-Responsible-Builder-Policy)
+says access must be requested and approved, and the create-app page links to that separately.
+
+The quickest way to find out where you stand is to ask for an app-only token:
+
+```console
+$ curl -sS -X POST -u "<client_id>:<client_secret>" \
+    -A "lanes-link/0.3" \
+    -d "grant_type=client_credentials" \
+    -w "\nHTTP %{http_code}\n" \
+    https://www.reddit.com/api/v1/access_token
+```
+
+`200` means the gate is open. `403`, or an HTML page instead of JSON, means the app exists but
+access has not been granted yet.
+
+## What you get
+
+Reads are granted by default. Writing needs the write bundle, and the three scopes that post,
+edit, and vote are marked broad on the consent screen because they act publicly under your
+username — a post is visible to everyone who reads the subreddit, and deleting it later leaves the
+deletion behind.
+
+Two things are worth knowing before an agent posts anywhere:
+
+- **Most subreddits require a flair.** `reddit.list_flairs` returns the templates and their ids;
+  pass one as `flair_id`. A submission without one is rejected by the subreddit, not by the API.
+- **`reddit.get_rules` is cheap and worth reading first.** Most removals are rule violations rather
+  than API errors, and the API will not tell you that.
+
+## When it stops working
+
+| What you see | What it is |
+|---|---|
+| `invalid redirect_uri` in the browser | The app's redirect uri is not exactly `http://127.0.0.1:8765/callback` |
+| Connected, then every call fails an hour later | The grant was made without `duration=permanent`. Reconnect with `--replace` |
+| `403` or HTML from every call | The app exists but API access has not been approved |
+| `429` | The hundred-per-minute limit for this client id. It is per client, so nothing else is spending it |
+| `Port 8765 is already in use` | Something else holds the port. The redirect names it exactly, so it cannot be moved — free the port |
+
+If you regenerate the secret, run:
+
+```console
+$ lanes link connect reddit --profile personal --target local --replace
+```

--- a/instructions/agents/lanes-link-scout.md
+++ b/instructions/agents/lanes-link-scout.md
@@ -56,8 +56,8 @@ to every future session.
 stops a write is policy on the endpoint:
 
 ```console
-$ lanes link policy deny memory.write
-$ lanes link policy list
+$ lanes link policy deny memory.write --profile <name> --target <name>
+$ lanes link policy list --profile <name>
 ```
 
 If you are running against a profile that grants writes, that is the owner's

--- a/instructions/skills/lanes-link/SKILL.md
+++ b/instructions/skills/lanes-link/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: lanes-link
-description: Use when the user refers to their own accounts, knowledge, procedures, or secrets through Lanes Link — "check my mail", "what do I know about X", "remember this", "which profile am I in" — or asks to connect, register, or set up their Lanes Link MCP server with this agent. Also covers what to do when a Lanes Link call is refused, or when the endpoint is not running.
+description: Use when the user refers to their own accounts, knowledge, procedures, or secrets through Lanes Link — "check my mail", "what do I know about X", "remember this", "which profile am I in" — or asks to connect, register, or set up their Lanes Link MCP server with this agent. Also covers operating the workspace from a shell — adding or removing a profile, checking what a target serves, deploying an endpoint or recovering a lost deployment — and what to do when a Lanes Link call is refused, or when the endpoint is not running.
 ---
 
 # Lanes Link
@@ -24,12 +24,32 @@ is listed first.** Quietly picking one crosses the line the profile exists to
 draw. There is no "current profile" to switch — the choice is made per call, and
 `lanes link profile list` shows what exists.
 
-**Every `lanes link` command names its profile and its target.** Both are required
-flags with no default, no environment variable, and nothing in a config file
-behind them, so a command missing either refuses rather than acting somewhere
-else. When you write one out for the owner, either fill both in or leave them as
-`<name>` for them to complete — never drop them. `lanes link target list
---profile <name>` shows what a profile declares.
+**What a command must be told is never inferred — but it is not always both.**
+Nothing resolves from an environment variable or a config default, so a command
+missing what it needs refuses rather than acting somewhere else. Passing a flag a
+command does not read is refused too, which makes "add both to be safe" its own
+failure. Four levels:
+
+- **Neither.** `lanes link profile list`, `lanes link mcp list`,
+  `lanes link version`.
+- **`--profile` alone.** `lanes link check`, `lanes link config show`,
+  `lanes link policy list`, `lanes link target list --profile <name>`,
+  `lanes link identity list`. Each is target-independent — one declaration in the
+  YAML that applies wherever the profile runs.
+- **`--target`, with the profiles derived from it.** `lanes link status`,
+  `lanes link deploy` and `lanes link sync targets` act on one endpoint serving
+  every profile that declares that target. `--profile` is accepted and *narrows*
+  the answer; it does not choose the subject.
+- **Both.** Everything acting on one account: `lanes link connect`,
+  `lanes link token rotate`, `lanes link secrets set`, `lanes link policy allow`,
+  `lanes link memory list`, `lanes link mcp add`.
+
+`lanes link profile add` and `lanes link profile remove` **reject** `--profile`.
+Both name their profile positionally, so a flag naming a second one could only
+disagree with it.
+
+When you write a command out for the owner, fill in what that command needs or
+leave it as `<name>` for them to complete — never drop a required one.
 
 A `connection` names an account within that profile. One profile may hold
 several of the same kind, and naming a connection belonging to a *different*
@@ -162,8 +182,101 @@ the line.
 **Never pass `--accept-broad-scopes` yourself.** When a provider asks for more than
 it needs, print the scopes and let the owner add the flag. Deciding that is theirs.
 
-A new connection is not served until the endpoint restarts, so a `setup_overview`
-straight after connecting will still not show it. Say so rather than retrying.
+**A new connection is served at once; the tools you were handed are not.**
+Connecting publishes the config to wherever that target's endpoint reads it and
+asks the endpoint to re-read it, so a `setup_overview` straight after connecting
+*does* show the account. What has not changed is the set of tools this session
+was given when it connected — the endpoint does not announce that its tools
+changed, so a capability for a freshly connected account is not callable until
+the client reconnects. Say that, rather than reporting the connection as missing
+or asking them to connect again.
+
+One exception, and it is the one that matters here: the authenticator is built
+once at boot and is not re-read, so a `lanes link token rotate` does need the
+endpoint restarted before the new token opens anything.
+
+## Operating the workspace
+
+If you have a shell, the commands that only *read* are yours to run without
+asking: `lanes link status`, `lanes link check`, `lanes link plan`,
+`lanes link doctor`, `lanes link profile list`, `lanes link target list`,
+`lanes link target show`, `lanes link tools`, `lanes link config show` and
+`lanes link audit tail`. None writes config, opens a browser, or costs anything,
+and running one beats asking the owner to paste its output back. Give each what
+its own level requires — they are not all the same, and the four levels are at
+the top of this file.
+
+**A command that writes runs `--dry-run` first, where it has one.** Show what it
+reported and wait for an answer. `lanes link deploy`, `lanes link sync targets`,
+`lanes link profile remove`, `lanes link secrets push` and `lanes link mcp add`
+all take it. For a write with no dry run — `lanes link token rotate`,
+`lanes link policy allow`, `lanes link secrets set` — say in one sentence what it
+will change, then let them decide. Never a browser sign-in: that belongs to
+whoever owns the account, as above.
+
+**`--json` is not everywhere.** It parses on every command and is read by only
+some, so one that ignores it prints its ordinary output and gives you nothing to
+key on — do not treat the absence of JSON as a failure. `status`, `doctor`,
+`tools`, `outputs`, `sync targets`, `target list`, `target show`, `profile list`,
+`connect` and `setup plan` implement it. `deploy`, `check`, `plan`,
+`config show`, `audit tail` and every `mcp` subcommand do not.
+
+**A profile is created and removed, never switched.** `lanes link profile add
+<name>` writes a new one and takes `--target <name>`, repeated once per target it
+should declare. `lanes link profile remove <name>` takes `--dry-run` and then
+`--yes`; given a `--target` it decommissions that one target's stores and leaves
+the profile file in place. Neither reads `--profile`.
+
+There is no current profile and no default target. `lanes link profile default`
+and `lanes link target use` are gone and now refuse with an explanation — if you
+meet one of those refusals, it is not a broken install, and there is no
+replacement to find. The choice is made per command, on purpose.
+
+## Deploying, and what it decides
+
+`lanes link deploy` builds an image and rolls a revision. Its subject is a
+**target**, and the profiles behind it are every profile declaring that target,
+so one deploy serves all of them — there is no per-profile deploy to run and no
+reason to loop over them.
+
+**Always `--dry-run` first, and show what it printed.** It creates cloud
+resources that cost money, it implements no `--json` to inspect instead, and that
+plan is the only place the consequences are visible while they are still
+avoidable.
+
+Two things it refuses to guess, and both are the owner's to answer:
+
+- **Whose bearer token opens the endpoint.** One token reaches every profile
+  behind that target, so this decides who gets in. With several candidates and
+  nothing recorded, it refuses and prints the command that names one.
+- **A first deploy.** A target no profile declares yet has no set to derive from,
+  so `--profile` is required there. It may be repeated, and the first one named
+  is the primary.
+
+**Never pass `--yes`, `--non-interactive`, `--access public` or
+`--service-account` yourself.** Each settles a question about who can reach their
+accounts. Print what the flag would decide and let them add it — the same rule
+this file already applies to `--accept-broad-scopes`.
+
+Deploying is how new code reaches the endpoint. It is not how an account gets
+connected and not how a config change lands; both of those publish themselves.
+
+## When the workspace and the endpoint disagree
+
+A deployment records where it lives, and a workspace can lose that record — a new
+machine, a reinstall, a profile file restored from something older. The endpoint
+is still serving; what went missing is the config that describes it. The symptom
+is a `lanes link status` that reports nothing deployed for a target you know is
+up.
+
+`lanes link sync targets` reconciles the two. `--discover` looks for a deployment
+the workspace has no record of, `--from <location>` names one directly, and
+`--dry-run` reports what it would merge without merging it. Run the dry run and
+show it.
+
+**`--prefer local` or `--prefer remote` is their answer, not yours.** It decides
+which side wins where the two disagree, and the losing value is the one nobody
+was asked about. Report what differs and let them pick.
 
 ## Registering it, and re-registering it
 
@@ -192,7 +305,7 @@ substitution form. If you have already printed one by accident, say so and offer
 Prefer `lanes link mcp add --profile <name> --target <name>` to writing the command yourself: it checks the
 endpoint is reachable, refuses to silently shadow an existing registration, and
 cannot mistype the token. For a harness it does not know, take the command from
-`lanes link outputs` rather than writing it blind — that command checks whether
+`lanes link outputs --profile <name> --target <name>` rather than writing it blind — that command checks whether
 `lanes` resolves on this machine and prints a longer working form if it does
 not, where guessing gives you an empty substitution, a `Bearer ` header, and a
 401 that reads as a bad token.
@@ -207,9 +320,20 @@ export LANES_LINK_TOKEN="$(lanes link token show --raw --profile <name> --target
 One registration covers every profile. Do not add one per profile; they share a
 URL and a token.
 
+`lanes link mcp list` needs neither flag and reports whether the registration and
+this document are current, out of date, or absent. That is the cheap first
+question when behaviour does not match what this file describes — an out-of-date
+copy means the rules you are reading are not the ones that shipped.
+
+Claude Desktop cannot be handed a URL, so it spawns the endpoint over stdio
+instead. That one is named in the client's own config file rather than registered
+by a command, as `lanes link mcp stdio --profile <name> --target <name>`; both
+flags are required, and nothing may be written to stdout.
+
 ## When it is not running
 
-`lanes link start` runs in the foreground and serves until stopped. Tell the
+`lanes link start --profile <name> --target <name>` runs in the foreground and
+serves until stopped. Tell the
 user the command rather than backgrounding it silently on their behalf.
 Registration works while it is down — the harness simply cannot reach it yet,
 and the first symptom is a failed call much later.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lanes-sh/link",
-  "version": "0.3.2",
+  "version": "0.4.0",
   "description": "A self-hostable MCP gateway for all your connections, memory, skills, and secrets",
   "license": "Apache-2.0",
   "homepage": "https://lanes.sh/link",

--- a/package.json
+++ b/package.json
@@ -49,7 +49,8 @@
     "typecheck": "tsc --noEmit",
     "lanes": "bun run ./src/cli/lanes.ts",
     "audit": "bun pm scan",
-    "vendor:google": "bun run ./src/providers/google/specs/vendor.ts"
+    "vendor:google": "bun run ./src/providers/google/specs/vendor.ts",
+    "vendor:bunq": "bun run ./src/providers/bunq/specs/vendor.ts"
   },
   "imports": {
     "#audit": "./src/audit/index.ts",

--- a/package.json
+++ b/package.json
@@ -49,8 +49,9 @@
     "typecheck": "tsc --noEmit",
     "lanes": "bun run ./src/cli/lanes.ts",
     "audit": "bun pm scan",
-    "vendor:google": "bun run ./src/providers/google/specs/vendor.ts",
-    "vendor:bunq": "bun run ./src/providers/bunq/specs/vendor.ts"
+    "vendor:bunq": "bun run ./src/providers/bunq/specs/vendor.ts",
+    "vendor:discord": "bun run ./src/providers/discord/specs/vendor.ts",
+    "vendor:google": "bun run ./src/providers/google/specs/vendor.ts"
   },
   "imports": {
     "#audit": "./src/audit/index.ts",

--- a/src/architecture.test.ts
+++ b/src/architecture.test.ts
@@ -138,7 +138,7 @@ describe('dependency direction', () => {
  * worse. What must not appear is a vendor name the code *branches on* or
  * *prints*.
  */
-const VENDORS = /\b(gmail|icloud|notion|linear|apple|google|dropbox|fastmail|reddit|bunq)\b/i;
+const VENDORS = /\b(gmail|icloud|notion|linear|apple|google|dropbox|fastmail|reddit|bunq|discord)\b/i;
 
 /**
  * Where the rule bites: the machinery a request passes through.
@@ -309,7 +309,6 @@ const KNOWN_LONG = new Set([
   'connectivity/transports/dav/ical.ts',
   'deployments/adapters/gcp-secret-manager.ts',
   'profile/schema.ts',
-  'providers/google/specs/vendor.ts',
   'providers/memory/provider.ts',
   'server/endpoint.ts',
   'server/harness.ts',

--- a/src/architecture.test.ts
+++ b/src/architecture.test.ts
@@ -138,7 +138,7 @@ describe('dependency direction', () => {
  * worse. What must not appear is a vendor name the code *branches on* or
  * *prints*.
  */
-const VENDORS = /\b(gmail|icloud|notion|linear|apple|google|dropbox|fastmail)\b/i;
+const VENDORS = /\b(gmail|icloud|notion|linear|apple|google|dropbox|fastmail|reddit)\b/i;
 
 /**
  * Where the rule bites: the machinery a request passes through.

--- a/src/architecture.test.ts
+++ b/src/architecture.test.ts
@@ -138,7 +138,7 @@ describe('dependency direction', () => {
  * worse. What must not appear is a vendor name the code *branches on* or
  * *prints*.
  */
-const VENDORS = /\b(gmail|icloud|notion|linear|apple|google|dropbox|fastmail|reddit)\b/i;
+const VENDORS = /\b(gmail|icloud|notion|linear|apple|google|dropbox|fastmail|reddit|bunq)\b/i;
 
 /**
  * Where the rule bites: the machinery a request passes through.

--- a/src/cli/argv.ts
+++ b/src/cli/argv.ts
@@ -1,6 +1,7 @@
 import type { GlobalFlags } from './runtime.ts';
 import type { OwnerFlags } from './commands/owner.ts';
 import type { KnowledgeFlags } from './commands/knowledge.ts';
+import type { CustomFlags } from './commands/connect/custom/spec.ts';
 
 /**
  * Turning argv into a command path and a flag bag.
@@ -140,5 +141,56 @@ export function knowledgeFlags(flags: Flags): KnowledgeFlags {
     replace: flags['replace'] === true,
     yes: flags['yes'] === true,
     json: flags['json'] === true,
+  };
+}
+
+/**
+ * `lanes link connect custom`'s flags.
+ *
+ * Here for the reason `ownerFlags` and `knowledgeFlags` are: the kebab-case
+ * spellings belong in the one place that parses argv. The list flags go through
+ * `all(argv, …)` rather than through `flags`, because `parseArgv` keeps only the
+ * last value of a repeated flag — so `--scopes a --scopes b` would silently
+ * become `b`, and a scope quietly dropped is a token that works until it does
+ * not.
+ *
+ * Which of these are read at all depends on the connectivity type and the
+ * credential type chosen; that is `custom/spec.ts`'s to know. This only spells
+ * them.
+ */
+export function customFlags(flags: Flags, argv: readonly string[]): CustomFlags {
+  return {
+    connector: text(flags, 'connector'),
+    auth: text(flags, 'auth'),
+    name: text(flags, 'name'),
+    description: text(flags, 'description'),
+    endpoint: text(flags, 'endpoint'),
+    baseUrl: text(flags, 'base-url'),
+    openapi: text(flags, 'openapi'),
+    operations: all(argv, 'operations'),
+    service: text(flags, 'service'),
+    host: text(flags, 'host'),
+    port: text(flags, 'port'),
+    smtpHost: text(flags, 'smtp-host'),
+    smtpPort: text(flags, 'smtp-port'),
+    root: text(flags, 'root'),
+    exclude: all(argv, 'exclude'),
+    header: all(argv, 'header'),
+    authHeader: text(flags, 'auth-header'),
+    authQuery: text(flags, 'auth-query'),
+    scopes: all(argv, 'scopes'),
+    authorizeUrl: text(flags, 'authorize-url'),
+    tokenUrl: text(flags, 'token-url'),
+    clientApp: text(flags, 'client-app'),
+    registration: text(flags, 'registration'),
+    redirectUri: text(flags, 'redirect-uri'),
+    authorizeParam: all(argv, 'authorize-param'),
+    strategy: text(flags, 'strategy'),
+    strategyOption: all(argv, 'strategy-option'),
+    identityUrl: text(flags, 'identity-url'),
+    identityField: text(flags, 'identity-field'),
+    setupDocs: text(flags, 'setup-docs'),
+    replaceManifest: flags['replace-manifest'] === true,
+    yes: flags['yes'] === true,
   };
 }

--- a/src/cli/commands/connect.test.ts
+++ b/src/cli/commands/connect.test.ts
@@ -128,6 +128,79 @@ describe('resolveAccount', () => {
   });
 
   /**
+   * The hole this closes.
+   *
+   * `accessToken` is `bearerTokenAsStored`, which throws for a stored
+   * `api_key`, `header` or `basic` credential — under a comment asserting the
+   * branch is unreachable. It is unreachable on an mcp connector, which is the
+   * only place `defineProvider` guarantees a bearer-shaped credential, and
+   * perfectly reachable on an http one. `resolveAccount`'s catch-all turned the
+   * throw into `null`, so an API-key provider with an `identity:` block was
+   * asked to name its account by hand on every reconnect — and a different
+   * answer each time is a new connection row rather than a repair, which is how
+   * `main2` and `main3` came to exist in the first place.
+   */
+  describe('an identity probe for a credential that is not a bearer token', () => {
+    const apiKeyProvider = manifest({
+      kind: 'http',
+      url: 'https://api.example.com/me',
+      field: 'email',
+    });
+
+    test('uses the authorizer, which knows every method', async () => {
+      let sent: Request | undefined;
+
+      const account = await resolveAccount(apiKeyProvider, {
+        accessToken: async () => {
+          throw new Error('a stored API key cannot be sent as a bearer token');
+        },
+        authorize: async (request) => {
+          const authorised = new Request(request, { headers: new Headers(request.headers) });
+          authorised.headers.set('x-api-key', 'k');
+          return authorised;
+        },
+        fetch: (async (request: Request) => {
+          sent = request;
+          return new Response(JSON.stringify({ email: 'me@example.com' }));
+        }) as unknown as typeof fetch,
+      });
+
+      expect(account).toBe('me@example.com');
+      expect(sent?.headers.get('x-api-key')).toBe('k');
+      expect(sent?.headers.get('authorization')).toBeNull();
+    });
+
+    test('and without one, this is the silent null it used to be', async () => {
+      // Pinned rather than left implicit: the fallback is still best-effort, and
+      // the fix is that a caller *can* supply the authorizer, not that the
+      // absence became an error. A label is never worth failing a connect over.
+      const account = await resolveAccount(apiKeyProvider, {
+        accessToken: async () => {
+          throw new Error('a stored API key cannot be sent as a bearer token');
+        },
+        fetch: (async () => new Response('{}')) as unknown as typeof fetch,
+      });
+
+      expect(account).toBeNull();
+    });
+
+    test('an oauth provider is untouched, and still sends its token', async () => {
+      // The reason `settle.ts` supplies `authorize` for three kinds and not for
+      // all of them: `requestAuthorizer` may refresh, and connect-time
+      // deliberately does not.
+      const account = await resolveAccount(apiKeyProvider, {
+        accessToken: async () => 'tok',
+        fetch: (async (_url: string, init?: RequestInit) => {
+          expect((init?.headers as Record<string, string>)['authorization']).toBe('Bearer tok');
+          return new Response(JSON.stringify({ email: 'me@example.com' }));
+        }) as unknown as typeof fetch,
+      });
+
+      expect(account).toBe('me@example.com');
+    });
+  });
+
+  /**
    * Where the vendor's idea of a user is scoped to something smaller than the
    * vendor. Slack's is: `auth.test` answers with a workspace-local handle, so
    * the same person in two workspaces returns the same `user`, and one account

--- a/src/cli/commands/connect/authorise.ts
+++ b/src/cli/commands/connect/authorise.ts
@@ -283,6 +283,11 @@ async function authoriseDirect(input: {
       ...(client.kind === 'brokered' && client.config.redirectUri
         ? { relayRedirect: client.config.redirectUri }
         : {}),
+      // The other spelling of the same need, for a vendor that takes a loopback
+      // redirect but matches it exactly. The manifest owns this URL because the
+      // vendor's console does — it has to be the string registered there, and
+      // `defineProvider` refuses a manifest declaring both this and a broker.
+      ...(manifest.auth.redirect_uri ? { fixedRedirect: manifest.auth.redirect_uri } : {}),
       scopes,
       connectionLabel: manifest.name,
       ...(manifest.auth.authorize_params

--- a/src/cli/commands/connect/custom/ask.test.ts
+++ b/src/cli/commands/connect/custom/ask.test.ts
@@ -1,0 +1,170 @@
+import { describe, expect, test } from 'bun:test';
+import type { Prompter } from '../../../prompt.ts';
+import { collect } from './ask.ts';
+import { AUTH_METHODS, CONNECTOR_KINDS, type CustomFlags } from './spec.ts';
+
+/**
+ * That every value has a flag *and* a question, and that a run with nobody to
+ * ask says everything it needs in one go.
+ *
+ * The second half is the one worth testing. A non-interactive caller is usually
+ * a script or an agent, and a refusal naming one missing flag at a time costs it
+ * a whole run per flag — which is the difference between one round trip and six.
+ */
+
+/** Records what was asked, and answers from a queue. */
+function answering(...answers: string[]): Prompter & { asked: string[] } {
+  const asked: string[] = [];
+  let next = 0;
+
+  return {
+    asked,
+    interactive: true,
+    ask: async (question) => {
+      asked.push(question.trim());
+      return answers[next++] ?? '';
+    },
+    askSecret: async () => {
+      throw new Error('collect must never ask for a secret — that is the manifest\'s job');
+    },
+    confirm: async () => true,
+  };
+}
+
+const silent: Prompter = {
+  interactive: false,
+  ask: async () => {
+    throw new Error('asked on a non-interactive run');
+  },
+  askSecret: async () => {
+    throw new Error('asked on a non-interactive run');
+  },
+  confirm: async () => {
+    throw new Error('asked on a non-interactive run');
+  },
+};
+
+const command = (missing: readonly string[]) =>
+  ['lanes link connect custom thing', ...missing.map((flag) => `--${flag} <value>`)].join(' ');
+
+const gather = (flags: CustomFlags, prompter: Prompter) =>
+  collect('thing', flags, prompter, command);
+
+describe('what the flags did not say is asked for', () => {
+  test('the two lists first, then the fields they decide', async () => {
+    // Order matters: which fields exist at all depends on the two answers, so
+    // they cannot be asked in the other order or asked together.
+    const prompter = answering('2', '2', 'https://api.example.com/v1', 'https://api.example.com/spec.json', '');
+    const result = await gather({}, prompter);
+
+    expect('missing' in result).toBe(false);
+    // Counted from the lists rather than written down: a member landing in
+    // either union is not a reason for this test to fail.
+    expect(prompter.asked[0]).toBe(`Choose 1-${CONNECTOR_KINDS.length}:`);
+    expect(prompter.asked[1]).toBe(`Choose 1-${AUTH_METHODS.length}:`);
+    expect(prompter.asked.slice(2, 4)).toEqual(['Base URL:', 'OpenAPI document:']);
+  });
+
+  test('a member can be typed by name instead of counted', async () => {
+    const result = await gather(
+      { connector: 'mcp' },
+      answering('bearer', 'https://mcp.example.com/mcp', ''),
+    );
+
+    expect(result).toMatchObject({ connector: 'mcp', auth: 'bearer' });
+  });
+
+  test('a name that is not a member says what the members are', async () => {
+    await expect(gather({ connector: 'mcp' }, answering('apikey'))).rejects.toThrow(
+      /not one of: none, bearer, api-key/,
+    );
+  });
+
+  test('an optional field is never asked for', async () => {
+    // A question nobody needs to answer is worse than a flag nobody types.
+    const prompter = answering('https://mcp.example.com/mcp', '');
+    await gather({ connector: 'mcp', auth: 'none' }, prompter);
+
+    expect(prompter.asked).toEqual(['MCP endpoint:', 'Display name [Thing]:']);
+  });
+
+  test('the display name defaults to the id, read as words', async () => {
+    const result = await gather(
+      { connector: 'fs', auth: 'none', root: '~/Notes' },
+      answering(''),
+    );
+
+    expect(result).toMatchObject({ name: 'Thing' });
+  });
+
+  test('and an answer overrides it', async () => {
+    const result = await gather(
+      { connector: 'fs', auth: 'none', root: '~/Notes' },
+      answering('Acme Billing'),
+    );
+
+    expect(result).toMatchObject({ name: 'Acme Billing' });
+  });
+});
+
+describe('a run with nobody to ask', () => {
+  test('names every missing value at once, not the first one', async () => {
+    const result = await gather({ connector: 'http', auth: 'header' }, silent);
+
+    expect(result).toMatchObject({ missing: ['base-url', 'openapi', 'auth-header'] });
+  });
+
+  test('and hands back a command that carries the selection', async () => {
+    // Asserted because a suggested command missing --profile or --target is
+    // refused the moment it is pasted, which reads as the tool being broken.
+    const result = await gather({ connector: 'mcp', auth: 'none' }, silent);
+
+    expect('missing' in result && result.command).toMatch(/--endpoint <value>/);
+  });
+
+  test('a missing list stops at the two lists, because the rest is not knowable yet', async () => {
+    // Which fields exist depends on both, so listing "the rest" would be a
+    // guess that is wrong for four of the five connectivity types.
+    const result = await gather({}, silent);
+
+    expect(result).toMatchObject({ missing: ['connector', 'auth'] });
+  });
+
+  test('the display name is defaulted rather than blocked on', async () => {
+    // Cosmetic, and never worth costing a scripted run a whole round trip.
+    const result = await gather(
+      { connector: 'fs', auth: 'none', root: '~/Notes' },
+      silent,
+    );
+
+    expect(result).toMatchObject({ name: 'Thing' });
+  });
+});
+
+describe('a pairing that cannot work', () => {
+  test('is refused before a single field is asked for', async () => {
+    // Six questions about a mailbox, and then a refusal about its credential
+    // type, is worse than refusing straight away.
+    const prompter = answering('imap.example.com');
+
+    await expect(gather({ connector: 'imap', auth: 'bearer' }, prompter)).rejects.toThrow(
+      /Use --auth basic/,
+    );
+    expect(prompter.asked).toEqual([]);
+  });
+});
+
+describe('a flag belonging to another kind', () => {
+  test('is ignored rather than smuggled into the manifest', async () => {
+    // `derive.ts` reads only the fields the chosen kind declares, so an imap
+    // flag on an mcp connector cannot reach the file. Pinned so a future change
+    // to the lookup does not quietly start honouring it.
+    const result = await gather(
+      { connector: 'mcp', auth: 'none', endpoint: 'https://mcp.example.com/mcp', host: 'imap.example.com' },
+      answering(''),
+    );
+
+    expect('missing' in result).toBe(false);
+    expect('values' in result && result.values).not.toHaveProperty('host');
+  });
+});

--- a/src/cli/commands/connect/custom/ask.ts
+++ b/src/cli/commands/connect/custom/ask.ts
@@ -1,0 +1,167 @@
+import { style } from '../../../output.ts';
+import type { Prompter } from '../../../prompt.ts';
+import { parseAuthMethod, parseConnectorKind, refuseIllegalPair } from './derive.ts';
+import {
+  AUTH_FIELDS,
+  AUTH_METHODS,
+  CONNECTOR_FIELDS,
+  CONNECTOR_KINDS,
+  camel,
+  titleCase,
+  type CustomAnswers,
+  type CustomFlags,
+  type FieldSpec,
+} from './spec.ts';
+
+/**
+ * Collecting what the flags did not say.
+ *
+ * Every value has a flag, so the whole command is scriptable — but the fields
+ * differ per connectivity type and per credential type, and nobody holds thirty
+ * flag names in their head to declare one provider. So a missing required value
+ * is asked for, in a fixed order, and the answers are indistinguishable from
+ * having been typed.
+ *
+ * Under `--non-interactive` nothing is asked and *everything* missing is named
+ * at once, with the command to re-run. One round trip rather than one refusal
+ * per flag, because the caller there is usually a script or an agent and each
+ * refusal costs it a whole run.
+ */
+
+/** Named, not asked: nothing can be collected until the two lists are picked. */
+export interface Blocked {
+  readonly missing: readonly string[];
+  readonly command: string;
+}
+
+export async function collect(
+  id: string,
+  flags: CustomFlags,
+  prompter: Prompter,
+  /** How to spell the re-run, when there is nothing to ask. */
+  commandFor: (missing: readonly string[]) => string,
+): Promise<CustomAnswers | Blocked> {
+  const missing: string[] = [];
+
+  const connector = flags.connector
+    ? parseConnectorKind(flags.connector)
+    : prompter.interactive
+      ? parseConnectorKind(await choose(prompter, 'How is this service reached?', CONNECTOR_KINDS))
+      : (missing.push('connector'), undefined);
+
+  const auth = flags.auth
+    ? parseAuthMethod(flags.auth)
+    : prompter.interactive
+      ? parseAuthMethod(await choose(prompter, 'How does it authenticate?', AUTH_METHODS))
+      : (missing.push('auth'), undefined);
+
+  // Which fields exist at all depends on the two answers above, so a
+  // non-interactive run missing either cannot list the rest yet. Saying so beats
+  // guessing at a list that would be wrong.
+  if (!connector || !auth) return { missing, command: commandFor(missing) };
+
+  // Before a single field is asked for. The pair is decided by the two answers
+  // above, so a combination that cannot work is knowable here — and asking six
+  // questions about a mailbox that will be refused for its credential type is
+  // worse than refusing straight away.
+  refuseIllegalPair(connector, auth);
+
+  const fields = [...CONNECTOR_FIELDS[connector], ...AUTH_FIELDS[auth], ...EXTRA];
+  const values: Record<string, string | readonly string[]> = {};
+
+  for (const field of fields) {
+    const given = flags[camel(field.flag) as keyof CustomFlags];
+
+    if (Array.isArray(given)) {
+      if (given.length > 0) values[field.flag] = given;
+      continue;
+    }
+    if (typeof given === 'string' && given.length > 0) {
+      values[field.flag] = given;
+      continue;
+    }
+    if (!field.required) continue;
+
+    if (!prompter.interactive) {
+      missing.push(field.flag);
+      continue;
+    }
+
+    const answer = field.choices
+      ? await choose(prompter, field.label, field.choices)
+      : await askFor(prompter, field);
+
+    if (answer.length > 0) values[field.flag] = answer;
+    else missing.push(field.flag);
+  }
+
+  if (missing.length > 0) return { missing, command: commandFor(missing) };
+
+  const name = flags.name ?? (prompter.interactive ? await askName(prompter, id) : titleCase(id));
+
+  return {
+    id,
+    name,
+    ...(flags.description ? { description: flags.description } : {}),
+    connector,
+    auth,
+    values,
+  };
+}
+
+/**
+ * Fields that belong to no single kind.
+ *
+ * All optional, so a non-interactive run is never blocked on one — and none is
+ * prompted for, because a question nobody needs to answer is worse than a flag
+ * nobody types. `derive.ts` refuses the combinations that do not work.
+ */
+const EXTRA: readonly FieldSpec[] = [
+  { flag: 'identity-url', label: 'Identity URL', required: false },
+  { flag: 'identity-field', label: 'Identity field', required: false },
+  { flag: 'setup-docs', label: 'Where to get the credential', required: false },
+];
+
+async function askFor(prompter: Prompter, field: FieldSpec): Promise<string> {
+  if (field.hint) print(style.dim(`  ${field.hint}`));
+  return (await prompter.ask(`${field.label}: `)).trim();
+}
+
+async function askName(prompter: Prompter, id: string): Promise<string> {
+  const suggested = titleCase(id);
+  const answer = (await prompter.ask(`Display name [${suggested}]: `)).trim();
+  return answer.length > 0 ? answer : suggested;
+}
+
+/**
+ * A closed set, offered as a numbered list.
+ *
+ * The same shape `chooseAuthMethod` uses for a provider with more than one way
+ * in, for the same reason: these are the members of a union, and typing one from
+ * memory is how somebody discovers a name is `api-key` and not `apikey` by
+ * being refused.
+ */
+async function choose(
+  prompter: Prompter,
+  question: string,
+  options: readonly string[],
+): Promise<string> {
+  print('');
+  print(question);
+  options.forEach((option, index) => print(`  ${index + 1}. ${option}`));
+
+  const answer = (await prompter.ask(`Choose 1-${options.length}: `)).trim();
+  const index = Number(answer);
+
+  // A name is accepted too. Somebody who already knows it should not have to
+  // count, and the numbers exist for somebody who does not.
+  if (options.includes(answer)) return answer;
+  if (Number.isInteger(index) && index >= 1 && index <= options.length) return options[index - 1]!;
+
+  throw new Error(`"${answer}" is not one of: ${options.join(', ')}.`);
+}
+
+/** Prompts and their hints go to stderr, so `--json` leaves stdout clean. */
+function print(line: string): void {
+  process.stderr.write(`${line}\n`);
+}

--- a/src/cli/commands/connect/custom/credential.ts
+++ b/src/cli/commands/connect/custom/credential.ts
@@ -1,0 +1,143 @@
+import { AUTH_KIND, type CustomAnswers } from './spec.ts';
+import { many, one, pairs } from './values.ts';
+
+/**
+ * The credential block, and the OAuth rules the schema does not carry.
+ *
+ * Split from `derive.ts` because it fails for a different reason. That file is
+ * about a connectivity type's fields, which are either given or defaulted; this
+ * one is about arrangements that *validate* and then cannot run — an
+ * authorization server with nowhere to send the browser, a client nobody
+ * registered, a header the transport will not read. Each of those surfaces after
+ * a credential has been stored or a consent screen approved, so each is refused
+ * here.
+ */
+
+export function authBlock(answers: CustomAnswers): Record<string, unknown> {
+  const method = answers.auth;
+  const kind = AUTH_KIND[method];
+  const header = one(answers, 'auth-header');
+  const query = one(answers, 'auth-query');
+
+  if (method === 'none' || method === 'basic') return { kind };
+
+  if (method === 'bearer') {
+    if (header && answers.connector === 'mcp') {
+      throw new Error(
+        'An mcp connector always sends its token as "Authorization: Bearer", so --auth-header ' +
+          `("${header}") could not be honoured — the transport never reads the resolved credential, ` +
+          'only the token, and the header would be dropped in silence.\n' +
+          '  Drop the flag, or reach this service with --connector http.',
+      );
+    }
+    return { kind, ...(header ? { header } : {}) };
+  }
+
+  if (method === 'header') {
+    if (query) {
+      throw new Error(
+        '--auth-query is only meaningful for --auth api-key, which may put its key in the query ' +
+          'string. A "header" credential is sent in a header of its own and nothing forwards a query ' +
+          'parameter, so this would be dropped in silence.',
+      );
+    }
+    return { kind, header };
+  }
+
+  if (method === 'strategy') {
+    // Whether the name resolves is the registry's to answer, not this file's: a
+    // strategy travels on a provider's definition, and `strategyFor` looks first
+    // at this manifest's own and then at every other registered provider's.
+    // `refuseStrategy` is what says a name reaches nothing, and it can list what
+    // does — which is why this does not try to.
+    const named = one(answers, 'strategy');
+    const options = pairs(answers, 'strategy-option');
+
+    return {
+      kind,
+      strategy: named,
+      ...(options ? { options } : {}),
+    };
+  }
+
+  if (method === 'api-key') {
+    if (header && query) {
+      throw new Error(
+        '--auth-header and --auth-query contradict: a key goes in a header or in the query string, ' +
+          'and declaring both leaves which one is sent up to whichever the transport reads last.',
+      );
+    }
+    return { kind, ...(header ? { header } : {}), ...(query ? { query } : {}) };
+  }
+
+  return oauthBlock(answers);
+}
+
+/**
+ * The one credential type with rules the schema does not carry.
+ *
+ * Each of these produces a manifest `defineProvider` accepts and `authorise`
+ * cannot run, which is worse than an invalid one: the operator finds out after
+ * approving a consent screen, or not until the first call.
+ */
+function oauthBlock(answers: CustomAnswers): Record<string, unknown> {
+  const scopes = many(answers, 'scopes');
+  const authorizeUrl = one(answers, 'authorize-url');
+  const tokenUrl = one(answers, 'token-url');
+  const app = one(answers, 'client-app');
+  const declared = one(answers, 'registration');
+  const redirect = one(answers, 'redirect-uri');
+  const authorizeParams = pairs(answers, 'authorize-param');
+
+  if (Boolean(authorizeUrl) !== Boolean(tokenUrl)) {
+    throw new Error(
+      'OAuth endpoints are declared together or not at all. `authorise` takes the direct path only ' +
+        'when both are present, so half a pair is ignored on an mcp connector and fatal on an http ' +
+        'one.\n  Add the missing one of --authorize-url / --token-url, or drop both.',
+    );
+  }
+
+  // A REST API has no MCP metadata document to discover from, so a client has
+  // to come from somewhere the manifest names.
+  const registration =
+    declared ?? (answers.connector === 'mcp' && !authorizeUrl && !app ? 'dynamic' : 'manual');
+
+  if (registration === 'dynamic' && answers.connector === 'http') {
+    throw new Error(
+      'Dynamic client registration is something an authorization server offers, and a REST API ' +
+        'publishes no registration endpoint — there would be no client to authorise with.\n' +
+        '  Register a client with the vendor and drop --registration, which then defaults to manual.',
+    );
+  }
+
+  if (registration === 'dynamic' && authorizeUrl) {
+    throw new Error(
+      'Declaring both endpoints is what takes an mcp connector off the SDK\'s own OAuth path and onto ' +
+        'ours, and ours needs a client to present (ADR-040). Registration cannot be dynamic there.\n' +
+        '  Drop --registration dynamic, or drop the two endpoint URLs and let the SDK register.',
+    );
+  }
+
+  if (registration === 'manual' && answers.connector === 'http' && !authorizeUrl) {
+    throw new Error(
+      'An http connector has no metadata document to discover an authorization server from: a REST ' +
+        'API is a base URL, and where consent happens is not something it announces.\n' +
+        '  Add --authorize-url and --token-url.',
+    );
+  }
+
+  return {
+    kind: 'oauth',
+    registration,
+    ...(registration === 'manual' ? { app: app ?? answers.id } : {}),
+    scopes,
+    ...(authorizeUrl ? { authorize_url: authorizeUrl } : {}),
+    ...(tokenUrl ? { token_url: tokenUrl } : {}),
+    ...(redirect ? { redirect_uri: redirect } : {}),
+    // Google needs `access_type=offline` and `prompt=consent`, without which it
+    // returns an access token and no refresh token — so the connection works for
+    // an hour and then dies, which is a miserable thing to debug. Any vendor can
+    // have one of these, and nothing but the vendor's own docs will say so.
+    ...(authorizeParams ? { authorize_params: authorizeParams } : {}),
+  };
+}

--- a/src/cli/commands/connect/custom/derive.test.ts
+++ b/src/cli/commands/connect/custom/derive.test.ts
@@ -1,0 +1,492 @@
+import { describe, expect, test } from 'bun:test';
+import { parseManifest } from '#providers/custom/index.ts';
+import { strategyFor } from '#connectivity';
+import { buildRegistry } from '../../../runtime/registry.ts';
+import { deriveDeclaration, deriveManifest, parseAuthMethod, parseConnectorKind } from './derive.ts';
+import { renderManifest } from './write.ts';
+import {
+  AUTH_METHODS,
+  CONNECTOR_KINDS,
+  type AuthMethod,
+  type ConnectorKind,
+  type CustomAnswers,
+} from './spec.ts';
+
+/**
+ * That composing the two fixed lists produces a manifest that can actually
+ * connect — not merely one that validates.
+ *
+ * The distinction is the whole point of this file. `defineProvider` refuses a
+ * manifest whose *shape* is wrong, and there are several ways to be shaped
+ * correctly and still be unusable: a credential type the transport has nowhere
+ * to put, an OAuth block with no client to present, a prompt key nothing looks
+ * up. Each of those fails after a credential has been stored or a consent screen
+ * approved, so each is refused here instead.
+ */
+
+/** The minimum each pair needs said, and nothing more. */
+const REQUIRED: Record<ConnectorKind, Record<string, string | readonly string[]>> = {
+  mcp: { endpoint: 'https://mcp.example.com/mcp' },
+  http: { 'base-url': 'https://api.example.com/v1', openapi: 'https://api.example.com/openapi.json' },
+  imap: { host: 'imap.example.com' },
+  dav: { 'base-url': 'https://dav.example.com', service: 'caldav' },
+  fs: { root: '~/Notes' },
+};
+
+const AUTH_REQUIRED: Partial<Record<AuthMethod, Record<string, string | readonly string[]>>> = {
+  header: { 'auth-header': 'X-Api-Key' },
+  oauth: { scopes: ['read'] },
+  strategy: { strategy: 'handshake' },
+};
+
+function answers(
+  connector: ConnectorKind,
+  auth: AuthMethod,
+  extra: Record<string, string | readonly string[]> = {},
+): CustomAnswers {
+  return {
+    id: 'thing',
+    name: 'Thing',
+    connector,
+    auth,
+    values: { ...REQUIRED[connector], ...(AUTH_REQUIRED[auth] ?? {}), ...extra },
+  };
+}
+
+/** Everything `defineProvider` permits, worked out from its own rules. */
+const LEGAL: ReadonlyArray<[ConnectorKind, AuthMethod]> = [
+  ['mcp', 'none'],
+  ['mcp', 'bearer'],
+  ['mcp', 'oauth'],
+  ['http', 'none'],
+  ['http', 'bearer'],
+  ['http', 'api-key'],
+  ['http', 'header'],
+  ['http', 'basic'],
+  ['http', 'oauth'],
+  ['http', 'strategy'],
+  ['imap', 'basic'],
+  ['dav', 'basic'],
+  ['fs', 'none'],
+];
+
+/** An http OAuth provider needs its endpoints; see `oauthBlock`. */
+const endpoints = {
+  'authorize-url': 'https://auth.example.com/authorize',
+  'token-url': 'https://auth.example.com/token',
+};
+
+const forPair = (connector: ConnectorKind, auth: AuthMethod): CustomAnswers =>
+  answers(connector, auth, connector === 'http' && auth === 'oauth' ? endpoints : {});
+
+describe('every legal pairing of the two fixed lists', () => {
+  test('the matrix under test is the one the schema actually permits', () => {
+    // Derived rather than asserted, so a rule relaxed in `defineProvider` shows
+    // up here as a pair this file forgot rather than as nothing at all.
+    const pairs = CONNECTOR_KINDS.flatMap((connector) =>
+      AUTH_METHODS.map((auth) => [connector, auth] as const),
+    );
+
+    const accepted = pairs.filter(([connector, auth]) => {
+      try {
+        deriveManifest(forPair(connector, auth));
+        return true;
+      } catch {
+        return false;
+      }
+    });
+
+    expect(accepted.map(([c, a]) => `${c}+${a}`).sort()).toEqual(
+      LEGAL.map(([c, a]) => `${c}+${a}`).sort(),
+    );
+  });
+
+  test.each(LEGAL)('%s + %s round-trips through the loader', (connector, auth) => {
+    // The assertion that matters most in this file: the text this command writes
+    // is re-read by the exact code the loader runs — entropy check, schema,
+    // every cross-field rule — and comes back the same manifest. A declaration
+    // that cannot survive being read back is not a declaration.
+    const written = renderManifest(deriveDeclaration(forPair(connector, auth)));
+
+    expect(parseManifest(written, 'derived.yaml')).toEqual(deriveManifest(forPair(connector, auth)));
+  });
+
+  test.each(LEGAL)('%s + %s can be connected, not just validated', (connector, auth) => {
+    const manifest = deriveManifest(forPair(connector, auth));
+
+    // `ensureStaticCredential` throws for a credential that is asked for rather
+    // than granted and finds no per-connection prompt. `none` is granted by the
+    // operating system or by nothing; `oauth` comes back from a browser.
+    const asked = auth !== 'none' && auth !== 'oauth';
+    const perAccount = (manifest.setup?.prompts ?? []).filter((p) => p.scope === 'connection');
+
+    expect(perAccount.length > 0).toBe(asked);
+  });
+});
+
+describe('a pairing the transport cannot carry', () => {
+  test('an mcp connector says where the credential would have gone, and what to use', () => {
+    for (const auth of ['api-key', 'header', 'basic'] as const) {
+      expect(() => deriveManifest(answers('mcp', auth))).toThrow(
+        /nowhere else on the request[\s\S]*--connector http/,
+      );
+    }
+  });
+
+  test('a mailbox and a calendar name the method that works', () => {
+    for (const connector of ['imap', 'dav'] as const) {
+      expect(() => deriveManifest(answers(connector, 'bearer'))).toThrow(/Use --auth basic/);
+      expect(() => deriveManifest(answers(connector, 'oauth'))).toThrow(/partner-gated/);
+    }
+  });
+
+  test('a folder holds no account', () => {
+    expect(() => deriveManifest(answers('fs', 'bearer'))).toThrow(/Use --auth none/);
+  });
+});
+
+describe('the one union member an operator cannot use', () => {
+  test('local is ours, and says so', () => {
+    expect(() => parseConnectorKind('local')).toThrow(/compiled into this build/);
+  });
+
+  test('and an unknown name lists what there is', () => {
+    expect(() => parseConnectorKind('graphql')).toThrow(/mcp, http, imap, dav, fs/);
+    expect(() => parseAuthMethod('sigv4')).toThrow(/none, bearer, api-key, header, basic, oauth/);
+  });
+});
+
+describe('an auth strategy', () => {
+  /**
+   * A strategy names code that travels on a provider's definition, so a
+   * declaration-only manifest reaches one by name — which is the only way to
+   * point a connection at a vendor's sandbox, since a built-in manifest's
+   * `options` are not the operator's to edit (ADR-046).
+   */
+  test('is named, and its options are passed through untouched', () => {
+    const manifest = deriveManifest(
+      answers('http', 'strategy', { 'strategy-option': ['environment=sandbox', 'retries=2'] }),
+    );
+
+    expect(manifest.auth).toMatchObject({
+      kind: 'strategy',
+      strategy: 'handshake',
+      options: { environment: 'sandbox', retries: '2' },
+    });
+  });
+
+  test('whether the name resolves is the registry\'s answer, not this file\'s', () => {
+    // Deliberately not validated here. `strategyFor` looks at this manifest's own
+    // definition and then at every registered provider's, and `refuseStrategy`
+    // is what says a name reaches nothing — this file has no registry to ask.
+    expect(() => deriveManifest(answers('http', 'strategy', { strategy: 'nothing_supplies_this' })))
+      .not.toThrow();
+  });
+
+  test('still asks for the secret the handshake starts from', () => {
+    // `ensureStaticCredential` throws for any credential that is asked for and
+    // finds no per-connection prompt, and a strategy is asked for.
+    const prompts = deriveManifest(answers('http', 'strategy')).setup?.prompts ?? [];
+
+    expect(prompts.map((p) => [p.key, p.secret, p.scope])).toEqual([['api_key', true, 'connection']]);
+  });
+
+  test('and it only works over a connector that makes a request to sign', () => {
+    for (const connector of ['mcp', 'imap', 'dav', 'fs'] as const) {
+      expect(() => deriveManifest(answers(connector, 'strategy'))).toThrow();
+    }
+  });
+
+  test('an option that is not one says what one looks like', () => {
+    expect(() =>
+      deriveManifest(answers('http', 'strategy', { 'strategy-option': ['nonsense'] })),
+    ).toThrow(/Write it as "key=value"/);
+  });
+
+  /**
+   * That a manifest this command writes actually reaches the code it names.
+   *
+   * Deriving `auth: { kind: strategy, strategy: x }` is worth nothing if the
+   * declaration-only path cannot resolve `x` — and that path exists precisely
+   * for a workspace YAML, which has no `ProviderDefinition` of its own. Asserted
+   * against the real `strategyFor` and a real registry rather than against the
+   * shape of the auth block.
+   */
+  test('and the manifest reaches a strategy a built-in supplies', () => {
+    const registry = buildRegistry();
+    const supplied = registry
+      .list()
+      .map((entry) => entry.definition?.authStrategy?.id)
+      .find((id): id is string => typeof id === 'string');
+
+    // If nothing in this build carries one, there is nothing to borrow and the
+    // rest of this test would assert its own premise.
+    expect(supplied).toBeString();
+
+    const manifest = deriveManifest(answers('http', 'strategy', { strategy: supplied! }));
+
+    expect(strategyFor(manifest, registry).id).toBe(supplied!);
+  });
+
+  test('while a name nothing supplies is refused by the registry, not by the schema', () => {
+    const manifest = deriveManifest(answers('http', 'strategy', { strategy: 'nothing_supplies_this' }));
+
+    expect(() => strategyFor(manifest, buildRegistry())).toThrow(/not registered/);
+  });
+});
+
+describe('an OAuth client the manifest promises and cannot present', () => {
+  test('half a pair of endpoints is refused, either half', () => {
+    for (const half of ['authorize-url', 'token-url'] as const) {
+      expect(() =>
+        deriveManifest(answers('mcp', 'oauth', { [half]: 'https://auth.example.com/x' })),
+      ).toThrow(/declared together or not at all/);
+    }
+  });
+
+  test('a REST API cannot register a client dynamically', () => {
+    expect(() =>
+      deriveManifest(answers('http', 'oauth', { ...endpoints, registration: 'dynamic' })),
+    ).toThrow(/publishes no registration endpoint/);
+  });
+
+  test('a REST API with no endpoints has nowhere to send the browser', () => {
+    // Refused before the write. Left alone this reaches `authoriseDirect`, which
+    // needs both URLs, after the operator has already answered two prompts.
+    expect(() => deriveManifest(answers('http', 'oauth'))).toThrow(/no metadata document/);
+  });
+
+  test('declaring endpoints on an mcp connector takes it off the SDK path, so it needs a client', () => {
+    expect(() =>
+      deriveManifest(answers('mcp', 'oauth', { ...endpoints, registration: 'dynamic' })),
+    ).toThrow(/ADR-040/);
+  });
+
+  test('mcp defaults to dynamic, and everything else to manual', () => {
+    expect(deriveManifest(answers('mcp', 'oauth')).auth).toMatchObject({
+      kind: 'oauth',
+      registration: 'dynamic',
+    });
+    expect(deriveManifest(answers('http', 'oauth', endpoints)).auth).toMatchObject({
+      registration: 'manual',
+      app: 'thing',
+    });
+  });
+
+  test('naming an app is enough to mean "my own client", even on mcp', () => {
+    const manifest = deriveManifest(answers('mcp', 'oauth', { 'client-app': 'shared' }));
+    expect(manifest.auth).toMatchObject({ registration: 'manual', app: 'shared' });
+  });
+});
+
+describe('a credential flag that would be dropped in silence', () => {
+  test('an mcp bearer token cannot be renamed', () => {
+    expect(() => deriveManifest(answers('mcp', 'bearer', { 'auth-header': 'X-Token' }))).toThrow(
+      /could not be honoured/,
+    );
+  });
+
+  test('a header credential has no query form', () => {
+    expect(() =>
+      deriveManifest(answers('http', 'header', { 'auth-query': 'key' })),
+    ).toThrow(/only meaningful for --auth api-key/);
+  });
+
+  test('an api key goes in one place or the other, never both', () => {
+    expect(() =>
+      deriveManifest(answers('http', 'api-key', { 'auth-header': 'X-Key', 'auth-query': 'key' })),
+    ).toThrow(/contradict/);
+  });
+
+  test('an identity URL with no field to read is refused', () => {
+    expect(() =>
+      deriveManifest(answers('http', 'bearer', { 'identity-url': 'https://api.example.com/me' })),
+    ).toThrow(/needs --identity-field/);
+  });
+});
+
+describe('what the manifest carries without being asked', () => {
+  test('a protocol that knows the account is told to say so', () => {
+    for (const connector of ['imap', 'dav', 'fs'] as const) {
+      const auth = connector === 'fs' ? 'none' : 'basic';
+      expect(deriveManifest(answers(connector, auth)).identity).toEqual({ kind: 'connector' });
+    }
+  });
+
+  test('and one that would have to guess a tool name is not', () => {
+    expect(deriveManifest(answers('mcp', 'bearer')).identity).toBeUndefined();
+  });
+
+  test('basic auth gets exactly one username and one password, in that order', () => {
+    // `defineProvider` requires exactly one of each, and the store holds them as
+    // `username:password`. Asserted for every connector that can use it.
+    for (const connector of ['http', 'imap', 'dav'] as const) {
+      const prompts = deriveManifest(answers(connector, 'basic')).setup?.prompts ?? [];
+      expect(prompts.map((p) => [p.key, p.field])).toEqual([
+        ['username', 'username'],
+        ['password', 'password'],
+      ]);
+    }
+  });
+
+  test('a secret is marked as one, so nothing echoes it', () => {
+    const prompts = deriveManifest(answers('http', 'bearer')).setup?.prompts ?? [];
+    expect(prompts).toHaveLength(1);
+    expect(prompts[0]).toMatchObject({ key: 'token', secret: true, scope: 'connection' });
+  });
+
+  test('dynamic registration asks for nothing at all', () => {
+    expect(deriveManifest(answers('mcp', 'oauth')).setup).toBeUndefined();
+  });
+
+  test('a sentence becomes a step and a URL becomes a link, never setup.docs', () => {
+    // `setup.docs` is read by nothing — `printSetup` renders `summary`,
+    // `docs_url` and `steps`. A manifest using it validates and shows nothing.
+    const sentence = deriveManifest(answers('http', 'bearer', { 'setup-docs': 'Ask your admin.' }));
+    expect(sentence.setup).toMatchObject({ steps: ['Ask your admin.'] });
+    expect(sentence.setup).not.toHaveProperty('docs');
+
+    const url = deriveManifest(
+      answers('http', 'bearer', { 'setup-docs': 'https://example.com/tokens' }),
+    );
+    expect(url.setup).toMatchObject({ docs_url: 'https://example.com/tokens' });
+    expect(url.setup?.steps).toEqual([]);
+  });
+
+  test('an OAuth walkthrough warns about the loopback redirect, which nobody guesses', () => {
+    const manifest = deriveManifest(
+      answers('http', 'oauth', { ...endpoints, 'setup-docs': 'https://example.com/apps' }),
+    );
+
+    expect(manifest.setup?.steps.join(' ')).toMatch(/port chosen per run/);
+  });
+
+  test('and names the flag for a vendor that matches the whole redirect URL', () => {
+    // `connect` listens on a port the kernel picks. A server that pins the URL
+    // refuses with `redirect_uri_mismatch`, which says nothing about what to do.
+    const manifest = deriveManifest(
+      answers('http', 'oauth', { ...endpoints, 'setup-docs': 'https://example.com/apps' }),
+    );
+
+    expect(manifest.setup?.steps.join(' ')).toMatch(/--redirect-uri/);
+  });
+
+  test('extra authorization parameters are passed through', () => {
+    // The difference between a connection that refreshes and one that works for
+    // an hour: Google needs `access_type=offline`, and nothing but a vendor's own
+    // docs says whether they do too.
+    const manifest = deriveManifest(
+      answers('http', 'oauth', {
+        ...endpoints,
+        'authorize-param': ['access_type=offline', 'prompt=consent'],
+      }),
+    );
+
+    expect(manifest.auth).toMatchObject({
+      authorize_params: { access_type: 'offline', prompt: 'consent' },
+    });
+  });
+
+  test('and one that is not a parameter names the flag it came from', () => {
+    expect(() =>
+      deriveManifest(answers('http', 'oauth', { ...endpoints, 'authorize-param': ['nope'] })),
+    ).toThrow(/--authorize-param "nope"/);
+  });
+
+  test('a fixed redirect is written when it is given', () => {
+    const manifest = deriveManifest(
+      answers('http', 'oauth', { ...endpoints, 'redirect-uri': 'http://127.0.0.1:8765/callback' }),
+    );
+
+    expect(manifest.auth).toMatchObject({ redirect_uri: 'http://127.0.0.1:8765/callback' });
+  });
+});
+
+describe('headers the vendor requires of a client', () => {
+  test('are written for the two connectors that have the field', () => {
+    for (const connector of ['mcp', 'http'] as const) {
+      const manifest = deriveManifest(
+        answers(connector, 'none', { header: ['User-Agent: thing:1.0 (by someone)'] }),
+      );
+
+      expect(manifest.connector).toMatchObject({
+        headers: { 'User-Agent': 'thing:1.0 (by someone)' },
+      });
+    }
+  });
+
+  test('a value with a colon in it survives, because only the first one separates', () => {
+    const manifest = deriveManifest(
+      answers('http', 'none', { header: ['X-Trace: a:b:c'] }),
+    );
+
+    expect(manifest.connector).toMatchObject({ headers: { 'X-Trace': 'a:b:c' } });
+  });
+
+  test('Authorization is refused here, where somebody is choosing', () => {
+    // `defineProvider` refuses it too, with the rule. This one says what to use.
+    expect(() =>
+      deriveManifest(answers('http', 'none', { header: ['Authorization: Bearer nope'] })),
+    ).toThrow(/--auth bearer/);
+  });
+
+  test('something that is not a header says what one looks like', () => {
+    expect(() => deriveManifest(answers('http', 'none', { header: ['nonsense'] }))).toThrow(
+      /Write it as "Name: value"/,
+    );
+  });
+});
+
+describe('a default is followed, not frozen into the file', () => {
+  test('an unstated port is absent, so a later default reaches this manifest', () => {
+    const connector = deriveDeclaration(answers('imap', 'basic'))['connector'];
+    expect(connector).not.toHaveProperty('port');
+    expect(connector).not.toHaveProperty('smtp');
+  });
+
+  test('no SMTP host means a read-only mailbox by construction', () => {
+    // `imap/index.ts` reads the absence of the block, so this is what makes a
+    // mailbox unable to send rather than merely ungranted.
+    const withSmtp = deriveDeclaration(answers('imap', 'basic', { 'smtp-host': 'smtp.example.com' }));
+    expect(withSmtp['connector']).toHaveProperty('smtp');
+  });
+
+  test('starttls follows the port it was given', () => {
+    const implicit = deriveManifest(
+      answers('imap', 'basic', { 'smtp-host': 'smtp.example.com', 'smtp-port': '465' }),
+    ).connector as { smtp: { starttls: boolean } };
+    const upgraded = deriveManifest(
+      answers('imap', 'basic', { 'smtp-host': 'smtp.example.com', 'smtp-port': '587' }),
+    ).connector as { smtp: { starttls: boolean } };
+
+    expect(implicit.smtp.starttls).toBe(false);
+    expect(upgraded.smtp.starttls).toBe(true);
+  });
+
+  test('a port that is not one is refused with the flag named', () => {
+    expect(() => deriveManifest(answers('imap', 'basic', { port: '99999' }))).toThrow(/--port/);
+    expect(() => deriveManifest(answers('imap', 'basic', { port: 'imap' }))).toThrow(/--port/);
+  });
+
+  test('operation filters are written only when asked for', () => {
+    expect(deriveDeclaration(answers('http', 'none'))['connector']).not.toHaveProperty('operations');
+    expect(
+      deriveDeclaration(answers('http', 'none', { operations: ['*Account*'] }))['connector'],
+    ).toMatchObject({ operations: { include: ['*Account*'] } });
+  });
+});
+
+describe('the written file', () => {
+  test('is byte-identical for the same answers', () => {
+    // A re-run compares parsed manifests, not bytes — but a writer that is not
+    // deterministic makes every other guarantee here harder to reason about.
+    const first = renderManifest(deriveDeclaration(answers('http', 'bearer')));
+    const second = renderManifest(deriveDeclaration(answers('http', 'bearer')));
+
+    expect(first).toBe(second);
+  });
+
+  test('says whose file it is now', () => {
+    expect(renderManifest(deriveDeclaration(answers('http', 'bearer')))).toMatch(/Yours to edit/);
+  });
+});

--- a/src/cli/commands/connect/custom/derive.ts
+++ b/src/cli/commands/connect/custom/derive.ts
@@ -1,0 +1,229 @@
+import { defineProvider, type ProviderManifest } from '#connectivity';
+import {
+  AUTH_METHODS,
+  CONNECTOR_KINDS,
+  type AuthMethod,
+  type ConnectorKind,
+  type CustomAnswers,
+} from './spec.ts';
+import { identityBlock, setupBlock } from './prompts.ts';
+import { authBlock } from './credential.ts';
+import { many, one, port } from './values.ts';
+
+/**
+ * Turning what the operator said into a manifest.
+ *
+ * The flag surface cannot mirror the schema, because `defineProvider` demands
+ * fields nobody should have to type: `setup.prompts` for every credential type
+ * that is asked for rather than granted, an `identity` block wherever the
+ * connector can answer, and — for a manual OAuth client — two prompt keys and
+ * two credential refs whose exact spelling is read back by literal string
+ * elsewhere. So this file derives them, and `defineProvider` still has the last
+ * word, exactly as it does for a hand-written file.
+ *
+ * It also refuses three things the schema accepts and `authorise` cannot run.
+ * That is the failure class worth the most care here: the manifest validates,
+ * the connection is declared, and the flow has nowhere to go — which is
+ * indistinguishable from a working setup right up until somebody uses it.
+ */
+
+export function parseConnectorKind(value: string): ConnectorKind {
+  if ((CONNECTOR_KINDS as readonly string[]).includes(value)) return value as ConnectorKind;
+
+  if (value === 'local') {
+    throw new Error(
+      '"local" is not a connectivity type you can declare: it means the capability code is ours, ' +
+        'compiled into this build — the example provider and the owner layer. There is nothing for a ' +
+        `manifest to point at. Pick one of: ${CONNECTOR_KINDS.join(', ')}.`,
+    );
+  }
+
+  throw new Error(`Unknown connectivity type "${value}". Pick one of: ${CONNECTOR_KINDS.join(', ')}.`);
+}
+
+export function parseAuthMethod(value: string): AuthMethod {
+  if ((AUTH_METHODS as readonly string[]).includes(value)) return value as AuthMethod;
+
+  throw new Error(`Unknown credential type "${value}". Pick one of: ${AUTH_METHODS.join(', ')}.`);
+}
+
+/**
+ * Which pairs `defineProvider` would refuse, refused here instead.
+ *
+ * Same rules, earlier, and naming the alternative. The point is not to
+ * duplicate the check — it runs regardless a moment later — but that its
+ * message states a rule where this one states what to do about it.
+ */
+export function refuseIllegalPair(connector: ConnectorKind, auth: AuthMethod): void {
+  if (connector === 'mcp' && auth !== 'none' && auth !== 'oauth' && auth !== 'bearer') {
+    throw new Error(
+      `An mcp connector sends exactly one header, "Authorization: Bearer", because that is what the ` +
+        `MCP specification says a client sends. There is nowhere else on the request for a "${auth}" ` +
+        'credential to go, so this would connect unauthenticated: no error, an empty tool list, and ' +
+        'nothing to read that says why.\n' +
+        '  Reach the same service over its REST API with --connector http, or use --auth bearer.',
+    );
+  }
+
+  if ((connector === 'imap' || connector === 'dav') && auth !== 'basic') {
+    throw new Error(
+      `An ${connector} connector authenticates with a username and password. Every mail and DAV host ` +
+        'that matters issues an app password and expects it over Basic; OAuth for these exists but is ' +
+        'partner-gated with no published scopes, so declaring it would validate and then fail to ' +
+        'authenticate.\n  Use --auth basic.',
+    );
+  }
+
+  if (auth === 'strategy' && connector !== 'http') {
+    throw new Error(
+      `A strategy signs or negotiates an HTTP request, and a ${connector} connector does not make ` +
+        'one it could sign.\n  Use --connector http.',
+    );
+  }
+
+  if (connector === 'fs' && auth !== 'none') {
+    throw new Error(
+      'An fs connector reads a folder on this machine and holds no account. The permission is the ' +
+        'operating system\'s, held against this process — there is nothing to store and nothing that ' +
+        'could be carried to another machine (ADR-011).\n  Use --auth none.',
+    );
+  }
+}
+
+/**
+ * What gets written: only the fields the operator's answers actually settle.
+ *
+ * Deliberately *not* a `ProviderManifest`, and the distinction is load-bearing
+ * twice over. `defineProvider` fills in every schema default, and writing those
+ * back out would freeze them — a manifest saying `port: 993` no longer follows
+ * the default if it ever changes, and a re-run diffs against a file full of
+ * values nobody chose.
+ *
+ * Worse, it would not even load. Defaulting `auth.refresh_token` to `required`
+ * puts a key ending in `_token` into the document, and the entropy check that
+ * guards a manifest refuses any such key that is not a `_ref` — so the file this
+ * command wrote would be rejected the next time anything read it. Rendering the
+ * declaration rather than the validated manifest is what keeps the two honest.
+ */
+export function deriveDeclaration(answers: CustomAnswers): Record<string, unknown> {
+  refuseIllegalPair(answers.connector, answers.auth);
+
+  const setup = setupBlock(answers);
+  const identity = identityBlock(answers);
+
+  return {
+    id: answers.id,
+    name: answers.name,
+    ...(answers.description ? { description: answers.description } : {}),
+    connector: connectorBlock(answers),
+    auth: authBlock(answers),
+    ...(identity ? { identity } : {}),
+    ...(setup ? { setup } : {}),
+  };
+}
+
+/** The same declaration, validated — which is what a re-run compares against. */
+export function deriveManifest(answers: CustomAnswers): ProviderManifest {
+  return defineProvider(deriveDeclaration(answers));
+}
+
+/**
+ * `--header 'Name: value'`, repeated.
+ *
+ * `Authorization` is refused here as well as by `defineProvider`, because this
+ * is where somebody is choosing: the credential comes from `auth`, and a
+ * manifest setting both would leave which one is sent up to merge order.
+ */
+function headers(answers: CustomAnswers): Record<string, string> | undefined {
+  const declared = many(answers, 'header');
+  if (declared.length === 0) return undefined;
+
+  const parsed: Record<string, string> = {};
+
+  for (const entry of declared) {
+    const split = entry.indexOf(':');
+    if (split < 1) {
+      throw new Error(`--header "${entry}" is not a header. Write it as "Name: value".`);
+    }
+
+    const name = entry.slice(0, split).trim();
+    if (name.toLowerCase() === 'authorization') {
+      throw new Error(
+        'The credential is the auth block\'s, so --header cannot set Authorization — setting both ' +
+          'would leave which one is sent up to merge order.\n' +
+          '  Use --auth bearer (or api-key, or header with --auth-header) instead.',
+      );
+    }
+
+    parsed[name] = entry.slice(split + 1).trim();
+  }
+
+  return parsed;
+}
+
+/**
+ * Only what was said, plus what cannot be defaulted.
+ *
+ * A schema default is deliberately not written: leaving `port` out means a
+ * manifest follows the default if it ever changes, and it keeps the diff on a
+ * re-run down to what actually differs.
+ */
+function connectorBlock(answers: CustomAnswers): Record<string, unknown> {
+  const kind = answers.connector;
+
+  const sent = headers(answers);
+
+  if (kind === 'mcp') {
+    return { kind, endpoint: one(answers, 'endpoint'), ...(sent ? { headers: sent } : {}) };
+  }
+
+  if (kind === 'http') {
+    const include = many(answers, 'operations');
+    return {
+      kind,
+      base_url: one(answers, 'base-url'),
+      openapi: one(answers, 'openapi'),
+      ...(include.length > 0 ? { operations: { include } } : {}),
+      ...(sent ? { headers: sent } : {}),
+    };
+  }
+
+  if (kind === 'imap') {
+    const smtpHost = one(answers, 'smtp-host');
+    const smtpPort = port(one(answers, 'smtp-port'), 'smtp-port');
+
+    return {
+      kind,
+      host: one(answers, 'host'),
+      ...(port(one(answers, 'port'), 'port') !== undefined
+        ? { port: port(one(answers, 'port'), 'port') }
+        : {}),
+      // No SMTP host, no send capability — `imap/index.ts` reads the absence of
+      // the block, so a mailbox declared without one is read-only by
+      // construction rather than by policy.
+      ...(smtpHost
+        ? {
+            smtp: {
+              host: smtpHost,
+              ...(smtpPort !== undefined ? { port: smtpPort } : {}),
+              // A consequence of the port rather than a separate question: 465
+              // is implicit TLS, 587 upgrades in-band, and the default is the
+              // latter. Written only when it is not the default.
+              ...(smtpPort === 465 ? { starttls: false } : {}),
+            },
+          }
+        : {}),
+    };
+  }
+
+  if (kind === 'dav') {
+    return { kind, base_url: one(answers, 'base-url'), service: one(answers, 'service') };
+  }
+
+  const exclude = many(answers, 'exclude');
+  return {
+    kind,
+    root: one(answers, 'root'),
+    ...(exclude.length > 0 ? { exclude } : {}),
+  };
+}

--- a/src/cli/commands/connect/custom/index.test.ts
+++ b/src/cli/commands/connect/custom/index.test.ts
@@ -1,0 +1,253 @@
+import { afterAll, afterEach, describe, expect, test } from 'bun:test';
+import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { layout } from '#profile';
+import type { ConnectOptions } from '../index.ts';
+import { NOTHING, type ConnectOutcome } from '../outcome.ts';
+import { connectCustom, type ConnectCustomOptions } from './index.ts';
+
+/**
+ * The orchestration: what is refused, what is written, and in which order.
+ *
+ * `runConnect` is replaced throughout, because everything worth asserting here
+ * happens before it — the whole design of this command is that anything that can
+ * be refused is refused before a file exists, so that a failure never leaves a
+ * malformed manifest behind. One bad file in `providers.d/` makes
+ * `loadProfileProviders` throw for the entire directory, which breaks `connect`,
+ * `doctor`, `plan`, `status`, `start` and `deploy` for that profile — and
+ * `check`, whose whole job is catching that, does not read the directory at all.
+ */
+
+const PROFILE = `contract: 1
+
+instance:
+  profile: personal
+  port: 7337
+
+targets:
+  local:
+    credentials: { adapter: file }
+    storage: { adapter: filesystem }
+`;
+
+const roots: string[] = [];
+const previousHome = process.env['LANES_LINK_HOME'];
+
+async function workspace(): Promise<string> {
+  const root = await mkdtemp(join(tmpdir(), 'lanes-link-connect-custom-'));
+  roots.push(root);
+  process.env['LANES_LINK_HOME'] = root;
+
+  await mkdir(join(root, 'profiles'), { recursive: true });
+  await writeFile(join(root, 'lanes-link.yaml'), 'contract: 1\ndefault_profile: personal\n');
+  await writeFile(join(root, 'profiles', 'personal.yaml'), PROFILE);
+  return root;
+}
+
+afterEach(() => {
+  process.exitCode = 0;
+});
+
+afterAll(async () => {
+  if (previousHome === undefined) delete process.env['LANES_LINK_HOME'];
+  else process.env['LANES_LINK_HOME'] = previousHome;
+  await Promise.all(roots.map((root) => rm(root, { recursive: true, force: true })));
+});
+
+/** Stands in for `runConnect`, recording that it was reached and with what. */
+function handOff(): {
+  calls: string[];
+  connectWith: (target: string, options: ConnectOptions) => Promise<ConnectOutcome>;
+} {
+  const calls: string[] = [];
+  return {
+    calls,
+    connectWith: async (target) => {
+      calls.push(target);
+      return { ...NOTHING, ok: true, key: `${target}.main` };
+    },
+  };
+}
+
+const declaring = (extra: Partial<ConnectCustomOptions> = {}): ConnectCustomOptions => ({
+  profile: 'personal',
+  target: 'local',
+  quiet: true,
+  json: true,
+  connector: 'mcp',
+  auth: 'none',
+  endpoint: 'https://mcp.example.com/mcp',
+  name: 'Thing',
+  ...extra,
+});
+
+const manifestAt = (root: string, id: string) =>
+  readFile(join(root, layout.providers('personal'), `${id}.yaml`), 'utf8');
+
+describe('declaring and connecting in one command', () => {
+  test('writes the manifest and then hands off', async () => {
+    const root = await workspace();
+    const { calls, connectWith } = handOff();
+
+    await connectCustom('thing', declaring({ connectWith }));
+
+    expect(await manifestAt(root, 'thing')).toMatch(/id: thing/);
+    expect(calls).toEqual(['thing']);
+  });
+
+  test('the manifest is written before the hand-off, because the registry reads it', async () => {
+    // `runConnect` opens the runtime on its first line, and the registry that
+    // opening builds is what reads `providers.d/`. Written afterwards, the
+    // provider would be unknown to the connect that was supposed to connect it.
+    const root = await workspace();
+    let existedAtHandOff = false;
+
+    await connectCustom(
+      'thing',
+      declaring({
+        connectWith: async (target) => {
+          existedAtHandOff = await manifestAt(root, 'thing').then(
+            () => true,
+            () => false,
+          );
+          return { ...NOTHING, ok: true, key: target };
+        },
+      }),
+    );
+
+    expect(existedAtHandOff).toBe(true);
+  });
+});
+
+describe('a declaration already on disk', () => {
+  const first = declaring();
+
+  test('identical answers are a repair, not a refusal', async () => {
+    // The common case is "the manifest was fine, the token was wrong", and the
+    // operator re-runs the whole line. Refusing there would be useless.
+    const root = await workspace();
+    await connectCustom('thing', { ...first, connectWith: handOff().connectWith });
+    const before = await manifestAt(root, 'thing');
+
+    const second = handOff();
+    await connectCustom('thing', { ...first, connectWith: second.connectWith });
+
+    expect(await manifestAt(root, 'thing')).toBe(before);
+    expect(second.calls).toEqual(['thing']);
+    expect(process.exitCode).not.toBe(1);
+  });
+
+  test('different answers refuse, and change nothing', async () => {
+    const root = await workspace();
+    await connectCustom('thing', { ...first, connectWith: handOff().connectWith });
+    const before = await manifestAt(root, 'thing');
+
+    const second = handOff();
+    await connectCustom('thing', {
+      ...first,
+      endpoint: 'https://other.example.com/mcp',
+      connectWith: second.connectWith,
+    });
+
+    expect(await manifestAt(root, 'thing')).toBe(before);
+    expect(second.calls).toEqual([]);
+    expect(process.exitCode).toBe(1);
+  });
+
+  test('--replace-manifest is what rewrites it', async () => {
+    const root = await workspace();
+    await connectCustom('thing', { ...first, connectWith: handOff().connectWith });
+
+    const second = handOff();
+    await connectCustom('thing', {
+      ...first,
+      endpoint: 'https://other.example.com/mcp',
+      replaceManifest: true,
+      connectWith: second.connectWith,
+    });
+
+    expect(await manifestAt(root, 'thing')).toMatch(/other\.example\.com/);
+    expect(second.calls).toEqual(['thing']);
+  });
+});
+
+describe('an id that cannot work', () => {
+  const cases: ReadonlyArray<[string, string, RegExp]> = [
+    ['custom', 'the second word of this command', /never connected/],
+    ['gmail', 'a built-in it would shadow', /already built in/],
+    ['memory', 'reserved for the owner layer', /reserved for what this endpoint provides/],
+    ['My-Thing', 'not a legal identifier', /lowercase, start with a letter/],
+  ];
+
+  test.each(cases)('%s is refused: %s', async (id, _why, message) => {
+    await workspace();
+    const { calls, connectWith } = handOff();
+
+    await expect(connectCustom(id, declaring({ connectWith }))).rejects.toThrow(message);
+    expect(calls).toEqual([]);
+  });
+
+  test('a hyphen is refused with the spelling that would work', async () => {
+    await workspace();
+    await expect(connectCustom('my-thing', declaring())).rejects.toThrow(/"my_thing"/);
+  });
+});
+
+describe('a workspace in a bucket', () => {
+  test('is refused, naming what to do instead', async () => {
+    // A manifest is read from the workspace and written to the filesystem, and a
+    // bucket only does the first. Not a limitation of this command: ADR-007 says
+    // a deployed revision never rewrites its own config.
+    const previous = process.env['LANES_LINK_HOME'];
+    process.env['LANES_LINK_HOME'] = 'gs://your-bucket';
+
+    try {
+      await expect(connectCustom('thing', declaring())).rejects.toThrow(
+        /manifest is written to a local filesystem/,
+      );
+    } finally {
+      if (previous === undefined) delete process.env['LANES_LINK_HOME'];
+      else process.env['LANES_LINK_HOME'] = previous;
+    }
+  });
+});
+
+describe('a run with nobody to ask', () => {
+  test('refuses with every missing value, and writes nothing', async () => {
+    const root = await workspace();
+    const { calls, connectWith } = handOff();
+
+    await connectCustom('thing', {
+      profile: 'personal',
+      target: 'local',
+      quiet: true,
+      json: true,
+      nonInteractive: true,
+      connector: 'http',
+      auth: 'header',
+      connectWith,
+    });
+
+    expect(process.exitCode).toBe(1);
+    expect(calls).toEqual([]);
+    await expect(manifestAt(root, 'thing')).rejects.toThrow();
+  });
+});
+
+describe('an unusable pairing never reaches the disk', () => {
+  test('refused before the write, so nothing has to be cleaned up', async () => {
+    const root = await workspace();
+    const { calls, connectWith } = handOff();
+
+    await expect(
+      connectCustom(
+        'thing',
+        declaring({ connector: 'imap', auth: 'bearer', host: 'imap.example.com', connectWith }),
+      ),
+    ).rejects.toThrow(/Use --auth basic/);
+
+    await expect(manifestAt(root, 'thing')).rejects.toThrow();
+    expect(calls).toEqual([]);
+  });
+});

--- a/src/cli/commands/connect/custom/index.ts
+++ b/src/cli/commands/connect/custom/index.ts
@@ -1,0 +1,285 @@
+import { relative } from 'node:path';
+import { RESERVED_PROVIDER_IDS } from '#connectivity';
+import { isRemoteWorkspace, resolveWorkspaceRoot } from '#profile';
+import { parseManifest } from '#providers/custom/index.ts';
+import { PROVIDER_MANIFESTS } from '#providers/index.ts';
+import { announce, emit, ok, progress } from '../../../output.ts';
+import { nonInteractivePrompter, terminalPrompter, type Prompter } from '../../../prompt.ts';
+import { resolveProfile, type GlobalFlags } from '../../../runtime.ts';
+import { PROGRAM } from '../../../usage.ts';
+import { runConnect, type ConnectOptions } from '../index.ts';
+import { renderOutcome, type ConnectOutcome } from '../outcome.ts';
+import { collect, type Blocked } from './ask.ts';
+import { deriveDeclaration, deriveManifest } from './derive.ts';
+import { RESERVED_BY_GRAMMAR, type CustomFlags } from './spec.ts';
+import {
+  checkOpenapiReachable,
+  manifestDiff,
+  manifestPath,
+  readExistingManifest,
+  renderManifest,
+  writeManifest,
+} from './write.ts';
+
+/**
+ * `lanes link connect custom <id>` — declare a provider, then connect it.
+ *
+ * The built-in list has never been the boundary: a manifest in the profile's
+ * `providers.d/` is validated by the same schema a built-in is and registered
+ * into the same registry, which is the scalability claim of the whole manifest
+ * design. What was missing was the way in. An operator had to find an
+ * undocumented directory, write YAML, and satisfy cross-field rules they could
+ * not see — and the one message that would have told them where to put the file
+ * named a directory nothing reads.
+ *
+ * So this composes the two closed unions: a connectivity type and a credential
+ * type. Anything not covered by a pair of them is not something to bolt on here
+ * — it is a member missing from one of those lists, which is a folder and a
+ * schema entry away. `docs/detailed/connectivity-coverage.md` is the standing
+ * account of which pairs work, which are closed on purpose, and which are not
+ * built yet.
+ *
+ * The manifest is written *before* `runConnect`, because the registry that reads
+ * `providers.d/` is built by `openRuntime` on its first line. Everything that
+ * can be refused is refused before the write.
+ */
+
+export interface ConnectCustomOptions extends GlobalFlags, CustomFlags {
+  readonly json?: boolean | undefined;
+  /** Forwarded to `connect` untouched. */
+  readonly id?: string | undefined;
+  readonly displayName?: string | undefined;
+  readonly replace?: boolean | undefined;
+  readonly nonInteractive?: boolean | undefined;
+  readonly acceptBroadScopes?: boolean | undefined;
+  /** Injected by tests, so the declaration can be checked without a runtime. */
+  readonly prompter?: Prompter | undefined;
+  readonly connectWith?:
+    | ((target: string, options: ConnectOptions, announced?: boolean) => Promise<ConnectOutcome>)
+    | undefined;
+}
+
+export async function connectCustom(
+  providerId: string | undefined,
+  options: ConnectCustomOptions,
+): Promise<void> {
+  if (!providerId) throw new Error(`Usage: ${PROGRAM} connect custom <provider-id>`);
+
+  // Both of these are answerable without reading anything, so they come before
+  // the profile is resolved: loading a config from a bucket is a network call,
+  // and refusing afterwards means having made it to say no.
+  refuseUnusableId(providerId);
+
+  // A manifest is read from the workspace and written to the filesystem, and a
+  // bucket only does the first. Not a limitation of this command: a deployed
+  // revision never rewrites its own config (ADR-007), so a declaration is
+  // authored where the operator is and carried up by the publish that follows.
+  const root = resolveWorkspaceRoot();
+  if (isRemoteWorkspace(root)) {
+    throw new Error(
+      `This workspace is ${root}, and a manifest is written to a local filesystem.\n` +
+        `  Declare it in the workspace you deploy from, and \`${PROGRAM} deploy\` carries it up.`,
+    );
+  }
+
+  const { resolution, target } = await resolveProfile(options);
+  const { workspaceRoot, profile } = resolution;
+
+  // Before it acts, because writing the manifest *is* acting and `usage.ts`
+  // promises every command says where. `runConnect` is told it has been said, so
+  // the line does not appear twice.
+  if (options.json !== true) announce(resolution);
+
+  const path = manifestPath(workspaceRoot, profile, providerId);
+  const rerun = `${PROGRAM} connect custom ${providerId} --profile ${profile} --target ${target}`;
+
+  const prompter =
+    options.prompter ??
+    (options.nonInteractive ? nonInteractivePrompter(rerun) : terminalPrompter);
+
+  const collected = await collect(providerId, options, prompter, (missing) =>
+    [rerun, ...missing.map((flag) => `--${flag} <value>`)].join(' '),
+  );
+
+  if ('missing' in collected) {
+    return refuse(blockedOn(collected, providerId), options.json);
+  }
+
+  const declaration = deriveDeclaration(collected);
+  const text = renderManifest(declaration);
+
+  // Through the loader's own gate, not a copy of it: the entropy check that
+  // refuses a pasted credential, then every cross-field rule. A second
+  // implementation of "is this a secret" is how the two come to disagree.
+  const derived = parseManifest(text, path);
+
+  if (derived.connector.kind === 'http') {
+    await checkOpenapiReachable(derived.connector.openapi, workspaceRoot, profile);
+  }
+
+  // A connection is labelled with the account it belongs to, and a provider that
+  // cannot report one has to be told. Interactively `settleIdentity` asks; with
+  // nobody to ask it throws — but only after the credential has been stored, so
+  // the operator gets two failed runs instead of one refusal. Checked here
+  // because this command is the one that knows no identity block was derived.
+  if (options.nonInteractive && !derived.identity && derived.auth.kind !== 'none' && !options.displayName) {
+    throw new Error(
+      `${derived.name} has no way to report whose account a connection is, so on a run with nobody ` +
+        'to ask it has to be named.\n  Nothing was written. Add --display-name "<label>"' +
+        (derived.connector.kind === 'http'
+          ? ', or --identity-url and --identity-field if the API can answer for itself.'
+          : '.'),
+    );
+  }
+
+  const shown = relative(workspaceRoot, path);
+  const existing = await readExistingManifest(path);
+  const differences = existing ? manifestDiff(deriveManifest(collected), existing) : [];
+
+  if (existing && differences.length > 0 && !options.replaceManifest) {
+    return refuse(alreadyDescribed(shown, differences, rerun, options.replace), options.json);
+  }
+
+  const changes: string[] = [];
+  if (!existing) {
+    await writeManifest(path, text);
+    changes.push(`wrote ${shown}`);
+  } else if (differences.length > 0) {
+    await writeManifest(path, text);
+    changes.push(`rewrote ${shown}`);
+  } else {
+    changes.push(`${shown} unchanged`);
+  }
+
+  // Said now rather than only in the outcome: the connect that follows may open
+  // a browser, and knowing the file landed is worth having before that.
+  progress(ok(changes[0]!));
+
+  // Named field by field rather than spread, because the two commands share a
+  // flag name that means different things. `--auth` here is the credential type
+  // in the manifest — `none`, `basic`, `api-key` — and on `connect` it names
+  // which *route* in, for a provider offering two. Spreading sent `--auth none`
+  // straight through, and `connect` refused a provider it had just been handed
+  // with "--auth accepts: oauth".
+  const handOff = options.connectWith ?? runConnect;
+  const outcome = await handOff(
+    providerId,
+    {
+      profile: options.profile,
+      target: options.target,
+      quiet: options.quiet ?? false,
+      ...(options.id ? { id: options.id } : {}),
+      ...(options.displayName ? { displayName: options.displayName } : {}),
+      ...(options.replace ? { replace: options.replace } : {}),
+      ...(options.nonInteractive ? { nonInteractive: options.nonInteractive } : {}),
+      ...(options.acceptBroadScopes ? { acceptBroadScopes: options.acceptBroadScopes } : {}),
+      ...(options.json ? { json: options.json } : {}),
+    },
+    true,
+  );
+
+  // The manifest first, because it is the change this command made and the rest
+  // is what `connect` made. It stays in the list on a failure too: the file is
+  // real, it is the operator's now, and the retry is plain `connect` — which is
+  // what `then` already says.
+  const merged: ConnectOutcome = { ...outcome, changes: [...changes, ...outcome.changes] };
+
+  if (!merged.ok) process.exitCode = 1;
+
+  // `--json` gets the manifest in `changes`, because that list is what a caller
+  // counts and matches on. The human rendering does not, because they were told
+  // above — before the connect, which is where it mattered — and the same
+  // sentence twice reads as two things having happened.
+  return emit(options.json, merged, () => renderOutcome(outcome));
+}
+
+/**
+ * Ids this command cannot create.
+ *
+ * `custom` is the second word of its own grammar, so such a provider could be
+ * declared, registered, and then never connected. The reserved owner ids are
+ * refused by `defineProvider` a moment later, but with a rule rather than with
+ * the reason — and this is the one place somebody is choosing a name.
+ */
+function refuseUnusableId(id: string): void {
+  if (!/^[a-z][a-z0-9_]*$/.test(id)) {
+    throw new Error(
+      `"${id}" cannot be a provider id: they are lowercase, start with a letter, and use ` +
+        'underscores rather than hyphens — it becomes part of every capability name and every ' +
+        `policy rule. Try "${id.toLowerCase().replace(/[^a-z0-9]+/g, '_').replace(/^_+|_+$/g, '')}".`,
+    );
+  }
+
+  if ((RESERVED_BY_GRAMMAR as readonly string[]).includes(id)) {
+    throw new Error(
+      `"${id}" is the second word of this command, so a provider called "${id}" could be declared ` +
+        `and then never connected — \`${PROGRAM} connect ${id}\` would always mean this command. ` +
+        'Pick another id.',
+    );
+  }
+
+  if (RESERVED_PROVIDER_IDS.includes(id)) {
+    throw new Error(
+      `"${id}" is reserved for what this endpoint provides itself — your memory, skills, vault, ` +
+        'setup surface and identity. Pick another id.',
+    );
+  }
+
+  if (PROVIDER_MANIFESTS.some((manifest) => manifest.id === id)) {
+    throw new Error(
+      `"${id}" is already built in, so a manifest of yours would shadow it — and a provider ` +
+        'silently answering differently from the one it is named after is very hard to diagnose ' +
+        `from the outside.\n  Connect the built-in with \`${PROGRAM} connect ${id}\`, or pick ` +
+        'another id.',
+    );
+  }
+}
+
+function blockedOn(blocked: Blocked, providerId: string): ConnectOutcome {
+  const plural = blocked.missing.length === 1 ? 'value' : 'values';
+
+  return {
+    ok: false,
+    changes: [],
+    granted: [],
+    discovered: 0,
+    reason: 'needs_declaration',
+    message:
+      `Declaring ${providerId} needs ${blocked.missing.length} more ${plural}, and this run is ` +
+      'non-interactive.\n  Nothing was written. Either run it in a terminal, or pass:',
+    needs: [],
+    then: blocked.command,
+  };
+}
+
+function alreadyDescribed(
+  shown: string,
+  differences: readonly string[],
+  rerun: string,
+  replacePassed: boolean | undefined,
+): ConnectOutcome {
+  // `--replace` and `--replace-manifest` are one word apart and do different
+  // things, so somebody who reached here with the wrong one is told which.
+  const confusion = replacePassed
+    ? '\n  (--replace asks for the credential again; the manifest is a separate thing.)'
+    : '';
+
+  return {
+    ok: false,
+    changes: [],
+    granted: [],
+    discovered: 0,
+    reason: 'needs_declaration',
+    message:
+      `${shown} already describes this provider, differently. Nothing was written.${confusion}\n` +
+      `${differences.map((line) => `    ${line}`).join('\n')}\n\n` +
+      '  Edit the file and connect it, or replace it:',
+    needs: [],
+    then: `${rerun} --replace-manifest`,
+  };
+}
+
+function refuse(outcome: ConnectOutcome, json: boolean | undefined): void | Promise<void> {
+  process.exitCode = 1;
+  return emit(json, outcome, () => renderOutcome(outcome));
+}

--- a/src/cli/commands/connect/custom/prompts.ts
+++ b/src/cli/commands/connect/custom/prompts.ts
@@ -1,0 +1,160 @@
+import type { CustomAnswers } from './spec.ts';
+
+/**
+ * What the manifest says about being connected: what to ask for, and how to
+ * label the account it turns out to be.
+ *
+ * Neither is optional decoration. `ensureStaticCredential` throws for any
+ * credential type that is asked for rather than granted and finds no
+ * per-connection prompt, so a manifest without one is a provider that cannot be
+ * connected at all. And without an `identity` block a connection list reads
+ * `Thing main`, `Thing main2` — which cannot answer the only question anyone
+ * asks of it, and leaves `connect` unable to tell a reconnect from a new
+ * account.
+ */
+
+/** Where a per-account prompt's ref comes from, so it must not be declared. */
+const PER_ACCOUNT = { scope: 'connection' } as const;
+
+/**
+ * The two prompt keys that are not ours to choose.
+ *
+ * `declareOwnClient` looks these up by literal key, and `resolveOAuthClient`
+ * reads `<app>/client_id` and `<app>/client_secret` out of the credential store
+ * by literal string. Spell either differently and the manifest validates,
+ * `connect` collects two secrets from the operator, stores them, and *then*
+ * refuses with "No OAuth client stored" — after they have been through a vendor
+ * console. There is no freedom here and the tests assert it against
+ * `declareOwnClient` rather than against a copy of these strings.
+ */
+const OAUTH_CLIENT_KEYS = ['client_id', 'client_secret'] as const;
+
+export function setupBlock(answers: CustomAnswers): Record<string, unknown> | undefined {
+  const prompts = promptsFor(answers);
+  const docs = documentation(answers);
+
+  if (prompts.length === 0 && Object.keys(docs).length === 0) return undefined;
+  return { ...docs, ...(prompts.length > 0 ? { prompts } : {}) };
+}
+
+function promptsFor(answers: CustomAnswers): Record<string, unknown>[] {
+  const { auth, name } = answers;
+
+  if (auth === 'none') return [];
+
+  if (auth === 'basic') {
+    // Exactly one of each, in this order: `basic` stores `username:password` —
+    // RFC 7617's own encoding — and cannot be assembled from anything else.
+    return [
+      { key: 'username', label: 'Username', ...PER_ACCOUNT, field: 'username' },
+      { key: 'password', label: 'Password', secret: true, ...PER_ACCOUNT, field: 'password' },
+    ];
+  }
+
+  if (auth === 'bearer') {
+    return [{ key: 'token', label: `${name} API token`, secret: true, ...PER_ACCOUNT }];
+  }
+
+  if (auth === 'api-key' || auth === 'header' || auth === 'strategy') {
+    // A strategy negotiates rather than just attaching, but what it starts from
+    // is still one secret the operator holds — bunq's handshake begins with an
+    // API key pasted from the app. If a strategy needs something else, the
+    // manifest is a file and this is one line of it.
+    return [{ key: 'api_key', label: `${name} API key`, secret: true, ...PER_ACCOUNT }];
+  }
+
+  // Dynamic registration asks for nothing: the authorization server hands out a
+  // client and the operator never sees one.
+  const app = clientApp(answers);
+  if (!app) return [];
+
+  return OAUTH_CLIENT_KEYS.map((key) => ({
+    key,
+    label: `${name} OAuth ${key.replace('_', ' ')}`,
+    ...(key === 'client_secret' ? { secret: true } : {}),
+    // Shared across every account of this profile, so the ref cannot derive
+    // from a connection and has to be named.
+    scope: 'shared',
+    credential_ref: `${app}/${key}`,
+  }));
+}
+
+/** The `oauth_apps` entry a manual client lands in, or nothing. */
+function clientApp(answers: CustomAnswers): string | undefined {
+  if (answers.auth !== 'oauth') return undefined;
+
+  const declared = answers.values['registration'];
+  const explicit = answers.values['client-app'];
+  const endpoints = answers.values['authorize-url'];
+
+  const dynamic =
+    declared === 'dynamic' ||
+    (declared === undefined && answers.connector === 'mcp' && !explicit && !endpoints);
+
+  if (dynamic) return undefined;
+  return typeof explicit === 'string' && explicit.length > 0 ? explicit : answers.id;
+}
+
+/**
+ * `--setup-docs`, placed by shape.
+ *
+ * Never into `setup.docs`, which nothing reads — `printSetup` renders `summary`,
+ * `docs_url` and `steps`, and `planFor` reads `docs_url`. A manifest using
+ * `docs` validates and then shows the operator nothing, which is the worst of
+ * the three outcomes.
+ */
+function documentation(answers: CustomAnswers): Record<string, unknown> {
+  const value = answers.values['setup-docs'];
+  if (typeof value !== 'string' || value.length === 0) return {};
+
+  if (!/^https?:\/\//i.test(value)) return { steps: [value] };
+
+  const app = clientApp(answers);
+  return {
+    docs_url: value,
+    // The one thing a vendor's console asks for that this command knows and the
+    // operator cannot guess: the redirect URI is a loopback address on a port
+    // chosen per run, so a fixed port registered there will not match.
+    ...(app
+      ? {
+          steps: [
+            `Register an OAuth client at ${value}. Its redirect URI is a loopback address on a port ` +
+              'chosen per run, which most authorization servers accept. One that matches the whole ' +
+              'URL will refuse the grant with redirect_uri_mismatch — declare the URL it was given ' +
+              'with --redirect-uri if so.',
+          ],
+        }
+      : {}),
+  };
+}
+
+/**
+ * How this provider will say whose account was authorised.
+ *
+ * Three transports implement `identify()` — imap, dav and fs — and for the first
+ * two it is also the credential check, since the answer is the name the *server
+ * accepted* rather than the one the operator typed. An mcp connector gets no
+ * block: the identity would be a tool call, and a guessed tool name turns a
+ * working connect into a failed probe. An http one gets a block only when both
+ * halves were given, because a URL with no field to read is not an identity.
+ */
+export function identityBlock(answers: CustomAnswers): Record<string, unknown> | undefined {
+  if (answers.connector === 'imap' || answers.connector === 'dav' || answers.connector === 'fs') {
+    return { kind: 'connector' };
+  }
+
+  if (answers.connector !== 'http') return undefined;
+
+  const url = answers.values['identity-url'];
+  const field = answers.values['identity-field'];
+  if (typeof url !== 'string' || url.length === 0) return undefined;
+
+  if (typeof field !== 'string' || field.length === 0) {
+    throw new Error(
+      '--identity-url needs --identity-field: the probe is one GET, and the field is which value in ' +
+        'the response names the account. Without it there is nothing to read out of the body.',
+    );
+  }
+
+  return { kind: 'http', url, field };
+}

--- a/src/cli/commands/connect/custom/spec.ts
+++ b/src/cli/commands/connect/custom/spec.ts
@@ -1,0 +1,293 @@
+/**
+ * The two fixed lists, as data, and what each member needs typed.
+ *
+ * `connect custom` exists to compose them: a connectivity type from
+ * `connectivity/manifest/connector.ts` and a credential type from
+ * `connectivity/manifest/auth.ts`, which are closed discriminated unions. So
+ * this file is a projection of those two schemas onto flags, and nothing here
+ * decides anything — `derive.ts` builds the manifest and `defineProvider` has
+ * the final word, exactly as it does for a hand-written file.
+ *
+ * One member is deliberately absent. `local` means the capability code is
+ * *ours*, compiled into this build, so there is nothing for a manifest to point
+ * at — refused by name rather than omitted in silence, because an operator
+ * reading the schema will find it and ask.
+ *
+ * `strategy` *is* offered, and naming one is a large part of what a declaration
+ * is for. A strategy travels on a provider's definition rather than in a global
+ * registry, so a YAML manifest reaches one by name — which is the only way to
+ * point a connection at a vendor's sandbox, since a built-in manifest's
+ * `options` are not the operator's to edit. See ADR-046.
+ */
+
+/** Reachable by declaring one. `local` is ours; see the note above. */
+export const CONNECTOR_KINDS = ['mcp', 'http', 'imap', 'dav', 'fs'] as const;
+export type ConnectorKind = (typeof CONNECTOR_KINDS)[number];
+
+/**
+ * Typed with a hyphen, stored with an underscore.
+ *
+ * The manifest spells it `api_key` because `identifier` does, and a flag spells
+ * it `api-key` because every other flag in this CLI is kebab-case. One place
+ * knows both.
+ */
+export const AUTH_METHODS = [
+  'none',
+  'bearer',
+  'api-key',
+  'header',
+  'basic',
+  'oauth',
+  'strategy',
+] as const;
+export type AuthMethod = (typeof AUTH_METHODS)[number];
+
+export const AUTH_KIND: Record<AuthMethod, string> = {
+  none: 'none',
+  bearer: 'bearer',
+  'api-key': 'api_key',
+  header: 'header',
+  basic: 'basic',
+  oauth: 'oauth',
+  strategy: 'strategy',
+};
+
+/**
+ * Provider ids this command's own grammar has taken.
+ *
+ * `custom` is the second word of `lanes link connect custom`, so a provider
+ * called `custom` could be declared, registered, and then never connected —
+ * that command would always mean this one. Refused in two places: here, so it
+ * cannot be created, and in `buildRegistryWithWorkspace`, so a file written by
+ * hand before this existed says why rather than being quietly unreachable.
+ *
+ * Not `RESERVED_PROVIDER_IDS`: that list is the owner layer's, it is surfaced to
+ * an agent as "the owner providers present in this profile", and the CLI
+ * registry passes `allowReserved: true` so it would not have fired here anyway.
+ */
+export const RESERVED_BY_GRAMMAR = ['custom'] as const;
+
+/** One value the operator supplies, and what to call it when asking. */
+export interface FieldSpec {
+  /** The kebab-case flag, which is also the key in `CustomFlags` once camelised. */
+  readonly flag: string;
+  readonly label: string;
+  readonly required: boolean;
+  /** One line under the prompt, where the answer is not obvious from the label. */
+  readonly hint?: string;
+  /** A closed set, offered as a choice rather than a free string. */
+  readonly choices?: readonly string[];
+}
+
+/**
+ * Per connectivity type: what must be said, and what may be.
+ *
+ * Only fields with no honest default appear. `port`, `max_body_bytes`,
+ * `max_range_days`, `max_file_bytes` and the rest are schema defaults and stay
+ * out of the written file, so a later change to a default reaches manifests
+ * already on disk instead of being frozen into each one.
+ */
+/**
+ * The one field `mcp` and `http` share, and the only one worth a flag.
+ *
+ * Repeatable. What the *vendor* requires of a client rather than what a caller
+ * wants from it: a `User-Agent` on a host that throttles the default one
+ * hardest, or the header an mcp server offers for asking it to expose fewer
+ * tools. `Authorization` is refused — that one belongs to `auth`.
+ */
+const HEADER: FieldSpec = {
+  flag: 'header',
+  label: 'Header sent on every request',
+  required: false,
+  hint: 'Name: value, repeatable. For what the vendor requires of a client, e.g. a User-Agent',
+};
+
+export const CONNECTOR_FIELDS: Record<ConnectorKind, readonly FieldSpec[]> = {
+  mcp: [
+    {
+      flag: 'endpoint',
+      label: 'MCP endpoint',
+      required: true,
+      hint: 'The URL the server speaks Streamable HTTP on, e.g. https://mcp.example.com/mcp',
+    },
+    HEADER,
+  ],
+  http: [
+    { flag: 'base-url', label: 'Base URL', required: true, hint: 'e.g. https://api.example.com/v1' },
+    {
+      flag: 'openapi',
+      label: 'OpenAPI document',
+      required: true,
+      hint: 'A URL, or a path to a file beside the manifest',
+    },
+    {
+      flag: 'operations',
+      label: 'Operations to expose',
+      required: false,
+      hint: 'Globs on operationId, path or tag. A large spec is a tool list no agent can reason over',
+    },
+    HEADER,
+  ],
+  imap: [
+    { flag: 'host', label: 'IMAP host', required: true, hint: 'e.g. imap.example.com' },
+    { flag: 'port', label: 'IMAP port', required: false, hint: 'Defaults to 993' },
+    {
+      flag: 'smtp-host',
+      label: 'SMTP host',
+      required: false,
+      hint: 'Leave empty for a read-only mailbox — without it there is no send capability',
+    },
+    { flag: 'smtp-port', label: 'SMTP port', required: false, hint: '465 for implicit TLS, 587 to upgrade in-band' },
+  ],
+  dav: [
+    { flag: 'base-url', label: 'Base URL', required: true, hint: 'Where discovery begins, e.g. https://dav.example.com' },
+    { flag: 'service', label: 'Service', required: true, choices: ['caldav', 'carddav'] },
+  ],
+  fs: [
+    { flag: 'root', label: 'Folder', required: true, hint: 'Everything under it is reachable and nothing above it. May start with ~' },
+    { flag: 'exclude', label: 'Names to exclude', required: false, hint: 'On top of .git, .ssh and node_modules, which are always refused' },
+  ],
+};
+
+/**
+ * Per credential type.
+ *
+ * The credential itself is never here, and never a flag. A flag value is in
+ * shell history, in `ps` output while the command runs, and in any transcript of
+ * the session — which is why `secrets set` reads from stdin and why this command
+ * writes `setup.prompts` into the manifest and lets the ordinary connect path
+ * ask. The upshot is that this change handles no secrets at all.
+ */
+export const AUTH_FIELDS: Record<AuthMethod, readonly FieldSpec[]> = {
+  none: [],
+  bearer: [
+    { flag: 'auth-header', label: 'Header name', required: false, hint: 'Defaults to Authorization' },
+  ],
+  'api-key': [
+    { flag: 'auth-header', label: 'Header name', required: false, hint: 'Defaults to X-API-Key' },
+    { flag: 'auth-query', label: 'Query parameter', required: false, hint: 'Instead of a header' },
+  ],
+  header: [
+    { flag: 'auth-header', label: 'Header name', required: true, hint: 'The header the value is sent in, verbatim' },
+  ],
+  basic: [],
+  strategy: [
+    {
+      flag: 'strategy',
+      label: 'Strategy name',
+      required: true,
+      hint: 'The name a provider in this build supplies, e.g. bunq',
+    },
+    {
+      flag: 'strategy-option',
+      label: 'Strategy option',
+      required: false,
+      hint: 'key=value, repeatable. Read by the strategy itself',
+    },
+  ],
+  oauth: [
+    { flag: 'scopes', label: 'Scopes', required: true, hint: 'What to ask the authorization server for' },
+    { flag: 'authorize-url', label: 'Authorize URL', required: false, hint: 'Required for an http connector; discovered for mcp' },
+    { flag: 'token-url', label: 'Token URL', required: false, hint: 'Declared with authorize-url or not at all' },
+    { flag: 'client-app', label: 'OAuth app name', required: false, hint: 'Which oauth_apps entry holds the client. Defaults to the provider id' },
+    { flag: 'registration', label: 'Registration', required: false, choices: ['dynamic', 'manual'] },
+    {
+      flag: 'authorize-param',
+      label: 'Extra authorization parameter',
+      required: false,
+      hint: 'key=value, repeatable. Some vendors need one to issue a refresh token at all',
+    },
+    {
+      flag: 'redirect-uri',
+      label: 'Redirect URI',
+      required: false,
+      hint: 'Only for a vendor that matches the whole URL — connect otherwise uses a port the kernel picks',
+    },
+  ],
+};
+
+/** Everything `connect custom` accepts, including what it forwards to `connect`. */
+export const CONNECT_CUSTOM_FLAGS: readonly string[] = [
+  'connector',
+  'auth',
+  'name',
+  'description',
+  ...new Set(
+    [...Object.values(CONNECTOR_FIELDS), ...Object.values(AUTH_FIELDS)]
+      .flat()
+      .map((field) => field.flag),
+  ),
+  'identity-url',
+  'identity-field',
+  'setup-docs',
+  'replace-manifest',
+  'yes',
+  // Forwarded to `connect` untouched, so declaring and connecting is one line.
+  // `--own-client` is not among them: it selects between an operator's client
+  // and a broker's, and a synthesized manifest never declares a broker.
+  'id',
+  'display-name',
+  'replace',
+  'non-interactive',
+  'accept-broad-scopes',
+];
+
+/** What the operator typed, before any of it has been judged. */
+export interface CustomFlags {
+  readonly connector?: string | undefined;
+  readonly auth?: string | undefined;
+  readonly name?: string | undefined;
+  readonly description?: string | undefined;
+  readonly endpoint?: string | undefined;
+  readonly baseUrl?: string | undefined;
+  readonly openapi?: string | undefined;
+  readonly operations?: readonly string[] | undefined;
+  readonly service?: string | undefined;
+  readonly host?: string | undefined;
+  readonly port?: string | undefined;
+  readonly smtpHost?: string | undefined;
+  readonly smtpPort?: string | undefined;
+  readonly root?: string | undefined;
+  readonly exclude?: readonly string[] | undefined;
+  readonly header?: readonly string[] | undefined;
+  readonly authHeader?: string | undefined;
+  readonly authQuery?: string | undefined;
+  readonly scopes?: readonly string[] | undefined;
+  readonly authorizeUrl?: string | undefined;
+  readonly tokenUrl?: string | undefined;
+  readonly clientApp?: string | undefined;
+  readonly registration?: string | undefined;
+  readonly redirectUri?: string | undefined;
+  readonly authorizeParam?: readonly string[] | undefined;
+  readonly strategy?: string | undefined;
+  readonly strategyOption?: readonly string[] | undefined;
+  readonly identityUrl?: string | undefined;
+  readonly identityField?: string | undefined;
+  readonly setupDocs?: string | undefined;
+  readonly replaceManifest?: boolean | undefined;
+  readonly yes?: boolean | undefined;
+}
+
+/** Everything settled, ready for `deriveManifest`. */
+export interface CustomAnswers {
+  readonly id: string;
+  readonly name: string;
+  readonly description?: string | undefined;
+  readonly connector: ConnectorKind;
+  readonly auth: AuthMethod;
+  readonly values: Readonly<Record<string, string | readonly string[]>>;
+}
+
+/** `acme_billing` reads as `Acme Billing` until somebody says otherwise. */
+export function titleCase(id: string): string {
+  return id
+    .split('_')
+    .filter((part) => part.length > 0)
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+    .join(' ');
+}
+
+/** camelCase, so a flag name indexes `CustomFlags` without a second table. */
+export function camel(flag: string): string {
+  return flag.replace(/-([a-z])/g, (_, letter: string) => letter.toUpperCase());
+}

--- a/src/cli/commands/connect/custom/values.ts
+++ b/src/cli/commands/connect/custom/values.ts
@@ -1,0 +1,53 @@
+import type { CustomAnswers } from './spec.ts';
+
+/**
+ * Reading what the operator said, in the shape the schema wants it.
+ *
+ * `values` is flag-keyed and every value arrived as a string or a list of them,
+ * because argv has nothing else to offer. These four are the only places that
+ * changes, so a field is read the same way wherever it is read.
+ */
+
+export const one = (answers: CustomAnswers, flag: string): string | undefined => {
+  const value = answers.values[flag];
+  return typeof value === 'string' && value.length > 0 ? value : undefined;
+};
+
+export const many = (answers: CustomAnswers, flag: string): readonly string[] => {
+  const value = answers.values[flag];
+  return Array.isArray(value) ? value.filter((entry) => entry.length > 0) : [];
+};
+
+/**
+ * `--strategy-option key=value` and `--authorize-param key=value`, repeated.
+ *
+ * Both untyped on purpose. A strategy's `options` are validated by the strategy
+ * itself, which is the only thing that knows what it takes; an authorization
+ * request's extra parameters are the vendor's vocabulary and not ours.
+ */
+export function pairs(answers: CustomAnswers, flag: string): Record<string, string> | undefined {
+  const declared = many(answers, flag);
+  if (declared.length === 0) return undefined;
+
+  const parsed: Record<string, string> = {};
+
+  for (const entry of declared) {
+    const split = entry.indexOf('=');
+    if (split < 1) {
+      throw new Error(`--${flag} "${entry}" is not a setting. Write it as "key=value".`);
+    }
+    parsed[entry.slice(0, split).trim()] = entry.slice(split + 1).trim();
+  }
+
+  return parsed;
+}
+
+export function port(value: string | undefined, flag: string): number | undefined {
+  if (value === undefined) return undefined;
+
+  const parsed = Number(value);
+  if (!Number.isInteger(parsed) || parsed < 1 || parsed > 65535) {
+    throw new Error(`--${flag} must be a port between 1 and 65535, not "${value}".`);
+  }
+  return parsed;
+}

--- a/src/cli/commands/connect/custom/write.test.ts
+++ b/src/cli/commands/connect/custom/write.test.ts
@@ -1,0 +1,230 @@
+import { afterAll, describe, expect, test } from 'bun:test';
+import { mkdtemp, readFile, rm, stat, writeFile, mkdir } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { layout } from '#profile';
+import { loadProfileProviders, parseManifest } from '#providers/custom/index.ts';
+import { deriveDeclaration, deriveManifest } from './derive.ts';
+import type { CustomAnswers } from './spec.ts';
+import {
+  checkOpenapiReachable,
+  manifestDiff,
+  manifestPath,
+  readExistingManifest,
+  renderManifest,
+  writeManifest,
+} from './write.ts';
+
+/**
+ * That the file this command writes is one the loader reads.
+ *
+ * Asserted against `loadProfileProviders` rather than against this file's own
+ * idea of the path, because "wrote a manifest" and "declared a provider" are
+ * only the same claim if the two agree about where manifests live — and the one
+ * message that used to tell an operator that named the wrong directory.
+ */
+
+const roots: string[] = [];
+const PROFILE = 'personal';
+
+async function workspace(): Promise<string> {
+  const root = await mkdtemp(join(tmpdir(), 'lanes-link-declare-'));
+  roots.push(root);
+  return root;
+}
+
+afterAll(async () => {
+  await Promise.all(roots.map((root) => rm(root, { recursive: true, force: true })));
+});
+
+const answers = (values: Record<string, string | readonly string[]> = {}): CustomAnswers => ({
+  id: 'thing',
+  name: 'Thing',
+  connector: 'http',
+  auth: 'bearer',
+  values: {
+    'base-url': 'https://api.example.com/v1',
+    openapi: 'https://api.example.com/openapi.json',
+    ...values,
+  },
+});
+
+describe('the manifest lands where the loader looks', () => {
+  test('and comes back as the provider that was declared', async () => {
+    const root = await workspace();
+    const path = manifestPath(root, PROFILE, 'thing');
+
+    await writeManifest(path, renderManifest(deriveDeclaration(answers())));
+
+    const loaded = await loadProfileProviders(root, PROFILE);
+    expect(loaded.map((entry) => entry.manifest.id)).toEqual(['thing']);
+    expect(loaded[0]?.manifest.auth).toMatchObject({ kind: 'bearer' });
+  });
+
+  test('creating the directory, which nothing else does', async () => {
+    // `layout.providers` is only ever read, listed and deleted — no command
+    // created it, so the first declaration in a profile has to.
+    const root = await workspace();
+    const path = manifestPath(root, PROFILE, 'thing');
+
+    await writeManifest(path, 'id: thing\n');
+
+    expect((await stat(join(root, layout.providers(PROFILE)))).isDirectory()).toBe(true);
+  });
+
+  test('readable only by its owner, like every other file here', async () => {
+    const root = await workspace();
+    const path = manifestPath(root, PROFILE, 'thing');
+
+    await writeManifest(path, 'id: thing\n');
+
+    expect((await stat(path)).mode & 0o777).toBe(0o600);
+  });
+
+  test('and nothing half-written survives a crash', async () => {
+    // The temp file is `.tmp`, which the filesystem blob store skips when it
+    // lists — so a crash between write and rename cannot leave a file the
+    // loader tries to parse, which would break every command for this profile.
+    const root = await workspace();
+    const path = manifestPath(root, PROFILE, 'thing');
+    await mkdir(join(root, layout.providers(PROFILE)), { recursive: true });
+    await writeFile(`${path}.tmp`, 'id: broken');
+
+    await expect(loadProfileProviders(root, PROFILE)).resolves.toEqual([]);
+  });
+});
+
+describe('a second run against the file already there', () => {
+  const derived = () => deriveManifest(answers());
+
+  test('the same answers are no difference at all', async () => {
+    const root = await workspace();
+    const path = manifestPath(root, PROFILE, 'thing');
+    await writeManifest(path, renderManifest(deriveDeclaration(answers())));
+
+    const existing = await readExistingManifest(path);
+    expect(manifestDiff(derived(), existing!)).toEqual([]);
+  });
+
+  test('and neither is something the operator added afterwards', async () => {
+    // The file is theirs the moment it exists. `redact` and `hints` are exactly
+    // what somebody adds once they have seen the tool list, and a re-run reading
+    // them as drift would refuse to proceed for no reason.
+    const root = await workspace();
+    const path = manifestPath(root, PROFILE, 'thing');
+    await writeManifest(
+      path,
+      `${renderManifest(deriveDeclaration(answers()))}\nredact:\n  list_things: [id]\nhints:\n  list_things: Prefer this.\n`,
+    );
+
+    const existing = await readExistingManifest(path);
+    expect(manifestDiff(derived(), existing!)).toEqual([]);
+  });
+
+  test('a changed value is named, with both sides', async () => {
+    const root = await workspace();
+    const path = manifestPath(root, PROFILE, 'thing');
+    await writeManifest(
+      path,
+      renderManifest(deriveDeclaration(answers({ 'base-url': 'https://api.example.com/v2' }))),
+    );
+
+    const existing = await readExistingManifest(path);
+    expect(manifestDiff(derived(), existing!)).toEqual([
+      'connector.base_url: https://api.example.com/v2 → https://api.example.com/v1',
+    ]);
+  });
+
+  test('a dropped flag is a difference too, not silence', async () => {
+    // Compared in both directions on purpose: answering "unchanged" here would
+    // leave an operation filter in place that the operator has just stopped
+    // asking for.
+    const root = await workspace();
+    const path = manifestPath(root, PROFILE, 'thing');
+    await writeManifest(
+      path,
+      renderManifest(deriveDeclaration(answers({ operations: ['*Account*'] }))),
+    );
+
+    const existing = await readExistingManifest(path);
+    expect(manifestDiff(derived(), existing!)).not.toEqual([]);
+  });
+
+  test('a relative spec path compares as written, not as resolved', async () => {
+    // `readExistingManifest` uses `parseManifest` rather than the loader's file
+    // variant for exactly this: resolving one side and not the other makes every
+    // re-run read as a change.
+    const root = await workspace();
+    const path = manifestPath(root, PROFILE, 'thing');
+    const relative = answers({ openapi: './thing.json' });
+    await writeManifest(path, renderManifest(deriveDeclaration(relative)));
+
+    const existing = await readExistingManifest(path);
+    expect(manifestDiff(deriveManifest(relative), existing!)).toEqual([]);
+  });
+
+  test('nothing there is nothing to compare', async () => {
+    const root = await workspace();
+    expect(await readExistingManifest(manifestPath(root, PROFILE, 'absent'))).toBeNull();
+  });
+});
+
+describe('an OpenAPI document named as a path', () => {
+  test('a URL is taken on trust and not fetched', async () => {
+    const root = await workspace();
+    await expect(
+      checkOpenapiReachable('https://api.example.com/openapi.json', root, PROFILE),
+    ).resolves.toBeUndefined();
+  });
+
+  test('one beside the manifest is found', async () => {
+    const root = await workspace();
+    const directory = join(root, layout.providers(PROFILE));
+    await mkdir(directory, { recursive: true });
+    await writeFile(join(directory, 'thing.json'), '{}');
+
+    await expect(checkOpenapiReachable('./thing.json', root, PROFILE)).resolves.toBeUndefined();
+  });
+
+  test('a missing one is refused before anything is written', async () => {
+    // Left alone this surfaces inside the OpenAPI generator, after the manifest
+    // is on disk — and `openRuntime` swallows a discovery failure so startup
+    // survives, leaving a provider with no capabilities and nothing saying why.
+    const root = await workspace();
+
+    await expect(checkOpenapiReachable('./thing.json', root, PROFILE)).rejects.toThrow(
+      /No OpenAPI document at/,
+    );
+  });
+
+  test('and one in the working directory instead says so, naming both', async () => {
+    // Everyone types `./spec.json` meaning "next to where I am". A manifest
+    // resolves it against the manifest, which is right and is not what they
+    // meant, so the refusal has to say both things.
+    const root = await workspace();
+    const here = join(process.cwd(), 'connect-custom-spec-fixture.json');
+    await writeFile(here, '{}');
+
+    try {
+      await expect(
+        checkOpenapiReachable('./connect-custom-spec-fixture.json', root, PROFILE),
+      ).rejects.toThrow(/It does exist at/);
+    } finally {
+      await rm(here, { force: true });
+    }
+  });
+});
+
+describe('the file a reader opens', () => {
+  test('says what wrote it and that editing it is expected', async () => {
+    const root = await workspace();
+    const path = manifestPath(root, PROFILE, 'thing');
+    await writeManifest(path, renderManifest(deriveDeclaration(answers())));
+
+    const text = await readFile(path, 'utf8');
+    expect(text).toMatch(/^# Written by `lanes link connect custom`/);
+    expect(text).toMatch(/re-reads this file every time/);
+    // And it is still a manifest after the comment.
+    expect(() => parseManifest(text, path)).not.toThrow();
+  });
+});

--- a/src/cli/commands/connect/custom/write.ts
+++ b/src/cli/commands/connect/custom/write.ts
@@ -1,0 +1,166 @@
+import { mkdir, readFile, rename, stat, writeFile } from 'node:fs/promises';
+import { dirname, isAbsolute, join, resolve } from 'node:path';
+import { stringify } from 'yaml';
+import type { ProviderManifest } from '#connectivity';
+import { layout } from '#profile';
+import { parseManifest } from '#providers/custom/index.ts';
+
+/**
+ * Putting the manifest where the loader will find it.
+ *
+ * The only filesystem code in this command, and the only place that decides what
+ * the file looks like. Writing is local: a deployed revision reads its
+ * manifests from a bucket but never writes its own config (ADR-007), so the
+ * operator's workspace is where a declaration is authored and `deploy` or the
+ * publish that follows a connect is what carries it.
+ */
+
+/** Where this profile keeps its own declarations. */
+export function manifestPath(workspaceRoot: string, profile: string, id: string): string {
+  return join(workspaceRoot, layout.providers(profile), `${id}.yaml`);
+}
+
+/**
+ * Fields this command never writes, so a hand-added one is not a difference.
+ *
+ * The file belongs to the operator the moment it exists. `redact` and `hints`
+ * are exactly what somebody adds after seeing the tool list — per-capability
+ * argument keys worth recording, and prose the vendor's own description leaves
+ * out — and a re-run must not read them as drift.
+ */
+const THEIRS = ['redact', 'hints', 'bundles'];
+
+/**
+ * One header line, about the file rather than about the fields.
+ *
+ * `manifestTemplate` is the other way round and stays that way: it is teaching
+ * material whose values are deliberately wrong and whose comments explain each
+ * field. This is a record of what somebody just said, where every value is
+ * theirs — so a comment describing a field would end up describing a different
+ * provider than the value beside it, and every optional field they declined
+ * would sit in the file as a value that now *is* declared.
+ */
+const HEADER =
+  '# Written by `lanes link connect custom`. Yours to edit from here —\n' +
+  '# `lanes link connect <id>` re-reads this file every time.\n';
+
+export function renderManifest(declaration: Record<string, unknown>): string {
+  return HEADER + stringify(declaration, { lineWidth: 0 });
+}
+
+/** The manifest already at this path, or null. Parsed, so defaults match. */
+export async function readExistingManifest(path: string): Promise<ProviderManifest | null> {
+  let text: string;
+  try {
+    text = await readFile(path, 'utf8');
+  } catch {
+    return null;
+  }
+
+  // Deliberately `parseManifest` and not the loader's file variant: a relative
+  // `openapi` must compare as it was written, not as it resolves, or every
+  // re-run reads as a change.
+  return parseManifest(text, path);
+}
+
+/**
+ * Where a re-run would differ from what is on disk, as dotted paths.
+ *
+ * Compared as parsed manifests rather than as bytes, so both sides have the same
+ * defaults applied and neither key order nor a reflowed line reads as drift.
+ * Both directions, minus `THEIRS`: dropping `--operations` from a second run is
+ * a real difference, and answering "unchanged" there would leave a filter in
+ * place that the operator has just stopped asking for.
+ */
+export function manifestDiff(derived: ProviderManifest, existing: ProviderManifest): string[] {
+  const differences: string[] = [];
+
+  const walk = (a: unknown, b: unknown, path: string): void => {
+    if (path.length > 0 && THEIRS.includes(path.split('.')[0]!)) return;
+
+    if (Array.isArray(a) || Array.isArray(b)) {
+      if (JSON.stringify(a) !== JSON.stringify(b)) differences.push(describe(path, a, b));
+      return;
+    }
+
+    if (isRecord(a) && isRecord(b)) {
+      for (const key of new Set([...Object.keys(a), ...Object.keys(b)])) {
+        walk(a[key], b[key], path.length > 0 ? `${path}.${key}` : key);
+      }
+      return;
+    }
+
+    if (a !== b) differences.push(describe(path, a, b));
+  };
+
+  walk(derived, existing, '');
+  return differences.sort();
+}
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === 'object' && value !== null;
+
+function describe(path: string, derived: unknown, existing: unknown): string {
+  return `${path}: ${show(existing)} → ${show(derived)}`;
+}
+
+const show = (value: unknown): string =>
+  value === undefined ? '(absent)' : typeof value === 'string' ? value : JSON.stringify(value);
+
+/** Write through a temp file, so a crash cannot leave half a declaration. */
+export async function writeManifest(path: string, text: string): Promise<void> {
+  await mkdir(dirname(path), { recursive: true });
+
+  // `.tmp` because the filesystem blob store skips that suffix when it lists —
+  // so a crash between write and rename leaves a file the loader will not try to
+  // parse, rather than one that breaks every command for this profile.
+  const temporary = `${path}.tmp`;
+  await writeFile(temporary, text, { mode: 0o600 });
+  await rename(temporary, path);
+}
+
+/**
+ * That an OpenAPI document named as a path is actually there.
+ *
+ * Checked before the manifest is written, because the alternative is bleak:
+ * discovery is the only thing that reads the spec, `openRuntime` swallows a
+ * discovery failure so startup survives a provider that is merely unreachable,
+ * and the result is a provider registered with zero capabilities and nothing
+ * anywhere saying why.
+ *
+ * A relative path resolves against `providers.d/`, which is what
+ * `resolveSpecPath` does when the loader reads it — and is almost never what
+ * somebody typing `./spec.json` at a shell prompt means. So when it is missing
+ * there and present in the working directory, say both.
+ */
+export async function checkOpenapiReachable(
+  value: string,
+  workspaceRoot: string,
+  profile: string,
+): Promise<void> {
+  if (/^https?:/i.test(value)) return;
+
+  const beside = isAbsolute(value)
+    ? value
+    : resolve(join(workspaceRoot, layout.providers(profile)), value);
+
+  if (await exists(beside)) return;
+
+  const here = isAbsolute(value) ? undefined : resolve(process.cwd(), value);
+  const alsoLookedAt =
+    here && here !== beside && (await exists(here))
+      ? `\n  It does exist at ${here}. A relative path in a manifest resolves against the manifest, ` +
+        'not against wherever you ran this from — copy it beside the manifest, or give an absolute ' +
+        'path or a URL.'
+      : '';
+
+  throw new Error(`No OpenAPI document at ${beside}.${alsoLookedAt}`);
+}
+
+const exists = async (path: string): Promise<boolean> => {
+  try {
+    return (await stat(path)).isFile();
+  } catch {
+    return false;
+  }
+};

--- a/src/cli/commands/connect/grant.ts
+++ b/src/cli/commands/connect/grant.ts
@@ -1,0 +1,27 @@
+import type { ConfigDocument } from '../../config-edit.ts';
+import { matchesRule } from './accounts.ts';
+
+/**
+ * What connecting grants.
+ *
+ * One rule per provider, not one per capability. The pinned-per-tool form this
+ * replaced was 85 lines for four providers and unreadable, and what it bought —
+ * a vendor cannot widen your policy by shipping a new tool — is preserved
+ * instead by `doctor`, which reports capabilities that appeared after you
+ * connected.
+ *
+ * Idempotent, and by matching rather than by equality: a profile already holding
+ * a broader rule that covers this one is not widened, and a second connect to
+ * the same provider adds nothing.
+ */
+export function grantProvider(
+  document: ConfigDocument,
+  allow: readonly { readonly capability: string }[],
+  providerId: string,
+): string[] {
+  const rule = `${providerId}.*`;
+  if (allow.some((existing) => matchesRule(existing.capability, rule))) return [];
+
+  document.addTo(['policy', 'allow'], rule, { inline: true });
+  return [rule];
+}

--- a/src/cli/commands/connect/index.ts
+++ b/src/cli/commands/connect/index.ts
@@ -16,6 +16,7 @@ import { ALREADY, NOTHING, renderOutcome, where, type ConnectOutcome } from './o
 import { nextAfterEdit, publishRuntimeEdit } from '#cli/publish.ts';
 import { ensureStaticCredential } from './setup.ts';
 import { settleIdentity } from './settle.ts';
+import { runStrategySetup } from './strategy.ts';
 import { announceConnectTarget } from './target-note.ts';
 
 /**
@@ -256,6 +257,9 @@ async function runConnect(
         prompter,
       });
     }
+
+    // 1b. The vendor's own handshake — see `./strategy.ts`, including why here.
+    await runStrategySetup(manifest, provisionalId, runtime);
 
     // 2. Ask the provider whose account that was.
     //

--- a/src/cli/commands/connect/index.ts
+++ b/src/cli/commands/connect/index.ts
@@ -4,7 +4,8 @@ import { ensureSetupConnection, repaired } from '../../config-repair.ts';
 import { emit, print } from '../../output.ts';
 import { nonInteractivePrompter, terminalPrompter, type Prompter } from '../../prompt.ts';
 import { openRuntime, type GlobalFlags } from '../../runtime.ts';
-import { matchesRule, moveCredential, siblingAccountId } from './accounts.ts';
+import { moveCredential, siblingAccountId } from './accounts.ts';
+import { grantProvider } from './grant.ts';
 import { discoverCapabilities } from './discover.ts';
 import { connectFamily, familyMembers } from './family.ts';
 import { authoriseWithKey } from './assertion.ts';
@@ -18,6 +19,7 @@ import { ensureStaticCredential } from './setup.ts';
 import { settleIdentity } from './settle.ts';
 import { runStrategySetup } from './strategy.ts';
 import { announceConnectTarget } from './target-note.ts';
+import { unknownProvider } from './unknown.ts';
 
 /**
  * `lanes link connect <provider>` — the one command that adds an account.
@@ -92,7 +94,14 @@ export async function connect(target: string, options: ConnectOptions): Promise<
   return emit(options.json, outcome, () => renderOutcome(outcome));
 }
 
-async function runConnect(
+/**
+ * Exported for `connect custom`, which declares a provider and then connects it.
+ *
+ * Narrow on purpose — no extra parameters, no second entry point into the five
+ * steps. The manifest is written before this is called, because the registry
+ * that reads `providers.d/` is built by `openRuntime` on the first line.
+ */
+export async function runConnect(
   target: string,
   options: ConnectOptions,
   /** A family member — the account this belongs to has already said where it goes. */
@@ -134,17 +143,13 @@ async function runConnect(
     }
 
     if (!entry) {
-      const available = registry.list();
-      const builtin = available.filter((c) => c.origin === 'builtin').map((c) => c.manifest.id);
-      const custom = available.filter((c) => c.origin === 'workspace').map((c) => c.manifest.id);
-
-      throw new Error(
-        `Unknown provider "${providerId}".\n` +
-          `  built in: ${builtin.join(', ')}\n` +
-          (custom.length > 0
-            ? `  yours:    ${custom.join(', ')}\n`
-            : `  add your own: a manifest in ${runtime.resolution.workspaceRoot}/providers/\n`),
-      );
+      throw unknownProvider({
+        providerId,
+        registry,
+        workspaceRoot: runtime.resolution.workspaceRoot,
+        profile: runtime.resolution.profile,
+        target: runtime.target,
+      });
     }
 
     const manifest = entry.manifest;
@@ -326,20 +331,8 @@ async function runConnect(
       changes.push(`re-authorised ${connectionKey}${method.id ? ` with ${method.id}` : ''}`);
     }
 
-    // 5. Grant it.
-    //
-    //    One rule per provider, not one per capability. The pinned-per-tool
-    //    form this replaced was 85 lines for four providers and unreadable, and
-    //    what it bought — a vendor cannot widen your policy by shipping a new
-    //    tool — is preserved instead by `doctor`, which reports capabilities
-    //    that appeared after you connected.
-    const granted: string[] = [];
-    const rule = `${providerId}.*`;
-
-    if (!runtime.config.policy.allow.some((existing) => matchesRule(existing.capability, rule))) {
-      document.addTo(['policy', 'allow'], rule, { inline: true });
-      granted.push(rule);
-    }
+    // 5. Grant it — one rule per provider; `grant.ts` says why not per capability.
+    const granted = grantProvider(document, runtime.config.policy.allow, providerId);
 
     // 6. Repair the setup surface if this profile predates it.
     //

--- a/src/cli/commands/connect/outcome.ts
+++ b/src/cli/commands/connect/outcome.ts
@@ -140,7 +140,9 @@ function renderBlocked(outcome: ConnectOutcome): void {
         ? 'a browser is needed'
         : outcome.reason === 'needs_terminal'
           ? 'a terminal is needed'
-          : 'more is needed first',
+          : outcome.reason === 'needs_declaration'
+            ? 'this provider is not declared yet'
+            : 'more is needed first',
     ),
   );
 

--- a/src/cli/commands/connect/requirements.ts
+++ b/src/cli/commands/connect/requirements.ts
@@ -37,7 +37,17 @@ export type BlockedReason =
   | 'needs_browser'
   /** A question only a person can answer, on a run with nobody to ask. */
   | 'needs_terminal'
-  | 'missing_credentials';
+  | 'missing_credentials'
+  /**
+   * The manifest itself is not settled yet — `connect custom` only.
+   *
+   * Unlike the others this is not about a credential: nothing has been written
+   * and nothing needs storing first, the declaration is simply incomplete or
+   * disagrees with the file already on disk. It shares `Blocked` because it
+   * shares the thing that matters about one — every missing piece named at
+   * once, and the command that ends it.
+   */
+  | 'needs_declaration';
 
 export interface Blocked {
   readonly reason: BlockedReason;

--- a/src/cli/commands/connect/settle.ts
+++ b/src/cli/commands/connect/settle.ts
@@ -27,6 +27,7 @@ export async function settleIdentity(input: {
     credentials: SecretStore;
     registry: { manifest(id: string): ProviderManifest | undefined };
     connectorFor(providerId: string, connectionId: string): AnyConnector | undefined;
+    authorizeRequest(providerId: string, connectionId: string, request: Request): Promise<Request>;
   };
   prompter?: Prompter;
 }): Promise<{ connectionId: string; account: string }> {
@@ -51,8 +52,24 @@ export async function settleIdentity(input: {
   if (!account) {
     const token = () => bearerTokenAsStored(manifest, provisionalId, runtime.credentials);
 
+    // Only where `accessToken` cannot answer: `requestAuthorizer` goes through
+    // `credentialResolver`, which may *refresh* an OAuth token, and
+    // `bearerTokenAsStored` is deliberately the connect-time variant that does
+    // not. Leaving oauth and bearer on the token keeps refresh behaviour
+    // exactly as it was; these three had no working path at all.
+    const carriesItsOwnHeader =
+      manifest.auth.kind === 'api_key' ||
+      manifest.auth.kind === 'header' ||
+      manifest.auth.kind === 'basic';
+
     account = await resolveAccount(manifest, {
       accessToken: token,
+      ...(carriesItsOwnHeader
+        ? {
+            authorize: (request: Request) =>
+              runtime.authorizeRequest(manifest.id, provisionalId, request),
+          }
+        : {}),
       // A protocol that authenticates by username has nothing to GET and no
       // tool to call — it knows, once the server has accepted the login.
       identify: async () =>

--- a/src/cli/commands/connect/setup-strategy.test.ts
+++ b/src/cli/commands/connect/setup-strategy.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, test } from 'bun:test';
+import { defineProvider } from '#connectivity';
+import type { SecretRef, SecretStore } from '#secrets';
+import type { Prompter } from '../../prompt.ts';
+import { ensureStaticCredential } from './setup.ts';
+
+/**
+ * The prompt a strategy provider needs, which it did not get.
+ *
+ * `ensureStaticCredential` returned early for `auth.kind === 'strategy'`, from
+ * when the kind was unreachable and the exclusion cost nothing. The first
+ * provider to use it made the exclusion exactly backwards: bunq's API key is a
+ * pasted value like any other — more so, since the handshake runs *on* it — so
+ * an interactive `lanes link connect bunq` stored nothing and then failed
+ * inside the handshake, complaining that no key had been stored.
+ *
+ * Worth its own file because nothing else here covers the shape: the provider
+ * that reaches this function without being `bearer`, `api_key`, or `basic`.
+ */
+const manifest = defineProvider({
+  id: 'acme',
+  name: 'Acme',
+  connector: { kind: 'http', base_url: 'https://api.acme.test/v1', openapi: './acme.json' },
+  auth: { kind: 'strategy', strategy: 'handshake' },
+  setup: {
+    prompts: [{ key: 'api_key', label: 'Acme API key', secret: true, scope: 'connection' as const }],
+  },
+});
+
+function memoryStore(): SecretStore & { seen: Map<string, string> } {
+  const map = new Map<string, string>();
+  return {
+    seen: map,
+    get: async (ref) => map.get(ref) ?? null,
+    set: async (ref, value) => void map.set(ref, value),
+    has: async (ref) => map.has(ref),
+    delete: async (ref) => void map.delete(ref),
+    list: async (prefix) =>
+      [...map.keys()].filter((k) => !prefix || k.startsWith(prefix)) as SecretRef[],
+  };
+}
+
+const answering = (value: string): Prompter => ({
+  interactive: true,
+  ask: async () => value,
+  askSecret: async () => value,
+  confirm: async () => true,
+});
+
+describe('a strategy provider on the interactive path', () => {
+  test('is asked for its credential, and it lands at the derived ref', async () => {
+    const credentials = memoryStore();
+
+    await ensureStaticCredential({
+      manifest,
+      connectionId: 'pending',
+      credentials,
+      replace: false,
+      provisional: true,
+      prompter: answering('pasted-api-key'),
+    });
+
+    // Derived, not declared — bunq issues one key per account, so a
+    // `credential_ref` on the manifest would make every connection share one.
+    expect(credentials.seen.get('acme/pending')).toBe('pasted-api-key');
+  });
+
+  test('is not asked again when the handshake already replaced it', async () => {
+    // The re-connect case: what is stored is no longer the pasted key but the
+    // whole installed context. Asking again without `--replace` would be a
+    // question the operator has already answered.
+    const credentials = memoryStore();
+    await credentials.set('acme/main', '{"api_key":"k","private_key":"p"}');
+
+    await ensureStaticCredential({
+      manifest,
+      connectionId: 'main',
+      credentials,
+      replace: false,
+      provisional: false,
+      prompter: answering('should-not-be-asked'),
+    });
+
+    expect(credentials.seen.get('acme/main')).toBe('{"api_key":"k","private_key":"p"}');
+  });
+
+  test('--replace asks again, which is how a rotated key gets in', async () => {
+    const credentials = memoryStore();
+    await credentials.set('acme/main', 'the-old-key');
+
+    await ensureStaticCredential({
+      manifest,
+      connectionId: 'main',
+      credentials,
+      replace: true,
+      provisional: false,
+      prompter: answering('the-new-key'),
+    });
+
+    expect(credentials.seen.get('acme/main')).toBe('the-new-key');
+  });
+});

--- a/src/cli/commands/connect/setup.ts
+++ b/src/cli/commands/connect/setup.ts
@@ -145,7 +145,15 @@ export async function ensureStaticCredential(input: {
   const { manifest, connectionId, credentials, replace, provisional } = input;
   const prompter = input.prompter ?? terminalPrompter;
   const auth = manifest.auth;
-  if (auth.kind === 'none' || auth.kind === 'oauth' || auth.kind === 'strategy') return;
+  // `strategy` used to be excluded here, from when no strategy existed and the
+  // kind was unreachable. It is exactly the wrong exclusion: a strategy
+  // provider's credential is *more* of a pasted value than most — bunq's API
+  // key is the input its handshake runs on — and skipping the prompt left
+  // `lanes link connect bunq` storing nothing and then failing inside the
+  // handshake with "no API key was stored", on the interactive path the setup
+  // documentation describes. Everything below is generic: the ref derives, the
+  // prompts come from the manifest.
+  if (auth.kind === 'none' || auth.kind === 'oauth') return;
 
   const ref = credentialRefForConnection(manifest, connectionId)!;
   const stored = await credentials.has(ref);

--- a/src/cli/commands/connect/strategy.test.ts
+++ b/src/cli/commands/connect/strategy.test.ts
@@ -1,0 +1,151 @@
+import { describe, expect, test } from 'bun:test';
+import { ProviderRegistry } from '#registry';
+import { createMemoryCredentials, createMemoryState } from '#stores/state/testing.ts';
+import { defineProvider, defineProviderWithStrategy } from '#connectivity';
+import type { AuthStrategy, AuthStrategyContext } from '#connectivity';
+import { runStrategySetup } from './strategy.ts';
+
+/**
+ * The half of the seam that only `connect` has: a writable credential store.
+ *
+ * Every other caller of a strategy is on the dispatch path, where `write` is
+ * deliberately absent. These tests pin the two things that would otherwise go
+ * unnoticed until a real handshake ran — that the writer works and lands where
+ * the connection can read it back, and that a provider without a strategy is
+ * untouched rather than refused.
+ */
+
+const strategyManifest = defineProvider({
+  id: 'acme',
+  name: 'Acme',
+  connector: { kind: 'http', base_url: 'https://api.acme.test/v1', openapi: './acme.json' },
+  auth: { kind: 'strategy', strategy: 'handshake', options: { sandbox: true } },
+});
+
+const plainManifest = defineProvider({
+  id: 'plain',
+  name: 'Plain',
+  connector: { kind: 'http', base_url: 'https://api.plain.test/v1', openapi: './plain.json' },
+  auth: { kind: 'bearer' },
+});
+
+function harness(setup?: AuthStrategy['setup']) {
+  const seen: AuthStrategyContext[] = [];
+  /** What the handshake read before it overwrote it. */
+  const read: Array<string | null> = [];
+  const strategy: AuthStrategy = {
+    id: 'handshake',
+    async authorize(request) {
+      return request;
+    },
+    ...(setup
+      ? { setup }
+      : {
+          async setup(context) {
+            seen.push(context);
+            read.push(await context.credentials.get(`acme/${context.connectionId}`));
+            await context.write!(`acme/${context.connectionId}`, 'the whole context');
+          },
+        }),
+  };
+
+  const registry = new ProviderRegistry();
+  registry.register(defineProviderWithStrategy({ manifest: strategyManifest, strategy }));
+  registry.register(plainManifest);
+
+  return {
+    seen,
+    read,
+    registry,
+    credentials: createMemoryCredentials({ 'acme/pending': 'pasted-api-key' }),
+    state: createMemoryState(),
+    resolution: { profile: 'personal' },
+  };
+}
+
+describe('runStrategySetup', () => {
+  test('runs the handshake and its write reaches the store', async () => {
+    const bench = harness();
+    await runStrategySetup(strategyManifest, 'pending', bench);
+
+    expect(await bench.credentials.get('acme/pending')).toBe('the whole context');
+  });
+
+  test('the strategy can read what the operator pasted', async () => {
+    const bench = harness();
+    await runStrategySetup(strategyManifest, 'pending', bench);
+
+    // Read during the handshake, because the handshake then replaces it — the
+    // API key is the input to an installation, and the whole context is the output.
+    expect(bench.read).toEqual(['pasted-api-key']);
+  });
+
+  test('carries the manifest options, so one provider can serve two environments', async () => {
+    const bench = harness();
+    await runStrategySetup(strategyManifest, 'pending', bench);
+
+    expect(bench.seen[0]!.options).toEqual({ sandbox: true });
+  });
+
+  test('credentials are scoped to this connection and nothing else', async () => {
+    const bench = harness();
+    await bench.credentials.set('acme/somebody-else', 'not yours');
+    await runStrategySetup(strategyManifest, 'pending', bench);
+
+    expect(bench.seen[0]!.credentials.get('acme/somebody-else')).rejects.toThrow();
+  });
+
+  test('state is scoped too, so a session cannot be read across connections', async () => {
+    const bench = harness();
+    await runStrategySetup(strategyManifest, 'pending', bench);
+    await bench.seen[0]!.state.set('session', 'token');
+
+    // Same registry and the same stores, a different connection.
+    await runStrategySetup(strategyManifest, 'other', bench);
+
+    expect(await bench.seen[1]!.state.get('session')).toBeNull();
+  });
+
+  test('carries the profile, so a process-wide cache cannot collide across profiles', async () => {
+    const bench = harness();
+    await runStrategySetup(strategyManifest, 'pending', bench);
+
+    expect(bench.seen[0]!.profile).toBe('personal');
+  });
+
+  test('the writer refuses a ref that is not this connection\'s credential', async () => {
+    // The read side is an allowlist; without this the write side is not, and a
+    // strategy could overwrite a credential it is not allowed to read.
+    const bench = harness(async (context) => {
+      await context.write!('google/main', 'not mine');
+    });
+
+    expect(runStrategySetup(strategyManifest, 'pending', bench)).rejects.toThrow(
+      /tried to write google\/main/,
+    );
+  });
+
+  test('a provider with no strategy is left alone', async () => {
+    const bench = harness();
+
+    expect(runStrategySetup(plainManifest, 'main', bench)).resolves.toBeUndefined();
+  });
+
+  test('a manifest naming a strategy nothing carries refuses, rather than connecting half a provider', async () => {
+    const bench = harness();
+    const registry = new ProviderRegistry();
+    registry.register(strategyManifest);
+
+    expect(runStrategySetup(strategyManifest, 'pending', { ...bench, registry })).rejects.toThrow(
+      /"handshake" is not registered/,
+    );
+  });
+
+  test('a failing handshake propagates, so connect stops before writing config', async () => {
+    const bench = harness(async () => {
+      throw new Error('bunq /device-server answered 400: wrong key');
+    });
+
+    expect(runStrategySetup(strategyManifest, 'pending', bench)).rejects.toThrow(/wrong key/);
+  });
+});

--- a/src/cli/commands/connect/strategy.ts
+++ b/src/cli/commands/connect/strategy.ts
@@ -1,0 +1,87 @@
+import { credentialRefForConnection, strategyContextFrom, strategyFor } from '#connectivity';
+import type { ProviderManifest } from '#connectivity';
+import { createScopedStore, scopeNamespace } from '#dispatch';
+import { scopeSecrets } from '#secrets';
+import type { SecretStore } from '#secrets';
+import type { RuntimeState } from '#stores/state';
+import type { ProviderRegistry } from '#registry';
+import { progress, style } from '../../output.ts';
+
+/**
+ * The handshake a strategy provider needs before it can be called at all.
+ *
+ * Ordinary providers finish authenticating the moment the operator pastes
+ * something: the value *is* the credential. A strategy provider has only half
+ * of one at that point — bunq's API key is the input to an installation, not a
+ * token — so this runs the vendor's own setup between storing what was pasted
+ * and asking whose account it is.
+ *
+ * **Why it sits where it does in `connect`.** After the credential is stored,
+ * because the handshake's input is what was pasted. Before identity is settled
+ * and anything is written to the config, because a key the vendor rejects
+ * should fail here — with the vendor's own message — rather than leaving a
+ * connection row describing an account that cannot be reached. It runs under
+ * the *provisional* connection id for the same reason every other step does:
+ * the real one is not known yet, and `connect` moves the credential when it is.
+ *
+ * Here rather than in `index.ts` because that file is at its size budget, and
+ * because this is one self-contained step: everything it needs is a manifest
+ * and a runtime, and everything it produces is in the credential store.
+ */
+export async function runStrategySetup(
+  manifest: ProviderManifest,
+  /** The provisional id. `connect` renames the connection afterwards and the credential follows. */
+  connectionId: string,
+  /** Structurally the CLI `Runtime`, named as the parts this actually reaches. */
+  runtime: {
+    readonly registry: ProviderRegistry;
+    readonly credentials: SecretStore;
+    readonly state: RuntimeState;
+    readonly resolution: { readonly profile: string };
+  },
+): Promise<void> {
+  const { registry, credentials, state } = runtime;
+  const profile = runtime.resolution.profile;
+  if (manifest.auth.kind !== 'strategy') return;
+
+  const strategy = strategyFor(manifest, registry);
+  if (!strategy.setup) return;
+
+  // The one ref this connection may read, which is also the one the pasted
+  // value landed in and the one the handshake will rewrite.
+  const ref = credentialRefForConnection(manifest, connectionId)!;
+
+  const context = strategyContextFrom({
+    source: {
+      credentials: scopeSecrets(credentials, [ref]),
+      state: createScopedStore(state, scopeNamespace(manifest.id, connectionId)),
+      log: {
+        debug: () => {},
+        info: (message) => progress(style.dim(`  ${message}`)),
+        warn: (message) => progress(style.dim(`  ${message}`)),
+        error: (message) => progress(style.dim(`  ${message}`)),
+      },
+    },
+    manifest,
+    connectionId,
+    profile,
+    // Writable *only* here — the dispatch path passes nothing, so a per-request
+    // handshake cannot persist anything.
+    //
+    // Scoped to the same single ref the reads are. Handing over the raw store
+    // would leave the write side of this boundary open while the read side is
+    // shut, which is the asymmetry that makes a boundary decorative: a strategy
+    // could not *read* `google/main` and could quietly overwrite it.
+    write: async (reference, value) => {
+      if (reference !== ref) {
+        throw new Error(
+          `The ${manifest.name} strategy tried to write ${reference}, which is not its connection's credential (${ref}).`,
+        );
+      }
+      await credentials.set(reference, value);
+    },
+  });
+
+  progress(style.dim(`  Registering this device with ${manifest.name}…`));
+  await strategy.setup(context);
+}

--- a/src/cli/commands/connect/unknown.ts
+++ b/src/cli/commands/connect/unknown.ts
@@ -1,0 +1,41 @@
+import { layout } from '#profile';
+import type { ProviderRegistry } from '#registry';
+import { PROGRAM } from '../../usage.ts';
+
+/**
+ * What to say when a name resolves to no provider.
+ *
+ * The one message that has to teach something, because a misspelling and a
+ * service nobody has integrated arrive here identically and want opposite
+ * answers. So it prints both lists — what is shipped, and what this profile has
+ * added — and then the command that adds another.
+ *
+ * It named `<root>/providers/` for a long time, which is not where manifests
+ * live and never was. The path comes from `layout` now, like every other
+ * profile-owned path, and the "add your own" line is printed whether or not the
+ * operator already has one: showing it only to somebody with none meant hiding
+ * it from everybody except the one person who could not yet know it existed.
+ */
+export function unknownProvider(input: {
+  readonly providerId: string;
+  readonly registry: ProviderRegistry;
+  readonly workspaceRoot: string;
+  readonly profile: string;
+  readonly target: string;
+}): Error {
+  const available = input.registry.list();
+  const builtin = available.filter((c) => c.origin === 'builtin').map((c) => c.manifest.id);
+  const yours = available.filter((c) => c.origin === 'workspace').map((c) => c.manifest.id);
+
+  const selection = `--profile ${input.profile} --target ${input.target}`;
+  const directory = `${input.workspaceRoot}/${layout.providers(input.profile)}`;
+
+  return new Error(
+    `Unknown provider "${input.providerId}".\n` +
+      `  built in: ${builtin.join(', ')}\n` +
+      (yours.length > 0 ? `  yours:    ${yours.join(', ')}\n` : '') +
+      `  add your own: ${PROGRAM} connect custom ${input.providerId}` +
+      ` --connector <kind> --auth <method> ${selection}\n` +
+      `                or a manifest in ${directory}\n`,
+  );
+}

--- a/src/cli/identity.ts
+++ b/src/cli/identity.ts
@@ -29,9 +29,29 @@ export function pluck(value: unknown, path: string): string | null {
   return typeof current === 'string' && current.length > 0 ? current : null;
 }
 
+/** The header an OAuth or bearer provider's probe carries. */
+async function bearerHeaders(probe: IdentityProbe): Promise<RequestInit> {
+  const token = await probe.accessToken();
+  return { headers: token ? { authorization: `Bearer ${token}` } : {} };
+}
+
 export interface IdentityProbe {
   /** A valid upstream access token, if the provider authenticates. */
   readonly accessToken: () => Promise<string | null>;
+  /**
+   * Put this connection's credential on a request, whatever method it is.
+   *
+   * Supplied where `accessToken` cannot answer. A stored `api_key`, `header` or
+   * `basic` credential is not a bearer token and `bearerToken` throws for all
+   * three — under a comment calling the branch unreachable, which it is on an
+   * mcp connector and is not on an http one. The throw was caught by the
+   * catch-all below, so an `identity: { kind: http }` block on the commonest
+   * custom shape there is — a REST API behind an API key — never worked and
+   * never said so: the operator was asked to name the account by hand on every
+   * reconnect, and a different answer each time is a new row rather than a
+   * repair.
+   */
+  readonly authorize?: (request: Request) => Promise<Request>;
   /** Call a capability on the upstream MCP server. */
   readonly callTool?: (name: string, args: Record<string, unknown>) => Promise<unknown>;
   /** Ask the connector, for a protocol whose identity is not a URL away. */
@@ -52,11 +72,15 @@ export async function resolveAccount(
     }
 
     if (identity.kind === 'http') {
-      const token = await probe.accessToken();
-      const request = probe.fetch ?? globalThis.fetch;
-      const response = await request(identity.url, {
-        headers: token ? { authorization: `Bearer ${token}` } : {},
-      });
+      const send = probe.fetch ?? globalThis.fetch;
+
+      // `authorize` where the caller supplied one, because it is the same
+      // switch the dispatch path uses and knows every method. The token is the
+      // fallback rather than the other way round only because the OAuth
+      // providers reached here first; both end at the same header for them.
+      const response = probe.authorize
+        ? await send(await probe.authorize(new Request(identity.url)))
+        : await send(identity.url, await bearerHeaders(probe));
       if (!response.ok) return null;
 
       const body = await response.json();

--- a/src/cli/instructions.test.ts
+++ b/src/cli/instructions.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, test } from 'bun:test';
+import type { Flags } from './argv.ts';
 import { ASSETS, readAsset } from './commands/mcp/assets.ts';
+import { assertKnownFlags, requirementFor, selectionKey } from './selection.ts';
 import { PROGRAM, USAGE } from './usage.ts';
 
 /**
@@ -39,6 +41,136 @@ const documented = new Set(
     }),
 );
 
+/**
+ * Every `lanes link …` invocation a document shows, as its own argv.
+ *
+ * Two passes, because the two places a command appears break differently.
+ * Inline code spans are matched whole rather than line by line: the prose wraps
+ * at the same width as everything else, so a command inside one pair of
+ * backticks may straddle two source lines — `identity add` does — and reading
+ * lines would drop the flags onto the floor and then report them missing. A
+ * fenced block has no backticks to bound a span, so those are read a line at a
+ * time, which is how they are written anyway.
+ *
+ * `PROGRAM` is searched for inside each candidate rather than anchored at its
+ * start, so the `$(lanes link token show …)` substitutions count too. Those are
+ * the invocations most worth checking, since they are meant to be pasted.
+ */
+function invocationsIn(text: string): Invocation[] {
+  const found: Invocation[] = [];
+  const lines = text.split('\n');
+
+  const offsets: number[] = [];
+  let at = 0;
+  for (const line of lines) {
+    offsets.push(at);
+    at += line.length + 1;
+  }
+  const lineOf = (index: number) => text.slice(0, index).split('\n').length;
+
+  const candidates: Array<{ text: string; index: number }> = [];
+
+  // Fenced blocks are blanked out before the span pass, keeping every offset
+  // where it was. A fence is three backticks, so a span regex left to itself
+  // pairs the third with the first of the closing fence and swallows the block
+  // whole — reporting each command in it against the fence's own line.
+  const masked: string[] = [];
+  let fenced = false;
+
+  for (const [number, line] of lines.entries()) {
+    if (line.trimStart().startsWith('```')) {
+      fenced = !fenced;
+      masked.push(' '.repeat(line.length));
+      continue;
+    }
+
+    masked.push(fenced ? ' '.repeat(line.length) : line);
+    if (fenced) candidates.push({ text: line, index: offsets[number]! });
+  }
+
+  for (const match of masked.join('\n').matchAll(/`([^`]+)`/g)) {
+    candidates.push({ text: match[1]!, index: match.index! });
+  }
+
+  for (const candidate of candidates) {
+    let from = candidate.text.indexOf(`${PROGRAM} `);
+    while (from !== -1) {
+      const argv = tokenise(candidate.text.slice(from + PROGRAM.length));
+      if (argv.length > 0) {
+        found.push({ argv, line: lineOf(candidate.index), shown: `${PROGRAM} ${argv.join(' ')}` });
+      }
+      from = candidate.text.indexOf(`${PROGRAM} `, from + 1);
+    }
+  }
+
+  return found;
+}
+
+interface Invocation {
+  readonly argv: readonly string[];
+  /** 1-indexed, so a failure names a line the reader can open. */
+  readonly line: number;
+  readonly shown: string;
+}
+
+/**
+ * One invocation's argv, stopping where the command does.
+ *
+ * A trailing comment is dropped, and so is the punctuation a command picks up
+ * from the sentence or the shell around it — `<name>)"` closing a substitution,
+ * or a full stop ending the line it sits on.
+ */
+function tokenise(tail: string): string[] {
+  const argv: string[] = [];
+
+  for (const raw of tail.replace(/\s+/g, ' ').trim().split(' ')) {
+    if (raw === '#' || raw.startsWith('#')) break;
+    const token = raw.replace(/^[`"'(]+/, '').replace(/[`"'),.;]+$/, '');
+    if (token === '' || token === '\\') continue;
+    argv.push(token);
+  }
+
+  return argv;
+}
+
+/** The flags an invocation shows, in the shape `assertKnownFlags` reads. */
+function flagsOf(argv: readonly string[]): Flags {
+  const flags: Flags = {};
+
+  for (const [index, token] of argv.entries()) {
+    if (!token.startsWith('--')) continue;
+    const next = argv[index + 1];
+    flags[token.slice(2)] = next && !next.startsWith('-') ? next : true;
+  }
+
+  return flags;
+}
+
+/**
+ * How many tokens of an invocation are the command path itself.
+ *
+ * A bare second word is part of the path even where `SELECTION` does not spell
+ * the pair out — `memory list` inherits from `memory`, and reading `list` as an
+ * argument turned a mention of the command into a whole invocation that was
+ * then reported for missing the flags a mention has no business carrying.
+ */
+function pathLength(argv: readonly string[]): number {
+  const second = argv[1];
+  return selectionKey(argv[0]!, second).includes(' ') || /^[a-z]+$/.test(second ?? '') ? 2 : 1;
+}
+
+/**
+ * Whether this occurrence is the labelled wrong half of a comparison.
+ *
+ * Same convention the token test below relies on, and for the same reason: a
+ * document that may only show correct commands cannot teach the difference
+ * between a right and a wrong one.
+ */
+function underWrongLabel(text: string, line: number): boolean {
+  const lines = text.split('\n');
+  return `${lines[line - 2] ?? ''}\n${lines[line - 1] ?? ''}`.includes('WRONG');
+}
+
 describe.each(ASSETS.map((asset) => [asset.label, asset] as const))('the bundled %s', (_label, asset) => {
   test('names only commands this CLI actually has', async () => {
     const named = commandsNamedIn(await readAsset(asset));
@@ -53,6 +185,53 @@ describe.each(ASSETS.map((asset) => [asset.label, asset] as const))('the bundled
 
   test('names at least one, or the check above passed on an empty list', async () => {
     expect(commandsNamedIn(await readAsset(asset)).length).toBeGreaterThan(0);
+  });
+
+  test('never shows a flag its command refuses', async () => {
+    // `assertKnownFlags` is the function the CLI refuses with, so this cannot
+    // disagree with the binary about what a command accepts. It is the half of
+    // ADR-037 the earlier check missed: naming a real command is not the same as
+    // naming it correctly, and `profile add --profile` is a real command with a
+    // flag that is rejected before dispatch.
+    const text = await readAsset(asset);
+    const refused: string[] = [];
+
+    for (const shown of invocationsIn(text)) {
+      try {
+        assertKnownFlags(shown.argv[0]!, shown.argv[1], flagsOf(shown.argv));
+      } catch (error) {
+        refused.push(`line ${shown.line}: ${shown.shown} — ${(error as Error).message.split('\n')[0]}`);
+      }
+    }
+
+    expect(refused).toEqual([]);
+  });
+
+  test('shows every flag its command requires, wherever it shows a whole command', async () => {
+    // Only where something follows the command path. A bare `lanes link deploy`
+    // in a sentence names the command; `lanes link deploy --dry-run` is meant to
+    // be run, and one missing `--target` makes it a line the owner pastes and
+    // watches refuse. ADR-043 is why this cannot simply demand both everywhere:
+    // `status`, `deploy` and `sync targets` take a target and no profile.
+    const text = await readAsset(asset);
+    const incomplete: string[] = [];
+
+    for (const shown of invocationsIn(text)) {
+      if (shown.argv.length <= pathLength(shown.argv)) continue;
+      if (underWrongLabel(text, shown.line)) continue;
+
+      const needs = requirementFor(shown.argv[0]!, shown.argv[1]);
+      const flags = flagsOf(shown.argv);
+      const missing = ['profile', 'target'].filter(
+        (flag) => needs.includes(flag) && !(flag in flags),
+      );
+
+      if (missing.length > 0) {
+        incomplete.push(`line ${shown.line}: ${shown.shown} — wants ${missing.map((f) => `--${f}`).join(' ')}`);
+      }
+    }
+
+    expect(incomplete).toEqual([]);
   });
 
   test('never tells an agent to print a token', async () => {
@@ -74,5 +253,31 @@ describe('the skill and the scout agree', () => {
     for (const asset of ASSETS) {
       expect(await readAsset(asset)).toContain('separate');
     }
+  });
+});
+
+describe('the skill covers the lifecycle, not only the calls', () => {
+  test('names the commands someone runs to own a workspace', async () => {
+    // The skill described using an endpoint and registering one, and nothing in
+    // between: no deploy, no status, no way to add a profile. An agent asked to
+    // deploy read the file, found nothing, and improvised from the CLI's help.
+    // Listing them here means the operator half cannot quietly fall out again.
+    const asset = ASSETS.find((candidate) => candidate.kind === 'skill')!;
+    const named = new Set(commandsNamedIn(await readAsset(asset)));
+
+    const wanted = [
+      'deploy',
+      'status',
+      'sync targets',
+      'profile add',
+      'profile remove',
+      'profile list',
+      'target list',
+      'doctor',
+      'mcp add',
+      'mcp list',
+    ];
+
+    expect(wanted.filter((command) => !named.has(command))).toEqual([]);
   });
 });

--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -1,4 +1,5 @@
 import { connect } from './commands/connect/index.ts';
+import { connectCustom } from './commands/connect/custom/index.ts';
 import {
   attachFile,
   auditTail,
@@ -29,7 +30,7 @@ import { secretsList, secretsPush, secretsSet } from './commands/secrets.ts';
 import { knowledgeShow, knowledgeUse } from './commands/knowledge.ts';
 import { dispatchOwner } from './dispatch-owner.ts';
 import { update } from './commands/update.ts';
-import { all, globalFlags, knowledgeFlags, ownerFlags, parseArgv, text } from './argv.ts';
+import { all, customFlags, globalFlags, knowledgeFlags, ownerFlags, parseArgv, text } from './argv.ts';
 import { assertKnownFlags, requireSelection } from './selection.ts';
 import { PROGRAM, USAGE } from './usage.ts';
 import { version } from './version.ts';
@@ -75,18 +76,41 @@ export async function run(argv: readonly string[]): Promise<void> {
 
   switch (first) {
     case 'connect':
-      if (!second) throw new Error(`Usage: ${PROGRAM} connect <provider>`);
-      return connect(second, {
-        ...global,
-        id: text(flags, 'id'),
-        displayName: text(flags, 'display-name'),
-        replace: flags['replace'] === true,
-        nonInteractive: flags['non-interactive'] === true,
-        acceptBroadScopes: flags['accept-broad-scopes'] === true,
-        ownClient: flags['own-client'] === true,
-        auth: text(flags, 'auth'),
-        json,
-      });
+      // A nested switch rather than an `if`, so `selection.test.ts` sees
+      // `connect custom` when it reads this file for `case` labels: it matches
+      // on eight-space indentation, and a command invisible to that check is a
+      // command that can default quietly.
+      switch (second) {
+        case 'custom':
+          return connectCustom(rest[0], {
+            ...global,
+            ...customFlags(flags, argv),
+            id: text(flags, 'id'),
+            displayName: text(flags, 'display-name'),
+            replace: flags['replace'] === true,
+            nonInteractive: flags['non-interactive'] === true,
+            acceptBroadScopes: flags['accept-broad-scopes'] === true,
+            json,
+          });
+
+        // Not a `case` label, so it adds no row to `SELECTION`: there is no
+        // command here to classify, only a usage error.
+        case undefined:
+          throw new Error(`Usage: ${PROGRAM} connect <provider>`);
+
+        default:
+          return connect(second, {
+            ...global,
+            id: text(flags, 'id'),
+            displayName: text(flags, 'display-name'),
+            replace: flags['replace'] === true,
+            nonInteractive: flags['non-interactive'] === true,
+            acceptBroadScopes: flags['accept-broad-scopes'] === true,
+            ownClient: flags['own-client'] === true,
+            auth: text(flags, 'auth'),
+            json,
+          });
+      }
 
     case 'setup':
       if (second !== 'plan' && second !== undefined) {

--- a/src/cli/oauth.test.ts
+++ b/src/cli/oauth.test.ts
@@ -521,3 +521,87 @@ describe('the exchange is a seam', () => {
     expect(sent['code_verifier']).toMatch(/^[\w-]{43}$/);
   });
 });
+
+describe('a redirect the vendor matches exactly', () => {
+  /**
+   * The third answer to "where does the browser come back to". A kernel-chosen
+   * port cannot be registered in a console months in advance, and a vendor that
+   * matches `redirect_uri` byte for byte refuses the grant rather than the
+   * port — so the failure is `redirect_uri_mismatch` after consent, which reads
+   * as a broken client rather than as a port that moved.
+   */
+  function freePort(): number {
+    const probe = Bun.serve({ hostname: '127.0.0.1', port: 0, fetch: () => new Response('') });
+    const { port } = probe;
+    probe.stop(true);
+    if (!port) throw new Error('Bun.serve bound no port');
+    return port;
+  }
+
+  test('the declared URL is what the vendor is told, verbatim', async () => {
+    const port = freePort();
+    const fixedRedirect = `http://127.0.0.1:${port}/callback`;
+    const { fetch: tokenFetch } = mockTokenEndpoint(SUCCESS);
+    let announced: string | undefined;
+
+    await runOAuthFlow(
+      options({
+        fixedRedirect,
+        fetch: tokenFetch,
+        openBrowser: (url: string) => {
+          announced = new URL(url).searchParams.get('redirect_uri') ?? undefined;
+          browserThatApproves()(url);
+        },
+      }) as never,
+    );
+
+    expect(announced).toBe(fixedRedirect);
+  });
+
+  test('the listener binds the port the vendor was told about', async () => {
+    // The two must agree by construction. If the flow announced the fixed URL
+    // but still listened on a kernel-chosen port, the browser would come back
+    // to a closed socket and this would time out rather than resolve.
+    const port = freePort();
+    const { fetch: tokenFetch } = mockTokenEndpoint(SUCCESS);
+
+    const tokens = await runOAuthFlow(
+      options({
+        fixedRedirect: `http://127.0.0.1:${port}/callback`,
+        fetch: tokenFetch,
+        openBrowser: browserThatApproves(),
+      }) as never,
+    );
+
+    expect(tokens.accessToken).toBe('access-1');
+  });
+
+  test('a redirect naming no port is refused before the browser opens', async () => {
+    await expect(
+      runOAuthFlow(
+        options({
+          fixedRedirect: 'https://example.com/callback',
+          openBrowser: () => {},
+        }) as never,
+      ),
+    ).rejects.toThrow(/names no port/);
+  });
+
+  test('a port already in use says so, and says why it cannot be moved', async () => {
+    const port = freePort();
+    const holder = Bun.serve({ hostname: '127.0.0.1', port, fetch: () => new Response('') });
+
+    try {
+      await expect(
+        runOAuthFlow(
+          options({
+            fixedRedirect: `http://127.0.0.1:${port}/callback`,
+            openBrowser: () => {},
+          }) as never,
+        ),
+      ).rejects.toThrow(/already in use/);
+    } finally {
+      holder.stop(true);
+    }
+  });
+});

--- a/src/cli/oauth.ts
+++ b/src/cli/oauth.ts
@@ -66,6 +66,27 @@ export interface OAuthFlowOptions {
    * on the way back. What changes is only the address the vendor is told.
    */
   readonly relayRedirect?: string;
+  /**
+   * A redirect this machine listens on, named to the vendor exactly as written.
+   *
+   * The third answer to "where does the browser come back to", and the one the
+   * comment above did not anticipate. `relayRedirect` exists for a vendor that
+   * will take no loopback address at all; this is for a vendor that takes one
+   * happily but matches it *exactly*, port included — so the kernel-chosen port
+   * below can never match a URL registered in a console months earlier.
+   *
+   * That is not a rare shape. It is the reason `providers/github/index.ts`
+   * gives for using a pasted token rather than OAuth: "an OAuth App matches its
+   * callback URL exactly, including the port, and `connect` listens on a port
+   * the kernel picks."
+   *
+   * The whole URL rather than just a port, because the two must be identical
+   * strings and only one of them is ours to choose. A console that accepts
+   * `localhost` but not `127.0.0.1` — or insists on a trailing path — decides
+   * the spelling, and a manifest that could only name a number would have to
+   * guess the rest right.
+   */
+  readonly fixedRedirect?: string;
   /** What the completion page names as connected. A provider's display name. */
   readonly connectionLabel?: string;
   /** How long to wait for the operator to finish in the browser. */
@@ -130,48 +151,80 @@ export async function runOAuthFlow(options: OAuthFlowOptions): Promise<OAuthToke
     rejectCode = reject;
   });
 
-  const server = Bun.serve({
-    hostname: '127.0.0.1',
-    port: 0, // let the OS choose; nothing outside this machine names this port
-    fetch(request) {
-      const url = new URL(request.url);
-      if (url.pathname !== '/callback') return new Response('Not found', { status: 404 });
+  // A fixed redirect is only fixed if we listen where it says. Parsed rather
+  // than configured separately so the two cannot disagree: the port the vendor
+  // was told is by construction the port this binds.
+  const fixed = options.fixedRedirect ? new URL(options.fixedRedirect) : undefined;
+  const fixedPort = fixed ? Number(fixed.port) : undefined;
 
-      const error = url.searchParams.get('error');
-      if (error) {
-        rejectCode(
-          new OAuthError(
-            error === 'access_denied'
-              ? 'Authorization was declined in the browser.'
-              : `Authorization failed: ${error}`,
-          ),
+  if (fixed && !fixedPort) {
+    throw new OAuthError(
+      `The redirect "${options.fixedRedirect}" names no port, so there is nothing for this machine to listen on. Register a redirect with an explicit port, such as http://127.0.0.1:8765/callback.`,
+    );
+  }
+
+  // Bun.serve throws synchronously when a port is taken. With a kernel-chosen
+  // port that cannot happen; with a fixed one it is the ordinary failure — a
+  // previous run still holding the socket, or another program on the port the
+  // vendor was told about. The raw EADDRINUSE names neither the provider nor
+  // the redirect, so it reads as a crash rather than as something to fix.
+  const server = ((): ReturnType<typeof Bun.serve> => {
+    try {
+    return Bun.serve({
+      hostname: '127.0.0.1',
+      // Zero lets the OS choose, which is right whenever nothing outside this
+      // machine names the port. A fixed redirect is exactly the case where
+      // something does.
+      port: fixedPort ?? 0,
+      fetch(request) {
+        const url = new URL(request.url);
+        if (url.pathname !== '/callback') return new Response('Not found', { status: 404 });
+
+        const error = url.searchParams.get('error');
+        if (error) {
+          rejectCode(
+            new OAuthError(
+              error === 'access_denied'
+                ? 'Authorization was declined in the browser.'
+                : `Authorization failed: ${error}`,
+            ),
+          );
+          return failedPage('You can close this tab.');
+        }
+
+        const returnedState = url.searchParams.get('state');
+        if (!returnedState || !stateMatches(state, returnedState)) {
+          // A mismatched state means this callback did not come from the
+          // request we started. Refuse it rather than redeeming whatever code
+          // it carries.
+          rejectCode(new OAuthError('State mismatch — ignoring an unexpected callback.'));
+          return failedPage('Unexpected callback.');
+        }
+
+        const code = url.searchParams.get('code');
+        if (!code) {
+          rejectCode(new OAuthError('The callback carried no authorization code.'));
+          return failedPage('No code returned.');
+        }
+
+        resolveCode(code);
+        return connectedPage(options.connectionLabel);
+      },
+    });
+    } catch (cause) {
+      if (fixedPort) {
+        throw new OAuthError(
+          `Port ${fixedPort} is already in use, so the callback for this connection cannot be served. The redirect registered with the provider names that port exactly, so it cannot simply be moved — free the port and try again.`,
         );
-        return failedPage('You can close this tab.');
       }
-
-      const returnedState = url.searchParams.get('state');
-      if (!returnedState || !stateMatches(state, returnedState)) {
-        // A mismatched state means this callback did not come from the
-        // request we started. Refuse it rather than redeeming whatever code
-        // it carries.
-        rejectCode(new OAuthError('State mismatch — ignoring an unexpected callback.'));
-        return failedPage('Unexpected callback.');
-      }
-
-      const code = url.searchParams.get('code');
-      if (!code) {
-        rejectCode(new OAuthError('The callback carried no authorization code.'));
-        return failedPage('No code returned.');
-      }
-
-      resolveCode(code);
-      return connectedPage(options.connectionLabel);
-    },
-  });
+      throw cause;
+    }
+  })();
 
   // Where the vendor is told to send the browser. The relay bounces it back
   // here; without one it comes here directly, which is every other provider.
-  const redirectUri = options.relayRedirect ?? `http://127.0.0.1:${server.port}/callback`;
+  const redirectUri =
+    options.relayRedirect ?? options.fixedRedirect ?? `http://127.0.0.1:${server.port}/callback`;
 
   /**
    * The CSRF binding, and — behind a relay — the only way home.

--- a/src/cli/runtime/open.ts
+++ b/src/cli/runtime/open.ts
@@ -79,6 +79,16 @@ export interface Runtime {
   readonly authenticator: BearerAuthenticator;
   /** Same factory the dispatcher uses, exposed for commands that probe upstream. */
   connectorFor(providerId: string, connectionId: string): AnyConnector | undefined;
+  /**
+   * Same authorizer the dispatcher uses, for the same reason `connectorFor` is here.
+   *
+   * A command that probes upstream needs the credential on the request, and it
+   * must not learn how to put it there — that is one switch on the resolved
+   * shape (`connectivity/auth/authorize.ts`) and a second copy would be a
+   * second answer. `settleIdentity` is the caller: it asks a provider whose
+   * account was just authorised, over whatever method that provider declares.
+   */
+  authorizeRequest(providerId: string, connectionId: string, request: Request): Promise<Request>;
   /** A provider's manifest, so an omitted `credential_ref` can be derived from it. */
   manifestFor(providerId: string): ProviderManifest | undefined;
   close(): Promise<void>;
@@ -309,13 +319,14 @@ export async function openRuntime(
   // the *same instance* whichever side asks for it, or a held session is held
   // twice.
   const connectorFor = connectorFactory({ registry, credentials });
+  const authorizeRequest = requestAuthorizer(registry, credentials);
   let closed = false;
 
   const dispatcher = new Dispatcher({
     config,
     registry,
     connectorFor,
-    authorizeRequest: requestAuthorizer(registry, credentials),
+    authorizeRequest,
     policy,
     state,
     audit: auditSink,
@@ -345,6 +356,7 @@ export async function openRuntime(
       credentials,
     }),
     connectorFor,
+    authorizeRequest,
     manifestFor: (providerId: string) => registry.manifest(providerId),
     // Sessions first, then the state: a connector may still want to log out
     // cleanly, and LOGOUT is worth more than the microsecond it costs.

--- a/src/cli/runtime/registry.ts
+++ b/src/cli/runtime/registry.ts
@@ -2,6 +2,7 @@ import type { BlobStore } from '#stores/blobs';
 import type { ProviderDefinition } from '#connectivity';
 import { ConfigError } from '#profile';
 import { ProviderRegistry } from '#registry';
+import { RESERVED_BY_GRAMMAR } from '../commands/connect/custom/spec.ts';
 import { loadProfileProviders } from '#providers/custom/index.ts';
 import { loadProfileSkills, type LoadedSkill } from '#providers/skills/store.ts';
 import { exampleProvider } from '#providers/example/provider.ts';
@@ -142,6 +143,17 @@ export async function buildRegistryWithWorkspace(
     if (registry.has(manifest.id)) {
       throw new ConfigError(
         `${path}: provider "${manifest.id}" is already built in. Rename it, or remove the file to use the built-in.`,
+      );
+    }
+    // An id the CLI's own grammar has taken. `connect custom` refuses to create
+    // one, and this is the other half: a file written by hand — or before that
+    // command existed — would otherwise register cleanly, be unreachable
+    // forever, and say nothing about why.
+    if ((RESERVED_BY_GRAMMAR as readonly string[]).includes(manifest.id)) {
+      throw new ConfigError(
+        `${path}: provider "${manifest.id}" cannot be reached — "${manifest.id}" is the second word ` +
+          `of \`lanes link connect ${manifest.id}\`, which is the command that declares one. ` +
+          'Rename it.',
       );
     }
     registry.register(manifest, 'workspace');

--- a/src/cli/scopes.test.ts
+++ b/src/cli/scopes.test.ts
@@ -182,7 +182,7 @@ describe('the Google manifests stay at the documented minimum', () => {
     );
   });
 
-  test('the broad scopes are exactly the thirteen that were argued for', () => {
+  test('the broad scopes are exactly the sixteen that were argued for', () => {
     const broad = PROVIDERS.flatMap((manifest) => {
       const scopes = manifest.auth.kind === 'oauth' ? manifest.auth.scopes : [];
       return describeScopes(scopes)
@@ -227,6 +227,21 @@ describe('the Google manifests stay at the documented minimum', () => {
         'slack im:history',
         'slack mpim:history',
         'slack chat:write',
+        // Reddit's three, and all three for one reason: they act publicly under
+        // the person's username. Everything above is broad for how much it
+        // reaches inside a private space; these are broad for being visible
+        // outside one, which is the other way a grant can be more than it
+        // sounds.
+        //
+        // They are also the only writes here that cannot be taken back.
+        // Deleting a post leaves the deletion behind, and anything quoted,
+        // cached, or replied to in the meantime stays — so "post as you" is
+        // nearer to publishing than to writing. `read` is deliberately not on
+        // this list: it reaches only what the account can already see, and what
+        // Reddit makes readable is public to begin with.
+        'reddit submit',
+        'reddit edit',
+        'reddit vote',
       ].sort(),
     );
   });

--- a/src/cli/selection.test.ts
+++ b/src/cli/selection.test.ts
@@ -1,7 +1,9 @@
 import { describe, expect, test } from 'bun:test';
 import { readFile } from 'node:fs/promises';
+import { readFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { assertKnownFlags, requireSelection, requirementFor, SELECTION } from './selection.ts';
+import { CONNECT_CUSTOM_FLAGS, RESERVED_BY_GRAMMAR } from './commands/connect/custom/spec.ts';
 
 /**
  * That every command says what it needs, and that nothing can be added without
@@ -250,6 +252,76 @@ describe('a target-independent command is runnable in the spelling it demands', 
     expect(() =>
       assertKnownFlags('profile', 'remove', { target: 'cloud', 'dry-run': true }),
     ).not.toThrow();
+  });
+
+  /**
+   * `connect custom` is a second word of `connect`, and its own row.
+   *
+   * The row is the whole mechanism: `selectionKey` returns a two-word key only
+   * when `SELECTION` holds one, and that is what gives the command its own
+   * `ACCEPTS` entry. Without it the thirty declaration flags would have to join
+   * `connect`'s list, where `--openapi` on `connect gmail` would be accepted and
+   * silently ignored — the defect this file exists for.
+   */
+  test('connect custom takes its own flags', () => {
+    expect(() =>
+      assertKnownFlags('connect', 'custom', {
+        connector: 'mcp',
+        endpoint: 'https://mcp.example.com/mcp',
+        auth: 'bearer',
+        'replace-manifest': true,
+      }),
+    ).not.toThrow();
+  });
+
+  test('and they stay off connect <provider>, which is why it has a row', () => {
+    expect(() => assertKnownFlags('connect', 'gmail', { connector: 'mcp' })).toThrow(
+      'Unknown flag "--connector"',
+    );
+    expect(() => assertKnownFlags('connect', 'gmail', { 'replace-manifest': true })).toThrow(
+      'Unknown flag',
+    );
+  });
+
+  test('connect custom does not take --own-client, which would be inert', () => {
+    // It selects between an operator's OAuth client and a broker's, and a
+    // synthesized manifest never declares a broker.
+    expect(() => assertKnownFlags('connect', 'custom', { 'own-client': true })).toThrow(
+      'Unknown flag',
+    );
+  });
+
+  test('and it needs both a profile and a target, like connect', async () => {
+    await expect(requireSelection('connect', 'custom', {}, nowhere)).rejects.toThrow(
+      '--profile is required',
+    );
+    await expect(
+      requireSelection('connect', 'custom', { profile: 'work', target: 'local' }, nowhere),
+    ).resolves.toBeUndefined();
+  });
+
+  test('every flag customFlags reads is a flag connect custom accepts', () => {
+    // Two files, one list: `argv.ts` spells the kebab-case names and
+    // `spec.ts` allowlists them. They drifted apart once for `--own-client`.
+    const source = readFileSync(join(import.meta.dir, 'argv.ts'), 'utf8');
+    const body = source.slice(source.indexOf('export function customFlags'));
+
+    const read = [
+      ...body.matchAll(/(?:text\(flags, |all\(argv, )'([a-z-]+)'/g),
+      ...body.matchAll(/flags\['([a-z-]+)'\]/g),
+    ].map((match) => match[1]!);
+
+    expect(read.length).toBeGreaterThan(20);
+    expect(read.filter((flag) => !CONNECT_CUSTOM_FLAGS.includes(flag))).toEqual([]);
+  });
+
+  test('every id the grammar reserves is actually a second word of connect', () => {
+    // The constant is what refuses `providers.d/custom.yaml` at load. If the
+    // spelling of the command ever changed, it would go on refusing a name
+    // nothing takes.
+    for (const id of RESERVED_BY_GRAMMAR) {
+      expect(`connect ${id}` in SELECTION).toBe(true);
+    }
   });
 
   test('the flags a command reads are flags it accepts', () => {

--- a/src/cli/selection.ts
+++ b/src/cli/selection.ts
@@ -10,6 +10,7 @@ import {
   targetsByName,
 } from '#profile';
 import type { Flags } from './argv.ts';
+import { CONNECT_CUSTOM_FLAGS } from './commands/connect/custom/spec.ts';
 import { nearest } from './nearest.ts';
 
 /**
@@ -110,6 +111,12 @@ export const SELECTION: Record<string, Requires> = {
   'identity list': 'profile',
 
   connect: 'profile+target',
+  // Its own row rather than an inheritance from `connect`. Both need the same
+  // two things, but the row is what makes `selectionKey` return the two-word
+  // key — and that is what keeps thirty declaration flags off
+  // `connect <provider>`, where a mistyped one would otherwise be accepted and
+  // ignored, which is the defect this whole file exists for.
+  'connect custom': 'profile+target',
   setup: 'profile+target',
   token: 'profile+target',
   audit: 'profile+target',
@@ -280,6 +287,11 @@ const UNIVERSAL = ['help', 'json', 'quiet'];
  * universal set plus whatever `SELECTION` says it must be told.
  */
 const ACCEPTS: Record<string, readonly string[]> = {
+  // Imported rather than written out. Thirty-odd entries here would take this
+  // file past the size budget for a data literal, and the command's own
+  // `spec.ts` already derives most of them from the per-kind field tables — so
+  // a flag added there cannot be forgotten here.
+  'connect custom': CONNECT_CUSTOM_FLAGS,
   // `own-client` is the older spelling of one of the routes `auth` names, kept
   // because it is in scripts and a year of documentation (ADR-038).
   connect: [

--- a/src/cli/usage.ts
+++ b/src/cli/usage.ts
@@ -26,6 +26,10 @@ ${style.bold('Everyday')}
   ${PROGRAM} connect <...> --replace    ask for the stored password or key again
   ${PROGRAM} connect <...> --auth <method>  pick how, where there is a choice
   ${PROGRAM} connect <...> --non-interactive [--json]
+  ${PROGRAM} connect custom <id> --connector <kind> --auth <method>
+                                 declare a service that is not built in, and connect it.
+                                 kinds: mcp, http, imap, dav, fs. Omit a value and it is
+                                 asked for; the manifest it writes is yours to edit
                                         answer nothing from a terminal: take every value
                                         from the credential store, or say what is missing
   ${PROGRAM} start [--only]             reconcile and serve every profile on one endpoint
@@ -137,7 +141,11 @@ ${style.bold('Other flags')}
                                  one this project operates (connect only)
   --auth <method>                which way in, where a provider offers two (connect
                                  only). "oauth" is the browser; the other is named
-                                 in the choice connect prints
+                                 in the choice connect prints. On connect custom it
+                                 names the credential type instead: none, bearer,
+                                 api-key, header, basic, oauth, strategy
+  --replace-manifest             rewrite a declaration that already exists and differs
+                                 (connect custom only — --replace is about the credential)
   --port <n>                     override the configured port (start only)
 
 Every command prints the profile and target it is acting on, before it acts.

--- a/src/connectivity/auth/README.md
+++ b/src/connectivity/auth/README.md
@@ -15,13 +15,20 @@ transport asks when it has a token to send and no request to attach it to.
 | `basic/` | `basic` | `username:password`, RFC 7617's own encoding |
 | `oauth-authcode/` | `oauth` | a refresh token, exchanged on every use |
 | `oauth-jwt/` | `oauth` + `assertion` | a private key, signed into an assertion per exchange |
-| `strategy/` | `strategy` | the escape hatch — per-vendor code, none registered |
+| `strategy/` | `strategy` | the escape hatch — the seam only; the code is the provider's |
 
 ## Adding one
 
 A folder, a member of `authSchema` in `../manifest/auth.ts`, and a case in
 `resolve.ts` (plus `authorize.ts` if it touches the request). Nothing else in
 the codebase learns about it — that is the point of the split.
+
+`strategy/` is the other shape, and holds no vendor code at all. It resolves the
+strategy a manifest names from the `ProviderDefinition` beside it and refuses
+when the two disagree; the implementation lives with its provider, because a
+folder of vendor code under `connectivity/` is precisely what the vendor-name
+rule in `architecture.test.ts` exists to prevent. `providers/bunq/strategy/` is
+the one there is. See [ADR-046](../../../docs/detailed/adr/046-an-auth-strategy-belongs-to-its-provider.md).
 
 `oauth-jwt/` is the exception that proves the shape rather than breaking it. It
 is not a `kind`, because it is a second way into a provider that already has

--- a/src/connectivity/auth/strategy/index.test.ts
+++ b/src/connectivity/auth/strategy/index.test.ts
@@ -1,0 +1,155 @@
+import { describe, expect, test } from 'bun:test';
+import { defineProvider, defineProviderWithStrategy } from '#connectivity';
+import type { AuthConfig, AuthStrategy, ProviderContext } from '#connectivity';
+import { refuseStrategy, strategyContextFrom, strategyFor } from './index.ts';
+
+/**
+ * The seam, on its own.
+ *
+ * A strategy is the one place per-vendor code is allowed, so the checks worth
+ * having here are the ones that keep it *a seam*: that a manifest and the code
+ * beside it cannot disagree silently, and that what a strategy is handed is
+ * narrower than what a provider is handed.
+ */
+
+const strategy: AuthStrategy = {
+  id: 'handshake',
+  async authorize(request) {
+    return request;
+  },
+};
+
+const manifestFor = (auth: AuthConfig) =>
+  defineProvider({
+    id: 'acme',
+    name: 'Acme',
+    connector: { kind: 'http', base_url: 'https://api.acme.test/v1', openapi: './acme.json' },
+    auth,
+  });
+
+const declared = manifestFor({
+  kind: 'strategy',
+  strategy: 'handshake',
+  credential_ref: 'acme/api_key',
+  options: { sandbox: true },
+});
+
+/** Only the four keys `strategyContextFrom` reads. */
+const providerContext = {
+  credentials: { get: async () => null } as unknown as ProviderContext['credentials'],
+  state: { get: async () => null } as unknown as ProviderContext['state'],
+  log: { debug() {}, info() {}, warn() {}, error() {} },
+} as unknown as ProviderContext;
+
+/** A registry, structurally — the two methods `strategyFor` asks for. */
+const source = (...entries: Array<{ id: string; definition?: unknown }>) => ({
+  get: (id: string) => entries.find((entry) => entry.id === id) as never,
+  list: () => entries as never,
+});
+
+describe('strategyFor', () => {
+  test('returns the strategy its own definition carries', () => {
+    const definition = defineProviderWithStrategy({ manifest: declared, strategy });
+
+    expect(strategyFor(declared, source({ id: 'acme', definition }))).toBe(strategy);
+  });
+
+  test('refuses when nothing registered supplies one by that name', () => {
+    // The failure `refuseStrategy` exists for: without it the request goes out
+    // unauthenticated and the vendor explains the wrong problem.
+    expect(() => strategyFor(declared, source())).toThrow(/"handshake" is not registered/);
+  });
+
+  test('refuses when the manifest and the code beside it disagree about which one', () => {
+    const definition = defineProviderWithStrategy({ manifest: declared, strategy });
+    const other = manifestFor({ kind: 'strategy', strategy: 'other' });
+
+    expect(() => strategyFor(other, source({ id: 'acme', definition }))).toThrow(
+      /declares auth strategy "other" but carries "handshake"/,
+    );
+  });
+
+  test('a declaration-only manifest borrows a strategy another provider supplies', () => {
+    // The workspace-YAML case, and the only way to point a connection at a
+    // vendor's sandbox: a manifest in `providers.d/` has no definition at all,
+    // so its strategy has to come from the built-in that carries the code.
+    const definition = defineProviderWithStrategy({ manifest: declared, strategy });
+    const borrower = manifestFor({ kind: 'strategy', strategy: 'handshake' });
+
+    expect(strategyFor(borrower, source({ id: 'acme', definition }, { id: 'acme_sandbox' }))).toBe(
+      strategy,
+    );
+  });
+
+  test('refuses a manifest that declares no strategy at all', () => {
+    expect(() => strategyFor(manifestFor({ kind: 'bearer' }), source())).toThrow(
+      /does not declare a strategy/,
+    );
+  });
+});
+
+describe('defineProviderWithStrategy', () => {
+  test('refuses a manifest whose auth kind is not strategy', () => {
+    expect(() => defineProviderWithStrategy({ manifest: manifestFor({ kind: 'bearer' }), strategy })).toThrow(
+      /declares auth.kind "bearer"/,
+    );
+  });
+
+  test('refuses a manifest naming a different strategy', () => {
+    expect(() =>
+      defineProviderWithStrategy({
+        manifest: manifestFor({ kind: 'strategy', strategy: 'other' }),
+        strategy,
+      }),
+    ).toThrow(/but carries "handshake"/);
+  });
+
+  test('carries no capabilities unless it is given some', () => {
+    expect(defineProviderWithStrategy({ manifest: declared, strategy }).capabilities).toEqual([]);
+  });
+});
+
+describe('strategyContextFrom', () => {
+  const context = strategyContextFrom({
+    source: providerContext,
+    manifest: declared,
+    connectionId: 'main',
+    profile: 'personal',
+  });
+
+  test('passes the manifest options through, so a strategy is configurable as data', () => {
+    expect(context.options).toEqual({ sandbox: true });
+  });
+
+  test('carries the connection it is acting for', () => {
+    expect(context.connectionId).toBe('main');
+    // One process serves every profile, so a strategy caching anything in
+    // memory needs this to build a key that cannot collide.
+    expect(context.profile).toBe('personal');
+    expect(context.credentials).toBe(providerContext.credentials);
+    expect(context.state).toBe(providerContext.state);
+  });
+
+  test('has no write, so per-request code structurally cannot store a credential', () => {
+    // The restriction that matters. A handshake persists what it produces and
+    // must only be able to during setup; the absence of the key is the rule.
+    expect(context.write).toBeUndefined();
+  });
+
+  test('an auth kind without options still yields an object rather than undefined', () => {
+    const bearer = strategyContextFrom({
+      source: providerContext,
+      manifest: manifestFor({ kind: 'bearer' }),
+      connectionId: 'main',
+      profile: 'personal',
+    });
+
+    expect(bearer.options).toEqual({});
+  });
+});
+
+describe('refuseStrategy', () => {
+  test('names the strategy and where to read about them', () => {
+    expect(() => refuseStrategy('handshake')).toThrow(/creating-a-provider\.md/);
+  });
+});

--- a/src/connectivity/auth/strategy/index.ts
+++ b/src/connectivity/auth/strategy/index.ts
@@ -1,10 +1,134 @@
+import type { AuthStrategy, AuthStrategyContext } from '../../connector.ts';
+import type { ProviderContext } from '../../context.ts';
+import type { ProviderDefinition } from '../../provider.ts';
+import type { ProviderManifest } from '../../manifest/index.ts';
+
 /**
  * The escape hatch: auth no declarative form should try to express.
  *
- * bunq generates an RSA keypair, runs a three-step handshake, signs every
- * request, and verifies the response signature. That earns code. Nothing is
- * registered yet, so this fails loudly rather than sending an unauthenticated
- * request that would fail confusingly upstream.
+ * A strategy is the one place per-vendor code is permitted outside `local`
+ * providers, and it stays *auth* — a request in, an authorised request out.
+ * The moment one starts translating endpoints, the problem ADR-008 removed has
+ * come back.
+ *
+ * There is no global registry here, and that is deliberate. A strategy is not a
+ * plugin the runtime discovers; it is a property of the provider that needs it,
+ * so it travels on that provider's `ProviderDefinition` the same way an authored
+ * capability does. Two things follow, both of them the point:
+ *
+ *   - this component stays free of vendor names, which is the rule
+ *     `architecture.test.ts` holds over everything a request passes through
+ *   - adding one is still a folder under `providers/` and a line in its index,
+ *     rather than a folder here plus a registration somewhere else
+ */
+
+/**
+ * What `strategyFor` needs from the registry, and no more.
+ *
+ * Structural rather than the real `ProviderRegistry`, so this file states its
+ * dependency as two methods instead of importing a component to name a type.
+ */
+export interface StrategySource {
+  get(id: string): { readonly definition?: ProviderDefinition | undefined } | undefined;
+  list(): readonly { readonly definition?: ProviderDefinition | undefined }[];
+}
+
+/**
+ * The strategy a manifest declares.
+ *
+ * Its own definition first, which is the built-in case: `providers/bunq`
+ * carries the code for the manifest beside it, and the two must agree about
+ * which strategy that is. A manifest naming `strategy: acme` while its
+ * definition carries something else is a wiring mistake that would otherwise
+ * surface as a signature the vendor rejects — a long way from its cause.
+ *
+ * Then any other registered provider that supplies one by that name, which is
+ * the case a declaration-only manifest needs. A workspace YAML in
+ * `providers.d/` is parsed into a `ProviderManifest` and has no definition at
+ * all, so without this it could name a strategy and never reach it — and naming
+ * one is exactly what a manifest is for. It is also the only way to point a
+ * connection at a vendor's sandbox, since a built-in manifest's `options` are
+ * not the operator's to edit.
+ *
+ * Borrowing the *code* is not borrowing the *credential*: the ref still derives
+ * from the manifest's own id, so `bunq_sandbox` reads `bunq_sandbox/<id>` and
+ * cannot reach what `bunq` holds.
+ */
+export function strategyFor(
+  manifest: ProviderManifest,
+  source: StrategySource,
+): AuthStrategy {
+  if (manifest.auth.kind !== 'strategy') {
+    throw new Error(`Provider "${manifest.id}" does not declare a strategy.`);
+  }
+
+  const named = manifest.auth.strategy;
+  const own = source.get(manifest.id)?.definition?.authStrategy;
+
+  if (own) {
+    if (own.id !== named) {
+      throw new Error(
+        `Provider "${manifest.id}" declares auth strategy "${named}" but carries "${own.id}".`,
+      );
+    }
+    return own;
+  }
+
+  const borrowed = source
+    .list()
+    .map((entry) => entry.definition?.authStrategy)
+    .find((strategy) => strategy?.id === named);
+
+  if (!borrowed) refuseStrategy(named);
+  return borrowed;
+}
+
+/**
+ * What a strategy is given, derived from what the provider is given.
+ *
+ * Narrower than a `ProviderContext` on purpose: the connection's own
+ * credentials read-only, its own scoped state, and its logger. Nothing else,
+ * and in particular no storage, no audit logger, and no signal — a strategy
+ * authenticates a request and has no business doing anything a provider does.
+ *
+ * `write` is the one part that varies, and the variation *is* the rule.
+ * Persisting a credential is a setup-time act, so `connect` passes a writer and
+ * the dispatch path does not. Per-request code then cannot store a credential
+ * because there is nothing on the object to store one with, rather than because
+ * somebody remembered not to.
+ *
+ * Takes the three fields it reads rather than a whole `ProviderContext`, so the
+ * two callers can be what they are: dispatch hands over the context it already
+ * built, and `connect` — which has no provider context, because the connection
+ * does not exist yet — assembles the same three from the runtime.
+ */
+export function strategyContextFrom(input: {
+  /** Dispatch hands over the `ProviderContext` it built; `connect` assembles the three itself. */
+  readonly source: Pick<ProviderContext, 'credentials' | 'state' | 'log'>;
+  readonly manifest: ProviderManifest;
+  readonly connectionId: string;
+  readonly profile: string;
+  readonly write?: ((ref: string, value: string) => Promise<void>) | undefined;
+}): AuthStrategyContext {
+  const { source, manifest, connectionId, profile, write } = input;
+
+  return {
+    manifest,
+    connectionId,
+    profile,
+    credentials: source.credentials,
+    state: source.state,
+    log: source.log,
+    options: manifest.auth.kind === 'strategy' ? (manifest.auth.options ?? {}) : {},
+    ...(write ? { write } : {}),
+  };
+}
+
+/**
+ * A manifest asked for a strategy nothing supplies.
+ *
+ * Fails loudly rather than sending an unauthenticated request, which would fail
+ * upstream with an error about the vendor rather than about the wiring.
  */
 export function refuseStrategy(strategy: string): never {
   throw new Error(

--- a/src/connectivity/connector.ts
+++ b/src/connectivity/connector.ts
@@ -159,6 +159,17 @@ export interface AuthStrategy {
 export interface AuthStrategyContext {
   readonly manifest: ProviderManifest;
   readonly connectionId: string;
+  /**
+   * Which profile this is acting for.
+   *
+   * Nothing about authenticating one request needs it. What needs it is any
+   * strategy that keeps something in process memory: one endpoint serves every
+   * profile in the workspace from one process, so `<provider>.<connection>` is
+   * not a unique key — two profiles each holding a bunq connection called
+   * `main` would share whatever it named. `state` and `credentials` are already
+   * scoped per profile and a cache in front of them must be too.
+   */
+  readonly profile: string;
   /** Read-only, scoped to this connection — the same boundary providers get. */
   readonly credentials: ProviderContext['credentials'];
   /**

--- a/src/connectivity/index.ts
+++ b/src/connectivity/index.ts
@@ -48,7 +48,17 @@ export {
  * Everything else is a manifest.
  */
 export type { AuthRequirement, ProviderDefinition } from './provider.ts';
-export { defineLocalProvider, defineProviderWithCapabilities } from './provider.ts';
+export {
+  defineLocalProvider,
+  defineProviderWithCapabilities,
+  defineProviderWithStrategy,
+} from './provider.ts';
+
+/**
+ * The strategy seam. Vendor-free by construction: these three know that a
+ * strategy exists and never which one.
+ */
+export { refuseStrategy, strategyContextFrom, strategyFor } from './auth/strategy/index.ts';
 
 export type {
   ProviderManifest,

--- a/src/connectivity/manifest/auth.ts
+++ b/src/connectivity/manifest/auth.ts
@@ -165,6 +165,25 @@ export const authOAuthSchema = z.object({
   authorize_url: z.url().optional(),
   token_url: z.url().optional(),
   /**
+   * A loopback redirect to name to the vendor verbatim, for one that matches it
+   * exactly rather than by prefix.
+   *
+   * `connect` normally listens on a port the kernel picks, which works because
+   * most authorization servers accept any loopback port. One that pins the
+   * whole URL cannot: the port it was told in a console months ago is not the
+   * port this run happens to get, and the grant is refused with
+   * `redirect_uri_mismatch`.
+   *
+   * The full URL rather than a port, because the vendor's console decides the
+   * spelling — `localhost` and `127.0.0.1` are different strings to a matcher
+   * even when they are the same host — and the two must be identical.
+   *
+   * Mutually exclusive with `broker`, which answers the same question the other
+   * way: there the redirect is the broker's HTTPS origin and the loopback port
+   * travels in `state`.
+   */
+  redirect_uri: z.url().optional(),
+  /**
    * Extra parameters on the authorization request.
    *
    * Google needs `access_type=offline` and `prompt=consent`, without which it

--- a/src/connectivity/manifest/connector.ts
+++ b/src/connectivity/manifest/connector.ts
@@ -56,6 +56,27 @@ export const httpConnectorSchema = z.object({
       exclude: z.array(z.string()).default([]),
     })
     .optional(),
+  /**
+   * Sent on every request this connector makes.
+   *
+   * The same field as `mcp`'s above and refused the same way for
+   * `Authorization` — but for the opposite reason. An mcp server chooses its
+   * own tool list and a header is the only way to ask it for less; a REST API
+   * asks for nothing, and this is for what the *vendor* requires of a client
+   * rather than what a caller wants from it.
+   *
+   * The case in hand is a `User-Agent`. Nothing else here sets one, so every
+   * install of this program looks identical to a host that rate-limits by
+   * client — and a service that asks callers to identify themselves throttles
+   * the default agent hardest, which reads as an outage rather than a refusal.
+   *
+   * Precedence is narrowest-wins: `accept` is a default this may override, a
+   * header parameter the operation itself declares overrides this, and
+   * `content-type` is derived from the document and overrides everything —
+   * a blanket header cannot silently change how one operation's body is
+   * encoded.
+   */
+  headers: z.record(z.string(), z.string()).optional(),
 });
 
 /**

--- a/src/connectivity/manifest/manifest.test.ts
+++ b/src/connectivity/manifest/manifest.test.ts
@@ -287,3 +287,88 @@ describe('an assertion alternative', () => {
     ).toThrow(/no way to learn what key to ask for/);
   });
 });
+
+describe('the two answers to "where does the browser come back to"', () => {
+  const httpProvider = (auth: Record<string, unknown>, extra: Record<string, unknown> = {}) =>
+    defineProvider({
+      id: 'vendor_api',
+      name: 'Vendor',
+      connector: { kind: 'http', base_url: 'https://api.example.com', openapi: 'specs/vendor.json' },
+      auth,
+      ...extra,
+    });
+
+  const oauth = (extra: Record<string, unknown>) => ({
+    kind: 'oauth',
+    registration: 'manual',
+    app: 'vendor',
+    authorize_url: 'https://accounts.example.com/authorize',
+    token_url: 'https://accounts.example.com/token',
+    ...extra,
+  });
+
+  test('a fixed loopback redirect is accepted on its own', () => {
+    expect(() =>
+      httpProvider(
+        oauth({ redirect_uri: 'http://127.0.0.1:8765/callback' }),
+        {
+          setup: {
+            summary: 'Register a client.',
+            prompts: [{ key: 'client_id', label: 'Client id', scope: 'shared', credential_ref: 'vendor/client_id' }],
+          },
+        },
+      ),
+    ).not.toThrow();
+  });
+
+  test('declaring a broker as well is refused', () => {
+    // Both are answers to the same question and the flow reads one of them. A
+    // brokered redirect is the broker's own origin, with the loopback port
+    // carried in `state`; a fixed redirect is this machine, named exactly.
+    expect(() =>
+      httpProvider(
+        oauth({
+          redirect_uri: 'http://127.0.0.1:8765/callback',
+          broker: { url: 'https://broker.example.com/v1/auth', operator: 'Someone' },
+        }),
+      ),
+    ).toThrow(/"broker" or "redirect_uri", not both/);
+  });
+});
+
+describe('connector headers may not carry the credential', () => {
+  // The rule was written when `mcp` was the only connector with headers, but
+  // the reasoning never had anything to do with which transport carried them:
+  // a manifest setting both leaves which one is sent up to merge order.
+  test('an http connector naming Authorization is refused', () => {
+    expect(() =>
+      defineProvider({
+        id: 'vendor_api',
+        name: 'Vendor',
+        connector: {
+          kind: 'http',
+          base_url: 'https://api.example.com',
+          openapi: 'specs/vendor.json',
+          headers: { Authorization: 'Bearer nope' },
+        },
+        auth: { kind: 'bearer' },
+      }),
+    ).toThrow(/may not set "Authorization"/);
+  });
+
+  test('any other header is fine', () => {
+    expect(() =>
+      defineProvider({
+        id: 'vendor_api',
+        name: 'Vendor',
+        connector: {
+          kind: 'http',
+          base_url: 'https://api.example.com',
+          openapi: 'specs/vendor.json',
+          headers: { 'User-Agent': 'vendor:1.0 (by someone)' },
+        },
+        auth: { kind: 'bearer' },
+      }),
+    ).not.toThrow();
+  });
+});

--- a/src/connectivity/manifest/manifest.test.ts
+++ b/src/connectivity/manifest/manifest.test.ts
@@ -108,7 +108,8 @@ describe('what an mcp connector may authenticate with', () => {
     expect(() => mcp({ kind: 'api_key' })).toThrow(/must be "none", "oauth", or "bearer"/);
     expect(() => mcp({ kind: 'header', header: 'X-Token' })).toThrow(/nowhere else on the request/);
     expect(() => mcp({ kind: 'basic' })).toThrow(/must be "none", "oauth", or "bearer"/);
-    expect(() => mcp({ kind: 'strategy', strategy: 'bunq' })).toThrow(/"strategy"/);
+    // `strategy` is refused too, but earlier and for every connector — see
+    // below. Asserting it here would read as an mcp rule, which it is not.
   });
 
   test('bearer may not rename its header here, though the schema allows it', () => {

--- a/src/connectivity/manifest/primitives.ts
+++ b/src/connectivity/manifest/primitives.ts
@@ -16,5 +16,9 @@ export const credentialRef = z
   .string()
   .regex(
     /^[a-z0-9][a-z0-9_-]*(?:\/[a-z0-9][a-z0-9_-]*)+$/,
-    'must be a credential reference like "bunq/api_key", not a literal value',
+    // A placeholder rather than a real provider id. The example teaches the
+    // shape either way, and this file is inside the scope
+    // `architecture.test.ts` keeps free of vendor names — an error message that
+    // names one is exactly the "message that assumes a vendor" the rule is for.
+    'must be a credential reference like "acme/api_key", not a literal value',
   );

--- a/src/connectivity/manifest/provider.ts
+++ b/src/connectivity/manifest/provider.ts
@@ -225,6 +225,36 @@ export function defineProvider(input: unknown): ProviderManifest {
     );
   }
 
+  // Two answers to "where does the browser come back to", and a manifest
+  // naming both leaves it to whichever the flow reads first. A broker's
+  // redirect is its own HTTPS origin, with the loopback port carried in
+  // `state`; a fixed redirect is this machine, named exactly. Neither is wrong,
+  // but they cannot both be in force.
+  if (manifest.auth.kind === 'oauth' && manifest.auth.broker && manifest.auth.redirect_uri) {
+    throw new Error(
+      `Provider "${manifest.id}": auth may declare "broker" or "redirect_uri", not both — a brokered flow redirects to the broker and carries the loopback port in state, so a fixed redirect would never be used.`,
+    );
+  }
+
+  // Connector headers are for what the *server* offers as configuration; the
+  // credential is the auth block's, and a manifest setting both would have one
+  // quietly overwrite the other depending on which the transport merged last.
+  //
+  // Checked for every connector that has the field rather than for `mcp` alone.
+  // It was written when `mcp` was the only one, and the reasoning never had
+  // anything to do with which transport carried the header — an `http`
+  // connector naming `Authorization` collides with `auth` in exactly the same
+  // way, and would have validated cleanly.
+  const connectorHeaders =
+    'headers' in manifest.connector ? (manifest.connector.headers ?? {}) : {};
+  for (const name of Object.keys(connectorHeaders)) {
+    if (name.toLowerCase() === 'authorization') {
+      throw new Error(
+        `Provider "${manifest.id}": connector.headers may not set "${name}" — the credential comes from auth, and setting both would leave which one is sent up to merge order.`,
+      );
+    }
+  }
+
   if (manifest.connector.kind === 'mcp') {
     const auth = manifest.auth;
 
@@ -249,18 +279,6 @@ export function defineProvider(input: unknown): ProviderManifest {
       throw new Error(
         `Provider "${manifest.id}": an mcp connector always sends its token as "Authorization: Bearer", so auth.header ("${auth.header}") cannot be honoured. Remove it, or reach this service with an http connector.`,
       );
-    }
-
-    // The third spelling of the same collision. Connector headers are for what
-    // the *server* offers as configuration; the credential is the auth block's,
-    // and a manifest setting both would have one quietly overwrite the other
-    // depending on which the transport merged last.
-    for (const name of Object.keys(manifest.connector.headers ?? {})) {
-      if (name.toLowerCase() === 'authorization') {
-        throw new Error(
-          `Provider "${manifest.id}": connector.headers may not set "${name}" — the credential comes from auth, and setting both would leave which one is sent up to merge order.`,
-        );
-      }
     }
   }
 

--- a/src/connectivity/provider.ts
+++ b/src/connectivity/provider.ts
@@ -1,6 +1,7 @@
 import { z } from 'zod';
 import type { SecretRef } from '#secrets';
 import type { Capability } from './capability.ts';
+import type { AuthStrategy } from './connector.ts';
 import type { ProviderContext } from './context.ts';
 import { bundleSchema, defineProvider, type ProviderManifest } from './manifest/index.ts';
 
@@ -31,6 +32,16 @@ export interface ProviderDefinition<
   readonly connectionSchema: ConnectionSchema;
 
   readonly capabilities: readonly Capability[];
+
+  /**
+   * Pluggable auth, for a vendor whose handshake no manifest field can describe.
+   *
+   * Carried here rather than in a registry the runtime searches, because a
+   * strategy belongs to exactly one provider and nothing else may use it. The
+   * manifest declares *that* there is one and names it; this is the code, and
+   * `strategyFor` checks the two agree.
+   */
+  readonly authStrategy?: AuthStrategy;
 
   /**
    * Which credential refs a connection may read. Core turns this into the
@@ -159,5 +170,49 @@ export function defineProviderWithCapabilities(input: {
     configSchema: z.unknown(),
     connectionSchema: z.unknown(),
     capabilities: input.capabilities,
+  };
+}
+
+/**
+ * A manifest-based provider whose authentication is code rather than a field.
+ *
+ * The sibling of `defineProviderWithCapabilities`, and rarer. That one exists
+ * where a vendor's API can do something its *document* cannot express; this one
+ * where a vendor's **handshake** can. Everything else about the provider stays
+ * declared — the connector kind, the operations, the redaction — and the
+ * strategy only ever sees a request on its way out and a response on its way
+ * back.
+ *
+ * ADR-008 puts a number on how much this is allowed to be: roughly 150 lines,
+ * for auth, once. A strategy that grows a second job is the 612-line problem
+ * returning by a different door.
+ */
+export function defineProviderWithStrategy(input: {
+  readonly manifest: ProviderManifest;
+  readonly strategy: AuthStrategy;
+  readonly capabilities?: readonly Capability[];
+}): ProviderDefinition {
+  const { manifest, strategy } = input;
+
+  if (manifest.auth.kind !== 'strategy') {
+    throw new Error(
+      `Provider "${manifest.id}" carries an auth strategy but declares auth.kind "${manifest.auth.kind}". Declare { kind: 'strategy', strategy: '${strategy.id}' }.`,
+    );
+  }
+
+  if (manifest.auth.strategy !== strategy.id) {
+    throw new Error(
+      `Provider "${manifest.id}" declares auth strategy "${manifest.auth.strategy}" but carries "${strategy.id}".`,
+    );
+  }
+
+  return {
+    manifest,
+    // Permissive for the same reason `defineProviderWithCapabilities` is: a
+    // manifest provider's connection is already described by its manifest.
+    configSchema: z.unknown(),
+    connectionSchema: z.unknown(),
+    capabilities: input.capabilities ?? [],
+    authStrategy: strategy,
   };
 }

--- a/src/connectivity/transports/factory.ts
+++ b/src/connectivity/transports/factory.ts
@@ -180,6 +180,7 @@ function build(
         ...(manifest.connector.operations?.exclude?.length
           ? { exclude: manifest.connector.operations.exclude }
           : {}),
+        ...(manifest.connector.headers ? { headers: manifest.connector.headers } : {}),
       });
   }
 }

--- a/src/connectivity/transports/http/http.test.ts
+++ b/src/connectivity/transports/http/http.test.ts
@@ -419,3 +419,158 @@ describe('array query parameters are repeated, not joined', () => {
     expect(url.search).not.toContain('open%2Cclosed');
   });
 });
+
+describe('a body is encoded the way the document declares', () => {
+  // A form-encoded write is not a legacy curiosity — it is what a large share
+  // of APIs that predate JSON request bodies still require. Sending JSON to one
+  // fails outright, and the error names the missing parameters rather than the
+  // encoding, so it reads as a bad request rather than a wrong content type.
+  const FORMS = {
+    openapi: '3.0.3',
+    info: { title: 'Acme', version: '1.0.0' },
+    servers: [{ url: 'https://api.acme.test/v1' }],
+    paths: {
+      '/submit': {
+        post: {
+          operationId: 'submitForm',
+          requestBody: {
+            required: true,
+            content: {
+              'application/x-www-form-urlencoded': {
+                schema: {
+                  type: 'object',
+                  properties: {
+                    title: { type: 'string' },
+                    tags: { type: 'array', items: { type: 'string' } },
+                  },
+                  required: ['title'],
+                },
+              },
+            },
+          },
+          responses: { '200': { description: 'ok' } },
+        },
+      },
+    },
+  };
+
+  async function formConnector(record: { request?: Request }) {
+    const root = await mkdtemp(join(tmpdir(), 'lanes-link-openapi-'));
+    roots.push(root);
+    const path = join(root, 'forms.json');
+    await writeFile(path, JSON.stringify(FORMS));
+    return createHttpConnector({
+      baseUrl: 'https://api.acme.test/v1',
+      openapi: path,
+      fetch: (async (request: Request) => {
+        record.request = request;
+        return new Response('{}', { status: 200 });
+      }) as unknown as typeof fetch,
+    });
+  }
+
+  test('a form-encoded operation is sent as a form, not as JSON', async () => {
+    const record: { request?: Request } = {};
+    const connector = await formConnector(record);
+    const [capability] = await connector.discover(CONTEXT);
+
+    await connector.invoke(capability!, { title: 'hello' }, contextWith(record));
+
+    expect(record.request!.headers.get('content-type')).toBe('application/x-www-form-urlencoded');
+    expect(await record.request!.text()).toBe('title=hello');
+  });
+
+  test('an array repeats, for the reason a query parameter does', async () => {
+    const record: { request?: Request } = {};
+    const connector = await formConnector(record);
+    const [capability] = await connector.discover(CONTEXT);
+
+    await connector.invoke(capability!, { title: 'hi', tags: ['a', 'b'] }, contextWith(record));
+
+    const sent = new URLSearchParams(await record.request!.text());
+    expect(sent.getAll('tags')).toEqual(['a', 'b']);
+  });
+
+  test('an operation declaring JSON is unchanged', async () => {
+    const record: { request?: Request } = {};
+    const connector = createHttpConnector({
+      baseUrl: 'https://api.acme.test/v1',
+      openapi: await specFile(),
+      fetch: (async (request: Request) => {
+        record.request = request;
+        return new Response('{}', { status: 200 });
+      }) as unknown as typeof fetch,
+    });
+
+    const capabilities = await connector.discover(CONTEXT);
+    const createPayment = capabilities.find((c) => c.name === 'createPayment')!;
+
+    await connector.invoke(createPayment, { amount: 5, to: 'someone' }, contextWith(record));
+
+    expect(record.request!.headers.get('content-type')).toBe('application/json');
+    expect(await record.request!.json()).toEqual({ amount: 5, to: 'someone' });
+  });
+});
+
+describe('headers declared on the connector', () => {
+  // Nothing else in this program sets a `User-Agent`, so every install looks
+  // identical to a host that rate-limits by client. A service that asks callers
+  // to identify themselves throttles the default agent hardest, which reads as
+  // an outage rather than as a refusal.
+  async function connectorWithHeaders(
+    record: { request?: Request },
+    headers: Record<string, string>,
+  ) {
+    return createHttpConnector({
+      baseUrl: 'https://api.acme.test/v1',
+      openapi: await specFile(),
+      headers,
+      fetch: (async (request: Request) => {
+        record.request = request;
+        return new Response('{}', { status: 200 });
+      }) as unknown as typeof fetch,
+    });
+  }
+
+  test('a declared header is sent on every request', async () => {
+    const record: { request?: Request } = {};
+    const connector = await connectorWithHeaders(record, { 'User-Agent': 'acme:1.0 (by someone)' });
+    const capabilities = await connector.discover(CONTEXT);
+    const listAccounts = capabilities.find((c) => c.name === 'listAccounts')!;
+
+    await connector.invoke(listAccounts, {}, contextWith(record));
+
+    expect(record.request!.headers.get('user-agent')).toBe('acme:1.0 (by someone)');
+  });
+
+  test('it may override `accept`, which is only a default', async () => {
+    const record: { request?: Request } = {};
+    const connector = await connectorWithHeaders(record, { accept: 'text/plain' });
+    const capabilities = await connector.discover(CONTEXT);
+
+    await connector.invoke(
+      capabilities.find((c) => c.name === 'listAccounts')!,
+      {},
+      contextWith(record),
+    );
+
+    expect(record.request!.headers.get('accept')).toBe('text/plain');
+  });
+
+  test('it may not override a content type the document derived', async () => {
+    // Which encoding an operation uses is the document's to state. A blanket
+    // header that silently changed it would be a bug nobody could see from the
+    // manifest — the request would go out well-formed and mean something else.
+    const record: { request?: Request } = {};
+    const connector = await connectorWithHeaders(record, { 'content-type': 'text/plain' });
+    const capabilities = await connector.discover(CONTEXT);
+
+    await connector.invoke(
+      capabilities.find((c) => c.name === 'createPayment')!,
+      { amount: 1, to: 'someone' },
+      contextWith(record),
+    );
+
+    expect(record.request!.headers.get('content-type')).toBe('application/json');
+  });
+});

--- a/src/connectivity/transports/http/index.ts
+++ b/src/connectivity/transports/http/index.ts
@@ -26,7 +26,68 @@ export interface HttpConnectorOptions {
   readonly openapi: string;
   readonly include?: readonly string[];
   readonly exclude?: readonly string[];
+  /** Sent on every request. Never `Authorization` — the manifest refuses it. */
+  readonly headers?: Readonly<Record<string, string>>;
   readonly fetch?: typeof globalThis.fetch;
+}
+
+/**
+ * The one body encoding that is not JSON often enough to be worth knowing about.
+ *
+ * A form-encoded write is not a legacy curiosity: it is what a large share of
+ * APIs that predate JSON request bodies still require, and one of them refusing
+ * `application/json` is not a negotiation — the request fails outright, with an
+ * error about the parameters rather than about the encoding.
+ */
+const FORM_ENCODED = 'application/x-www-form-urlencoded';
+
+/**
+ * What the *document* says the body is, rather than what we would prefer.
+ *
+ * `mcp-from-openapi` records the declared media type on each body entry of the
+ * mapper, so this needs nothing threaded through `target` — the mapper is
+ * already cached there, which is what lets a cold instance encode correctly
+ * without re-reading the spec.
+ *
+ * JSON is the default because an operation with no declared request body has no
+ * media type to read, and because it is what this connector always sent.
+ */
+function bodyContentType(mapper: readonly ParameterMapper[]): string {
+  for (const entry of mapper) {
+    if (entry.type !== 'body') continue;
+    const declared = entry.serialization?.contentType;
+    if (declared) return declared;
+  }
+
+  return 'application/json';
+}
+
+/**
+ * Arrays repeat rather than join, for the reason the query string does above.
+ *
+ * A nested object is JSON inside the field, which is the only thing a
+ * form-encoded body can do with one — there is no standard spelling of nesting
+ * here, and every API that accepts one accepts it as a string.
+ */
+function encodeBody(body: Readonly<Record<string, unknown>>, contentType: string): string {
+  if (!contentType.startsWith(FORM_ENCODED)) return JSON.stringify(body);
+
+  const form = new URLSearchParams();
+
+  for (const [key, value] of Object.entries(body)) {
+    if (value === undefined || value === null) continue;
+
+    if (Array.isArray(value)) {
+      for (const element of value) {
+        if (element !== undefined && element !== null) form.append(key, String(element));
+      }
+      continue;
+    }
+
+    form.set(key, typeof value === 'object' ? JSON.stringify(value) : String(value));
+  }
+
+  return form.toString();
 }
 
 /**
@@ -148,6 +209,12 @@ export function createHttpConnector(options: HttpConnectorOptions): Connector {
 
       const url = new URL(options.baseUrl.replace(/\/$/, '') + buildPath(template, args, mapper));
       const headers = new Headers({ accept: 'application/json' });
+
+      // After `accept`, which is a default worth overriding, and before the
+      // operation's own header parameters, which are narrower than a header
+      // declared once for the whole connector.
+      for (const [key, value] of Object.entries(options.headers ?? {})) headers.set(key, value);
+
       const body = collect(args, mapper, 'body');
 
       for (const [key, value] of Object.entries(collect(args, mapper, 'query'))) {
@@ -174,7 +241,11 @@ export function createHttpConnector(options: HttpConnectorOptions): Connector {
       }
 
       const hasBody = Object.keys(body).length > 0;
-      if (hasBody) headers.set('content-type', 'application/json');
+      const contentType = bodyContentType(mapper);
+      // Last, so it beats a connector-wide header. Which encoding an operation
+      // uses is the document's to state, and a blanket `content-type` that
+      // silently changed it would be a bug nobody could see from the manifest.
+      if (hasBody) headers.set('content-type', contentType);
 
       // Auth is attached by core, from the manifest's auth kind or its strategy.
       // A connector never sees a raw credential.
@@ -182,7 +253,7 @@ export function createHttpConnector(options: HttpConnectorOptions): Connector {
         new Request(url.href, {
           method,
           headers,
-          ...(hasBody ? { body: JSON.stringify(body) } : {}),
+          ...(hasBody ? { body: encodeBody(body, contentType) } : {}),
           signal: context.provider.signal,
         }),
       );

--- a/src/dispatch/dispatch.ts
+++ b/src/dispatch/dispatch.ts
@@ -6,8 +6,14 @@ import type { RuntimeState } from '#stores/state';
 import type { PolicyDocument } from '#policy';
 import { RateLimiter, evaluate } from '#policy';
 import type { BlobStore } from '#stores/blobs';
-import type { AnyConnector, CapabilityResult, ConnectorContext, Logger } from '#connectivity';
-import { isToolResult } from '#connectivity';
+import type {
+  AnyConnector,
+  AuthStrategyContext,
+  CapabilityResult,
+  ConnectorContext,
+  Logger,
+} from '#connectivity';
+import { isToolResult, strategyContextFrom, strategyFor } from '#connectivity';
 import type { Config } from '#profile';
 import { buildProviderContext, createProviderLogger } from './context.ts';
 import { stageAttachment, type StagedAttachment, type StageRequest } from './staging.ts';
@@ -252,13 +258,38 @@ export class Dispatcher {
         },
       };
 
+      // A provider whose authentication is code rather than a manifest field.
+      // The strategy stands in for the credential resolver completely: it holds
+      // whatever session the vendor issues, signs the outbound request, and
+      // checks the reply. Looked up once, because both halves of the connector
+      // context come from the same one.
+      const strategy =
+        entry.manifest.auth.kind === 'strategy'
+          ? strategyFor(entry.manifest, this.#deps.registry)
+          : undefined;
+
+      // Derived from the provider context — which is handed the closure below,
+      // so it cannot exist yet. Both are only ever *called* after this block
+      // finishes, and memoising keeps one context per invocation rather than
+      // one per outbound request.
+      let strategyContext: AuthStrategyContext | undefined;
+      const forStrategy = (): AuthStrategyContext =>
+        (strategyContext ??= strategyContextFrom({
+          source: providerContext,
+          manifest: entry.manifest,
+          connectionId: declared.id,
+          profile: this.#deps.config.instance.profile,
+        }));
+
       // One closure, handed to both contexts. A provider that authors a
       // capability its transport cannot express still calls the vendor through
       // the same authorizer the transport would have used.
       const authorize = (outbound: Request): Promise<Request> =>
-        this.#deps.authorizeRequest
-          ? this.#deps.authorizeRequest(providerId, declared.id, outbound)
-          : Promise.resolve(outbound);
+        strategy
+          ? strategy.authorize(outbound, forStrategy())
+          : this.#deps.authorizeRequest
+            ? this.#deps.authorizeRequest(providerId, declared.id, outbound)
+            : Promise.resolve(outbound);
 
       const providerContext = buildProviderContext({
         manifest: entry.manifest,
@@ -288,10 +319,18 @@ export class Dispatcher {
         });
       }
 
+      // Only where the strategy asks for it. A vendor that signs its replies
+      // expects them verified, and the transport clones the response so the
+      // check costs the caller nothing.
+      const verifyResponse = strategy?.verify?.bind(strategy);
+
       const connectorContext: ConnectorContext = {
         manifest: entry.manifest,
         provider: providerContext,
         authorize,
+        ...(verifyResponse
+          ? { verify: (response: Response) => verifyResponse(response, forStrategy()) }
+          : {}),
       };
 
       // The connector owns argument validation: a local provider validates

--- a/src/dispatch/strategy.test.ts
+++ b/src/dispatch/strategy.test.ts
@@ -1,0 +1,217 @@
+import { afterAll, describe, expect, test } from 'bun:test';
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { ownerPrincipal } from '#auth';
+import { createMemoryCredentials, createMemoryState } from '#stores/state/testing.ts';
+import { createMemoryBlobStore } from '#stores/blobs/testing.ts';
+import { createBlobAuditStore } from '#deployments/adapters/audit-blob.ts';
+import { RateLimiter } from '#policy';
+import { createHttpConnector } from '#connectivity/transports';
+import {
+  defineProvider,
+  defineProviderWithStrategy,
+  type AnyConnector,
+  type AuthStrategy,
+  type AuthStrategyContext,
+} from '#connectivity';
+import { parseConfig } from '#profile';
+import { Dispatcher } from './dispatch.ts';
+import { ProviderRegistry, toPolicyDocument } from '#registry';
+
+/**
+ * The seam, wired.
+ *
+ * `strategy/index.test.ts` covers the lookup in isolation. What matters here is
+ * the part no unit test can show: that a request reaching a strategy provider
+ * goes through the strategy instead of the credential resolver, that the
+ * strategy sees the **body** — which is what a vendor that signs its requests
+ * needs — and that a reply comes back through `verify`.
+ */
+
+const directory = await mkdtemp(join(tmpdir(), 'strategy-spec-'));
+const specPath = join(directory, 'acme.json');
+
+await writeFile(
+  specPath,
+  JSON.stringify({
+    openapi: '3.0.3',
+    info: { title: 'Acme', version: '1.0.0' },
+    paths: {
+      '/payments': {
+        post: {
+          operationId: 'createPayment',
+          summary: 'Create a payment',
+          requestBody: {
+            required: true,
+            content: {
+              'application/json': {
+                schema: {
+                  type: 'object',
+                  properties: { amount: { type: 'string' }, to: { type: 'string' } },
+                },
+              },
+            },
+          },
+          responses: { '200': { description: 'ok' } },
+        },
+      },
+    },
+  }),
+);
+
+afterAll(async () => {
+  await rm(directory, { recursive: true, force: true });
+});
+
+const CONFIG = parseConfig(`
+contract: 1
+instance:
+  profile: personal
+  default_target: local
+targets:
+  local:
+    credentials: { adapter: file, path: ./data/personal.credentials.enc }
+    storage: { adapter: filesystem, path: ./data/files }
+limits:
+  requests_per_minute: 100
+  upstream_calls_per_minute: 100
+connections:
+  - id: main
+    provider: acme
+    account: A
+policy:
+  allow:
+    - "acme.*"
+`).config;
+
+const manifest = defineProvider({
+  id: 'acme',
+  name: 'Acme',
+  connector: { kind: 'http', base_url: 'https://api.acme.test/v1', openapi: specPath },
+  auth: {
+    kind: 'strategy',
+    strategy: 'handshake',
+    credential_ref: 'acme/api_key',
+    options: { sandbox: true },
+  },
+});
+
+interface Seen {
+  readonly signed: string;
+  readonly context: AuthStrategyContext;
+}
+
+function harness() {
+  const authorized: Seen[] = [];
+  const verified: number[] = [];
+
+  const strategy: AuthStrategy = {
+    id: 'handshake',
+    async authorize(request, context) {
+      // Reading the body is the whole reason the seam takes a request rather
+      // than an operation: a vendor that signs, signs this.
+      authorized.push({ signed: await request.clone().text(), context });
+      const stamped = new Request(request, { headers: new Headers(request.headers) });
+      stamped.headers.set('x-acme-signature', 'signed');
+      return stamped;
+    },
+    async verify(response, _context) {
+      verified.push(response.status);
+    },
+  };
+
+  const registry = new ProviderRegistry();
+  registry.register(defineProviderWithStrategy({ manifest, strategy }));
+
+  const requests: Request[] = [];
+  const fetched = (async (request: Request) => {
+    requests.push(request);
+    return new Response(JSON.stringify({ id: 1 }), {
+      status: 200,
+      headers: { 'content-type': 'application/json' },
+    });
+  }) as unknown as typeof globalThis.fetch;
+
+  const connector = createHttpConnector({
+    baseUrl: 'https://api.acme.test/v1',
+    openapi: specPath,
+    fetch: fetched,
+  });
+
+  const dispatcher = new Dispatcher({
+    config: CONFIG,
+    registry,
+    connectorFor: (): AnyConnector | undefined => connector as unknown as AnyConnector,
+    // A strategy provider must never reach this. It throws so the test would
+    // fail loudly rather than quietly authenticating the ordinary way.
+    authorizeRequest: async () => {
+      throw new Error('the credential resolver was reached for a strategy provider');
+    },
+    policy: toPolicyDocument(CONFIG),
+    state: createMemoryState(),
+    audit: createBlobAuditStore({ storage: createMemoryBlobStore() }),
+    credentials: createMemoryCredentials(),
+    storage: createMemoryBlobStore(),
+    limiter: new RateLimiter(),
+    log: { debug() {}, info() {}, warn() {}, error() {} },
+  });
+
+  return { dispatcher, registry, connector, authorized, verified, requests };
+}
+
+async function invoke() {
+  const bench = harness();
+  bench.registry.setDiscovered('acme', await bench.connector.discover({ manifest }));
+
+  const outcome = await bench.dispatcher.invoke({
+    principal: ownerPrincipal('personal'),
+    capabilityId: 'acme.createPayment',
+    connectionKey: 'acme.main',
+    arguments: { amount: '10.00', to: 'NL00ACME0000000000' },
+  });
+
+  return { ...bench, outcome };
+}
+
+describe('a provider whose auth is a strategy', () => {
+  test('reaches the vendor, and the strategy signed the way out', async () => {
+    const { outcome, requests } = await invoke();
+
+    expect(outcome.ok).toBe(true);
+    expect(requests).toHaveLength(1);
+    expect(requests[0]!.headers.get('x-acme-signature')).toBe('signed');
+  });
+
+  test('the strategy is handed the request body, not just its headers', async () => {
+    const { authorized } = await invoke();
+
+    expect(authorized).toHaveLength(1);
+    expect(JSON.parse(authorized[0]!.signed)).toEqual({
+      amount: '10.00',
+      to: 'NL00ACME0000000000',
+    });
+  });
+
+  test('the response comes back through verify', async () => {
+    const { verified } = await invoke();
+
+    expect(verified).toEqual([200]);
+  });
+
+  test('the context carries the manifest options and cannot write a credential', async () => {
+    const { authorized } = await invoke();
+    const context = authorized[0]!.context;
+
+    expect(context.connectionId).toBe('main');
+    expect(context.options).toEqual({ sandbox: true });
+    expect(context.write).toBeUndefined();
+  });
+
+  test('state is scoped to the connection, which is where a session belongs', async () => {
+    const { authorized } = await invoke();
+
+    await authorized[0]!.context.state.set('session', 'token');
+    expect(await authorized[0]!.context.state.get('session')).toBe('token');
+  });
+});

--- a/src/profile/docs.test.ts
+++ b/src/profile/docs.test.ts
@@ -67,16 +67,27 @@ async function manifestExamples(relative: string): Promise<string[]> {
 }
 
 describe('documented provider manifests parse', () => {
-  // The same lesson as above, applied where the copy-paste actually happens. The
-  // custom-provider page is the one someone follows verbatim, and its example
-  // silently could not connect until this milestone — so it is worth having a
-  // test rather than a promise.
-  test('docs/detailed/creating-a-provider.md', async () => {
-    const examples = await manifestExamples('docs/detailed/creating-a-provider.md');
+  /**
+   * The same lesson as above, applied where the copy-paste actually happens. The
+   * custom-provider page is the one someone follows verbatim, and its example
+   * silently could not connect until this milestone — so it is worth having a
+   * test rather than a promise.
+   *
+   * The coverage page is here for a sharper version of the same reason: its
+   * examples are one per open row of a matrix, which means they are precisely the
+   * combinations no built-in exercises. A page that claims a cell works is worth
+   * less than nothing if its example for that cell does not parse.
+   */
+  const pages = ['docs/detailed/creating-a-provider.md', 'docs/detailed/connectivity-coverage.md'];
+
+  test.each(pages)('%s', async (page: string) => {
+    const examples = await manifestExamples(page);
+    // Per file, not across them: the guard is against a page whose fences drift
+    // out of the selector and then passes by not looking.
     expect(examples.length).toBeGreaterThan(3);
 
     for (const example of examples) {
-      expect(() => parseManifest(example, 'docs/detailed/creating-a-provider.md')).not.toThrow();
+      expect(() => parseManifest(example, page)).not.toThrow();
     }
   });
 });

--- a/src/providers/bunq/hints.ts
+++ b/src/providers/bunq/hints.ts
@@ -1,0 +1,43 @@
+/**
+ * What bunq's own descriptions leave out, and an agent has to know.
+ *
+ * Appended to the generated description at discovery. Three things earn a line
+ * here: the distinction that decides whether money moves, the shape of an
+ * amount, and the identifier an agent cannot guess.
+ */
+export const BUNQ_HINTS: Record<string, string> = {
+  List_all_User:
+    'Call this first. Every other bunq tool is addressed under a userID, and this is the only thing that reports it.',
+
+  List_all_MonetaryAccount_for_User:
+    'Returns every account: current, savings, joint, and closed ones. Each is wrapped in a type key ' +
+    '(MonetaryAccountBank, MonetaryAccountSavings, …) and the id inside it is the `monetary-accountID` ' +
+    'the payment tools take. Check `status` is ACTIVE before paying from one.',
+
+  CREATE_Payment_for_User_MonetaryAccount:
+    'This executes immediately and is not reversible. The money leaves the account as soon as bunq accepts the call — ' +
+    'there is no confirmation step, in the app or anywhere else. Use draft-payment instead when a human should see it first. ' +
+    'amount is { "value": "10.00", "currency": "EUR" } — a decimal string, not a number, and never cents. ' +
+    'counterparty_alias is { "type": "IBAN", "value": "<iban>", "name": "<account holder>" }, and for IBAN the name must match ' +
+    'the one on the receiving account. type may also be EMAIL or PHONE_NUMBER for another bunq user.',
+
+  CREATE_DraftPayment_for_User_MonetaryAccount:
+    'Prepares a payment without sending it: it waits in the bunq app until a human approves it, which is the checkpoint ' +
+    'a direct payment does not have. Takes `entries`, an array of { amount, counterparty_alias, description } shaped exactly ' +
+    'like a direct payment, plus number_of_required_accepts (1 for a personal account).',
+
+  UPDATE_DraftPayment_for_User_MonetaryAccount:
+    'Changes a draft that is still pending — status ACCEPTED sends it, REJECTED cancels it. ' +
+    'previous_updated_timestamp is required and comes from reading the draft first; it is what stops two ' +
+    'callers acting on the same draft.',
+
+  CREATE_PaymentBatch_for_User_MonetaryAccount:
+    'Up to 350 payments in one call. Executes immediately, like a direct payment, and is all-or-nothing: bunq rejects ' +
+    'the whole batch if any entry is invalid. `payments` must be an ARRAY of { amount, counterparty_alias, description } ' +
+    'objects, each shaped exactly like a direct payment — bunq\'s specification declares the field as an object rather ' +
+    'than an array, which is wrong, so the schema here cannot tell you that and this line has to.',
+
+  List_all_Payment_for_User_MonetaryAccount:
+    'Newest first, one page at a time. bunq pages with `count`, `older_id` and `newer_id` rather than an offset, ' +
+    'but its specification does not declare them, so this tool returns the most recent page and no more.',
+};

--- a/src/providers/bunq/index.ts
+++ b/src/providers/bunq/index.ts
@@ -1,0 +1,87 @@
+import { defineProvider, defineProviderWithStrategy } from '#connectivity';
+import { BUNQ_HINTS } from './hints.ts';
+import { BUNQ_REDACT } from './redact.ts';
+import { createBunqStrategy } from './strategy/index.ts';
+
+const specPath = (name: string): string => new URL(`./specs/${name}`, import.meta.url).pathname;
+
+/**
+ * bunq — accounts, transaction history, and payments.
+ *
+ * The one provider here whose authentication is code. Everything else about it
+ * is declared like any other manifest, and the eleven operations it can reach
+ * come from a vendored OpenAPI document rather than from anything written by
+ * hand. What earns the exception is the handshake: bunq generates nothing for
+ * you, it wants a keypair you made, an installation, a registered device, and a
+ * session, and then it wants every request body signed. No manifest field
+ * describes that. See ADR-008 and `./strategy/`.
+ *
+ * `base_url` carries the version in the **path**, like Sheets and unlike Drive.
+ * `https://api.bunq.com` alone 404s on every call.
+ *
+ * Sandbox is not a second provider and not a flag either: the strategy reads
+ * its host from `base_url`, so a manifest in `providers.d/` naming
+ * `public-api.sandbox.bunq.com` handshakes and pays there, borrowing this
+ * strategy through `strategyFor`. That is where anything touching this should
+ * be proven before it is pointed at a real account.
+ *
+ * No `identity` block, and that is not an omission. The generic HTTP identity
+ * probe sends `Authorization: Bearer <token>`, which bunq does not accept and
+ * would fail in a way that reads as a bad credential rather than as an
+ * inapplicable probe. `connect` asks what to call the connection instead.
+ */
+const manifest = defineProvider({
+  id: 'bunq',
+  name: 'bunq',
+  description:
+    'Bank accounts, balances, transaction history, and payments — including batches and drafts that wait for approval in the bunq app.',
+  connector: {
+    kind: 'http',
+    base_url: 'https://api.bunq.com/v1',
+    openapi: specPath('bunq.v1.json'),
+  },
+  auth: {
+    kind: 'strategy',
+    strategy: 'bunq',
+    // No `credential_ref`, so it derives per connection — `bunq/<id>`. bunq
+    // issues one API key per account, and a declared ref would mean every
+    // connection sharing one, which is the opposite of true here.
+  },
+  redact: BUNQ_REDACT,
+  hints: BUNQ_HINTS,
+  setup: {
+    summary:
+      'bunq issues an API key from inside the app, not from a web console. The key is bound to the IP addresses ' +
+      'it is used from unless you mark it as a wildcard key — which you must do in the app if this endpoint will ' +
+      'ever run anywhere but this machine.',
+    docs: 'docs/detailed/setup/bunq.md',
+    docs_url: 'https://doc.bunq.com/basics/authentication/api-keys',
+    steps: [
+      'In the bunq app: Profile → Security & Settings → Developers → API keys → Add API key.',
+      'Name it "Lanes Link", so you can revoke this one later without touching your others.',
+      'Set a spending limit on the key while you are there. It is the only bound that does not depend on this software being correct — policy rules and tool lists are ours to get wrong, and a limit at the bank is not.',
+      'If this endpoint will run deployed rather than on this machine, mark the key as a wildcard key in the same screen. bunq refuses to set that over the API, deliberately, so it cannot be done for you.',
+      'Copy the key and paste it below. Nothing is sent anywhere until you do — the handshake that registers this device runs immediately afterwards.',
+      'You will be asked what to call this connection. bunq has no endpoint that reports whose account a key belongs to, so the label is yours to choose.',
+      'To try this without a real account first, use bunq\'s sandbox: https://public-api.sandbox.bunq.com issues a test key and needs no bank account at all. Put a manifest of your own in providers.d/ naming that base_url — see docs/detailed/setup/bunq.md.',
+    ],
+    troubleshooting:
+      'bunq refused the key. The usual causes are a key that was revoked in the app, a request from an address the key ' +
+      'does not permit (mark it as a wildcard key if this runs deployed), or a session that ended because the account\'s ' +
+      'auto-logout elapsed — that last one recovers by itself on the next call. Generate a new key in the app and re-run: ' +
+      'lanes link connect bunq --replace.',
+    prompts: [
+      {
+        key: 'api_key',
+        label: 'bunq API key',
+        secret: true,
+        scope: 'connection' as const,
+      },
+    ],
+  },
+});
+
+export const bunq = defineProviderWithStrategy({
+  manifest,
+  strategy: createBunqStrategy(),
+});

--- a/src/providers/bunq/redact.ts
+++ b/src/providers/bunq/redact.ts
@@ -1,0 +1,64 @@
+/**
+ * A payment log that can answer "what moved, and to whom".
+ *
+ * The default is wrong here, and actively so. It withholds every value, which
+ * for mail is the right instinct — the body is the private part — and for a
+ * bank produces an audit log recording that a payment happened without
+ * recording its amount or its recipient. That is not a redaction, it is an
+ * erasure of the only facts anyone would ever go looking for.
+ *
+ * So the judgement runs the other way round from every other provider here: a
+ * payment argument is a *fact about a transaction*, not a piece of the user's
+ * content, and every one of them is kept. There is no equivalent of a message
+ * body in this provider's write surface — the nearest thing is `description`,
+ * which is the reference that appears on the recipient's statement and is
+ * therefore already shared with a third party.
+ *
+ * The reads are listed for the same reason Sheets lists its own: they carry
+ * identifiers and a page size, no query, and nothing worth protecting. Leaving
+ * them out would mean a log that cannot distinguish reading one payment from
+ * enumerating the account.
+ *
+ * Names are the generated argument names, which the OpenAPI generator prefixes
+ * where a body field and a path parameter would otherwise collide.
+ */
+export const BUNQ_REDACT: Record<string, string[]> = {
+  // Reads.
+  List_all_User: [],
+  List_all_MonetaryAccount_for_User: ['userID'],
+  List_all_Payment_for_User_MonetaryAccount: ['userID', 'monetary-accountID'],
+  READ_Payment_for_User_MonetaryAccount: ['userID', 'monetary-accountID', 'itemId'],
+  List_all_DraftPayment_for_User_MonetaryAccount: ['userID', 'monetary-accountID'],
+  READ_DraftPayment_for_User_MonetaryAccount: ['userID', 'monetary-accountID', 'itemId'],
+  List_all_PaymentBatch_for_User_MonetaryAccount: ['userID', 'monetary-accountID'],
+
+  // Writes. Everything, because everything is a fact worth reconstructing: the
+  // account it left, the amount, who received it, and what the reference said.
+  CREATE_Payment_for_User_MonetaryAccount: [
+    'userID',
+    'monetary-accountID',
+    'amount',
+    'counterparty_alias',
+    'description',
+    'merchant_reference',
+    'allow_bunqto',
+  ],
+  CREATE_DraftPayment_for_User_MonetaryAccount: [
+    'userID',
+    'monetary-accountID',
+    'entries',
+    'number_of_required_accepts',
+    'status',
+    'schedule',
+  ],
+  UPDATE_DraftPayment_for_User_MonetaryAccount: [
+    'userID',
+    'monetary-accountID',
+    'itemId',
+    'status',
+    'entries',
+    'previous_updated_timestamp',
+    'number_of_required_accepts',
+  ],
+  CREATE_PaymentBatch_for_User_MonetaryAccount: ['userID', 'monetary-accountID', 'payments'],
+};

--- a/src/providers/bunq/specs/bunq.v1.json
+++ b/src/providers/bunq/specs/bunq.v1.json
@@ -1,0 +1,864 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "bunq API",
+    "description": "Trimmed from the published bunq specification. See x-vendored-from for the original, and https://doc.bunq.com for the reference.",
+    "termsOfService": "http://bunq.com/terms-api/",
+    "contact": {
+      "name": "bunq Developer Support",
+      "url": "http://bunq.com/developer"
+    },
+    "license": {
+      "name": "Apache 2.0",
+      "url": "https://www.apache.org/licenses/LICENSE-2.0.html"
+    },
+    "version": "1.0",
+    "x-vendored-from": "https://raw.githubusercontent.com/bunq/doc/master/swagger.json",
+    "x-vendored-note": "Trimmed by src/providers/bunq/specs/vendor.ts. Committed deliberately: a spec decides which paths are called with the operator credential, and this one can move money."
+  },
+  "servers": [
+    {
+      "url": "https://api.bunq.com/v1"
+    }
+  ],
+  "paths": {
+    "/user/{userID}/monetary-account/{monetary-accountID}/draft-payment": {
+      "post": {
+        "tags": [
+          "draft-payment"
+        ],
+        "summary": "",
+        "operationId": "CREATE_DraftPayment_for_User_MonetaryAccount",
+        "description": "Create a new DraftPayment.",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "userID",
+            "description": "",
+            "required": true,
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "in": "path",
+            "name": "monetary-accountID",
+            "description": "",
+            "required": true,
+            "schema": {
+              "type": "integer"
+            }
+          }
+        ],
+        "requestBody": {
+          "description": "",
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/DraftPayment"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success. The response body is returned verbatim."
+          }
+        }
+      },
+      "get": {
+        "tags": [
+          "draft-payment"
+        ],
+        "summary": "",
+        "operationId": "List_all_DraftPayment_for_User_MonetaryAccount",
+        "description": "Get a listing of all DraftPayments from a given MonetaryAccount.",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "userID",
+            "description": "",
+            "required": true,
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "in": "path",
+            "name": "monetary-accountID",
+            "description": "",
+            "required": true,
+            "schema": {
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success. The response body is returned verbatim."
+          }
+        }
+      }
+    },
+    "/user/{userID}/monetary-account/{monetary-accountID}/draft-payment/{itemId}": {
+      "put": {
+        "tags": [
+          "draft-payment"
+        ],
+        "summary": "",
+        "operationId": "UPDATE_DraftPayment_for_User_MonetaryAccount",
+        "description": "Update a DraftPayment.",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "userID",
+            "description": "",
+            "required": true,
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "in": "path",
+            "name": "monetary-accountID",
+            "description": "",
+            "required": true,
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "in": "path",
+            "name": "itemId",
+            "description": "",
+            "required": true,
+            "schema": {
+              "type": "integer"
+            }
+          }
+        ],
+        "requestBody": {
+          "description": "",
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/DraftPayment"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success. The response body is returned verbatim."
+          }
+        }
+      },
+      "get": {
+        "tags": [
+          "draft-payment"
+        ],
+        "summary": "",
+        "operationId": "READ_DraftPayment_for_User_MonetaryAccount",
+        "description": "Get a specific DraftPayment.",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "userID",
+            "description": "",
+            "required": true,
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "in": "path",
+            "name": "monetary-accountID",
+            "description": "",
+            "required": true,
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "in": "path",
+            "name": "itemId",
+            "description": "",
+            "required": true,
+            "schema": {
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success. The response body is returned verbatim."
+          }
+        }
+      }
+    },
+    "/user/{userID}/monetary-account": {
+      "get": {
+        "tags": [
+          "monetary-account"
+        ],
+        "summary": "",
+        "operationId": "List_all_MonetaryAccount_for_User",
+        "description": "Get a collection of all your MonetaryAccounts.",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "userID",
+            "description": "",
+            "required": true,
+            "schema": {
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success. The response body is returned verbatim."
+          }
+        }
+      }
+    },
+    "/user/{userID}/monetary-account/{monetary-accountID}/payment": {
+      "post": {
+        "tags": [
+          "payment"
+        ],
+        "summary": "",
+        "operationId": "CREATE_Payment_for_User_MonetaryAccount",
+        "description": "Create a new Payment.",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "userID",
+            "description": "",
+            "required": true,
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "in": "path",
+            "name": "monetary-accountID",
+            "description": "",
+            "required": true,
+            "schema": {
+              "type": "integer"
+            }
+          }
+        ],
+        "requestBody": {
+          "description": "",
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Payment"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success. The response body is returned verbatim."
+          }
+        }
+      },
+      "get": {
+        "tags": [
+          "payment"
+        ],
+        "summary": "",
+        "operationId": "List_all_Payment_for_User_MonetaryAccount",
+        "description": "Get a listing of all Payments performed on a given MonetaryAccount (incoming and outgoing).",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "userID",
+            "description": "",
+            "required": true,
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "in": "path",
+            "name": "monetary-accountID",
+            "description": "",
+            "required": true,
+            "schema": {
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success. The response body is returned verbatim."
+          }
+        }
+      }
+    },
+    "/user/{userID}/monetary-account/{monetary-accountID}/payment/{itemId}": {
+      "get": {
+        "tags": [
+          "payment"
+        ],
+        "summary": "",
+        "operationId": "READ_Payment_for_User_MonetaryAccount",
+        "description": "Get a specific previous Payment.",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "userID",
+            "description": "",
+            "required": true,
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "in": "path",
+            "name": "monetary-accountID",
+            "description": "",
+            "required": true,
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "in": "path",
+            "name": "itemId",
+            "description": "",
+            "required": true,
+            "schema": {
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success. The response body is returned verbatim."
+          }
+        }
+      }
+    },
+    "/user/{userID}/monetary-account/{monetary-accountID}/payment-batch": {
+      "post": {
+        "tags": [
+          "payment-batch"
+        ],
+        "summary": "",
+        "operationId": "CREATE_PaymentBatch_for_User_MonetaryAccount",
+        "description": "Create a payment batch by sending an array of single payment objects, that will become part of the batch.",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "userID",
+            "description": "",
+            "required": true,
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "in": "path",
+            "name": "monetary-accountID",
+            "description": "",
+            "required": true,
+            "schema": {
+              "type": "integer"
+            }
+          }
+        ],
+        "requestBody": {
+          "description": "",
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/PaymentBatch"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success. The response body is returned verbatim."
+          }
+        }
+      },
+      "get": {
+        "tags": [
+          "payment-batch"
+        ],
+        "summary": "",
+        "operationId": "List_all_PaymentBatch_for_User_MonetaryAccount",
+        "description": "Return all the payment batches for a monetary account.",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "userID",
+            "description": "",
+            "required": true,
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "in": "path",
+            "name": "monetary-accountID",
+            "description": "",
+            "required": true,
+            "schema": {
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success. The response body is returned verbatim."
+          }
+        }
+      }
+    },
+    "/user": {
+      "get": {
+        "tags": [
+          "user"
+        ],
+        "summary": "",
+        "operationId": "List_all_User",
+        "description": "Get a collection of all available users.",
+        "responses": {
+          "200": {
+            "description": "Success. The response body is returned verbatim."
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "Address": {
+        "type": "object",
+        "properties": {
+          "street": {
+            "type": "string",
+            "description": "The street.",
+            "readOnly": false,
+            "writeOnly": false
+          },
+          "house_number": {
+            "type": "string",
+            "description": "The house number.",
+            "readOnly": false,
+            "writeOnly": false
+          },
+          "po_box": {
+            "type": "string",
+            "description": "The PO box.",
+            "readOnly": false,
+            "writeOnly": false
+          },
+          "postal_code": {
+            "type": "string",
+            "description": "The postal code.",
+            "readOnly": false,
+            "writeOnly": false
+          },
+          "city": {
+            "type": "string",
+            "description": "The city.",
+            "readOnly": false,
+            "writeOnly": false
+          },
+          "country": {
+            "type": "string",
+            "description": "The country as an ISO 3166-1 alpha-2 country code.",
+            "readOnly": false,
+            "writeOnly": false
+          },
+          "extra": {
+            "type": "string",
+            "description": "The apartment, building or other extra information for addresses.",
+            "readOnly": false,
+            "writeOnly": false
+          },
+          "mailbox_name": {
+            "type": "string",
+            "description": "The name on the mailbox (only used for Postal and Shipping addresses).",
+            "readOnly": false,
+            "writeOnly": false
+          }
+        }
+      },
+      "Amount": {
+        "type": "object",
+        "properties": {
+          "value": {
+            "type": "string",
+            "description": "The amount formatted to two decimal places.",
+            "readOnly": false,
+            "writeOnly": false
+          },
+          "currency": {
+            "type": "string",
+            "description": "The currency of the amount. It is an ISO 4217 formatted currency code.",
+            "readOnly": false,
+            "writeOnly": false
+          }
+        }
+      },
+      "AttachmentMonetaryAccountPayment": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "description": "The id of the attached Attachment.",
+            "readOnly": false,
+            "writeOnly": false
+          }
+        }
+      },
+      "Avatar": {
+        "type": "object",
+        "properties": {
+          "uuid": {
+            "type": "string",
+            "description": "The public UUID of the avatar.",
+            "readOnly": false,
+            "writeOnly": false
+          }
+        }
+      },
+      "DraftPayment": {
+        "type": "object",
+        "properties": {
+          "status": {
+            "type": "string",
+            "description": "The status of the DraftPayment.",
+            "readOnly": false,
+            "writeOnly": false
+          },
+          "entries": {
+            "type": "array",
+            "description": "The list of entries in the DraftPayment. Each entry will result in a payment when the DraftPayment is accepted.",
+            "readOnly": false,
+            "writeOnly": false,
+            "items": {
+              "$ref": "#/components/schemas/DraftPaymentEntry"
+            }
+          },
+          "previous_updated_timestamp": {
+            "type": "string",
+            "description": "The last updated_timestamp that you received for this DraftPayment. This needs to be provided to prevent race conditions.",
+            "readOnly": false,
+            "writeOnly": true
+          },
+          "number_of_required_accepts": {
+            "type": "integer",
+            "description": "The number of accepts that are required for the draft payment to receive status ACCEPTED. Currently only 1 is valid.",
+            "readOnly": false,
+            "writeOnly": true
+          },
+          "schedule": {
+            "type": "object",
+            "description": "The schedule details when creating or updating a scheduled payment.",
+            "readOnly": false,
+            "writeOnly": false,
+            "$ref": "#/components/schemas/Schedule"
+          }
+        },
+        "required": [
+          "entries",
+          "number_of_required_accepts"
+        ]
+      },
+      "DraftPaymentEntry": {
+        "type": "object",
+        "properties": {
+          "amount": {
+            "type": "object",
+            "description": "The amount of the payment.",
+            "readOnly": false,
+            "writeOnly": false,
+            "$ref": "#/components/schemas/Amount"
+          },
+          "counterparty_alias": {
+            "type": "object",
+            "description": "The LabelMonetaryAccount containing the public information of the other (counterparty) side of the DraftPayment.",
+            "readOnly": false,
+            "writeOnly": false,
+            "$ref": "#/components/schemas/LabelMonetaryAccount"
+          },
+          "description": {
+            "type": "string",
+            "description": "The description for the DraftPayment. Maximum 140 characters for DraftPayments to external IBANs, 9000 characters for DraftPayments to only other bunq MonetaryAccounts.",
+            "readOnly": false,
+            "writeOnly": false
+          },
+          "merchant_reference": {
+            "type": "string",
+            "description": "Optional data to be included with the Payment specific to the merchant.",
+            "readOnly": false,
+            "writeOnly": false
+          },
+          "attachment": {
+            "type": "array",
+            "description": "The Attachments attached to the DraftPayment.",
+            "readOnly": false,
+            "writeOnly": false,
+            "items": {
+              "$ref": "#/components/schemas/AttachmentMonetaryAccountPayment"
+            }
+          }
+        }
+      },
+      "Error": {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "properties": {
+            "error_description": {
+              "type": "string",
+              "description": "The error description in English."
+            },
+            "error_description_translated": {
+              "type": "string",
+              "description": "The error description translated to the user's language."
+            }
+          }
+        }
+      },
+      "Geolocation": {
+        "type": "object",
+        "properties": {
+          "latitude": {
+            "type": "integer",
+            "description": "The latitude for a geolocation restriction.",
+            "readOnly": false,
+            "writeOnly": false
+          },
+          "longitude": {
+            "type": "integer",
+            "description": "The longitude for a geolocation restriction.",
+            "readOnly": false,
+            "writeOnly": false
+          },
+          "altitude": {
+            "type": "integer",
+            "description": "The altitude for a geolocation restriction.",
+            "readOnly": false,
+            "writeOnly": false
+          },
+          "radius": {
+            "type": "integer",
+            "description": "The radius for a geolocation restriction.",
+            "readOnly": false,
+            "writeOnly": false
+          }
+        }
+      },
+      "GinmonTransaction": {
+        "type": "object",
+        "additionalProperties": true,
+        "description": "Every field bunq documents here is read-only, so its request shape is not described by the specification — send the object the tool description names."
+      },
+      "Image": {
+        "type": "object",
+        "additionalProperties": true,
+        "description": "Every field bunq documents here is read-only, so its request shape is not described by the specification — send the object the tool description names."
+      },
+      "LabelMonetaryAccount": {
+        "type": "object",
+        "additionalProperties": true,
+        "description": "Every field bunq documents here is read-only, so its request shape is not described by the specification — send the object the tool description names."
+      },
+      "LabelUser": {
+        "type": "object",
+        "properties": {
+          "uuid": {
+            "type": "string",
+            "description": "The public UUID of the label-user.",
+            "readOnly": false,
+            "writeOnly": false
+          },
+          "display_name": {
+            "type": "string",
+            "description": "The name to be displayed for this user, as it was given on the request.",
+            "readOnly": false,
+            "writeOnly": false
+          },
+          "country": {
+            "type": "string",
+            "description": "The country of the user. 000 stands for \"unknown\"",
+            "readOnly": false,
+            "writeOnly": false
+          }
+        }
+      },
+      "Payment": {
+        "type": "object",
+        "properties": {
+          "amount": {
+            "type": "object",
+            "description": "The Amount transferred by the Payment. Will be negative for outgoing Payments and positive for incoming Payments (relative to the MonetaryAccount indicated by monetary_account_id).",
+            "readOnly": false,
+            "writeOnly": false,
+            "$ref": "#/components/schemas/Amount"
+          },
+          "counterparty_alias": {
+            "type": "object",
+            "description": "The LabelMonetaryAccount containing the public information of the other (counterparty) side of the Payment.",
+            "readOnly": false,
+            "writeOnly": false,
+            "$ref": "#/components/schemas/LabelMonetaryAccount"
+          },
+          "description": {
+            "type": "string",
+            "description": "The description for the Payment. Maximum 140 characters for Payments to external IBANs, 9000 characters for Payments to only other bunq MonetaryAccounts.",
+            "readOnly": false,
+            "writeOnly": false
+          },
+          "attachment": {
+            "type": "array",
+            "description": "The Attachments attached to the Payment.",
+            "readOnly": false,
+            "writeOnly": false,
+            "items": {
+              "$ref": "#/components/schemas/AttachmentMonetaryAccountPayment"
+            }
+          },
+          "merchant_reference": {
+            "type": "string",
+            "description": "Optional data included with the Payment specific to the merchant.",
+            "readOnly": false,
+            "writeOnly": false
+          },
+          "allow_bunqto": {
+            "type": "boolean",
+            "description": "Whether or not sending a bunq.to payment is allowed.",
+            "readOnly": false,
+            "writeOnly": true
+          }
+        }
+      },
+      "PaymentArrivalExpected": {
+        "type": "object",
+        "additionalProperties": true,
+        "description": "Every field bunq documents here is read-only, so its request shape is not described by the specification — send the object the tool description names."
+      },
+      "PaymentAutoAllocateInstance": {
+        "type": "object",
+        "additionalProperties": true,
+        "description": "Every field bunq documents here is read-only, so its request shape is not described by the specification — send the object the tool description names."
+      },
+      "PaymentBatch": {
+        "type": "object",
+        "properties": {
+          "payments": {
+            "type": "object",
+            "description": "The list of mutations that were made.",
+            "readOnly": false,
+            "writeOnly": false,
+            "$ref": "#/components/schemas/PaymentBatchAnchoredPayment"
+          }
+        }
+      },
+      "PaymentBatchAnchoredPayment": {
+        "type": "object",
+        "additionalProperties": true,
+        "description": "Every field bunq documents here is read-only, so its request shape is not described by the specification — send the object the tool description names."
+      },
+      "PaymentFee": {
+        "type": "object",
+        "additionalProperties": true,
+        "description": "Every field bunq documents here is read-only, so its request shape is not described by the specification — send the object the tool description names."
+      },
+      "PaymentSuspendedOutgoing": {
+        "type": "object",
+        "properties": {
+          "status": {
+            "type": "string",
+            "description": "The status of the payment.",
+            "readOnly": false,
+            "writeOnly": false
+          }
+        }
+      },
+      "Pointer": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "description": "The alias type, can be: EMAIL|PHONE_NUMBER|IBAN.",
+            "readOnly": false,
+            "writeOnly": false
+          },
+          "value": {
+            "type": "string",
+            "description": "The alias value.",
+            "readOnly": false,
+            "writeOnly": false
+          },
+          "name": {
+            "type": "string",
+            "description": "The alias name.",
+            "readOnly": false,
+            "writeOnly": false
+          },
+          "service": {
+            "type": "string",
+            "description": "The pointer service. Only required for external counterparties.",
+            "readOnly": false,
+            "writeOnly": true
+          }
+        }
+      },
+      "RequestInquiryReference": {
+        "type": "object",
+        "additionalProperties": true,
+        "description": "Every field bunq documents here is read-only, so its request shape is not described by the specification — send the object the tool description names."
+      },
+      "Schedule": {
+        "type": "object",
+        "properties": {
+          "time_start": {
+            "type": "string",
+            "description": "The schedule start time (UTC).",
+            "readOnly": false,
+            "writeOnly": false
+          },
+          "time_end": {
+            "type": "string",
+            "description": "The schedule end time (UTC).",
+            "readOnly": false,
+            "writeOnly": false
+          },
+          "recurrence_unit": {
+            "type": "string",
+            "description": "The schedule recurrence unit, options: ONCE, HOURLY, DAILY, WEEKLY, MONTHLY, YEARLY",
+            "readOnly": false,
+            "writeOnly": false
+          },
+          "recurrence_size": {
+            "type": "integer",
+            "description": "The schedule recurrence size. For example size 4 and unit WEEKLY means the recurrence is every 4 weeks.",
+            "readOnly": false,
+            "writeOnly": false
+          }
+        }
+      },
+      "ScheduleAnchorObject": {
+        "type": "object",
+        "additionalProperties": true,
+        "description": "Every field bunq documents here is read-only, so its request shape is not described by the specification — send the object the tool description names."
+      }
+    }
+  }
+}

--- a/src/providers/bunq/specs/specs.test.ts
+++ b/src/providers/bunq/specs/specs.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, test } from 'bun:test';
+import { createHttpConnector } from '#connectivity/transports';
+import { bunq } from '../index.ts';
+
+/**
+ * What the vendored spec and the manifest have to keep agreeing about.
+ *
+ * `cli/tools.test.ts` checks these in one direction for every HTTP provider:
+ * a redact key must name an argument that exists, a hint must name a capability
+ * that exists. The other direction is the one that matters here, and only here.
+ *
+ * If an operation loses its redact entry — a bunq rename, a refresh that
+ * changes a generated name — dispatch falls back to `redactAllValues` and the
+ * log records that a payment happened without recording its amount or its
+ * recipient. That is precisely the erasure `../redact.ts` exists to prevent, it
+ * is silent, and no existing test looks for it. Scoped to bunq deliberately:
+ * for a mailbox, withholding everything is the *right* default, so this is a
+ * property of the provider that moves money rather than of HTTP providers.
+ */
+
+const manifest = bunq.manifest;
+const connector = manifest.connector as { base_url: string; openapi: string };
+
+const discovered = await createHttpConnector({
+  baseUrl: connector.base_url,
+  openapi: connector.openapi,
+}).discover({ manifest });
+
+/** The two that spend with no human step anywhere. */
+const EXECUTES_IMMEDIATELY = [
+  'CREATE_Payment_for_User_MonetaryAccount',
+  'CREATE_PaymentBatch_for_User_MonetaryAccount',
+];
+
+describe('the vendored spec and the manifest agree', () => {
+  test('the eleven operations are all there, and nothing else is', () => {
+    expect(discovered.map((capability) => capability.name).sort()).toEqual([
+      'CREATE_DraftPayment_for_User_MonetaryAccount',
+      'CREATE_PaymentBatch_for_User_MonetaryAccount',
+      'CREATE_Payment_for_User_MonetaryAccount',
+      'List_all_DraftPayment_for_User_MonetaryAccount',
+      'List_all_MonetaryAccount_for_User',
+      'List_all_PaymentBatch_for_User_MonetaryAccount',
+      'List_all_Payment_for_User_MonetaryAccount',
+      'List_all_User',
+      'READ_DraftPayment_for_User_MonetaryAccount',
+      'READ_Payment_for_User_MonetaryAccount',
+      'UPDATE_DraftPayment_for_User_MonetaryAccount',
+    ]);
+  });
+
+  test('every capability is redacted deliberately, rather than by default', () => {
+    // The default withholds every value. For a payment that is not caution, it
+    // is an audit record with the two facts anybody would ever want removed.
+    const undeclared = discovered
+      .filter((capability) => !manifest.redact?.[capability.name])
+      .map((capability) => capability.name);
+
+    expect(undeclared).toEqual([]);
+  });
+
+  test('a write keeps the amount and the counterparty, which is the whole point', () => {
+    const kept = manifest.redact?.['CREATE_Payment_for_User_MonetaryAccount'] ?? [];
+
+    expect(kept).toContain('amount');
+    expect(kept).toContain('counterparty_alias');
+    expect(kept).toContain('monetary-accountID');
+  });
+
+  test('the tools that spend say so in their description', () => {
+    // A generated description says what the arguments are. That a call moves
+    // money and cannot be undone is not in bunq's document and has to be added,
+    // and it is the single most important sentence this provider serves.
+    for (const name of EXECUTES_IMMEDIATELY) {
+      const capability = discovered.find((entry) => entry.name === name)!;
+      expect(capability.description).toMatch(/executes immediately|Executes immediately/);
+    }
+  });
+
+  test('no protocol header is offered as an argument', () => {
+    // `X-Bunq-Client-Authentication` is the session token. It reaching a tool
+    // schema would invite a model to fill it in, and make a tool call able to
+    // carry a credential the strategy owns.
+    const leaked = discovered.flatMap((capability) => {
+      const properties = (capability.inputSchema?.['properties'] ?? {}) as Record<string, unknown>;
+      return Object.keys(properties)
+        .filter((name) => /^(x-bunq-|cache-control$|user-agent$)/i.test(name))
+        .map((name) => `${capability.name}.${name}`);
+    });
+
+    expect(leaked).toEqual([]);
+  });
+
+  test('the committed spec carries no component the paths do not use', () => {
+    // Including, before this was filtered, a definition of the session header.
+    const spec = require(connector.openapi) as { components: Record<string, unknown> };
+
+    expect(Object.keys(spec.components)).toEqual(['schemas']);
+  });
+});

--- a/src/providers/bunq/specs/vendor.ts
+++ b/src/providers/bunq/specs/vendor.ts
@@ -1,0 +1,338 @@
+/**
+ * Vendor a trimmed OpenAPI spec for bunq.
+ *
+ * The output is **committed**, for the reason the Google script gives and then
+ * some: a spec decides which paths get called with the operator's credential,
+ * and this credential moves money. `connect` grants everything a provider
+ * discovers, so the reviewable surface has to be a file in the repository
+ * rather than a document fetched from GitHub at connect time.
+ *
+ * bunq's published spec cannot be used as it stands, and not marginally. It is
+ * 1.37 MB across 271 paths, and generating tools from it fails on **55
+ * operations with `Maximum call stack size exceeded`** — including every single
+ * payment endpoint, because `Payment` recurses through `RequestInquiry` and
+ * `RequestResponse` and `mcp-from-openapi` inlines `$ref`s. `cutCycles` is what
+ * makes this provider possible at all; without it there is nothing here worth
+ * shipping.
+ *
+ *   bun run vendor:bunq
+ */
+
+import { mkdir, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { OpenAPIToolGenerator, type McpOpenAPITool } from 'mcp-from-openapi';
+import { cutCycles, referenced, type Spec } from '../../shared/openapi.ts';
+
+const SOURCE = 'https://raw.githubusercontent.com/bunq/doc/master/swagger.json';
+const OUT = 'bunq.v1.json';
+
+/** Kept in step with `BUDGET_KB` in `src/cli/tools.test.ts`, which enforces it. */
+const BUDGET_KB = 64;
+
+/**
+ * Everything this provider can reach, and nothing else.
+ *
+ * The list *is* the security boundary, ahead of policy and ahead of the
+ * connection's bundles: an operation absent here has no tool, so no rule can
+ * allow it and no agent can find it. Adding a line is the decision worth
+ * arguing about, which is why each one says why it is here.
+ *
+ * Reading: what an agent needs to know before it can pay anything — which
+ * accounts exist, what is in them, and what has already gone out.
+ *
+ * Writing: the three shapes bunq offers for sending money. `Payment` executes
+ * immediately. `DraftPayment` does not — it waits for approval in the bunq app,
+ * which is the human checkpoint, and `UPDATE_DraftPayment` is how one is
+ * cancelled or accepted. `PaymentBatch` is up to 350 payments in one call,
+ * which is the whole point of automating a payment run rather than a payment.
+ */
+const OPERATIONS = [
+  // Read. `List_all_User` first because every other path is addressed under a
+  // userID, and nothing reports it but this.
+  'List_all_User',
+  'List_all_MonetaryAccount_for_User',
+  'List_all_Payment_for_User_MonetaryAccount',
+  'READ_Payment_for_User_MonetaryAccount',
+  'List_all_DraftPayment_for_User_MonetaryAccount',
+  'READ_DraftPayment_for_User_MonetaryAccount',
+  'List_all_PaymentBatch_for_User_MonetaryAccount',
+  // Write.
+  'CREATE_Payment_for_User_MonetaryAccount',
+  'CREATE_DraftPayment_for_User_MonetaryAccount',
+  'UPDATE_DraftPayment_for_User_MonetaryAccount',
+  'CREATE_PaymentBatch_for_User_MonetaryAccount',
+  //
+  // Not vendored, deliberately:
+  //
+  // `CREATE_RequestInquiry_*` — 355 KB generated, 5.5x the per-tool budget on
+  // its own, and it asks *for* money rather than sending it. Neither half of
+  // that is worth solving for a capability nobody asked for.
+  //
+  // `schedule-payment` and `schedule` — recurring payments. They fail cycle
+  // cutting as well, and a standing order that an agent can create is a
+  // different risk from a payment it can make: one is a decision taken once,
+  // the other repeats without anybody looking. The bunq app does this well.
+  //
+  // Every `monetary-account-*` creation path — opening and closing accounts is
+  // not paying bills, and `CREATE_MonetaryAccountBank` is a 15 KB body whose
+  // only purpose here would be to widen what a compromised session can do.
+  //
+  // `card-*` — ordering and freezing cards, same argument.
+] as const;
+
+const METHODS = ['get', 'post', 'put', 'patch', 'delete', 'head'];
+
+/**
+ * Drop every referenced parameter, which for bunq means every protocol header.
+ *
+ * bunq declares seven headers on almost every operation — `Cache-Control`,
+ * `User-Agent`, `X-Bunq-Language`, `X-Bunq-Region`, `X-Bunq-Geolocation`,
+ * `X-Bunq-Client-Request-Id` and `X-Bunq-Client-Authentication` — and the
+ * generator turns each into a tool argument. That is wrong twice over. They are
+ * noise on every schema, and the last one is the **session token**: leaving it
+ * as an argument invites a model to fill it in, and means a tool call could
+ * carry a credential the strategy is supposed to own.
+ *
+ * Every parameter bunq puts in `components.parameters` is one of these, so
+ * dropping referenced parameters wholesale is exact rather than a heuristic —
+ * the path parameters that must survive are declared inline. Google's script
+ * needs a name list for the same job because Google mixes the two.
+ */
+function dropProtocolParameters(item: Record<string, unknown>): number {
+  let dropped = 0;
+
+  const filter = (holder: Record<string, unknown>): void => {
+    const parameters = holder['parameters'];
+    if (!Array.isArray(parameters)) return;
+
+    const kept = parameters.filter((parameter) => {
+      const reference = (parameter as { $ref?: string }).$ref;
+      if (typeof reference !== 'string' || !reference.startsWith('#/components/parameters/')) {
+        return true;
+      }
+      dropped++;
+      return false;
+    });
+
+    if (kept.length > 0) holder['parameters'] = kept;
+    else delete holder['parameters'];
+  };
+
+  filter(item);
+  for (const [method, operation] of Object.entries(item)) {
+    if (!METHODS.includes(method)) continue;
+    filter(operation as Record<string, unknown>);
+  }
+
+  return dropped;
+}
+
+/**
+ * Strip the properties OpenAPI already marks as response-only.
+ *
+ * bunq describes a request body by pointing at the *whole* resource, so the
+ * body schema for creating a payment carries `id`, `created`, `updated`,
+ * `balance_after_mutation` and two dozen more — fields bunq computes and
+ * ignores on the way in. The document says so itself: they carry
+ * `readOnly: true`, which the specification defines as "MAY be sent as part of
+ * a response and SHOULD NOT be sent as part of the request".
+ *
+ * So this is the document's own judgement applied rather than ours invented,
+ * which is the difference between this and a hand-written field list that would
+ * go stale. It is safe only because responses have already been replaced above:
+ * these schemas are now reachable from request bodies alone.
+ *
+ * **A schema left with nothing is opened rather than emptied.** Nine of bunq's
+ * are, `LabelMonetaryAccount` among them — and that one is `counterparty_alias`
+ * on a payment, which is to say the single field that decides who gets the
+ * money. Every property of it is marked read-only because the document points
+ * the *request* at the response type; what a payment actually takes there is a
+ * `Pointer`, `{ type, value, name }`, as bunq's own guide says and as this
+ * provider's `hints` repeat. Neither shape is worth asserting from here. What
+ * matters is the difference between `{}` — which reads as "this field takes
+ * nothing", and is the one thing that is certainly false — and an open object,
+ * which reads as "send what the description says".
+ */
+function dropReadOnly(node: unknown): number {
+  if (node === null || typeof node !== 'object') return 0;
+  if (Array.isArray(node)) return node.reduce<number>((total, item) => total + dropReadOnly(item), 0);
+
+  let dropped = 0;
+  const record = node as Record<string, unknown>;
+  const properties = record['properties'];
+
+  if (properties && typeof properties === 'object') {
+    const fields = properties as Record<string, unknown>;
+    const writable = Object.entries(fields).filter(
+      ([, schema]) => (schema as { readOnly?: boolean })?.readOnly !== true,
+    );
+
+    if (writable.length === 0 && Object.keys(fields).length > 0) {
+      delete record['properties'];
+      record['additionalProperties'] = true;
+      record['description'] =
+        `${record['description'] ?? ''} Every field bunq documents here is read-only, so its request shape is not described by the specification — send the object the tool description names.`.trim();
+      return dropped;
+    }
+
+    for (const [name, schema] of Object.entries(fields)) {
+      if ((schema as { readOnly?: boolean })?.readOnly === true) {
+        delete fields[name];
+        dropped++;
+      }
+    }
+  }
+
+  for (const value of Object.values(record)) dropped += dropReadOnly(value);
+  return dropped;
+}
+
+
+async function vendor(): Promise<void> {
+  const response = await fetch(SOURCE);
+  if (!response.ok) throw new Error(`${SOURCE}: HTTP ${response.status}`);
+  const spec = (await response.json()) as Spec;
+
+  const wanted = new Set<string>(OPERATIONS);
+  const paths: Spec['paths'] = {};
+  const seen = new Set<string>();
+
+  for (const [path, item] of Object.entries(spec.paths)) {
+    const kept: Record<string, unknown> = {};
+
+    for (const [method, operation] of Object.entries(item)) {
+      // Path-level keys are not operations and must survive — `parameters`
+      // here holds what every method on the path shares.
+      if (!METHODS.includes(method)) {
+        kept[method] = operation;
+        continue;
+      }
+      const operationId = operation.operationId;
+      if (!operationId || !wanted.has(operationId)) continue;
+      kept[method] = operation;
+      seen.add(operationId);
+    }
+
+    if (!Object.keys(kept).some((key) => METHODS.includes(key))) continue;
+    paths[path] = kept as Spec['paths'][string];
+  }
+
+  // Drop response schemas, before `referenced` so nothing they reach is kept.
+  //
+  // The same two reasons as Google's, in the same order of importance. Nothing
+  // reads them — the connector hands the body back as text. And bunq's response
+  // schemas are where most of the recursion lives, so keeping them would drag
+  // the whole `Payment`/`RequestInquiry` cycle into a document that does not
+  // otherwise need it.
+  for (const item of Object.values(paths)) {
+    for (const [method, operation] of Object.entries(item)) {
+      if (!METHODS.includes(method)) continue;
+      (operation as { responses?: unknown }).responses = {
+        '200': { description: 'Success. The response body is returned verbatim.' },
+      };
+    }
+  }
+
+  let headers = 0;
+  for (const item of Object.values(paths)) {
+    headers += dropProtocolParameters(item as unknown as Record<string, unknown>);
+  }
+
+  const missing = OPERATIONS.filter((operationId) => !seen.has(operationId));
+  if (missing.length > 0) {
+    // Loudly: an upstream rename should fail the refresh rather than quietly
+    // shrinking what this provider can do.
+    throw new Error(`these operations are not in the spec — ${missing.join(', ')}`);
+  }
+
+  const schemas = spec.components?.schemas ?? {};
+  const keep = referenced(paths, schemas);
+  const trimmedSchemas = Object.fromEntries(
+    Object.entries(schemas).filter(([name]) => keep.has(name)),
+  );
+  const cuts = cutCycles(trimmedSchemas);
+  const readOnly = dropReadOnly(trimmedSchemas);
+
+  const trimmed: Spec = {
+    openapi: spec.openapi,
+    info: {
+      ...spec.info,
+      // Replaced, not carried. bunq's own `description` is 73 KB of product
+      // tour — 78% of what this file would otherwise weigh — and it is
+      // documentation of the bank rather than of the API. It also carries
+      // example addresses at bunq's own registrable domain, which
+      // `architecture.test.ts` refuses anywhere a reader of this repository can
+      // see. Both problems are the same field, and dropping it is better than
+      // exempting the file: an exemption would also cover whatever the next
+      // refresh brings in.
+      description:
+        'Trimmed from the published bunq specification. See x-vendored-from for the original, and https://doc.bunq.com for the reference.',
+      'x-vendored-from': SOURCE,
+      'x-vendored-note':
+        'Trimmed by src/providers/bunq/specs/vendor.ts. Committed deliberately: a spec decides which paths are called with the operator credential, and this one can move money.',
+    },
+    // Rewritten rather than carried over. bunq's document declares both the
+    // sandbox and production servers with a templated `{basePath}`, and the
+    // manifest names one concrete `base_url` — leaving two in the spec invites
+    // a reader to think the choice is made here. It is made by the strategy.
+    servers: [{ url: 'https://api.bunq.com/v1' }],
+    paths,
+    // Schemas only. Carrying `...spec.components` kept bunq's `parameters`,
+    // `responses` and `headers` — none of them referenced by a surviving path,
+    // and among them the definition of `X-Bunq-Client-Authentication`, which
+    // `dropProtocolParameters` above exists to make unreachable. A committed
+    // spec is committed so it can be read; dead definitions of the session
+    // header are the opposite of that.
+    components: { schemas: trimmedSchemas },
+  };
+
+  const directory = import.meta.dir;
+  await mkdir(directory, { recursive: true });
+  await writeFile(join(directory, OUT), `${JSON.stringify(trimmed, null, 2)}\n`);
+
+  const size = Math.round(JSON.stringify(trimmed).length / 1024);
+  console.log(
+    `  bunq   ${String(Object.keys(paths).length).padStart(2)} paths, ` +
+      `${seen.size} operations, ${Object.keys(trimmedSchemas).length} schemas, ` +
+      `${cuts} cycle${cuts === 1 ? '' : 's'} cut, ${headers} protocol params dropped, ` +
+      `${readOnly} read-only fields dropped, ${size}KB`,
+  );
+
+  await report(trimmed);
+}
+
+/**
+ * What the budget is actually about: the **generated** input schema.
+ *
+ * Orders of magnitude away from the spec size on the line above, because
+ * `$ref`s are inlined. Printed so a refresh that adds an operation shows what
+ * it costs, rather than leaving `cli/tools.test.ts` to say so afterwards.
+ */
+async function report(trimmed: Spec): Promise<void> {
+  try {
+    const generator = await OpenAPIToolGenerator.fromJSON(trimmed);
+    const tools = await generator.generateTools();
+
+    const measured = tools
+      .map((tool: McpOpenAPITool) => ({
+        name: tool.metadata.operationId ?? tool.name,
+        kb: JSON.stringify(tool.inputSchema).length / 1024,
+      }))
+      .sort((a, b) => b.kb - a.kb);
+
+    for (const { name, kb } of measured.slice(0, 4)) {
+      const over = kb > BUDGET_KB ? `  ✗ over the ${BUDGET_KB}KB budget` : '';
+      console.log(`         ${name.padEnd(46)} ${kb.toFixed(1).padStart(7)}KB${over}`);
+    }
+
+    const surface = tools.reduce(
+      (total, tool) => total + JSON.stringify({ description: tool.description, inputSchema: tool.inputSchema }).length,
+      0,
+    );
+    console.log(`         ${'whole advertised surface'.padEnd(46)} ${(surface / 1024).toFixed(1).padStart(7)}KB`);
+  } catch (error) {
+    console.log(`         (could not measure generated schemas: ${String(error)})`);
+  }
+}
+
+await vendor();

--- a/src/providers/bunq/strategy/handshake.ts
+++ b/src/providers/bunq/strategy/handshake.ts
@@ -1,0 +1,211 @@
+import { signBody } from './keys.ts';
+
+/**
+ * bunq's three-step API context, which is why this provider needs code at all.
+ *
+ * Most APIs take a key and are done. bunq takes a key and then wants an
+ * *installation* (here is my public key), a *device* (this key may be used, from
+ * these addresses), and a *session* (and now let me in) — three round trips
+ * producing three different tokens, of which only the last one authenticates an
+ * ordinary call. No manifest field describes that, which is the whole argument
+ * for `AuthStrategy` in ADR-008.
+ *
+ * Nothing in this file names an operation. It knows how to open a session and
+ * nothing about what the session is then used for.
+ */
+
+export const PRODUCTION = 'https://api.bunq.com/v1';
+export const SANDBOX = 'https://public-api.sandbox.bunq.com/v1';
+
+/**
+ * Which bunq this connection talks to: whatever its manifest says.
+ *
+ * One provider serves both environments, because they are the same API and the
+ * same tool list — a second provider id would duplicate the manifest, the
+ * vendored spec, and every policy rule written against it. The built-in names
+ * production; a workspace manifest in `providers.d/` naming the sandbox gets
+ * the sandbox, and borrows this strategy through `strategyFor`.
+ *
+ * This used to be a `sandbox: true` option on the strategy, with `authorize`
+ * rewriting the request origin to match. That was a second source of truth for
+ * something `base_url` already states, and the two could disagree — a manifest
+ * pointed at the sandbox but missing the flag (or carrying `sandbox: "true"`,
+ * which is not `true`) would have spent against production while its own
+ * `base_url` said otherwise. Reading the manifest makes the disagreement
+ * impossible rather than documented, and the transport and the handshake now
+ * cannot end up on different hosts because neither chooses.
+ */
+export function hostFor(manifest: { connector: { kind: string } }): string {
+  const connector = manifest.connector as { kind: string; base_url?: string };
+  if (connector.kind !== 'http' || !connector.base_url) {
+    throw new Error('The bunq strategy needs an http connector with a base_url.');
+  }
+
+  return connector.base_url.replace(/\/$/, '');
+}
+
+export interface Installation {
+  /** Authenticates device-server and session-server, and nothing else. */
+  readonly token: string;
+  /** bunq's half, for checking that a reply is bunq's. */
+  readonly serverPublicKey: string;
+}
+
+/**
+ * Everything bunq requires on a request that is not the signature.
+ *
+ * `X-Bunq-Client-Request-Id` must differ per request; bunq uses it to
+ * de-duplicate, so reusing one would make a retried payment silently a no-op —
+ * which is the behaviour you want, but only if the id is genuinely fresh when
+ * the payment is genuinely new.
+ */
+export function baseHeaders(): Record<string, string> {
+  return {
+    // No `content-type`. Every handshake call below adds it because every one
+    // of them posts JSON, but `authorize` applies this set to reads too, and a
+    // GET that carries no body should not claim one.
+    'cache-control': 'no-cache',
+    'user-agent': 'lanes-link/1.0',
+    'x-bunq-language': 'en_US',
+    'x-bunq-region': 'en_US',
+    'x-bunq-geolocation': '0 0 0 0 000',
+    'x-bunq-client-request-id': crypto.randomUUID(),
+  };
+}
+
+/**
+ * bunq answers everything as `{ Response: [ { Key: value }, … ] }`.
+ *
+ * An array of single-key objects rather than one object, so reading a field
+ * means searching for the wrapper that holds it.
+ */
+function pick(payload: unknown, wrapper: string): Record<string, unknown> | undefined {
+  const entries = (payload as { Response?: unknown[] } | null)?.Response;
+  if (!Array.isArray(entries)) return undefined;
+
+  for (const entry of entries) {
+    const found = (entry as Record<string, unknown>)?.[wrapper];
+    if (found && typeof found === 'object') return found as Record<string, unknown>;
+  }
+
+  return undefined;
+}
+
+async function call(
+  url: string,
+  body: unknown,
+  headers: Record<string, string>,
+  fetcher: typeof globalThis.fetch,
+): Promise<unknown> {
+  const payload = JSON.stringify(body);
+  const response = await fetcher(url, {
+    method: 'POST',
+    headers: { ...headers, 'content-type': 'application/json' },
+    body: payload,
+  });
+  const text = await response.text();
+
+  if (!response.ok) {
+    // bunq's errors are readable and specific — a wrong key, an IP that is not
+    // permitted, a session created too soon. Passing the text through is what
+    // makes the difference visible; swallowing it leaves "connect failed".
+    throw new Error(`bunq ${new URL(url).pathname} answered ${response.status}: ${text}`);
+  }
+
+  return JSON.parse(text);
+}
+
+/**
+ * Step one: hand bunq the public key. The only call needing no authentication
+ * and no signature, because bunq has nothing to check one against yet.
+ */
+export async function createInstallation(
+  host: string,
+  publicKey: string,
+  fetcher: typeof globalThis.fetch,
+): Promise<Installation> {
+  const payload = await call(
+    `${host}/installation`,
+    { client_public_key: publicKey },
+    baseHeaders(),
+    fetcher,
+  );
+
+  const token = pick(payload, 'Token')?.['token'];
+  const serverPublicKey = pick(payload, 'ServerPublicKey')?.['server_public_key'];
+
+  if (typeof token !== 'string' || typeof serverPublicKey !== 'string') {
+    throw new Error('bunq /installation returned no token or no server public key.');
+  }
+
+  return { token, serverPublicKey };
+}
+
+/**
+ * Step two: register the key against the addresses it may be used from.
+ *
+ * `permitted_ips` is deliberately not passed. bunq refuses the wildcard `*` over
+ * the API — it can only be set in the app — and any list written here would be
+ * this machine's address at connect time, which is wrong the moment the
+ * endpoint is deployed or the operator's ISP renumbers. Omitting it lets bunq
+ * default to the calling address, and the setup doc says plainly that a
+ * deployment needs a key marked wildcard in the app.
+ *
+ * Idempotent in practice: re-registering an existing device answers 200.
+ */
+export async function registerDevice(
+  host: string,
+  installationToken: string,
+  apiKey: string,
+  description: string,
+  privateKey: string,
+  fetcher: typeof globalThis.fetch,
+): Promise<void> {
+  const body = { secret: apiKey, description };
+
+  await call(
+    `${host}/device-server`,
+    body,
+    {
+      ...baseHeaders(),
+      'x-bunq-client-authentication': installationToken,
+      'x-bunq-client-signature': signBody(JSON.stringify(body), privateKey),
+    },
+    fetcher,
+  );
+}
+
+/**
+ * Step three, and the only one that runs again later.
+ *
+ * A session lasts as long as the account's auto-logout setting — a week by
+ * default — and `/session-server` is rate-limited to **one call per thirty
+ * seconds**. That limit is the reason the token is persisted in shared state
+ * rather than held per instance: a deployed endpoint that opened a session per
+ * cold start would spend most of its life being refused.
+ */
+export async function createSession(
+  host: string,
+  installationToken: string,
+  apiKey: string,
+  privateKey: string,
+  fetcher: typeof globalThis.fetch,
+): Promise<string> {
+  const body = { secret: apiKey };
+
+  const payload = await call(
+    `${host}/session-server`,
+    body,
+    {
+      ...baseHeaders(),
+      'x-bunq-client-authentication': installationToken,
+      'x-bunq-client-signature': signBody(JSON.stringify(body), privateKey),
+    },
+    fetcher,
+  );
+
+  const token = pick(payload, 'Token')?.['token'];
+  if (typeof token !== 'string') throw new Error('bunq /session-server returned no token.');
+
+  return token;
+}

--- a/src/providers/bunq/strategy/index.ts
+++ b/src/providers/bunq/strategy/index.ts
@@ -1,0 +1,298 @@
+import type { AuthStrategy, AuthStrategyContext } from '#connectivity';
+import { createInstallation, createSession, hostFor, registerDevice, baseHeaders } from './handshake.ts';
+import { generateKeypair, signBody, verifyBody } from './keys.ts';
+
+/**
+ * bunq, whose authentication is a protocol rather than a header.
+ *
+ * The one strategy, and the case ADR-008 was written around. Everything else
+ * about this provider is declared — the connector, the vendored operations, the
+ * redaction — and this file only ever sees a request on its way out and a
+ * response on its way back. It contains no endpoint knowledge and must not gain
+ * any.
+ *
+ * Three durable things come out of `setup` and live in the credential store:
+ * the private key, the installation token, and bunq's own public key. One
+ * ephemeral thing comes out of every session and lives in `state`: the session
+ * token. The split is forced rather than chosen — `AuthStrategyContext.write`
+ * is absent outside setup, and `rotatableCredentialRefs` grants a deployed
+ * revision write on nothing for a non-OAuth provider, so a session token
+ * physically cannot go in the credential store. `state` is the right home
+ * anyway: it is documented for exactly this, and everything in it is
+ * reconstructible from the API key.
+ */
+
+/** Where the whole credential lives. Derived per connection: `bunq/<id>`. */
+interface Stored {
+  readonly api_key: string;
+  readonly private_key: string;
+  readonly installation_token: string;
+  readonly server_public_key: string;
+}
+
+const SESSION_KEY = 'bunq:session';
+
+/**
+ * When to open a new session before bunq closes the old one.
+ *
+ * bunq expires a session after the account's auto-logout setting, a week by
+ * default, and there is no endpoint that reports what that setting is. Six days
+ * is under the default with room to spare; an operator who shortened theirs is
+ * covered by the other half — `verify` clears the session on a 401, so the call
+ * after a surprise expiry succeeds. Costing one failed call is the honest
+ * trade against guessing a number we cannot read.
+ */
+const SESSION_MAX_AGE_MS = 6 * 24 * 60 * 60 * 1000;
+
+interface Session {
+  readonly token: string;
+  readonly createdAt: number;
+}
+
+/**
+ * One cache and one in-flight map, per process.
+ *
+ * The cache spares a state read per request. The in-flight map is the one that
+ * matters: `/session-server` allows **one call per thirty seconds**, so two
+ * concurrent requests both finding no session would make the second fail. They
+ * wait on the first instead.
+ *
+ * Keyed by **profile** as well as provider and connection, and that is not
+ * belt-and-braces. One endpoint process opens a `Runtime` per profile in the
+ * workspace, so `bunq.main` names two different bank accounts as soon as two
+ * profiles each connect bunq without renaming the connection. `state` and
+ * `credentials` are already scoped per profile; a process-wide cache in front
+ * of them is the one place that scoping could be lost, and losing it would send
+ * one profile's session token — signed with the other's key — to a bank.
+ */
+const cached = new Map<string, Session>();
+const opening = new Map<string, Promise<string>>();
+
+/** Unique across everything that could hold a different bunq session. */
+const cacheKey = (context: AuthStrategyContext): string =>
+  `${context.profile}.${context.manifest.id}.${context.connectionId}`;
+
+function parse(raw: string | null, connectionId: string): Stored {
+  if (!raw) {
+    throw new Error(
+      `No bunq credential stored for connection "${connectionId}". Run: lanes link connect bunq`,
+    );
+  }
+
+  let value: unknown;
+  try {
+    value = JSON.parse(raw);
+  } catch {
+    // The API key as pasted, before `setup` has replaced it with the whole
+    // context. A connection in this state has not completed the handshake.
+    throw new Error(
+      `The bunq connection "${connectionId}" holds an API key but no installation. Run: lanes link connect bunq --replace`,
+    );
+  }
+
+  const stored = value as Partial<Stored>;
+  if (!stored.api_key || !stored.private_key || !stored.installation_token) {
+    throw new Error(`The bunq credential for "${connectionId}" is incomplete. Run: lanes link connect bunq --replace`);
+  }
+
+  return stored as Stored;
+}
+
+/**
+ * The API key, whether the ref holds one or a whole installed context.
+ *
+ * Re-running `connect` on an installed connection is the ordinary way to
+ * recover from a rotated key or a revoked device, so it has to be the same
+ * conversation as the first run rather than a different failure.
+ */
+function apiKeyFrom(raw: string): string {
+  if (!raw.startsWith('{')) return raw;
+
+  try {
+    const parsed = JSON.parse(raw) as Partial<Stored>;
+    if (typeof parsed.api_key === 'string' && parsed.api_key.length > 0) return parsed.api_key;
+  } catch {
+    // Not JSON after all — a key that happens to start with a brace.
+  }
+
+  return raw;
+}
+
+async function sessionToken(
+  context: AuthStrategyContext,
+  stored: Stored,
+  fetcher: typeof globalThis.fetch,
+): Promise<string> {
+  const key = cacheKey(context);
+  const fresh = (session: Session | null): boolean =>
+    session !== null && Date.now() - session.createdAt < SESSION_MAX_AGE_MS;
+
+  const memo = cached.get(key) ?? null;
+  if (fresh(memo)) return memo!.token;
+
+  const persisted = await context.state.getJson<Session>(SESSION_KEY);
+  if (fresh(persisted)) {
+    cached.set(key, persisted!);
+    return persisted!.token;
+  }
+
+  const already = opening.get(key);
+  if (already) return already;
+
+  const attempt = (async () => {
+    context.log.debug('opening a bunq session');
+    const token = await createSession(
+      hostFor(context.manifest),
+      stored.installation_token,
+      stored.api_key,
+      stored.private_key,
+      fetcher,
+    );
+    const session: Session = { token, createdAt: Date.now() };
+    cached.set(key, session);
+    await context.state.setJson(SESSION_KEY, session);
+    return token;
+  })().finally(() => opening.delete(key));
+
+  opening.set(key, attempt);
+  return attempt;
+}
+
+export function createBunqStrategy(fetcher: typeof globalThis.fetch = globalThis.fetch): AuthStrategy {
+  return {
+    id: 'bunq',
+
+    /**
+     * Installation and device registration, run once at connect time.
+     *
+     * Ends by rewriting the credential the operator pasted: it arrives as a
+     * bare API key and leaves as the whole context. That keeps everything
+     * durable behind the single ref a connection is allowed to read, rather
+     * than inventing three more the allowlist would refuse.
+     *
+     * Deliberately stops short of opening a session, though it easily could and
+     * an earlier draft did. Two reasons, both about *when* this runs. `connect`
+     * performs the handshake under a provisional connection id and renames the
+     * connection afterwards — the credential moves with it, but state does not,
+     * so a session opened here would be stranded under `bunq.pending`. And
+     * `/session-server` allows one call per thirty seconds, so a stranded
+     * session is not merely wasted: it is thirty seconds during which the first
+     * real call is refused. The key is already proven by `device-server`, which
+     * is the step that rejects a wrong one.
+     */
+    async setup(context) {
+      const write = context.write;
+      if (!write) throw new Error('The bunq strategy can only be set up where credentials are writable.');
+
+      const ref = `${context.manifest.id}/${context.connectionId}`;
+      const held = (await context.credentials.get(ref))?.trim();
+      if (!held) throw new Error(`No bunq API key was stored at ${ref}.`);
+
+      // What is at the ref depends on whether this connection has been set up
+      // before. First time it is the key the operator pasted; on a re-connect
+      // it is the whole context this function wrote last time. Reading it as a
+      // key either way would send a JSON blob to `/device-server` as `secret`,
+      // and bunq would reject it with a wrong-key error naming nothing the
+      // operator did.
+      const apiKey = apiKeyFrom(held);
+
+      const host = hostFor(context.manifest);
+      const keys = generateKeypair();
+
+      const installation = await createInstallation(host, keys.publicKey, fetcher);
+      await registerDevice(
+        host,
+        installation.token,
+        apiKey,
+        String(context.options['description'] ?? 'Lanes Link'),
+        keys.privateKey,
+        fetcher,
+      );
+
+      const installed: Stored = {
+        api_key: apiKey,
+        private_key: keys.privateKey,
+        installation_token: installation.token,
+        server_public_key: installation.serverPublicKey,
+      };
+      await write(ref, JSON.stringify(installed));
+    },
+
+    async authorize(request, context) {
+      const stored = parse(
+        await context.credentials.get(`${context.manifest.id}/${context.connectionId}`),
+        context.connectionId,
+      );
+
+      const token = await sessionToken(context, stored, fetcher);
+      const body = request.method === 'GET' || request.method === 'HEAD' ? '' : await request.clone().text();
+
+      // The URL is left exactly as the transport built it. It comes from the
+      // manifest's `base_url`, which is also where the handshake got its host,
+      // so there is nothing here that could put the two on different bunqs.
+      const authorised = new Request(request.url, {
+        method: request.method,
+        headers: new Headers(request.headers),
+        ...(body === '' ? {} : { body }),
+        signal: request.signal,
+      });
+
+      for (const [key, value] of Object.entries(baseHeaders())) {
+        // Never overwrite what the transport set from the operation itself.
+        if (!authorised.headers.has(key)) authorised.headers.set(key, value);
+      }
+      authorised.headers.set('x-bunq-client-authentication', token);
+      authorised.headers.set('x-bunq-client-signature', signBody(body, stored.private_key));
+
+      return authorised;
+    },
+
+    /**
+     * Two jobs, and the second is why this hook is wired at all.
+     *
+     * A 401 means the session went away earlier than the age check expected —
+     * an operator with a short auto-logout, or a session ended from the app.
+     * Dropping the cached token here is what makes the *next* call work without
+     * anyone intervening.
+     *
+     * The first job is the one bunq documents: the reply carries a signature
+     * over its body, and checking it against the key installation returned is
+     * how we know the answer came from bunq. A failure is logged rather than
+     * thrown — the response has already been received, the check is documented
+     * as optional, and turning a delivered answer into an exception would make
+     * a payment that *did* happen look like one that did not.
+     */
+    async verify(response, context) {
+      const key = cacheKey(context);
+
+      if (response.status === 401) {
+        cached.delete(key);
+        await context.state.delete(SESSION_KEY);
+        context.log.warn('bunq rejected the session; the next call will open a new one');
+        return;
+      }
+
+      // bunq signs its replies but does not promise to sign every one, and the
+      // documentation calls checking them optional. An absent header is
+      // therefore not a failure; a present one that does not verify is.
+      const signature = response.headers.get('x-bunq-server-signature');
+      if (!signature) return;
+
+      const raw = await context.credentials.get(`${context.manifest.id}/${context.connectionId}`);
+      let publicKey: string | undefined;
+      try {
+        publicKey = raw ? (JSON.parse(raw) as Partial<Stored>).server_public_key : undefined;
+      } catch {
+        // A connection still holding the bare pasted key. `authorize` has
+        // already refused it with a message that says what to do, and repeating
+        // that here would replace it with a parse error.
+        return;
+      }
+      if (!publicKey) return;
+
+      if (!verifyBody(await response.text(), signature, publicKey)) {
+        context.log.error('a bunq response failed signature verification');
+      }
+    },
+  };
+}

--- a/src/providers/bunq/strategy/keys.test.ts
+++ b/src/providers/bunq/strategy/keys.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, test } from 'bun:test';
+import { generateKeypair, signBody, verifyBody } from './keys.ts';
+
+const keys = generateKeypair();
+
+describe('generateKeypair', () => {
+  test('produces the PEM shapes bunq and node each expect', () => {
+    expect(keys.publicKey).toStartWith('-----BEGIN PUBLIC KEY-----');
+    expect(keys.privateKey).toStartWith('-----BEGIN PRIVATE KEY-----');
+  });
+
+  test('is a fresh pair each time, so one connection cannot sign for another', () => {
+    expect(generateKeypair().privateKey).not.toBe(keys.privateKey);
+  });
+});
+
+describe('signBody', () => {
+  test('round-trips against the public half', () => {
+    const body = JSON.stringify({ amount: { value: '10.00', currency: 'EUR' } });
+
+    expect(verifyBody(body, signBody(body, keys.privateKey), keys.publicKey)).toBe(true);
+  });
+
+  test('a changed body no longer verifies — the point of signing it', () => {
+    const signature = signBody('{"value":"10.00"}', keys.privateKey);
+
+    expect(verifyBody('{"value":"1000.00"}', signature, keys.publicKey)).toBe(false);
+  });
+
+  test('an empty body signs and verifies, which is what a GET sends', () => {
+    expect(verifyBody('', signBody('', keys.privateKey), keys.publicKey)).toBe(true);
+  });
+
+  test('another keypair cannot produce an accepted signature', () => {
+    const other = generateKeypair();
+
+    expect(verifyBody('body', signBody('body', other.privateKey), keys.publicKey)).toBe(false);
+  });
+
+  test('the signature is base64, which is what the header carries', () => {
+    expect(signBody('body', keys.privateKey)).toMatch(/^[A-Za-z0-9+/]+=*$/);
+  });
+});
+
+describe('verifyBody', () => {
+  test('a malformed signature is a refusal rather than a throw', () => {
+    expect(verifyBody('body', 'not base64 at all !!', keys.publicKey)).toBe(false);
+  });
+
+  test('a malformed key is a refusal rather than a throw', () => {
+    expect(verifyBody('body', signBody('body', keys.privateKey), 'not a key')).toBe(false);
+  });
+});

--- a/src/providers/bunq/strategy/keys.ts
+++ b/src/providers/bunq/strategy/keys.ts
@@ -1,0 +1,72 @@
+import { createSign, createVerify, generateKeyPairSync } from 'node:crypto';
+
+/**
+ * The signing half of bunq's authentication.
+ *
+ * bunq is asymmetric where most APIs are not: the client generates a keypair,
+ * hands bunq the public half once during installation, and thereafter proves
+ * each request by signing it. Nothing here knows what a payment is or which
+ * endpoint it is going to — that is the boundary ADR-008 draws around a
+ * strategy, and this file is the part of it that is pure arithmetic.
+ *
+ * **Only the body is signed.** bunq used to require a signature over the whole
+ * request — method, path, headers, body — and stopped validating those on 28
+ * April 2020. Signing the old way now produces a signature bunq rejects, so
+ * getting this wrong fails closed rather than silently: `Sign only the request
+ * body (no headers, no URLs)`.
+ */
+
+export interface Keypair {
+  /** PKCS#8 PEM. Stored, never sent. */
+  readonly privateKey: string;
+  /** SPKI PEM. This is what `POST /installation` hands over. */
+  readonly publicKey: string;
+}
+
+/**
+ * RSA 2048, which is what bunq's installation endpoint accepts.
+ *
+ * Generated once per connection at connect time and then persisted, because
+ * the public half is registered upstream — a new keypair would mean a new
+ * installation, and the old one would keep existing on bunq's side.
+ */
+export function generateKeypair(): Keypair {
+  const { privateKey, publicKey } = generateKeyPairSync('rsa', {
+    modulusLength: 2048,
+    publicKeyEncoding: { type: 'spki', format: 'pem' },
+    privateKeyEncoding: { type: 'pkcs8', format: 'pem' },
+  });
+
+  return { privateKey, publicKey };
+}
+
+/**
+ * SHA-256 with RSA PKCS#1 v1.5, base64 — the value of `X-Bunq-Client-Signature`.
+ *
+ * A GET carries no body and signs the empty string, which is a signature bunq
+ * accepts and not a reason to omit the header.
+ */
+export function signBody(body: string, privateKey: string): string {
+  return createSign('RSA-SHA256').update(body, 'utf8').sign(privateKey, 'base64');
+}
+
+/**
+ * Check `X-Bunq-Server-Signature` against the key installation returned.
+ *
+ * bunq documents this as optional and it is implemented anyway: a strategy that
+ * moves money is exactly where the reply being genuinely bunq's is worth
+ * establishing, and the seam already carries a `verify` hook for it.
+ *
+ * Returns a boolean rather than throwing so the caller decides what a mismatch
+ * means — which differs between a response that omitted the header entirely and
+ * one that carried a wrong signature.
+ */
+export function verifyBody(body: string, signature: string, publicKey: string): boolean {
+  try {
+    return createVerify('RSA-SHA256').update(body, 'utf8').verify(publicKey, signature, 'base64');
+  } catch {
+    // A malformed key or a signature that is not base64. Indistinguishable from
+    // a wrong signature as far as the caller is concerned, and both are refusals.
+    return false;
+  }
+}

--- a/src/providers/bunq/strategy/strategy.test.ts
+++ b/src/providers/bunq/strategy/strategy.test.ts
@@ -1,0 +1,417 @@
+import { describe, expect, test } from 'bun:test';
+import type { AuthStrategyContext, ProviderManifest } from '#connectivity';
+import { createBunqStrategy } from './index.ts';
+import { PRODUCTION, SANDBOX } from './handshake.ts';
+import { generateKeypair, signBody } from './keys.ts';
+
+/**
+ * The strategy against a bunq that is not there.
+ *
+ * Everything worth pinning here is a sequence rather than a value: that setup
+ * performs three calls and not two, that a second request does not open a
+ * second session, that two concurrent ones do not either, and that a 401 leaves
+ * the connection able to recover on its own. Those are the failures that would
+ * otherwise be found against a real bank.
+ */
+
+let counter = 0;
+/** A fresh connection per test: the session cache is per process and keyed by it. */
+const nextConnection = () => `c${++counter}`;
+
+const manifestFor = (baseUrl: string) =>
+  ({
+    id: 'bunq',
+    connector: { kind: 'http', base_url: baseUrl },
+    auth: { kind: 'strategy', strategy: 'bunq' },
+  }) as unknown as ProviderManifest;
+
+const manifest = manifestFor(PRODUCTION);
+
+interface Bench {
+  readonly context: AuthStrategyContext;
+  readonly calls: Array<{ url: string; path: string; headers: Headers; body: string }>;
+  readonly secrets: Map<string, string>;
+  readonly state: Map<string, string>;
+  /** Status the next non-handshake call answers with. */
+  status: number;
+}
+
+function bench(
+  baseUrl: string = PRODUCTION,
+  seed: 'raw-key' | 'installed' | 'none' = 'installed',
+  connectionId = nextConnection(),
+  profile = 'personal',
+): Bench {
+  const calls: Bench['calls'] = [];
+  const secrets = new Map<string, string>();
+  const state = new Map<string, string>();
+  const ref = `bunq/${connectionId}`;
+
+  const keys = generateKeypair();
+  if (seed === 'raw-key') secrets.set(ref, 'api-key-from-the-app');
+  if (seed === 'installed') {
+    secrets.set(
+      ref,
+      JSON.stringify({
+        api_key: 'api-key-from-the-app',
+        private_key: keys.privateKey,
+        installation_token: 'installation-token',
+        server_public_key: keys.publicKey,
+      }),
+    );
+  }
+
+  const self: Bench = {
+    calls,
+    secrets,
+    state,
+    status: 200,
+    context: {
+      manifest: manifestFor(baseUrl),
+      connectionId,
+      profile,
+      credentials: {
+        async get(reference: string) {
+          return secrets.get(reference) ?? null;
+        },
+        async has(reference: string) {
+          return secrets.has(reference);
+        },
+      },
+      write: async (reference: string, value: string) => {
+        secrets.set(reference, value);
+      },
+      state: {
+        async get(key: string) {
+          return state.get(key) ?? null;
+        },
+        async set(key: string, value: string) {
+          state.set(key, value);
+        },
+        async delete(key: string) {
+          state.delete(key);
+        },
+        async keys() {
+          return [...state.keys()];
+        },
+        async getJson<T>(key: string) {
+          const raw = state.get(key);
+          return raw ? (JSON.parse(raw) as T) : null;
+        },
+        async setJson(key: string, value: unknown) {
+          state.set(key, JSON.stringify(value));
+        },
+      },
+      log: { debug() {}, info() {}, warn() {}, error() {} },
+      options: {},
+    } as unknown as AuthStrategyContext,
+  };
+
+  return self;
+}
+
+function stub(target: Bench): typeof globalThis.fetch {
+  return (async (input: string | Request, init?: RequestInit) => {
+    const url = typeof input === 'string' ? input : input.url;
+    const path = new URL(url).pathname;
+    target.calls.push({
+      url,
+      path,
+      headers: new Headers(init?.headers ?? {}),
+      body: String(init?.body ?? ''),
+    });
+
+    if (path.endsWith('/installation')) {
+      return Response.json({
+        Response: [
+          { Id: { id: 1 } },
+          { Token: { token: 'installation-token' } },
+          { ServerPublicKey: { server_public_key: 'server-public-key' } },
+        ],
+      });
+    }
+    if (path.endsWith('/device-server')) return Response.json({ Response: [{ Id: { id: 2 } }] });
+    if (path.endsWith('/session-server')) {
+      return Response.json({
+        Response: [
+          { Id: { id: 3 } },
+          // Stamped with the profile, so a token that crossed a profile
+          // boundary is visible rather than coincidentally equal.
+          { Token: { token: `session-${target.context.profile}-${target.calls.length}` } },
+        ],
+      });
+    }
+
+    return Response.json({ Response: [] }, { status: target.status });
+  }) as unknown as typeof globalThis.fetch;
+}
+
+const payment = (host: string = PRODUCTION) =>
+  new Request(`${host}/user/1/monetary-account/2/payment`, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ amount: { value: '10.00', currency: 'EUR' } }),
+  });
+
+describe('setup', () => {
+  test('installs and registers the device, and stops there', async () => {
+    // No session. `connect` runs this under a provisional connection id and
+    // renames afterwards, so a session opened here would be stranded under the
+    // old id — and `/session-server` allows one call per thirty seconds, which
+    // makes a stranded session a refused first call rather than a wasted one.
+    const target = bench(PRODUCTION, 'raw-key');
+    await createBunqStrategy(stub(target)).setup!(target.context);
+
+    expect(target.calls.map((c) => c.path)).toEqual(['/v1/installation', '/v1/device-server']);
+  });
+
+  test('replaces the pasted key with the whole context, under the one ref a connection may read', async () => {
+    const target = bench(PRODUCTION, 'raw-key');
+    await createBunqStrategy(stub(target)).setup!(target.context);
+
+    const stored = JSON.parse(target.secrets.get(`bunq/${target.context.connectionId}`)!);
+    expect(Object.keys(stored).sort()).toEqual([
+      'api_key',
+      'installation_token',
+      'private_key',
+      'server_public_key',
+    ]);
+    expect(stored.api_key).toBe('api-key-from-the-app');
+    expect(stored.private_key).toStartWith('-----BEGIN PRIVATE KEY-----');
+  });
+
+  test('sends the public key to installation and never the private one', async () => {
+    const target = bench(PRODUCTION, 'raw-key');
+    await createBunqStrategy(stub(target)).setup!(target.context);
+
+    const sent = JSON.stringify(target.calls);
+    expect(JSON.parse(target.calls[0]!.body).client_public_key).toStartWith('-----BEGIN PUBLIC KEY-----');
+    expect(sent).not.toContain('BEGIN PRIVATE KEY');
+  });
+
+  test('signs device-server and session-server, but not installation', async () => {
+    const target = bench(PRODUCTION, 'raw-key');
+    await createBunqStrategy(stub(target)).setup!(target.context);
+
+    // Installation cannot be signed: bunq has no key to check it against yet.
+    expect(target.calls[0]!.headers.get('x-bunq-client-signature')).toBeNull();
+    expect(target.calls[1]!.headers.get('x-bunq-client-signature')).not.toBeNull();
+  });
+
+  test('refuses where credentials are not writable, rather than half-installing', async () => {
+    const target = bench(PRODUCTION, 'raw-key');
+    const context = { ...target.context, write: undefined } as unknown as AuthStrategyContext;
+
+    expect(createBunqStrategy(stub(target)).setup!(context)).rejects.toThrow(/can only be set up/);
+  });
+
+  test('re-running on an installed connection reuses the key rather than sending the blob', async () => {
+    // The recovery path for a rotated key or a revoked device. The ref already
+    // holds the whole context this function wrote last time; reading it as a
+    // key would post a JSON blob to /device-server as `secret`.
+    const target = bench(PRODUCTION, 'installed');
+    await createBunqStrategy(stub(target)).setup!(target.context);
+
+    const device = target.calls.find((c) => c.path.endsWith('/device-server'))!;
+    expect(JSON.parse(device.body).secret).toBe('api-key-from-the-app');
+  });
+
+  test('a bunq error is passed through with its body, not flattened', async () => {
+    const target = bench(PRODUCTION, 'raw-key');
+    const failing = (async () =>
+      new Response('{"Error":[{"error_description":"Insufficient authorisation"}]}', {
+        status: 403,
+      })) as unknown as typeof globalThis.fetch;
+
+    expect(createBunqStrategy(failing).setup!(target.context)).rejects.toThrow(
+      /answered 403.*Insufficient authorisation/s,
+    );
+  });
+});
+
+describe('authorize', () => {
+  test('signs the body and carries the session, verifiably', async () => {
+    const target = bench(PRODUCTION);
+    const request = await createBunqStrategy(stub(target)).authorize(payment(), target.context);
+    const body = await request.clone().text();
+
+    const stored = JSON.parse(target.secrets.get(`bunq/${target.context.connectionId}`)!);
+    expect(request.headers.get('x-bunq-client-signature')).toBe(signBody(body, stored.private_key));
+    expect(request.headers.get('x-bunq-client-authentication')).toStartWith('session-');
+  });
+
+  test('the body survives the rewrite — a signature over a lost body is worthless', async () => {
+    const target = bench(PRODUCTION);
+    const request = await createBunqStrategy(stub(target)).authorize(payment(), target.context);
+
+    expect(JSON.parse(await request.text())).toEqual({
+      amount: { value: '10.00', currency: 'EUR' },
+    });
+  });
+
+  test('a GET signs the empty string and still sends the header', async () => {
+    const target = bench(PRODUCTION);
+    const get = new Request('https://api.bunq.com/v1/user');
+    const request = await createBunqStrategy(stub(target)).authorize(get, target.context);
+
+    const stored = JSON.parse(target.secrets.get(`bunq/${target.context.connectionId}`)!);
+    expect(request.headers.get('x-bunq-client-signature')).toBe(signBody('', stored.private_key));
+  });
+
+  test('gives every request its own request id, so a retry is not de-duplicated as the original', async () => {
+    const target = bench(PRODUCTION);
+    const strategy = createBunqStrategy(stub(target));
+    const first = await strategy.authorize(payment(), target.context);
+    const second = await strategy.authorize(payment(), target.context);
+
+    expect(first.headers.get('x-bunq-client-request-id')).not.toBe(
+      second.headers.get('x-bunq-client-request-id'),
+    );
+  });
+
+  test('opens one session and reuses it', async () => {
+    const target = bench(PRODUCTION);
+    const strategy = createBunqStrategy(stub(target));
+    await strategy.authorize(payment(), target.context);
+    await strategy.authorize(payment(), target.context);
+
+    expect(target.calls.filter((c) => c.path.endsWith('/session-server'))).toHaveLength(1);
+  });
+
+  test('two concurrent first calls still open only one session', async () => {
+    // `/session-server` allows one call per thirty seconds, so the second of a
+    // simultaneous pair would be refused outright.
+    const target = bench(PRODUCTION);
+    const strategy = createBunqStrategy(stub(target));
+    await Promise.all([
+      strategy.authorize(payment(), target.context),
+      strategy.authorize(payment(), target.context),
+    ]);
+
+    expect(target.calls.filter((c) => c.path.endsWith('/session-server'))).toHaveLength(1);
+  });
+
+  test('reuses a session another instance persisted, rather than opening its own', async () => {
+    const target = bench(PRODUCTION);
+    target.state.set(
+      'bunq:session',
+      JSON.stringify({ token: 'from-another-instance', createdAt: Date.now() }),
+    );
+
+    const request = await createBunqStrategy(stub(target)).authorize(payment(), target.context);
+
+    expect(request.headers.get('x-bunq-client-authentication')).toBe('from-another-instance');
+    expect(target.calls).toHaveLength(0);
+  });
+
+  test('an expired session is replaced', async () => {
+    const target = bench(PRODUCTION);
+    target.state.set(
+      'bunq:session',
+      JSON.stringify({ token: 'stale', createdAt: Date.now() - 7 * 24 * 60 * 60 * 1000 }),
+    );
+
+    const request = await createBunqStrategy(stub(target)).authorize(payment(), target.context);
+
+    expect(request.headers.get('x-bunq-client-authentication')).not.toBe('stale');
+  });
+
+  test('a sandbox manifest handshakes and pays against the sandbox', async () => {
+    // Both halves from one source. When this was a `sandbox` flag beside
+    // `base_url` the two could disagree, and the failure was silent: a session
+    // opened against one bunq and spent against the other authenticates
+    // cleanly and then answers about an account that does not exist.
+    const target = bench(SANDBOX);
+    const request = await createBunqStrategy(stub(target)).authorize(payment(SANDBOX), target.context);
+
+    expect(request.url).toStartWith(new URL(SANDBOX).origin);
+    expect(target.calls[0]!.url).toBe(`${SANDBOX}/session-server`);
+  });
+
+  test('a production manifest stays on production', async () => {
+    const target = bench(PRODUCTION);
+    const request = await createBunqStrategy(stub(target)).authorize(payment(), target.context);
+
+    expect(request.url).toStartWith(new URL(PRODUCTION).origin);
+    expect(target.calls[0]!.url).toBe(`${PRODUCTION}/session-server`);
+  });
+
+  test('a connection holding only the pasted key says so, rather than failing upstream', async () => {
+    const target = bench(PRODUCTION, 'raw-key');
+
+    expect(
+      createBunqStrategy(stub(target)).authorize(payment(), target.context),
+    ).rejects.toThrow(/holds an API key but no installation/);
+  });
+
+  test('a connection with nothing stored names the command that fixes it', async () => {
+    const target = bench(PRODUCTION, 'none');
+
+    expect(createBunqStrategy(stub(target)).authorize(payment(), target.context)).rejects.toThrow(
+      /lanes link connect bunq/,
+    );
+  });
+});
+
+describe('two profiles in one process', () => {
+  test('do not share a session, even with a connection of the same name', async () => {
+    // One endpoint opens a Runtime per profile in the same process. Before the
+    // cache key carried the profile, `bunq.main` named both of these — so the
+    // second profile would send the first's session token, signed with its own
+    // key, to a bank.
+    const personal = bench(PRODUCTION, 'installed', 'main', 'personal');
+    const work = bench(PRODUCTION, 'installed', 'main', 'work');
+
+    const a = await createBunqStrategy(stub(personal)).authorize(payment(), personal.context);
+    const b = await createBunqStrategy(stub(work)).authorize(payment(), work.context);
+
+    expect(a.headers.get('x-bunq-client-authentication')).not.toBe(
+      b.headers.get('x-bunq-client-authentication'),
+    );
+    expect(work.calls.filter((c) => c.path.endsWith('/session-server'))).toHaveLength(1);
+  });
+});
+
+describe('verify', () => {
+  test('a 401 drops the session, so the next call opens a new one', async () => {
+    const target = bench(PRODUCTION);
+    const strategy = createBunqStrategy(stub(target));
+
+    const first = await strategy.authorize(payment(), target.context);
+    await strategy.verify!(new Response(null, { status: 401 }), target.context);
+    const second = await strategy.authorize(payment(), target.context);
+
+    expect(target.state.has('bunq:session')).toBe(true); // rewritten, not merely cleared
+    expect(second.headers.get('x-bunq-client-authentication')).not.toBe(
+      first.headers.get('x-bunq-client-authentication'),
+    );
+    expect(target.calls.filter((c) => c.path.endsWith('/session-server'))).toHaveLength(2);
+  });
+
+  test('an ordinary response with no signature is left alone', async () => {
+    const target = bench(PRODUCTION);
+    const strategy = createBunqStrategy(stub(target));
+    await strategy.authorize(payment(), target.context);
+
+    expect(strategy.verify!(new Response('{}', { status: 200 }), target.context)).resolves.toBeUndefined();
+  });
+
+  test('a bad signature is logged, not thrown — the answer has already arrived', async () => {
+    const target = bench(PRODUCTION);
+    const strategy = createBunqStrategy(stub(target));
+    await strategy.authorize(payment(), target.context);
+
+    const errors: string[] = [];
+    const context = {
+      ...target.context,
+      log: { debug() {}, info() {}, warn() {}, error: (m: string) => errors.push(m) },
+    } as unknown as AuthStrategyContext;
+
+    await strategy.verify!(
+      new Response('{}', { status: 200, headers: { 'x-bunq-server-signature': 'wrong' } }),
+      context,
+    );
+
+    expect(errors).toEqual(['a bunq response failed signature verification']);
+  });
+});

--- a/src/providers/custom/index.ts
+++ b/src/providers/custom/index.ts
@@ -12,10 +12,5 @@
  * connectivity type; `load.ts` reads and validates them.
  */
 
-export {
-  loadProfileProviders,
-  parseManifest,
-  parseManifestFile,
-  type LoadedManifest,
-} from './load.ts';
+export { loadProfileProviders, parseManifest, type LoadedManifest } from './load.ts';
 export { manifestTemplate } from './template.ts';

--- a/src/providers/custom/load.test.ts
+++ b/src/providers/custom/load.test.ts
@@ -3,6 +3,8 @@ import { mkdtemp, mkdir, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { layout } from '#profile';
+import { createMemoryBlobStore } from '#stores/blobs/testing.ts';
+import type { BlobStore } from '#stores/blobs';
 import { loadProfileProviders, parseManifest } from './load.ts';
 import { manifestTemplate } from './template.ts';
 
@@ -84,21 +86,30 @@ setup:
     expect(manifest.setup?.docs).toContain('acme.com/settings/api');
   });
 
+  /**
+   * A strategy names code, and a declaration-only manifest is the case
+   * `strategyFor` added the borrowing path for: a YAML file has no definition of
+   * its own, so it reaches a registered provider's strategy by name. Which is
+   * also the only way to point a connection at a vendor's sandbox, since a
+   * built-in manifest's `options` are not the operator's to edit.
+   *
+   * Whether the name resolves is not a question this schema can answer — the
+   * registry knows, and `refuseStrategy` is what says so.
+   */
   test('a pluggable auth strategy is expressible in YAML', () => {
     const manifest = parseManifest(`
-id: bunq
-name: bunq
+id: thing_sandbox
+name: Thing Sandbox
 connector:
   kind: http
-  base_url: https://public-api.sandbox.bunq.com/v1
-  openapi: ./bunq.json
+  base_url: https://public-api.sandbox.example.com/v1
+  openapi: ./thing.json
 auth:
   kind: strategy
-  strategy: bunq
-  credential_ref: bunq/api_key
+  strategy: thing
 `);
 
-    expect(manifest.auth).toMatchObject({ kind: 'strategy', strategy: 'bunq' });
+    expect(manifest.auth).toMatchObject({ kind: 'strategy', strategy: 'thing' });
   });
 });
 
@@ -215,5 +226,91 @@ describe('a relative openapi path', () => {
 describe('the starting templates are themselves valid', () => {
   test.each(['mcp', 'http', 'imap', 'dav', 'fs'] as const)('%s template parses', (kind) => {
     expect(() => parseManifest(manifestTemplate(kind))).not.toThrow();
+  });
+});
+
+/**
+ * A workspace in a bucket, which is what a deployed revision is handed.
+ *
+ * The keys are the same ones the filesystem store uses, because that is the
+ * property the fix turns on: the manifest is addressed by key either way, and
+ * only the store behind it changes.
+ */
+async function bucketWith(files: Record<string, string>): Promise<BlobStore> {
+  const store = createMemoryBlobStore();
+  for (const [name, contents] of Object.entries(files)) {
+    await store.put(`${layout.providers(PROFILE)}/${name}`, new TextEncoder().encode(contents));
+  }
+  return store;
+}
+
+describe('a workspace in a bucket', () => {
+  const manifest =
+    'id: acme\nname: Acme\nconnector: { kind: mcp, endpoint: https://mcp.example.com/mcp }\n';
+
+  /**
+   * The bug this describe block exists for.
+   *
+   * `loadProfileProviders` used `join(workspaceRoot, …)` against `node:fs`, and
+   * `join('gs://b', 'data/p/providers.d')` is `gs:/b/data/p/providers.d` — so
+   * `readdir` threw ENOENT and the catch reported an empty list, which is
+   * indistinguishable from a workspace that has no manifests. The manifest was
+   * uploaded, the read grant covered it, and it silently did not exist.
+   */
+  test('loads the manifests a deployed revision was given', async () => {
+    const store = await bucketWith({ 'acme.yaml': manifest });
+    const loaded = await loadProfileProviders('gs://your-bucket', PROFILE, store);
+
+    expect(loaded.map((entry) => entry.manifest.id)).toEqual(['acme']);
+  });
+
+  test('names the manifest by its bucket URL, so a refusal can be acted on', async () => {
+    const store = await bucketWith({ 'acme.yaml': manifest });
+    const [loaded] = await loadProfileProviders('gs://your-bucket', PROFILE, store);
+
+    expect(loaded?.path).toBe(`gs://your-bucket/${layout.providers(PROFILE)}/acme.yaml`);
+  });
+
+  test('applies the same filters as a directory does', async () => {
+    const store = await bucketWith({
+      'acme.yaml': manifest,
+      'notes.md': 'not a manifest',
+      'template.example.yaml': 'id: bad',
+    });
+
+    const loaded = await loadProfileProviders('gs://your-bucket', PROFILE, store);
+    expect(loaded.map((entry) => entry.manifest.id)).toEqual(['acme']);
+  });
+
+  test('a spec beside a manifest is not itself a manifest', async () => {
+    // A relative `openapi:` points at a sibling, and `upload.ts` carries it into
+    // the same prefix. Listing a prefix returns both; only one is a declaration.
+    const store = await bucketWith({
+      'acme.yaml':
+        'id: acme\nname: Acme\n' +
+        'connector: { kind: http, base_url: https://api.example.com, openapi: https://api.example.com/openapi.json }\n',
+    });
+    await store.put(
+      `${layout.providers(PROFILE)}/specs/acme.json`,
+      new TextEncoder().encode('{}'),
+    );
+
+    const loaded = await loadProfileProviders('gs://your-bucket', PROFILE, store);
+    expect(loaded.map((entry) => entry.manifest.id)).toEqual(['acme']);
+  });
+
+  test('refuses a relative openapi path rather than resolving it into nothing', async () => {
+    // There is no directory to resolve against, and the generator wants a file
+    // or a URL. Left to itself this surfaces as a discovery failure the runtime
+    // swallows, leaving a provider with no capabilities and nothing saying why.
+    const store = await bucketWith({
+      'acme.yaml':
+        'id: acme\nname: Acme\n' +
+        'connector: { kind: http, base_url: https://api.example.com, openapi: ./acme.json }\n',
+    });
+
+    await expect(loadProfileProviders('gs://your-bucket', PROFILE, store)).rejects.toThrow(
+      /relative path.*publish the spec at a URL/s,
+    );
   });
 });

--- a/src/providers/custom/load.ts
+++ b/src/providers/custom/load.ts
@@ -1,9 +1,9 @@
-import { readdir, readFile } from 'node:fs/promises';
 import { dirname, isAbsolute, join, resolve } from 'node:path';
 import { parse as parseYaml } from 'yaml';
 import { defineProvider, type ProviderManifest } from '#connectivity';
-import { ConfigError, layout } from '#profile';
+import { ConfigError, isRemoteWorkspace, layout, readWorkspaceFile, workspaceFiles } from '#profile';
 import { findSecrets, formatSecretFindings } from '#profile';
+import type { BlobStore } from '#stores/blobs';
 
 /**
  * Provider manifests supplied by the operator.
@@ -21,41 +21,66 @@ import { findSecrets, formatSecretFindings } from '#profile';
  * personal's to read. The path comes from `layout` for the same reason every
  * other profile-owned path does: one place that knows the on-disk shape.
  * ADR-030.
+ *
+ * **Read through the workspace's store, not through `node:fs`.** A deployed
+ * revision is handed `LANES_LINK_HOME=gs://<bucket>`, and `join` collapses that
+ * to `gs:/bucket/…` — so a `readdir` threw ENOENT and the catch below reported
+ * the same empty list it reports for a workspace that simply has no manifests.
+ * The manifest was uploaded, the read grant covered it, and nothing looked at
+ * it: a custom provider worked locally and silently did not exist once
+ * deployed. Skills were already read through a `BlobStore` for exactly this
+ * reason; manifests now are too. ADR-046.
  */
 
 export interface LoadedManifest {
   readonly manifest: ProviderManifest;
+  /** Where this came from, for a refusal to name. A path, or a bucket URL. */
   readonly path: string;
 }
 
 export async function loadProfileProviders(
   workspaceRoot: string,
   profile: string,
+  /** Injected for tests. A bucket is the case this exists to cover. */
+  store?: BlobStore,
 ): Promise<LoadedManifest[]> {
-  const directory = join(workspaceRoot, layout.providers(profile));
+  const files = store ?? workspaceFiles(workspaceRoot);
+  const directory = layout.providers(profile);
 
-  let entries: string[];
+  let keys: string[];
   try {
-    entries = await readdir(directory);
+    keys = (await files.list(`${directory}/`)).map((entry) => entry.key);
   } catch {
     return []; // No custom providers is the normal case.
   }
 
   const loaded: LoadedManifest[] = [];
 
-  for (const name of entries.sort()) {
+  for (const key of keys.sort()) {
+    const name = key.slice(directory.length + 1);
+
+    // A manifest is a file in this directory, not below it. An OpenAPI document
+    // a manifest points at may well sit in a subdirectory, and it is not one.
+    if (name.length === 0 || name.includes('/')) continue;
     if (!name.endsWith('.yaml') && !name.endsWith('.yml')) continue;
     if (name.endsWith('.example.yaml')) continue;
 
-    const path = join(directory, name);
-    loaded.push({ manifest: await parseManifestFile(path), path });
+    const text = await readWorkspaceFile(files, key);
+    if (text === null) continue; // Listed, then gone. Not worth failing over.
+
+    const where = describe(workspaceRoot, key);
+    loaded.push({
+      manifest: resolveSpecPath(parseManifest(text, where), workspaceRoot, key),
+      path: where,
+    });
   }
 
   return loaded;
 }
 
-export async function parseManifestFile(path: string): Promise<ProviderManifest> {
-  return resolveSpecPath(parseManifest(await readFile(path, 'utf8'), path), path);
+/** Where a manifest came from, in the spelling this workspace uses. */
+function describe(workspaceRoot: string, key: string): string {
+  return isRemoteWorkspace(workspaceRoot) ? `${workspaceRoot}/${key}` : join(workspaceRoot, key);
 }
 
 /**
@@ -69,15 +94,34 @@ export async function parseManifestFile(path: string): Promise<ProviderManifest>
  *
  * Resolved against the manifest's own directory, the way one file referencing
  * another normally works.
+ *
+ * A bucket-hosted workspace has no such directory to resolve against: the
+ * generator wants a filesystem path or a URL, and `gs://…/spec.json` is
+ * neither. Refused here rather than at the first call, where it arrives as a
+ * discovery failure the runtime swallows — leaving a provider with no
+ * capabilities and nothing saying why.
  */
-function resolveSpecPath(manifest: ProviderManifest, source: string): ProviderManifest {
+function resolveSpecPath(
+  manifest: ProviderManifest,
+  workspaceRoot: string,
+  key: string,
+): ProviderManifest {
   const connector = manifest.connector;
   if (connector.kind !== 'http') return manifest;
   if (/^https?:/i.test(connector.openapi) || isAbsolute(connector.openapi)) return manifest;
 
+  if (isRemoteWorkspace(workspaceRoot)) {
+    throw new ConfigError(
+      `${describe(workspaceRoot, key)}: openapi "${connector.openapi}" is a relative path, ` +
+        `but this workspace is ${workspaceRoot}. A document in a bucket cannot be opened as a ` +
+        'file — publish the spec at a URL and name that instead.',
+    );
+  }
+
+  const directory = dirname(join(workspaceRoot, key));
   return {
     ...manifest,
-    connector: { ...connector, openapi: resolve(dirname(source), connector.openapi) },
+    connector: { ...connector, openapi: resolve(directory, connector.openapi) },
   };
 }
 
@@ -111,5 +155,3 @@ export function parseManifest(text: string, source = '<manifest>'): ProviderMani
     throw new ConfigError(`${source}: ${(error as Error).message}`);
   }
 }
-
-/** A starting point, written out by `lanes link provider new`. */

--- a/src/providers/custom/template.ts
+++ b/src/providers/custom/template.ts
@@ -1,5 +1,5 @@
 /**
- * The scaffold `lanes link` writes, one per connectivity type.
+ * A hand-editable starting point, one per connectivity type.
  *
  * A custom provider is the same declaration a built-in is — this is the *only*
  * difference between `#providers/google/gmail/` and a file an operator drops in

--- a/src/providers/discord/discord.test.ts
+++ b/src/providers/discord/discord.test.ts
@@ -1,0 +1,166 @@
+import { describe, expect, test } from 'bun:test';
+import { readFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { discord } from './index.ts';
+import { DISCORD_HINTS } from './hints.ts';
+import { DISCORD_REDACT } from './redact.ts';
+
+/**
+ * What `cli/tools.test.ts` cannot say.
+ *
+ * That file already measures the generated surface against every http provider
+ * at once: legal property names, the size budgets, that each declared hint
+ * arrives, that each `redact` key names a real argument. None of it is repeated
+ * here.
+ *
+ * What is left is the part that is a *decision* rather than a measurement — the
+ * shape of the auth block, the absence of an identity probe, and above all which
+ * operations were vendored. That last one is the security boundary: `connect`
+ * writes a single `discord.*` policy rule, so the operation list is the only
+ * thing standing between an agent and Discord's moderation endpoints. A list
+ * cannot defend itself, so it is pinned here.
+ */
+
+const spec = JSON.parse(
+  await readFile(join(import.meta.dir, 'specs', 'discord.v10.json'), 'utf8'),
+) as {
+  servers: Array<{ url: string }>;
+  paths: Record<string, Record<string, { operationId?: string }>>;
+};
+
+const METHODS = ['get', 'post', 'put', 'patch', 'delete', 'head'];
+
+const vendored = Object.values(spec.paths)
+  .flatMap((item) => Object.entries(item))
+  .filter(([method]) => METHODS.includes(method))
+  .map(([, operation]) => operation.operationId!)
+  .sort();
+
+describe('the vendored operation list', () => {
+  test('is exactly these twenty, so adding one is a visible decision', () => {
+    // Deliberately spelled out rather than derived. A refresh that picks up a
+    // new operation should fail here and be read, not merge quietly — the list
+    // *is* the policy, because `discord.*` grants whatever is in it.
+    expect(vendored).toEqual([
+      'add_my_message_reaction',
+      'create_message',
+      'create_pin',
+      'create_thread_from_message',
+      'create_webhook',
+      'crosspost_message',
+      'delete_message',
+      'execute_webhook',
+      'get_active_guild_threads',
+      'get_channel',
+      'get_guild',
+      'get_message',
+      'get_my_user',
+      'list_channel_webhooks',
+      'list_guild_channels',
+      'list_message_reactions_by_emoji',
+      'list_messages',
+      'list_my_guilds',
+      'list_pins',
+      'update_message',
+    ]);
+  });
+
+  test('excludes moderation and mass deletion, which exist upstream', () => {
+    // Every id here is real in Discord's document, so this asserts a choice
+    // rather than a typo. `bulk_delete_messages` is the one to watch: it sits
+    // beside `delete_message` in the spec and would let one call clear a channel.
+    for (const refused of [
+      'bulk_delete_messages',
+      'delete_channel',
+      'ban_user_from_guild',
+      'delete_guild_member',
+      'update_guild',
+      'update_guild_member',
+      'create_guild_role',
+      'delete_webhook',
+      'deprecated_delete_pin',
+    ]) {
+      expect(vendored).not.toContain(refused);
+    }
+  });
+
+  test('every operation carries a hint and a redaction rule', () => {
+    // Discord describes 17 of its 242 operations, none of them ours, so a hint
+    // is not decoration — it is the only description an agent gets. And an
+    // operation with no `redact` entry logs nothing but type markers.
+    expect(Object.keys(DISCORD_HINTS).sort()).toEqual(vendored);
+    expect(Object.keys(DISCORD_REDACT).sort()).toEqual(vendored);
+  });
+});
+
+describe('the manifest', () => {
+  test('reaches the host the vendored spec names', () => {
+    expect(discord.connector.kind).toBe('http');
+    const base = discord.connector.kind === 'http' ? discord.connector.base_url : '';
+    expect(base).toBe(spec.servers[0]!.url);
+  });
+
+  test('sends the credential as a raw Authorization header, not as a bearer token', () => {
+    // Discord's scheme word is `Bot`, and a bearer credential is assembled as
+    // `Bearer <token>` with no way to say otherwise. `header` writes the stored
+    // value verbatim, so the scheme travels inside the value the operator pastes.
+    expect(discord.auth.kind).toBe('header');
+    expect(discord.auth.kind === 'header' ? discord.auth.header : undefined).toBe('Authorization');
+  });
+
+  test('asks for the token once, secretly, and spells out the prefix', () => {
+    // Only the first prompt's answer is stored for a non-basic credential, so a
+    // second prompt would be collected and silently dropped.
+    const prompts = discord.setup?.prompts ?? [];
+    expect(prompts.map((prompt) => prompt.key)).toEqual(['token']);
+    expect(prompts[0]?.scope).toBe('connection');
+    expect(prompts[0]?.secret).toBe(true);
+    // The whole mitigation for a footgun: a token pasted bare 401s with nothing
+    // to read, so the label is where it gets said.
+    expect(prompts[0]?.label).toContain('Bot');
+    expect(discord.setup?.troubleshooting).toContain('Bot ');
+  });
+
+  test('declares no identity, because the probe would send the wrong scheme', () => {
+    // `resolveAccount` sends `Authorization: Bearer <stored value>`, which here
+    // would be `Bearer Bot MTIz…` — a 401 and a null after a round trip, on
+    // every connect. Naming the connection falls to the operator instead.
+    expect(discord.identity).toBeUndefined();
+  });
+
+  test('tells the operator to switch the message content intent on', () => {
+    // Reads succeed without it and return empty bodies, which is the failure
+    // nothing else reports. It has to be in the walkthrough.
+    const steps = (discord.setup?.steps ?? []).join(' ');
+    expect(steps).toContain('MESSAGE CONTENT');
+    expect(discord.setup?.troubleshooting).toContain('MESSAGE CONTENT');
+  });
+});
+
+describe('redaction', () => {
+  test('never keeps a webhook token, which is a credential in a path parameter', () => {
+    // `execute_webhook` authenticates with a token in its URL. Keeping it would
+    // write a reusable channel-posting credential into the audit log in clear.
+    for (const [capability, kept] of Object.entries(DISCORD_REDACT)) {
+      expect(kept, `${capability} keeps webhook_token`).not.toContain('webhook_token');
+    }
+  });
+
+  test('withholds message bodies while keeping where the message went', () => {
+    for (const posting of ['create_message', 'update_message', 'execute_webhook']) {
+      const kept = DISCORD_REDACT[posting]!;
+      for (const content of ['content', 'embeds', 'components', 'attachments', 'poll']) {
+        expect(kept, `${posting} keeps ${content}`).not.toContain(content);
+      }
+      // Not content, and the one fact about a post that is unrecoverable once it
+      // is edited: whether it was allowed to ping the room.
+      expect(kept).toContain('allowed_mentions');
+    }
+
+    expect(DISCORD_REDACT['create_message']).toContain('channel_id');
+    expect(DISCORD_REDACT['execute_webhook']).toContain('webhook_id');
+    // A webhook post deliberately wears a name that is not the app's, so the
+    // log is illegible without it.
+    expect(DISCORD_REDACT['execute_webhook']).toContain('username');
+  });
+});

--- a/src/providers/discord/hints.ts
+++ b/src/providers/discord/hints.ts
@@ -1,0 +1,195 @@
+/**
+ * The documentation, because Discord's spec has none.
+ *
+ * Their OpenAPI document is machine-generated and carries a `summary` or
+ * `description` on 17 of its 242 operations — none of them ours. So
+ * `mcp-from-openapi` synthesises `POST /channels/{channel_id}/messages` and that
+ * is the *entire* description an agent would otherwise read. A hint is appended
+ * to it, which here means a hint is the whole of it.
+ *
+ * Every operation therefore gets one, including the ones whose names look
+ * self-explanatory. Two reasons. The names are self-explanatory to someone who
+ * already knows Discord's model, and the model has sharp edges — a channel id is
+ * not a channel name, `list_messages` pages backwards, an announcement is only
+ * publishable from one kind of channel. And `cli/tools.test.ts` looks each hint
+ * up by capability name, so a full set is also the check that all twenty tools
+ * generated: a hint keyed to a tool that silently failed to generate fails the
+ * suite, which is the one failure the size and shape tests cannot see.
+ *
+ * Prose costs 3.4 KB of a 192 KB surface budget. It is not the constraint.
+ */
+export const DISCORD_HINTS: Record<string, string> = {
+  get_my_user: [
+    'Returns the bot application this token belongs to — its id, username, and discriminator.',
+    'Costs nothing and needs no permissions, so it is the call to make first when a connection',
+    'is misbehaving: a 401 here means the stored token is wrong or is missing its `Bot ` prefix,',
+    'and everything else will fail the same way.',
+  ].join(' '),
+
+  list_my_guilds: [
+    'The servers this bot has been added to — not the servers you are a member of.',
+    'A server the bot was never invited to is invisible here and unreachable by every other',
+    'tool, so an empty list means the invite step was missed rather than that you have no servers.',
+    'Returns id, name, and your permissions in each. Start here to turn a server name into the',
+    'id every other call wants.',
+  ].join(' '),
+
+  get_guild: [
+    'One server by id: name, description, icon, owner, and feature flags.',
+    'Pass `with_counts: true` to also get approximate member and presence counts.',
+    'Use this to confirm you have the right server before posting to it.',
+  ].join(' '),
+
+  list_guild_channels: [
+    'Every channel in a server, which is how a channel *name* becomes the `channel_id`',
+    'the posting and reading tools require. Check the `type` field before posting:',
+    '0 is a normal text channel, 5 is an announcement channel (the only kind',
+    '`crosspost_message` works on), 15 is a forum, and 2 and 13 are voice and stage,',
+    'which cannot take messages. `parent_id` is the category a channel sits under.',
+  ].join(' '),
+
+  get_channel: [
+    'One channel by id — its name, type, topic, and which category it belongs to.',
+    'Worth calling before a first post to a channel an agent has not written to before,',
+    'to confirm it is the one intended and that it takes messages at all.',
+  ].join(' '),
+
+  list_messages: [
+    'Read a channel\'s recent messages. This is the triage read, and the only one:',
+    'Discord exposes no message search to bot applications, so finding something means',
+    'paging this and filtering yourself.',
+    'Newest first by default, up to `limit: 100` per call. Page *backwards* through history',
+    'with `before` set to the oldest id you have seen; page forward for new arrivals with',
+    '`after` set to the newest. `around` centres on one message.',
+    'If every `content` comes back empty, the Message Content intent is switched off for',
+    'this application — that is a toggle in the developer portal, not a permission on the',
+    'invite, and nothing else reports it.',
+  ].join(' '),
+
+  get_message: [
+    'One message by id, with its author, timestamp, attachments, reactions, and any embeds.',
+    'Use it to re-read a single message in full after `list_messages` has narrowed things down,',
+    'or to check whether an edit or a reaction landed.',
+  ].join(' '),
+
+  list_pins: [
+    'The pinned messages in a channel. Pinning is how this integration marks something as',
+    'handled or important where a human will see it, so this is the read that shows what',
+    'has been marked. Note the path is the current one — Discord also serves a deprecated',
+    'pins endpoint that is not exposed here.',
+  ].join(' '),
+
+  list_message_reactions_by_emoji: [
+    'Who reacted to a message with one specific emoji. Pass a Unicode emoji directly',
+    '(`emoji_name: "✅"`); a custom server emoji is `name:id`.',
+    'Useful for reading a lightweight vote or acknowledgement off a message rather than',
+    'asking people to reply.',
+  ].join(' '),
+
+  get_active_guild_threads: [
+    'Every thread in a server that is not archived, across all channels at once.',
+    'Cheaper than walking channels one at a time when the question is "what conversations',
+    'are open right now", which is the usual first step of a triage pass.',
+  ].join(' '),
+
+  create_message: [
+    'Post a message to a channel, as the bot application — it will carry an APP badge',
+    'and the application\'s own name and avatar. To post under your own name instead,',
+    'use `execute_webhook`.',
+    'For a plain message, pass `content` (up to 2000 characters, Discord-flavoured markdown).',
+    'For an announcement, prefer `embeds`: an embed gives you a title, a coloured left border,',
+    'a description, and up to 25 name/value `fields`, and it is what makes a post read as',
+    'deliberate rather than typed. `color` is a decimal integer, not a hex string —',
+    '0x5865F2 is 5793266.',
+    'Set `allowed_mentions` explicitly on anything that could ping a room:',
+    '`{"parse": []}` suppresses every mention even if the text contains @everyone.',
+    'Reply to something by passing `message_reference` with the message id.',
+    'Attachments are not available here — files need a multipart request, which Discord accepts',
+    'and this connector cannot encode.',
+  ].join(' '),
+
+  update_message: [
+    'Edit a message this application posted. It cannot edit anyone else\'s, including one',
+    'posted through a webhook — that needs the webhook\'s own edit endpoint.',
+    'This is the typo fix for an announcement already out. Only the fields you pass are',
+    'changed; passing `content` alone leaves existing embeds in place, and clearing an',
+    'embed means passing `embeds: []` explicitly.',
+    'Discord shows an "edited" marker afterwards, which cannot be suppressed.',
+  ].join(' '),
+
+  delete_message: [
+    'Delete a message — the retraction, for an announcement that should not have gone out.',
+    'Irreversible, and it leaves no trace in the channel for anyone who had not already read it.',
+    'The application can always delete its own messages; deleting somebody else\'s needs',
+    'Manage Messages in that channel.',
+    'There is deliberately no bulk delete here: this removes one message named by id, so',
+    'clearing a channel is not something an agent can do in one call.',
+  ].join(' '),
+
+  crosspost_message: [
+    'Publish a message that was posted in an *announcement* channel out to every server',
+    'that follows it. This is what makes an announcement channel worth using: subscribers',
+    'see the post in their own server without joining yours.',
+    'Only works on channel `type: 5`, and only on a message already posted there — so the',
+    'sequence is `create_message` then this, with the id it returned.',
+    'Rate limited far more tightly than posting, and it cannot be undone.',
+  ].join(' '),
+
+  add_my_message_reaction: [
+    'React to a message as this application. The cheapest way to mark a message as seen,',
+    'triaged, or categorised — a ✅ or 👀 costs nothing, notifies nobody, and is visible',
+    'to everyone reading the channel.',
+    'Pass a Unicode emoji directly (`emoji_name: "✅"`); a custom server emoji is `name:id`.',
+    'Remove one with the matching delete tool, which is not exposed here.',
+  ].join(' '),
+
+  create_pin: [
+    'Pin a message to its channel, where it stays visible in the channel\'s pinned list.',
+    'The heavier alternative to a reaction for marking something important: a pin is',
+    'channel-wide and appears in the header, so it is the right weight for "this is the',
+    'announcement that matters" and the wrong weight for routine triage.',
+    'Needs Manage Messages. A channel holds at most 50 pins.',
+  ].join(' '),
+
+  create_thread_from_message: [
+    'Start a thread hanging off an existing message, which is how a post becomes a',
+    'discussion without cluttering the channel. `name` is the thread title and is required.',
+    '`auto_archive_duration` is in minutes and accepts only 60, 1440, 4320, or 10080.',
+    'Use this to route a triaged message somewhere people can talk about it, rather than',
+    'replying inline where it scrolls away.',
+  ].join(' '),
+
+  list_channel_webhooks: [
+    'The webhooks already configured on a channel, with their ids and tokens.',
+    'Check here before calling `create_webhook`: a channel accumulates a webhook per call',
+    'and there is a limit of 15, so reusing the one you made last time is the difference',
+    'between a working integration and a channel full of clutter.',
+    'Needs Manage Webhooks. The response includes each webhook\'s token, which is a',
+    'credential — see the note on `execute_webhook`.',
+  ].join(' '),
+
+  create_webhook: [
+    'Create a webhook on a channel, which is what makes posting under your own name',
+    'possible. Do this once per channel and keep the id and token; call',
+    '`list_channel_webhooks` first to find an existing one rather than making another.',
+    '`name` is a fallback label only — the name and avatar that actually appear are the',
+    'ones passed per message to `execute_webhook`. `avatar` takes a base64 data URI,',
+    'not a URL, and is optional.',
+    'Needs Manage Webhooks. The returned `token` is a standalone credential: anybody',
+    'holding it can post to this channel without any other authentication.',
+  ].join(' '),
+
+  execute_webhook: [
+    'Post through a webhook, setting the name and avatar on the message itself.',
+    'This is how an announcement appears under your own name rather than the',
+    'application\'s: pass `username` and `avatar_url` and the message wears them.',
+    'It still carries an APP badge — Discord has no way to remove that, and no API for',
+    'posting as a real user account.',
+    'Takes the same `content` and `embeds` as `create_message`. Pass `wait: true` to get',
+    'the created message back, which is the only way to learn its id.',
+    '`thread_id` posts into an existing thread in the webhook\'s channel.',
+    'Note what this cannot do: a webhook only posts. It cannot read the channel, and the',
+    'message it creates cannot be edited by `update_message` — a webhook message is',
+    'editable only through the webhook that sent it.',
+  ].join(' '),
+};

--- a/src/providers/discord/index.ts
+++ b/src/providers/discord/index.ts
@@ -1,0 +1,121 @@
+import { defineProvider } from '#connectivity';
+import { DISCORD_HINTS } from './hints.ts';
+import { DISCORD_REDACT } from './redact.ts';
+
+/**
+ * Discord asks callers to identify themselves and blocks the ones that do not.
+ *
+ * Their documented format is `DiscordBot ($url, $version)`, and a request with a
+ * generic or absent agent is refused at the edge rather than by the API — so it
+ * presents as a network failure with no JSON to read. `connector.headers` on an
+ * `http` connector is what carries it (ADR-045 added the field for the same
+ * problem at Reddit).
+ *
+ * No handle or address in it: this file is public, and `architecture.test.ts`
+ * refuses a real identifier anywhere a reader can see. A name and a URL are what
+ * the check actually looks for.
+ */
+const DISCORD_USER_AGENT = 'DiscordBot (https://lanes.sh/link, 0.3)';
+
+/** The vendored spec sits beside this file. See `specs/vendor.ts`. */
+function specPath(name: string): string {
+  return new URL(`./specs/${name}`, import.meta.url).pathname;
+}
+
+/**
+ * Discord's v10 HTTP API, reached with a bot token the operator pasted.
+ *
+ * There is no user-account path and it is not for want of looking. Discord
+ * publishes no API for acting as yourself: automating a user token is
+ * self-botting, which their terms forbid and which gets accounts terminated, and
+ * the OAuth2 user scopes cover neither posting to a channel nor reading its
+ * history. Everything an integration can legitimately do, it does as an
+ * application. So a message will always carry an APP badge — that part is not
+ * negotiable — but the *name and avatar* on it are, per message, through a
+ * webhook. `execute_webhook` is why the three webhook operations are vendored:
+ * an announcement can read as the operator while an ordinary reply reads as the
+ * integration, from the one token.
+ *
+ * Not OAuth, and for a reason of its own rather than the one ADR-033 gave. That
+ * reason — a vendor matching its callback URL exactly, against a port the kernel
+ * picks — was withdrawn by ADR-045, which added `auth.redirect_uri`; so it is no
+ * longer an argument for a pasted token anywhere. What holds here is narrower and
+ * not fixable on our side: a Discord OAuth2 flow with the `bot` scope installs an
+ * application into a server, but the credential that then calls the API is the
+ * *application's* bot token, a property of the app rather than anything the
+ * exchange returns — so a browser flow would end with the operator still copying
+ * a token out of the developer portal. The `webhook.incoming` scope does return a
+ * usable credential, and it is write-only to a single channel: it cannot read, so
+ * it cannot serve the half of this that is triage.
+ *
+ * `auth.kind` is `header` rather than `bearer` because Discord's scheme word is
+ * `Bot`, not `Bearer`, and a bearer credential is assembled as `Bearer <token>`
+ * with no way to say otherwise. `header` writes the stored value into
+ * `Authorization` verbatim, so the value the operator pastes carries its own
+ * scheme — `Bot MTIz…`. That keeps the whole provider inside this folder at the
+ * cost of a prefix somebody can forget, which is why the prompt label spells it
+ * out and `troubleshooting` names it as the first thing to check.
+ *
+ * No `identity` block, and its absence is deliberate rather than an omission.
+ * The probe sends `Authorization: Bearer <stored value>`, which for this
+ * provider would be `Bearer Bot MTIz…` — a 401 and a null, after a network round
+ * trip, every single connect. Naming the connection falls to the operator
+ * instead. Re-running `connect` with the *same* label repairs the existing
+ * connection rather than adding a second one, because `settleIdentity` matches
+ * on the label; a scripted run passes `--display-name`.
+ */
+export const discord = defineProvider({
+  id: 'discord',
+  name: 'Discord',
+  description:
+    'Post announcements, read channels, and triage messages in the servers your bot has been added to, via the Discord v10 HTTP API.',
+  connector: {
+    kind: 'http',
+    base_url: 'https://discord.com/api/v10',
+    // Vendored, not fetched, and doubly so here: upstream is a public preview
+    // Discord says may break without notice, and `connect` grants everything a
+    // provider discovers. See `specs/vendor.ts`.
+    openapi: specPath('discord.v10.json'),
+    headers: { 'User-Agent': DISCORD_USER_AGENT },
+  },
+  auth: { kind: 'header', header: 'Authorization' },
+  redact: DISCORD_REDACT,
+  hints: DISCORD_HINTS,
+  setup: {
+    summary:
+      'Discord authenticates an integration as an application, not as you. You create one in ' +
+      'their developer portal, copy its bot token, and invite it to the servers you want ' +
+      'reachable. Posts will carry an APP badge; the name and avatar on them are yours to set. ' +
+      'You are asked for the token once.',
+    docs: 'docs/detailed/setup/discord.md',
+    docs_url: 'https://discord.com/developers/applications',
+    steps: [
+      'Open https://discord.com/developers/applications and choose "New Application". Name it whatever you want the posts to read as — this is the name people will see.',
+      'On the General Information page, set the icon. That is the avatar posts will carry.',
+      'Open the Bot tab. Set the username, then under "Privileged Gateway Intents" switch on MESSAGE CONTENT — without it every message you read comes back with an empty body, and nothing else will tell you why. An app in fewer than 10,000 servers can just toggle it; there is no review.',
+      'Still on the Bot tab, choose "Reset Token" and copy what it shows you. Discord shows it once. Paste it below prefixed with the word Bot and a space, exactly as: Bot MTIzNDU2Nzg5.abcdef',
+      'Turn off "Public Bot" on the same page unless you want strangers adding it to their servers.',
+      'Now invite it. Take the Application ID from General Information and open: https://discord.com/oauth2/authorize?client_id=<application-id>&scope=bot&permissions=309774593088',
+      'Pick a server you own and authorise. Those permission bits are exactly what the vendored operations need: view channels, send messages, manage messages (for pinning), read message history, add reactions, create public threads, send in threads, and manage webhooks. Repeat per server.',
+      'A private channel needs the bot added to it as well — server-wide permissions do not reach a channel it cannot see.',
+      'To rotate: "Reset Token" in the portal, then run: lanes link connect discord --replace',
+    ],
+    troubleshooting:
+      'Discord refused the token. Check the prefix first — the stored value must begin with ' +
+      '"Bot " and a token pasted bare is the usual cause of a 401 that names nothing. ' +
+      'After that: a token invalidated by a later "Reset Token", or an application that was ' +
+      'deleted. If calls authenticate but a channel 403s, the bot is in the server but not ' +
+      'that channel, or the invite was authorised without the permissions above. If reads ' +
+      'succeed and every message body is empty, the MESSAGE CONTENT intent is off. ' +
+      'Reset the token at https://discord.com/developers/applications and re-run: ' +
+      'lanes link connect discord --replace',
+    prompts: [
+      {
+        key: 'token',
+        label: 'Discord bot token, prefixed — Bot <token>',
+        secret: true,
+        scope: 'connection' as const,
+      },
+    ],
+  },
+});

--- a/src/providers/discord/redact.ts
+++ b/src/providers/discord/redact.ts
@@ -1,0 +1,99 @@
+/**
+ * What survives into the audit log when Discord is read or posted to.
+ *
+ * The default withholds every value, which for a write log means recording that
+ * something was posted somewhere without recording where — so every operation
+ * here names its identifiers explicitly. Snowflake ids are kept throughout:
+ * which guild, which channel, which message, which webhook. Pagination cursors
+ * and limits are kept too, because "read 50 messages after this one" is the
+ * whole shape of a triage pass and none of it is anybody's content.
+ *
+ * Message bodies are withheld. `content`, `embeds`, `components`, `attachments`,
+ * `poll`, and a thread's `name` are the operator's own words, and a log that
+ * reproduces them is a second copy of the channel.
+ *
+ * Two departures worth stating.
+ *
+ * `allowed_mentions` is **kept** on every operation that posts. It is not
+ * content, it is the blast radius: whether a post was allowed to ping
+ * `@everyone` is exactly the fact an operator wants in the log, and it is
+ * unrecoverable from anywhere else once the message is edited or deleted.
+ *
+ * `username` is **kept** on `execute_webhook` and `webhook_token` is not.
+ * Keeping the username is what makes the log legible — a webhook post is
+ * deliberately wearing a name that is not the app's, and "posted as Ops in
+ * channel 123" answers the question the entry exists for. The token is a
+ * standalone credential for posting to that channel, so it is withheld by
+ * omission and appears as a type marker; `avatar_url` goes the same way for
+ * being cosmetic rather than a fact about what happened.
+ */
+export const DISCORD_REDACT: Record<string, string[]> = {
+  // Reads. Everything an argument can be here is an id, a cursor, or a count.
+  get_my_user: [],
+  list_my_guilds: ['before', 'after', 'limit', 'with_counts'],
+  get_guild: ['guild_id', 'with_counts'],
+  list_guild_channels: ['guild_id'],
+  get_channel: ['channel_id'],
+  list_messages: ['channel_id', 'around', 'before', 'after', 'limit'],
+  get_message: ['channel_id', 'message_id'],
+  list_pins: ['channel_id', 'before', 'limit'],
+  list_message_reactions_by_emoji: [
+    'channel_id',
+    'message_id',
+    'emoji_name',
+    'after',
+    'limit',
+    'type',
+  ],
+  get_active_guild_threads: ['guild_id'],
+
+  // Posting. `content`, `embeds`, `components`, `attachments`, `poll`, and
+  // `shared_client_theme` are withheld by omission.
+  create_message: [
+    'channel_id',
+    'allowed_mentions',
+    'message_reference',
+    'sticker_ids',
+    'flags',
+    'tts',
+    'nonce',
+    'enforce_nonce',
+  ],
+  update_message: [
+    'channel_id',
+    'message_id',
+    'allowed_mentions',
+    'sticker_ids',
+    'flags',
+  ],
+  delete_message: ['channel_id', 'message_id'],
+  crosspost_message: ['channel_id', 'message_id'],
+
+  // Triage marking. An emoji is a reaction, not private content, and which one
+  // was used is the entire meaning of the action.
+  add_my_message_reaction: ['channel_id', 'message_id', 'emoji_name'],
+  create_pin: ['channel_id', 'message_id'],
+  // `name` withheld: a thread title is the operator's words.
+  create_thread_from_message: [
+    'channel_id',
+    'message_id',
+    'auto_archive_duration',
+    'rate_limit_per_user',
+  ],
+
+  // Webhooks. `avatar` on creation is base64 image bytes; withholding it is the
+  // same call `gmail.send_message` makes about attachments.
+  list_channel_webhooks: ['channel_id'],
+  create_webhook: ['channel_id', 'name'],
+  execute_webhook: [
+    'webhook_id',
+    'username',
+    'thread_id',
+    'allowed_mentions',
+    'applied_tags',
+    'with_components',
+    'wait',
+    'flags',
+    'tts',
+  ],
+};

--- a/src/providers/discord/specs/discord.v10.json
+++ b/src/providers/discord/specs/discord.v10.json
@@ -1,0 +1,2333 @@
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "Discord HTTP API (Preview)",
+    "description": "Preview of the Discord v10 HTTP API specification. See https://discord.com/developers/docs for more details.",
+    "termsOfService": "https://discord.com/developers/docs/policies-and-agreements/developer-terms-of-service",
+    "license": {
+      "name": "MIT",
+      "identifier": "MIT"
+    },
+    "version": "10",
+    "x-vendored-from": "https://raw.githubusercontent.com/discord/discord-api-spec/main/specs/openapi.json",
+    "x-vendored-note": "Trimmed by src/providers/discord/specs/vendor.ts. Committed deliberately: upstream is a public preview that may change without notice, and a spec decides which paths are called with the operator bot token — so it must be reviewable rather than fetched at connect time."
+  },
+  "servers": [
+    {
+      "url": "https://discord.com/api/v10"
+    }
+  ],
+  "paths": {
+    "/channels/{channel_id}": {
+      "get": {
+        "operationId": "get_channel",
+        "responses": {
+          "200": {
+            "description": "Success. The response body is returned verbatim."
+          }
+        },
+        "security": [
+          {
+            "BotToken": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "channel_id",
+            "in": "path",
+            "schema": {
+              "$ref": "#/components/schemas/SnowflakeType"
+            },
+            "required": true
+          }
+        ]
+      }
+    },
+    "/channels/{channel_id}/messages": {
+      "get": {
+        "operationId": "list_messages",
+        "parameters": [
+          {
+            "name": "channel_id",
+            "in": "path",
+            "schema": {
+              "$ref": "#/components/schemas/SnowflakeType"
+            },
+            "required": true
+          },
+          {
+            "name": "around",
+            "in": "query",
+            "schema": {
+              "$ref": "#/components/schemas/SnowflakeType"
+            }
+          },
+          {
+            "name": "before",
+            "in": "query",
+            "schema": {
+              "$ref": "#/components/schemas/SnowflakeType"
+            }
+          },
+          {
+            "name": "after",
+            "in": "query",
+            "schema": {
+              "$ref": "#/components/schemas/SnowflakeType"
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 100
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success. The response body is returned verbatim."
+          }
+        },
+        "security": [
+          {
+            "BotToken": []
+          }
+        ]
+      },
+      "post": {
+        "operationId": "create_message",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/MessageCreateRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Success. The response body is returned verbatim."
+          }
+        },
+        "security": [
+          {
+            "BotToken": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "channel_id",
+            "in": "path",
+            "schema": {
+              "$ref": "#/components/schemas/SnowflakeType"
+            },
+            "required": true
+          }
+        ]
+      }
+    },
+    "/channels/{channel_id}/messages/pins": {
+      "get": {
+        "operationId": "list_pins",
+        "parameters": [
+          {
+            "name": "channel_id",
+            "in": "path",
+            "schema": {
+              "$ref": "#/components/schemas/SnowflakeType"
+            },
+            "required": true
+          },
+          {
+            "name": "before",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "format": "date-time"
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 50
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success. The response body is returned verbatim."
+          }
+        },
+        "security": [
+          {
+            "BotToken": []
+          }
+        ]
+      }
+    },
+    "/channels/{channel_id}/messages/pins/{message_id}": {
+      "put": {
+        "operationId": "create_pin",
+        "responses": {
+          "200": {
+            "description": "Success. The response body is returned verbatim."
+          }
+        },
+        "security": [
+          {
+            "BotToken": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "channel_id",
+            "in": "path",
+            "schema": {
+              "$ref": "#/components/schemas/SnowflakeType"
+            },
+            "required": true
+          },
+          {
+            "name": "message_id",
+            "in": "path",
+            "schema": {
+              "$ref": "#/components/schemas/SnowflakeType"
+            },
+            "required": true
+          }
+        ]
+      }
+    },
+    "/channels/{channel_id}/messages/{message_id}": {
+      "get": {
+        "operationId": "get_message",
+        "responses": {
+          "200": {
+            "description": "Success. The response body is returned verbatim."
+          }
+        },
+        "security": [
+          {
+            "BotToken": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "channel_id",
+            "in": "path",
+            "schema": {
+              "$ref": "#/components/schemas/SnowflakeType"
+            },
+            "required": true
+          },
+          {
+            "name": "message_id",
+            "in": "path",
+            "schema": {
+              "$ref": "#/components/schemas/SnowflakeType"
+            },
+            "required": true
+          }
+        ]
+      },
+      "delete": {
+        "operationId": "delete_message",
+        "responses": {
+          "200": {
+            "description": "Success. The response body is returned verbatim."
+          }
+        },
+        "security": [
+          {
+            "BotToken": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "channel_id",
+            "in": "path",
+            "schema": {
+              "$ref": "#/components/schemas/SnowflakeType"
+            },
+            "required": true
+          },
+          {
+            "name": "message_id",
+            "in": "path",
+            "schema": {
+              "$ref": "#/components/schemas/SnowflakeType"
+            },
+            "required": true
+          }
+        ]
+      },
+      "patch": {
+        "operationId": "update_message",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/MessageEditRequestPartial"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Success. The response body is returned verbatim."
+          }
+        },
+        "security": [
+          {
+            "BotToken": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "channel_id",
+            "in": "path",
+            "schema": {
+              "$ref": "#/components/schemas/SnowflakeType"
+            },
+            "required": true
+          },
+          {
+            "name": "message_id",
+            "in": "path",
+            "schema": {
+              "$ref": "#/components/schemas/SnowflakeType"
+            },
+            "required": true
+          }
+        ]
+      }
+    },
+    "/channels/{channel_id}/messages/{message_id}/crosspost": {
+      "post": {
+        "operationId": "crosspost_message",
+        "responses": {
+          "200": {
+            "description": "Success. The response body is returned verbatim."
+          }
+        },
+        "security": [
+          {
+            "BotToken": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "channel_id",
+            "in": "path",
+            "schema": {
+              "$ref": "#/components/schemas/SnowflakeType"
+            },
+            "required": true
+          },
+          {
+            "name": "message_id",
+            "in": "path",
+            "schema": {
+              "$ref": "#/components/schemas/SnowflakeType"
+            },
+            "required": true
+          }
+        ]
+      }
+    },
+    "/channels/{channel_id}/messages/{message_id}/reactions/{emoji_name}": {
+      "get": {
+        "operationId": "list_message_reactions_by_emoji",
+        "parameters": [
+          {
+            "name": "channel_id",
+            "in": "path",
+            "schema": {
+              "$ref": "#/components/schemas/SnowflakeType"
+            },
+            "required": true
+          },
+          {
+            "name": "message_id",
+            "in": "path",
+            "schema": {
+              "$ref": "#/components/schemas/SnowflakeType"
+            },
+            "required": true
+          },
+          {
+            "name": "emoji_name",
+            "in": "path",
+            "schema": {
+              "type": "string",
+              "maxLength": 152133
+            },
+            "required": true
+          },
+          {
+            "name": "after",
+            "in": "query",
+            "schema": {
+              "$ref": "#/components/schemas/SnowflakeType"
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 100
+            }
+          },
+          {
+            "name": "type",
+            "in": "query",
+            "schema": {
+              "$ref": "#/components/schemas/ReactionTypes"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success. The response body is returned verbatim."
+          }
+        },
+        "security": [
+          {
+            "BotToken": []
+          }
+        ]
+      }
+    },
+    "/channels/{channel_id}/messages/{message_id}/reactions/{emoji_name}/@me": {
+      "put": {
+        "operationId": "add_my_message_reaction",
+        "responses": {
+          "200": {
+            "description": "Success. The response body is returned verbatim."
+          }
+        },
+        "security": [
+          {
+            "BotToken": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "channel_id",
+            "in": "path",
+            "schema": {
+              "$ref": "#/components/schemas/SnowflakeType"
+            },
+            "required": true
+          },
+          {
+            "name": "message_id",
+            "in": "path",
+            "schema": {
+              "$ref": "#/components/schemas/SnowflakeType"
+            },
+            "required": true
+          },
+          {
+            "name": "emoji_name",
+            "in": "path",
+            "schema": {
+              "type": "string",
+              "maxLength": 152133
+            },
+            "required": true
+          }
+        ]
+      }
+    },
+    "/channels/{channel_id}/messages/{message_id}/threads": {
+      "post": {
+        "operationId": "create_thread_from_message",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateTextThreadWithMessageRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Success. The response body is returned verbatim."
+          }
+        },
+        "security": [
+          {
+            "BotToken": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "channel_id",
+            "in": "path",
+            "schema": {
+              "$ref": "#/components/schemas/SnowflakeType"
+            },
+            "required": true
+          },
+          {
+            "name": "message_id",
+            "in": "path",
+            "schema": {
+              "$ref": "#/components/schemas/SnowflakeType"
+            },
+            "required": true
+          }
+        ]
+      }
+    },
+    "/channels/{channel_id}/webhooks": {
+      "get": {
+        "operationId": "list_channel_webhooks",
+        "responses": {
+          "200": {
+            "description": "Success. The response body is returned verbatim."
+          }
+        },
+        "security": [
+          {
+            "BotToken": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "channel_id",
+            "in": "path",
+            "schema": {
+              "$ref": "#/components/schemas/SnowflakeType"
+            },
+            "required": true
+          }
+        ]
+      },
+      "post": {
+        "operationId": "create_webhook",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "name": {
+                    "type": "string",
+                    "minLength": 1,
+                    "maxLength": 80
+                  },
+                  "avatar": {
+                    "type": [
+                      "string",
+                      "null"
+                    ],
+                    "contentEncoding": "base64"
+                  }
+                },
+                "required": [
+                  "name"
+                ]
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Success. The response body is returned verbatim."
+          }
+        },
+        "security": [
+          {
+            "BotToken": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "channel_id",
+            "in": "path",
+            "schema": {
+              "$ref": "#/components/schemas/SnowflakeType"
+            },
+            "required": true
+          }
+        ]
+      }
+    },
+    "/guilds/{guild_id}": {
+      "get": {
+        "operationId": "get_guild",
+        "parameters": [
+          {
+            "name": "guild_id",
+            "in": "path",
+            "schema": {
+              "$ref": "#/components/schemas/SnowflakeType"
+            },
+            "required": true
+          },
+          {
+            "name": "with_counts",
+            "in": "query",
+            "schema": {
+              "type": "boolean"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success. The response body is returned verbatim."
+          }
+        },
+        "security": [
+          {
+            "BotToken": []
+          }
+        ]
+      }
+    },
+    "/guilds/{guild_id}/channels": {
+      "get": {
+        "operationId": "list_guild_channels",
+        "responses": {
+          "200": {
+            "description": "Success. The response body is returned verbatim."
+          }
+        },
+        "security": [
+          {
+            "BotToken": []
+          },
+          {
+            "OAuth2": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "guild_id",
+            "in": "path",
+            "schema": {
+              "$ref": "#/components/schemas/SnowflakeType"
+            },
+            "required": true
+          }
+        ]
+      }
+    },
+    "/guilds/{guild_id}/threads/active": {
+      "get": {
+        "operationId": "get_active_guild_threads",
+        "responses": {
+          "200": {
+            "description": "Success. The response body is returned verbatim."
+          }
+        },
+        "security": [
+          {
+            "BotToken": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "guild_id",
+            "in": "path",
+            "schema": {
+              "$ref": "#/components/schemas/SnowflakeType"
+            },
+            "required": true
+          }
+        ]
+      }
+    },
+    "/users/@me": {
+      "get": {
+        "operationId": "get_my_user",
+        "responses": {
+          "200": {
+            "description": "Success. The response body is returned verbatim."
+          }
+        },
+        "security": [
+          {
+            "BotToken": []
+          },
+          {
+            "OAuth2": [
+              "identify"
+            ]
+          }
+        ]
+      }
+    },
+    "/users/@me/guilds": {
+      "get": {
+        "operationId": "list_my_guilds",
+        "parameters": [
+          {
+            "name": "before",
+            "in": "query",
+            "schema": {
+              "$ref": "#/components/schemas/SnowflakeType"
+            }
+          },
+          {
+            "name": "after",
+            "in": "query",
+            "schema": {
+              "$ref": "#/components/schemas/SnowflakeType"
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 200
+            }
+          },
+          {
+            "name": "with_counts",
+            "in": "query",
+            "schema": {
+              "type": "boolean"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success. The response body is returned verbatim."
+          }
+        },
+        "security": [
+          {
+            "BotToken": []
+          },
+          {
+            "OAuth2": [
+              "guilds"
+            ]
+          }
+        ]
+      }
+    },
+    "/webhooks/{webhook_id}/{webhook_token}": {
+      "post": {
+        "operationId": "execute_webhook",
+        "parameters": [
+          {
+            "name": "webhook_id",
+            "in": "path",
+            "schema": {
+              "$ref": "#/components/schemas/SnowflakeType"
+            },
+            "required": true
+          },
+          {
+            "name": "webhook_token",
+            "in": "path",
+            "schema": {
+              "type": "string",
+              "maxLength": 152133
+            },
+            "required": true
+          },
+          {
+            "name": "wait",
+            "in": "query",
+            "schema": {
+              "type": "boolean"
+            }
+          },
+          {
+            "name": "thread_id",
+            "in": "query",
+            "schema": {
+              "$ref": "#/components/schemas/SnowflakeType"
+            }
+          },
+          {
+            "name": "with_components",
+            "in": "query",
+            "schema": {
+              "type": "boolean"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/IncomingWebhookRequestPartial"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Success. The response body is returned verbatim."
+          }
+        },
+        "security": [
+          {},
+          {
+            "BotToken": []
+          }
+        ]
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "ActionRowComponentForMessageRequest": {
+        "type": "object",
+        "additionalProperties": true,
+        "description": "A ActionRowComponentForMessageRequest. Structure omitted: this union inlines to hundreds of kilobytes. Pass the object as documented at https://discord.com/developers/docs/components/reference."
+      },
+      "AllowedMentionTypes": {
+        "type": "string",
+        "oneOf": [
+          {
+            "title": "USERS",
+            "description": "Controls role mentions",
+            "const": "users"
+          },
+          {
+            "title": "ROLES",
+            "description": "Controls user mentions",
+            "const": "roles"
+          },
+          {
+            "title": "EVERYONE",
+            "description": "Controls @everyone and @here mentions",
+            "const": "everyone"
+          }
+        ]
+      },
+      "ContainerComponentForMessageRequest": {
+        "type": "object",
+        "additionalProperties": true,
+        "description": "A ContainerComponentForMessageRequest. Structure omitted: this union inlines to hundreds of kilobytes. Pass the object as documented at https://discord.com/developers/docs/components/reference."
+      },
+      "CreateTextThreadWithMessageRequest": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 100
+          },
+          "auto_archive_duration": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/ThreadAutoArchiveDuration"
+              }
+            ]
+          },
+          "rate_limit_per_user": {
+            "type": [
+              "integer",
+              "null"
+            ],
+            "minimum": 0,
+            "maximum": 21600,
+            "format": "int32"
+          }
+        },
+        "required": [
+          "name"
+        ]
+      },
+      "CustomClientThemeShareRequest": {
+        "type": "object",
+        "properties": {
+          "colors": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "minLength": 6,
+              "maxLength": 6
+            },
+            "minItems": 1,
+            "maxItems": 5
+          },
+          "gradient_angle": {
+            "type": "integer",
+            "minimum": 0,
+            "maximum": 360,
+            "format": "int32"
+          },
+          "base_mix": {
+            "type": "integer",
+            "minimum": 0,
+            "maximum": 100,
+            "format": "int32"
+          },
+          "base_theme": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/MessageShareCustomUserThemeBaseTheme"
+              }
+            ]
+          }
+        },
+        "required": [
+          "colors",
+          "gradient_angle",
+          "base_mix"
+        ]
+      },
+      "FileComponentForMessageRequest": {
+        "type": "object",
+        "additionalProperties": true,
+        "description": "A FileComponentForMessageRequest. Structure omitted: this union inlines to hundreds of kilobytes. Pass the object as documented at https://discord.com/developers/docs/components/reference."
+      },
+      "IncomingWebhookRequestPartial": {
+        "type": "object",
+        "properties": {
+          "content": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "maxLength": 2000
+          },
+          "embeds": {
+            "type": [
+              "array",
+              "null"
+            ],
+            "items": {
+              "$ref": "#/components/schemas/RichEmbed"
+            },
+            "maxItems": 10
+          },
+          "allowed_mentions": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/MessageAllowedMentionsRequest"
+              }
+            ]
+          },
+          "components": {
+            "type": [
+              "array",
+              "null"
+            ],
+            "items": {
+              "oneOf": [
+                {
+                  "$ref": "#/components/schemas/ActionRowComponentForMessageRequest"
+                },
+                {
+                  "$ref": "#/components/schemas/ContainerComponentForMessageRequest"
+                },
+                {
+                  "$ref": "#/components/schemas/FileComponentForMessageRequest"
+                },
+                {
+                  "$ref": "#/components/schemas/MediaGalleryComponentForMessageRequest"
+                },
+                {
+                  "$ref": "#/components/schemas/SectionComponentForMessageRequest"
+                },
+                {
+                  "$ref": "#/components/schemas/SeparatorComponentForMessageRequest"
+                },
+                {
+                  "$ref": "#/components/schemas/TextDisplayComponentForMessageRequest"
+                }
+              ]
+            },
+            "maxItems": 40
+          },
+          "attachments": {
+            "type": [
+              "array",
+              "null"
+            ],
+            "items": {
+              "$ref": "#/components/schemas/MessageAttachmentRequest"
+            },
+            "maxItems": 10
+          },
+          "poll": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/PollCreateRequest"
+              }
+            ]
+          },
+          "tts": {
+            "type": [
+              "boolean",
+              "null"
+            ]
+          },
+          "flags": {
+            "type": [
+              "integer",
+              "null"
+            ]
+          },
+          "username": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "minLength": 1,
+            "maxLength": 80
+          },
+          "avatar_url": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "maxLength": 2048,
+            "format": "uri"
+          },
+          "thread_name": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "minLength": 0,
+            "maxLength": 100
+          },
+          "applied_tags": {
+            "type": [
+              "array",
+              "null"
+            ],
+            "items": {
+              "$ref": "#/components/schemas/SnowflakeType"
+            },
+            "maxItems": 5
+          }
+        }
+      },
+      "MediaGalleryComponentForMessageRequest": {
+        "type": "object",
+        "additionalProperties": true,
+        "description": "A MediaGalleryComponentForMessageRequest. Structure omitted: this union inlines to hundreds of kilobytes. Pass the object as documented at https://discord.com/developers/docs/components/reference."
+      },
+      "MessageAllowedMentionsRequest": {
+        "type": "object",
+        "properties": {
+          "parse": {
+            "type": [
+              "array",
+              "null"
+            ],
+            "items": {
+              "oneOf": [
+                {
+                  "type": "null"
+                },
+                {
+                  "$ref": "#/components/schemas/AllowedMentionTypes"
+                }
+              ]
+            },
+            "maxItems": 1521,
+            "uniqueItems": true
+          },
+          "users": {
+            "type": [
+              "array",
+              "null"
+            ],
+            "items": {
+              "oneOf": [
+                {
+                  "type": "null"
+                },
+                {
+                  "$ref": "#/components/schemas/SnowflakeType"
+                }
+              ]
+            },
+            "maxItems": 100,
+            "uniqueItems": true
+          },
+          "roles": {
+            "type": [
+              "array",
+              "null"
+            ],
+            "items": {
+              "oneOf": [
+                {
+                  "type": "null"
+                },
+                {
+                  "$ref": "#/components/schemas/SnowflakeType"
+                }
+              ]
+            },
+            "maxItems": 100,
+            "uniqueItems": true
+          },
+          "replied_user": {
+            "type": [
+              "boolean",
+              "null"
+            ]
+          }
+        }
+      },
+      "MessageAttachmentRequest": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "$ref": "#/components/schemas/SnowflakeType"
+          },
+          "filename": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "minLength": 1,
+            "maxLength": 1024
+          },
+          "description": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "maxLength": 1024
+          },
+          "duration_secs": {
+            "type": [
+              "number",
+              "null"
+            ],
+            "minimum": 0,
+            "maximum": 2147483647,
+            "format": "double"
+          },
+          "waveform": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "maxLength": 400
+          },
+          "title": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "maxLength": 1024
+          },
+          "is_spoiler": {
+            "type": [
+              "boolean",
+              "null"
+            ]
+          },
+          "is_remix": {
+            "type": [
+              "boolean",
+              "null"
+            ]
+          }
+        },
+        "required": [
+          "id"
+        ]
+      },
+      "MessageCreateRequest": {
+        "type": "object",
+        "properties": {
+          "content": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "maxLength": 4000
+          },
+          "embeds": {
+            "type": [
+              "array",
+              "null"
+            ],
+            "items": {
+              "$ref": "#/components/schemas/RichEmbed"
+            },
+            "maxItems": 10
+          },
+          "allowed_mentions": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/MessageAllowedMentionsRequest"
+              }
+            ]
+          },
+          "sticker_ids": {
+            "type": [
+              "array",
+              "null"
+            ],
+            "items": {
+              "$ref": "#/components/schemas/SnowflakeType"
+            },
+            "maxItems": 3
+          },
+          "components": {
+            "type": [
+              "array",
+              "null"
+            ],
+            "items": {
+              "oneOf": [
+                {
+                  "$ref": "#/components/schemas/ActionRowComponentForMessageRequest"
+                },
+                {
+                  "$ref": "#/components/schemas/ContainerComponentForMessageRequest"
+                },
+                {
+                  "$ref": "#/components/schemas/FileComponentForMessageRequest"
+                },
+                {
+                  "$ref": "#/components/schemas/MediaGalleryComponentForMessageRequest"
+                },
+                {
+                  "$ref": "#/components/schemas/SectionComponentForMessageRequest"
+                },
+                {
+                  "$ref": "#/components/schemas/SeparatorComponentForMessageRequest"
+                },
+                {
+                  "$ref": "#/components/schemas/TextDisplayComponentForMessageRequest"
+                }
+              ]
+            },
+            "maxItems": 40
+          },
+          "flags": {
+            "type": [
+              "integer",
+              "null"
+            ]
+          },
+          "attachments": {
+            "type": [
+              "array",
+              "null"
+            ],
+            "items": {
+              "$ref": "#/components/schemas/MessageAttachmentRequest"
+            },
+            "maxItems": 10
+          },
+          "poll": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/PollCreateRequest"
+              }
+            ]
+          },
+          "shared_client_theme": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/CustomClientThemeShareRequest"
+              }
+            ]
+          },
+          "message_reference": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/MessageReferenceRequest"
+              }
+            ]
+          },
+          "nonce": {
+            "oneOf": [
+              {
+                "type": "integer",
+                "minimum": -9223372036854776000,
+                "maximum": 9223372036854776000,
+                "format": "int64"
+              },
+              {
+                "type": "string",
+                "maxLength": 25,
+                "format": "nonce"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "enforce_nonce": {
+            "type": [
+              "boolean",
+              "null"
+            ]
+          },
+          "tts": {
+            "type": [
+              "boolean",
+              "null"
+            ]
+          }
+        }
+      },
+      "MessageEditRequestPartial": {
+        "type": "object",
+        "properties": {
+          "content": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "maxLength": 4000
+          },
+          "embeds": {
+            "type": [
+              "array",
+              "null"
+            ],
+            "items": {
+              "$ref": "#/components/schemas/RichEmbed"
+            },
+            "maxItems": 10
+          },
+          "flags": {
+            "type": [
+              "integer",
+              "null"
+            ]
+          },
+          "allowed_mentions": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/MessageAllowedMentionsRequest"
+              }
+            ]
+          },
+          "sticker_ids": {
+            "type": [
+              "array",
+              "null"
+            ],
+            "items": {
+              "$ref": "#/components/schemas/SnowflakeType"
+            },
+            "maxItems": 1521
+          },
+          "components": {
+            "type": [
+              "array",
+              "null"
+            ],
+            "items": {
+              "oneOf": [
+                {
+                  "$ref": "#/components/schemas/ActionRowComponentForMessageRequest"
+                },
+                {
+                  "$ref": "#/components/schemas/ContainerComponentForMessageRequest"
+                },
+                {
+                  "$ref": "#/components/schemas/FileComponentForMessageRequest"
+                },
+                {
+                  "$ref": "#/components/schemas/MediaGalleryComponentForMessageRequest"
+                },
+                {
+                  "$ref": "#/components/schemas/SectionComponentForMessageRequest"
+                },
+                {
+                  "$ref": "#/components/schemas/SeparatorComponentForMessageRequest"
+                },
+                {
+                  "$ref": "#/components/schemas/TextDisplayComponentForMessageRequest"
+                }
+              ]
+            },
+            "maxItems": 40
+          },
+          "attachments": {
+            "type": [
+              "array",
+              "null"
+            ],
+            "items": {
+              "$ref": "#/components/schemas/MessageAttachmentRequest"
+            },
+            "maxItems": 10
+          }
+        }
+      },
+      "MessageReferenceRequest": {
+        "type": "object",
+        "properties": {
+          "guild_id": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/SnowflakeType"
+              }
+            ]
+          },
+          "channel_id": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/SnowflakeType"
+              }
+            ]
+          },
+          "message_id": {
+            "$ref": "#/components/schemas/SnowflakeType"
+          },
+          "fail_if_not_exists": {
+            "type": [
+              "boolean",
+              "null"
+            ]
+          },
+          "type": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/MessageReferenceType"
+              }
+            ]
+          }
+        },
+        "required": [
+          "message_id"
+        ]
+      },
+      "MessageReferenceType": {
+        "type": "integer",
+        "oneOf": [
+          {
+            "title": "DEFAULT",
+            "description": "Reference to a message",
+            "const": 0
+          }
+        ],
+        "format": "int32"
+      },
+      "MessageShareCustomUserThemeBaseTheme": {
+        "type": "integer",
+        "oneOf": [
+          {
+            "title": "UNSET",
+            "description": "No base theme",
+            "const": 0
+          },
+          {
+            "title": "DARK",
+            "description": "Dark base theme",
+            "const": 1
+          },
+          {
+            "title": "LIGHT",
+            "description": "Light base theme",
+            "const": 2
+          },
+          {
+            "title": "DARKER",
+            "description": "Darker base theme",
+            "const": 3
+          },
+          {
+            "title": "MIDNIGHT",
+            "description": "Midnight base theme",
+            "const": 4
+          }
+        ],
+        "format": "int32"
+      },
+      "PollAnswerCreateRequest": {
+        "type": "object",
+        "properties": {
+          "poll_media": {
+            "$ref": "#/components/schemas/PollMediaCreateRequest",
+            "description": "The data of the answer"
+          }
+        },
+        "required": [
+          "poll_media"
+        ]
+      },
+      "PollCreateRequest": {
+        "type": "object",
+        "properties": {
+          "question": {
+            "$ref": "#/components/schemas/PollMedia",
+            "description": "The question of the poll. Only `text` is supported."
+          },
+          "answers": {
+            "type": "array",
+            "description": "Each of the answers available in the poll, up to 10",
+            "items": {
+              "$ref": "#/components/schemas/PollAnswerCreateRequest"
+            },
+            "minItems": 1,
+            "maxItems": 10
+          },
+          "allow_multiselect": {
+            "type": [
+              "boolean",
+              "null"
+            ],
+            "description": "Whether a user can select multiple answers"
+          },
+          "layout_type": {
+            "description": "The layout type of the poll. Defaults to... DEFAULT!",
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/PollLayoutTypes"
+              }
+            ]
+          },
+          "duration": {
+            "type": [
+              "integer",
+              "null"
+            ],
+            "description": "Number of hours the poll should be open for, up to 32 days. Defaults to 24",
+            "minimum": 1,
+            "maximum": 768,
+            "format": "int32"
+          }
+        },
+        "required": [
+          "question",
+          "answers"
+        ]
+      },
+      "PollEmoji": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "description": "The ID of the custom emoji",
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/SnowflakeType"
+              }
+            ]
+          },
+          "name": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "The name of the emoji, or the unicode emoji character",
+            "maxLength": 32
+          },
+          "animated": {
+            "type": [
+              "boolean",
+              "null"
+            ],
+            "description": "Whether the emoji is animated"
+          }
+        }
+      },
+      "PollEmojiCreateRequest": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "description": "The ID of the custom emoji",
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/SnowflakeType"
+              }
+            ]
+          },
+          "name": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "The name of the emoji, or the unicode emoji character",
+            "maxLength": 32
+          },
+          "animated": {
+            "type": [
+              "boolean",
+              "null"
+            ],
+            "description": "Whether the emoji is animated"
+          }
+        }
+      },
+      "PollLayoutTypes": {
+        "type": "integer",
+        "oneOf": [
+          {
+            "title": "DEFAULT",
+            "description": "The, uhm, default layout type.",
+            "const": 1
+          }
+        ],
+        "format": "int32"
+      },
+      "PollMedia": {
+        "type": "object",
+        "properties": {
+          "text": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "The text of the field",
+            "minLength": 1,
+            "maxLength": 300
+          },
+          "emoji": {
+            "description": "The emoji of the field",
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/PollEmoji"
+              }
+            ]
+          }
+        }
+      },
+      "PollMediaCreateRequest": {
+        "type": "object",
+        "properties": {
+          "text": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "The text of the field",
+            "minLength": 1,
+            "maxLength": 300
+          },
+          "emoji": {
+            "description": "The emoji of the field",
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/PollEmojiCreateRequest"
+              }
+            ]
+          }
+        }
+      },
+      "ReactionTypes": {
+        "type": "integer",
+        "oneOf": [
+          {
+            "title": "NORMAL",
+            "description": "Normal reaction type",
+            "const": 0
+          },
+          {
+            "title": "BURST",
+            "description": "Burst reaction type",
+            "const": 1
+          }
+        ],
+        "format": "int32"
+      },
+      "RichEmbed": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "maxLength": 152133
+          },
+          "url": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "maxLength": 2048,
+            "format": "uri"
+          },
+          "title": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "maxLength": 256
+          },
+          "color": {
+            "type": [
+              "integer",
+              "null"
+            ],
+            "minimum": 0,
+            "maximum": 16777215
+          },
+          "timestamp": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "format": "date-time"
+          },
+          "description": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "maxLength": 4096
+          },
+          "author": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/RichEmbedAuthor"
+              }
+            ]
+          },
+          "image": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/RichEmbedImage"
+              }
+            ]
+          },
+          "thumbnail": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/RichEmbedThumbnail"
+              }
+            ]
+          },
+          "footer": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/RichEmbedFooter"
+              }
+            ]
+          },
+          "fields": {
+            "type": [
+              "array",
+              "null"
+            ],
+            "items": {
+              "$ref": "#/components/schemas/RichEmbedField"
+            },
+            "maxItems": 25
+          },
+          "provider": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/RichEmbedProvider"
+              }
+            ]
+          },
+          "video": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/RichEmbedVideo"
+              }
+            ]
+          }
+        }
+      },
+      "RichEmbedAuthor": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "maxLength": 256
+          },
+          "url": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "maxLength": 2048,
+            "format": "uri"
+          },
+          "icon_url": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "maxLength": 2048,
+            "format": "uri"
+          }
+        }
+      },
+      "RichEmbedField": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string",
+            "maxLength": 256
+          },
+          "value": {
+            "type": "string",
+            "maxLength": 1024
+          },
+          "inline": {
+            "type": [
+              "boolean",
+              "null"
+            ]
+          }
+        },
+        "required": [
+          "name",
+          "value"
+        ]
+      },
+      "RichEmbedFooter": {
+        "type": "object",
+        "properties": {
+          "text": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "maxLength": 2048
+          },
+          "icon_url": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "maxLength": 2048,
+            "format": "uri"
+          }
+        }
+      },
+      "RichEmbedImage": {
+        "type": "object",
+        "properties": {
+          "url": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "maxLength": 2048,
+            "format": "uri"
+          },
+          "width": {
+            "type": [
+              "integer",
+              "null"
+            ]
+          },
+          "height": {
+            "type": [
+              "integer",
+              "null"
+            ]
+          },
+          "placeholder": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "maxLength": 64
+          },
+          "placeholder_version": {
+            "type": [
+              "integer",
+              "null"
+            ],
+            "minimum": 0,
+            "maximum": 2147483647
+          },
+          "is_animated": {
+            "type": [
+              "boolean",
+              "null"
+            ]
+          },
+          "description": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "maxLength": 4096
+          }
+        }
+      },
+      "RichEmbedProvider": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "maxLength": 256
+          },
+          "url": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "maxLength": 2048,
+            "format": "uri"
+          }
+        }
+      },
+      "RichEmbedThumbnail": {
+        "type": "object",
+        "properties": {
+          "url": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "maxLength": 2048,
+            "format": "uri"
+          },
+          "width": {
+            "type": [
+              "integer",
+              "null"
+            ]
+          },
+          "height": {
+            "type": [
+              "integer",
+              "null"
+            ]
+          },
+          "placeholder": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "maxLength": 64
+          },
+          "placeholder_version": {
+            "type": [
+              "integer",
+              "null"
+            ],
+            "minimum": 0,
+            "maximum": 2147483647
+          },
+          "is_animated": {
+            "type": [
+              "boolean",
+              "null"
+            ]
+          },
+          "description": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "maxLength": 4096
+          }
+        }
+      },
+      "RichEmbedVideo": {
+        "type": "object",
+        "properties": {
+          "url": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "maxLength": 2048,
+            "format": "uri"
+          },
+          "width": {
+            "type": [
+              "integer",
+              "null"
+            ]
+          },
+          "height": {
+            "type": [
+              "integer",
+              "null"
+            ]
+          },
+          "placeholder": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "maxLength": 64
+          },
+          "placeholder_version": {
+            "type": [
+              "integer",
+              "null"
+            ],
+            "minimum": 0,
+            "maximum": 2147483647
+          },
+          "is_animated": {
+            "type": [
+              "boolean",
+              "null"
+            ]
+          },
+          "description": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "maxLength": 4096
+          }
+        }
+      },
+      "SectionComponentForMessageRequest": {
+        "type": "object",
+        "additionalProperties": true,
+        "description": "A SectionComponentForMessageRequest. Structure omitted: this union inlines to hundreds of kilobytes. Pass the object as documented at https://discord.com/developers/docs/components/reference."
+      },
+      "SeparatorComponentForMessageRequest": {
+        "type": "object",
+        "additionalProperties": true,
+        "description": "A SeparatorComponentForMessageRequest. Structure omitted: this union inlines to hundreds of kilobytes. Pass the object as documented at https://discord.com/developers/docs/components/reference."
+      },
+      "SnowflakeType": {
+        "type": "string",
+        "pattern": "^(0|[1-9][0-9]*)$",
+        "format": "snowflake"
+      },
+      "TextDisplayComponentForMessageRequest": {
+        "type": "object",
+        "additionalProperties": true,
+        "description": "A TextDisplayComponentForMessageRequest. Structure omitted: this union inlines to hundreds of kilobytes. Pass the object as documented at https://discord.com/developers/docs/components/reference."
+      },
+      "ThreadAutoArchiveDuration": {
+        "type": "integer",
+        "oneOf": [
+          {
+            "title": "ONE_HOUR",
+            "description": "One hour",
+            "const": 60
+          },
+          {
+            "title": "ONE_DAY",
+            "description": "One day",
+            "const": 1440
+          },
+          {
+            "title": "THREE_DAY",
+            "description": "Three days",
+            "const": 4320
+          },
+          {
+            "title": "SEVEN_DAY",
+            "description": "Seven days",
+            "const": 10080
+          }
+        ],
+        "format": "int32"
+      }
+    },
+    "securitySchemes": {
+      "BotToken": {
+        "type": "apiKey",
+        "description": "Discord bot token",
+        "name": "Authorization",
+        "in": "header"
+      },
+      "OAuth2": {
+        "type": "oauth2",
+        "flows": {
+          "implicit": {
+            "authorizationUrl": "https://discord.com/api/oauth2/authorize",
+            "refreshUrl": "https://discord.com/api/oauth2/token",
+            "scopes": {
+              "activities.invites.write": "allows your app to send activity invites - requires Discord approval (NOT REQUIRED FOR GAMESDK ACTIVITY MANAGER)",
+              "activities.read": "allows your app to fetch data from a user's \"Now Playing/Recently Played\" list - requires Discord approval",
+              "activities.write": "allows your app to update a user's activity - requires Discord approval (NOT REQUIRED FOR GAMESDK ACTIVITY MANAGER)",
+              "applications.builds.read": "allows your app to read build data for a user's applications",
+              "applications.builds.upload": "allows your app to upload/update builds for a user's applications - requires Discord approval",
+              "applications.commands": "allows your app to use commands in a guild",
+              "applications.commands.permissions.update": "allows your app to update permissions for its commands in a guild a user has permissions to",
+              "applications.entitlements": "allows your app to read entitlements for a user's applications",
+              "applications.store.update": "allows your app to read and update store data (SKUs, store listings, achievements, etc.) for a user's applications",
+              "bot": "for oauth2 bots, this puts the bot in the user's selected guild by default",
+              "connections": "allows /users/@me/connections to return linked third-party accounts",
+              "dm_channels.read": "allows your app to see information about the user's DMs and group DMs - requires Discord approval",
+              "email": "enables /users/@me to return an email",
+              "gdm.join": "allows your app to join users to a group dm",
+              "guilds": "allows /users/@me/guilds to return basic information about all of a user's guilds",
+              "guilds.join": "allows /guilds/{guild.id}/members/{user.id} to be used for joining users to a guild",
+              "guilds.members.read": "allows /users/@me/guilds/{guild.id}/member to return a user's member information in a guild",
+              "identify": "allows /users/@me without email",
+              "messages.read": "for local rpc server api access, this allows you to read messages from all client channels (otherwise restricted to channels/guilds your app creates)",
+              "openid": "for OpenID Connect, this allows your app to receive user id and basic profile information",
+              "relationships.read": "allows your app to know a user's friends and implicit relationships - requires Discord approval",
+              "rpc": "for local rpc server access, this allows you to control a user's local Discord client - requires Discord approval",
+              "rpc.activities.write": "for local rpc server access, this allows you to update a user's activity - requires Discord approval",
+              "rpc.notifications.read": "for local rpc server access, this allows you to receive notifications pushed out to the user - requires Discord approval",
+              "rpc.screenshare.read": "for local rpc server access, this allows you to read a user's screenshare status- requires Discord approval",
+              "rpc.screenshare.write": "for local rpc server access, this allows you to update a user's screenshare settings- requires Discord approval",
+              "rpc.video.read": "for local rpc server access, this allows you to read a user's video status - requires Discord approval",
+              "rpc.video.write": "for local rpc server access, this allows you to update a user's video settings - requires Discord approval",
+              "rpc.voice.read": "for local rpc server access, this allows you to read a user's voice settings and listen for voice events - requires Discord approval",
+              "rpc.voice.write": "for local rpc server access, this allows you to update a user's voice settings - requires Discord approval",
+              "voice": "allows your app to connect to voice on user's behalf and see all the voice members - requires Discord approval",
+              "webhook.incoming": "this generates a webhook that is returned in the oauth token response for authorization code grants"
+            }
+          },
+          "clientCredentials": {
+            "tokenUrl": "https://discord.com/api/oauth2/token",
+            "refreshUrl": "https://discord.com/api/oauth2/token",
+            "scopes": {
+              "activities.invites.write": "allows your app to send activity invites - requires Discord approval (NOT REQUIRED FOR GAMESDK ACTIVITY MANAGER)",
+              "activities.read": "allows your app to fetch data from a user's \"Now Playing/Recently Played\" list - requires Discord approval",
+              "activities.write": "allows your app to update a user's activity - requires Discord approval (NOT REQUIRED FOR GAMESDK ACTIVITY MANAGER)",
+              "applications.builds.read": "allows your app to read build data for a user's applications",
+              "applications.builds.upload": "allows your app to upload/update builds for a user's applications - requires Discord approval",
+              "applications.commands": "allows your app to use commands in a guild",
+              "applications.commands.permissions.update": "allows your app to update permissions for its commands in a guild a user has permissions to",
+              "applications.commands.update": "allows your app to update its commands using a Bearer token - client credentials grant only",
+              "applications.entitlements": "allows your app to read entitlements for a user's applications",
+              "applications.store.update": "allows your app to read and update store data (SKUs, store listings, achievements, etc.) for a user's applications",
+              "bot": "for oauth2 bots, this puts the bot in the user's selected guild by default",
+              "connections": "allows /users/@me/connections to return linked third-party accounts",
+              "dm_channels.read": "allows your app to see information about the user's DMs and group DMs - requires Discord approval",
+              "email": "enables /users/@me to return an email",
+              "gdm.join": "allows your app to join users to a group dm",
+              "guilds": "allows /users/@me/guilds to return basic information about all of a user's guilds",
+              "guilds.join": "allows /guilds/{guild.id}/members/{user.id} to be used for joining users to a guild",
+              "guilds.members.read": "allows /users/@me/guilds/{guild.id}/member to return a user's member information in a guild",
+              "identify": "allows /users/@me without email",
+              "messages.read": "for local rpc server api access, this allows you to read messages from all client channels (otherwise restricted to channels/guilds your app creates)",
+              "openid": "for OpenID Connect, this allows your app to receive user id and basic profile information",
+              "relationships.read": "allows your app to know a user's friends and implicit relationships - requires Discord approval",
+              "rpc": "for local rpc server access, this allows you to control a user's local Discord client - requires Discord approval",
+              "rpc.activities.write": "for local rpc server access, this allows you to update a user's activity - requires Discord approval",
+              "rpc.notifications.read": "for local rpc server access, this allows you to receive notifications pushed out to the user - requires Discord approval",
+              "rpc.screenshare.read": "for local rpc server access, this allows you to read a user's screenshare status- requires Discord approval",
+              "rpc.screenshare.write": "for local rpc server access, this allows you to update a user's screenshare settings- requires Discord approval",
+              "rpc.video.read": "for local rpc server access, this allows you to read a user's video status - requires Discord approval",
+              "rpc.video.write": "for local rpc server access, this allows you to update a user's video settings - requires Discord approval",
+              "rpc.voice.read": "for local rpc server access, this allows you to read a user's voice settings and listen for voice events - requires Discord approval",
+              "rpc.voice.write": "for local rpc server access, this allows you to update a user's voice settings - requires Discord approval",
+              "voice": "allows your app to connect to voice on user's behalf and see all the voice members - requires Discord approval",
+              "webhook.incoming": "this generates a webhook that is returned in the oauth token response for authorization code grants"
+            }
+          },
+          "authorizationCode": {
+            "authorizationUrl": "https://discord.com/api/oauth2/authorize",
+            "tokenUrl": "https://discord.com/api/oauth2/token",
+            "refreshUrl": "https://discord.com/api/oauth2/token",
+            "scopes": {
+              "activities.invites.write": "allows your app to send activity invites - requires Discord approval (NOT REQUIRED FOR GAMESDK ACTIVITY MANAGER)",
+              "activities.read": "allows your app to fetch data from a user's \"Now Playing/Recently Played\" list - requires Discord approval",
+              "activities.write": "allows your app to update a user's activity - requires Discord approval (NOT REQUIRED FOR GAMESDK ACTIVITY MANAGER)",
+              "applications.builds.read": "allows your app to read build data for a user's applications",
+              "applications.builds.upload": "allows your app to upload/update builds for a user's applications - requires Discord approval",
+              "applications.commands": "allows your app to use commands in a guild",
+              "applications.commands.permissions.update": "allows your app to update permissions for its commands in a guild a user has permissions to",
+              "applications.entitlements": "allows your app to read entitlements for a user's applications",
+              "applications.store.update": "allows your app to read and update store data (SKUs, store listings, achievements, etc.) for a user's applications",
+              "bot": "for oauth2 bots, this puts the bot in the user's selected guild by default",
+              "connections": "allows /users/@me/connections to return linked third-party accounts",
+              "dm_channels.read": "allows your app to see information about the user's DMs and group DMs - requires Discord approval",
+              "email": "enables /users/@me to return an email",
+              "gdm.join": "allows your app to join users to a group dm",
+              "guilds": "allows /users/@me/guilds to return basic information about all of a user's guilds",
+              "guilds.join": "allows /guilds/{guild.id}/members/{user.id} to be used for joining users to a guild",
+              "guilds.members.read": "allows /users/@me/guilds/{guild.id}/member to return a user's member information in a guild",
+              "identify": "allows /users/@me without email",
+              "messages.read": "for local rpc server api access, this allows you to read messages from all client channels (otherwise restricted to channels/guilds your app creates)",
+              "openid": "for OpenID Connect, this allows your app to receive user id and basic profile information",
+              "relationships.read": "allows your app to know a user's friends and implicit relationships - requires Discord approval",
+              "role_connections.write": "allows your app to update a user's connection and metadata for the app",
+              "rpc": "for local rpc server access, this allows you to control a user's local Discord client - requires Discord approval",
+              "rpc.activities.write": "for local rpc server access, this allows you to update a user's activity - requires Discord approval",
+              "rpc.notifications.read": "for local rpc server access, this allows you to receive notifications pushed out to the user - requires Discord approval",
+              "rpc.screenshare.read": "for local rpc server access, this allows you to read a user's screenshare status- requires Discord approval",
+              "rpc.screenshare.write": "for local rpc server access, this allows you to update a user's screenshare settings- requires Discord approval",
+              "rpc.video.read": "for local rpc server access, this allows you to read a user's video status - requires Discord approval",
+              "rpc.video.write": "for local rpc server access, this allows you to update a user's video settings - requires Discord approval",
+              "rpc.voice.read": "for local rpc server access, this allows you to read a user's voice settings and listen for voice events - requires Discord approval",
+              "rpc.voice.write": "for local rpc server access, this allows you to update a user's voice settings - requires Discord approval",
+              "voice": "allows your app to connect to voice on user's behalf and see all the voice members - requires Discord approval",
+              "webhook.incoming": "this generates a webhook that is returned in the oauth token response for authorization code grants"
+            }
+          }
+        }
+      }
+    },
+    "responses": {
+      "ClientErrorResponse": {
+        "description": "Client error response",
+        "headers": {
+          "X-RateLimit-Limit": {
+            "$ref": "#/components/headers/X-RateLimit-Limit"
+          },
+          "X-RateLimit-Remaining": {
+            "$ref": "#/components/headers/X-RateLimit-Remaining"
+          },
+          "X-RateLimit-Reset": {
+            "$ref": "#/components/headers/X-RateLimit-Reset"
+          },
+          "X-RateLimit-Reset-After": {
+            "$ref": "#/components/headers/X-RateLimit-Reset-After"
+          },
+          "X-RateLimit-Bucket": {
+            "$ref": "#/components/headers/X-RateLimit-Bucket"
+          }
+        },
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/ErrorResponse"
+            }
+          }
+        }
+      },
+      "ClientRatelimitedResponse": {
+        "description": "Client ratelimited response",
+        "headers": {
+          "X-RateLimit-Limit": {
+            "$ref": "#/components/headers/X-RateLimit-Limit"
+          },
+          "X-RateLimit-Remaining": {
+            "$ref": "#/components/headers/X-RateLimit-Remaining"
+          },
+          "X-RateLimit-Reset": {
+            "$ref": "#/components/headers/X-RateLimit-Reset"
+          },
+          "X-RateLimit-Reset-After": {
+            "$ref": "#/components/headers/X-RateLimit-Reset-After"
+          },
+          "X-RateLimit-Bucket": {
+            "$ref": "#/components/headers/X-RateLimit-Bucket"
+          }
+        },
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/RatelimitedResponse"
+            }
+          }
+        }
+      }
+    },
+    "headers": {
+      "X-RateLimit-Limit": {
+        "schema": {
+          "type": "integer"
+        },
+        "description": "The maximum number of requests that can be made in the current ratelimit window"
+      },
+      "X-RateLimit-Remaining": {
+        "schema": {
+          "type": "integer"
+        },
+        "description": "The number of requests remaining in the current ratelimit window"
+      },
+      "X-RateLimit-Reset": {
+        "schema": {
+          "type": "number"
+        },
+        "description": "A unix timestamp in seconds at which the current ratelimit window resets"
+      },
+      "X-RateLimit-Reset-After": {
+        "schema": {
+          "type": "number"
+        },
+        "description": "The duration in seconds until the current ratelimit window resets"
+      },
+      "X-RateLimit-Bucket": {
+        "schema": {
+          "type": "string"
+        },
+        "description": "The bucket that the request belongs to"
+      }
+    }
+  }
+}

--- a/src/providers/discord/specs/vendor.ts
+++ b/src/providers/discord/specs/vendor.ts
@@ -1,0 +1,164 @@
+/**
+ * Vendor a trimmed OpenAPI spec for Discord's v10 HTTP API.
+ *
+ * Discord publishes an OpenAPI document of its own, which is unusual and
+ * welcome, but ships it as a public preview: "subject to breaking changes
+ * without advance notice, and should not be used within production
+ * environments". Vendoring is what answers that. The committed copy never moves
+ * under us, so a breaking change upstream becomes a diff in a refresh commit
+ * rather than a provider that stops working — and the surface an operator's bot
+ * token can reach stays reviewable.
+ *
+ *   bun run vendor:discord
+ *
+ * The pipeline is `src/providers/shared/vendor-spec.ts`. What stays here is what
+ * only Discord knows: which operations are worth exposing, and the three shapes
+ * in its document that the generator cannot take as written.
+ */
+
+import { vendorSpec } from '../../shared/vendor-spec.ts';
+
+const SOURCE = 'https://raw.githubusercontent.com/discord/discord-api-spec/main/specs/openapi.json';
+
+/**
+ * The operations this provider exposes, out of 242 in the document.
+ *
+ * Curated hard, and the curation is load-bearing rather than tidy: `connect`
+ * writes one policy rule, `discord.*`, so an operation vendored here is an
+ * operation an agent may call. This list *is* the boundary. Discord's own API
+ * would otherwise hand over kick, ban, timeout, role assignment, channel
+ * deletion, and guild settings against a server the operator owns.
+ *
+ * What is deliberately absent, so a later refresh does not quietly add it back:
+ * `bulk_delete_messages` (a mass action no announcement workflow needs), every
+ * `deprecated_*` pin variant (superseded paths, kept by Discord for old
+ * clients), and everything under members, roles, bans, invites, and guild
+ * settings.
+ */
+const READS = [
+  // Whose token this is. The first call worth making after connecting, and the
+  // one that proves the `Bot ` prefix survived being pasted.
+  'get_my_user',
+  // Navigation: which servers the bot was added to, what is in them, and what
+  // one channel is. An agent cannot post to a channel it cannot name.
+  'list_my_guilds',
+  'get_guild',
+  'list_guild_channels',
+  'get_channel',
+  // The triage read. Discord exposes no message search to bots, so reading a
+  // channel means paging `list_messages` with `after` and `limit`.
+  'list_messages',
+  'get_message',
+  'list_pins',
+  'list_message_reactions_by_emoji',
+  'get_active_guild_threads',
+] as const;
+
+const WRITES = [
+  // Posting, as the app.
+  'create_message',
+  // Editing and retracting one's own announcement. `update_message` is the
+  // typo fix; `delete_message` is the retraction, which is why it is here and
+  // `bulk_delete_messages` is not.
+  'update_message',
+  'delete_message',
+  // Publishing a message posted in an announcement channel out to the servers
+  // that follow it — the one operation that makes an announcement channel worth
+  // using rather than an ordinary one.
+  'crosspost_message',
+  // Triage marking: react to it, pin it, or turn it into a thread. All three
+  // are how a human reads back what the agent decided.
+  'add_my_message_reaction',
+  'create_pin',
+  'create_thread_from_message',
+] as const;
+
+/**
+ * Posting under the operator's own name rather than the app's.
+ *
+ * Discord has no API for acting as a user account — automating one violates
+ * their terms — so an integration posts as an application, and an application's
+ * messages carry an `APP` badge that cannot be removed. What *can* be set is the
+ * name and avatar, and `execute_webhook` sets them per message. So an
+ * announcement can read as the operator while an ordinary reply reads as the
+ * integration, from one bot token.
+ *
+ * The cost is stated in `docs/detailed/security.md`: `create_webhook` and
+ * `list_channel_webhooks` return the webhook's token in their response, and a
+ * webhook token is a standalone credential for posting to that channel.
+ */
+const WEBHOOKS = ['list_channel_webhooks', 'create_webhook', 'execute_webhook'] as const;
+
+/**
+ * Discord's v2 message components, collapsed to open objects.
+ *
+ * `mcp-from-openapi` inlines `$ref`s, and this union is referenced by four
+ * request schemas and again from inside two of its own members — so inlining
+ * duplicates the whole tree six times over. There is no wrapper schema to
+ * collapse instead; the union is written out inline at each site.
+ *
+ * Measured, this is the difference between a provider that ships and one that
+ * cannot: `execute_webhook` generates a 148.9 KB input schema against a 64 KB
+ * per-tool budget, `create_message` 76.2 KB, `update_message` 72.6 KB, and the
+ * whole surface 305.4 KB against a 192 KB budget. Opaque brings the worst tool to
+ * 10.4 KB and the surface to 34.1 KB.
+ *
+ * `RichEmbed` is deliberately *not* here. It costs 3.1 KB — 1.6% of the surface
+ * budget — and it is how an announcement gets a title, a colour, and fields, so
+ * it is the one rich shape worth schematising. Collapsing it instead was
+ * measured and moves the worst tool from 148.9 KB to 144.2 KB, which is to say
+ * embeds were never the problem.
+ */
+const OPAQUE = [
+  'ActionRowComponentForMessageRequest',
+  'ContainerComponentForMessageRequest',
+  'FileComponentForMessageRequest',
+  'MediaGalleryComponentForMessageRequest',
+  'SectionComponentForMessageRequest',
+  'SeparatorComponentForMessageRequest',
+  'TextDisplayComponentForMessageRequest',
+];
+
+await vendorSpec('discord', {
+  source: SOURCE,
+  outputDirectory: import.meta.dir,
+  out: 'discord.v10.json',
+  operations: [...READS, ...WRITES, ...WEBHOOKS],
+  opaque: OPAQUE,
+  opaqueNote:
+    'Structure omitted: this union inlines to hundreds of kilobytes. ' +
+    'Pass the object as documented at https://discord.com/developers/docs/components/reference.',
+  vendoredNote:
+    'Trimmed by src/providers/discord/specs/vendor.ts. Committed deliberately: upstream is a public preview that may change without notice, and a spec decides which paths are called with the operator bot token — so it must be reviewable rather than fetched at connect time.',
+
+  // Discord declares path parameters on the path item, not the operation. That
+  // is legal, and `mcp-from-openapi`'s validator does not read it: without this
+  // the document fails outright with 29 × MISSING_PATH_PARAMETER and generates
+  // no tools at all.
+  hoistPathParameters: true,
+
+  // `create_message`, `update_message` and `execute_webhook` also offer
+  // `multipart/form-data`, whose file fields are named `files[0]`. That is not a
+  // legal tool property name, and one illegal name rejects the entire tools list
+  // for every provider on the endpoint — so the only thing standing between us
+  // and that is the generator preferring JSON of its own accord.
+  //
+  // The transport can now form-encode as well as JSON-encode (ADR-045), but not
+  // multipart, so a multipart branch is unsendable regardless of which one the
+  // generator picks. Attachments are unavailable as a result, which is the honest
+  // state: ADR-017's machinery is the route to them, not a branch nothing sends.
+  requestContentTypes: ['application/json'],
+
+  // `execute_webhook`'s body is a top-level `anyOf` of two complete payload
+  // schemas. A union has no `properties` to walk, so the generator emits one
+  // argument literally named `body` and the connector then sends
+  // `{"body":{"content":"…"}}` where Discord expects `{"content":"…"}`. Nothing
+  // in the test suite can see this: the name is legal, the size is fine, the
+  // base_url matches — only a live call fails.
+  //
+  // Naming the branch that is actually wanted flattens it back to 17 real
+  // arguments. Lossless: the other branch's properties are a strict subset.
+  rewriteRequestBody: {
+    execute_webhook: { $ref: '#/components/schemas/IncomingWebhookRequestPartial' },
+  },
+});

--- a/src/providers/google/specs/vendor.ts
+++ b/src/providers/google/specs/vendor.ts
@@ -15,16 +15,13 @@
  * command rather than a hand edit.
  *
  *   bun run vendor:google
+ *
+ * The pipeline itself is `src/providers/shared/vendor-spec.ts`. What stays here
+ * is what only Google knows: which operations are worth exposing, and which of
+ * its system parameters have to go.
  */
 
-import { mkdir, writeFile } from 'node:fs/promises';
-import { join } from 'node:path';
-import { OpenAPIToolGenerator, type McpOpenAPITool } from 'mcp-from-openapi';
-import { cutCycles, referenced, type Spec } from '../../shared/openapi.ts';
-
-/** Kept in step with `BUDGET_KB` in `src/cli/tools.test.ts`, which enforces it. */
-const BUDGET_KB = 64;
-
+import { vendorSpec } from '../../shared/vendor-spec.ts';
 
 /**
  * The operations each provider exposes.
@@ -314,50 +311,6 @@ const SELECTION: Record<
   // field but `title` on it anyway.
 };
 
-
-
-/**
- * Replace a named schema with an open object.
- *
- * Same device as `cutCycles` and a different disease. That one cuts recursion;
- * this one cuts *fan-out*. `mcp-from-openapi` inlines `$ref`s, so a schema's
- * cost to us is not its size in the document but its size once every reference
- * below it has been expanded — and Sheets' `Request` is a union of some eighty
- * variants, each with its own nested grid, filter, and chart schemas, sharing
- * sub-schemas that inlining duplicates per occurrence.
- *
- * Measured: `sheets.spreadsheets.batchUpdate` generates a 2,469KB input schema,
- * against 45KB for the whole of Drive. That is unusable — it would be sent on
- * every `tools/list` — and it is also the only operation that can add a tab,
- * freeze a header, or format a cell, so dropping it is no better.
- *
- * Opaque keeps the operation and costs 3KB. The agent fills in `requests` from
- * the API it already knows, which is the same bet `raw` makes for a Gmail draft:
- * a well-known wire format is cheaper described than schematised. The pointer to
- * Google's reference is in the description because that is the only thing lost.
- *
- * Applied before `referenced`, so the schemas that were reachable only through
- * the replaced one leave the document entirely rather than lingering unused.
- */
-function makeOpaque(schemas: Record<string, unknown>, names: readonly string[]): number {
-  let replaced = 0;
-
-  for (const name of names) {
-    if (!(name in schemas)) continue;
-    const original = schemas[name] as { description?: string };
-    schemas[name] = {
-      type: 'object',
-      additionalProperties: true,
-      description:
-        `${original.description ?? `A ${name}.`} Structure omitted: it expands to megabytes ` +
-        'when inlined. Pass the object as documented at https://developers.google.com/workspace.',
-    };
-    replaced++;
-  }
-
-  return replaced;
-}
-
 /**
  * Google's system parameters, dropped from every operation.
  *
@@ -391,188 +344,33 @@ const SYSTEM_PARAMETERS = new Set([
 ]);
 
 /**
- * Strip system parameters from a path item or an operation.
- *
- * They arrive as `$ref`s into `components.parameters`, and the component *key*
- * is not the parameter name — `$.xgafv` is keyed `_.xgafv`, because a `$` is
- * awkward in a JSON pointer. Matching on the key would therefore miss exactly
- * the one that breaks everything, so the ref is resolved first.
+ * The note recorded in each spec's `info`, and the one `makeOpaque` leaves
+ * behind. Both are baked into the committed JSON, so they are passed verbatim
+ * rather than reworded.
  */
-function dropSystemParameters(
-  holder: Record<string, unknown>,
-  components: Record<string, unknown>,
-): number {
-  const parameters = holder['parameters'];
-  if (!Array.isArray(parameters)) return 0;
+const VENDORED_NOTE =
+  'Trimmed by src/providers/google/specs/vendor.ts. Committed deliberately: a spec decides which paths are called with the operator token, so it must be reviewable rather than fetched at connect time.';
 
-  const nameOf = (parameter: unknown): string | undefined => {
-    const record = parameter as { name?: string; $ref?: string };
-    if (record.name) return record.name;
-    if (!record.$ref) return undefined;
+const OPAQUE_NOTE =
+  'Structure omitted: it expands to megabytes when inlined. ' +
+  'Pass the object as documented at https://developers.google.com/workspace.';
 
-    const key = record.$ref.replace('#/components/parameters/', '');
-    return (components[key] as { name?: string } | undefined)?.name;
-  };
-
-  const kept = parameters.filter((parameter) => {
-    const name = nameOf(parameter);
-    return !(name && SYSTEM_PARAMETERS.has(name));
+for (const [id, selection] of Object.entries(SELECTION)) {
+  await vendorSpec(id, {
+    source: selection.source,
+    // `import.meta.dir` *is* the specs directory — this script lives beside what
+    // it writes. It used to be `scripts/vendor-google-specs.ts` and reached
+    // across the tree; commit 3cd03ce moved the script and the specs together
+    // but not the path arithmetic, so for a while this resolved to
+    // `src/providers/google/providers/builtin/specs`, created it, reported
+    // success, and left the committed spec untouched — making the documented
+    // "re-run the script" step a silent no-op.
+    outputDirectory: import.meta.dir,
+    out: selection.out,
+    operations: selection.operations,
+    ...(selection.opaque ? { opaque: selection.opaque } : {}),
+    opaqueNote: OPAQUE_NOTE,
+    vendoredNote: VENDORED_NOTE,
+    systemParameters: SYSTEM_PARAMETERS,
   });
-
-  holder['parameters'] = kept;
-  return parameters.length - kept.length;
 }
-
-const METHODS = ['get', 'post', 'put', 'patch', 'delete', 'head'];
-
-async function vendor(id: string): Promise<void> {
-  const { source, out, operations, opaque } = SELECTION[id]!;
-  const wanted = new Set(operations);
-
-  const response = await fetch(source);
-  if (!response.ok) throw new Error(`${source}: HTTP ${response.status}`);
-  const spec = (await response.json()) as Spec;
-
-  const paths: Spec['paths'] = {};
-  const seen = new Set<string>();
-
-  for (const [path, item] of Object.entries(spec.paths)) {
-    const kept: Record<string, unknown> = {};
-    for (const [method, operation] of Object.entries(item)) {
-      // Path-level keys are not operations and must survive: `parameters` here
-      // is where Google puts the query parameters shared by every method on the
-      // path, and `fields` is one of them — which `drive.about.get` *requires*.
-      // Dropping it produced a tool with no arguments at all and a 400 on every
-      // call.
-      if (!METHODS.includes(method)) {
-        kept[method] = operation;
-        continue;
-      }
-      const operationId = operation.operationId;
-      if (!operationId || !wanted.has(operationId)) continue;
-      kept[method] = operation;
-      seen.add(operationId);
-    }
-
-    // Only path-level keys survived, so no operation here was wanted.
-    if (!Object.keys(kept).some((key) => METHODS.includes(key))) continue;
-    if (Object.keys(kept).length > 0) paths[path] = kept as Spec['paths'][string];
-  }
-
-  const componentParameters = (spec.components?.['parameters'] ?? {}) as Record<string, unknown>;
-
-  let dropped = 0;
-  for (const item of Object.values(paths)) {
-    dropped += dropSystemParameters(item as unknown as Record<string, unknown>, componentParameters);
-    for (const [method, operation] of Object.entries(item)) {
-      if (!METHODS.includes(method)) continue;
-      dropped += dropSystemParameters(
-        operation as unknown as Record<string, unknown>,
-        componentParameters,
-      );
-    }
-  }
-
-  // Drop response schemas.
-  //
-  // Two reasons, and the second is the blocking one. Nothing reads them: the
-  // connector hands the response body back as text, because an agent wants the
-  // JSON, not a validated shape. And Gmail's response schemas are recursive —
-  // `Message.payload` is a `MessagePart`, which contains `MessagePart[]` — which
-  // sends the OpenAPI tool generator into infinite recursion and silently drops
-  // eight of Gmail's twelve operations from the tool list.
-  for (const item of Object.values(paths)) {
-    for (const [method, operation] of Object.entries(item)) {
-      if (!METHODS.includes(method)) continue;
-      (operation as { responses?: unknown }).responses = {
-        '200': { description: 'Success. The response body is returned verbatim.' },
-      };
-    }
-  }
-
-  const missing = operations.filter((operationId) => !seen.has(operationId));
-  if (missing.length > 0) {
-    // Loudly, rather than shipping a provider quietly missing capabilities: an
-    // upstream rename should fail the refresh, not shrink the tool list.
-    throw new Error(`${id}: these operations are not in the spec — ${missing.join(', ')}`);
-  }
-
-  const schemas = spec.components?.schemas ?? {};
-  const opaqued = makeOpaque(schemas, opaque ?? []);
-  const keep = referenced(paths, schemas);
-  const trimmedSchemas = Object.fromEntries(
-    Object.entries(schemas).filter(([name]) => keep.has(name)),
-  );
-  const cuts = cutCycles(trimmedSchemas);
-
-  const trimmed: Spec = {
-    openapi: spec.openapi,
-    info: {
-      ...spec.info,
-      'x-vendored-from': source,
-      'x-vendored-note':
-        'Trimmed by src/providers/google/specs/vendor.ts. Committed deliberately: a spec decides which paths are called with the operator token, so it must be reviewable rather than fetched at connect time.',
-    },
-    ...(spec.servers ? { servers: spec.servers } : {}),
-    paths,
-    components: { ...spec.components, schemas: trimmedSchemas },
-  };
-
-  // `import.meta.dir` *is* the specs directory — this script lives beside what it
-  // writes. It used to be `scripts/vendor-google-specs.ts` and reached across the
-  // tree; commit 3cd03ce moved the script and the specs together but not the path
-  // arithmetic, so for a while this resolved to
-  // `src/providers/google/providers/builtin/specs`, created it, reported success,
-  // and left the committed spec untouched — making the documented "re-run the
-  // script" step a silent no-op.
-  const directory = import.meta.dir;
-  await mkdir(directory, { recursive: true });
-  await writeFile(join(directory, out), `${JSON.stringify(trimmed, null, 2)}\n`);
-
-  const size = Math.round(JSON.stringify(trimmed).length / 1024);
-  console.log(
-    `  ${id.padEnd(6)} ${String(Object.keys(paths).length).padStart(2)} paths, ` +
-      `${seen.size} operations, ${Object.keys(trimmedSchemas).length} schemas, ` +
-      `${cuts} cycle${cuts === 1 ? '' : 's'} cut, ${opaqued} made opaque, ` +
-      `${dropped} system params dropped, ${size}KB`,
-  );
-
-  await reportLargestTools(trimmed);
-}
-
-/**
- * The number the budget is actually about.
- *
- * Everything on the line above counts the *spec*; `cli/tools.test.ts` measures
- * the **generated input schema**, and the two differ by orders of magnitude
- * because `mcp-from-openapi` inlines `$ref`s — a schema shared by ten fields is
- * ten copies once generated. Reasoning about `spreadsheets.create` from a schema
- * count put it at 122 KB when the real figure was 1,133 KB, which is the whole
- * difference between "just over" and "seventeen times over".
- *
- * Printed here so the refresh that adds an operation shows its cost, rather than
- * leaving it to a test failure to say so after the fact.
- */
-async function reportLargestTools(trimmed: Spec): Promise<void> {
-  try {
-    const generator = await OpenAPIToolGenerator.fromJSON(trimmed);
-    const measured = (await generator.generateTools())
-      .map((tool: McpOpenAPITool) => ({
-        name: tool.metadata.operationId ?? tool.name,
-        kb: JSON.stringify(tool.inputSchema).length / 1024,
-      }))
-      .sort((a, b) => b.kb - a.kb);
-
-    for (const { name, kb } of measured.slice(0, 3)) {
-      const over = kb > BUDGET_KB ? `  ✗ over the ${BUDGET_KB}KB budget` : '';
-      console.log(`         ${name.padEnd(38)} ${kb.toFixed(1).padStart(8)}KB${over}`);
-    }
-  } catch (error) {
-    // A generator failure is a real problem, but it is `tools.test.ts`'s to
-    // report against every provider at once. Refusing to finish the vendoring
-    // over it would leave the specs half-written.
-    console.log(`         (could not measure generated schemas: ${String(error)})`);
-  }
-}
-
-for (const id of Object.keys(SELECTION)) await vendor(id);

--- a/src/providers/google/specs/vendor.ts
+++ b/src/providers/google/specs/vendor.ts
@@ -20,18 +20,11 @@
 import { mkdir, writeFile } from 'node:fs/promises';
 import { join } from 'node:path';
 import { OpenAPIToolGenerator, type McpOpenAPITool } from 'mcp-from-openapi';
+import { cutCycles, referenced, type Spec } from '../../shared/openapi.ts';
 
 /** Kept in step with `BUDGET_KB` in `src/cli/tools.test.ts`, which enforces it. */
 const BUDGET_KB = 64;
 
-interface Spec {
-  openapi: string;
-  info: Record<string, unknown>;
-  servers?: Array<{ url: string }>;
-  paths: Record<string, Record<string, { operationId?: string } & Record<string, unknown>>>;
-  components?: { schemas?: Record<string, unknown> } & Record<string, unknown>;
-  [key: string]: unknown;
-}
 
 /**
  * The operations each provider exposes.
@@ -321,83 +314,7 @@ const SELECTION: Record<
   // field but `title` on it anyway.
 };
 
-/** Every `$ref` target reachable from a value, transitively. */
-function referenced(root: unknown, schemas: Record<string, unknown>): Set<string> {
-  const found = new Set<string>();
-  const queue: unknown[] = [root];
 
-  while (queue.length > 0) {
-    const node = queue.pop();
-    if (node === null || typeof node !== 'object') continue;
-
-    if (Array.isArray(node)) {
-      queue.push(...node);
-      continue;
-    }
-
-    for (const [key, value] of Object.entries(node)) {
-      if (key === '$ref' && typeof value === 'string') {
-        const name = value.replace('#/components/schemas/', '');
-        if (!found.has(name) && name in schemas) {
-          found.add(name);
-          queue.push(schemas[name]);
-        }
-        continue;
-      }
-      queue.push(value);
-    }
-  }
-
-  return found;
-}
-
-/**
- * Cut reference cycles, replacing the back-edge with an open object.
- *
- * Gmail's `MessagePart` contains `MessagePart[]` — a MIME tree, so the
- * recursion is honest — and the OpenAPI tool generator inlines `$ref`s, so it
- * recurses until the stack ends. That silently costs the two draft-writing
- * operations, which are the useful half of `gmail.compose`.
- *
- * Cutting the back-edge rather than dropping the operation keeps the tool: the
- * field that matters for creating a draft is `raw`, an RFC 2822 message, and
- * nothing below the cut is required to fill it in. A depth-first walk marks the
- * names currently on the path, and any `$ref` reaching back to one of them
- * becomes a plain object.
- */
-function cutCycles(schemas: Record<string, unknown>): number {
-  let cuts = 0;
-
-  const walk = (node: unknown, path: Set<string>): void => {
-    if (node === null || typeof node !== 'object') return;
-
-    if (Array.isArray(node)) {
-      for (const item of node) walk(item, path);
-      return;
-    }
-
-    const record = node as Record<string, unknown>;
-    for (const [key, value] of Object.entries(record)) {
-      if (key === '$ref' && typeof value === 'string') {
-        const name = value.replace('#/components/schemas/', '');
-        if (path.has(name)) {
-          delete record['$ref'];
-          record['type'] = 'object';
-          record['additionalProperties'] = true;
-          record['description'] = `A nested ${name}. Structure omitted: it recurses.`;
-          cuts++;
-        } else if (name in schemas) {
-          walk(schemas[name], new Set([...path, name]));
-        }
-        continue;
-      }
-      walk(value, path);
-    }
-  };
-
-  for (const [name, schema] of Object.entries(schemas)) walk(schema, new Set([name]));
-  return cuts;
-}
 
 /**
  * Replace a named schema with an open object.

--- a/src/providers/index.ts
+++ b/src/providers/index.ts
@@ -1,6 +1,7 @@
 import type { ProviderDefinition, ProviderManifest } from '#connectivity';
 import { bunq } from './bunq/index.ts';
 import { calendar } from './google/calendar/index.ts';
+import { discord } from './discord/index.ts';
 import { contacts } from './google/contacts/index.ts';
 import { docs } from './google/docs/index.ts';
 import { github } from './github/index.ts';
@@ -56,6 +57,7 @@ export const PROVIDERS: readonly (ProviderManifest | ProviderDefinition)[] = [
   github,
   slack,
   reddit,
+  discord,
   gmail,
   drive,
   sheets,
@@ -100,6 +102,7 @@ export {
 } from './google/index.ts';
 export { icloudCalendar, icloudContacts, icloudDrive, icloudMail } from './icloud/index.ts';
 export { bunq } from './bunq/index.ts';
+export { discord } from './discord/index.ts';
 export { github } from './github/index.ts';
 export { linear } from './linear/index.ts';
 export { notion } from './notion/index.ts';

--- a/src/providers/index.ts
+++ b/src/providers/index.ts
@@ -16,6 +16,7 @@ import { icloudDrive } from './icloud/drive/index.ts';
 import { icloudMail } from './icloud/mail/index.ts';
 import { linear } from './linear/index.ts';
 import { notion } from './notion/index.ts';
+import { reddit } from './reddit/index.ts';
 import { slack } from './slack/index.ts';
 
 /**
@@ -53,6 +54,7 @@ export const PROVIDERS: readonly (ProviderManifest | ProviderDefinition)[] = [
   linear,
   github,
   slack,
+  reddit,
   gmail,
   drive,
   sheets,
@@ -98,5 +100,6 @@ export { icloudCalendar, icloudContacts, icloudDrive, icloudMail } from './iclou
 export { github } from './github/index.ts';
 export { linear } from './linear/index.ts';
 export { notion } from './notion/index.ts';
+export { reddit } from './reddit/index.ts';
 export { slack } from './slack/index.ts';
 export { SCOPE_MEANINGS, type ScopeMeaning } from './scopes.ts';

--- a/src/providers/index.ts
+++ b/src/providers/index.ts
@@ -1,4 +1,5 @@
 import type { ProviderDefinition, ProviderManifest } from '#connectivity';
+import { bunq } from './bunq/index.ts';
 import { calendar } from './google/calendar/index.ts';
 import { contacts } from './google/contacts/index.ts';
 import { docs } from './google/docs/index.ts';
@@ -69,6 +70,7 @@ export const PROVIDERS: readonly (ProviderManifest | ProviderDefinition)[] = [
   icloudCalendar,
   icloudContacts,
   icloudDrive,
+  bunq,
 ];
 
 /** The manifest half of an entry, whichever shape it arrived in. */
@@ -97,6 +99,7 @@ export {
   tasks,
 } from './google/index.ts';
 export { icloudCalendar, icloudContacts, icloudDrive, icloudMail } from './icloud/index.ts';
+export { bunq } from './bunq/index.ts';
 export { github } from './github/index.ts';
 export { linear } from './linear/index.ts';
 export { notion } from './notion/index.ts';

--- a/src/providers/reddit/index.ts
+++ b/src/providers/reddit/index.ts
@@ -1,0 +1,113 @@
+import { defineProvider } from '#connectivity';
+import {
+  REDDIT_APP,
+  REDDIT_REDIRECT_URI,
+  REDDIT_SCOPES,
+  REDDIT_USER_AGENT,
+  specPath,
+} from './oauth.ts';
+import { REDDIT_REDACT } from './redact.ts';
+
+/**
+ * Reddit, through its own REST API.
+ *
+ * No MCP server exists to proxy and no OpenAPI document is published, so the
+ * spec beside this file is hand-authored — fifteen operations chosen rather
+ * than a whole API filtered down. That is a real cost and it buys the thing
+ * ADR-008 is about: the operations still become capabilities mechanically, and
+ * there is no per-endpoint translation code anywhere in this folder.
+ *
+ * Reddit was the first provider to need three things the transports did not
+ * have — a form-encoded request body, a `User-Agent`, and an OAuth redirect on
+ * a port fixed in advance. All three are now general, because each was a gap
+ * rather than a Reddit quirk: the last one is the exact reason `../github`
+ * gives for using a pasted token instead of OAuth.
+ */
+export const reddit = defineProvider({
+  id: 'reddit',
+  name: 'Reddit',
+  description:
+    'Read subreddits, posts, comments, and search, and post, comment, vote, and edit as your account, via the Reddit API.',
+  connector: {
+    kind: 'http',
+    // Host only. Reddit puts no version in the path, and this must equal the
+    // spec's `servers[0].url` — `cli/tools.test.ts` checks that they agree.
+    base_url: 'https://oauth.reddit.com',
+    openapi: specPath('reddit.v1.json'),
+    headers: { 'User-Agent': REDDIT_USER_AGENT },
+  },
+  auth: {
+    kind: 'oauth',
+    registration: 'manual',
+    app: REDDIT_APP,
+    /**
+     * `www.reddit.com` for the grant, `oauth.reddit.com` for the API. Mixing
+     * the two 404s, and the 404 says nothing about which half was wrong.
+     */
+    authorize_url: 'https://www.reddit.com/api/v1/authorize',
+    token_url: 'https://www.reddit.com/api/v1/access_token',
+    redirect_uri: REDDIT_REDIRECT_URI,
+    scopes: [...REDDIT_SCOPES],
+    /**
+     * Without `duration=permanent` Reddit returns an access token and no
+     * refresh token. The connection then works for exactly one hour and stops,
+     * which is a miserable thing to debug an hour after a successful connect —
+     * the same failure `authorize_params` was added for, where Google needs
+     * `access_type=offline`.
+     */
+    authorize_params: { duration: 'permanent' },
+    revoke_url: 'https://www.reddit.com/api/v1/revoke_token',
+  },
+  identity: { kind: 'http', url: 'https://oauth.reddit.com/api/v1/me', field: 'name' },
+  redact: REDDIT_REDACT,
+  /**
+   * Said once here rather than left for the tool descriptions to imply.
+   *
+   * Both are things an agent gets wrong on the first attempt and cannot learn
+   * from the error: Reddit answers a bare id with a generic failure, and a
+   * subreddit that requires a flair rejects the submission without saying that
+   * a flair was what was missing.
+   */
+  hints: {
+    add_comment:
+      'thing_id must be a fullname — t3_<id> for a post, t1_<id> for a comment — not the bare id that appears in a URL.',
+    submit_post:
+      'Many subreddits reject a submission with no flair. Call list_flairs first and pass flair_id, and read get_rules when posting somewhere unfamiliar.',
+  },
+  setup: {
+    summary:
+      'Reddit needs an app of your own, which takes a couple of minutes in a browser. There is no shared ' +
+      'client for this one on purpose: Reddit rate-limits per client id, so a client everyone shared would ' +
+      'mean strangers using up your hundred requests a minute. Your own app gets its own budget.',
+    docs: 'docs/detailed/setup/reddit.md',
+    docs_url: 'https://www.reddit.com/prefs/apps',
+    steps: [
+      'Open https://www.reddit.com/prefs/apps and choose "create another app...".',
+      'Name it something you will recognise later — the name is how you revoke this one without touching your others.',
+      'Choose "web app". "script" only ever reaches your own account, and "installed app" has no secret for this to hold.',
+      `Set the redirect uri to exactly ${REDDIT_REDIRECT_URI} — Reddit matches it character for character, and this is the address this command listens on.`,
+      'Create the app. The client id is the string under the app name; the secret is the field labelled "secret".',
+      'Reddit also asks you to register for API access separately, from the link on that page. Creating the app is not the same as being allowed to call the API.',
+      'If you regenerate the secret later, run: lanes link connect reddit --replace.',
+    ],
+    troubleshooting:
+      'Reddit refused the connection. If the browser said "invalid redirect_uri", the value registered on the app ' +
+      `is not exactly ${REDDIT_REDIRECT_URI}. If the call failed after connecting, the app exists but API access ` +
+      'has not been granted — that is a separate registration, linked from https://www.reddit.com/prefs/apps. ' +
+      'A 429 means the hundred-per-minute limit for this client id was reached.',
+    prompts: [
+      {
+        key: 'client_id',
+        label: 'Reddit client ID',
+        secret: false,
+        credential_ref: `${REDDIT_APP}/client_id`,
+      },
+      {
+        key: 'client_secret',
+        label: 'Reddit client secret',
+        secret: true,
+        credential_ref: `${REDDIT_APP}/client_secret`,
+      },
+    ],
+  },
+});

--- a/src/providers/reddit/oauth.ts
+++ b/src/providers/reddit/oauth.ts
@@ -1,0 +1,77 @@
+/**
+ * The Reddit client, and why it is the operator's rather than ours.
+ *
+ * Every other pre-registered provider here reaches for the broker ADR-028
+ * built: one client Lanes operates, so nobody visits a console. That is the
+ * right default and it is the wrong answer for Reddit, for a reason particular
+ * to how Reddit meters access.
+ *
+ * Reddit's rate limit is a hundred queries a minute *per OAuth client id* —
+ * not per user, not per token. A shared client would pool every install of this
+ * program into one bucket, so the limit would be reached by strangers and the
+ * failure would arrive as somebody else's traffic. An operator registering
+ * their own gets their own hundred, which is the whole budget for one person
+ * and nowhere near it for the next.
+ *
+ * The cost is a console visit, which is what the broker exists to avoid. It is
+ * worth paying once here because the alternative degrades with every new user,
+ * and a shared limit is not a thing a later change could unpick.
+ */
+export const REDDIT_APP = 'reddit';
+
+/**
+ * How this program names itself to Reddit.
+ *
+ * Reddit asks callers to identify themselves and throttles the default agent
+ * hardest — a client that does not set one is treated as a scraper, which
+ * surfaces as sporadic 429s rather than as a refusal anybody can read. Nothing
+ * else in this repository sets a `User-Agent`, so `connector.headers` is what
+ * carries it.
+ *
+ * Reddit's documented format ends with the author's handle. That is omitted
+ * deliberately: this file is public, a handle is a real identifier, and
+ * `architecture.test.ts` refuses one anywhere a reader can see. A descriptive
+ * name and a URL satisfy what the throttle actually looks for.
+ */
+export const REDDIT_USER_AGENT = 'lanes-link/0.3 (+https://lanes.sh/link)';
+
+/**
+ * Where the browser comes back to, named to Reddit exactly as written.
+ *
+ * Reddit matches `redirect_uri` byte for byte, and `connect` normally listens
+ * on whatever port the kernel hands out — so a URL registered in the console
+ * months earlier could never match. Declaring it pins the listener to this
+ * port instead. See `cli/oauth.ts` and ADR-045.
+ *
+ * The port is high and otherwise unused, which is the only property it needs:
+ * nothing else in this program listens here, and the operator types the same
+ * string into Reddit's form.
+ */
+export const REDDIT_REDIRECT_URI = 'http://127.0.0.1:8765/callback';
+
+/**
+ * What the browser grant asks for.
+ *
+ * `identity` and `read` carry the reads; `submit` posts and comments; `edit`,
+ * `vote`, `save`, and `flair` cover what an author does to their own content
+ * afterwards. `mysubreddits` is what lists the subreddits this account follows.
+ *
+ * Absent on purpose: `privatemessages`, `history`, and every `mod*` scope.
+ * Nothing vendored needs them, and a scope on the consent screen that no tool
+ * can use is a grant asked for and never spent.
+ */
+export const REDDIT_SCOPES = [
+  'identity',
+  'read',
+  'submit',
+  'edit',
+  'vote',
+  'save',
+  'flair',
+  'mysubreddits',
+] as const;
+
+/** Resolve a vendored spec beside this folder. */
+export function specPath(name: string): string {
+  return new URL(`./specs/${name}`, import.meta.url).pathname;
+}

--- a/src/providers/reddit/redact.ts
+++ b/src/providers/reddit/redact.ts
@@ -1,0 +1,33 @@
+/**
+ * What survives into the audit log when Reddit is written to.
+ *
+ * The line is Gmail's and Slack's, because it is the same object: something a
+ * person wrote for other people to read. Where it went is recorded, what it
+ * said is not. A log that quoted the body would be a second copy of everything
+ * this account has ever posted, held somewhere nobody expects one.
+ *
+ * `title` is withheld along with the body, which is worth saying because it
+ * looks like metadata and is not — a Reddit title is usually the whole of the
+ * post, and the body is often empty. Keeping it would defeat the rest.
+ *
+ * Keys are the *shortened* names. `shortenName` strips a redundant provider
+ * prefix, so these must match what the capability is finally called — keying
+ * this block on anything else matches nothing and withholds everything,
+ * silently and with the log still looking correct.
+ */
+export const REDDIT_REDACT: Record<string, string[]> = {
+  // Everything that says where the post went and how it was marked, and nothing
+  // that says what it said. `url` is withheld with the body: for kind="link"
+  // the URL *is* the submission.
+  submit_post: ['sr', 'kind', 'flair_id', 'nsfw', 'spoiler', 'sendreplies', 'api_type'],
+  add_comment: ['thing_id', 'api_type'],
+  edit_text: ['thing_id', 'api_type'],
+  // Kept whole. Every argument is an identifier or a value from a fixed
+  // vocabulary, and an entry recording that something was voted on without
+  // recording which way records nothing anyone would look for — the reading
+  // that lets Slack keep an emoji name.
+  vote: ['id', 'dir'],
+  delete_thing: ['id'],
+  save_thing: ['id', 'category'],
+  set_flair: ['sr', 'link', 'flair_template_id', 'api_type'],
+};

--- a/src/providers/reddit/reddit.test.ts
+++ b/src/providers/reddit/reddit.test.ts
@@ -1,0 +1,189 @@
+import { describe, expect, test } from 'bun:test';
+import { createHttpConnector } from '../../connectivity/transports/http/index.ts';
+import { reddit } from './index.ts';
+import { REDDIT_REDIRECT_URI, REDDIT_SCOPES } from './oauth.ts';
+import { REDDIT_SCOPE_MEANINGS } from './scopes.ts';
+
+/**
+ * The spec beside this file is hand-authored, which is the whole reason these
+ * tests exist. A vendored Google document is wrong only if Google is wrong;
+ * this one is wrong if anybody mistyped a path, and nothing upstream would say
+ * so. `cli/tools.test.ts` already checks the budgets and the redaction keys for
+ * every `http` provider — what is here is what is particular to Reddit.
+ */
+
+const connector = reddit.connector as {
+  kind: string;
+  base_url: string;
+  openapi: string;
+  headers?: Record<string, string>;
+};
+
+async function capabilities() {
+  return createHttpConnector({
+    baseUrl: connector.base_url,
+    openapi: connector.openapi,
+    ...(connector.headers ? { headers: connector.headers } : {}),
+  }).discover({ manifest: reddit } as never);
+}
+
+describe('the vendored spec becomes the capabilities it claims to', () => {
+  test('every operation is discovered, and named without a redundant prefix', async () => {
+    const names = (await capabilities()).map((c) => c.name).sort();
+
+    expect(names).toEqual([
+      'add_comment',
+      'delete_thing',
+      'edit_text',
+      'get_post',
+      'get_rules',
+      'get_subreddit',
+      'list_flairs',
+      'list_my_subreddits',
+      'list_posts',
+      'save_thing',
+      'search',
+      'set_flair',
+      'submit_post',
+      'vote',
+      'whoami',
+    ]);
+  });
+
+  test('reads land in read and writes in write, decided by the verb alone', async () => {
+    const byBundle = new Map((await capabilities()).map((c) => [c.name, c.bundle]));
+
+    // What `connect` grants by default is the read bundle, so a write landing
+    // in it would be granted silently. The split is derived from the HTTP
+    // method rather than curated, which is what makes that safe — but only if
+    // the spec uses the right verb, and this is where a GET on /api/submit
+    // would show up.
+    expect(byBundle.get('list_posts')).toBe('read');
+    expect(byBundle.get('get_post')).toBe('read');
+    expect(byBundle.get('search')).toBe('read');
+    expect(byBundle.get('whoami')).toBe('read');
+    expect(byBundle.get('submit_post')).toBe('write');
+    expect(byBundle.get('add_comment')).toBe('write');
+    expect(byBundle.get('vote')).toBe('write');
+    expect(byBundle.get('delete_thing')).toBe('write');
+  });
+
+  test('the writes are form-encoded, because Reddit takes nothing else', async () => {
+    // A JSON body is rejected outright, and the error names the missing
+    // parameters rather than the encoding — so this failing looks like a bad
+    // request rather than a wrong content type.
+    const writes = (await capabilities()).filter((c) => c.bundle === 'write');
+    expect(writes.length).toBeGreaterThan(0);
+
+    for (const capability of writes) {
+      const mapper = capability.target?.['mapper'] as { type: string; serialization?: { contentType?: string } }[];
+      const body = mapper.filter((entry) => entry.type === 'body');
+
+      expect(body.length).toBeGreaterThan(0);
+      for (const entry of body) {
+        expect(entry.serialization?.contentType).toBe('application/x-www-form-urlencoded');
+      }
+    }
+  });
+});
+
+describe('what the manifest has to get exactly right', () => {
+  test('the base url matches the spec server, or every call 404s', async () => {
+    const spec = (await Bun.file(String(connector.openapi)).json()) as { servers: { url: string }[] };
+    const server = spec.servers[0]?.url;
+
+    expect(server).toBeTruthy();
+    expect(connector.base_url).toBe(server!);
+  });
+
+  test('the grant is at www, the API at oauth — mixing them 404s', () => {
+    const auth = reddit.auth as { authorize_url: string; token_url: string };
+    expect(new URL(auth.authorize_url).host).toBe('www.reddit.com');
+    expect(new URL(auth.token_url).host).toBe('www.reddit.com');
+    expect(new URL(connector.base_url).host).toBe('oauth.reddit.com');
+  });
+
+  test('duration=permanent is asked for, or the connection dies after an hour', () => {
+    // Reddit returns an access token and no refresh token without it. The
+    // connection then works, and stops an hour later with nothing to point at.
+    const auth = reddit.auth as { authorize_params?: Record<string, string> };
+    expect(auth.authorize_params?.['duration']).toBe('permanent');
+  });
+
+  test('a refresh token is required, unlike Slack', () => {
+    // Slack sets this to optional because a long-lived token and no refresh is
+    // its successful answer. Here a missing one is the failure above.
+    expect((reddit.auth as { refresh_token: string }).refresh_token).toBe('required');
+  });
+
+  test('the redirect names a port, since Reddit matches it exactly', () => {
+    const auth = reddit.auth as { redirect_uri: string; broker?: unknown };
+    expect(auth.redirect_uri).toBe(REDDIT_REDIRECT_URI);
+    expect(new URL(auth.redirect_uri).port).not.toBe('');
+    // Both would answer "where does the browser come back to", and the flow
+    // reads one of them. `defineProvider` refuses the pair.
+    expect(auth.broker).toBeUndefined();
+  });
+
+  test('a User-Agent is declared, because the default one is throttled hardest', () => {
+    expect(connector.headers?.['User-Agent']).toBeTruthy();
+    // Reddit's documented format ends with the author's handle. It is left out
+    // on purpose — this repository refuses a real identifier anywhere a reader
+    // can see, and the throttle looks for a descriptive name, not a person.
+    expect(connector.headers?.['User-Agent']).not.toMatch(/\/u\//);
+  });
+});
+
+describe('scopes are asked for in words, and only where something uses them', () => {
+  test('every requested scope has a meaning to show before consent', () => {
+    for (const scope of REDDIT_SCOPES) {
+      expect(REDDIT_SCOPE_MEANINGS[scope]?.meaning).toBeTruthy();
+    }
+  });
+
+  test('the three that act publicly as the person are marked broad', () => {
+    expect(REDDIT_SCOPE_MEANINGS['submit']?.broad).toBe(true);
+    expect(REDDIT_SCOPE_MEANINGS['edit']?.broad).toBe(true);
+    expect(REDDIT_SCOPE_MEANINGS['vote']?.broad).toBe(true);
+    // Not `read`: it reaches only what the account can already see, and what
+    // Reddit makes readable is public to begin with.
+    expect(REDDIT_SCOPE_MEANINGS['read']?.broad).toBeUndefined();
+  });
+
+  test('nothing is requested that no capability can spend', () => {
+    // A scope on the consent screen that no tool uses is a grant asked for and
+    // never spent, which is the thing least likely to be noticed later.
+    const declared = new Set<string>(REDDIT_SCOPES);
+    expect(declared.has('privatemessages')).toBe(false);
+    expect(declared.has('history')).toBe(false);
+    expect([...declared].some((s) => s.startsWith('mod'))).toBe(false);
+  });
+});
+
+describe('what reaches the audit log when Reddit is written to', () => {
+  test('a post records where it went and not what it said', () => {
+    const kept = reddit.redact?.['submit_post'] ?? [];
+
+    expect(kept).toContain('sr');
+    expect(kept).toContain('flair_id');
+    // A Reddit title is usually the whole of the post and the body is often
+    // empty, so keeping it would defeat withholding the body.
+    expect(kept).not.toContain('title');
+    expect(kept).not.toContain('text');
+    // For kind="link" the URL *is* the submission.
+    expect(kept).not.toContain('url');
+  });
+
+  test('a comment records which thread and not the comment', () => {
+    expect(reddit.redact?.['add_comment']).toEqual(['thing_id', 'api_type']);
+    expect(reddit.redact?.['edit_text']).toEqual(['thing_id', 'api_type']);
+  });
+
+  test('every write has a redaction entry, so none defaults to withholding all', async () => {
+    // The default withholds every value, which makes a write log useless: it
+    // records that something changed without recording what. A new write
+    // arriving with no entry is the silent version of that.
+    const writes = (await capabilities()).filter((c) => c.bundle === 'write').map((c) => c.name);
+    for (const name of writes) expect(reddit.redact?.[name]).toBeDefined();
+  });
+});

--- a/src/providers/reddit/scopes.ts
+++ b/src/providers/reddit/scopes.ts
@@ -1,0 +1,27 @@
+import type { ScopeMeaning } from '../scopes.ts';
+
+/**
+ * Reddit's scopes, in Reddit's own words.
+ *
+ * Taken verbatim from `https://www.reddit.com/api/v1/scopes`, which publishes a
+ * description per scope, rather than paraphrased. A paraphrase is where a
+ * consent screen quietly starts understating what it asks for, and the vendor's
+ * own sentence is the one that can be checked against the vendor.
+ *
+ * Three are marked broad, and all three for the same reason: they act publicly
+ * as the person. A post, a comment, a vote, and an edit are visible under their
+ * username to everyone who reads the subreddit, and unlike a private write they
+ * cannot be quietly undone — `delete` leaves the fact of the deletion behind,
+ * and anything cached or quoted stays. `read` is not marked: it reaches only
+ * what the account can already see, and Reddit's readable surface is public.
+ */
+export const REDDIT_SCOPE_MEANINGS: Record<string, ScopeMeaning> = {
+  identity: { meaning: 'read your username and signup date' },
+  read: { meaning: 'read posts and comments' },
+  submit: { meaning: 'post and comment publicly as you', broad: true },
+  edit: { meaning: 'edit and delete your posts and comments', broad: true },
+  vote: { meaning: 'vote on posts and comments as you', broad: true },
+  save: { meaning: 'save and unsave posts and comments' },
+  flair: { meaning: 'set the flair on your posts' },
+  mysubreddits: { meaning: 'list the subreddits you belong to' },
+};

--- a/src/providers/reddit/specs/reddit.v1.json
+++ b/src/providers/reddit/specs/reddit.v1.json
@@ -1,0 +1,700 @@
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "Reddit",
+    "version": "1.0.0",
+    "description": "The subset of the Reddit API this provider exposes. Hand-authored: Reddit publishes no OpenAPI document."
+  },
+  "servers": [
+    {
+      "url": "https://oauth.reddit.com"
+    }
+  ],
+  "paths": {
+    "/r/{subreddit}/{sort}": {
+      "get": {
+        "operationId": "list_posts",
+        "summary": "List posts in a subreddit",
+        "description": "Posts from one subreddit in a given order. Returns a Listing envelope: {kind, data:{after, children:[{kind, data}]}}.",
+        "tags": [
+          "read"
+        ],
+        "parameters": [
+          {
+            "name": "subreddit",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "description": "Subreddit name without the \"r/\" prefix."
+            }
+          },
+          {
+            "name": "sort",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "enum": [
+                "hot",
+                "new",
+                "top",
+                "rising"
+              ],
+              "description": "Ordering."
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "description": "How many to return, up to 100."
+            }
+          },
+          {
+            "name": "after",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "description": "Fullname to page after, from a previous \"after\"."
+            }
+          },
+          {
+            "name": "t",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "hour",
+                "day",
+                "week",
+                "month",
+                "year",
+                "all"
+              ],
+              "description": "Time window. Only meaningful when sort is \"top\"."
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    },
+    "/comments/{article}": {
+      "get": {
+        "operationId": "get_post",
+        "summary": "Read a post and its comments",
+        "description": "One post with its comment tree. `article` is the base36 id WITHOUT the t3_ prefix. Returns a two-element array: the post, then the comments.",
+        "tags": [
+          "read"
+        ],
+        "parameters": [
+          {
+            "name": "article",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "description": "Post id in base36, no t3_ prefix."
+            }
+          },
+          {
+            "name": "sort",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "confidence",
+                "top",
+                "new",
+                "controversial",
+                "old",
+                "qa"
+              ],
+              "description": "Comment ordering."
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "description": "How many comments to return."
+            }
+          },
+          {
+            "name": "depth",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "description": "How many levels of replies to descend."
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    },
+    "/r/{subreddit}/search": {
+      "get": {
+        "operationId": "search",
+        "summary": "Search within a subreddit",
+        "description": "Full-text search. Returns a Listing envelope: {kind, data:{after, children:[{kind, data}]}}.",
+        "tags": [
+          "read"
+        ],
+        "parameters": [
+          {
+            "name": "subreddit",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "description": "Subreddit name."
+            }
+          },
+          {
+            "name": "q",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "description": "Search query."
+            }
+          },
+          {
+            "name": "restrict_sr",
+            "in": "query",
+            "schema": {
+              "type": "boolean",
+              "description": "True to search only this subreddit rather than all of Reddit."
+            }
+          },
+          {
+            "name": "sort",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "relevance",
+                "hot",
+                "top",
+                "new",
+                "comments"
+              ],
+              "description": "Ordering."
+            }
+          },
+          {
+            "name": "t",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "hour",
+                "day",
+                "week",
+                "month",
+                "year",
+                "all"
+              ],
+              "description": "Time window."
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "description": "How many to return, up to 100."
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    },
+    "/r/{subreddit}/about": {
+      "get": {
+        "operationId": "get_subreddit",
+        "summary": "Read a subreddit profile",
+        "description": "Description, subscriber count, and whether posting requires a flair (`link_flair_enabled`, `submission_type`).",
+        "tags": [
+          "read"
+        ],
+        "parameters": [
+          {
+            "name": "subreddit",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "description": "Subreddit name."
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    },
+    "/r/{subreddit}/about/rules": {
+      "get": {
+        "operationId": "get_rules",
+        "summary": "Read a subreddit’s posting rules",
+        "description": "The rules a submission must satisfy. Worth reading before posting to an unfamiliar subreddit — most removals are rule violations, not API errors.",
+        "tags": [
+          "read"
+        ],
+        "parameters": [
+          {
+            "name": "subreddit",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "description": "Subreddit name."
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    },
+    "/api/v1/{subreddit}/link_flair_v2": {
+      "get": {
+        "operationId": "list_flairs",
+        "summary": "List a subreddit’s post flairs",
+        "description": "Available post flairs and their ids. Many subreddits reject a submission with no flair_id, so call this first when submitting somewhere new.",
+        "tags": [
+          "read"
+        ],
+        "parameters": [
+          {
+            "name": "subreddit",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "description": "Subreddit name."
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    },
+    "/api/v1/me": {
+      "get": {
+        "operationId": "whoami",
+        "summary": "Read the authenticated account",
+        "description": "Username, karma, and account age for the connected account.",
+        "tags": [
+          "read"
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    },
+    "/subreddits/mine/subscriber": {
+      "get": {
+        "operationId": "list_my_subreddits",
+        "summary": "List subscribed subreddits",
+        "description": "Subreddits the connected account subscribes to. Returns a Listing envelope: {kind, data:{after, children:[{kind, data}]}}.",
+        "tags": [
+          "read"
+        ],
+        "parameters": [
+          {
+            "name": "limit",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "description": "How many to return."
+            }
+          },
+          {
+            "name": "after",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "description": "Fullname to page after."
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    },
+    "/api/submit": {
+      "post": {
+        "operationId": "submit_post",
+        "summary": "Submit a post to a subreddit",
+        "description": "Create a text or link post. kind=\"self\" needs `text`; kind=\"link\" needs `url`. Check list_flairs first — many subreddits reject a post with no flair_id.",
+        "tags": [
+          "write"
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/x-www-form-urlencoded": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "sr": {
+                    "type": "string",
+                    "description": "Subreddit name without the \"r/\" prefix."
+                  },
+                  "kind": {
+                    "type": "string",
+                    "enum": [
+                      "self",
+                      "link"
+                    ],
+                    "description": "\"self\" for a text post, \"link\" for a URL post."
+                  },
+                  "title": {
+                    "type": "string",
+                    "description": "Post title, up to 300 characters."
+                  },
+                  "text": {
+                    "type": "string",
+                    "description": "Body, as markdown. Only for kind=\"self\"."
+                  },
+                  "url": {
+                    "type": "string",
+                    "description": "Target URL. Only for kind=\"link\"."
+                  },
+                  "flair_id": {
+                    "type": "string",
+                    "description": "Flair template id from list_flairs."
+                  },
+                  "nsfw": {
+                    "type": "boolean",
+                    "description": "Mark as not safe for work."
+                  },
+                  "spoiler": {
+                    "type": "boolean",
+                    "description": "Mark as a spoiler."
+                  },
+                  "sendreplies": {
+                    "type": "boolean",
+                    "description": "Send reply notifications to the account inbox."
+                  },
+                  "api_type": {
+                    "type": "string",
+                    "enum": [
+                      "json"
+                    ],
+                    "default": "json",
+                    "description": "Always \"json\". Without it the response is not JSON and errors are unreadable."
+                  }
+                },
+                "required": [
+                  "sr",
+                  "kind",
+                  "title",
+                  "api_type"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    },
+    "/api/comment": {
+      "post": {
+        "operationId": "add_comment",
+        "summary": "Comment on a post or reply to a comment",
+        "description": "thing_id is a FULLNAME, not a bare id: t3_<id> for a post, t1_<id> for a comment. A bare id is silently rejected.",
+        "tags": [
+          "write"
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/x-www-form-urlencoded": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "thing_id": {
+                    "type": "string",
+                    "description": "Fullname of the parent: t3_<id> for a post, t1_<id> for a comment."
+                  },
+                  "text": {
+                    "type": "string",
+                    "description": "Comment body, as markdown."
+                  },
+                  "api_type": {
+                    "type": "string",
+                    "enum": [
+                      "json"
+                    ],
+                    "default": "json",
+                    "description": "Always \"json\". Without it the response is not JSON and errors are unreadable."
+                  }
+                },
+                "required": [
+                  "thing_id",
+                  "text",
+                  "api_type"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    },
+    "/api/editusertext": {
+      "post": {
+        "operationId": "edit_text",
+        "summary": "Edit your own post or comment",
+        "description": "Replaces the body of something this account authored. Only works on a text post or a comment.",
+        "tags": [
+          "write"
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/x-www-form-urlencoded": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "thing_id": {
+                    "type": "string",
+                    "description": "Fullname of the item to edit: t3_<id> or t1_<id>."
+                  },
+                  "text": {
+                    "type": "string",
+                    "description": "Replacement body, as markdown."
+                  },
+                  "api_type": {
+                    "type": "string",
+                    "enum": [
+                      "json"
+                    ],
+                    "default": "json",
+                    "description": "Always \"json\". Without it the response is not JSON and errors are unreadable."
+                  }
+                },
+                "required": [
+                  "thing_id",
+                  "text",
+                  "api_type"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    },
+    "/api/vote": {
+      "post": {
+        "operationId": "vote",
+        "summary": "Vote on a post or comment",
+        "description": "dir is 1 to upvote, -1 to downvote, 0 to clear an existing vote.",
+        "tags": [
+          "write"
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/x-www-form-urlencoded": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "id": {
+                    "type": "string",
+                    "description": "Fullname of the target: t3_<id> or t1_<id>."
+                  },
+                  "dir": {
+                    "type": "integer",
+                    "enum": [
+                      1,
+                      0,
+                      -1
+                    ],
+                    "description": "1 upvote, 0 clear, -1 downvote."
+                  }
+                },
+                "required": [
+                  "id",
+                  "dir"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    },
+    "/api/del": {
+      "post": {
+        "operationId": "delete_thing",
+        "summary": "Delete your own post or comment",
+        "description": "Permanent. Reddit has no trash for this — a deleted item cannot be restored through the API.",
+        "tags": [
+          "write"
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/x-www-form-urlencoded": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "id": {
+                    "type": "string",
+                    "description": "Fullname to delete: t3_<id> or t1_<id>."
+                  }
+                },
+                "required": [
+                  "id"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    },
+    "/api/save": {
+      "post": {
+        "operationId": "save_thing",
+        "summary": "Save a post or comment",
+        "description": "Adds to the account’s saved items.",
+        "tags": [
+          "write"
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/x-www-form-urlencoded": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "id": {
+                    "type": "string",
+                    "description": "Fullname to save: t3_<id> or t1_<id>."
+                  },
+                  "category": {
+                    "type": "string",
+                    "description": "Optional saved-items category name."
+                  }
+                },
+                "required": [
+                  "id"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    },
+    "/api/selectflair": {
+      "post": {
+        "operationId": "set_flair",
+        "summary": "Set the flair on your own post",
+        "description": "Applies a flair template from list_flairs to a post this account authored.",
+        "tags": [
+          "write"
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/x-www-form-urlencoded": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "sr": {
+                    "type": "string",
+                    "description": "Subreddit name without the \"r/\" prefix."
+                  },
+                  "link": {
+                    "type": "string",
+                    "description": "Fullname of the post: t3_<id>."
+                  },
+                  "flair_template_id": {
+                    "type": "string",
+                    "description": "Flair template id from list_flairs."
+                  },
+                  "api_type": {
+                    "type": "string",
+                    "enum": [
+                      "json"
+                    ],
+                    "default": "json",
+                    "description": "Always \"json\". Without it the response is not JSON and errors are unreadable."
+                  }
+                },
+                "required": [
+                  "sr",
+                  "link",
+                  "flair_template_id",
+                  "api_type"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    }
+  }
+}

--- a/src/providers/scopes.ts
+++ b/src/providers/scopes.ts
@@ -1,5 +1,6 @@
 import { GOOGLE_SCOPE_MEANINGS } from './google/shared/scopes.ts';
 import { LINEAR_SCOPE_MEANINGS } from './linear/scopes.ts';
+import { REDDIT_SCOPE_MEANINGS } from './reddit/scopes.ts';
 import { SLACK_SCOPE_MEANINGS } from './slack/scopes.ts';
 
 /**
@@ -24,5 +25,6 @@ export interface ScopeMeaning {
 export const SCOPE_MEANINGS: Record<string, ScopeMeaning> = {
   ...GOOGLE_SCOPE_MEANINGS,
   ...LINEAR_SCOPE_MEANINGS,
+  ...REDDIT_SCOPE_MEANINGS,
   ...SLACK_SCOPE_MEANINGS,
 };

--- a/src/providers/shared/openapi.ts
+++ b/src/providers/shared/openapi.ts
@@ -1,0 +1,109 @@
+/**
+ * Spec surgery that is not about any one vendor.
+ *
+ * Two operations, both forced on us by the same property of
+ * `mcp-from-openapi`: it **inlines** `$ref`s. That makes a generated input
+ * schema cost what the reference graph below it costs, not what the document
+ * says — so a cycle is unbounded recursion rather than a self-reference, and a
+ * shared schema is duplicated at every use site.
+ *
+ * These lived inside `google/specs/vendor.ts` while Google was the only
+ * vendored spec. bunq is the second, and it needs `cutCycles` more urgently
+ * than Google does: bunq's published document fails to generate **55**
+ * operations, every payment endpoint among them, because `Payment` recurses
+ * through `RequestInquiry` and `RequestResponse`. Copying seventy lines into a
+ * second script is how the two come to disagree about what a cycle is.
+ *
+ * Deliberately not moved: `makeOpaque`. It writes a sentence into the schema it
+ * replaces, and that sentence points at the vendor's own reference
+ * documentation — which makes it a Google function that happens to look
+ * generic.
+ */
+
+/** The shape both vendoring scripts read and write. Generic OpenAPI 3.x. */
+export interface Spec {
+  openapi: string;
+  info: Record<string, unknown>;
+  servers?: Array<{ url: string }>;
+  paths: Record<string, Record<string, { operationId?: string } & Record<string, unknown>>>;
+  components?: { schemas?: Record<string, unknown> } & Record<string, unknown>;
+  [key: string]: unknown;
+}
+
+/** Every `$ref` target reachable from a value, transitively. */
+export function referenced(root: unknown, schemas: Record<string, unknown>): Set<string> {
+  const found = new Set<string>();
+  const queue: unknown[] = [root];
+
+  while (queue.length > 0) {
+    const node = queue.pop();
+    if (node === null || typeof node !== 'object') continue;
+
+    if (Array.isArray(node)) {
+      queue.push(...node);
+      continue;
+    }
+
+    for (const [key, value] of Object.entries(node)) {
+      if (key === '$ref' && typeof value === 'string') {
+        const name = value.replace('#/components/schemas/', '');
+        if (!found.has(name) && name in schemas) {
+          found.add(name);
+          queue.push(schemas[name]);
+        }
+        continue;
+      }
+      queue.push(value);
+    }
+  }
+
+  return found;
+}
+
+/**
+ * Cut reference cycles, replacing the back-edge with an open object.
+ *
+ * Gmail's `MessagePart` contains `MessagePart[]` — a MIME tree, so the
+ * recursion is honest — and the OpenAPI tool generator inlines `$ref`s, so it
+ * recurses until the stack ends. That silently costs the two draft-writing
+ * operations, which are the useful half of `gmail.compose`.
+ *
+ * Cutting the back-edge rather than dropping the operation keeps the tool: the
+ * field that matters for creating a draft is `raw`, an RFC 2822 message, and
+ * nothing below the cut is required to fill it in. A depth-first walk marks the
+ * names currently on the path, and any `$ref` reaching back to one of them
+ * becomes a plain object.
+ */
+export function cutCycles(schemas: Record<string, unknown>): number {
+  let cuts = 0;
+
+  const walk = (node: unknown, path: Set<string>): void => {
+    if (node === null || typeof node !== 'object') return;
+
+    if (Array.isArray(node)) {
+      for (const item of node) walk(item, path);
+      return;
+    }
+
+    const record = node as Record<string, unknown>;
+    for (const [key, value] of Object.entries(record)) {
+      if (key === '$ref' && typeof value === 'string') {
+        const name = value.replace('#/components/schemas/', '');
+        if (path.has(name)) {
+          delete record['$ref'];
+          record['type'] = 'object';
+          record['additionalProperties'] = true;
+          record['description'] = `A nested ${name}. Structure omitted: it recurses.`;
+          cuts++;
+        } else if (name in schemas) {
+          walk(schemas[name], new Set([...path, name]));
+        }
+        continue;
+      }
+      walk(value, path);
+    }
+  };
+
+  for (const [name, schema] of Object.entries(schemas)) walk(schema, new Set([name]));
+  return cuts;
+}

--- a/src/providers/shared/openapi.ts
+++ b/src/providers/shared/openapi.ts
@@ -14,10 +14,12 @@
  * through `RequestInquiry` and `RequestResponse`. Copying seventy lines into a
  * second script is how the two come to disagree about what a cycle is.
  *
- * Deliberately not moved: `makeOpaque`. It writes a sentence into the schema it
- * replaces, and that sentence points at the vendor's own reference
- * documentation — which makes it a Google function that happens to look
- * generic.
+ * `makeOpaque` was held back at first for a good reason: it writes a sentence
+ * into the schema it replaces, and that sentence points at the vendor's own
+ * reference documentation, which made it a Google function that happened to look
+ * generic. Taking the sentence as a parameter is what actually settles that —
+ * the surgery is generic, only the pointer was not — so it lives here now, with
+ * each caller passing its own note. Discord is the third vendor to need it.
  */
 
 /** The shape both vendoring scripts read and write. Generic OpenAPI 3.x. */
@@ -106,4 +108,48 @@ export function cutCycles(schemas: Record<string, unknown>): number {
 
   for (const [name, schema] of Object.entries(schemas)) walk(schema, new Set([name]));
   return cuts;
+}
+
+/**
+ * Replace a named schema with an open object.
+ *
+ * Same device as `cutCycles` and a different disease. That one cuts recursion;
+ * this one cuts *fan-out*. Because `$ref`s are inlined, a union of eighty
+ * variants — each with its own nested grid, filter, and chart schemas, sharing
+ * sub-schemas that inlining duplicates per occurrence — costs orders of
+ * magnitude more generated than it does on disk.
+ *
+ * Measured on the worst case in the repository: one spreadsheet operation
+ * generated a 2,469KB input schema against 45KB for a whole other API. That is
+ * unusable — it would be sent on every `tools/list` — and it was also the only
+ * operation that could add a tab, freeze a header, or format a cell, so
+ * dropping it was no better.
+ *
+ * Opaque keeps the operation for a few KB. The agent fills the field in from the
+ * API it already knows, which is the same bet `raw` makes for a mail draft: a
+ * well-known wire format is cheaper described than schematised. `note` carries
+ * the pointer to the vendor's reference, because that is the only thing lost.
+ *
+ * Apply before `referenced`, so the schemas that were reachable only through the
+ * replaced one leave the document entirely rather than lingering unused.
+ */
+export function makeOpaque(
+  schemas: Record<string, unknown>,
+  names: readonly string[],
+  note: string,
+): number {
+  let replaced = 0;
+
+  for (const name of names) {
+    if (!(name in schemas)) continue;
+    const original = schemas[name] as { description?: string };
+    schemas[name] = {
+      type: 'object',
+      additionalProperties: true,
+      description: `${original.description ?? `A ${name}.`} ${note}`,
+    };
+    replaced++;
+  }
+
+  return replaced;
 }

--- a/src/providers/shared/vendor-operations.ts
+++ b/src/providers/shared/vendor-operations.ts
@@ -1,0 +1,98 @@
+/**
+ * Document surgery on path items and operations.
+ *
+ * The other axis from `vendor-schemas.ts`: that file rewrites the schemas map,
+ * this one rewrites what an operation declares it takes — its parameters and the
+ * content types its request body offers. Both exist because the generated tool,
+ * not the document, is what has to be correct and small.
+ */
+
+export const METHODS = ['get', 'post', 'put', 'patch', 'delete', 'head'];
+
+/** The name a parameter goes by, resolving a `$ref` into `components.parameters`. */
+export function parameterName(
+  parameter: unknown,
+  components: Record<string, unknown>,
+): string | undefined {
+  const record = parameter as { name?: string; $ref?: string };
+  if (record.name) return record.name;
+  if (!record.$ref) return undefined;
+
+  // The component *key* is not the parameter name — `$.xgafv` is keyed
+  // `_.xgafv`, because a `$` is awkward in a JSON pointer. Matching on the key
+  // would therefore miss exactly the one that breaks everything.
+  const key = record.$ref.replace('#/components/parameters/', '');
+  return (components[key] as { name?: string } | undefined)?.name;
+}
+
+/** Strip vendor system parameters from a path item or an operation. */
+export function dropSystemParameters(
+  holder: Record<string, unknown>,
+  components: Record<string, unknown>,
+  system: ReadonlySet<string>,
+): number {
+  const parameters = holder['parameters'];
+  if (!Array.isArray(parameters)) return 0;
+
+  const kept = parameters.filter((parameter) => {
+    const name = parameterName(parameter, components);
+    return !(name && system.has(name));
+  });
+
+  holder['parameters'] = kept;
+  return parameters.length - kept.length;
+}
+
+/** Move a path item's shared `parameters` onto each of its operations. */
+export function hoistParameters(
+  item: Record<string, unknown>,
+  components: Record<string, unknown>,
+): number {
+  const shared = item['parameters'];
+  if (!Array.isArray(shared) || shared.length === 0) return 0;
+
+  let moved = 0;
+  for (const [method, operation] of Object.entries(item)) {
+    if (!METHODS.includes(method)) continue;
+
+    const holder = operation as Record<string, unknown>;
+    const own = Array.isArray(holder['parameters']) ? (holder['parameters'] as unknown[]) : [];
+    const taken = new Set(
+      own.map((parameter) => parameterName(parameter, components)).filter(Boolean),
+    );
+
+    // An operation that already declares the parameter keeps its own. Adding
+    // both is what produces a renamed duplicate.
+    const inherited = shared.filter(
+      (parameter) => !taken.has(parameterName(parameter, components)),
+    );
+    holder['parameters'] = [...inherited, ...own];
+    moved += inherited.length;
+  }
+
+  delete item['parameters'];
+  return moved;
+}
+
+/** Keep only the listed request body content types, refusing to empty a body. */
+export function narrowRequestBody(
+  operation: Record<string, unknown>,
+  operationId: string,
+  allowed: readonly string[],
+): number {
+  const body = operation['requestBody'] as { content?: Record<string, unknown> } | undefined;
+  if (!body?.content) return 0;
+
+  const before = Object.keys(body.content);
+  const kept = before.filter((type) => allowed.includes(type));
+  if (kept.length === 0) {
+    // Silently leaving the body alone would reintroduce whatever the filter was
+    // added to remove, so this is a refusal rather than a fallback.
+    throw new Error(
+      `${operationId}: request body offers ${before.join(', ')}, none of which is kept by requestContentTypes (${allowed.join(', ')}).`,
+    );
+  }
+
+  body.content = Object.fromEntries(kept.map((type) => [type, body.content![type]]));
+  return before.length - kept.length;
+}

--- a/src/providers/shared/vendor-spec.ts
+++ b/src/providers/shared/vendor-spec.ts
@@ -1,0 +1,309 @@
+/**
+ * Trim an upstream OpenAPI document down to a reviewable, committed spec.
+ *
+ * The output is **committed**, and that is the point. A spec decides which paths
+ * get called with the operator's token, and `connect` grants everything a
+ * provider discovers — so a spec fetched at connect time from a third party
+ * could introduce, say, a DELETE operation that lands on the vendor's own host
+ * holding a real credential. Vendoring makes the surface reviewable and the
+ * build reproducible; a per-provider script exists so refreshing it is one
+ * command rather than a hand edit.
+ *
+ * Every caller passes its own `outputDirectory`, its own note strings, and opts
+ * in to the repairs its upstream document happens to need. Nothing here knows
+ * which vendor it is trimming: a document that declares path parameters one
+ * level up is a shape, not a brand, and the flag that fixes it is set by the
+ * provider that has that shape.
+ */
+
+import { mkdir, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { OpenAPIToolGenerator, type McpOpenAPITool } from 'mcp-from-openapi';
+import { cutCycles, makeOpaque, referenced, type Spec } from './openapi.ts';
+import {
+  METHODS,
+  dropSystemParameters,
+  hoistParameters,
+  narrowRequestBody,
+} from './vendor-operations.ts';
+
+/** Kept in step with `BUDGET_KB` in `src/cli/tools.test.ts`, which enforces it. */
+export const BUDGET_KB = 64;
+
+export interface VendorSpecOptions {
+  /** The upstream document. */
+  readonly source: string;
+  /**
+   * Where to write, which is the caller's own `import.meta.dir`.
+   *
+   * A parameter rather than this module's own directory, and not a stylistic
+   * choice: resolving it here would write every provider's spec into
+   * `providers/shared/`, report success, and leave the committed file untouched.
+   * That exact no-op shipped once before — see the note in the Google script.
+   */
+  readonly outputDirectory: string;
+  readonly out: string;
+  /** The operations to keep, by `operationId`. Everything else is dropped. */
+  readonly operations: readonly string[];
+  /** Schemas to replace with an open object, before reachability is computed. */
+  readonly opaque?: readonly string[];
+  /** The sentence `makeOpaque` appends, naming where the real shape is documented. */
+  readonly opaqueNote?: string;
+  /** What `info['x-vendored-note']` records about why this file is committed. */
+  readonly vendoredNote: string;
+  /** Vendor-specific query parameters to strip from every operation. */
+  readonly systemParameters?: ReadonlySet<string>;
+  /**
+   * Move path-item `parameters` onto each operation, and delete the shared copy.
+   *
+   * Off by default, because a document that already declares its parameters per
+   * operation must not be rewritten — and a path-item `parameters` array is also
+   * where some vendors put the query parameters shared by every method on the
+   * path, which the operations genuinely need to inherit rather than own.
+   *
+   * On, it repairs a document whose path parameters live only at the path level.
+   * `mcp-from-openapi`'s validator reads `operation.parameters` and nothing else,
+   * so such a document fails validation outright with one
+   * `MISSING_PATH_PARAMETER` per parameter and generates zero tools. Deleting the
+   * shared copy is half the fix: leaving both makes the generator see the same
+   * parameter twice and rename one of them.
+   */
+  readonly hoistPathParameters?: boolean;
+  /**
+   * Request body content types to keep. Omit to keep all of them.
+   *
+   * The HTTP connector encodes a body as JSON or form-urlencoded, whichever the
+   * document declares (ADR-045). It cannot do `multipart/form-data` at all — a
+   * multipart branch would be JSON-stringified under a multipart content type —
+   * so that branch describes a request it cannot make, and carries the cost of
+   * one anyway.
+   *
+   * Worse than dead weight: multipart file fields are named `files[0]`, which is
+   * not a legal tool property name, and one illegal name rejects the *entire*
+   * tools list for every provider on the endpoint. Nothing but the generator's
+   * own content-type preference order keeps it out of the generated schema, and
+   * that is a third party's choice to change.
+   */
+  readonly requestContentTypes?: readonly string[];
+  /**
+   * Replace an operation's whole request body schema, by `operationId`.
+   *
+   * For a body the generator cannot flatten. A top-level `anyOf` has no
+   * `properties` to walk, so it emits a single argument literally named `body`
+   * and the connector then sends `{"body":{…}}` where the vendor expects
+   * `{…}` — every test in the repository passes and only a live call fails.
+   * Naming the branch that is actually wanted flattens it back out.
+   *
+   * Applied before reachability, so a branch that is no longer referenced leaves
+   * the document rather than lingering unused.
+   */
+  readonly rewriteRequestBody?: Readonly<Record<string, unknown>>;
+}
+
+export async function vendorSpec(id: string, options: VendorSpecOptions): Promise<void> {
+  const { source, operations } = options;
+  const wanted = new Set(operations);
+
+  const response = await fetch(source);
+  if (!response.ok) throw new Error(`${source}: HTTP ${response.status}`);
+  const spec = (await response.json()) as Spec;
+
+  const paths: Spec['paths'] = {};
+  const seen = new Set<string>();
+
+  for (const [path, item] of Object.entries(spec.paths)) {
+    const kept: Record<string, unknown> = {};
+    for (const [method, operation] of Object.entries(item)) {
+      // Path-level keys are not operations and must survive: `parameters` here
+      // is where some vendors put the query parameters shared by every method on
+      // the path, and one of those may be *required* by an operation. Dropping
+      // it produced a tool with no arguments at all and a 400 on every call.
+      if (!METHODS.includes(method)) {
+        kept[method] = operation;
+        continue;
+      }
+      const operationId = operation.operationId;
+      if (!operationId || !wanted.has(operationId)) continue;
+      kept[method] = operation;
+      seen.add(operationId);
+    }
+
+    // Only path-level keys survived, so no operation here was wanted.
+    if (!Object.keys(kept).some((key) => METHODS.includes(key))) continue;
+    if (Object.keys(kept).length > 0) paths[path] = kept as Spec['paths'][string];
+  }
+
+  const componentParameters = (spec.components?.['parameters'] ?? {}) as Record<string, unknown>;
+  const system = options.systemParameters ?? new Set<string>();
+
+  let hoisted = 0;
+  if (options.hoistPathParameters) {
+    for (const item of Object.values(paths)) {
+      hoisted += hoistParameters(item as unknown as Record<string, unknown>, componentParameters);
+    }
+  }
+
+  let dropped = 0;
+  for (const item of Object.values(paths)) {
+    dropped += dropSystemParameters(
+      item as unknown as Record<string, unknown>,
+      componentParameters,
+      system,
+    );
+    for (const [method, operation] of Object.entries(item)) {
+      if (!METHODS.includes(method)) continue;
+      dropped += dropSystemParameters(
+        operation as unknown as Record<string, unknown>,
+        componentParameters,
+        system,
+      );
+    }
+  }
+
+  let narrowed = 0;
+  for (const item of Object.values(paths)) {
+    for (const [method, operation] of Object.entries(item)) {
+      if (!METHODS.includes(method)) continue;
+      const holder = operation as unknown as Record<string, unknown>;
+
+      if (options.requestContentTypes) {
+        narrowed += narrowRequestBody(
+          holder,
+          operation.operationId ?? `${method} path`,
+          options.requestContentTypes,
+        );
+      }
+
+      const replacement = operation.operationId
+        ? options.rewriteRequestBody?.[operation.operationId]
+        : undefined;
+      if (replacement) {
+        const body = holder['requestBody'] as { content?: Record<string, unknown> } | undefined;
+        for (const type of Object.keys(body?.content ?? {})) {
+          (body!.content![type] as Record<string, unknown>)['schema'] = replacement;
+        }
+      }
+    }
+  }
+
+  // Drop response schemas.
+  //
+  // Two reasons, and the second is the blocking one. Nothing reads them: the
+  // connector hands the response body back as text, because an agent wants the
+  // JSON, not a validated shape. And a recursive response schema — a message
+  // whose payload is a part, which contains parts — sends the OpenAPI tool
+  // generator into infinite recursion and silently drops operations from the
+  // tool list.
+  for (const item of Object.values(paths)) {
+    for (const [method, operation] of Object.entries(item)) {
+      if (!METHODS.includes(method)) continue;
+      (operation as { responses?: unknown }).responses = {
+        '200': { description: 'Success. The response body is returned verbatim.' },
+      };
+    }
+  }
+
+  const missing = operations.filter((operationId) => !seen.has(operationId));
+  if (missing.length > 0) {
+    // Loudly, rather than shipping a provider quietly missing capabilities: an
+    // upstream rename should fail the refresh, not shrink the tool list.
+    throw new Error(`${id}: these operations are not in the spec — ${missing.join(', ')}`);
+  }
+
+  const schemas = spec.components?.schemas ?? {};
+  const opaqued = makeOpaque(schemas, options.opaque ?? [], options.opaqueNote ?? '');
+  const keep = referenced(paths, schemas);
+  const trimmedSchemas = Object.fromEntries(
+    Object.entries(schemas).filter(([name]) => keep.has(name)),
+  );
+  const cuts = cutCycles(trimmedSchemas);
+
+  const trimmed: Spec = {
+    openapi: spec.openapi,
+    info: {
+      ...spec.info,
+      'x-vendored-from': source,
+      'x-vendored-note': options.vendoredNote,
+    },
+    ...(spec.servers ? { servers: spec.servers } : {}),
+    paths,
+    components: { ...spec.components, schemas: trimmedSchemas },
+  };
+
+  await mkdir(options.outputDirectory, { recursive: true });
+  await writeFile(
+    join(options.outputDirectory, options.out),
+    `${JSON.stringify(trimmed, null, 2)}\n`,
+  );
+
+  const size = Math.round(JSON.stringify(trimmed).length / 1024);
+  const extra = [
+    options.hoistPathParameters ? `${hoisted} params hoisted` : '',
+    narrowed > 0 ? `${narrowed} body types dropped` : '',
+  ].filter(Boolean);
+  console.log(
+    `  ${id.padEnd(6)} ${String(Object.keys(paths).length).padStart(2)} paths, ` +
+      `${seen.size} operations, ${Object.keys(trimmedSchemas).length} schemas, ` +
+      `${cuts} cycle${cuts === 1 ? '' : 's'} cut, ${opaqued} made opaque, ` +
+      `${dropped} system params dropped, ${size}KB` +
+      (extra.length > 0 ? `, ${extra.join(', ')}` : ''),
+  );
+
+  await reportLargestTools(id, trimmed, seen.size);
+}
+
+/**
+ * The number the budget is actually about, and a count that proves nothing fell out.
+ *
+ * Everything on the line above counts the *spec*; `cli/tools.test.ts` measures
+ * the **generated input schema**, and the two differ by orders of magnitude
+ * because `mcp-from-openapi` inlines `$ref`s — a schema shared by ten fields is
+ * ten copies once generated. Reasoning about one operation from a schema count
+ * put it at 122 KB when the real figure was 1,133 KB, which is the whole
+ * difference between "just over" and "seventeen times over".
+ *
+ * Printed here so the refresh that adds an operation shows its cost, rather than
+ * leaving it to a test failure to say so after the fact.
+ *
+ * The count is the other half. The generator answers an unresolvable reference by
+ * logging to the console and omitting that one tool, so a document can trim
+ * cleanly, write successfully, and quietly advertise less than it selected.
+ * `tools.test.ts` only asserts the surface is non-empty, so nothing downstream
+ * would notice.
+ */
+async function reportLargestTools(id: string, trimmed: Spec, expected: number): Promise<void> {
+  let measured: Array<{ name: string; kb: number }>;
+
+  try {
+    const generator = await OpenAPIToolGenerator.fromJSON(trimmed);
+    const tools = await generator.generateTools();
+
+    if (tools.length !== expected) {
+      throw new Error(
+        `${id}: the spec holds ${expected} operations but only ${tools.length} generated. ` +
+          'The generator omits a tool it cannot resolve — check for a dangling $ref, ' +
+          'including into components this script trimmed.',
+      );
+    }
+
+    measured = tools
+      .map((tool: McpOpenAPITool) => ({
+        name: tool.metadata.operationId ?? tool.name,
+        kb: JSON.stringify(tool.inputSchema).length / 1024,
+      }))
+      .sort((a, b) => b.kb - a.kb);
+  } catch (error) {
+    // A count mismatch is this script's to report — it is the one failure
+    // `tools.test.ts` cannot see. A generator failure is not: that shows up
+    // against every provider at once, and refusing to finish over it would
+    // leave the specs half-written.
+    if (error instanceof Error && error.message.startsWith(`${id}: the spec holds`)) throw error;
+    console.log(`         (could not measure generated schemas: ${String(error)})`);
+    return;
+  }
+
+  for (const { name, kb } of measured.slice(0, 3)) {
+    const over = kb > BUDGET_KB ? `  ✗ over the ${BUDGET_KB}KB budget` : '';
+    console.log(`         ${name.padEnd(38)} ${kb.toFixed(1).padStart(8)}KB${over}`);
+  }
+}


### PR DESCRIPTION
Merging this to main publishes 0.4.0 to npm.

Since v0.3.2:

- Declare a provider from the two fixed lists, and connect it (#56)
- Add Discord, posting as an application you own (#54)
- Register the AuthStrategy seam, and add bunq to it (#52)
- Add Reddit (#53)
- Teach the bundled skill to operate a workspace, not just use one

Three new providers and a registered auth seam earn a minor rather than the workflow's patch bump. The version is set on `develop` so this push to `main` arrives untagged and `release.yml` publishes it directly, leaving both branches on the same tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)