### PR TITLE
Give the draft-payment update the fields bunq actually accepts

### DIFF
--- a/src/providers/bunq/hints.ts
+++ b/src/providers/bunq/hints.ts
@@ -29,7 +29,9 @@ export const BUNQ_HINTS: Record<string, string> = {
   UPDATE_DraftPayment_for_User_MonetaryAccount:
     'Changes a draft that is still pending — status ACCEPTED sends it, REJECTED cancels it. ' +
     'previous_updated_timestamp is required and comes from reading the draft first; it is what stops two ' +
-    'callers acting on the same draft.',
+    'callers acting on the same draft. Those two fields are the entire call — bunq refuses entries and ' +
+    'number_of_required_accepts here as superfluous — so changing what a draft pays means rejecting it and ' +
+    'creating another.',
 
   CREATE_PaymentBatch_for_User_MonetaryAccount:
     'Up to 350 payments in one call. Executes immediately, like a direct payment, and is all-or-nothing: bunq rejects ' +

--- a/src/providers/bunq/redact.ts
+++ b/src/providers/bunq/redact.ts
@@ -51,14 +51,25 @@ export const BUNQ_REDACT: Record<string, string[]> = {
     'status',
     'schedule',
   ],
+  // Five, not seven: `entries` and `number_of_required_accepts` are no longer
+  // arguments at all. This is the one write here whose event cannot name an
+  // amount or a counterparty, because the call does not carry them — it says
+  // which draft was accepted and against which version of it, and that is
+  // everything there is to keep.
+  //
+  // Not everything a reader wants, though, and worth being honest that the gap
+  // is real rather than closed. The entries are on the event that *created* the
+  // draft, and nothing joins the two: an `AuditEvent` records arguments only,
+  // and bunq returns the draft id in the create's response. Reconstructing what
+  // an ACCEPTED draft paid means matching by hand. `context.audit.annotate`,
+  // which `gmail.send_message` uses to record resolved facts, is the shape of a
+  // fix and is a change to dispatch rather than to this list.
   UPDATE_DraftPayment_for_User_MonetaryAccount: [
     'userID',
     'monetary-accountID',
     'itemId',
     'status',
-    'entries',
     'previous_updated_timestamp',
-    'number_of_required_accepts',
   ],
   CREATE_PaymentBatch_for_User_MonetaryAccount: ['userID', 'monetary-accountID', 'payments'],
 };

--- a/src/providers/bunq/specs/bunq.v1.json
+++ b/src/providers/bunq/specs/bunq.v1.json
@@ -144,7 +144,26 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/DraftPayment"
+                "type": "object",
+                "description": "The whole of what this call takes. bunq refuses any other field here as superfluous — the rest of the schema it shares belongs to the call that creates one.",
+                "properties": {
+                  "status": {
+                    "type": "string",
+                    "description": "The status of the DraftPayment.",
+                    "readOnly": false,
+                    "writeOnly": false
+                  },
+                  "previous_updated_timestamp": {
+                    "type": "string",
+                    "description": "The last updated_timestamp that you received for this DraftPayment. This needs to be provided to prevent race conditions.",
+                    "readOnly": false,
+                    "writeOnly": true
+                  }
+                },
+                "required": [
+                  "status",
+                  "previous_updated_timestamp"
+                ]
               }
             }
           }

--- a/src/providers/bunq/specs/specs.test.ts
+++ b/src/providers/bunq/specs/specs.test.ts
@@ -91,6 +91,52 @@ describe('the vendored spec and the manifest agree', () => {
     expect(leaked).toEqual([]);
   });
 
+  test('the tool that accepts a draft can be called correctly', () => {
+    // Not a missing capability — a present one that could not be used. bunq
+    // describes its update with the schema of its create, whose `required`
+    // names `entries` and `number_of_required_accepts`, and then refuses both
+    // here as superfluous. Every accept and every reject failed, and the two
+    // bodies a model can reach for when a schema demands entries on a draft
+    // that already has them — the array echoed back, or `[]` — both ask bunq to
+    // rewrite what the draft pays on the way to approving it.
+    //
+    // Nothing else looked. `redact` and `hints` are checked against the tools
+    // and the tools against the spec, but no test asked whether a schema
+    // describes a call the vendor would accept.
+    const update = discovered.find(
+      (entry) => entry.name === 'UPDATE_DraftPayment_for_User_MonetaryAccount',
+    )!;
+    const properties = Object.keys((update.inputSchema?.['properties'] ?? {}) as object);
+
+    expect(((update.inputSchema?.['required'] ?? []) as string[]).sort()).toEqual([
+      'itemId',
+      'monetary-accountID',
+      'previous_updated_timestamp',
+      'status',
+      'userID',
+    ]);
+    expect(properties).not.toContain('entries');
+    expect(properties).not.toContain('number_of_required_accepts');
+    // `schedule` is the exclusion argued on risk rather than on the call
+    // failing, so it is the one a revert would restore quietly: bunq accepts it
+    // here, and it would come back as an *optional* property that the assertion
+    // on `required` above cannot see.
+    expect(properties).not.toContain('schedule');
+  });
+
+  test('creating a draft still asks for the payment it is a draft of', () => {
+    // The other half of the same fix: the narrowing is keyed by operation, and
+    // aimed at the wrong one it would leave a tool with no way to say what to
+    // pay — which fails in the same silent shape, one call later.
+    const create = discovered.find(
+      (entry) => entry.name === 'CREATE_DraftPayment_for_User_MonetaryAccount',
+    )!;
+    const required = (create.inputSchema?.['required'] ?? []) as string[];
+
+    expect(required).toContain('entries');
+    expect(required).toContain('number_of_required_accepts');
+  });
+
   test('the committed spec carries no component the paths do not use', () => {
     // Including, before this was filtered, a definition of the session header.
     const spec = require(connector.openapi) as { components: Record<string, unknown> };

--- a/src/providers/bunq/specs/vendor.ts
+++ b/src/providers/bunq/specs/vendor.ts
@@ -22,6 +22,7 @@ import { mkdir, writeFile } from 'node:fs/promises';
 import { join } from 'node:path';
 import { OpenAPIToolGenerator, type McpOpenAPITool } from 'mcp-from-openapi';
 import { cutCycles, referenced, type Spec } from '../../shared/openapi.ts';
+import { projectRequestBody } from '../../shared/vendor-operations.ts';
 
 const SOURCE = 'https://raw.githubusercontent.com/bunq/doc/master/swagger.json';
 const OUT = 'bunq.v1.json';
@@ -187,6 +188,34 @@ function dropReadOnly(node: unknown): number {
   return dropped;
 }
 
+/**
+ * The operations bunq describes with the schema of a *different* operation.
+ *
+ * `PUT .../draft-payment/{itemId}` points at `DraftPayment`, the same schema as
+ * the `POST` that creates one, which requires `entries` and
+ * `number_of_required_accepts`. For a create those two *are* the payment. For an
+ * update bunq refuses both as superfluous — its own generated SDK sends only
+ * `status`, `previous_updated_timestamp` and `schedule` here — so the tool asked
+ * for exactly what the bank rejects and every accept failed. Worse than the
+ * error: made to send `entries` for a draft that has them, a model reaches for
+ * the array echoed back or for `[]`, and both ask bunq to rewrite what the draft
+ * pays on the way to approving it. A hint cannot fix a required argument, which
+ * is the difference between this and the `payments`-is-really-an-array note
+ * above: nothing stops an agent sending an array, and nothing lets it omit a
+ * required field. `required` is asserted here rather than projected because
+ * bunq's own is the one written for the create.
+ *
+ * `schedule` is deliberately not projected: it carries `recurrence_unit` and
+ * `recurrence_size`, so approving a one-off draft would be a place to acquire a
+ * standing order — the risk `OPERATIONS` gives for leaving the scheduling
+ * *endpoints* out. Not the whole of that risk, though: `CREATE_DraftPayment`
+ * still offers the same field, because it comes with bunq's create schema.
+ * Closing that changes what the provider can do rather than whether a call
+ * works, and is not done here.
+ */
+const UPDATE_BODIES: Record<string, readonly string[]> = {
+  UPDATE_DraftPayment_for_User_MonetaryAccount: ['status', 'previous_updated_timestamp'],
+};
 
 async function vendor(): Promise<void> {
   const response = await fetch(SOURCE);
@@ -246,6 +275,34 @@ async function vendor(): Promise<void> {
   }
 
   const schemas = spec.components?.schemas ?? {};
+
+  const projected = new Set<string>();
+  for (const item of Object.values(paths)) {
+    for (const [method, operation] of Object.entries(item)) {
+      if (!METHODS.includes(method)) continue;
+      const fields = operation.operationId ? UPDATE_BODIES[operation.operationId] : undefined;
+      if (!fields || !operation.operationId) continue;
+
+      projectRequestBody(
+        operation as unknown as Record<string, unknown>,
+        operation.operationId,
+        schemas,
+        fields,
+        'The whole of what this call takes. bunq refuses any other field here as superfluous — the rest ' +
+          'of the schema it shares belongs to the call that creates one.',
+      );
+      projected.add(operation.operationId);
+    }
+  }
+
+  // The same refusal as `missing` above, and for a sharper reason: an entry that
+  // matches nothing narrows nothing, and what is left is the wide body this
+  // exists to remove — printed as a success.
+  const unprojected = Object.keys(UPDATE_BODIES).filter((id) => !projected.has(id));
+  if (unprojected.length > 0) {
+    throw new Error(`UPDATE_BODIES names operations the spec does not have — ${unprojected.join(', ')}`);
+  }
+
   const keep = referenced(paths, schemas);
   const trimmedSchemas = Object.fromEntries(
     Object.entries(schemas).filter(([name]) => keep.has(name)),
@@ -295,7 +352,8 @@ async function vendor(): Promise<void> {
     `  bunq   ${String(Object.keys(paths).length).padStart(2)} paths, ` +
       `${seen.size} operations, ${Object.keys(trimmedSchemas).length} schemas, ` +
       `${cuts} cycle${cuts === 1 ? '' : 's'} cut, ${headers} protocol params dropped, ` +
-      `${readOnly} read-only fields dropped, ${size}KB`,
+      `${readOnly} read-only fields dropped, ${projected.size} update ` +
+      `bod${projected.size === 1 ? 'y' : 'ies'} projected, ${size}KB`,
   );
 
   await report(trimmed);

--- a/src/providers/shared/vendor-operations.test.ts
+++ b/src/providers/shared/vendor-operations.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, test } from 'bun:test';
+import { projectRequestBody } from './vendor-operations.ts';
+
+/**
+ * What `projectRequestBody` promises, held to it.
+ *
+ * The bug it was written for was a schema that described a call the vendor
+ * would refuse, and what let that ship was a claim nothing checked. Its own
+ * docstring now makes four promises to refuse rather than guess, and a refusal
+ * that does not fire is the same kind of claim — so each one is exercised here
+ * against a spec fragment rather than asserted in a comment.
+ */
+
+const schemas = (): Record<string, unknown> => ({
+  Draft: {
+    type: 'object',
+    properties: {
+      status: { type: 'string', description: 'The status of the Draft.' },
+      entries: { type: 'array', items: {} },
+      id: { type: 'integer', readOnly: true },
+    },
+    required: ['entries'],
+  },
+});
+
+const operation = (schema: unknown = { $ref: '#/components/schemas/Draft' }): Record<string, unknown> => ({
+  operationId: 'UPDATE_Draft',
+  requestBody: { content: { 'application/json': { schema } } },
+});
+
+const body = (op: Record<string, unknown>): Record<string, unknown> => {
+  const content = (op['requestBody'] as { content: Record<string, { schema: Record<string, unknown> }> })
+    .content;
+  return content['application/json']!.schema;
+};
+
+describe('projectRequestBody', () => {
+  test('keeps the vendor’s own type and description, and asserts the caller’s required', () => {
+    const op = operation();
+    projectRequestBody(op, 'UPDATE_Draft', schemas(), ['status'], 'Only this.');
+
+    expect(body(op)).toEqual({
+      type: 'object',
+      description: 'Only this.',
+      properties: { status: { type: 'string', description: 'The status of the Draft.' } },
+      required: ['status'],
+    });
+    // The projection replaces the reference outright: `entries` was required by
+    // the schema this used to point at, and that is the whole disease.
+    expect(JSON.stringify(body(op))).not.toContain('entries');
+  });
+
+  test('refuses a field the vendor no longer describes', () => {
+    // A rename upstream must fail the refresh. Skipping the field instead would
+    // publish a narrower tool; leaving the body alone would restore the wide one.
+    expect(() => projectRequestBody(operation(), 'UPDATE_Draft', schemas(), ['gone'], '')).toThrow(
+      /no longer describes "gone"/,
+    );
+  });
+
+  test('refuses a read-only field', () => {
+    // Projected fields are inlined into the path, where the read-only strip does
+    // not reach — so this would become a required argument the vendor ignores.
+    expect(() => projectRequestBody(operation(), 'UPDATE_Draft', schemas(), ['id'], '')).toThrow(
+      /read-only/,
+    );
+  });
+
+  test('refuses a body offering a content type it does not rewrite', () => {
+    const op = operation();
+    (op['requestBody'] as { content: Record<string, unknown> }).content['application/xml'] = {
+      schema: { $ref: '#/components/schemas/Draft' },
+    };
+
+    // Narrowing one branch and leaving the other wide makes the fix depend on
+    // which branch the generator prefers, which is a third party's choice.
+    expect(() => projectRequestBody(op, 'UPDATE_Draft', schemas(), ['status'], '')).toThrow(
+      /application\/xml/,
+    );
+  });
+
+  test('refuses a reference that does not point into components.schemas', () => {
+    // Otherwise the pointer survives `slice` unchanged, no schema is found, and
+    // the error blames a renamed field for what is a different problem.
+    const op = operation({ $ref: '#/components/requestBodies/Draft' });
+
+    expect(() => projectRequestBody(op, 'UPDATE_Draft', schemas(), ['status'], '')).toThrow(
+      /not a schema reference/,
+    );
+  });
+});

--- a/src/providers/shared/vendor-operations.ts
+++ b/src/providers/shared/vendor-operations.ts
@@ -96,3 +96,84 @@ export function narrowRequestBody(
   body.content = Object.fromEntries(kept.map((type) => [type, body.content![type]]));
   return before.length - kept.length;
 }
+
+/**
+ * Replace a request body with a projection of the schema it points at.
+ *
+ * The third surgery on this axis, and the first about the body being *wrong*
+ * rather than too wide. A document that describes two operations with one schema
+ * describes at least one of them wrongly, and `required` is where it bites: the
+ * generated tool asks for arguments the vendor refuses on the call they are
+ * attached to, so there is no correct call to make. It fails at the vendor, on
+ * every attempt, and nothing before the request can see it.
+ *
+ * Projecting rather than hand-writing is what keeps this tied to the document.
+ * The named fields are copied out of the vendor's own schema with their types
+ * and descriptions, so the tool still says what the vendor says. Everything this
+ * cannot verify it refuses instead: a field that is gone, a field the document
+ * marks read-only, a body offering a content type this does not rewrite, a
+ * `$ref` that does not point into `components.schemas`. A vendor refresh should
+ * fail loudly here rather than quietly restore the body it was called to fix.
+ *
+ * `required` is the one thing NOT projected — it is the caller's assertion, and
+ * necessarily so, since the whole disease is a `required` written for the other
+ * operation. Say why in the caller.
+ *
+ * `note` becomes the body schema's description. It lands in the committed
+ * document for whoever reads it there; it does **not** reach the agent, because
+ * the generator flattens body properties to the top level and drops the body
+ * schema's own description. The sentence an agent needs goes in `hints`.
+ *
+ * Apply before reachability, so a schema the projection no longer reaches leaves
+ * the document rather than lingering unused.
+ */
+export function projectRequestBody(
+  operation: Record<string, unknown>,
+  operationId: string,
+  schemas: Record<string, unknown>,
+  fields: readonly string[],
+  note: string,
+): void {
+  const content = (operation['requestBody'] as { content?: Record<string, { schema?: { $ref?: string } }> })
+    ?.content;
+  const types = Object.keys(content ?? {});
+
+  const other = types.filter((type) => type !== 'application/json');
+  if (!content || types.length === 0 || other.length > 0) {
+    // A body left pointing at the wide schema on a second content type is the
+    // bug still present on whichever branch the generator happens to prefer.
+    throw new Error(
+      `${operationId}: expected a lone application/json request body to project, found ${types.join(', ') || 'none'}`,
+    );
+  }
+
+  const json = content['application/json'];
+  const reference = json?.schema?.$ref;
+  if (!json || typeof reference !== 'string' || !reference.startsWith('#/components/schemas/')) {
+    throw new Error(`${operationId}: request body is ${reference ?? 'not a $ref'}, not a schema reference`);
+  }
+
+  const name = reference.slice('#/components/schemas/'.length);
+  const source = (schemas[name] as { properties?: Record<string, unknown> } | undefined)?.properties ?? {};
+
+  const properties: Record<string, unknown> = {};
+  for (const field of fields) {
+    const property = source[field] as { readOnly?: boolean } | undefined;
+    if (!property) throw new Error(`${operationId}: ${name} no longer describes "${field}"`);
+    if (property.readOnly === true) {
+      // Projected fields are inlined into the path, where the read-only strip
+      // does not reach — so a field the vendor computes would survive here and
+      // be demanded as an argument it ignores.
+      throw new Error(`${operationId}: ${name}.${field} is read-only and cannot be a request field`);
+    }
+    properties[field] = property;
+  }
+
+  json.schema = {
+    type: 'object',
+    description: note,
+    properties,
+    required: [...fields],
+  } as never;
+}
+


### PR DESCRIPTION
Accepting or rejecting a pending bunq draft payment failed every time — not sometimes, every time — and had since the provider shipped.

## What was wrong

A tool's argument list is generated from the OpenAPI document, one for one. If the document marks a field `required`, it becomes a required argument and the model has no way to leave it out.

bunq's document says the "accept a draft payment" call requires `entries` (the payments themselves) and `number_of_required_accepts`. That is true of *creating* a draft. It is false of *accepting* one — bunq rejects both fields there as superfluous. So the tool asked for exactly what the bank refuses.

Worse than the error: forced to supply `entries` for a draft that already has them, a model has to invent something. In practice it sends the array copied back, or `[]`. Both ask bunq to change what the draft pays while approving it. Being refused was the good outcome.

```
before  required: ["userID","monetary-accountID","itemId","entries","number_of_required_accepts"]
after   required: ["userID","monetary-accountID","itemId","status","previous_updated_timestamp"]
```

## Why it needs a mechanism rather than an edit

Checked before writing any code:

- **It is not a typo upstream.** 65 of bunq's schemas serve as both a `POST` body and a `PUT` body; 33 of those declare `required`. One schema per resource, both verbs pointed at it. We only trip over one because we vendor eleven operations and one is a `PUT`.
- **There is no correct schema upstream to switch to.** bunq does ship `DraftPaymentUpdate` — but it is the *response*: `{ id }`, read-only. Same for `DraftPaymentCreate` and `PaymentCreate`.
- **The generator has no knob.** `mcp-from-openapi`'s `GenerateOptions` filters operations, names tools, picks response codes. Nothing edits a schema, by design.
- **bunq's own SDK settles the real contract**: [`DraftPayment.update()`](https://raw.githubusercontent.com/bunq/sdk_python/develop/bunq/sdk/model/generated/endpoint.py) sends `status`, `previous_updated_timestamp`, `schedule` — and `create()` is the one taking the other two.

So the document is the only place to fix it, which is what the vendor script already exists for. It cuts a recursion cycle (without it every payment endpoint fails to generate), drops 77 protocol headers including the session token, drops 38 read-only fields, replaces the responses and the server list. This is a fifth item on that list, and the first about a call being *wrong* rather than too big.

## The change

`projectRequestBody` lands in `shared/vendor-operations.ts`, whose stated axis is what an operation declares it takes — beside `narrowRequestBody`, which does the same job for content types. It copies the named fields out of the vendor's own schema with their types and descriptions intact, so the tool still says what the vendor says, and it refuses anything it cannot verify: a field that is gone, a field marked read-only, a body offering a content type it does not rewrite, a `$ref` that is not into `components.schemas`.

`required` is the one thing it does not project — it cannot, since the disease *is* a `required` written for the other operation. The caller asserts it and says why.

The caller also refuses an entry that matched no operation, which is the difference between a mechanism and a trap: without it, a rename upstream narrows nothing, leaves the wide body in place, and prints success. Verified by renaming the key and watching `vendor:bunq` fail.

## Two comments that were wrong, now accurate

- `schedule` is left off the update because it carries `recurrence_unit`/`recurrence_size` — approving a one-off draft should not be a way to acquire a standing order. It is **not** true that scheduling is excluded entirely: `CREATE_DraftPayment` still offers the same field. Closing that changes what the provider can do rather than whether a call works, so it is flagged, not done here.
- `redact` no longer claims the removed `entries` stay recoverable. They are on the event that *created* the draft, and nothing joins the two — an audit event records arguments only, and bunq returns the draft id in the create's response. So the ACCEPTED event names the draft and its version and no amount. Written down as a real gap, with `context.audit.annotate` named as the shape of a fix.

## Tests

The gap that let this ship: nothing asked whether a vendored tool can be *called correctly*. `redact` and `hints` were checked against the tools, and the tools against the spec, but no test compared a schema with what the vendor would accept.

- `specs.test.ts` pins the update's five arguments, the absence of the two that broke it and of `schedule`, and that the create still asks for the payment it is a draft of. Confirmed against the pre-fix spec, where it fails on exactly those field names.
- `vendor-operations.test.ts` exercises each refusal — a docstring promising to fail loudly is the same kind of unchecked claim as the one that caused this.

`bun test` 2393 pass / 0 fail, `bun run typecheck` clean, and `bun run vendor:bunq` reproduces the committed spec byte for byte.

Not done here: merging, deploying, or accepting a real draft.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
