### PR TITLE
Let the last connection of a provider be disconnected

### DIFF
--- a/src/cli/commands/connection.test.ts
+++ b/src/cli/commands/connection.test.ts
@@ -287,3 +287,58 @@ describe('the plan reports which providers are reserved', () => {
     expect(drive?.reserved).toBe(false);
   });
 });
+
+/**
+ * The rule goes with the last connection that justified it.
+ *
+ * Not a tidiness feature. `assertReferentialIntegrity` refuses an allow rule
+ * naming a provider with no connection, and `removeConnection` saves through
+ * `validateConfig` — so disconnecting the last account of a provider failed, on
+ * a policy line the operator had not touched, and removed nothing. Every
+ * single-account provider was undisconnectable, which is most of them.
+ */
+describe('disconnecting the last connection of a provider', () => {
+  /** The policy line itself — the template's comments quote `allow: [` too. */
+  const POLICY = 'allow: [memory.*';
+
+  /** The fixture's profile, plus the `gmail.*` rule `connect` would have written. */
+  async function granted(): Promise<string> {
+    const root = await workspace();
+    const path = join(root, 'profiles', 'personal.yaml');
+    const text = await Bun.file(path).text();
+    await Bun.write(path, text.replace(POLICY, 'allow: [gmail.*, gmail.send_message, memory.*'));
+    return root;
+  }
+
+  test('works at all, which is the whole of the bug', async () => {
+    // It did not. `save` validates, and the loader refuses an allow rule naming
+    // a provider with no connection — so removing the last Gmail failed on a
+    // policy line the operator had not touched, and removed nothing.
+    const root = await granted();
+
+    await removeConnection('gmail.main', { ...WHERE, yes: true });
+    await removeConnection('gmail.side', { ...WHERE, yes: true });
+
+    const config = await onDisk(root);
+    expect(keys(config).filter((key) => key.startsWith('gmail.'))).toEqual([]);
+    expect(config.policy.allow.map((rule) => rule.capability)).not.toContain('gmail.*');
+  });
+
+  test('leaves the rule while a sibling still needs it', async () => {
+    const root = await granted();
+    await removeConnection('gmail.side', { ...WHERE, yes: true });
+
+    expect((await onDisk(root)).policy.allow.map((rule) => rule.capability)).toContain('gmail.*');
+  });
+
+  test('never touches a blanket allow, which names no provider', async () => {
+    const root = await workspace();
+    const path = join(root, 'profiles', 'personal.yaml');
+    await Bun.write(path, (await Bun.file(path).text()).replace(POLICY, "allow: ['*', memory.*"));
+
+    await removeConnection('gmail.main', { ...WHERE, yes: true });
+    await removeConnection('gmail.side', { ...WHERE, yes: true });
+
+    expect((await onDisk(root)).policy.allow.map((rule) => rule.capability)).toContain('*');
+  });
+});

--- a/src/cli/commands/connection.ts
+++ b/src/cli/commands/connection.ts
@@ -138,6 +138,57 @@ export function connectionsSharingCredential(
     .map((one) => `${one.provider}.${one.id}`);
 }
 
+/**
+ * Take back the allow rules that named the provider, once nothing declares it.
+ *
+ * Not a tidy-up. `assertReferentialIntegrity` refuses an allow rule naming a
+ * provider with no connection, and `save` validates — so disconnecting the last
+ * connection of a provider *failed*, with a config error about a policy line the
+ * operator had not touched, and nothing removed. Every single-account provider
+ * was undisconnectable, which is most of them: the bug reproduced on `slack.*`
+ * and would have on `bunq.*`, while a profile with two Gmail accounts could
+ * disconnect one perfectly well.
+ *
+ * Symmetry is the argument for removing rather than warning. `connect` writes
+ * the row *and* the rule, and the pair is what `config-repair.ts` calls both
+ * halves or neither — a rule with nothing behind it grants nothing and is what
+ * that file exists to stop being written.
+ *
+ * `allow: ['*']` is untouched: it names no provider, so nothing about it becomes
+ * false. Narrower rules go with the wide one — `gmail.send_message` is as
+ * dangling as `gmail.*` once the last Gmail is gone, and the loader refuses it
+ * for the same reason.
+ *
+ * `deny` is left alone, deliberately. The loader permits a deny naming a
+ * provider with no connection, because denying something you have not connected
+ * yet is a reasonable thing to write ahead of time — and removing it here would
+ * silently re-permit whatever it covered if the account came back.
+ */
+function dropProviderRules(document: ConfigDocument, config: Config, index: number): void {
+  const going = config.connections[index];
+  if (!going) return;
+
+  const stillDeclared = config.connections.some(
+    (one, i) => i !== index && one.provider === going.provider,
+  );
+  if (stillDeclared) return;
+
+  const rules = document.getIn(['policy', 'allow']) as { items?: unknown[] } | null;
+  const doomed: number[] = [];
+
+  (rules?.items ?? []).forEach((_rule, at) => {
+    const bare = document.getIn(['policy', 'allow', at]);
+    const capability =
+      typeof bare === 'string' ? bare : document.getIn(['policy', 'allow', at, 'capability']);
+    if (typeof capability !== 'string') return;
+
+    if (capability.split('.')[0] === going.provider) doomed.push(at);
+  });
+
+  // Descending, so each removal cannot move the index of one still to come.
+  for (const at of doomed.reverse()) document.removeFrom(['policy', 'allow'], at);
+}
+
 export async function removeConnection(
   key: string,
   flags: DisconnectFlags,
@@ -162,6 +213,10 @@ export async function removeConnection(
     // running `connect`. The reverse — credential gone, declaration kept, edit
     // failed — is the same state, so ordering costs nothing either way; doing the
     // edit first means the file is right even if the store is unreachable.
+    // Both edits before the one `save`, so the file is never written in the
+    // state where the row is gone and the rule that named it is not — which is
+    // the state the loader refuses.
+    dropProviderRules(document, config, located.index);
     document.removeFrom(['connections'], located.index);
     await document.save();
 


### PR DESCRIPTION
`disconnect` removed the connection row and saved, and `save` validates. `assertReferentialIntegrity` refuses an allow rule naming a provider with no connection — so removing the **last** account of a provider failed on a policy line the operator had never touched, and removed nothing:

```
error  profiles/personal.yaml:
  policy.allow[7]: "slack.*" names provider "slack", which has no connection (have: setup, gmail, drive, …)
```

Every single-account provider was undisconnectable, which is most of them. A profile with two Gmail accounts could disconnect one perfectly well — which is why the fixture never caught it: the failure needs the last one to go.

## The fix

The rule goes with it. `connect` writes the row and the rule together, and `config-repair.ts` already calls that pair both halves or neither. Removed now means removed; connecting again starts from the beginning, which is what `connect` has always done.

- Narrower rules go with the wide one — `gmail.send_message` is as dangling as `gmail.*` once the last Gmail is gone.
- `allow: ['*']` is untouched: it names no provider, so nothing about it became false.
- `deny` is untouched: the loader permits a deny against a provider you have not connected, and taking it back would silently re-permit what it covered if the account returned.

Not reported as its own outcome — the rule going is how "removed" is spelled in the file, not a second thing that happened.

## Verification

`bun test` 2501 pass / 0 fail (2498 before), `bun run typecheck` clean. Three new tests; the first fails with the fix commented out, which is the check that it pins the bug rather than the behaviour.

Also run against a disposable copy of the profile this was found on: `relabel` then `disconnect` of the last `bunq` account both exit 0, the file diff is exactly the row and its allow rule, comments intact, and the profile still loads.

Found by verifying #69 against the profile it was written for — with the config loading again, this was the next thing in the way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
