### PR TITLE
Stop the connection tests declaring an owner layer the template now ships

### DIFF
--- a/src/cli/commands/connection.test.ts
+++ b/src/cli/commands/connection.test.ts
@@ -31,6 +31,10 @@ import { connectionsSharingCredential, removeConnection, renameConnection } from
 
 const WHERE = { profile: 'personal', target: 'local' } as const;
 
+// Only the accounts. The owner layer is not declared here: a fresh profile
+// arrives with `memory.main` and its siblings already granted (ADR-050), and
+// declaring one of them a second time is a duplicate the parser refuses — which
+// would fail every test in this file for a reason none of them is about.
 const CONNECTIONS = `
   - id: main
     provider: gmail
@@ -38,9 +42,6 @@ const CONNECTIONS = `
   - id: side
     provider: gmail
     account: second@example.com
-  - id: main
-    provider: memory
-    account: Memory
 `;
 
 const roots: string[] = [];
@@ -154,8 +155,9 @@ describe('disconnect', () => {
     const root = await workspace();
     const path = join(root, 'profiles', 'personal.yaml');
     const text = await Bun.file(path).text();
-    // `memory` and `setup` the template already declares; declaring one twice is
-    // a config the parser refuses, which would fail this for the wrong reason.
+    // The template already declares every reserved id but `identity`; declaring
+    // one twice is a config the parser refuses, which would fail this for the
+    // wrong reason.
     if (!text.includes(`provider: ${provider}`)) {
       await Bun.write(
         path,


### PR DESCRIPTION
Two pull requests merged in parallel and left develop red. #65 added
disconnect and relabel with a fixture that declared `memory.main` by hand,
because at the time nothing else did. #61 shipped the owner layer switched
on, so `createProfile` now writes that row itself.

Neither pull request was wrong and both were green against their own base.
Together the fixture declares `memory.main` twice, and
`assertReferentialIntegrity` refuses a duplicate connection — so all 19
tests in the file failed on a config error, before reaching anything they
were about.

The fixture now holds only the two Gmail accounts. Every assertion naming
`memory.main` reads the template's own row, which is what they each meant:
that disconnect refuses the owner layer and relabel allows it. The `test.each`
over `RESERVED_PROVIDER_IDS` already guarded against this, and its comment
was stale in the same direction — the template declares all seven but
`identity` now, not just `memory` and `setup`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
