### PR TITLE
Release 0.5.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lanes-sh/link",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "description": "A self-hostable MCP gateway for all your connections, memory, tasks, files, and secrets",
   "license": "Apache-2.0",
   "homepage": "https://lanes.sh/link",


### PR DESCRIPTION
Merging this publishes 0.5.2 to npm.

Since v0.5.1:

- Let the last connection of a provider be disconnected (#72)

`disconnect` left the `<provider>.*` allow rule behind and `save` validates, so removing the last account of a provider failed on a policy line the operator had never touched. The rule now goes with it.