### PR TITLE
Release 0.4.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lanes-sh/link",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "A self-hostable MCP gateway for all your connections, memory, skills, and secrets",
   "license": "Apache-2.0",
   "homepage": "https://lanes.sh/link",


### PR DESCRIPTION
Merging this publishes 0.4.1 to npm.

Since v0.4.0:

- Give the draft-payment update the fields bunq actually accepts (#60)
- Answer mcp list --json for real, so a UI can tell add from re-add (#62)
- Squash every pull request except the one whose squash would strand develop (#59)
- Record which branches the ruleset actually covers, and put main back inside it
- Write down the lifecycle a release follows, and where develop fits