### PR TITLE
Answer mcp list --json for real, so a UI can tell add from re-add

### DIFF
--- a/src/cli/commands/mcp/list.test.ts
+++ b/src/cli/commands/mcp/list.test.ts
@@ -1,0 +1,123 @@
+import { describe, expect, test } from 'bun:test';
+import { HARNESSES } from './harnesses.ts';
+import { listRegistrations, mcpList, type McpListing } from './list.ts';
+
+/**
+ * `lanes link mcp list`, and its `--json`.
+ *
+ * The property under test is the one the flag exists for: both renderings
+ * describe the same snapshot. A UI deciding between "add" and "re-add" reads the
+ * JSON; a person reads the text; and a probe taken twice would let the two
+ * disagree about a registration that changed in between.
+ *
+ * Nothing here stubs `Bun.which` or the harness binaries, so the assertions are
+ * about shape and about agreement rather than about which harnesses happen to be
+ * installed on the machine running the suite.
+ */
+
+/** Everything written to stdout while `body` runs. */
+async function captureStdout(body: () => Promise<void>): Promise<string> {
+  const original = process.stdout.write.bind(process.stdout);
+  let captured = '';
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (process.stdout as any).write = (chunk: string | Uint8Array): boolean => {
+    captured += typeof chunk === 'string' ? chunk : new TextDecoder().decode(chunk);
+    return true;
+  };
+
+  try {
+    await body();
+  } finally {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (process.stdout as any).write = original;
+  }
+
+  return captured;
+}
+
+describe('the listing', () => {
+  test('carries one entry per known harness, in registry order', async () => {
+    const listing = await listRegistrations('lanes-link', 'user');
+
+    expect(listing.harnesses.map((one) => one.id)).toEqual(HARNESSES.map((one) => one.id));
+    expect(listing.name).toBe('lanes-link');
+    expect(listing.scope).toBe('user');
+  });
+
+  test('a harness with no binary reports nothing about its documents', async () => {
+    // With no binary there is nothing to register the documents against, and
+    // reporting them would describe a setup that does not exist. The text
+    // rendering already stops at "not installed"; the JSON has to agree.
+    const listing = await listRegistrations('lanes-link', 'user');
+
+    for (const harness of listing.harnesses) {
+      if (harness.installed) continue;
+      expect(harness.binary).toBeNull();
+      expect(harness.registered).toBe(false);
+      expect(harness.documents).toEqual([]);
+    }
+  });
+
+  test('every document state is one the renderer knows how to draw', async () => {
+    const listing = await listRegistrations('lanes-link', 'user');
+    const known = ['current', 'stale', 'missing', 'unreadable'];
+
+    for (const harness of listing.harnesses) {
+      for (const document of harness.documents) {
+        expect(known).toContain(document.state);
+        expect(document.label.length).toBeGreaterThan(0);
+        expect(document.path.length).toBeGreaterThan(0);
+      }
+    }
+  });
+
+  test('the name is what registrations are looked up under', async () => {
+    // Not a cosmetic field: `exists()` asks each harness for *this* name, so a
+    // listing under a different name is a different question with a different
+    // answer.
+    const listing = await listRegistrations('something-else', 'user');
+    expect(listing.name).toBe('something-else');
+  });
+});
+
+describe('--json', () => {
+  test('prints parseable JSON and nothing else', async () => {
+    const raw = await captureStdout(() => mcpList({ json: true }));
+
+    const parsed = JSON.parse(raw) as McpListing;
+    expect(parsed.name).toBe('lanes-link');
+    expect(parsed.harnesses.map((one) => one.id)).toEqual(HARNESSES.map((one) => one.id));
+  });
+
+  test('agrees with the text rendering about what is registered', async () => {
+    const raw = await captureStdout(() => mcpList({ json: true }));
+    const text = await captureStdout(() => mcpList({ json: false }));
+    const parsed = JSON.parse(raw) as McpListing;
+
+    for (const harness of parsed.harnesses) {
+      expect(text).toContain(harness.label);
+
+      if (!harness.installed) {
+        // The one line a missing harness gets.
+        expect(text).toMatch(new RegExp(`${harness.label}\\s+.*not installed`));
+        continue;
+      }
+
+      expect(text).toMatch(
+        harness.registered
+          ? new RegExp(`${harness.label}\\s+.*\\bregistered`)
+          : new RegExp(`${harness.label}\\s+.*not registered`),
+      );
+
+      for (const document of harness.documents) {
+        expect(text).toContain(document.label);
+      }
+    }
+  });
+
+  test('the scope reaches the payload, so a local-scope listing says so', async () => {
+    const raw = await captureStdout(() => mcpList({ json: true, scope: 'local' }));
+    expect((JSON.parse(raw) as McpListing).scope).toBe('local');
+  });
+});

--- a/src/cli/commands/mcp/list.ts
+++ b/src/cli/commands/mcp/list.ts
@@ -1,7 +1,45 @@
-import { heading, print, style } from '../../output.ts';
+import { emit, heading, print, style } from '../../output.ts';
 import { assetState, plannedAssets, readAsset } from './assets.ts';
 import { HARNESSES, type Harness } from './harnesses.ts';
 import { exists } from './register.ts';
+
+/** Why a document this harness can hold is not what we ship, if it is not. */
+export type DocumentState = 'current' | 'stale' | 'missing' | 'unreadable';
+
+export interface ListedDocument {
+  readonly label: string;
+  readonly path: string;
+  readonly state: DocumentState;
+  /** Only for `unreadable` — what went wrong reading the bundled copy. */
+  readonly detail?: string;
+}
+
+export interface ListedHarness {
+  readonly id: string;
+  readonly label: string;
+  readonly installed: boolean;
+  /** The resolved binary, so a caller can see *which* claude answered. */
+  readonly binary: string | null;
+  readonly registered: boolean;
+  /**
+   * Empty when the harness is not installed, matching what the text rendering
+   * says: with no binary there is nothing to register the documents against, and
+   * reporting them would describe a setup that does not exist.
+   */
+  readonly documents: readonly ListedDocument[];
+}
+
+export interface McpListing {
+  readonly name: string;
+  readonly scope: string;
+  readonly harnesses: readonly ListedHarness[];
+}
+
+export interface McpListFlags {
+  readonly name?: string | undefined;
+  readonly scope?: string | undefined;
+  readonly json?: boolean | undefined;
+}
 
 /**
  * `lanes link mcp list` — where this endpoint is registered, and whether what
@@ -11,58 +49,114 @@ import { exists } from './register.ts';
  * different fixes. A registration without the skill is a working endpoint
  * nobody reaches for; a skill against no registration is a document describing
  * tools that are not there.
+ *
+ * The listing is gathered before anything is printed, so `--json` and the text
+ * rendering describe the same snapshot rather than two probes taken a moment
+ * apart. `--json` exists because this is the one command another program has a
+ * reason to read: it is how a UI decides between "add" and "re-add", and the
+ * `stale` state is the only signal that a re-run would do something.
  */
-export async function mcpList(options: { name?: string | undefined; scope?: string | undefined }): Promise<void> {
+export async function mcpList(options: McpListFlags): Promise<void> {
   const name = options.name ?? 'lanes-link';
   const scope = options.scope ?? 'user';
 
-  heading(`Registered as ${style.bold(name)}`);
+  const listing = await listRegistrations(name, scope);
+
+  await emit(options.json, listing, () => render(listing));
+}
+
+/** The whole answer, gathered. No printing, so a caller can have it as data. */
+export async function listRegistrations(name: string, scope: string): Promise<McpListing> {
+  const harnesses: ListedHarness[] = [];
 
   for (const harness of HARNESSES) {
     const binary = Bun.which(harness.binary);
 
     if (!binary) {
+      harnesses.push({
+        id: harness.id,
+        label: harness.label,
+        installed: false,
+        binary: null,
+        registered: false,
+        documents: [],
+      });
+      continue;
+    }
+
+    harnesses.push({
+      id: harness.id,
+      label: harness.label,
+      installed: true,
+      binary,
+      registered: exists(binary, harness, name),
+      documents: await documents(harness, scope),
+    });
+  }
+
+  return { name, scope, harnesses };
+}
+
+/** One entry per document this harness can hold, saying whether it is current. */
+async function documents(harness: Harness, scope: string): Promise<ListedDocument[]> {
+  const listed: ListedDocument[] = [];
+
+  for (const plan of plannedAssets(harness, scope)) {
+    try {
+      listed.push({
+        label: plan.asset.label,
+        path: plan.path,
+        state: await assetState(plan, await readAsset(plan.asset)),
+      });
+    } catch (error) {
+      // A checkout without `instructions/` — a container image, say. Worth one
+      // line rather than a thrown error that hides the registration column.
+      listed.push({
+        label: plan.asset.label,
+        path: plan.path,
+        state: 'unreadable',
+        detail: message(error),
+      });
+    }
+  }
+
+  return listed;
+}
+
+function render(listing: McpListing): void {
+  heading(`Registered as ${style.bold(listing.name)}`);
+
+  for (const harness of listing.harnesses) {
+    if (!harness.installed) {
       print(`  ${harness.label.padEnd(14)} ${style.dim('not installed')}`);
       continue;
     }
 
     print(
       `  ${harness.label.padEnd(14)} ${
-        exists(binary, harness, name)
+        harness.registered
           ? style.green('registered')
           : style.dim(`not registered — lanes link mcp add ${harness.id}`)
       }`,
     );
 
-    for (const line of await documentLines(harness, scope)) print(`  ${' '.repeat(14)} ${line}`);
+    for (const document of harness.documents) {
+      print(`  ${' '.repeat(14)} ${documentLine(harness.id, document)}`);
+    }
   }
 }
 
-/** One line per document this harness can hold, saying whether it is current. */
-async function documentLines(harness: Harness, scope: string): Promise<string[]> {
-  const lines: string[] = [];
-
-  for (const plan of plannedAssets(harness, scope)) {
-    try {
-      const state = await assetState(plan, await readAsset(plan.asset));
-
-      lines.push(
-        state === 'current'
-          ? style.dim(`${plan.asset.label}: `) + style.green('up to date')
-          : style.dim(
-              state === 'stale'
-                ? `${plan.asset.label}: out of date — lanes link mcp add ${harness.id}`
-                : `${plan.asset.label}: not installed — lanes link mcp add ${harness.id}`,
-            ),
-      );
-    } catch (error) {
-      // A checkout without `instructions/` — a container image, say. Worth one
-      // line rather than a thrown error that hides the registration column.
-      lines.push(style.dim(`${plan.asset.label}: ${message(error)}`));
-    }
+function documentLine(id: string, document: ListedDocument): string {
+  switch (document.state) {
+    case 'current':
+      return style.dim(`${document.label}: `) + style.green('up to date');
+    case 'stale':
+      return style.dim(`${document.label}: out of date — lanes link mcp add ${id}`);
+    case 'missing':
+      return style.dim(`${document.label}: not installed — lanes link mcp add ${id}`);
+    case 'unreadable':
+      return style.dim(`${document.label}: ${document.detail}`);
   }
-
-  return lines;
 }
 
 function message(error: unknown): string {

--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -321,7 +321,11 @@ export async function run(argv: readonly string[]): Promise<void> {
           return mcpStdio({ ...global, ...(flags['only'] === true ? { only: true } : {}) });
         case 'list':
         case undefined:
-          return mcpList({ name: text(flags, 'name'), scope: text(flags, 'scope') });
+          return mcpList({
+            name: text(flags, 'name'),
+            scope: text(flags, 'scope'),
+            json: flags['json'] === true,
+          });
         default:
           throw new Error(`Unknown: ${PROGRAM} mcp ${second}`);
       }


### PR DESCRIPTION
## What

`lanes link mcp list --json` now emits JSON. It previously printed ANSI-coloured text and exited 0, because `--json` is in the universal accepted set in `selection.ts` — so the flag was accepted and inert, and a caller had no way to tell it had not been understood.

```json
{
  "name": "lanes-link",
  "scope": "user",
  "harnesses": [
    { "id": "claude", "label": "Claude Code", "installed": true,
      "binary": "/Users/…/bin/claude", "registered": true,
      "documents": [
        { "label": "skill", "path": "/Users/…/.claude/skills/lanes-link/SKILL.md", "state": "stale" },
        { "label": "scout agent", "path": "/Users/…/.claude/agents/lanes-link-scout.md", "state": "stale" }
      ] },
    { "id": "codex", "label": "Codex", "installed": false, "binary": null,
      "registered": false, "documents": [] }
  ]
}
```

`state` is `current | stale | missing | unreadable`, straight from `assetState`.

## Why

This is the one command another program has a reason to read. A UI showing where the endpoint is registered has to tell three states apart, and only two are expressible as a boolean: not registered, registered, and registered against a document that is no longer what we ship.

That third state is the only signal that re-running `mcp add` would do anything for somebody already set up — and it is not a corner case. Both harnesses on the machine this was written against report `skill: out of date`. The first caller is Lanes desktop's Lanes Link page, which picks between **Add to Claude Code**, **Re-add** and **Update files** from exactly that field.

## Approach, and what was rejected

- **The listing is gathered before anything prints.** `emit(json, payload, render)` is the guard every other `--json` command goes through, and building the payload first is what makes both renderings describe one snapshot rather than two probes taken a moment apart. `listRegistrations` is exported for the same reason, so an in-process caller gets the data without going through stdout.
- **Not left to the caller to parse the text.** It carries ANSI, the states are prose (`out of date`, `not installed`, `up to date`), and each line ends in the command that fixes it. A parser would be pinned to wording that exists to be read — and that wording is free to change precisely because nothing was reading it.
- **`documents` is empty for a harness with no binary**, which is what the text already said by stopping at `not installed`: with no binary there is nothing to register the documents against, so reporting them would describe a setup that does not exist. The new test asserts the two renderings agree on this.
- **`selection.ts` is untouched.** `mcp list` was already `'none'` and `--json` was already accepted.

## Verification

- `bun test` — baseline on `develop` 2386 pass / 0 fail; with this change **2393 pass / 0 fail** (+7).
- `bun run typecheck` — clean.
- **The text rendering is byte-identical**, checked by diffing `lanes link mcp list` against the same tree before the refactor. This is the assertion I most wanted, since the refactor moved every line through a new payload type.
- New `src/cli/commands/mcp/list.test.ts` pins that the JSON and text paths agree per harness, that an uninstalled harness reports nothing about its documents, that every `state` is one the renderer can draw, and that `--scope` reaches the payload.

## Note on consumers

Nothing depends on this yet. Lanes desktop treats an unparseable response as *unknown* rather than an error — the client rows lose their checkmark and the Add button still works — so it runs against 0.4.0 as shipped and gains the state once this is released.

🤖 Generated with [Claude Code](https://claude.com/claude-code)