### PR TITLE
Let an account be removed and renamed, and say which providers are not accounts

### DIFF
--- a/docs/detailed/commands.md
+++ b/docs/detailed/commands.md
@@ -59,6 +59,60 @@ $ lanes link connect gmail --profile personal --target local --id work
 `--target` never points at a running endpoint: `connect --target cloud` runs consent locally and
 writes the token into the deployment's store.
 
+### `lanes link disconnect <provider>.<id>`
+
+Remove one account, and delete the credential it authorised. The counterpart to `connect`, and the
+two edits it takes: the entry leaves `connections:` in the profile, and the credential leaves the
+target's store.
+
+The key must be exact. `connect gmail` can create an account and choose the id; there is nothing to
+choose here, and a bare `gmail` with two accounts declared would be a command guessing which one to
+throw away — so it refuses and names them.
+
+```console
+$ lanes link disconnect gmail.side --profile personal --target local
+$ lanes link disconnect gmail.side --profile personal --target local --yes --json
+$ lanes link disconnect gmail.side --profile personal --target local --keep-credential
+```
+
+**Three things it deliberately does not do.**
+
+It does not delete the state record. Reconcile marks an undeclared connection `disabled` rather than
+deleting it so the audit log keeps meaning something, and reaching past that to erase the record
+would undo the one guarantee the log offers. The next reconcile marks it, and the command says so.
+
+It does not delete a credential something else still resolves to. A reference is per connection for
+an OAuth provider (`<provider>/<id>`), and *shared* for a manifest declaring `credential_ref` —
+deleting that one while a sibling resolves to it would take the sibling's credential with it, and
+the sibling would then report `unauthorized` for a `connect` nobody ran. When that happens the
+credential is kept and the output names what still needs it.
+
+It does not touch the owner layer. `memory`, `skills`, `vault`, `setup` and `identity` hold no
+credential and are granted by a policy line this command does not touch, so removing the connection
+alone would leave the policy granting against nothing — wrong, not merely untidy. It refuses and
+points at the file, where both lines are next to each other.
+
+### `lanes link relabel <provider>.<id> <name>`
+
+Rename what an account is called. The label is what `status` and any surface built on it shows; it
+is not an identifier, so nothing addresses the connection by it and changing one breaks nothing.
+
+```console
+$ lanes link relabel gmail.main "Work mail" --profile personal --target local
+$ lanes link relabel gmail.main Work mail --profile personal --target local
+```
+
+Both forms work: an unquoted multi-word name is joined, because quoting is what someone remembers
+second and refusing it teaches nothing.
+
+`connect` writes this field from the identity the provider reports at connect time, which is right
+for `gmail.main` and useless for a provider with no such endpoint — a bunq key belongs to an account
+bunq will not name. This is how that gets a name a person recognises. Allowed for the owner layer,
+unlike `disconnect`: a display name is harmless, and "Memory" is the operator's word for their own
+store.
+
+The state store keeps the old name until the next reconcile, which updates it.
+
 ### `lanes link connect custom <id>`
 
 Declare a service that is not built in, and connect it. The provider is composed from two fixed

--- a/src/cli/commands/connection.test.ts
+++ b/src/cli/commands/connection.test.ts
@@ -1,0 +1,287 @@
+import { afterAll, describe, expect, test } from 'bun:test';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { RESERVED_PROVIDER_IDS } from '#connectivity';
+import type { ProviderManifest } from '#connectivity';
+import { parseConfig, type Config } from '#profile';
+import { PROVIDER_MANIFESTS } from '#providers/index.ts';
+import { planAll } from '#providers/setup/plan.ts';
+import { createProfile } from './profile.ts';
+import { connectionsSharingCredential, removeConnection, renameConnection } from './connection.ts';
+
+/**
+ * `lanes link disconnect` and `lanes link relabel`.
+ *
+ * Three properties, and only the first is the obvious one.
+ *
+ * **The edit is surgical.** Both go through `ConfigDocument`, so an operator's
+ * comments and key order survive. A CLI that reformats the file on every edit
+ * makes the file hostile to hand-editing, which then makes the CLI mandatory.
+ *
+ * **A shared credential is not collateral.** A reference is per connection for an
+ * OAuth provider and *shared* for a manifest declaring `credential_ref`. Deleting
+ * one while a sibling still resolves to it takes the sibling's credential with
+ * it, and the sibling then reports `unauthorized` for a `connect` nobody ran.
+ *
+ * **The owner layer is refused.** `memory` and its siblings hold no credential and
+ * are granted by a policy line this command does not touch, so removing the
+ * connection alone leaves the policy granting against nothing.
+ */
+
+const WHERE = { profile: 'personal', target: 'local' } as const;
+
+const CONNECTIONS = `
+  - id: main
+    provider: gmail
+    account: first@example.com
+  - id: side
+    provider: gmail
+    account: second@example.com
+  - id: main
+    provider: memory
+    account: Memory
+`;
+
+const roots: string[] = [];
+const previousHome = process.env['LANES_LINK_HOME'];
+
+async function workspace(): Promise<string> {
+  const root = await mkdtemp(join(tmpdir(), 'lanes-link-connection-'));
+  roots.push(root);
+  process.env['LANES_LINK_HOME'] = root;
+  await createProfile('personal', { targets: ['local'] });
+
+  // Declared by hand rather than through `connect`, which would want a browser
+  // and a real Google account.
+  const path = join(root, 'profiles', 'personal.yaml');
+  const text = await Bun.file(path).text();
+  await Bun.write(path, text.replace('connections:', `connections:${CONNECTIONS}`));
+  return root;
+}
+
+afterAll(async () => {
+  if (previousHome === undefined) delete process.env['LANES_LINK_HOME'];
+  else process.env['LANES_LINK_HOME'] = previousHome;
+  await Promise.all(roots.map((root) => rm(root, { recursive: true, force: true })));
+});
+
+async function onDisk(root: string): Promise<Config> {
+  const text = await Bun.file(join(root, 'profiles', 'personal.yaml')).text();
+  return parseConfig(text).config;
+}
+
+function keys(config: Config): string[] {
+  return config.connections.map((one) => `${one.provider}.${one.id}`);
+}
+
+describe('disconnect', () => {
+  test('removes the declaration and leaves its neighbours alone', async () => {
+    const root = await workspace();
+
+    const outcome = await removeConnection('gmail.side', { ...WHERE, yes: true });
+
+    expect(outcome).not.toBeNull();
+    expect(outcome!.disconnected.key).toBe('gmail.side');
+    expect(outcome!.disconnected.account).toBe('second@example.com');
+    expect(keys(await onDisk(root))).not.toContain('gmail.side');
+    expect(keys(await onDisk(root))).toContain('gmail.main');
+    expect(keys(await onDisk(root))).toContain('memory.main');
+  });
+
+  test('keeps the operator’s comments', async () => {
+    const root = await workspace();
+    await removeConnection('gmail.side', { ...WHERE, yes: true });
+
+    const text = await Bun.file(join(root, 'profiles', 'personal.yaml')).text();
+    // The template's own commentary, which a reformatting writer would drop.
+    expect(text).toContain('# One entry per authorised account');
+  });
+
+  test('reports the credential it deleted', async () => {
+    await workspace();
+    const outcome = await removeConnection('gmail.side', { ...WHERE, yes: true });
+
+    // OAuth derives `<provider>/<id>`, so this one is per connection.
+    expect(outcome!.disconnected.credential).toBe('gmail/side');
+    expect(outcome!.disconnected.credentialSharedWith).toEqual([]);
+  });
+
+  test('leaves the credential alone when asked to', async () => {
+    await workspace();
+    const outcome = await removeConnection('gmail.side', {
+      ...WHERE,
+      yes: true,
+      keepCredential: true,
+    });
+
+    expect(outcome!.disconnected.credential).toBeNull();
+    // The declaration still goes; only the secret stays.
+    expect(keys(await onDisk(await roots[roots.length - 1]!))).not.toContain('gmail.side');
+  });
+
+  test('refuses a bare provider, and says which connections it has', async () => {
+    await workspace();
+
+    // Nothing to choose: `connect gmail` can create an account and pick the id,
+    // but a `disconnect gmail` with two declared would be guessing which to throw
+    // away.
+    await expect(removeConnection('gmail', { ...WHERE, yes: true })).rejects.toThrow(
+      /names a provider, not a connection[\s\S]*gmail\.main, gmail\.side/,
+    );
+  });
+
+  test('refuses a key the profile does not declare', async () => {
+    await workspace();
+    await expect(removeConnection('gmail.nope', { ...WHERE, yes: true })).rejects.toThrow(
+      /does not declare "gmail\.nope"/,
+    );
+  });
+
+  test('refuses the owner layer, and says to edit the file', async () => {
+    const root = await workspace();
+
+    await expect(removeConnection('memory.main', { ...WHERE, yes: true })).rejects.toThrow(
+      /part of what this profile is[\s\S]*by hand/,
+    );
+    // And refuses before writing anything.
+    expect(keys(await onDisk(root))).toContain('memory.main');
+  });
+
+  // Every reserved id, so one added to `RESERVED_PROVIDER_IDS` is covered here
+  // the moment it exists rather than the next time somebody remembers.
+  test.each([...RESERVED_PROVIDER_IDS])('refuses %s', async (provider) => {
+    const root = await workspace();
+    const path = join(root, 'profiles', 'personal.yaml');
+    const text = await Bun.file(path).text();
+    // `memory` and `setup` the template already declares; declaring one twice is
+    // a config the parser refuses, which would fail this for the wrong reason.
+    if (!text.includes(`provider: ${provider}`)) {
+      await Bun.write(
+        path,
+        text.replace('connections:', `connections:\n  - id: main\n    provider: ${provider}\n    account: X\n`),
+      );
+    }
+
+    await expect(removeConnection(`${provider}.main`, { ...WHERE, yes: true })).rejects.toThrow(
+      /part of what this profile is/,
+    );
+  });
+
+  test('refuses without --yes when there is nobody to ask', async () => {
+    // stdin is not a terminal under the test runner, so this is the real path a
+    // script hits.
+    const root = await workspace();
+    await expect(removeConnection('gmail.side', WHERE)).rejects.toThrow(/Pass --yes/);
+    expect(keys(await onDisk(root))).toContain('gmail.side');
+  });
+});
+
+describe('a credential two connections resolve to', () => {
+  const shared: ProviderManifest = {
+    id: 'shared',
+    name: 'Shared',
+    description: '',
+    auth: { kind: 'api_key', credential_ref: 'shared/key' },
+    capabilities: [],
+  } as unknown as ProviderManifest;
+
+  const config = {
+    connections: [
+      { id: 'one', provider: 'shared', account: 'a' },
+      { id: 'two', provider: 'shared', account: 'b' },
+    ],
+  } as unknown as Config;
+
+  test('is named, not deleted', () => {
+    // The whole reason the check exists: a manifest-level `credential_ref` is one
+    // reference for every connection of that provider.
+    const found = connectionsSharingCredential(config, 'shared/key', 0, () => shared);
+    expect(found).toEqual(['shared.two']);
+  });
+
+  test('is deleted once nothing else resolves to it', () => {
+    const only = { connections: [config.connections[0]] } as unknown as Config;
+    expect(connectionsSharingCredential(only, 'shared/key', 0, () => only && shared)).toEqual([]);
+  });
+
+  test('does not confuse two OAuth connections, whose refs differ', () => {
+    const oauth = {
+      id: 'gmail',
+      name: 'Gmail',
+      description: '',
+      auth: { kind: 'oauth' },
+      capabilities: [],
+    } as unknown as ProviderManifest;
+    const two = {
+      connections: [
+        { id: 'main', provider: 'gmail', account: 'a' },
+        { id: 'side', provider: 'gmail', account: 'b' },
+      ],
+    } as unknown as Config;
+
+    expect(connectionsSharingCredential(two, 'gmail/main', 0, () => oauth)).toEqual([]);
+  });
+});
+
+describe('relabel', () => {
+  test('changes what an account is called', async () => {
+    const root = await workspace();
+
+    const { relabelled } = await renameConnection('gmail.main', 'Work Mail', WHERE);
+
+    expect(relabelled.from).toBe('first@example.com');
+    expect(relabelled.to).toBe('Work Mail');
+    const config = await onDisk(root);
+    expect(config.connections.find((c) => c.provider === 'gmail' && c.id === 'main')?.account)
+      .toBe('Work Mail');
+  });
+
+  test('touches nothing else', async () => {
+    const root = await workspace();
+    await renameConnection('gmail.main', 'Work Mail', WHERE);
+
+    const config = await onDisk(root);
+    expect(keys(config)).toContain('gmail.side');
+    expect(config.connections.find((c) => c.id === 'side')?.account).toBe('second@example.com');
+  });
+
+  test('is allowed for the owner layer, which has a label like anything else', async () => {
+    // Unlike disconnect: a display name is harmless to change, and "Memory" is
+    // the operator's word for their own store.
+    const root = await workspace();
+    await renameConnection('memory.main', 'My notes', WHERE);
+
+    const config = await onDisk(root);
+    expect(config.connections.find((c) => c.provider === 'memory')?.account).toBe('My notes');
+  });
+
+  test('refuses a key the profile does not declare', async () => {
+    await workspace();
+    await expect(renameConnection('gmail.nope', 'X', WHERE)).rejects.toThrow(/does not declare/);
+  });
+});
+
+describe('the plan reports which providers are reserved', () => {
+  const context = { profile: 'personal', target: 'local', connections: [] };
+
+  test('is exactly the owner layer among the shipped manifests', () => {
+    const plans = planAll(PROVIDER_MANIFESTS, context as never);
+    const reserved = plans.filter((one) => one.reserved).map((one) => one.id);
+
+    // The shipped third-party set contains none of them, which is the point of
+    // the reserved list: a manifest cannot claim one of those ids.
+    expect(reserved).toEqual([]);
+  });
+
+  test('does not confuse `auth: none` with the owner layer', () => {
+    // `icloud_drive` is `auth: none` because Apple exposes a synced folder rather
+    // than a protocol. A surface grouping on `multiAccount` would file it with
+    // memory and skills, which is what `reserved` exists to prevent.
+    const plans = planAll(PROVIDER_MANIFESTS, context as never);
+    const drive = plans.find((one) => one.id === 'icloud_drive');
+
+    expect(drive?.multiAccount).toBe(false);
+    expect(drive?.reserved).toBe(false);
+  });
+});

--- a/src/cli/commands/connection.ts
+++ b/src/cli/commands/connection.ts
@@ -1,0 +1,298 @@
+import { RESERVED_PROVIDER_IDS } from '#connectivity';
+import { credentialRefFor } from '#registry';
+import type { ConnectionConfig, Config, Resolution } from '#profile';
+import { ConfigDocument } from '../config-edit.ts';
+import { announce, emit, ok, print, style, warn } from '../output.ts';
+import { openRuntime, type GlobalFlags } from '../runtime.ts';
+import { nextAfterEdit, publishProfileEdit } from '../publish.ts';
+import { confirm, isInteractive } from '../prompt.ts';
+
+/**
+ * `lanes link disconnect` and `lanes link relabel` — the two edits to an
+ * existing connection that were not possible without opening the YAML.
+ *
+ * Both are control-plane commands under ADR-007: they write the profile config,
+ * and `disconnect` also deletes from the target's credential store. Neither is
+ * reachable through MCP, for the same reason `connect` is not.
+ *
+ * `disconnect` is the counterpart to `connect`, and deliberately not "delete":
+ * the state record is left alone. Reconcile marks an undeclared connection
+ * `disabled` rather than deleting it so the audit log keeps meaning something,
+ * and a command that reached past that to erase the record would be undoing the
+ * one guarantee the audit log offers.
+ *
+ * Each command is a data function plus a printing wrapper, the shape
+ * `commands/identity.ts` uses: `--json` needs the facts without the rendering.
+ */
+
+/** Where a connection is, and what it says, before anything is changed. */
+interface Located {
+  readonly index: number;
+  readonly connection: ConnectionConfig;
+}
+
+export interface Disconnected {
+  readonly profile: string;
+  readonly target: string;
+  readonly key: string;
+  readonly account: string;
+  /**
+   * The credential reference this removed, if it removed one. `null` when the
+   * provider has none (the owner layer), when `--keep-credential` was passed, or
+   * when a sibling connection still resolves to the same reference.
+   */
+  readonly credential: string | null;
+  /** Set when the credential was left because something else still needs it. */
+  readonly credentialSharedWith: readonly string[];
+  readonly remaining: number;
+  readonly published: string;
+}
+
+export interface Relabelled {
+  readonly profile: string;
+  readonly target: string;
+  readonly key: string;
+  readonly from: string;
+  readonly to: string;
+  readonly published: string;
+}
+
+export interface DisconnectFlags extends GlobalFlags {
+  readonly yes?: boolean | undefined;
+  readonly keepCredential?: boolean | undefined;
+  readonly json?: boolean | undefined;
+}
+
+export interface RelabelFlags extends GlobalFlags {
+  readonly json?: boolean | undefined;
+}
+
+/**
+ * Find the one connection a key names.
+ *
+ * The key must be exact — `gmail.main`, never `gmail`. `connect` accepts the
+ * bare provider because it can then create an account and choose the id; there
+ * is nothing to choose here, and a bare `gmail` with two accounts declared would
+ * be a command guessing which one to throw away.
+ */
+function locate(config: Config, key: string, profile: string): Located {
+  if (!key.includes('.')) {
+    const matches = config.connections.filter((one) => one.provider === key);
+    throw new Error(
+      `"${key}" names a provider, not a connection.\n` +
+        (matches.length > 0
+          ? `  This profile declares ${matches.map((one) => `${one.provider}.${one.id}`).join(', ')}.\n`
+          : '') +
+        `  Run: lanes link status --profile ${profile}`,
+    );
+  }
+
+  const index = config.connections.findIndex((one) => `${one.provider}.${one.id}` === key);
+  if (index === -1) {
+    throw new Error(
+      `Profile "${profile}" does not declare "${key}".\n` +
+        `  Run: lanes link status --profile ${profile}`,
+    );
+  }
+
+  return { index, connection: config.connections[index] as ConnectionConfig };
+}
+
+/**
+ * Refuse for a reserved provider, and say what to do instead.
+ *
+ * `memory`, `skills`, `vault`, `setup` and `identity` are not accounts — they are
+ * what the profile is *for*, they hold no credential, and each is granted by a
+ * policy line this command does not touch. Removing the connection alone would
+ * leave the policy granting `memory.*` against nothing: a config that is wrong
+ * rather than merely untidy, which is the same reason `knowledge use` takes its
+ * own block back. Hand-editing is the honest path and the file says so.
+ */
+function refuseReserved(key: string, provider: string, path: string): void {
+  if (!RESERVED_PROVIDER_IDS.includes(provider)) return;
+  throw new Error(
+    `"${key}" is part of what this profile is, not an account it holds.\n` +
+      `  ${provider} keeps no credential, and its policy grant is a separate line this command does not touch.\n` +
+      `  To remove it, delete both from ${path} by hand.`,
+  );
+}
+
+/**
+ * Which other connections resolve to the same credential reference.
+ *
+ * The check exists because a reference is not always per connection. An OAuth
+ * provider derives `<provider>/<id>` and is safe, but a manifest declaring
+ * `credential_ref: mything/api_key` shares one reference across every connection
+ * of that provider — so deleting it while a sibling still resolves to it would
+ * take that sibling's credential with it, and the sibling would report
+ * `unauthorized` for a `connect` nobody ran.
+ */
+export function connectionsSharingCredential(
+  config: Config,
+  ref: string,
+  exceptIndex: number,
+  manifestFor: (provider: string) => Parameters<typeof credentialRefFor>[1],
+): string[] {
+  return config.connections
+    .filter((one, i) => i !== exceptIndex && credentialRefFor(one, manifestFor(one.provider)) === ref)
+    .map((one) => `${one.provider}.${one.id}`);
+}
+
+export async function removeConnection(
+  key: string,
+  flags: DisconnectFlags,
+): Promise<{ resolution: Resolution; disconnected: Disconnected } | null> {
+  const runtime = await openRuntime(flags);
+
+  try {
+    const { resolution, config, target } = runtime;
+    const located = locate(config, key, resolution.profile);
+    const document = await ConfigDocument.open(resolution.workspaceRoot, resolution.profile);
+
+    refuseReserved(key, located.connection.provider, document.path);
+
+    if (!(await confirmed(key, flags))) return null;
+
+    const manifestFor = (provider: string) => runtime.registry.get(provider)?.manifest;
+    const ref = credentialRefFor(located.connection, manifestFor(located.connection.provider));
+    const shared = ref ? connectionsSharingCredential(config, ref, located.index, manifestFor) : [];
+
+    // The config edit first. If deleting the credential fails, a connection left
+    // declared with no credential reports `unauthorized`, which is recoverable by
+    // running `connect`. The reverse — credential gone, declaration kept, edit
+    // failed — is the same state, so ordering costs nothing either way; doing the
+    // edit first means the file is right even if the store is unreachable.
+    document.removeFrom(['connections'], located.index);
+    await document.save();
+
+    let removed: string | null = null;
+    if (ref && shared.length === 0 && flags.keepCredential !== true) {
+      await runtime.credentials.delete(ref);
+      removed = ref;
+    }
+
+    return {
+      resolution,
+      disconnected: {
+        profile: resolution.profile,
+        target,
+        key,
+        account: located.connection.account,
+        credential: removed,
+        credentialSharedWith: shared,
+        remaining: config.connections.length - 1,
+        published: nextAfterEdit(await publishProfileEdit({ resolution, config, target })),
+      },
+    };
+  } finally {
+    await runtime.close();
+  }
+}
+
+/** A plain y/N. Not `profile remove`'s type-the-name, which guards the
+ *  destruction of whole stores; this takes back one authorisation that `connect`
+ *  can grant again. */
+async function confirmed(key: string, flags: DisconnectFlags): Promise<boolean> {
+  if (flags.yes === true) return true;
+  if (!isInteractive()) {
+    throw new Error(
+      `Disconnecting "${key}" deletes its credential, and stdin is not a terminal, so there is nobody to ask.\n` +
+        `  Pass --yes to proceed.`,
+    );
+  }
+  // Defaults to no: this deletes a credential, and a stray return should not.
+  return confirm(`Disconnect ${key} and delete its credential?`, false);
+}
+
+export async function disconnect(key: string | undefined, flags: DisconnectFlags): Promise<void> {
+  if (!key) throw new Error('Which connection? Run: lanes link status');
+
+  const outcome = await removeConnection(key, flags);
+  if (outcome === null) {
+    print(warn('nothing was changed'));
+    return;
+  }
+  const { resolution, disconnected: result } = outcome;
+
+  return emit(flags.json, result, () => {
+    announce(resolution);
+    print(ok(`disconnected ${style.bold(result.key)}${result.account ? ` (${result.account})` : ''}`));
+
+    if (result.credential) {
+      print(`      credential  ${style.dim(result.credential)} deleted`);
+    } else if (result.credentialSharedWith.length > 0) {
+      // Named rather than silent: the operator asked for a credential to go and
+      // it did not, and the reason is a fact about their config.
+      print(
+        `      credential  kept — ${result.credentialSharedWith.join(', ')} still ${
+          result.credentialSharedWith.length === 1 ? 'resolves' : 'resolve'
+        } to it`,
+      );
+    }
+
+    print(style.dim(`      ${result.remaining} connection(s) left in this profile.`));
+    // The state record survives on purpose, and the next reconcile is what marks
+    // it disabled. Saying so stops "it is still in `status`" reading as a failure.
+    print(
+      style.dim(
+        '      The state record stays until the next reconcile, which marks it disabled rather than deleting it.',
+      ),
+    );
+    if (result.published) print(style.dim(`      ${result.published}`));
+  })
+}
+
+export async function renameConnection(
+  key: string,
+  account: string,
+  flags: RelabelFlags,
+): Promise<{ resolution: Resolution; relabelled: Relabelled }> {
+  const runtime = await openRuntime(flags);
+
+  try {
+    const { resolution, config, target } = runtime;
+    const located = locate(config, key, resolution.profile);
+    const document = await ConfigDocument.open(resolution.workspaceRoot, resolution.profile);
+
+    document.setIn(['connections', located.index, 'account'], account);
+    await document.save();
+
+    return {
+      resolution,
+      relabelled: {
+        profile: resolution.profile,
+        target,
+        key,
+        from: located.connection.account,
+        to: account,
+        published: nextAfterEdit(await publishProfileEdit({ resolution, config, target })),
+      },
+    };
+  } finally {
+    await runtime.close();
+  }
+}
+
+export async function relabel(
+  key: string | undefined,
+  account: string | undefined,
+  flags: RelabelFlags,
+): Promise<void> {
+  if (!key) throw new Error('Which connection? Run: lanes link status');
+  if (!account) throw new Error(`What should ${key} be called? Run: lanes link relabel ${key} "New name"`);
+
+  const { resolution, relabelled: result } = await renameConnection(key, account, flags);
+
+  return emit(flags.json, result, () => {
+    announce(resolution);
+    print(ok(`${style.bold(result.key)} is now ${style.bold(result.to)}`));
+    if (result.from) print(`      was     ${style.dim(result.from)}`);
+    // The label is a display name in two places, and only one of them changed.
+    print(
+      style.dim(
+        '      The state store keeps the old name until the next reconcile, which updates it.',
+      ),
+    );
+    if (result.published) print(style.dim(`      ${result.published}`));
+  })
+}

--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -1,5 +1,6 @@
 import { connect } from './commands/connect/index.ts';
 import { connectCustom } from './commands/connect/custom/index.ts';
+import { disconnect, relabel } from './commands/connection.ts';
 import {
   attachFile,
   auditTail,
@@ -329,6 +330,21 @@ export async function run(argv: readonly string[]): Promise<void> {
         default:
           throw new Error(`Unknown: ${PROGRAM} mcp ${second}`);
       }
+    case 'disconnect':
+      return disconnect(second, {
+        ...global,
+        yes: flags['yes'] === true,
+        keepCredential: flags['keep-credential'] === true,
+        json: flags['json'] === true,
+      });
+    // The new label is joined rather than taken as `rest[0]`, so an unquoted
+    // multi-word name works: `relabel gmail.main Work Mail` is what someone
+    // types before they think about quoting, and refusing it teaches nothing.
+    case 'relabel':
+      return relabel(second, rest.length > 0 ? rest.join(' ') : undefined, {
+        ...global,
+        json: flags['json'] === true,
+      });
     case 'start':
       return start({
         ...global,

--- a/src/cli/selection.ts
+++ b/src/cli/selection.ts
@@ -111,6 +111,11 @@ export const SELECTION: Record<string, Requires> = {
   'identity list': 'profile',
 
   connect: 'profile+target',
+  // Both edit the profile config, and `disconnect` also opens the target's
+  // credential store to delete from it. Same requirement as `connect` for the
+  // same reasons.
+  disconnect: 'profile+target',
+  relabel: 'profile+target',
   // Its own row rather than an inheritance from `connect`. Both need the same
   // two things, but the row is what makes `selectionKey` return the two-word
   // key — and that is what keeps thirty declaration flags off
@@ -310,6 +315,8 @@ const ACCEPTS: Record<string, readonly string[]> = {
   // `removalPlan`, and was refused here — the flag existed everywhere except in
   // the list that decides whether it may be typed.
   'profile remove': ['dry-run', 'yes', 'target'],
+  disconnect: ['yes', 'keep-credential'],
+  relabel: [],
   'target list': ['urls', 'target'],
   'target show': ['target'],
   'token show': ['show', 'raw'],

--- a/src/cli/usage.ts
+++ b/src/cli/usage.ts
@@ -26,6 +26,9 @@ ${style.bold('Everyday')}
   ${PROGRAM} connect <...> --replace    ask for the stored password or key again
   ${PROGRAM} connect <...> --auth <method>  pick how, where there is a choice
   ${PROGRAM} connect <...> --non-interactive [--json]
+  ${PROGRAM} disconnect <provider>.<id>  remove an account, and delete its credential
+  ${PROGRAM} disconnect <...> --keep-credential   leave the credential in the store
+  ${PROGRAM} relabel <provider>.<id> <name>      rename what an account is called
   ${PROGRAM} connect custom <id> --connector <kind> --auth <method>
                                  declare a service that is not built in, and connect it.
                                  kinds: mcp, http, imap, dav, fs. Omit a value and it is

--- a/src/providers/setup/plan.ts
+++ b/src/providers/setup/plan.ts
@@ -1,5 +1,5 @@
 import type { ProviderManifest } from '#connectivity';
-import { hasOwnClientPath, setupRequirements, type SetupRequirement } from '#connectivity';
+import { hasOwnClientPath, RESERVED_PROVIDER_IDS, setupRequirements, type SetupRequirement } from '#connectivity';
 
 /**
  * What connecting a provider involves, assembled from its manifest.
@@ -19,6 +19,21 @@ export interface ProviderPlan {
   readonly id: string;
   readonly name: string;
   readonly description: string;
+  /**
+   * This provider is part of what a profile *is*, not an account it holds.
+   *
+   * The owner layer — `memory`, `skills`, `vault`, `setup`, `identity` — keyed off
+   * `RESERVED_PROVIDER_IDS`, which is the same list the registry uses to stop a
+   * third-party manifest claiming one of those ids.
+   *
+   * Reported because it is the fact a surface needs and cannot derive.
+   * `multiAccount` is the nearest thing and it is not it: that is a credential
+   * test, and `icloud_drive` is `auth: none` without being owner-layer at all. A
+   * client wanting to group these, or to withhold a disconnect that would leave a
+   * dangling policy grant, was left hardcoding the list — which then goes stale
+   * the next time one is added here. This travels with the release instead.
+   */
+  readonly reserved: boolean;
   /** Connection keys of this provider already configured, e.g. `gmail.main`. */
   readonly connected: readonly string[];
   /**
@@ -122,6 +137,7 @@ export function planFor(
     id: manifest.id,
     name: manifest.name,
     description: manifest.description,
+    reserved: RESERVED_PROVIDER_IDS.includes(manifest.id),
     connected,
     multiAccount: manifest.auth.kind !== 'none',
     browser: manifest.auth.kind === 'oauth',


### PR DESCRIPTION
Three gaps, found by building a GUI on top of this CLI and discovering the two things it could not ask for.

## `lanes link disconnect <provider>.<id>`

The counterpart to `connect`, which did not exist. Removing an account meant opening the YAML, deleting an entry, and remembering the credential it left behind in the store.

```console
$ lanes link disconnect gmail.side --profile personal --target local
$ lanes link disconnect gmail.side --profile personal --target local --yes --json
$ lanes link disconnect gmail.side --profile personal --target local --keep-credential
```

The key must be exact. `connect gmail` can create an account and choose the id; there is nothing to choose here, and a bare `gmail` with two declared would be a command guessing which to throw away — so it refuses and names them.

**Three things it deliberately does not do**, each of which was the interesting part:

| | |
|---|---|
| Delete the state record | Reconcile marks an undeclared connection `disabled` rather than deleting it so the audit log keeps meaning something. Reaching past that would undo the one guarantee the log offers. The next reconcile marks it, and the output says so. |
| Delete a shared credential | An OAuth provider derives `<provider>/<id>` and is safe. A manifest declaring `credential_ref` shares one reference across every connection of that provider — deleting it while a sibling resolves to it takes the sibling's credential with it, and the sibling then reports `unauthorized` for a `connect` nobody ran. Kept, and the output names what still needs it. |
| Touch the owner layer | `memory`, `skills`, `vault`, `setup`, `identity` hold no credential and are granted by a policy line this command does not touch, so removing the connection alone leaves the policy granting against nothing. Wrong, not merely untidy — the same reason `knowledge use` takes its own block back. It refuses and points at the file, where both lines sit together. |

The sharing check routes through `credentialRefFor`, the same authority reconcile uses, rather than re-deriving. Those two disagreeing is a bug this repository has already had once.

## `lanes link relabel <provider>.<id> <name>`

Also did not exist. `connect` writes `account` from the identity the provider reports, which is right for `gmail.main` and useless where there is no such endpoint — a bunq key belongs to an account bunq will not name, so the label was whatever got typed once and never again.

```console
$ lanes link relabel gmail.main "Work mail" --profile personal --target local
$ lanes link relabel gmail.main Work mail --profile personal --target local
```

Both forms work: an unquoted multi-word name is joined, because quoting is what someone remembers second and refusing it teaches nothing. Allowed for the owner layer, unlike `disconnect`: a display name is harmless, and "Memory" is the operator's word for their own store.

## `ProviderPlan` now reports `reserved`

The one that saves the most work later. A surface wanting to group the owner layer, or to withhold a disconnect that would leave a dangling policy grant, had to hardcode `['memory','skills','vault','setup','identity']` — which goes stale the next time one is added here.

`multiAccount` looks like the answer and is not. That is a credential test, and `icloud_drive` is `auth: none` without being owner-layer at all, so grouping on it files a synced folder with somebody's notes:

```
  example          reserved=false  multiAccount=false
  icloud_drive     reserved=false  multiAccount=false
  identity         reserved=true   multiAccount=false
  memory           reserved=true   multiAccount=false
  setup            reserved=true   multiAccount=false
  skills           reserved=true   multiAccount=false
  vault            reserved=true   multiAccount=false
```

Keyed off `RESERVED_PROVIDER_IDS`, the same list the registry uses to stop a manifest claiming one of those ids. The fact now travels with the release.

## Notes

- Both commands go through `ConfigDocument`, so comments and key order survive. A test pins the template's own commentary across a disconnect.
- Both are `profile+target` in `SELECTION`, for the reason `connect` is: they write the profile and open the target's credential store.
- `disconnect` defaults its confirmation to **no** and refuses without `--yes` when stdin is not a terminal, since it deletes a credential.

## Verification

- `bun test` — baseline on `develop` 2400 pass / 0 fail; with this change **2422 pass / 0 fail** (+22).
- `bun run typecheck` — clean.
- Exercised against a scratch workspace under `LANES_LINK_HOME` (never the operator's): the three refusals, an unquoted rename with comments intact afterwards, a disconnect reporting `credential: "gmail/side"`, and the `reserved` table above.
- `test.each([...RESERVED_PROVIDER_IDS])` covers every reserved id, so one added later is covered the moment it exists rather than the next time somebody remembers.

## Consumer

Lanes desktop's Lanes Link page is the caller: a per-connection `⋯` menu with Remove and Rename, the owner layer grouped and not removable, driven by `reserved` rather than a copy of the list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)