### PR TITLE
Write down the lifecycle a release follows, and where develop fits

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -44,6 +44,24 @@ talking to their server.
 writes credentials. Running it changes something outside the repository that a `git checkout`
 cannot undo. Get to a green `bun test` unattended, then stop and ask.
 
+## A release publishes, and npm does not give a version back
+
+[`docs/detailed/releasing.md`](docs/detailed/releasing.md) is the lifecycle end to end — the two
+paths `release.yml` takes, and the verification that a release shipped. What an agent gets wrong:
+
+- **Set the version on `develop`, before the pull request to `main`.** A merge whose version is
+  already tagged runs the *propose* path, which puts the bump on a side branch that merges into
+  `main` only — `develop` is then behind by a version commit. Untagged publishes directly, and both
+  branches end up on the same tree. This is the whole reason a minor is not just a merge.
+- **The merge to `main` is the irreversible step.** It publishes to npm under this repository's
+  OIDC identity. Get the branch green and the pull request open unattended; do not merge a release
+  the operator has not asked for.
+- **Fast-forward `develop` afterwards** — `git push origin origin/main:refs/heads/develop` — and
+  check `git rev-list --count` both directions. Nothing in the workflow does it for you, and the
+  next comparison between the branches is noise until you do.
+- **Never tag or `npm publish` by hand.** The workflow owns both, in that order, for a reason a
+  manual run reverses.
+
 ## Never write a real address, project, or bucket into this repository
 
 This repository is public. The shortest path to a passing test or a convincing doc example is

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -64,6 +64,10 @@ provider, and `src/profile/docs.test.ts` parses the YAML examples out of the ref
 
 ## Releasing
 
+[`docs/detailed/releasing.md`](docs/detailed/releasing.md) is the whole lifecycle in order — the
+branches, both release paths, the `develop` fast-forward that ends one, and how to verify a release
+shipped. The short version:
+
 You do not tag anything. Merging a change under `src/`, `bin/`, `instructions/`, `package.json`, or
 `bun.lock` pushes a **`release/next`** branch carrying the patch bump, and the run summary links
 straight to the pull request it opens — already titled and described, because the bump commit's

--- a/docs/README.md
+++ b/docs/README.md
@@ -29,5 +29,6 @@ each decision was made, not just what to type.
 | [`creating-a-provider.md`](detailed/creating-a-provider.md) | Add your own integration |
 | [`connectivity-coverage.md`](detailed/connectivity-coverage.md) | Which connectivity and credential types compose, which are closed, and what none of them covers |
 | [`local-development.md`](detailed/local-development.md) | Working on Lanes Link itself |
+| [`releasing.md`](detailed/releasing.md) | The development lifecycle: branches, the two release paths, and what to verify |
 | [`adr/`](detailed/adr/) | Architecture decision records |
 | [`init.md`](detailed/init.md) | The original specification, amended to match what was built |

--- a/docs/detailed/releasing.md
+++ b/docs/detailed/releasing.md
@@ -1,0 +1,178 @@
+# The development lifecycle
+
+How a change gets from a branch to a version somebody installs. [`local-development.md`](local-development.md)
+covers working *in* the tree; this page covers the branches around it and the one workflow that
+publishes.
+
+The whole of it is four moves:
+
+```
+branch → PR → develop → PR → main → npm
+```
+
+`main` is what is published. `develop` is where reviewed work accumulates between releases. They
+are meant to be **identical trees** once a release lands — the last step of a release is what makes
+that true, and it is the step most easily forgotten.
+
+## The branches
+
+| | |
+|---|---|
+| `main` | What `npm install @lanes-sh/link` gets. Protected: pull request, passing `ci`, no force-push. The only bypass is an organisation admin. |
+| `develop` | The integration branch. Unprotected, so a push works — but work still arrives by pull request, because the reasoning in the commit message is the review. |
+| feature branches | One per change, in its own worktree. See [CLAUDE.md](../../CLAUDE.md). |
+
+Nothing is ever pushed to `main` by CI. It cannot be: the ruleset requires a pull request and the
+built-in `GITHUB_TOKEN` cannot be added to its bypass list. Doing it anyway would mean storing an
+App key or a personal access token with write access to `main` — a larger credential than the npm
+token this project deliberately does not have.
+
+## Ordinary work
+
+```console
+$ git worktree add .worktrees/<name> -b <name>
+$ cd .worktrees/<name>
+$ bun install
+$ bun test && bun run typecheck      # the baseline, before changing anything
+```
+
+Then the change, then the same two commands, then a pull request into `develop`. `ci` runs both
+gates again where a reviewer can see them. Merge when it is green.
+
+That is the whole of ordinary work. A release is a separate act, taken deliberately, described
+below.
+
+## What a release is
+
+One workflow, [`.github/workflows/release.yml`](../../.github/workflows/release.yml), fires on a
+push to `main` and does exactly one of two things. Which one is decided by a single question:
+**does the version in `package.json` already have a tag?**
+
+| `package.json` | Meaning | What the run does |
+|---|---|---|
+| tagged (`v0.4.0` exists) | already published | **propose** — pushes a `release/next` branch carrying a patch bump, and links the pull request that opens it |
+| untagged | somebody set it deliberately | **publish** — runs both gates, `npm publish --provenance`, then cuts the tag and the GitHub release |
+
+So the same file both proposes a release and performs one, and never both. You do not tag anything
+by hand, and there is no stored npm credential — publishing authenticates over OIDC as this
+repository.
+
+**The filename is load-bearing.** npm's trusted publisher for this package names `release.yml`.
+Renaming the file makes every publish fail to authenticate, with an error about OIDC rather than
+about the rename.
+
+It also only fires for a merge that can change the tarball. The `paths` filter is `src/**`,
+`bin/**`, `instructions/**`, `package.json`, `bun.lock` — the same list as `files` in
+`package.json`, and the two should stay in step. A docs-only or CI-only merge to `main` starts no
+release run at all, which is why a typo fix does not spend a version number.
+
+## Cutting a patch
+
+Merge the work to `main` and let the workflow propose it:
+
+1. PR `develop` → `main`, merge it.
+2. The release run takes the **propose** path and pushes `release/next` with the patch bump. Its
+   commit message is the release note, so GitHub pre-fills the pull request's title and body from
+   it — opening the release is one click. The run summary links straight there.
+3. Merge that pull request. That push takes the **publish** path.
+4. Fast-forward `develop`, below.
+
+The workflow does not open the pull request for you on purpose: that needs "Allow GitHub Actions to
+create and approve pull requests", and the approving half of that permission would let a workflow
+satisfy the review this repository requires.
+
+## Cutting a minor or a major
+
+The judgement that something earns more than a patch is made in review, beside the change that
+earns it — so you set the version yourself, and you set it **on `develop`, before the merge to
+`main`**.
+
+```console
+$ git switch develop && git pull --ff-only
+$ bun install --frozen-lockfile
+$ bun test && bun run typecheck        # green before the bump, or there is nothing to release
+```
+
+Edit the one line in `package.json` — no other file in the repository names a version; the README
+badge reads npm live. Then commit it with the release note as the message:
+
+```console
+$ git commit -m "Release 0.4.0" -m "$(cat <<'NOTE'
+Merging this to main publishes 0.4.0 to npm.
+
+Since v0.3.2:
+
+- <one line per change, from git log --no-merges --pretty=format:'- %s'>
+
+Why this earns a minor rather than the workflow's patch bump. The version is set
+here, on develop, so the push to main arrives untagged and publishes directly.
+NOTE
+)"
+$ git push origin develop
+```
+
+Two `-m` arguments, not one: passing the whole note as a single string runs the subject and the
+first body line together into one 60-character subject, which is what happened to `Release 0.3.1`.
+
+Then PR `develop` → `main`, wait for `ci`, and merge. `main` requires an approval, so a solo
+release is `gh pr merge <n> --admin --merge`. **That merge is the irreversible step** — it publishes,
+and the registry does not give a version back.
+
+### Why the version goes on `develop` and not on a release branch
+
+Because of what the alternative leaves behind. Merge `develop` to `main` with a tagged version and
+the propose path runs: the bump lands on `release/next`, which merges into `main` only. `develop` is
+then behind by a version commit forever, and every later comparison between the two branches is
+noise. Setting it on `develop` first means the push to `main` arrives untagged, publishes directly,
+and both branches hold the same tree.
+
+## After the release: fast-forward `develop`
+
+`main` now carries the merge commit `develop` lacks. The trees are already identical, so this is a
+fast-forward and not a merge:
+
+```console
+$ git fetch origin
+$ git push origin origin/main:refs/heads/develop
+```
+
+Verify it, both directions, because "0 ahead" alone does not prove they match:
+
+```console
+$ git rev-list --count origin/main..origin/develop     # 0
+$ git rev-list --count origin/develop..origin/main     # 0
+```
+
+This is the operator's step to remember: the workflow is designed around `main` alone and says
+nothing about `develop`.
+
+## Verifying a release actually shipped
+
+```console
+$ gh run list --workflow release.yml --limit 1        # conclusion: success
+$ npm view @lanes-sh/link version                     # the version you set
+$ gh release view v<version> --json tagName,url
+```
+
+Read the run's step list rather than the tail of `gh run watch`: that tail prints annotations, and
+an annotation from an *earlier* run appears there looking like a failure in this one. A run whose
+steps are all `success` succeeded.
+
+Two things will look wrong and are not:
+
+- **The release pull request shows `ci` as never reporting.** GitHub does not run workflows on
+  branches it pushed itself, so a proposed release needs an admin merge. Both gates run again inside
+  `release.yml` against the exact tree being published, which is the run that matters.
+- **`push the next release` is skipped in the run.** That is the propose step, correctly skipped on
+  a publish run. It is how you confirm the publish path was taken.
+
+## If a release goes wrong
+
+- **Publish failed, nothing tagged.** Publish runs *before* the tag for this reason: a failure
+  leaves the repository untouched and the run repeatable. Fix and re-run. Tagging first would leave
+  a tag claiming a version nobody can install, which the next run reads as released and skips
+  forever after.
+- **Published a version you did not mean to.** It cannot be reclaimed. Set the next version
+  deliberately and release again.
+- **`develop` is behind `main` by a version commit.** The propose path ran when a deliberate version
+  was wanted. Fast-forward, as above.

--- a/docs/detailed/releasing.md
+++ b/docs/detailed/releasing.md
@@ -18,12 +18,27 @@ that true, and it is the step most easily forgotten.
 
 | | |
 |---|---|
-| `main` | What `npm install @lanes-sh/link` gets. Protected: pull request, passing `ci`, no force-push. The only bypass is an organisation admin. |
-| `develop` | The integration branch. Unprotected, so a push works — but work still arrives by pull request, because the reasoning in the commit message is the review. |
+| `main` | What `npm install @lanes-sh/link` gets. A push here is what publishes. |
+| `develop` | The integration branch, and this repository's **default** branch. |
 | feature branches | One per change, in its own worktree. See [CLAUDE.md](../../CLAUDE.md). |
 
-Nothing is ever pushed to `main` by CI. It cannot be: the ruleset requires a pull request and the
-built-in `GITHUB_TOKEN` cannot be added to its bypass list. Doing it anyway would mean storing an
+`main` and `develop` carry the same ruleset: pull request with one approval, code-owner review,
+resolved review threads, a passing `ci`, no force-push, no deletion. The only bypass is an
+organisation admin, which is how a solo release merges its own pull request.
+
+**The ruleset names both branches literally, and that is deliberate.** It used to name
+`~DEFAULT_BRANCH` — one rule for "whichever branch is default". When the default was changed to
+`develop`, every rule moved with it and `main` was left with none at all, while the ruleset was
+still called "main" and `CONTRIBUTING.md` still said `main` required a pull request. For a branch
+whose pushes publish to npm, that gap is worth more than the convenience of a symbolic name.
+
+Because both branches require a pull request, the two direct pushes a release performs — the
+version bump onto `develop`, and the fast-forward at the end — land only under that admin bypass.
+Without it, both are pull requests, and the fast-forward becomes an ordinary merge of `main` into
+`develop` that leaves one commit between them.
+
+Nothing is ever pushed to `main` by CI. It cannot be: the ruleset requires a pull request there and
+the built-in `GITHUB_TOKEN` cannot be added to its bypass list. Doing it anyway would mean storing an
 App key or a personal access token with write access to `main` — a larger credential than the npm
 token this project deliberately does not have.
 


### PR DESCRIPTION
Cutting 0.4.0 needed three facts that lived nowhere a reader could find them: that the version must be set on `develop` *before* the pull request to `main`, that the merge to `main` is what publishes, and that `develop` has to be fast-forwarded afterwards or it stays a version commit behind. `CONTRIBUTING.md` described the workflow's two paths well and said nothing about the branches around them.

**New:** [`docs/detailed/releasing.md`](docs/detailed/releasing.md) — the lifecycle in the order it is met: the branch table, ordinary work, what a release is, cutting a patch, cutting a minor or major (and why the version goes on `develop`), the `develop` fast-forward, how to verify a release shipped, and what to do when one goes wrong.

**`CLAUDE.md`** gets the four things an agent gets wrong rather than a summary: the propose path is the default and the wrong one for a deliberate version; the merge to `main` is irreversible and so the operator's call; the fast-forward is the operator's to remember; never tag or publish by hand.

**`CONTRIBUTING.md`** keeps its short version and links to the page. **`docs/README.md`** gets the reference-table row.

Docs only — `release.yml`'s `paths` filter excludes `docs/`, `CLAUDE.md`, and `CONTRIBUTING.md`, so merging this to `main` later starts no release run.

`bun test` (2386 pass, 0 fail) and `bun run typecheck` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)