### PR TITLE
Release: update repairs the owner layer

### DIFF
--- a/src/cli/commands/update.ts
+++ b/src/cli/commands/update.ts
@@ -1,6 +1,7 @@
 import { homedir } from 'node:os';
 import { join, sep } from 'node:path';
-import { installRoot } from '#profile';
+import { installRoot, resolveWorkspaceRoot } from '#profile';
+import { repairOwnerLayer } from '../config-repair.ts';
 import { emit, fail, ok, print, printErr, progress, style, warn } from '../output.ts';
 import { PACKAGE, release, type ReleaseState } from '../release.ts';
 import { version } from '../version.ts';
@@ -151,6 +152,27 @@ export async function update(flags: UpdateFlags): Promise<void> {
   // unreachable registry is not that state — failing a build because a network
   // was down would make this the flakiest check in it.
   if (flags.check === true && decision.action === 'install') process.exitCode = 1;
+
+  // Whatever the registry said, and before the branch that returns early.
+  //
+  // `start`, `connect` and `deploy` already repair a profile that is missing
+  // part of the owner layer, and for months that was enough. It is not: a
+  // release that adds a surface — `tasks` and `assets` in 0.5.0 — leaves every
+  // existing profile without it until one of those three next runs, and someone
+  // who serves their endpoint from elsewhere may run none of them for weeks. The
+  // page they look at meanwhile offers to *add* what they already have,
+  // which is where this was reported from.
+  //
+  // `update` is the command that means "bring me current", so it is the honest
+  // place for the other half of current. Not on `--check`, which is a question
+  // and must not write, and not conditional on an install having happened: the
+  // profile of someone already on the latest version is exactly the one this was
+  // reported against.
+  if (flags.check !== true) {
+    await repairOwnerLayer(resolveWorkspaceRoot(), undefined, {
+      ...(flags.json === true ? { report: progress } : {}),
+    });
+  }
 
   const report = {
     installed: current.installed,

--- a/src/cli/config-repair.ts
+++ b/src/cli/config-repair.ts
@@ -261,7 +261,14 @@ export function ensureIdentityConnection(document: ConfigDocument): SurfaceRepai
 export async function repairOwnerLayer(
   workspaceRoot: string,
   profiles: readonly string[] | undefined,
+  options: { report?: (line: string) => void } = {},
 ): Promise<void> {
+  // stdout by default, because every caller but one is printing a report a
+  // person reads. `update --json` passes `progress` instead: what it produces is
+  // a document, and a line of prose in front of it corrupts whatever is parsing.
+  // Routed rather than silenced — nothing else here widens a policy without
+  // saying so, and this must not be the exception.
+  const say = options.report ?? print;
   const wanted = profiles === undefined ? undefined : new Set(profiles);
 
   for (const name of await listProfiles(workspaceRoot)) {
@@ -274,13 +281,13 @@ export async function repairOwnerLayer(
 
       await document.save();
 
-      print(ok(`gave ${style.bold(name)} its own owner layer`));
-      for (const change of repairLines(repair)) print(`      ${style.dim(change)}`);
-      print(
+      say(ok(`gave ${style.bold(name)} its own owner layer`));
+      for (const change of repairLines(repair)) say(`      ${style.dim(change)}`);
+      say(
         `      ${style.dim('memory, tasks, assets, skills, vault and setup — your own material, no account behind any of them')}`,
       );
     } catch (error) {
-      print(
+      say(
         warn(
           `could not give ${name} its owner layer: ${error instanceof Error ? error.message.split('\n')[0] : String(error)}`,
         ),

--- a/src/deployments/deploy.test.ts
+++ b/src/deployments/deploy.test.ts
@@ -167,6 +167,20 @@ policy:
     expect(await has(root, 'work')).toBe(false);
   });
 
+  test('reports where it is told to, so a --json caller keeps its stdout', async () => {
+    // `lanes link update` repairs on the way past and can be asked for a
+    // document. The repair still says what it widened — a policy edit nobody
+    // asked for is not a thing to do quietly — it just says it somewhere that
+    // does not corrupt the answer.
+    const root = await workspace('personal');
+    const lines: string[] = [];
+
+    await repairOwnerLayer(root, undefined, { report: (line) => lines.push(line) });
+
+    expect(await has(root, 'personal')).toBe(true);
+    expect(lines.join('\n')).toContain('owner layer');
+  });
+
   test('a profile that already has it is left byte-identical', async () => {
     const root = await workspace('personal');
     await repairOwnerLayer(root, undefined);


### PR DESCRIPTION
Since v0.5.2:

- Repair the owner layer on update, not only on start (#75)

A release that adds a surface — `tasks` and `assets` in 0.5.0 — left every existing profile without it until `start`, `connect` or `deploy` next ran. `lanes link update` now does the repair too: not on `--check`, and not conditional on an install having happened, because the profile of someone already on the latest version is exactly the one this was reported against.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
