### PR TITLE
Release: develop into main

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,6 +20,10 @@ $ bun test          # establish the baseline before changing anything
 has no `node_modules`. Getting a green baseline first is what makes a later failure
 attributable.
 
+Work lands by pull request into `develop`, squashed — `gh pr merge <n> --squash --delete-branch`.
+Both `develop` and `main` require a passing `ci` and an approval, so a solo merge adds `--admin`.
+The one pull request that is not squashed is the release; see below.
+
 ## Never run `lanes link` from a worktree without `LANES_LINK_HOME`
 
 `resolveWorkspaceRoot` (`src/profile/workspace.ts`) checks `LANES_LINK_HOME`, then
@@ -56,9 +60,14 @@ paths `release.yml` takes, and the verification that a release shipped. What an 
 - **The merge to `main` is the irreversible step.** It publishes to npm under this repository's
   OIDC identity. Get the branch green and the pull request open unattended; do not merge a release
   the operator has not asked for.
-- **Fast-forward `develop` afterwards** — `git push origin origin/main:refs/heads/develop` — and
-  check `git rev-list --count` both directions. Nothing in the workflow does it for you, and the
-  next comparison between the branches is noise until you do.
+- **Squash every pull request except the release one.** `gh pr merge <n> --squash
+  --delete-branch` for work landing in `develop`. The `develop` → `main` release pull request is
+  the exception and must be `--merge`: a squash writes a new commit onto `main`, `develop`'s tip
+  stops being an ancestor, and the fast-forward below is then rejected as non-fast-forward even
+  though the trees are identical. Rebase-merging is disabled for the same reason.
+- **A release is finished when `develop` and `main` are 0/0, not when npm has the version.**
+  Fast-forward with `git push origin origin/main:refs/heads/develop`, then check
+  `git rev-list --count` in *both* directions. Nothing in the workflow does it for you.
 - **Never tag or `npm publish` by hand.** The workflow owns both, in that order, for a reason a
   manual run reverses.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -62,6 +62,16 @@ Two tests hold the layers to the code, and both should stay green rather than be
 `src/readme.test.ts` asserts the README names a working `lanes link connect` command for every
 provider, and `src/profile/docs.test.ts` parses the YAML examples out of the reference pages.
 
+## Merging
+
+Pull requests are **squashed** — one change, one commit on `develop`, carrying the message written
+for the change. `gh pr merge <n> --squash --delete-branch`. Rebase-merging is disabled.
+
+The single exception is the release pull request, `develop` → `main`, which is merged as a **merge
+commit**. Squashing it would leave `develop` no longer an ancestor of `main`, and the fast-forward
+that ends a release — the step that leaves the two branches identical — would be rejected. See
+[`docs/detailed/releasing.md`](docs/detailed/releasing.md#how-a-pull-request-is-merged).
+
 ## Releasing
 
 [`docs/detailed/releasing.md`](docs/detailed/releasing.md) is the whole lifecycle in order — the

--- a/docs/detailed/releasing.md
+++ b/docs/detailed/releasing.md
@@ -42,6 +42,43 @@ the built-in `GITHUB_TOKEN` cannot be added to its bypass list. Doing it anyway 
 App key or a personal access token with write access to `main` — a larger credential than the npm
 token this project deliberately does not have.
 
+## How a pull request is merged
+
+**Squash, with one exception.** Every pull request into `develop` is squashed: one change becomes
+one commit, and the commit message is the one written for the change rather than a merge line
+naming a branch nobody can see any more. `gh pr merge <n> --squash --delete-branch`.
+
+**The release pull request, `develop` → `main`, is a merge commit.** Not a preference — squashing it
+makes the closing fast-forward impossible. A squash writes a *new* commit onto `main` whose parent
+is `main`'s old tip, so `develop`'s tip stops being an ancestor of `main`. The trees are then
+identical and the branches have still diverged:
+
+```console
+$ git merge --squash develop && git commit -m "squashed"
+$ git rev-parse main^{tree} develop^{tree}      # the same tree
+$ git merge-base --is-ancestor develop main     # false
+$ git push origin origin/main:refs/heads/develop
+ ! [rejected]  (non-fast-forward)
+```
+
+The only way out of that is a force-push of `develop`, which the ruleset blocks and which would
+rewrite reviewed history to fix a cosmetic choice. A merge commit keeps `develop`'s tip an ancestor,
+which is exactly what the fast-forward needs. `gh pr merge <n> --admin --merge`.
+
+A proposed `release/next` pull request may be squashed — it holds one commit, and `develop`'s tip
+is already an ancestor of `main` by then, so nothing depends on how that one lands.
+
+**Rebase-merging is disabled**, in the repository settings and in the ruleset's
+`allowed_merge_methods`. It rewrites the commits onto `main` under new hashes, which breaks the
+ancestry the same way a squash does while looking like it preserved history.
+
+| Pull request | Method |
+|---|---|
+| anything → `develop` | squash |
+| `develop` → `main` (the release) | merge commit |
+| `release/next` → `main` | squash or merge commit |
+| any pull request | never rebase — the method is disabled |
+
 ## Ordinary work
 
 ```console
@@ -52,7 +89,11 @@ $ bun test && bun run typecheck      # the baseline, before changing anything
 ```
 
 Then the change, then the same two commands, then a pull request into `develop`. `ci` runs both
-gates again where a reviewer can see them. Merge when it is green.
+gates again where a reviewer can see them. Squash it when it is green:
+
+```console
+$ gh pr merge <n> --squash --delete-branch
+```
 
 That is the whole of ordinary work. A release is a separate act, taken deliberately, described
 below.
@@ -129,9 +170,10 @@ $ git push origin develop
 Two `-m` arguments, not one: passing the whole note as a single string runs the subject and the
 first body line together into one 60-character subject, which is what happened to `Release 0.3.1`.
 
-Then PR `develop` → `main`, wait for `ci`, and merge. `main` requires an approval, so a solo
-release is `gh pr merge <n> --admin --merge`. **That merge is the irreversible step** — it publishes,
-and the registry does not give a version back.
+Then PR `develop` → `main`, wait for `ci`, and merge it **as a merge commit** — `gh pr merge <n>
+--admin --merge`, the `--admin` because `main` requires an approval and the `--merge` because a
+squash here would strand `develop` (see [above](#how-a-pull-request-is-merged)). **That merge is the
+irreversible step** — it publishes, and the registry does not give a version back.
 
 ### Why the version goes on `develop` and not on a release branch
 
@@ -158,8 +200,13 @@ $ git rev-list --count origin/main..origin/develop     # 0
 $ git rev-list --count origin/develop..origin/main     # 0
 ```
 
-This is the operator's step to remember: the workflow is designed around `main` alone and says
-nothing about `develop`.
+**A release is not finished until both of those read `0`.** The workflow is designed around `main`
+alone and says nothing about `develop`, so this is the operator's step to remember — and the reason
+the pull request above is a merge commit rather than a squash.
+
+If the second count is not `0`, something published from `main` that `develop` never saw — usually
+the propose path's patch bump. Fast-forward again. If the *first* is not `0`, `develop` has moved on
+since the release, which is ordinary.
 
 ## Verifying a release actually shipped
 

--- a/src/cli/commands/mcp/list.test.ts
+++ b/src/cli/commands/mcp/list.test.ts
@@ -1,0 +1,123 @@
+import { describe, expect, test } from 'bun:test';
+import { HARNESSES } from './harnesses.ts';
+import { listRegistrations, mcpList, type McpListing } from './list.ts';
+
+/**
+ * `lanes link mcp list`, and its `--json`.
+ *
+ * The property under test is the one the flag exists for: both renderings
+ * describe the same snapshot. A UI deciding between "add" and "re-add" reads the
+ * JSON; a person reads the text; and a probe taken twice would let the two
+ * disagree about a registration that changed in between.
+ *
+ * Nothing here stubs `Bun.which` or the harness binaries, so the assertions are
+ * about shape and about agreement rather than about which harnesses happen to be
+ * installed on the machine running the suite.
+ */
+
+/** Everything written to stdout while `body` runs. */
+async function captureStdout(body: () => Promise<void>): Promise<string> {
+  const original = process.stdout.write.bind(process.stdout);
+  let captured = '';
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (process.stdout as any).write = (chunk: string | Uint8Array): boolean => {
+    captured += typeof chunk === 'string' ? chunk : new TextDecoder().decode(chunk);
+    return true;
+  };
+
+  try {
+    await body();
+  } finally {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (process.stdout as any).write = original;
+  }
+
+  return captured;
+}
+
+describe('the listing', () => {
+  test('carries one entry per known harness, in registry order', async () => {
+    const listing = await listRegistrations('lanes-link', 'user');
+
+    expect(listing.harnesses.map((one) => one.id)).toEqual(HARNESSES.map((one) => one.id));
+    expect(listing.name).toBe('lanes-link');
+    expect(listing.scope).toBe('user');
+  });
+
+  test('a harness with no binary reports nothing about its documents', async () => {
+    // With no binary there is nothing to register the documents against, and
+    // reporting them would describe a setup that does not exist. The text
+    // rendering already stops at "not installed"; the JSON has to agree.
+    const listing = await listRegistrations('lanes-link', 'user');
+
+    for (const harness of listing.harnesses) {
+      if (harness.installed) continue;
+      expect(harness.binary).toBeNull();
+      expect(harness.registered).toBe(false);
+      expect(harness.documents).toEqual([]);
+    }
+  });
+
+  test('every document state is one the renderer knows how to draw', async () => {
+    const listing = await listRegistrations('lanes-link', 'user');
+    const known = ['current', 'stale', 'missing', 'unreadable'];
+
+    for (const harness of listing.harnesses) {
+      for (const document of harness.documents) {
+        expect(known).toContain(document.state);
+        expect(document.label.length).toBeGreaterThan(0);
+        expect(document.path.length).toBeGreaterThan(0);
+      }
+    }
+  });
+
+  test('the name is what registrations are looked up under', async () => {
+    // Not a cosmetic field: `exists()` asks each harness for *this* name, so a
+    // listing under a different name is a different question with a different
+    // answer.
+    const listing = await listRegistrations('something-else', 'user');
+    expect(listing.name).toBe('something-else');
+  });
+});
+
+describe('--json', () => {
+  test('prints parseable JSON and nothing else', async () => {
+    const raw = await captureStdout(() => mcpList({ json: true }));
+
+    const parsed = JSON.parse(raw) as McpListing;
+    expect(parsed.name).toBe('lanes-link');
+    expect(parsed.harnesses.map((one) => one.id)).toEqual(HARNESSES.map((one) => one.id));
+  });
+
+  test('agrees with the text rendering about what is registered', async () => {
+    const raw = await captureStdout(() => mcpList({ json: true }));
+    const text = await captureStdout(() => mcpList({ json: false }));
+    const parsed = JSON.parse(raw) as McpListing;
+
+    for (const harness of parsed.harnesses) {
+      expect(text).toContain(harness.label);
+
+      if (!harness.installed) {
+        // The one line a missing harness gets.
+        expect(text).toMatch(new RegExp(`${harness.label}\\s+.*not installed`));
+        continue;
+      }
+
+      expect(text).toMatch(
+        harness.registered
+          ? new RegExp(`${harness.label}\\s+.*\\bregistered`)
+          : new RegExp(`${harness.label}\\s+.*not registered`),
+      );
+
+      for (const document of harness.documents) {
+        expect(text).toContain(document.label);
+      }
+    }
+  });
+
+  test('the scope reaches the payload, so a local-scope listing says so', async () => {
+    const raw = await captureStdout(() => mcpList({ json: true, scope: 'local' }));
+    expect((JSON.parse(raw) as McpListing).scope).toBe('local');
+  });
+});

--- a/src/cli/commands/mcp/list.ts
+++ b/src/cli/commands/mcp/list.ts
@@ -1,7 +1,45 @@
-import { heading, print, style } from '../../output.ts';
+import { emit, heading, print, style } from '../../output.ts';
 import { assetState, plannedAssets, readAsset } from './assets.ts';
 import { HARNESSES, type Harness } from './harnesses.ts';
 import { exists } from './register.ts';
+
+/** Why a document this harness can hold is not what we ship, if it is not. */
+export type DocumentState = 'current' | 'stale' | 'missing' | 'unreadable';
+
+export interface ListedDocument {
+  readonly label: string;
+  readonly path: string;
+  readonly state: DocumentState;
+  /** Only for `unreadable` — what went wrong reading the bundled copy. */
+  readonly detail?: string;
+}
+
+export interface ListedHarness {
+  readonly id: string;
+  readonly label: string;
+  readonly installed: boolean;
+  /** The resolved binary, so a caller can see *which* claude answered. */
+  readonly binary: string | null;
+  readonly registered: boolean;
+  /**
+   * Empty when the harness is not installed, matching what the text rendering
+   * says: with no binary there is nothing to register the documents against, and
+   * reporting them would describe a setup that does not exist.
+   */
+  readonly documents: readonly ListedDocument[];
+}
+
+export interface McpListing {
+  readonly name: string;
+  readonly scope: string;
+  readonly harnesses: readonly ListedHarness[];
+}
+
+export interface McpListFlags {
+  readonly name?: string | undefined;
+  readonly scope?: string | undefined;
+  readonly json?: boolean | undefined;
+}
 
 /**
  * `lanes link mcp list` — where this endpoint is registered, and whether what
@@ -11,58 +49,114 @@ import { exists } from './register.ts';
  * different fixes. A registration without the skill is a working endpoint
  * nobody reaches for; a skill against no registration is a document describing
  * tools that are not there.
+ *
+ * The listing is gathered before anything is printed, so `--json` and the text
+ * rendering describe the same snapshot rather than two probes taken a moment
+ * apart. `--json` exists because this is the one command another program has a
+ * reason to read: it is how a UI decides between "add" and "re-add", and the
+ * `stale` state is the only signal that a re-run would do something.
  */
-export async function mcpList(options: { name?: string | undefined; scope?: string | undefined }): Promise<void> {
+export async function mcpList(options: McpListFlags): Promise<void> {
   const name = options.name ?? 'lanes-link';
   const scope = options.scope ?? 'user';
 
-  heading(`Registered as ${style.bold(name)}`);
+  const listing = await listRegistrations(name, scope);
+
+  await emit(options.json, listing, () => render(listing));
+}
+
+/** The whole answer, gathered. No printing, so a caller can have it as data. */
+export async function listRegistrations(name: string, scope: string): Promise<McpListing> {
+  const harnesses: ListedHarness[] = [];
 
   for (const harness of HARNESSES) {
     const binary = Bun.which(harness.binary);
 
     if (!binary) {
+      harnesses.push({
+        id: harness.id,
+        label: harness.label,
+        installed: false,
+        binary: null,
+        registered: false,
+        documents: [],
+      });
+      continue;
+    }
+
+    harnesses.push({
+      id: harness.id,
+      label: harness.label,
+      installed: true,
+      binary,
+      registered: exists(binary, harness, name),
+      documents: await documents(harness, scope),
+    });
+  }
+
+  return { name, scope, harnesses };
+}
+
+/** One entry per document this harness can hold, saying whether it is current. */
+async function documents(harness: Harness, scope: string): Promise<ListedDocument[]> {
+  const listed: ListedDocument[] = [];
+
+  for (const plan of plannedAssets(harness, scope)) {
+    try {
+      listed.push({
+        label: plan.asset.label,
+        path: plan.path,
+        state: await assetState(plan, await readAsset(plan.asset)),
+      });
+    } catch (error) {
+      // A checkout without `instructions/` — a container image, say. Worth one
+      // line rather than a thrown error that hides the registration column.
+      listed.push({
+        label: plan.asset.label,
+        path: plan.path,
+        state: 'unreadable',
+        detail: message(error),
+      });
+    }
+  }
+
+  return listed;
+}
+
+function render(listing: McpListing): void {
+  heading(`Registered as ${style.bold(listing.name)}`);
+
+  for (const harness of listing.harnesses) {
+    if (!harness.installed) {
       print(`  ${harness.label.padEnd(14)} ${style.dim('not installed')}`);
       continue;
     }
 
     print(
       `  ${harness.label.padEnd(14)} ${
-        exists(binary, harness, name)
+        harness.registered
           ? style.green('registered')
           : style.dim(`not registered — lanes link mcp add ${harness.id}`)
       }`,
     );
 
-    for (const line of await documentLines(harness, scope)) print(`  ${' '.repeat(14)} ${line}`);
+    for (const document of harness.documents) {
+      print(`  ${' '.repeat(14)} ${documentLine(harness.id, document)}`);
+    }
   }
 }
 
-/** One line per document this harness can hold, saying whether it is current. */
-async function documentLines(harness: Harness, scope: string): Promise<string[]> {
-  const lines: string[] = [];
-
-  for (const plan of plannedAssets(harness, scope)) {
-    try {
-      const state = await assetState(plan, await readAsset(plan.asset));
-
-      lines.push(
-        state === 'current'
-          ? style.dim(`${plan.asset.label}: `) + style.green('up to date')
-          : style.dim(
-              state === 'stale'
-                ? `${plan.asset.label}: out of date — lanes link mcp add ${harness.id}`
-                : `${plan.asset.label}: not installed — lanes link mcp add ${harness.id}`,
-            ),
-      );
-    } catch (error) {
-      // A checkout without `instructions/` — a container image, say. Worth one
-      // line rather than a thrown error that hides the registration column.
-      lines.push(style.dim(`${plan.asset.label}: ${message(error)}`));
-    }
+function documentLine(id: string, document: ListedDocument): string {
+  switch (document.state) {
+    case 'current':
+      return style.dim(`${document.label}: `) + style.green('up to date');
+    case 'stale':
+      return style.dim(`${document.label}: out of date — lanes link mcp add ${id}`);
+    case 'missing':
+      return style.dim(`${document.label}: not installed — lanes link mcp add ${id}`);
+    case 'unreadable':
+      return style.dim(`${document.label}: ${document.detail}`);
   }
-
-  return lines;
 }
 
 function message(error: unknown): string {

--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -321,7 +321,11 @@ export async function run(argv: readonly string[]): Promise<void> {
           return mcpStdio({ ...global, ...(flags['only'] === true ? { only: true } : {}) });
         case 'list':
         case undefined:
-          return mcpList({ name: text(flags, 'name'), scope: text(flags, 'scope') });
+          return mcpList({
+            name: text(flags, 'name'),
+            scope: text(flags, 'scope'),
+            json: flags['json'] === true,
+          });
         default:
           throw new Error(`Unknown: ${PROGRAM} mcp ${second}`);
       }

--- a/src/providers/bunq/hints.ts
+++ b/src/providers/bunq/hints.ts
@@ -29,7 +29,9 @@ export const BUNQ_HINTS: Record<string, string> = {
   UPDATE_DraftPayment_for_User_MonetaryAccount:
     'Changes a draft that is still pending — status ACCEPTED sends it, REJECTED cancels it. ' +
     'previous_updated_timestamp is required and comes from reading the draft first; it is what stops two ' +
-    'callers acting on the same draft.',
+    'callers acting on the same draft. Those two fields are the entire call — bunq refuses entries and ' +
+    'number_of_required_accepts here as superfluous — so changing what a draft pays means rejecting it and ' +
+    'creating another.',
 
   CREATE_PaymentBatch_for_User_MonetaryAccount:
     'Up to 350 payments in one call. Executes immediately, like a direct payment, and is all-or-nothing: bunq rejects ' +

--- a/src/providers/bunq/redact.ts
+++ b/src/providers/bunq/redact.ts
@@ -51,14 +51,25 @@ export const BUNQ_REDACT: Record<string, string[]> = {
     'status',
     'schedule',
   ],
+  // Five, not seven: `entries` and `number_of_required_accepts` are no longer
+  // arguments at all. This is the one write here whose event cannot name an
+  // amount or a counterparty, because the call does not carry them — it says
+  // which draft was accepted and against which version of it, and that is
+  // everything there is to keep.
+  //
+  // Not everything a reader wants, though, and worth being honest that the gap
+  // is real rather than closed. The entries are on the event that *created* the
+  // draft, and nothing joins the two: an `AuditEvent` records arguments only,
+  // and bunq returns the draft id in the create's response. Reconstructing what
+  // an ACCEPTED draft paid means matching by hand. `context.audit.annotate`,
+  // which `gmail.send_message` uses to record resolved facts, is the shape of a
+  // fix and is a change to dispatch rather than to this list.
   UPDATE_DraftPayment_for_User_MonetaryAccount: [
     'userID',
     'monetary-accountID',
     'itemId',
     'status',
-    'entries',
     'previous_updated_timestamp',
-    'number_of_required_accepts',
   ],
   CREATE_PaymentBatch_for_User_MonetaryAccount: ['userID', 'monetary-accountID', 'payments'],
 };

--- a/src/providers/bunq/specs/bunq.v1.json
+++ b/src/providers/bunq/specs/bunq.v1.json
@@ -144,7 +144,26 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/DraftPayment"
+                "type": "object",
+                "description": "The whole of what this call takes. bunq refuses any other field here as superfluous — the rest of the schema it shares belongs to the call that creates one.",
+                "properties": {
+                  "status": {
+                    "type": "string",
+                    "description": "The status of the DraftPayment.",
+                    "readOnly": false,
+                    "writeOnly": false
+                  },
+                  "previous_updated_timestamp": {
+                    "type": "string",
+                    "description": "The last updated_timestamp that you received for this DraftPayment. This needs to be provided to prevent race conditions.",
+                    "readOnly": false,
+                    "writeOnly": true
+                  }
+                },
+                "required": [
+                  "status",
+                  "previous_updated_timestamp"
+                ]
               }
             }
           }

--- a/src/providers/bunq/specs/specs.test.ts
+++ b/src/providers/bunq/specs/specs.test.ts
@@ -91,6 +91,52 @@ describe('the vendored spec and the manifest agree', () => {
     expect(leaked).toEqual([]);
   });
 
+  test('the tool that accepts a draft can be called correctly', () => {
+    // Not a missing capability — a present one that could not be used. bunq
+    // describes its update with the schema of its create, whose `required`
+    // names `entries` and `number_of_required_accepts`, and then refuses both
+    // here as superfluous. Every accept and every reject failed, and the two
+    // bodies a model can reach for when a schema demands entries on a draft
+    // that already has them — the array echoed back, or `[]` — both ask bunq to
+    // rewrite what the draft pays on the way to approving it.
+    //
+    // Nothing else looked. `redact` and `hints` are checked against the tools
+    // and the tools against the spec, but no test asked whether a schema
+    // describes a call the vendor would accept.
+    const update = discovered.find(
+      (entry) => entry.name === 'UPDATE_DraftPayment_for_User_MonetaryAccount',
+    )!;
+    const properties = Object.keys((update.inputSchema?.['properties'] ?? {}) as object);
+
+    expect(((update.inputSchema?.['required'] ?? []) as string[]).sort()).toEqual([
+      'itemId',
+      'monetary-accountID',
+      'previous_updated_timestamp',
+      'status',
+      'userID',
+    ]);
+    expect(properties).not.toContain('entries');
+    expect(properties).not.toContain('number_of_required_accepts');
+    // `schedule` is the exclusion argued on risk rather than on the call
+    // failing, so it is the one a revert would restore quietly: bunq accepts it
+    // here, and it would come back as an *optional* property that the assertion
+    // on `required` above cannot see.
+    expect(properties).not.toContain('schedule');
+  });
+
+  test('creating a draft still asks for the payment it is a draft of', () => {
+    // The other half of the same fix: the narrowing is keyed by operation, and
+    // aimed at the wrong one it would leave a tool with no way to say what to
+    // pay — which fails in the same silent shape, one call later.
+    const create = discovered.find(
+      (entry) => entry.name === 'CREATE_DraftPayment_for_User_MonetaryAccount',
+    )!;
+    const required = (create.inputSchema?.['required'] ?? []) as string[];
+
+    expect(required).toContain('entries');
+    expect(required).toContain('number_of_required_accepts');
+  });
+
   test('the committed spec carries no component the paths do not use', () => {
     // Including, before this was filtered, a definition of the session header.
     const spec = require(connector.openapi) as { components: Record<string, unknown> };

--- a/src/providers/bunq/specs/vendor.ts
+++ b/src/providers/bunq/specs/vendor.ts
@@ -22,6 +22,7 @@ import { mkdir, writeFile } from 'node:fs/promises';
 import { join } from 'node:path';
 import { OpenAPIToolGenerator, type McpOpenAPITool } from 'mcp-from-openapi';
 import { cutCycles, referenced, type Spec } from '../../shared/openapi.ts';
+import { projectRequestBody } from '../../shared/vendor-operations.ts';
 
 const SOURCE = 'https://raw.githubusercontent.com/bunq/doc/master/swagger.json';
 const OUT = 'bunq.v1.json';
@@ -187,6 +188,34 @@ function dropReadOnly(node: unknown): number {
   return dropped;
 }
 
+/**
+ * The operations bunq describes with the schema of a *different* operation.
+ *
+ * `PUT .../draft-payment/{itemId}` points at `DraftPayment`, the same schema as
+ * the `POST` that creates one, which requires `entries` and
+ * `number_of_required_accepts`. For a create those two *are* the payment. For an
+ * update bunq refuses both as superfluous — its own generated SDK sends only
+ * `status`, `previous_updated_timestamp` and `schedule` here — so the tool asked
+ * for exactly what the bank rejects and every accept failed. Worse than the
+ * error: made to send `entries` for a draft that has them, a model reaches for
+ * the array echoed back or for `[]`, and both ask bunq to rewrite what the draft
+ * pays on the way to approving it. A hint cannot fix a required argument, which
+ * is the difference between this and the `payments`-is-really-an-array note
+ * above: nothing stops an agent sending an array, and nothing lets it omit a
+ * required field. `required` is asserted here rather than projected because
+ * bunq's own is the one written for the create.
+ *
+ * `schedule` is deliberately not projected: it carries `recurrence_unit` and
+ * `recurrence_size`, so approving a one-off draft would be a place to acquire a
+ * standing order — the risk `OPERATIONS` gives for leaving the scheduling
+ * *endpoints* out. Not the whole of that risk, though: `CREATE_DraftPayment`
+ * still offers the same field, because it comes with bunq's create schema.
+ * Closing that changes what the provider can do rather than whether a call
+ * works, and is not done here.
+ */
+const UPDATE_BODIES: Record<string, readonly string[]> = {
+  UPDATE_DraftPayment_for_User_MonetaryAccount: ['status', 'previous_updated_timestamp'],
+};
 
 async function vendor(): Promise<void> {
   const response = await fetch(SOURCE);
@@ -246,6 +275,34 @@ async function vendor(): Promise<void> {
   }
 
   const schemas = spec.components?.schemas ?? {};
+
+  const projected = new Set<string>();
+  for (const item of Object.values(paths)) {
+    for (const [method, operation] of Object.entries(item)) {
+      if (!METHODS.includes(method)) continue;
+      const fields = operation.operationId ? UPDATE_BODIES[operation.operationId] : undefined;
+      if (!fields || !operation.operationId) continue;
+
+      projectRequestBody(
+        operation as unknown as Record<string, unknown>,
+        operation.operationId,
+        schemas,
+        fields,
+        'The whole of what this call takes. bunq refuses any other field here as superfluous — the rest ' +
+          'of the schema it shares belongs to the call that creates one.',
+      );
+      projected.add(operation.operationId);
+    }
+  }
+
+  // The same refusal as `missing` above, and for a sharper reason: an entry that
+  // matches nothing narrows nothing, and what is left is the wide body this
+  // exists to remove — printed as a success.
+  const unprojected = Object.keys(UPDATE_BODIES).filter((id) => !projected.has(id));
+  if (unprojected.length > 0) {
+    throw new Error(`UPDATE_BODIES names operations the spec does not have — ${unprojected.join(', ')}`);
+  }
+
   const keep = referenced(paths, schemas);
   const trimmedSchemas = Object.fromEntries(
     Object.entries(schemas).filter(([name]) => keep.has(name)),
@@ -295,7 +352,8 @@ async function vendor(): Promise<void> {
     `  bunq   ${String(Object.keys(paths).length).padStart(2)} paths, ` +
       `${seen.size} operations, ${Object.keys(trimmedSchemas).length} schemas, ` +
       `${cuts} cycle${cuts === 1 ? '' : 's'} cut, ${headers} protocol params dropped, ` +
-      `${readOnly} read-only fields dropped, ${size}KB`,
+      `${readOnly} read-only fields dropped, ${projected.size} update ` +
+      `bod${projected.size === 1 ? 'y' : 'ies'} projected, ${size}KB`,
   );
 
   await report(trimmed);

--- a/src/providers/shared/vendor-operations.test.ts
+++ b/src/providers/shared/vendor-operations.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, test } from 'bun:test';
+import { projectRequestBody } from './vendor-operations.ts';
+
+/**
+ * What `projectRequestBody` promises, held to it.
+ *
+ * The bug it was written for was a schema that described a call the vendor
+ * would refuse, and what let that ship was a claim nothing checked. Its own
+ * docstring now makes four promises to refuse rather than guess, and a refusal
+ * that does not fire is the same kind of claim — so each one is exercised here
+ * against a spec fragment rather than asserted in a comment.
+ */
+
+const schemas = (): Record<string, unknown> => ({
+  Draft: {
+    type: 'object',
+    properties: {
+      status: { type: 'string', description: 'The status of the Draft.' },
+      entries: { type: 'array', items: {} },
+      id: { type: 'integer', readOnly: true },
+    },
+    required: ['entries'],
+  },
+});
+
+const operation = (schema: unknown = { $ref: '#/components/schemas/Draft' }): Record<string, unknown> => ({
+  operationId: 'UPDATE_Draft',
+  requestBody: { content: { 'application/json': { schema } } },
+});
+
+const body = (op: Record<string, unknown>): Record<string, unknown> => {
+  const content = (op['requestBody'] as { content: Record<string, { schema: Record<string, unknown> }> })
+    .content;
+  return content['application/json']!.schema;
+};
+
+describe('projectRequestBody', () => {
+  test('keeps the vendor’s own type and description, and asserts the caller’s required', () => {
+    const op = operation();
+    projectRequestBody(op, 'UPDATE_Draft', schemas(), ['status'], 'Only this.');
+
+    expect(body(op)).toEqual({
+      type: 'object',
+      description: 'Only this.',
+      properties: { status: { type: 'string', description: 'The status of the Draft.' } },
+      required: ['status'],
+    });
+    // The projection replaces the reference outright: `entries` was required by
+    // the schema this used to point at, and that is the whole disease.
+    expect(JSON.stringify(body(op))).not.toContain('entries');
+  });
+
+  test('refuses a field the vendor no longer describes', () => {
+    // A rename upstream must fail the refresh. Skipping the field instead would
+    // publish a narrower tool; leaving the body alone would restore the wide one.
+    expect(() => projectRequestBody(operation(), 'UPDATE_Draft', schemas(), ['gone'], '')).toThrow(
+      /no longer describes "gone"/,
+    );
+  });
+
+  test('refuses a read-only field', () => {
+    // Projected fields are inlined into the path, where the read-only strip does
+    // not reach — so this would become a required argument the vendor ignores.
+    expect(() => projectRequestBody(operation(), 'UPDATE_Draft', schemas(), ['id'], '')).toThrow(
+      /read-only/,
+    );
+  });
+
+  test('refuses a body offering a content type it does not rewrite', () => {
+    const op = operation();
+    (op['requestBody'] as { content: Record<string, unknown> }).content['application/xml'] = {
+      schema: { $ref: '#/components/schemas/Draft' },
+    };
+
+    // Narrowing one branch and leaving the other wide makes the fix depend on
+    // which branch the generator prefers, which is a third party's choice.
+    expect(() => projectRequestBody(op, 'UPDATE_Draft', schemas(), ['status'], '')).toThrow(
+      /application\/xml/,
+    );
+  });
+
+  test('refuses a reference that does not point into components.schemas', () => {
+    // Otherwise the pointer survives `slice` unchanged, no schema is found, and
+    // the error blames a renamed field for what is a different problem.
+    const op = operation({ $ref: '#/components/requestBodies/Draft' });
+
+    expect(() => projectRequestBody(op, 'UPDATE_Draft', schemas(), ['status'], '')).toThrow(
+      /not a schema reference/,
+    );
+  });
+});

--- a/src/providers/shared/vendor-operations.ts
+++ b/src/providers/shared/vendor-operations.ts
@@ -96,3 +96,84 @@ export function narrowRequestBody(
   body.content = Object.fromEntries(kept.map((type) => [type, body.content![type]]));
   return before.length - kept.length;
 }
+
+/**
+ * Replace a request body with a projection of the schema it points at.
+ *
+ * The third surgery on this axis, and the first about the body being *wrong*
+ * rather than too wide. A document that describes two operations with one schema
+ * describes at least one of them wrongly, and `required` is where it bites: the
+ * generated tool asks for arguments the vendor refuses on the call they are
+ * attached to, so there is no correct call to make. It fails at the vendor, on
+ * every attempt, and nothing before the request can see it.
+ *
+ * Projecting rather than hand-writing is what keeps this tied to the document.
+ * The named fields are copied out of the vendor's own schema with their types
+ * and descriptions, so the tool still says what the vendor says. Everything this
+ * cannot verify it refuses instead: a field that is gone, a field the document
+ * marks read-only, a body offering a content type this does not rewrite, a
+ * `$ref` that does not point into `components.schemas`. A vendor refresh should
+ * fail loudly here rather than quietly restore the body it was called to fix.
+ *
+ * `required` is the one thing NOT projected — it is the caller's assertion, and
+ * necessarily so, since the whole disease is a `required` written for the other
+ * operation. Say why in the caller.
+ *
+ * `note` becomes the body schema's description. It lands in the committed
+ * document for whoever reads it there; it does **not** reach the agent, because
+ * the generator flattens body properties to the top level and drops the body
+ * schema's own description. The sentence an agent needs goes in `hints`.
+ *
+ * Apply before reachability, so a schema the projection no longer reaches leaves
+ * the document rather than lingering unused.
+ */
+export function projectRequestBody(
+  operation: Record<string, unknown>,
+  operationId: string,
+  schemas: Record<string, unknown>,
+  fields: readonly string[],
+  note: string,
+): void {
+  const content = (operation['requestBody'] as { content?: Record<string, { schema?: { $ref?: string } }> })
+    ?.content;
+  const types = Object.keys(content ?? {});
+
+  const other = types.filter((type) => type !== 'application/json');
+  if (!content || types.length === 0 || other.length > 0) {
+    // A body left pointing at the wide schema on a second content type is the
+    // bug still present on whichever branch the generator happens to prefer.
+    throw new Error(
+      `${operationId}: expected a lone application/json request body to project, found ${types.join(', ') || 'none'}`,
+    );
+  }
+
+  const json = content['application/json'];
+  const reference = json?.schema?.$ref;
+  if (!json || typeof reference !== 'string' || !reference.startsWith('#/components/schemas/')) {
+    throw new Error(`${operationId}: request body is ${reference ?? 'not a $ref'}, not a schema reference`);
+  }
+
+  const name = reference.slice('#/components/schemas/'.length);
+  const source = (schemas[name] as { properties?: Record<string, unknown> } | undefined)?.properties ?? {};
+
+  const properties: Record<string, unknown> = {};
+  for (const field of fields) {
+    const property = source[field] as { readOnly?: boolean } | undefined;
+    if (!property) throw new Error(`${operationId}: ${name} no longer describes "${field}"`);
+    if (property.readOnly === true) {
+      // Projected fields are inlined into the path, where the read-only strip
+      // does not reach — so a field the vendor computes would survive here and
+      // be demanded as an argument it ignores.
+      throw new Error(`${operationId}: ${name}.${field} is read-only and cannot be a request field`);
+    }
+    properties[field] = property;
+  }
+
+  json.schema = {
+    type: 'object',
+    description: note,
+    properties,
+    required: [...fields],
+  } as never;
+}
+


### PR DESCRIPTION
Merging this starts the release run, which takes the **propose** path — `package.json` is
`0.4.0` and `v0.4.0` is tagged, so the run pushes `release/next` carrying the `0.4.1` bump.
Merging that second pull request is what publishes.

Since v0.4.0:

- Give the draft-payment update the fields bunq actually accepts (#60)
- Answer mcp list --json for real, so a UI can tell add from re-add (#62)
- Squash every pull request except the one whose squash would strand develop (#59)
- Record which branches the ruleset actually covers, and put main back inside it
- Write down the lifecycle a release follows, and where develop fits