### PR TITLE
Release 0.5.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lanes-sh/link",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "A self-hostable MCP gateway for all your connections, memory, tasks, files, and secrets",
   "license": "Apache-2.0",
   "homepage": "https://lanes.sh/link",


### PR DESCRIPTION
Merging this publishes 0.5.1 to npm.

Since v0.5.0:

- Give a renamed provider a migration, so an upgrade is not a brick (#69)

0.5.0 moved Google Tasks to `google_tasks` and shipped the migration as a refusal at config load, which took every command for an upgraded profile down with it and left hand-editing YAML as the only way back. `lanes link doctor --fix` is now that way back, moving the connection row, its policy rules and the stored credential together.