### PR TITLE
Squash every pull request except the one whose squash would strand develop

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,6 +20,10 @@ $ bun test          # establish the baseline before changing anything
 has no `node_modules`. Getting a green baseline first is what makes a later failure
 attributable.
 
+Work lands by pull request into `develop`, squashed — `gh pr merge <n> --squash --delete-branch`.
+Both `develop` and `main` require a passing `ci` and an approval, so a solo merge adds `--admin`.
+The one pull request that is not squashed is the release; see below.
+
 ## Never run `lanes link` from a worktree without `LANES_LINK_HOME`
 
 `resolveWorkspaceRoot` (`src/profile/workspace.ts`) checks `LANES_LINK_HOME`, then
@@ -56,9 +60,14 @@ paths `release.yml` takes, and the verification that a release shipped. What an 
 - **The merge to `main` is the irreversible step.** It publishes to npm under this repository's
   OIDC identity. Get the branch green and the pull request open unattended; do not merge a release
   the operator has not asked for.
-- **Fast-forward `develop` afterwards** — `git push origin origin/main:refs/heads/develop` — and
-  check `git rev-list --count` both directions. Nothing in the workflow does it for you, and the
-  next comparison between the branches is noise until you do.
+- **Squash every pull request except the release one.** `gh pr merge <n> --squash
+  --delete-branch` for work landing in `develop`. The `develop` → `main` release pull request is
+  the exception and must be `--merge`: a squash writes a new commit onto `main`, `develop`'s tip
+  stops being an ancestor, and the fast-forward below is then rejected as non-fast-forward even
+  though the trees are identical. Rebase-merging is disabled for the same reason.
+- **A release is finished when `develop` and `main` are 0/0, not when npm has the version.**
+  Fast-forward with `git push origin origin/main:refs/heads/develop`, then check
+  `git rev-list --count` in *both* directions. Nothing in the workflow does it for you.
 - **Never tag or `npm publish` by hand.** The workflow owns both, in that order, for a reason a
   manual run reverses.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -62,6 +62,16 @@ Two tests hold the layers to the code, and both should stay green rather than be
 `src/readme.test.ts` asserts the README names a working `lanes link connect` command for every
 provider, and `src/profile/docs.test.ts` parses the YAML examples out of the reference pages.
 
+## Merging
+
+Pull requests are **squashed** — one change, one commit on `develop`, carrying the message written
+for the change. `gh pr merge <n> --squash --delete-branch`. Rebase-merging is disabled.
+
+The single exception is the release pull request, `develop` → `main`, which is merged as a **merge
+commit**. Squashing it would leave `develop` no longer an ancestor of `main`, and the fast-forward
+that ends a release — the step that leaves the two branches identical — would be rejected. See
+[`docs/detailed/releasing.md`](docs/detailed/releasing.md#how-a-pull-request-is-merged).
+
 ## Releasing
 
 [`docs/detailed/releasing.md`](docs/detailed/releasing.md) is the whole lifecycle in order — the

--- a/docs/detailed/releasing.md
+++ b/docs/detailed/releasing.md
@@ -42,6 +42,43 @@ the built-in `GITHUB_TOKEN` cannot be added to its bypass list. Doing it anyway 
 App key or a personal access token with write access to `main` — a larger credential than the npm
 token this project deliberately does not have.
 
+## How a pull request is merged
+
+**Squash, with one exception.** Every pull request into `develop` is squashed: one change becomes
+one commit, and the commit message is the one written for the change rather than a merge line
+naming a branch nobody can see any more. `gh pr merge <n> --squash --delete-branch`.
+
+**The release pull request, `develop` → `main`, is a merge commit.** Not a preference — squashing it
+makes the closing fast-forward impossible. A squash writes a *new* commit onto `main` whose parent
+is `main`'s old tip, so `develop`'s tip stops being an ancestor of `main`. The trees are then
+identical and the branches have still diverged:
+
+```console
+$ git merge --squash develop && git commit -m "squashed"
+$ git rev-parse main^{tree} develop^{tree}      # the same tree
+$ git merge-base --is-ancestor develop main     # false
+$ git push origin origin/main:refs/heads/develop
+ ! [rejected]  (non-fast-forward)
+```
+
+The only way out of that is a force-push of `develop`, which the ruleset blocks and which would
+rewrite reviewed history to fix a cosmetic choice. A merge commit keeps `develop`'s tip an ancestor,
+which is exactly what the fast-forward needs. `gh pr merge <n> --admin --merge`.
+
+A proposed `release/next` pull request may be squashed — it holds one commit, and `develop`'s tip
+is already an ancestor of `main` by then, so nothing depends on how that one lands.
+
+**Rebase-merging is disabled**, in the repository settings and in the ruleset's
+`allowed_merge_methods`. It rewrites the commits onto `main` under new hashes, which breaks the
+ancestry the same way a squash does while looking like it preserved history.
+
+| Pull request | Method |
+|---|---|
+| anything → `develop` | squash |
+| `develop` → `main` (the release) | merge commit |
+| `release/next` → `main` | squash or merge commit |
+| any pull request | never rebase — the method is disabled |
+
 ## Ordinary work
 
 ```console
@@ -52,7 +89,11 @@ $ bun test && bun run typecheck      # the baseline, before changing anything
 ```
 
 Then the change, then the same two commands, then a pull request into `develop`. `ci` runs both
-gates again where a reviewer can see them. Merge when it is green.
+gates again where a reviewer can see them. Squash it when it is green:
+
+```console
+$ gh pr merge <n> --squash --delete-branch
+```
 
 That is the whole of ordinary work. A release is a separate act, taken deliberately, described
 below.
@@ -129,9 +170,10 @@ $ git push origin develop
 Two `-m` arguments, not one: passing the whole note as a single string runs the subject and the
 first body line together into one 60-character subject, which is what happened to `Release 0.3.1`.
 
-Then PR `develop` → `main`, wait for `ci`, and merge. `main` requires an approval, so a solo
-release is `gh pr merge <n> --admin --merge`. **That merge is the irreversible step** — it publishes,
-and the registry does not give a version back.
+Then PR `develop` → `main`, wait for `ci`, and merge it **as a merge commit** — `gh pr merge <n>
+--admin --merge`, the `--admin` because `main` requires an approval and the `--merge` because a
+squash here would strand `develop` (see [above](#how-a-pull-request-is-merged)). **That merge is the
+irreversible step** — it publishes, and the registry does not give a version back.
 
 ### Why the version goes on `develop` and not on a release branch
 
@@ -158,8 +200,13 @@ $ git rev-list --count origin/main..origin/develop     # 0
 $ git rev-list --count origin/develop..origin/main     # 0
 ```
 
-This is the operator's step to remember: the workflow is designed around `main` alone and says
-nothing about `develop`.
+**A release is not finished until both of those read `0`.** The workflow is designed around `main`
+alone and says nothing about `develop`, so this is the operator's step to remember — and the reason
+the pull request above is a merge commit rather than a squash.
+
+If the second count is not `0`, something published from `main` that `develop` never saw — usually
+the propose path's patch bump. Fast-forward again. If the *first* is not `0`, `develop` has moved on
+since the release, which is ordinary.
 
 ## Verifying a release actually shipped
 


### PR DESCRIPTION
Asked for: always squash merge, and `develop`/`main` at 0/0 after a release. Those conflict on exactly one pull request, so this writes down which one and why.

**Squash a PR into `develop`** — one change, one commit, carrying the message written for the change. `gh pr merge <n> --squash --delete-branch`.

**Merge-commit the release PR `develop` → `main`.** A squash there writes a new commit onto `main` whose parent is `main`'s old tip, so `develop`'s tip stops being an ancestor and the closing fast-forward is rejected — with identical trees. Probed locally:

```console
$ git rev-parse main^{tree} develop^{tree}      # same tree
$ git merge-base --is-ancestor develop main     # false
$ git push origin origin/main:refs/heads/develop
 ! [rejected]  (non-fast-forward)
```

The only recovery is force-pushing `develop`, which the ruleset blocks. A merge commit keeps the ancestry the fast-forward needs.

**Rebase-merging is now disabled** — repository setting `allow_rebase_merge: false`, and the ruleset's `allowed_merge_methods` is `["squash","merge"]` on both branches. It breaks the same ancestry while looking like it preserved history.

Docs: `docs/detailed/releasing.md` gets the section, the table, and the probe; `CONTRIBUTING.md` states the rule and its one exception; `CLAUDE.md` says it where an agent picks a merge flag, plus that a release is finished at 0/0 rather than at a published version.

`bun test` (2386 pass, 0 fail) and `bun run typecheck` green. This PR gets squashed, per its own rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)