### PR TITLE
Stop a deploy writing this machine's pointer into the target it deploys

### DIFF
--- a/src/cli/commands/operate/migrate.ts
+++ b/src/cli/commands/operate/migrate.ts
@@ -42,16 +42,24 @@ export async function migratedRenamedProviders(
 ): Promise<boolean> {
   if (!(refusal instanceof ConfigError)) return false;
 
-  const selection = await resolveSelection({ profileFlag: flags.profile });
-  const document = await ConfigDocument.open(selection.workspaceRoot, selection.profile);
+  // **The target's workspace, not this machine's.** `resolveSelection` defaults
+  // to the local root, which is where this looked before ADR-052 — and there was
+  // only one place a profile could be. The row that needs renaming is in the
+  // file the *named target* holds, so a bucket's stale row was invisible from
+  // here while the refusal kept naming this command as the fix.
+  const target = flags.target ?? '';
+  const localRoot = resolveWorkspaceRoot();
+  const root = await resolveTargetWorkspace(localRoot, target).catch(() => localRoot);
+
+  const selection = await resolveSelection({ profileFlag: flags.profile, root });
+  const document = await ConfigDocument.open(root, selection.profile);
   if (pendingRenames(document).length === 0) return false;
 
   // Shape-only, because the check this document fails runs after the schema.
   // Throws when it is malformed beyond a rename, which is a better sentence
   // than the referential one it would otherwise be reported under.
   const config = shapeOf(document);
-  const target = flags.target ?? '';
-  const credentials = await openSecretStoreFor(config, selection.workspaceRoot, target);
+  const credentials = await openSecretStoreFor(config, root, target);
 
   const migration = await migrateRenamedProviders(document, credentials, {
     apply: flags.fix === true,
@@ -70,6 +78,7 @@ export async function migratedRenamedProviders(
       ok: applied && migration.blocked.length === 0,
       profile: selection.profile,
       target,
+      workspace: root,
       applied,
       rows: migration.rows,
       changes: migration.changes,

--- a/src/deployments/deploy.test.ts
+++ b/src/deployments/deploy.test.ts
@@ -29,9 +29,16 @@ afterAll(async () => {
  * calls itself load-bearing; this is the same boundary for the upload.
  */
 describe('what a deploy sends up', () => {
-  test('config goes', () => {
-    expect(isWorkspaceConfig('lanes-link.yaml')).toBe(true);
+  test('profiles go, and the workspace file does not', () => {
     expect(isWorkspaceConfig('profiles/personal.yaml')).toBe(true);
+
+    // The one file that must not travel. It holds the target registry, and the
+    // two workspaces have different ones: this machine's says
+    // `cloud: workspace: gs://…`, so copying it into that bucket left the bucket
+    // pointing at itself — a loop `openTarget` refuses, on the target that had
+    // just been deployed (ADR-052). The bucket's own registry is written by
+    // `deploy`, from the declaration, once the upload is done.
+    expect(isWorkspaceConfig('lanes-link.yaml')).toBe(false);
   });
 
   test('the authored areas inside a profile go — they are config, not state', () => {
@@ -456,13 +463,12 @@ describe('the allowlist against a real workspace listing', () => {
       'data/personal/providers.d/acme.yaml',
       'data/personal/skills.d/review-diff/SKILL.md',
       'data/work/skills.d/triage.md',
-      'lanes-link.yaml',
       'profiles/personal.yaml',
       'profiles/work.yaml',
     ]);
   });
 
-  test('naming a profile sends that profile and the workspace file', async () => {
+  test('naming a profile sends that profile and nothing of its siblings', async () => {
     const { source, destination } = await populated();
 
     await uploadWorkspace(source, destination, ['personal']);
@@ -470,7 +476,6 @@ describe('the allowlist against a real workspace listing', () => {
     expect(await landed(destination)).toEqual([
       'data/personal/providers.d/acme.yaml',
       'data/personal/skills.d/review-diff/SKILL.md',
-      'lanes-link.yaml',
       'profiles/personal.yaml',
     ]);
   });

--- a/src/deployments/deploy.ts
+++ b/src/deployments/deploy.ts
@@ -272,7 +272,18 @@ export async function deploy(flags: DeployFlags): Promise<void> {
     // Before the rollout, so the revision that comes up finds a config to read.
     // Uploading after would leave a window where the service is serving and the
     // workspace it was told to read is not there yet.
-    await uploadWorkspace(resolution.workspaceRoot, workspace, serving);
+    // **Only when there is somewhere to copy from.** After ADR-052 the profiles
+    // a deployed target serves *live in* that target's workspace, so
+    // `resolution.workspaceRoot` and `workspace` are the same bucket and this is
+    // a copy onto itself. It ran, and the self-copy is how the bucket's registry
+    // came to be overwritten.
+    //
+    // What it is still for is the one-way trip: a first deploy, where the
+    // profile is on this machine and the bucket does not hold it yet. That is a
+    // move, not a sync — the next deploy finds it already there.
+    if (resolution.workspaceRoot !== workspace) {
+      await uploadWorkspace(resolution.workspaceRoot, workspace, serving);
+    }
 
     // **The bucket's own migration, here and nowhere else.**
     //
@@ -304,7 +315,11 @@ export async function deploy(flags: DeployFlags): Promise<void> {
       last_deploy: stamped,
     });
 
-    await recordTarget(resolution.workspaceRoot, target, {
+    // **This machine's registry, not the target's.** `resolution.workspaceRoot`
+    // is the workspace the profile was *found* in, which for a deployed target is
+    // the bucket — so writing the pointer there pointed the bucket at itself, and
+    // the revision that came up refused to open its own target.
+    await recordTarget(resolveWorkspaceRoot(), target, {
       workspace,
       primary: resolution.profile,
       last_deploy: stamped,

--- a/src/deployments/gcp/driver.test.ts
+++ b/src/deployments/gcp/driver.test.ts
@@ -67,12 +67,22 @@ describe('the steps', () => {
     expect(plan()[1]?.tolerateFailure).toBeUndefined();
   });
 
-  test('the build names the Dockerfile through a build config', () => {
+  test('the build names the Dockerfile through a build config, in the install', () => {
     // `gcloud builds submit --tag` always builds ./Dockerfile, and this one
     // lives under src/deployments/gcp/.
+    //
+    // Absolute, and rooted at the installed package rather than the working
+    // directory. Both were relative, so a deploy worked from a checkout and
+    // failed everywhere else with a missing cloudbuild.yaml — which reads as a
+    // broken install rather than as a wrong cwd.
     const build = plan().find((step) => step.argv[0] === 'builds')!;
-    expect(build.argv).toContain('src/deployments/gcp/cloudbuild.yaml');
-    expect(build.argv.at(-1)).toBe('.');
+    const config = build.argv[build.argv.indexOf('--config') + 1]!;
+    const context = build.argv.at(-1)!;
+
+    expect(config).toEndWith('src/deployments/gcp/cloudbuild.yaml');
+    expect(config).toStartWith('/');
+    expect(context).toStartWith('/');
+    expect(config).toStartWith(context);
   });
 
   test('the revision is told which target to open', () => {

--- a/src/deployments/gcp/driver.ts
+++ b/src/deployments/gcp/driver.ts
@@ -7,7 +7,8 @@ import type {
   SurveyInput,
   SurveyResult,
 } from '../driver.ts';
-import type { DeployConfig } from '#profile';
+import { join } from 'node:path';
+import { installRoot, type DeployConfig } from '#profile';
 import { encodeRef } from '../adapters/gcp-secret-manager.ts';
 import {
   captureGcloud,
@@ -50,6 +51,10 @@ export function deployPlan(input: PlanInput): DeployStep[] {
   const cloudrun = requireProject(input.deploy, input.target);
   const image = imageReference(cloudrun, input.tag);
   const scope = ['--project', cloudrun.project, '--region', cloudrun.region];
+  // Where this package is installed, which is where the Dockerfile and the build
+  // config live. Never the working directory: `lanes link deploy` is run from
+  // wherever somebody happens to be standing.
+  const root = installRoot(import.meta.dir);
 
   return [
     {
@@ -80,10 +85,15 @@ export function deployPlan(input: PlanInput): DeployStep[] {
         '--project',
         cloudrun.project,
         '--config',
-        'src/deployments/gcp/cloudbuild.yaml',
+        join(root, 'src/deployments/gcp/cloudbuild.yaml'),
         '--substitutions',
         `_IMAGE=${image}`,
-        '.',
+        // The build context, and the config beside it, are the *installed
+        // package* — not whatever directory the operator happened to run from.
+        // Both were relative, so `lanes link deploy` worked from a checkout and
+        // failed everywhere else with a missing cloudbuild.yaml, which reads as
+        // a broken install rather than as a wrong working directory.
+        root,
       ],
     },
     {

--- a/src/deployments/upload.ts
+++ b/src/deployments/upload.ts
@@ -64,7 +64,15 @@ export function deployedWorkspace(declared: TargetConfig): string | undefined {
  * between matching it and not is a credential in a bucket.
  */
 export function isWorkspaceConfig(key: string, profiles?: readonly string[]): boolean {
-  if (key === WORKSPACE_FILE) return true;
+  // **Never the workspace file.** It was sent, and it is the one file that must
+  // not be: it holds the *target registry*, and the two workspaces have
+  // different ones. This machine's says `cloud: workspace: gs://…`, so copying
+  // it into that bucket left the bucket pointing at itself — a loop `openTarget`
+  // refuses, on the target it had just deployed (ADR-052).
+  //
+  // The bucket's own registry is written by `deploy`, from the declaration, once
+  // the upload is done.
+  if (key === WORKSPACE_FILE) return false;
 
   // A set rather than one name, because a deploy now sends every profile that
   // declares the target rather than the single one it was told. `undefined`

--- a/src/profile/deployments.test.ts
+++ b/src/profile/deployments.test.ts
@@ -69,6 +69,24 @@ describe('recording where a target lives', () => {
     expect(registry['cloud']?.workspace).toBe('gs://second-bucket');
   });
 
+  test('a declaration replaces a pointer, so a bucket never points at itself', async () => {
+    // `deploy` writes the bucket's own registry after the upload. Merging there
+    // left this machine's `workspace:` on the entry — and a bucket pointing at
+    // itself is a loop `openTarget` refuses, on the target just deployed.
+    const root = await workspace('contract: 2\n');
+    await recordTarget(root, 'cloud', { workspace: 'gs://your-bucket', primary: 'personal' });
+    await recordTarget(root, 'cloud', {
+      credentials: { adapter: 'gcp-secret-manager', project: 'p' },
+      storage: { adapter: 'gcs', bucket: 'your-bucket' },
+    });
+
+    const entry = (await readRegistry(root))['cloud']!;
+    expect(entry.workspace).toBeUndefined();
+    expect(entry.storage?.bucket).toBe('your-bucket');
+    // The deploy record is the one thing that crosses either way.
+    expect(entry.primary).toBe('personal');
+  });
+
   test('the deploy record survives a declaration becoming a pointer', async () => {
     // A redeploy that does not ask who the primary is must not silently unset
     // it — and handing the target over to its own workspace is exactly when the

--- a/src/profile/deployments.ts
+++ b/src/profile/deployments.ts
@@ -39,11 +39,14 @@ export async function recordTarget(
 ): Promise<void> {
   await editRegistry(workspaceRoot, (targets) => {
     const previous = targets[target];
+    // Neither shape merges into the other, and the symmetry is the point: an
+    // entry carrying both a `workspace:` and adapters is what the schema refuses.
+    //
     // A pointer replacing a declaration is `deploy` handing the target over to
-    // the workspace it just wrote, so the adapter keys have to go rather than
-    // merge — an entry carrying both is what the schema refuses.
-    targets[target] =
-      entry.workspace !== undefined ? { ...pick(previous), ...entry } : { ...previous, ...entry };
+    // the workspace it just wrote. A declaration replacing a pointer is the same
+    // command writing the bucket's own registry — and merging there left the
+    // laptop's `workspace:` on it, pointing the bucket at itself.
+    targets[target] = { ...pick(previous), ...entry };
   });
 }
 
@@ -54,7 +57,7 @@ export async function removeTarget(workspaceRoot: string, target: string): Promi
   });
 }
 
-/** The fields that survive a declaration becoming a pointer: the deploy record. */
+/** The fields that survive an entry changing shape: the deploy record, and only it. */
 function pick(previous: WorkspaceTarget | undefined): Partial<WorkspaceTarget> {
   if (!previous) return {};
   return {


### PR DESCRIPTION
Four faults, all the same shape: `resolution.workspaceRoot` changed meaning under ADR-052 — it is the workspace the *profile was found in*, which for a deployed target is the bucket — and four call sites still read it as "this machine".

Found by deploying for real. The revision came up and Cloud Run failed its health check:

```
gs://personal-lanes points target "cloud" at gs://personal-lanes, which points somewhere else again.
Container called exit(1).
```

## The pointer went into the bucket

`recordTarget(resolution.workspaceRoot, …, { workspace })` wrote `cloud: workspace: gs://b` **into** `gs://b`. `openTarget` refuses that as a loop, correctly — so the revision could not open its own target. It takes `resolveWorkspaceRoot()` now: this machine's registry, the only one a pointer belongs in.

## The upload copied the bucket onto itself

After ADR-052 the profiles a deployed target serves live *in* that target's workspace, so source and destination are the same place. It runs only when they differ — the one case it is still for is a first deploy, moving a profile from this machine into a bucket that does not hold it yet.

## The workspace file travelled

`isWorkspaceConfig` sent `lanes-link.yaml`, and that is the one file that must not: it holds the target registry, and the two workspaces have different ones.

## `doctor --fix` looked in the wrong workspace

It resolved the profile from the local root, so a stale provider row in a bucket was invisible from the command the refusal kept naming as the fix.

## Also, pre-existing

`gcloud builds submit` was given `--config src/deployments/gcp/cloudbuild.yaml` and `.`, both relative to the working directory — so `deploy` worked from a checkout and failed everywhere else with a missing `cloudbuild.yaml`, which reads as a broken install rather than a wrong cwd. Both resolve against `installRoot` now.

And `recordTarget` is symmetric: neither shape merges into the other, so a declaration replacing a pointer drops the `workspace:` key rather than keeping it.

## Verified

Deployed against the real service. The endpoint is answering:

```console
$ curl -o /dev/null -w '%{http_code}' https://…run.app/health
200
$ lanes link status --target cloud
Profiles
  personal  18 connection(s)
```

`bun test`: 2490 pass, 0 fail. `bun run typecheck`: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
