### PR TITLE
Release: a renamed provider no longer bricks an upgraded profile

### DIFF
--- a/docs/detailed/adr/051-tasks-and-assets-are-their-own-stores.md
+++ b/docs/detailed/adr/051-tasks-and-assets-are-their-own-stores.md
@@ -109,6 +109,24 @@ to want, exactly as several memory connections are, so `id !== 'main'` would ref
 forever to catch a one-release migration. Labelling them all `Tasks` is what the accountless
 providers already do — every memory connection is `Memory`.
 
+**A refusal at load has to name a command, and the command has to exist.** This one was shipped
+saying "set provider to `google_tasks` here", meaning by hand, and that was not enough. The refusal
+is in `validateConfig`, which every command opens the config through, so one stale row takes
+`status`, `start`, `plan` and `doctor` down together — and the only route back was to edit YAML, for
+a state an upgrade put the operator in without asking. `lanes link doctor --fix` is that route, and
+`src/cli/config-migrate.ts` is what it runs: the row, its policy rules, and the stored credential,
+moved together through `ConfigDocument` so the file's comments survive.
+
+The repair inherits the refusal's rule about not guessing, and needs a stronger form of it. Both
+readings are still live, so what decides is **evidence rather than a heuristic**: a credential at
+`tasks/<id>` can only belong to the OAuth connection, because the built-in holds none and never has.
+With no credential stored, `--fix` reports both readings and changes nothing — the second version of
+the mistake the heuristic above already made once.
+
+Deliberately still not automatic. `start` could run this on the way past, as it does the owner-layer
+repair, but that repair adds what a profile lacks while this one rebinds what it already has, and a
+credential moving without anyone asking is the thing ADR-007 keeps on the control plane.
+
 The rename also lengthened every redaction key, and that is worth recording because it fails
 silently. `shortenName` strips the *provider id* from a discovered tool name and Google namespaces
 its operations under the *API* name; while the id was `tasks` those were the same string, so

--- a/docs/detailed/commands.md
+++ b/docs/detailed/commands.md
@@ -952,6 +952,18 @@ the command that fixes it.
 $ lanes link doctor --profile personal --target local
 ```
 
+`--fix` applies the one repair `doctor` can make on its own: a provider this project renamed under
+you, where the profile still names the old id. That refusal happens at config load, so it takes
+every other command down with it — `doctor` is the one that still answers, and it moves the
+connection row, its policy rules and the stored credential together. Everything else `doctor`
+reports is a decision only you can make, and `--fix` does not touch it.
+
+```console
+$ lanes link doctor --fix --profile personal --target local
+```
+
+Without `--fix` it prints what it would move and writes nothing.
+
 ### `lanes link plan`
 
 What reconcile would change, and nothing else. Reconcile disables undeclared connections, which

--- a/src/cli/commands/operate/inspect.ts
+++ b/src/cli/commands/operate/inspect.ts
@@ -2,9 +2,10 @@ import { credentialRefFor, formatPlan, planIsNoop, planReconcile } from '#regist
 import { DEFAULT_SURFACES } from '../../config-repair.ts';
 import { announce, announceProfile, emit, fail, ok, print, warn } from '../../output.ts';
 import { staleNudge } from '../../release.ts';
-import { openRuntime, resolveProfileOnly, type GlobalFlags } from '../../runtime.ts';
+import { openRuntime, resolveProfileOnly, type GlobalFlags, type Runtime } from '../../runtime.ts';
 import type { FetchLike } from '#deployments/knowledge.ts';
 import { credentialAge, reportCapabilityDrift } from './findings.ts';
+import { migratedRenamedProviders } from './migrate.ts';
 
 /**
  * The gate order — check, doctor, plan, start — exists so failures surface in
@@ -41,6 +42,8 @@ export async function plan(flags: GlobalFlags): Promise<void> {
 
 export interface DoctorFlags extends GlobalFlags {
   readonly json?: boolean | undefined;
+  /** Apply a repair `doctor` would otherwise only report. */
+  readonly fix?: boolean | undefined;
   /** Injected for tests. A knowledge repository is the only thing doctor fetches. */
   readonly fetch?: FetchLike | undefined;
 }
@@ -63,7 +66,18 @@ export interface DoctorFinding {
 
 /** Read-only external checks: credentials resolve, stores reachable. */
 export async function doctor(flags: DoctorFlags): Promise<void> {
-  const runtime = await openRuntime(flags, { fetch: flags.fetch });
+  // The one check that cannot use a runtime, because it answers for the profiles
+  // that cannot open one. A provider rename left in the config refuses at load,
+  // which takes every command down together — including the rest of this one —
+  // so it is asked first and, with `--fix`, undone. Anything else that refused
+  // is rethrown untouched.
+  let runtime: Runtime;
+  try {
+    runtime = await openRuntime(flags, { fetch: flags.fetch });
+  } catch (refusal) {
+    if (await migratedRenamedProviders(flags, refusal)) return;
+    throw refusal;
+  }
 
   const checks: string[] = [];
   const warnings: DoctorFinding[] = [];

--- a/src/cli/commands/operate/migrate.ts
+++ b/src/cli/commands/operate/migrate.ts
@@ -1,0 +1,100 @@
+import { ConfigError, resolveSelection } from '#profile';
+import { ConfigDocument } from '../../config-edit.ts';
+import { migrateRenamedProviders, pendingRenames, shapeOf } from '../../config-migrate.ts';
+import { emit, fail, ok, print, style, warn } from '../../output.ts';
+import { openSecretStoreFor, type GlobalFlags } from '../../runtime.ts';
+
+/**
+ * `doctor` answering for a profile whose config will not load.
+ *
+ * Here rather than in `inspect.ts` because it is the opposite of everything
+ * there: every other check reads a runtime, and this one runs precisely when no
+ * runtime can be opened. Keeping it beside them would have put a second
+ * `try`/`catch` shape around a file that is otherwise one long list of findings.
+ *
+ * Why `doctor` at all, and not a command of its own: it is already the command
+ * whose job is to say what is wrong and name the fix, and a `lanes link migrate`
+ * would be a command an operator has to know exists before their config breaks.
+ * `doctor` is what someone runs when something is broken, so it has to be the
+ * one that works when everything else refuses.
+ */
+
+export interface RenameFlags extends GlobalFlags {
+  readonly json?: boolean | undefined;
+  /** Apply the migration rather than reporting it. */
+  readonly fix?: boolean | undefined;
+}
+
+/**
+ * Whether a refusal to load was a provider rename, and — with `--fix` — undo it.
+ *
+ * Returns false for anything else, so the caller rethrows the original error
+ * rather than replacing a real config problem with "nothing to migrate".
+ *
+ * The selection is resolved again here, and cheaply: `resolveSelection` reads
+ * the workspace and the flag, never a profile's config, which is what makes it
+ * usable on the path where the config is the thing that is broken.
+ */
+export async function migratedRenamedProviders(
+  flags: RenameFlags,
+  refusal: unknown,
+): Promise<boolean> {
+  if (!(refusal instanceof ConfigError)) return false;
+
+  const selection = await resolveSelection({ profileFlag: flags.profile });
+  const document = await ConfigDocument.open(selection.workspaceRoot, selection.profile);
+  if (pendingRenames(document).length === 0) return false;
+
+  // Shape-only, because the check this document fails runs after the schema.
+  // Throws when it is malformed beyond a rename, which is a better sentence
+  // than the referential one it would otherwise be reported under.
+  const config = shapeOf(document);
+  const target = flags.target ?? '';
+  const credentials = await openSecretStoreFor(config, selection.workspaceRoot, target);
+
+  const migration = await migrateRenamedProviders(document, credentials, {
+    apply: flags.fix === true,
+  });
+
+  const applied = flags.fix === true && migration.changes.length > 0;
+
+  // A report is a problem, because the profile is still unusable. A repair that
+  // left nothing behind is not, and one that could not decide every row is —
+  // those rows are exactly as broken as before.
+  if (!applied || migration.blocked.length > 0) process.exitCode = 1;
+
+  await emit(
+    flags.json,
+    {
+      ok: applied && migration.blocked.length === 0,
+      profile: selection.profile,
+      target,
+      applied,
+      rows: migration.rows,
+      changes: migration.changes,
+      blocked: migration.blocked,
+    },
+    () => {
+      print(`profile ${style.bold(selection.profile)}  target ${style.bold(target)}`);
+      print();
+
+      if (applied) {
+        print(ok(`${document.path} no longer names a provider that has moved`));
+      } else {
+        print(fail(`${document.path} names a provider that has moved, so nothing can load it`));
+      }
+
+      for (const change of migration.changes) {
+        print(`      ${style.dim(applied ? change : `would ${change}`)}`);
+      }
+      for (const problem of migration.blocked) print(warn(problem));
+
+      if (!applied && migration.changes.length > 0) {
+        print();
+        print(`Run the same command with ${style.bold('--fix')} to apply it.`);
+      }
+    },
+  );
+
+  return true;
+}

--- a/src/cli/config-migrate.test.ts
+++ b/src/cli/config-migrate.test.ts
@@ -1,0 +1,228 @@
+import { afterAll, describe, expect, test } from 'bun:test';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { parseConfig, type Config } from '#profile';
+import type { SecretStore } from '#secrets';
+import { doctor } from './commands/operate.ts';
+import { createProfile } from './commands/profile.ts';
+import { ConfigDocument } from './config-edit.ts';
+import { migrateRenamedProviders, pendingRenames, shapeOf } from './config-migrate.ts';
+import { openSecretStoreFor } from './runtime.ts';
+
+/**
+ * Undoing a provider rename on a profile that will not load because of one.
+ *
+ * The property that matters most is the one that is easiest to lose: **nothing
+ * is guessed**. A `tasks` row labelled anything but `Tasks` is ambiguous between
+ * a pre-rename Google Tasks connection and a hand-edited built-in one, and the
+ * two fixes are opposite — so the stored credential decides, because only the
+ * OAuth connection has ever had one. Take the evidence away and the repair must
+ * report rather than pick, which is what most of this file is about.
+ *
+ * The second property is that a repair which cannot be finished is not started:
+ * the credential is copied before the config is saved, and the old reference
+ * removed only after `save` has validated what landed.
+ */
+
+const roots: string[] = [];
+const previousHome = process.env['LANES_LINK_HOME'];
+
+/** The pre-rename row, exactly as a profile written before ADR-051 holds it. */
+const GOOGLE_TASKS = '  - { id: personal, provider: tasks, account: personal }';
+
+/**
+ * A workspace whose profile still names the old id.
+ *
+ * Built by rewriting the template's built-in row rather than by appending, so
+ * the file holds one `tasks` row and one `tasks.*` rule — the shape a real
+ * pre-0.5.0 profile has, where the built-in did not exist yet to be declared.
+ */
+async function brokenWorkspace(options: { keepBuiltIn?: boolean } = {}): Promise<string> {
+  const root = await mkdtemp(join(tmpdir(), 'lanes-link-migrate-'));
+  roots.push(root);
+  process.env['LANES_LINK_HOME'] = root;
+  await createProfile('personal', { targets: ['local'] });
+
+  const path = join(root, 'profiles', 'personal.yaml');
+  const text = await Bun.file(path).text();
+  const builtIn = '  - { id: main, provider: tasks, account: Tasks }';
+
+  await Bun.write(
+    path,
+    text.replace(builtIn, options.keepBuiltIn === true ? `${builtIn}\n${GOOGLE_TASKS}` : GOOGLE_TASKS),
+  );
+
+  return root;
+}
+
+async function open(root: string): Promise<{ document: ConfigDocument; credentials: SecretStore }> {
+  const document = await ConfigDocument.open(root, 'personal');
+  return { document, credentials: await openSecretStoreFor(shapeOf(document), root, 'local') };
+}
+
+async function onDisk(root: string): Promise<Config> {
+  return parseConfig(await Bun.file(join(root, 'profiles', 'personal.yaml')).text()).config;
+}
+
+function keys(config: Config): string[] {
+  return config.connections.map((one) => `${one.provider}.${one.id}`);
+}
+
+afterAll(async () => {
+  if (previousHome === undefined) delete process.env['LANES_LINK_HOME'];
+  else process.env['LANES_LINK_HOME'] = previousHome;
+  await Promise.all(roots.map((root) => rm(root, { recursive: true, force: true })));
+});
+
+describe('a profile still naming a renamed provider', () => {
+  test('is refused by the loader, which is the state this repairs', async () => {
+    const root = await brokenWorkspace();
+    await expect(onDisk(root)).rejects.toThrow(/set provider to google_tasks/);
+  });
+
+  test('is found in raw YAML, which is all there is to read', async () => {
+    const root = await brokenWorkspace();
+    const { document } = await open(root);
+
+    expect(pendingRenames(document)).toEqual([
+      expect.objectContaining({ from: 'tasks', to: 'google_tasks', id: 'personal' }),
+    ]);
+  });
+});
+
+describe('with a stored credential to prove what the row was', () => {
+  async function ready(options: { keepBuiltIn?: boolean } = {}) {
+    const root = await brokenWorkspace(options);
+    const { document, credentials } = await open(root);
+    await credentials.set('tasks/personal', '{"refresh_token":"not-a-real-token"}');
+    return { root, document, credentials };
+  }
+
+  test('reports what it would do, and writes nothing', async () => {
+    const { root, document, credentials } = await ready();
+
+    const migration = await migrateRenamedProviders(document, credentials, { apply: false });
+
+    expect(migration.changes).toContain('credential: tasks/personal → google_tasks/personal');
+    expect(migration.blocked).toEqual([]);
+    await expect(onDisk(root)).rejects.toThrow(/set provider to google_tasks/);
+    expect(await credentials.has('tasks/personal')).toBe(true);
+    expect(await credentials.has('google_tasks/personal')).toBe(false);
+  });
+
+  test('moves the row, the rule and the credential together', async () => {
+    const { root, document, credentials } = await ready();
+
+    const migration = await migrateRenamedProviders(document, credentials, { apply: true });
+    expect(migration.blocked).toEqual([]);
+
+    const config = await onDisk(root);
+    expect(keys(config)).toContain('google_tasks.personal');
+    expect(keys(config)).not.toContain('tasks.personal');
+    expect(config.policy.allow.map((rule) => rule.capability)).toContain('google_tasks.*');
+    expect(config.policy.allow.map((rule) => rule.capability)).not.toContain('tasks.*');
+
+    // All three, because any one alone is inert: the row without the rule is
+    // granted nothing, and either without the credential is unauthorized.
+    expect(await credentials.has('google_tasks/personal')).toBe(true);
+    expect(await credentials.has('tasks/personal')).toBe(false);
+    expect(await credentials.get('google_tasks/personal')).toBe('{"refresh_token":"not-a-real-token"}');
+  });
+
+  test('leaves the comments an operator reads the file for', async () => {
+    const { root, document, credentials } = await ready();
+    await migrateRenamedProviders(document, credentials, { apply: true });
+
+    const text = await Bun.file(join(root, 'profiles', 'personal.yaml')).text();
+    expect(text).toContain('# Lanes Link profile: personal');
+    expect(text).toContain('# Only what is listed here is reachable');
+  });
+
+  test('is a no-op the second time, because there is nothing left to move', async () => {
+    const { root, credentials } = await ready();
+    await migrateRenamedProviders(await ConfigDocument.open(root, 'personal'), credentials, {
+      apply: true,
+    });
+
+    const again = await migrateRenamedProviders(
+      await ConfigDocument.open(root, 'personal'),
+      credentials,
+      { apply: true },
+    );
+    expect(again.rows).toEqual([]);
+    expect(again.changes).toEqual([]);
+  });
+
+  test('keeps a rule that two providers would then share', async () => {
+    // A profile declaring the built-in *and* a pre-rename row has one `tasks.*`
+    // serving both, so moving it would silently revoke the one that kept its
+    // name. The row still moves; the rule is reported instead.
+    const { root, document, credentials } = await ready({ keepBuiltIn: true });
+
+    const migration = await migrateRenamedProviders(document, credentials, { apply: true });
+
+    expect(migration.blocked.join('\n')).toMatch(/still declares a "tasks" connection/);
+
+    const config = await onDisk(root);
+    expect(keys(config)).toContain('google_tasks.personal');
+    expect(config.policy.allow.map((rule) => rule.capability)).toContain('tasks.*');
+  });
+});
+
+describe('a deny rule follows the rename too', () => {
+  test('because leaving it behind re-enables what was switched off', async () => {
+    const root = await brokenWorkspace();
+    const path = join(root, 'profiles', 'personal.yaml');
+    await Bun.write(
+      path,
+      (await Bun.file(path).text()).replace('deny: []', 'deny: [tasks.tasks.tasks.delete]'),
+    );
+
+    const { document, credentials } = await open(root);
+    await credentials.set('tasks/personal', 'token');
+    await migrateRenamedProviders(document, credentials, { apply: true });
+
+    expect((await onDisk(root)).policy.deny.map((rule) => rule.capability)).toEqual([
+      'google_tasks.tasks.tasks.delete',
+    ]);
+  });
+});
+
+describe('through doctor, which is the command an operator reaches for', () => {
+  test('--fix closes the loop the refusal opens', async () => {
+    // The end-to-end property: the load refusal names `doctor --fix`, and
+    // running it makes the profile load. Everything else here tests a half of
+    // that; this is the half nobody can verify by reading.
+    const root = await brokenWorkspace();
+    const { credentials } = await open(root);
+    await credentials.set('tasks/personal', 'token');
+
+    // Restored, because `doctor` reports a repair by exit code and a test runner
+    // reads the same one.
+    const previous = process.exitCode;
+    try {
+      await doctor({ profile: 'personal', target: 'local', fix: true, quiet: true });
+    } finally {
+      process.exitCode = previous;
+    }
+
+    expect(keys(await onDisk(root))).toContain('google_tasks.personal');
+  });
+});
+
+describe('with nothing to prove what the row was', () => {
+  test('reports both readings and changes nothing', async () => {
+    // The hand-edited built-in is a real profile too, and its fix is the
+    // opposite one. Picking here would be the silent rebind the refusal exists
+    // to prevent, arrived at from the other direction.
+    const root = await brokenWorkspace();
+    const { document, credentials } = await open(root);
+
+    const migration = await migrateRenamedProviders(document, credentials, { apply: true });
+
+    expect(migration.changes).toEqual([]);
+    expect(migration.blocked.join('\n')).toMatch(/no stored credential/);
+    await expect(onDisk(root)).rejects.toThrow(/set provider to google_tasks/);
+  });
+});

--- a/src/cli/config-migrate.ts
+++ b/src/cli/config-migrate.ts
@@ -1,0 +1,251 @@
+import { ConfigError, renamedProviderFor, validateConfigShape, type Config } from '#profile';
+import type { SecretStore } from '#secrets';
+import { ConfigDocument } from './config-edit.ts';
+
+/**
+ * Applying a provider rename to a profile that still names the old id.
+ *
+ * Apart from `config-repair.ts` because the subject differs, not because either
+ * file grew: that one gives a profile a surface it never had, reading a config
+ * that loads. This one runs when the config does *not* load, which is the whole
+ * difficulty. `renamedProviderFor` refuses a stale row at load (`#profile`), and
+ * every command opens the config — so one row left saying `provider: tasks`
+ * takes `status`, `start`, `plan` and `doctor` down together, for a state an
+ * upgrade put the operator in without asking. The only way back was to
+ * hand-edit YAML, which is not a thing a CLI should require to undo its own
+ * release.
+ *
+ * So this reads raw YAML through `ConfigDocument` and edits it comment-first,
+ * exactly as the other repairs do.
+ *
+ * **It never guesses.** A `tasks` row labelled anything but `Tasks` is either a
+ * pre-rename Google Tasks connection or a hand-edited built-in one, and the
+ * refusal names both because the two fixes are opposite. What decides here is
+ * evidence rather than a heuristic: a stored credential at `tasks/<id>` can only
+ * belong to the OAuth connection, because the built-in holds none and never
+ * has. With no credential this reports both readings and changes nothing.
+ */
+
+/** One row that has to move. */
+export interface PendingRename {
+  readonly index: number;
+  readonly from: string;
+  readonly to: string;
+  readonly id: string;
+  readonly account: string;
+  /** `provider.id`, as the rest of the CLI addresses a connection. */
+  readonly key: string;
+}
+
+export interface RenameMigration {
+  /** Every stale row found, whether or not it could be moved. */
+  readonly rows: readonly PendingRename[];
+  /** What was done, or would be — spelled for display. */
+  readonly changes: readonly string[];
+  /** What was left alone, each with why. */
+  readonly blocked: readonly string[];
+}
+
+/**
+ * The rows a document still spells the old way.
+ *
+ * Raw YAML, so nothing here has been through a schema — this runs on a file the
+ * loader has already refused, and every field is whatever was typed. A row
+ * missing `provider` or `account` is not a rename, it is a shape error, and
+ * reporting that is `validateConfig`'s job rather than this one's.
+ */
+export function pendingRenames(document: ConfigDocument): PendingRename[] {
+  const pending: PendingRename[] = [];
+
+  connectionsOf(document).forEach((row, index) => {
+    const { provider, id, account } = (row ?? {}) as {
+      provider?: unknown;
+      id?: unknown;
+      account?: unknown;
+    };
+    if (typeof provider !== 'string' || typeof id !== 'string' || typeof account !== 'string') {
+      return;
+    }
+
+    const moved = renamedProviderFor({ provider, account });
+    if (moved) {
+      pending.push({ index, from: provider, to: moved.to, id, account, key: `${provider}.${id}` });
+    }
+  });
+
+  return pending;
+}
+
+/**
+ * Report what a profile is owed, and optionally apply it.
+ *
+ * Takes the credential store rather than opening one, so the caller decides
+ * whether the target is reachable and a test needs no adapter. `apply: false` is
+ * what `doctor` prints without `--fix`: the same reading against the same
+ * evidence, with nothing written.
+ *
+ * The credential is copied *before* the config is saved, and the old reference
+ * deleted only after. A crash between the two leaves a second copy of a secret
+ * the operator already holds — recoverable, and invisible. The other order
+ * leaves a config naming a credential that is gone, which presents as a
+ * connection that lost its authorisation for no reason anyone can see.
+ */
+export async function migrateRenamedProviders(
+  document: ConfigDocument,
+  credentials: SecretStore,
+  options: { apply: boolean },
+): Promise<RenameMigration> {
+  const rows = pendingRenames(document);
+  if (rows.length === 0) return { rows, changes: [], blocked: [] };
+
+  const changes: string[] = [];
+  const blocked: string[] = [];
+  const accepted: PendingRename[] = [];
+
+  for (const row of rows) {
+    if (await credentials.has(`${row.from}/${row.id}`)) {
+      accepted.push(row);
+      changes.push(`connections[${row.index}]: ${row.from} → ${row.to} (${row.key})`);
+      changes.push(`credential: ${row.from}/${row.id} → ${row.to}/${row.id}`);
+    } else {
+      blocked.push(
+        `${row.key} has no stored credential, so nothing proves it was ${row.to} rather than a ` +
+          `built-in row labelled "${row.account}" by hand — set its provider or its account in ` +
+          `the file itself`,
+      );
+    }
+  }
+
+  // The policy rules second, because whether one can move depends on what is
+  // left declaring the old id once the rows above have.
+  for (const [from, to] of new Map(accepted.map((row) => [row.from, row.to]))) {
+    const policy = renamePolicyRules(document, { from, to }, {
+      stillDeclared: keepsDeclaring(document, from, accepted),
+      apply: options.apply,
+    });
+    changes.push(...policy.changes);
+    blocked.push(...policy.blocked);
+  }
+
+  if (!options.apply || accepted.length === 0) return { rows, changes, blocked };
+
+  for (const row of accepted) {
+    document.setIn(['connections', row.index, 'provider'], row.to);
+
+    const value = await credentials.get(`${row.from}/${row.id}`);
+    if (value !== null) await credentials.set(`${row.to}/${row.id}`, value);
+  }
+
+  // Throws unless the result is a config that loads, which is the assertion
+  // worth having here — the whole premise was that it did not.
+  await document.save();
+
+  for (const row of accepted) await credentials.delete(`${row.from}/${row.id}`);
+
+  return { rows, changes, blocked };
+}
+
+/**
+ * Rewrite the policy rules that named the old id, where that is unambiguous.
+ *
+ * A rule names a provider and never an account, so `tasks.*` written for Google
+ * Tasks has to follow the rename or the migrated connection is granted nothing
+ * — `allowedConnections` drops a provider no rule covers before policy is even
+ * consulted, so the repair would land a row that serves exactly as little as
+ * the broken one did.
+ *
+ * But a profile declaring *both* — a Google Tasks row and the built-in — has one
+ * rule serving two providers, and moving it would silently revoke the one that
+ * kept its name. That profile keeps its rule and is told to add the second,
+ * which is a sentence rather than a guess at which was meant.
+ *
+ * Both lists. A `deny` written to switch Google Tasks off means it as firmly as
+ * an allow means it on, and leaving it behind would re-enable something the
+ * operator turned off.
+ */
+function renamePolicyRules(
+  document: ConfigDocument,
+  provider: { from: string; to: string },
+  options: { stillDeclared: boolean; apply: boolean },
+): { changes: string[]; blocked: string[] } {
+  const changes: string[] = [];
+  const blocked: string[] = [];
+
+  for (const field of ['allow', 'deny'] as const) {
+    const rules = document.getIn(['policy', field]) as { items?: unknown[] } | null;
+
+    (rules?.items ?? []).forEach((_item, index) => {
+      // Either spelling: a bare pattern, or `{ capability, expires_at }`. The
+      // path to it differs; the decision does not.
+      const bare = document.getIn(['policy', field, index]);
+      const path =
+        typeof bare === 'string'
+          ? (['policy', field, index] as const)
+          : (['policy', field, index, 'capability'] as const);
+
+      const capability = typeof bare === 'string' ? bare : document.getIn(path);
+      if (typeof capability !== 'string') return;
+
+      const [named, ...rest] = capability.split('.');
+      if (named !== provider.from) return;
+
+      const moved = [provider.to, ...rest].join('.');
+
+      if (options.stillDeclared) {
+        blocked.push(
+          `policy.${field} keeps "${capability}" — this profile still declares a ` +
+            `"${provider.from}" connection, so add "${moved}" rather than moving it`,
+        );
+        return;
+      }
+
+      if (options.apply) document.setIn(path, moved);
+      changes.push(`policy.${field}: ${capability} → ${moved}`);
+    });
+  }
+
+  return { changes, blocked };
+}
+
+/**
+ * Whether a row naming the old provider survives the migration.
+ *
+ * Computed against the accepted set rather than by re-reading the document,
+ * because the same answer has to hold on a report-only run, where nothing has
+ * been rewritten yet.
+ */
+function keepsDeclaring(
+  document: ConfigDocument,
+  provider: string,
+  accepted: readonly PendingRename[],
+): boolean {
+  return connectionsOf(document).some(
+    (row, index) =>
+      (row as { provider?: unknown } | null)?.provider === provider &&
+      !accepted.some((moved) => moved.index === index),
+  );
+}
+
+function connectionsOf(document: ConfigDocument): unknown[] {
+  const config = document.toJSON() as { connections?: unknown } | null;
+  return Array.isArray(config?.connections) ? config.connections : [];
+}
+
+/**
+ * The config of a document the loader has refused, shape-checked only.
+ *
+ * `openSecretStoreFor` needs a `Config` to name the target's adapter, and the
+ * document in hand fails the check that runs *after* the schema — so this is
+ * that parse without it. A document failing the schema itself is beyond this
+ * repair, and says so rather than reporting a rename it cannot see.
+ */
+export function shapeOf(document: ConfigDocument): Config {
+  try {
+    return validateConfigShape(document.toJSON(), document.path);
+  } catch (error) {
+    throw new ConfigError(
+      `${document.path} is malformed beyond a provider rename, so there is nothing to migrate.\n` +
+        `  ${error instanceof Error ? error.message : String(error)}`,
+    );
+  }
+}

--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -277,7 +277,7 @@ export async function run(argv: readonly string[]): Promise<void> {
     case 'plan':
       return plan(global);
     case 'doctor':
-      return doctor({ ...global, json });
+      return doctor({ ...global, json, fix: flags['fix'] === true });
     case 'status':
       return status({ ...global, json });
     case 'outputs':

--- a/src/cli/selection.ts
+++ b/src/cli/selection.ts
@@ -320,6 +320,10 @@ const ACCEPTS: Record<string, readonly string[]> = {
   // the list that decides whether it may be typed.
   'profile remove': ['dry-run', 'yes', 'target'],
   disconnect: ['yes', 'keep-credential'],
+  // The one repair `doctor` can apply rather than only name. Narrow on purpose:
+  // it undoes a provider rename this project shipped, and every other finding
+  // there is something only the operator can decide.
+  doctor: ['fix'],
   relabel: [],
   'target list': ['urls', 'target'],
   'target show': ['target'],

--- a/src/cli/usage.ts
+++ b/src/cli/usage.ts
@@ -127,6 +127,8 @@ ${style.bold('Deploying')}
 ${style.bold('Inspection')}
   ${PROGRAM} check                      static validation, no external calls
   ${PROGRAM} doctor [--json]            credentials resolve, stores reachable
+  ${PROGRAM} doctor --fix               apply a repair it can make itself, such as
+                                        a provider this project renamed under you
   ${PROGRAM} tools [--json]             what the endpoint advertises to a client
   ${PROGRAM} plan                       what reconcile would change
   ${PROGRAM} audit tail [--limit N] [--denied-only] [--format md]

--- a/src/profile/index.ts
+++ b/src/profile/index.ts
@@ -38,10 +38,14 @@ export {
 
 export {
   ConfigError,
+  RENAMED_PROVIDERS,
   loadConfigFile,
   parseConfig,
+  renamedProviderFor,
   validateConfig,
+  validateConfigShape,
   type LoadedConfig,
+  type ProviderRename,
 } from './load.ts';
 
 export {

--- a/src/profile/load.test.ts
+++ b/src/profile/load.test.ts
@@ -274,6 +274,24 @@ describe('a provider whose id has been renamed', () => {
     expect(() => parseConfig(withTasks('work', 'Work'))).toThrow(/set account to Tasks/);
   });
 
+  test('the refusal names the command that applies it, with the selection it needs', () => {
+    // The refusal is at *load*, so it takes every command down with it and the
+    // operator's only way back was to hand-edit YAML. Both flags come off the
+    // document rather than off whatever command tripped over it, because nothing
+    // has resolved anything at this point.
+    expect(() => parseConfig(withTasks('personal', 'personal'))).toThrow(
+      /lanes link doctor --fix --profile personal --target local/,
+    );
+  });
+
+  test('a profile with several targets gets a placeholder rather than a guess', () => {
+    const twoTargets = withTasks('personal', 'personal').replace(
+      '    storage: { adapter: filesystem, path: ./data/personal/files }',
+      '    storage: { adapter: filesystem, path: ./data/personal/files }\n  cloud:\n    credentials: { adapter: gcp-secret-manager, project: p }\n    storage: { adapter: gcs, bucket: b }',
+    );
+    expect(() => parseConfig(twoTargets)).toThrow(/--target <local\|cloud>/);
+  });
+
   test('google_tasks itself is fine, which is the whole point', () => {
     const yaml = VALID.replace(
       '  - id: a\n    provider: example\n    account: Scratch',

--- a/src/profile/load.ts
+++ b/src/profile/load.ts
@@ -40,6 +40,25 @@ export interface LoadedConfig {
  *  4. Referential integrity, which needs a well-formed document to check.
  */
 export function validateConfig(raw: unknown, source = '<config>'): Config {
+  const config = validateConfigShape(raw, source);
+  assertReferentialIntegrity(config, source);
+  return config;
+}
+
+/**
+ * The first three steps, without the fourth.
+ *
+ * Only one caller, and it is the repair: `migrateRenamedProviders` has to open
+ * the credential store of a config that referential integrity has just refused,
+ * because whether a credential is stored is the evidence deciding which of two
+ * readings a row gets. A shape-valid document is enough to name a target's
+ * adapter, and nothing here trusts the part that failed.
+ *
+ * Not exported as a way to *load* a config. Everything that acts on one goes
+ * through `validateConfig`, and the split exists so that the one command whose
+ * job is to fix a refusal is not blocked by it.
+ */
+export function validateConfigShape(raw: unknown, source = '<config>'): Config {
   if (raw === null || typeof raw !== 'object' || Array.isArray(raw)) {
     throw new ConfigError(`${source}: expected a YAML mapping at the top level`);
   }
@@ -59,7 +78,6 @@ export function validateConfig(raw: unknown, source = '<config>'): Config {
     throw new ConfigError(`${source}:\n${formatZodIssues(parsed.error)}`);
   }
 
-  assertReferentialIntegrity(parsed.data, source);
   return parsed.data;
 }
 
@@ -138,15 +156,85 @@ function formatZodIssues(error: z.ZodError): string {
  * are, and keying on `id !== 'main'` would refuse a valid profile forever to
  * catch a one-release migration. Labelling both `Tasks` is consistent with what
  * the accountless providers already do — every memory connection is `Memory`.
+ *
+ * **The refusal names a command, because it is a refusal at load.** Every
+ * command opens the config, so this one takes `status`, `start` and `doctor`
+ * down together and leaves hand-editing YAML as the only way back — for a state
+ * an upgrade put the operator in, without asking. `doctor --fix` is that way
+ * back, and it is named here because this is the only place anyone sees.
  */
-function renamedProvider(connection: { provider: string; account: string }): string | null {
-  if (connection.provider !== 'tasks' || connection.account === 'Tasks') return null;
+export interface ProviderRename {
+  /** What a row naming the old id should say instead. */
+  readonly to: string;
+  /** The account label that means this row is the built-in, not a vendor one. */
+  readonly keeps: string;
+  /** What the plain noun now names, for the sentence below. */
+  readonly becomes: string;
+  /** What it used to name. */
+  readonly was: string;
+  /** The built-in, in the operator's words. */
+  readonly noun: string;
+}
+
+/**
+ * Provider ids that have moved, and everything two places need to agree on.
+ *
+ * `renamedProviderFor` refuses a row still naming the old id; `#cli`'s
+ * `migrateRenamedProviders` rewrites one. A rename landing in one and not the
+ * other is a refusal with no fix, or a fix nothing asks for — which is why the
+ * pair reads from one table rather than each knowing the rename itself.
+ *
+ * `keeps` is the single spelling `newProfileTemplate` and `ensureReservedConnection`
+ * write for the built-in's row. Keep it in step with `RESERVED_SURFACES` there.
+ */
+export const RENAMED_PROVIDERS: Readonly<Record<string, ProviderRename>> = {
+  tasks: {
+    to: 'google_tasks',
+    keeps: 'Tasks',
+    becomes: 'the built-in task list',
+    was: 'Google Tasks',
+    noun: 'task list',
+  },
+};
+
+/**
+ * The repair, spelled with the selection it will refuse without.
+ *
+ * Both flags come off the document being validated rather than off the command
+ * that is running: nothing has resolved anything yet, and the profile is written
+ * in the file. A profile declaring one target names it; one declaring several
+ * cannot be guessed at, and a placeholder is more honest than picking.
+ */
+function repairCommand(config: Config): string {
+  const targets = Object.keys(config.targets);
+  const target = targets.length === 1 ? targets[0] : `<${targets.join('|') || 'target'}>`;
+  return `lanes link doctor --fix --profile ${config.instance.profile} --target ${target}`;
+}
+
+/** The rename a row is owed, or `null` when it is owed none. */
+export function renamedProviderFor(connection: {
+  provider: string;
+  account: string;
+}): ProviderRename | null {
+  const moved = RENAMED_PROVIDERS[connection.provider];
+  if (!moved || connection.account === moved.keeps) return null;
+  return moved;
+}
+
+function renamedProvider(
+  connection: { provider: string; account: string },
+  repair: string,
+): string | null {
+  const moved = renamedProviderFor(connection);
+  if (!moved) return null;
 
   return (
-    `"tasks" is now the built-in task list, and this row is labelled ` +
-    `"${connection.account}" rather than "Tasks".\n` +
-    '  If it was Google Tasks: set provider to google_tasks here, and rename any "tasks.*" policy rule.\n' +
-    '  If it is your own task list: set account to Tasks.'
+    `"${connection.provider}" is now ${moved.becomes}, and this row is labelled ` +
+    `"${connection.account}" rather than "${moved.keeps}".\n` +
+    `  If it was ${moved.was}: set provider to ${moved.to} here, and rename any ` +
+    `"${connection.provider}.*" policy rule.\n` +
+    `  If it is your own ${moved.noun}: set account to ${moved.keeps}.\n` +
+    `  ${repair} applies the first, where a stored credential proves it.`
   );
 }
 
@@ -186,7 +274,7 @@ function assertReferentialIntegrity(config: Config, source: string): void {
     }
     connectionKeys.add(key);
 
-    const renamed = renamedProvider(connection);
+    const renamed = renamedProvider(connection, repairCommand(config));
     if (renamed) problems.push(`connections[${index}]: ${renamed}`);
   });
 


### PR DESCRIPTION
Since v0.5.0:

- Give a renamed provider a migration, so an upgrade is not a brick (#69)

A patch, and taken as the workflow's proposed one rather than set here: nothing about a profile's shape changed and no command is new. `doctor` gains `--fix`, which exists only to deliver the repair.

0.5.0 moved Google Tasks to `google_tasks` and shipped the migration as a refusal in `assertReferentialIntegrity`. That refusal is at config **load**, so a profile still naming the old id stopped answering `status`, `start`, `plan` and `doctor` alike, and the only route back was hand-editing YAML. `lanes link doctor --fix` is now that route, and it moves the connection row, its policy rules and the stored credential together.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
