### PR TITLE
Release 0.5.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lanes-sh/link",
-  "version": "0.5.3",
+  "version": "0.5.4",
   "description": "A self-hostable MCP gateway for all your connections, memory, tasks, files, and secrets",
   "license": "Apache-2.0",
   "homepage": "https://lanes.sh/link",


### PR DESCRIPTION
**Merging this publishes 0.5.4 to npm.** That is the irreversible step, and it is yours to take.

Since v0.5.3:

- Ask what to call a connection, and give the answer somewhere to live (#78)

`connect` now asks what to call a connection on every interactive run, offering the account it just
resolved — press Enter and it takes the account, writing no `label` line at all.

The bug it fixes is live in 0.5.3: `lanes link relabel` wrote over `account`, which three things read
as an identity — the reconnect match in `settleIdentity`, the connection id derived from it, and the
`From` header `gmail.send_message` writes. Renaming a connection therefore left a row the next
`connect` no longer recognised, and appended a second one beside it.

After merging, fast-forward `develop` — nothing in the workflow does it:

```console
$ git push origin origin/main:refs/heads/develop
$ git rev-list --count origin/main..origin/develop   # expect 0
$ git rev-list --count origin/develop..origin/main   # expect 0
```