### PR TITLE
Release 0.6.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lanes-sh/link",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "A self-hostable MCP gateway for all your connections, memory, tasks, files, and secrets",
   "license": "Apache-2.0",
   "homepage": "https://lanes.sh/link",

--- a/src/cli/migrate-plan.ts
+++ b/src/cli/migrate-plan.ts
@@ -1,0 +1,160 @@
+import { ConfigError, layout, isRemoteWorkspace, type LegacyTarget, type WorkspaceTarget } from '#profile';
+import { deployedWorkspace } from '#deployments/upload.ts';
+
+/**
+ * What one contract-1 target block becomes, and where.
+ *
+ * Apart from `workspace-migrate.ts`, which reads and writes: this is the
+ * decision, and it is the half that has been wrong twice. Both times the shape
+ * was right and the *perspective* was not — the same `cloud:` block is a pointer
+ * seen from a laptop and a declaration seen from inside the bucket, and a
+ * migration that cannot tell which end it is on writes `gs://b` pointing at
+ * `gs://b`.
+ *
+ * So the workspace being migrated is an argument to every function here, and the
+ * tests drive them directly.
+ */
+
+/**
+ * Every profile's target blocks, folded into one registry.
+ *
+ * Two refusals rather than guesses, because both are cases where one target
+ * would need two different answers and picking either silently is the class of
+ * bug this whole change is about.
+ */
+export async function hoist(
+  legacy: readonly { profile: string; targets: Record<string, LegacyTarget> }[],
+  workspaceRoot: string,
+): Promise<Record<string, WorkspaceTarget>> {
+  const registry: Record<string, WorkspaceTarget> = {};
+  const seenFrom: Record<string, string> = {};
+
+  for (const { profile, targets } of legacy) {
+    for (const [name, declared] of Object.entries(targets)) {
+      const entry = toEntry(name, declared, profile, workspaceRoot);
+      if (entry === null) continue;
+      const previous = registry[name];
+
+      if (previous === undefined) {
+        registry[name] = entry;
+        seenFrom[name] = profile;
+        continue;
+      }
+
+      if (JSON.stringify(previous) !== JSON.stringify(entry)) {
+        throw new ConfigError(
+          `Profiles "${seenFrom[name]}" and "${profile}" both declare target "${name}", and they ` +
+            `do not agree.\n` +
+            `  A target is declared once by the workspace it lives in (ADR-052), so one of these\n` +
+            `  has to win and this cannot pick.\n\n` +
+            `    ${seenFrom[name]}: ${summarise(previous)}\n` +
+            `    ${profile}: ${summarise(entry)}\n\n` +
+            `  Edit one of them to match the other, then run this again.`,
+        );
+      }
+    }
+  }
+
+  return registry;
+}
+
+/**
+ * One contract-1 target block as a registry entry.
+ *
+ * A block whose storage names a bucket becomes a pointer: that bucket is a
+ * workspace, it holds the profiles served there, and under ADR-052 it is the
+ * thing that declares the target. The adapters are not copied into the pointer —
+ * they travel to the bucket on the next `deploy`, which is the only command that
+ * can write there and roll an image that understands what it wrote.
+ *
+ * Per-profile paths are dropped when they are the layout defaults, which is the
+ * ordinary case: `./data/<profile>` and `./data/<profile>/credentials.enc` are
+ * exactly what `layout.ts` derives, so a workspace-level target that omits them
+ * addresses the same bytes. A genuinely custom path cannot be hoisted — one
+ * target cannot hold a different path per profile — and is refused by name.
+ */
+export function toEntry(
+  name: string,
+  declared: LegacyTarget,
+  profile: string,
+  workspaceRoot: string,
+): WorkspaceTarget | null {
+  const remote = deployedWorkspace(declared);
+
+  // **A target whose bucket is the workspace being migrated declares itself.**
+  //
+  // Migrating happens on both ends, and the second one is inside the bucket: the
+  // profile there carries the same `cloud` block, and deriving a pointer from it
+  // produces `gs://b` pointing at `gs://b`. That is a loop, and `openTarget`
+  // refuses it — which made `deploy` unable to run against the bucket it had
+  // just migrated, on the one command the refusal names as the fix.
+  if (remote && remote !== workspaceRoot) return { workspace: remote };
+
+  // **A filesystem target is dropped from a remote workspace.**
+  //
+  // The bucket's copy of a profile was uploaded from a laptop, so it carries
+  // that laptop's `local:` block — paths under `./data/` that address a disk the
+  // endpoint has never seen. Hoisting it would leave the bucket declaring a
+  // target it can never open, and `workspacePath` refuses that combination the
+  // moment anything tries.
+  //
+  // Nothing is lost: the machine that owns `local` has its own copy, and that is
+  // the one that was ever real.
+  if (isRemoteWorkspace(workspaceRoot) && declared.storage.adapter === 'filesystem') return null;
+
+  const storagePath = declared.storage.path;
+  const credentialsPath = declared.credentials.path;
+
+  const defaultStorage = `./${layout.blobs(profile)}`;
+  const defaultCredentials = `./${layout.credentials(profile)}`;
+
+  refuseCustomPath(name, profile, workspaceRoot, 'storage.path', storagePath, defaultStorage);
+  refuseCustomPath(
+    name,
+    profile,
+    workspaceRoot,
+    'credentials.path',
+    credentialsPath,
+    defaultCredentials,
+  );
+
+  const { path: _storage, ...storage } = declared.storage;
+  const { path: _credentials, ...credentials } = declared.credentials;
+
+  return {
+    credentials,
+    storage,
+    ...(declared.audit ? { audit: declared.audit } : {}),
+    ...(declared.vault ? { vault: declared.vault } : {}),
+    ...(declared.deploy ? { deploy: declared.deploy } : {}),
+  };
+}
+
+function refuseCustomPath(
+  target: string,
+  profile: string,
+  workspaceRoot: string,
+  field: string,
+  value: string | undefined,
+  expected: string,
+): void {
+  if (value === undefined) return;
+  // Both spellings of the same directory: `./data/personal` and `data/personal`
+  // resolve identically and the template has written each at different times.
+  if (value === expected || value === expected.replace(/^\.\//, '')) return;
+
+  throw new ConfigError(
+    `Profile "${profile}" declares target "${target}" with a custom ${field}:\n` +
+      `    ${value}\n` +
+      `  A target is declared once for the whole workspace now (ADR-052), so it cannot hold a\n` +
+      `  different path per profile. The default it would get is ${expected}.\n\n` +
+      `  Move the data there and delete the line, or keep this profile in a workspace of its\n` +
+      `  own: LANES_LINK_HOME=${workspaceRoot}/<somewhere> lanes link profile add ${profile} --target ${target}`,
+  );
+}
+
+export function summarise(entry: WorkspaceTarget): string {
+  if (entry.workspace !== undefined) return `points at ${entry.workspace}`;
+  const parts = [entry.credentials?.adapter, entry.storage?.adapter].filter(Boolean);
+  return `${parts.join(' + ')}${entry.deploy ? `, deploys ${entry.deploy.service}` : ''}`;
+}

--- a/src/cli/workspace-migrate.test.ts
+++ b/src/cli/workspace-migrate.test.ts
@@ -1,0 +1,163 @@
+import { afterAll, describe, expect, test } from 'bun:test';
+import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { legacyTargetSchema, readRegistry } from '#profile';
+import { migrateWorkspace, needsMigration } from './workspace-migrate.ts';
+import { toEntry } from './migrate-plan.ts';
+
+/**
+ * Contract 1 → 2, against the shapes a real workspace actually holds.
+ *
+ * Every case here is one that got through review and was caught by running the
+ * thing against a live bucket, which is the argument for the file existing: the
+ * migration reads somebody's only copy of where their accounts are, and its
+ * failures are the quiet kind.
+ */
+
+const roots: string[] = [];
+
+/** A contract-1 profile declaring the given target blocks. */
+const legacy = (profile: string, targets: string): string =>
+  `contract: 1\ninstance:\n  profile: ${profile}\n  default_target: local\ntargets:\n${targets}` +
+  `connections:\n  - { id: main, provider: setup, account: Setup }\npolicy:\n  allow: [setup.*]\n`;
+
+const LOCAL = `  local:\n    credentials: { adapter: file, path: ./data/PROFILE/credentials.enc }\n    storage: { adapter: filesystem, path: ./data/PROFILE }\n`;
+
+const CLOUD = `  cloud:\n    credentials: { adapter: gcp-secret-manager, project: my-project }\n    storage: { adapter: gcs, bucket: personal-lanes }\n    vault: { adapter: secret }\n`;
+
+async function workspace(
+  profiles: Record<string, string>,
+  file = 'contract: 1\ndefault_profile: personal\n',
+): Promise<string> {
+  const root = await mkdtemp(join(tmpdir(), 'lanes-link-migrate-'));
+  roots.push(root);
+  await mkdir(join(root, 'profiles'), { recursive: true });
+  await writeFile(join(root, 'lanes-link.yaml'), file);
+  for (const [name, body] of Object.entries(profiles)) {
+    await writeFile(join(root, 'profiles', `${name}.yaml`), body);
+  }
+  return root;
+}
+
+afterAll(async () => {
+  await Promise.all(roots.map((root) => rm(root, { recursive: true, force: true })));
+});
+
+describe('hoisting a profile’s targets into the workspace', () => {
+  test('a local target is declared here and a bucket becomes a pointer', async () => {
+    const root = await workspace({
+      personal: legacy('personal', LOCAL.replaceAll('PROFILE', 'personal') + CLOUD),
+    });
+
+    await migrateWorkspace(root);
+    const registry = await readRegistry(root);
+
+    expect(registry['local']?.storage?.adapter).toBe('filesystem');
+    expect(registry['cloud']?.workspace).toBe('gs://personal-lanes');
+    expect(registry['cloud']?.storage).toBeUndefined();
+  });
+
+  test('the profile keeps everything except its targets', async () => {
+    const root = await workspace({
+      personal: legacy('personal', LOCAL.replaceAll('PROFILE', 'personal')),
+    });
+
+    await migrateWorkspace(root);
+    const written = await readFile(join(root, 'profiles', 'personal.yaml'), 'utf8');
+
+    expect(written).toContain('contract: 2');
+    expect(written).not.toContain('targets:');
+    expect(written).not.toContain('default_target');
+    expect(written).toContain('provider: setup');
+  });
+
+  test('two profiles declaring one target disagree loudly rather than silently', async () => {
+    const other = `  cloud:\n    credentials: { adapter: gcp-secret-manager, project: other }\n    storage: { adapter: gcs, bucket: someone-else }\n`;
+    const root = await workspace({
+      personal: legacy('personal', CLOUD),
+      work: legacy('work', other),
+    });
+
+    await expect(migrateWorkspace(root)).rejects.toThrow(/do not agree/);
+  });
+
+  test('a custom path is refused, because one target cannot hold two', async () => {
+    const custom = `  local:\n    credentials: { adapter: file, path: ./data/personal/credentials.enc }\n    storage: { adapter: filesystem, path: ./somewhere-else }\n`;
+    const root = await workspace({ personal: legacy('personal', custom) });
+
+    await expect(migrateWorkspace(root)).rejects.toThrow(/custom storage.path/);
+  });
+});
+
+describe('migrating the workspace a target already lives in', () => {
+  /**
+   * The bucket's own copy, which is the second end of the same migration.
+   *
+   * Against `toEntry` rather than the whole run, because the decision under test
+   * is "what does *this* workspace make of this target block" and the only thing
+   * that varies is which workspace is asking. Driving it through
+   * `migrateWorkspace` would need a real bucket to be the root.
+   */
+  const parse = (yaml: string) =>
+    legacyTargetSchema.parse({
+      credentials: { adapter: 'gcp-secret-manager', project: 'my-project' },
+      storage: { adapter: 'gcs', bucket: 'personal-lanes' },
+      vault: { adapter: 'secret' },
+      ...(yaml === 'filesystem'
+        ? { credentials: { adapter: 'file' }, storage: { adapter: 'filesystem' } }
+        : {}),
+    });
+
+  test('a target whose bucket is this workspace declares itself, never points at itself', () => {
+    // From a laptop the same block is a pointer; from inside the bucket it is the
+    // declaration. Getting this wrong wrote `gs://b` pointing at `gs://b`, which
+    // `openTarget` refuses as a loop — leaving `deploy` unable to run against the
+    // bucket it had just migrated, on the one command the refusal names as the fix.
+    const fromLaptop = toEntry('cloud', parse('gcs'), 'personal', '/Users/x/.lanes-link');
+    expect(fromLaptop?.workspace).toBe('gs://personal-lanes');
+
+    const fromBucket = toEntry('cloud', parse('gcs'), 'personal', 'gs://personal-lanes');
+    expect(fromBucket?.workspace).toBeUndefined();
+    expect(fromBucket?.storage?.bucket).toBe('personal-lanes');
+  });
+
+  test('and a filesystem target is dropped, because a bucket can never open one', () => {
+    // The bucket's copy of a profile was uploaded from a laptop, so it carries
+    // that laptop's `local:` block — paths on a disk the endpoint has never seen.
+    expect(toEntry('local', parse('filesystem'), 'personal', 'gs://personal-lanes')).toBeNull();
+
+    // On the machine that owns it, it is kept.
+    expect(toEntry('local', parse('filesystem'), 'personal', '/Users/x/.lanes-link')).not.toBeNull();
+  });
+});
+
+describe('reporting without writing', () => {
+  test('apply: false changes nothing on disk', async () => {
+    // `deploy --dry-run` runs this, and a dry run that migrated a bucket for real
+    // is how the live endpoint in front of one stopped being able to read it.
+    const root = await workspace({
+      personal: legacy('personal', LOCAL.replaceAll('PROFILE', 'personal') + CLOUD),
+    });
+    const before = await readFile(join(root, 'profiles', 'personal.yaml'), 'utf8');
+
+    const plan = await migrateWorkspace(root, { apply: false });
+
+    expect(plan.alreadyCurrent).toBe(false);
+    expect(plan.changes.length).toBeGreaterThan(0);
+    expect(await readFile(join(root, 'profiles', 'personal.yaml'), 'utf8')).toBe(before);
+    expect(await readRegistry(root)).toEqual({});
+    expect(await needsMigration(root)).toBe(true);
+  });
+
+  test('a workspace already at contract 2 is a no-op that says so', async () => {
+    const root = await workspace({ personal: legacy('personal', LOCAL.replaceAll('PROFILE', 'personal')) });
+    await migrateWorkspace(root);
+
+    const again = await migrateWorkspace(root);
+
+    expect(again.alreadyCurrent).toBe(true);
+    expect(again.changes).toEqual([]);
+    expect(await needsMigration(root)).toBe(false);
+  });
+});

--- a/src/cli/workspace-migrate.ts
+++ b/src/cli/workspace-migrate.ts
@@ -6,6 +6,7 @@ import {
   layout,
   listProfiles,
   readWorkspaceFile,
+  isRemoteWorkspace,
   workspaceFiles,
   isLegacyProfile,
   legacyConfigSchema,
@@ -13,8 +14,8 @@ import {
   type LegacyTarget,
   type WorkspaceTarget,
 } from '#profile';
-import { deployedWorkspace } from '#deployments/upload.ts';
 import { ConfigDocument } from './config-edit.ts';
+import { hoist, summarise } from './migrate-plan.ts';
 
 /**
  * Contract 1 → 2: the target moves out of the profile and into the workspace.
@@ -169,123 +170,6 @@ export async function migrateWorkspace(
 }
 
 /**
- * Every profile's target blocks, folded into one registry.
- *
- * Two refusals rather than guesses, because both are cases where one target
- * would need two different answers and picking either silently is the class of
- * bug this whole change is about.
- */
-async function hoist(
-  legacy: readonly { profile: string; targets: Record<string, LegacyTarget> }[],
-  workspaceRoot: string,
-): Promise<Record<string, WorkspaceTarget>> {
-  const registry: Record<string, WorkspaceTarget> = {};
-  const seenFrom: Record<string, string> = {};
-
-  for (const { profile, targets } of legacy) {
-    for (const [name, declared] of Object.entries(targets)) {
-      const entry = toEntry(name, declared, profile, workspaceRoot);
-      const previous = registry[name];
-
-      if (previous === undefined) {
-        registry[name] = entry;
-        seenFrom[name] = profile;
-        continue;
-      }
-
-      if (JSON.stringify(previous) !== JSON.stringify(entry)) {
-        throw new ConfigError(
-          `Profiles "${seenFrom[name]}" and "${profile}" both declare target "${name}", and they ` +
-            `do not agree.\n` +
-            `  A target is declared once by the workspace it lives in (ADR-052), so one of these\n` +
-            `  has to win and this cannot pick.\n\n` +
-            `    ${seenFrom[name]}: ${summarise(previous)}\n` +
-            `    ${profile}: ${summarise(entry)}\n\n` +
-            `  Edit one of them to match the other, then run this again.`,
-        );
-      }
-    }
-  }
-
-  return registry;
-}
-
-/**
- * One contract-1 target block as a registry entry.
- *
- * A block whose storage names a bucket becomes a pointer: that bucket is a
- * workspace, it holds the profiles served there, and under ADR-052 it is the
- * thing that declares the target. The adapters are not copied into the pointer —
- * they travel to the bucket on the next `deploy`, which is the only command that
- * can write there and roll an image that understands what it wrote.
- *
- * Per-profile paths are dropped when they are the layout defaults, which is the
- * ordinary case: `./data/<profile>` and `./data/<profile>/credentials.enc` are
- * exactly what `layout.ts` derives, so a workspace-level target that omits them
- * addresses the same bytes. A genuinely custom path cannot be hoisted — one
- * target cannot hold a different path per profile — and is refused by name.
- */
-function toEntry(
-  name: string,
-  declared: LegacyTarget,
-  profile: string,
-  workspaceRoot: string,
-): WorkspaceTarget {
-  const remote = deployedWorkspace(declared);
-  if (remote) return { workspace: remote };
-
-  const storagePath = declared.storage.path;
-  const credentialsPath = declared.credentials.path;
-
-  const defaultStorage = `./${layout.blobs(profile)}`;
-  const defaultCredentials = `./${layout.credentials(profile)}`;
-
-  refuseCustomPath(name, profile, workspaceRoot, 'storage.path', storagePath, defaultStorage);
-  refuseCustomPath(
-    name,
-    profile,
-    workspaceRoot,
-    'credentials.path',
-    credentialsPath,
-    defaultCredentials,
-  );
-
-  const { path: _storage, ...storage } = declared.storage;
-  const { path: _credentials, ...credentials } = declared.credentials;
-
-  return {
-    credentials,
-    storage,
-    ...(declared.audit ? { audit: declared.audit } : {}),
-    ...(declared.vault ? { vault: declared.vault } : {}),
-    ...(declared.deploy ? { deploy: declared.deploy } : {}),
-  };
-}
-
-function refuseCustomPath(
-  target: string,
-  profile: string,
-  workspaceRoot: string,
-  field: string,
-  value: string | undefined,
-  expected: string,
-): void {
-  if (value === undefined) return;
-  // Both spellings of the same directory: `./data/personal` and `data/personal`
-  // resolve identically and the template has written each at different times.
-  if (value === expected || value === expected.replace(/^\.\//, '')) return;
-
-  throw new ConfigError(
-    `Profile "${profile}" declares target "${target}" with a custom ${field}:\n` +
-      `    ${value}\n` +
-      `  A target is declared once for the whole workspace now (ADR-052), so it cannot hold a\n` +
-      `  different path per profile. The default it would get is ${expected}.\n\n` +
-      `  Move the data there and delete the line, or keep this profile in a workspace of its\n` +
-      `  own: LANES_LINK_HOME=${workspaceRoot}/<somewhere> lanes link profile add ${profile} --target ${target}`,
-  );
-}
-
-/**
  * Write the registry into the workspace file, creating it when absent.
  *
  * The whole object is assembled in plain JS and set once. Setting `targets` and
@@ -349,12 +233,6 @@ function describe(
       ? { name, kind: 'pointer' as const, where: entry.workspace }
       : { name, kind: 'declared' as const },
   );
-}
-
-function summarise(entry: WorkspaceTarget): string {
-  if (entry.workspace !== undefined) return `points at ${entry.workspace}`;
-  const parts = [entry.credentials?.adapter, entry.storage?.adapter].filter(Boolean);
-  return `${parts.join(' + ')}${entry.deploy ? `, deploys ${entry.deploy.service}` : ''}`;
 }
 
 /**

--- a/src/deployments/deploy.ts
+++ b/src/deployments/deploy.ts
@@ -1,6 +1,7 @@
 import {
   ConfigError,
   recordTarget,
+  resolveTargetWorkspace,
   resolveWorkspaceRoot,
   type DeployConfig,
 } from '#profile';
@@ -61,6 +62,23 @@ export interface DeployFlags extends GlobalFlags {
 }
 
 export async function deploy(flags: DeployFlags): Promise<void> {
+  // **The target's own workspace is migrated before anything resolves it.**
+  //
+  // This is the first thing the command does, and it has to be. `deploy` is what
+  // the refusal on a contract-1 bucket tells you to run — and every other read of
+  // that bucket goes through `openTarget`, which refuses it for the same reason.
+  // Migrating after resolution made the instruction circular: the command named
+  // as the fix could not get past the problem it fixes.
+  //
+  // `resolveTargetWorkspace` is the one lookup that does not need the far end to
+  // declare anything: it reads this machine's pointer and stops. So the bucket is
+  // located, migrated, and only then opened.
+  //
+  // Idempotent, and silent on a workspace already at contract 2 — a listing and
+  // no writes. `--dry-run` reports what it would do and writes nothing, like
+  // every other step of this command.
+  if (!(await migrateTargetWorkspace(requireTargetFlag(flags), flags.dryRun !== true))) return;
+
   // The one command allowed to name a target that does not exist yet: creating
   // it is what a first deploy is for.
   //
@@ -258,21 +276,13 @@ export async function deploy(flags: DeployFlags): Promise<void> {
 
     // **The bucket's own migration, here and nowhere else.**
     //
-    // Contract 1 is not read by this binary at all (ADR-052), so the moment a
-    // bucket becomes contract 2 the revision in front of it stops being able to
-    // read its own config. Doing it here puts that window between an upload and
-    // a rollout that are seconds apart, rather than leaving it open until
-    // somebody happens to redeploy.
-    //
-    // After the upload, because the upload is what puts the profiles there for
-    // it to migrate. Idempotent, so a bucket already at contract 2 costs one
+    // A second pass, and it is not redundant. The one at the top of the command
+    // migrated whatever the bucket already held; this catches what the upload
+    // just put there — profiles from a workspace that is itself at contract 2
+    // arrive migrated, but a first deploy of a *newly created* bucket writes
+    // them here for the first time. Idempotent, so the ordinary case is one
     // listing and no writes.
-    const migrated = await migrateWorkspace(workspace);
-    if (!migrated.alreadyCurrent) {
-      heading('Migrated');
-      for (const change of migrated.changes) print(`  ${change}`);
-      print(style.dim('  The revision below is the first that can read it.'));
-    }
+    await migrateWorkspace(workspace, { apply: true });
 
     // **The target hands itself over to the workspace it now lives in.**
     //
@@ -329,4 +339,43 @@ function requireTargetFlag(flags: DeployFlags): string {
     throw new ConfigError('--target is required. It names the deployment this acts on.');
   }
   return flags.target;
+}
+
+/**
+ * Bring a target's own workspace to the current contract, before it is opened.
+ *
+ * Deliberately tolerant of a target this workspace has no pointer for: that is a
+ * first deploy, where there is nothing to migrate and `deploy` is about to create
+ * the workspace itself.
+ *
+ * Narrated when it does something. This rewrites every profile in somebody's
+ * bucket, and a command that reshapes that silently is one they cannot audit
+ * afterwards.
+ */
+async function migrateTargetWorkspace(target: string, apply: boolean): Promise<boolean> {
+  const root = resolveWorkspaceRoot();
+
+  const workspace = await resolveTargetWorkspace(root, target).catch(() => null);
+  if (workspace === null || workspace === root) return true;
+
+  const migrated = await migrateWorkspace(workspace, { apply });
+  if (migrated.alreadyCurrent) return true;
+
+  heading(apply ? 'Migrated' : 'Would migrate');
+  print(style.dim(`  ${workspace}`));
+  for (const change of migrated.changes) print(`  ${change}`);
+  if (apply) {
+    print(style.dim('  The revision this deploy rolls is the first that can read it.'));
+    return true;
+  }
+
+  // A dry run stops here rather than pressing on to survey and plan. Everything
+  // past this point opens the target, and the target is not readable until the
+  // migration above has actually happened — so continuing would report a second,
+  // confusing refusal about the thing the first paragraph just offered to fix.
+  print(style.dim('  Nothing was written, and nothing else was checked: the rest of this'));
+  print(style.dim('  command opens the target, which is not readable until this has run.'));
+  print('');
+  print(style.dim(`  Run it for real:  lanes link deploy --target ${target}`));
+  return false;
 }


### PR DESCRIPTION
Merging this to `main` publishes **0.6.1** to npm.

## Since v0.6.0

- Let deploy migrate the bucket it is about to be refused by (#83)

A patch, and the three faults in it are all the same shape: 0.6.0's migration was written against fixtures and met a live deployment for the first time afterwards.

- `deploy` could not run against the contract-1 bucket it was the named fix for — every read of one goes through `openTarget`, which refuses it.
- `--dry-run` migrated a live workspace for real, leaving the revision in front of it unable to read its own config.
- Migrating a bucket derived a pointer from that bucket to itself, which `openTarget` refuses as a loop.

## If you already ran 0.6.0

`lanes link deploy --target <name> --dry-run` against a deployed target **migrated that workspace**, despite the flag. The revision in front of it cannot read the result until a real deploy rolls a new image. `lanes link deploy --target <name>` fixes it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
