### PR TITLE
fix: bind a credential to the revision that serves it, at connect time

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,10 @@
     "!src/**/*.test.ts",
     "instructions",
     "README.md",
-    "LICENSE"
+    "LICENSE",
+    "bun.lock",
+    "bunfig.toml",
+    ".dockerignore"
   ],
   "scripts": {
     "test": "bun test",

--- a/src/cli/commands/connect/bind-credential.ts
+++ b/src/cli/commands/connect/bind-credential.ts
@@ -1,0 +1,48 @@
+import { bindConnectionCredentials, type BindOutcome } from '#deployments/bind.ts';
+import type { Runtime } from '../../runtime.ts';
+
+/**
+ * Step 7 of `connect`: bind the credential to the revision that will serve it.
+ *
+ * Split out for the reason every other step in this directory was — `index.ts`
+ * holds the order, not the substance, and the file has a size budget
+ * (`architecture.test.ts`) that exists to keep it that way.
+ *
+ * What it is for is in `deployments/bind.ts`. Two decisions belong here.
+ *
+ * **It is called ahead of `connect`'s early return, not after it.** Re-running
+ * `connect` against an existing connection is what an operator does to repair
+ * one, and that run reaches the end with no config changes to make. Binding
+ * after the return would skip the repair path, leaving the command that looks
+ * like the fix doing nothing about the actual fault.
+ *
+ * **A failure is a note, never a throw.** The credential is in the store and the
+ * config is about to be saved by the time this runs, so failing the command
+ * would report "connect failed" about a connect that happened — and connecting
+ * an account against a deployed target from a machine that has never had
+ * `gcloud` installed has to keep working.
+ *
+ * The third decision is which connection to bind. The declared row is
+ * preferred over one assembled from the arguments, because an operator may have
+ * written a `credential_ref` into the profile by hand and that field decides
+ * where a `local` provider's credential lives — binding the derived ref instead
+ * would grant a secret nobody writes and leave the written one unbound, which is
+ * the failure `rotatableCredentialRefsFor` documents from the other direction.
+ */
+export function bindNewCredential(
+  runtime: Runtime,
+  providerId: string,
+  connectionId: string,
+  account: string,
+): Promise<BindOutcome> {
+  const declared = runtime.config.connections.find(
+    (candidate) => candidate.provider === providerId && candidate.id === connectionId,
+  );
+
+  return bindConnectionCredentials({
+    deploy: runtime.declared.deploy,
+    target: runtime.target,
+    connection: declared ?? { provider: providerId, id: connectionId, account },
+    manifest: runtime.manifestFor(providerId),
+  });
+}

--- a/src/cli/commands/connect/index.ts
+++ b/src/cli/commands/connect/index.ts
@@ -16,6 +16,7 @@ import { chooseAuthMethod } from './method.ts';
 import { preflight } from './requirements.ts';
 import { ALREADY, NOTHING, renderOutcome, where, type ConnectOutcome } from './outcome.ts';
 import { nextAfterEdit, publishRuntimeEdit } from '#cli/publish.ts';
+import { bindNewCredential } from './bind-credential.ts';
 import { ensureStaticCredential } from './setup.ts';
 import { settleIdentity } from './settle.ts';
 import { runStrategySetup } from './strategy.ts';
@@ -356,6 +357,9 @@ export async function runConnect(
       ? ['that is your own memory, tasks, assets, skills and vault — no account, nothing stored until you use them']
       : [];
 
+    // 7. Bind the credential to the revision that serves it — `bind-credential.ts`.
+    const bound = await bindNewCredential(runtime, providerId, connectionId, account);
+    if (bound.failed) notes.push(bound.failed);
     if (changes.length === 0 && granted.length === 0) {
       return {
         ...NOTHING,
@@ -364,6 +368,7 @@ export async function runConnect(
         account,
         label,
         ...where(runtime),
+        ...(notes.length > 0 ? { notes } : {}),
         discovered: discovered.length,
         next: ALREADY,
       };

--- a/src/cli/commands/operate/inspect.ts
+++ b/src/cli/commands/operate/inspect.ts
@@ -4,6 +4,7 @@ import { announce, announceProfile, emit, fail, ok, print, warn } from '../../ou
 import { staleNudge } from '../../release.ts';
 import { openRuntime, resolveProfileOnly, type GlobalFlags, type Runtime } from '../../runtime.ts';
 import type { FetchLike } from '#deployments/knowledge.ts';
+import { unboundRotatableRefs } from '#deployments/bind.ts';
 import { credentialAge, reportCapabilityDrift } from './findings.ts';
 import { migratedContract, migratedRenamedProviders } from './migrate.ts';
 
@@ -274,6 +275,37 @@ export async function doctor(flags: DoctorFlags): Promise<void> {
         message: 'runtime state differs from config — run: lanes link plan',
         fix: forSelection('lanes link plan'),
       });
+    }
+
+    // Whether the revision can still rewrite what it serves.
+    //
+    // A *problem*, not a warning: an unbound credential is a connection that
+    // works until its access token expires and then stops, and every other
+    // report on this machine calls it healthy in the meantime — `status` and
+    // `setup_overview` read the state store, and the state store knows nothing
+    // about IAM. This is the only place that asks the thing that decides.
+    //
+    // Skipped entirely for a local target, where credentials are a file this
+    // process owns and there is no revision to grant anything to.
+    const rotation = await unboundRotatableRefs({
+      deploy: runtime.declared.deploy,
+      target: runtime.target,
+      connections: runtime.config.connections,
+      manifestFor: runtime.manifestFor,
+    });
+    if (rotation.unbound.length > 0) {
+      problems.push({
+        kind: 'unbound_credentials',
+        message:
+          `the deployed endpoint can read ${rotation.unbound.join(', ')} but not rotate ` +
+          `${rotation.unbound.length === 1 ? 'it' : 'them'} — so ${rotation.unbound.length === 1 ? 'that connection' : 'those connections'} ` +
+          'will fail about an hour after each use, when the token refresh tries to persist. ' +
+          'A connection made since the last deploy is the usual cause',
+        fix: forSelection('lanes link deploy'),
+      });
+    }
+    if (rotation.unavailable) {
+      warnings.push({ kind: 'rotation_uncheckable', message: rotation.unavailable });
     }
 
     if (problems.length > 0) process.exitCode = 1;

--- a/src/deployments/bind.test.ts
+++ b/src/deployments/bind.test.ts
@@ -1,0 +1,271 @@
+import { describe, expect, test } from 'bun:test';
+import { defineProvider } from '#connectivity';
+import type { ConnectionConfig, DeployConfig } from '#profile';
+import type { CommandResult, DeployDriver } from './driver.ts';
+import { bindConnectionCredentials, unboundRotatableRefs } from './bind.ts';
+
+/**
+ * That a connection made between two deploys is bound to the revision serving it.
+ *
+ * The gap this closes is not a wrong answer anywhere. `provisionSteps` binds the
+ * connections the config held when it ran, `connect` adds one and binds nothing,
+ * and every report in between says the connection is fine — because it is, for
+ * about an hour. Read is unaffected, so it authorises and answers; only the
+ * write on the far side of the first token refresh is denied, long after the
+ * command that caused it.
+ *
+ * So these assert argv rather than an outcome: what matters is that the binding
+ * a connect performs is the same binding a deploy would have performed, and the
+ * only way for those to agree is for both to come out of the same function.
+ */
+
+const cloudrun = {
+  platform: 'cloudrun',
+  project: 'my-project',
+  region: 'europe-west1',
+  service: 'lanes-link',
+  access: 'public',
+  service_account: 'lanes-link-run@my-project.iam.gserviceaccount.com',
+  min_instances: 0,
+} as const satisfies DeployConfig;
+
+const connection: ConnectionConfig = {
+  provider: 'sheets',
+  id: 'ada',
+  account: 'ada@example.com',
+} as ConnectionConfig;
+
+/** An OAuth provider, so it has a credential the revision has to rewrite. */
+const manifest = defineProvider({
+  id: 'sheets',
+  name: 'Sheets',
+  connector: { kind: 'mcp', endpoint: 'https://sheets.example.com/mcp' },
+  auth: { kind: 'oauth' },
+});
+
+/** Records what was run, and answers however the test says. */
+function fakeDriver(answer: (argv: readonly string[]) => CommandResult): {
+  driver: DeployDriver;
+  calls: string[][];
+} {
+  const calls: string[][] = [];
+  const driver = {
+    tool: 'gcloud',
+    plan: () => [],
+    provision: () => Promise.resolve([]),
+    run: (argv: readonly string[]): Promise<CommandResult> => {
+      calls.push([...argv]);
+      return Promise.resolve(answer(argv));
+    },
+  } as unknown as DeployDriver;
+  return { driver, calls };
+}
+
+const OK: CommandResult = { ok: true, stdout: '', stderr: '' };
+
+describe('binding a connection made since the last deploy', () => {
+  test('grants the revision both read and rotate on its credential', async () => {
+    const { driver, calls } = fakeDriver(() => OK);
+
+    const outcome = await bindConnectionCredentials({
+      deploy: cloudrun,
+      target: 'cloud',
+      connection,
+      manifest,
+      driver,
+    });
+
+    expect(outcome.failed).toBeUndefined();
+    const roles = calls.map((argv) => argv[argv.indexOf('--role') + 1]).filter(Boolean);
+
+    // Read is the half an older deployment's project-wide `secretAccessor`
+    // happens to cover, which is exactly what made the failure partial and slow
+    // to find. A deployment provisioned since that changed has neither.
+    expect(roles).toContain('roles/secretmanager.secretAccessor');
+    // The half that is never covered by anything else, and the one a token
+    // refresh needs.
+    expect(roles).toContain('roles/secretmanager.secretVersionAdder');
+
+    // The secret is created here so the revision only ever needs to add a
+    // version, never `secrets.create` — a project-level permission that would
+    // let it mint credential references of its own.
+    expect(calls.some((argv) => argv[0] === 'secrets' && argv[1] === 'create')).toBe(true);
+
+    // Every binding names the revision's own service account, and every call
+    // names the project. The create step carries no member, which is the point
+    // of it: it exists so the binding below can stay resource-level.
+    for (const argv of calls) expect(argv).toContain('--project');
+    for (const argv of calls.filter((a) => a.includes('add-iam-policy-binding'))) {
+      expect(argv.join(' ')).toContain(cloudrun.service_account);
+    }
+  });
+
+  test('does nothing for a target that runs here', async () => {
+    const { driver, calls } = fakeDriver(() => OK);
+
+    const outcome = await bindConnectionCredentials({
+      deploy: undefined,
+      target: 'local',
+      connection,
+      manifest,
+      driver,
+    });
+
+    expect(outcome.bound).toEqual([]);
+    expect(outcome.skipped).toBeDefined();
+    expect(calls).toEqual([]);
+  });
+
+  test('does nothing for a provider that authenticates with nothing', async () => {
+    // "A provider needing no credential is authorized by construction"
+    // (`reconcile.ts`), so there is no secret to bind and no gcloud to invoke.
+    const { driver, calls } = fakeDriver(() => OK);
+    const local = defineProvider({
+      id: 'notes',
+      name: 'Notes',
+      connector: { kind: 'fs', root: '/tmp/notes' },
+      auth: { kind: 'none' },
+    });
+
+    const outcome = await bindConnectionCredentials({
+      deploy: cloudrun,
+      target: 'cloud',
+      connection: { provider: 'notes', id: 'main', account: 'Notes' } as ConnectionConfig,
+      manifest: local,
+      driver,
+    });
+
+    expect(outcome.bound).toEqual([]);
+    expect(calls).toEqual([]);
+  });
+
+  test('reports a refused binding rather than failing the connect', async () => {
+    // By the time this runs the credential is in the store and the config is
+    // about to be saved, so throwing would report "connect failed" about a
+    // connect that happened. The operator gets the sentence and the command.
+    const { driver } = fakeDriver((argv) =>
+      argv.includes('add-iam-policy-binding')
+        ? { ok: false, stdout: '', stderr: 'ERROR: PERMISSION_DENIED' }
+        : OK,
+    );
+
+    const outcome = await bindConnectionCredentials({
+      deploy: cloudrun,
+      target: 'cloud',
+      connection,
+      manifest,
+      driver,
+    });
+
+    expect(outcome.bound).toEqual([]);
+    expect(outcome.failed).toContain('lanes link deploy --target cloud');
+    expect(outcome.failed).toContain('rotate');
+  });
+
+  test('tolerates a secret that already exists', async () => {
+    // The create step's success case on every run after the first. Only a
+    // refused *binding* is worth reporting.
+    const { driver } = fakeDriver((argv) =>
+      argv[1] === 'create'
+        ? { ok: false, stdout: '', stderr: 'ERROR: ALREADY_EXISTS' }
+        : OK,
+    );
+
+    const outcome = await bindConnectionCredentials({
+      deploy: cloudrun,
+      target: 'cloud',
+      connection,
+      manifest,
+      driver,
+    });
+
+    expect(outcome.failed).toBeUndefined();
+    expect(outcome.bound.length).toBeGreaterThan(0);
+  });
+});
+
+describe('finding a credential the revision cannot rewrite', () => {
+  const policy = (roles: string[]): string =>
+    JSON.stringify({
+      bindings: roles.map((role) => ({ role, members: [`serviceAccount:${cloudrun.service_account}`] })),
+    });
+
+  const manifestFor = (id: string) => (id === 'sheets' ? manifest : undefined);
+
+  test('names the ref that is granted read and not rotate', async () => {
+    // The exact live shape: a project-level `secretAccessor` from an older
+    // deployment covers the read, and only the per-secret write is missing. That
+    // asymmetry is why the connection answers for an hour before it stops.
+    const { driver } = fakeDriver(() => ({
+      ok: true,
+      stdout: policy(['roles/secretmanager.secretAccessor']),
+      stderr: '',
+    }));
+
+    const found = await unboundRotatableRefs({
+      deploy: cloudrun,
+      target: 'cloud',
+      connections: [connection],
+      manifestFor,
+      driver,
+    });
+
+    expect(found.unbound.length).toBeGreaterThan(0);
+    expect(found.unavailable).toBeUndefined();
+  });
+
+  test('says nothing when the binding is there', async () => {
+    const { driver } = fakeDriver(() => ({
+      ok: true,
+      stdout: policy([
+        'roles/secretmanager.secretAccessor',
+        'roles/secretmanager.secretVersionAdder',
+      ]),
+      stderr: '',
+    }));
+
+    expect(
+      await unboundRotatableRefs({
+        deploy: cloudrun,
+        target: 'cloud',
+        connections: [connection],
+        manifestFor,
+        driver,
+      }),
+    ).toEqual({ unbound: [] });
+  });
+
+  test('does not call a policy it could not read unbound', async () => {
+    // "Could not look" and "is not granted" send an operator to different
+    // places, and this check is a *problem* rather than a warning — so it has to
+    // be trusted about the second one. A machine with no gcloud reports that it
+    // could not check, and reports nothing else.
+    const { driver } = fakeDriver(() => ({ ok: false, stdout: '', stderr: 'gcloud: not found' }));
+
+    const found = await unboundRotatableRefs({
+      deploy: cloudrun,
+      target: 'cloud',
+      connections: [connection],
+      manifestFor,
+      driver,
+    });
+
+    expect(found.unbound).toEqual([]);
+    expect(found.unavailable).toContain('could not be read');
+  });
+
+  test('asks nothing at all for a target that runs here', async () => {
+    const { driver, calls } = fakeDriver(() => ({ ok: true, stdout: '{}', stderr: '' }));
+
+    expect(
+      await unboundRotatableRefs({
+        deploy: undefined,
+        target: 'local',
+        connections: [connection],
+        manifestFor,
+        driver,
+      }),
+    ).toEqual({ unbound: [] });
+    expect(calls).toEqual([]);
+  });
+});

--- a/src/deployments/bind.ts
+++ b/src/deployments/bind.ts
@@ -1,0 +1,214 @@
+import type { ConnectionConfig, DeployConfig } from '#profile';
+import { credentialRefFor, rotatableCredentialRefsFor } from '#registry';
+import type { SecretRef } from '#secrets';
+import type { DeployDriver } from './driver.ts';
+import { driverFor } from './drivers.ts';
+import { secretGrantSteps } from './gcp/provision.ts';
+import { requireProject } from './gcp/gcloud.ts';
+import { encodeRef } from './adapters/gcp-secret-manager.ts';
+
+/**
+ * Binding one connection's credentials to the revision that will serve them.
+ *
+ * **The invariant this restores: a revision can rotate every credential it
+ * serves.** `provisionSteps` establishes it over the connections the config held
+ * *at deploy time*, one secret at a time, which is the right shape — a
+ * resource-level grant needs no condition to be scoped. What nothing did was
+ * keep it true afterwards. `connect` writes a credential into the same store and
+ * binds nothing, so from the next connect until the next deploy the invariant is
+ * false and no command says so.
+ *
+ * The failure it produces is the worst shape available. Read is unaffected, so
+ * the connection authorises, answers, and reports `active`; only the *write* on
+ * the far side of the first token refresh is denied, roughly an hour later, by
+ * which time the connect that caused it is not the recent event. `status` and
+ * `setup_overview` both keep saying "connected and reachable" throughout,
+ * because both read the state store and the state store knows nothing about IAM.
+ *
+ * **Every path that writes a credential reaches this one.** `connect custom`
+ * delegates to `runConnect` after writing its manifest, and `connectFamily`
+ * calls `runConnect` per member, so binding at that one call site covers all
+ * three. The reverse direction needs nothing: `disconnect` deletes the whole
+ * secret rather than a version, and a secret's IAM policy goes with it, so there
+ * is no orphaned binding to revoke.
+ *
+ * Same steps as the deploy, from the same functions, over one connection's refs.
+ * Not a second implementation of the grant: `reconcile.ts` argues that a preview
+ * computed differently from the mutation eventually becomes a lie, and the
+ * argument is stronger here, because two spellings of a grant do not disagree on
+ * screen — they disagree about which permission actually exists.
+ */
+
+export interface BindOutcome {
+  /** Refs the revision can now read and rotate. Empty is a normal result. */
+  readonly bound: readonly SecretRef[];
+  /**
+   * Why nothing was bound, when nothing was and that is fine: a local target, a
+   * deployment with no runtime service account, or a provider holding no
+   * credential at all.
+   */
+  readonly skipped?: string | undefined;
+  /**
+   * A binding that could not be applied, as a sentence for the operator.
+   *
+   * Carried rather than thrown, and that is deliberate. By the time this runs
+   * the credential is already in the store and the config is already saved, so
+   * failing the command would report "connect failed" about a connect that
+   * happened. It also must not require `gcloud` to be installed: someone can
+   * legitimately connect an account against a deployed target from a machine
+   * that has never deployed one.
+   */
+  readonly failed?: string | undefined;
+}
+
+const NOTHING_TO_BIND = 'this provider stores no credential';
+
+export async function bindConnectionCredentials(input: {
+  readonly deploy: DeployConfig | undefined;
+  readonly target: string;
+  readonly connection: ConnectionConfig;
+  /**
+   * The provider's manifest, so an omitted `credential_ref` can be derived.
+   *
+   * Typed off `#registry`'s own signature rather than by importing
+   * `ProviderManifest`: `#deployments` may not import `#connectivity`
+   * (`architecture.test.ts`), which is the same rule that put `credentialRefFor`
+   * in `#registry` in the first place. `prepare.ts` avoids it by never naming
+   * the type; this one has to name it, so it derives it.
+   */
+  readonly manifest: Parameters<typeof rotatableCredentialRefsFor>[1];
+  /** Injectable so a test asserts the argv without a cloud project near it. */
+  readonly driver?: DeployDriver | undefined;
+}): Promise<BindOutcome> {
+  const { deploy, connection, manifest } = input;
+  if (!deploy) return { bound: [], skipped: 'this target runs here, not on a platform' };
+
+  const cloudrun = requireProject(deploy, input.target);
+  const serviceAccount = cloudrun.service_account;
+  if (!serviceAccount) {
+    return { bound: [], skipped: 'this deployment declares no runtime service account' };
+  }
+
+  // Both halves, because a connection made since the last deploy has neither.
+  // The read grant is the one an older deployment's project-wide
+  // `secretAccessor` happens to cover, which is exactly what made this failure
+  // partial and therefore slow to find; a deployment provisioned since that
+  // changed has no read on it either.
+  const readable = credentialRefFor(connection, manifest);
+  const rotatable = rotatableCredentialRefsFor(connection, manifest);
+  if (!readable && rotatable.length === 0) return { bound: [], skipped: NOTHING_TO_BIND };
+
+  const steps = secretGrantSteps({
+    project: cloudrun.project,
+    serviceAccount,
+    readable: readable ? [readable] : [],
+    rotatable,
+  });
+
+  const driver = input.driver ?? (await driverFor(deploy.platform));
+
+  for (const step of steps) {
+    const result = await driver.run(step.argv, { quiet: true });
+    // `tolerateFailure` on these means "the secret may already exist", which is
+    // the create step's success case. A binding that genuinely could not be
+    // applied is still worth saying out loud — quietly tolerating it here is how
+    // the deploy path let this class of gap through in the first place.
+    if (!result.ok && !step.argv.includes('add-iam-policy-binding')) continue;
+    if (!result.ok) {
+      return {
+        bound: [],
+        failed:
+          `could not bind ${connection.provider}.${connection.id}'s credential to ` +
+          `${serviceAccount}, so the deployed endpoint will be able to read it and not ` +
+          'rotate it — which fails about an hour after the first use. ' +
+          `Run \`lanes link deploy --target ${input.target}\` to bind it. ` +
+          `(${driver.tool}: ${result.stderr.trim().split('\n').slice(-1)[0] ?? 'failed'})`,
+      };
+    }
+  }
+
+  return { bound: readable ? [readable, ...rotatable] : rotatable };
+}
+
+/**
+ * The credentials a deployed revision serves but cannot rewrite.
+ *
+ * The detection half of the same invariant `bindConnectionCredentials` keeps.
+ * Binding at connect time closes the gap going forward; this one answers for a
+ * workspace that already has it, and for every way a binding can go missing that
+ * no command is watching — a secret rebuilt by hand, a service account replaced,
+ * a profile edited in an editor, a connection made by an older CLI.
+ *
+ * Asked of the platform rather than derived from a record this repository keeps,
+ * because a record would only ever agree with itself. IAM is the thing that
+ * actually decides, so IAM is what gets read.
+ *
+ * One call per ref, concurrently. `doctor` is the command where a few seconds
+ * buys an answer nothing else on the machine can give — and the alternative,
+ * finding out from a 403 an hour after a connect, is the failure this exists to
+ * pre-empt.
+ */
+export async function unboundRotatableRefs(input: {
+  readonly deploy: DeployConfig | undefined;
+  readonly target: string;
+  readonly connections: readonly ConnectionConfig[];
+  readonly manifestFor: (providerId: string) => Parameters<typeof rotatableCredentialRefsFor>[1];
+  readonly driver?: DeployDriver | undefined;
+}): Promise<{ unbound: readonly SecretRef[]; unavailable?: string | undefined }> {
+  const { deploy } = input;
+  if (!deploy) return { unbound: [] };
+
+  const cloudrun = requireProject(deploy, input.target);
+  const serviceAccount = cloudrun.service_account;
+  if (!serviceAccount) return { unbound: [] };
+
+  const refs = new Set<SecretRef>();
+  for (const connection of input.connections) {
+    for (const ref of rotatableCredentialRefsFor(connection, input.manifestFor(connection.provider))) {
+      refs.add(ref);
+    }
+  }
+  if (refs.size === 0) return { unbound: [] };
+
+  const driver = input.driver ?? (await driverFor(deploy.platform));
+  const member = `serviceAccount:${serviceAccount}`;
+
+  const verdicts = await Promise.all(
+    [...refs].map(async (ref) => {
+      const result = await driver.run(
+        ['secrets', 'get-iam-policy', encodeRef(ref), '--project', cloudrun.project, '--format', 'json'],
+        { quiet: true },
+      );
+      // A ref whose policy cannot be read is not reported as unbound: "could not
+      // look" and "is not granted" send an operator to different places, and
+      // this command exists to be trusted about the second one.
+      if (!result.ok) return { ref, bound: true, unreadable: true };
+
+      try {
+        const policy = JSON.parse(result.stdout) as {
+          bindings?: { role?: string; members?: string[] }[];
+        };
+        const bound = (policy.bindings ?? []).some(
+          (binding) =>
+            binding.role === 'roles/secretmanager.secretVersionAdder' &&
+            (binding.members ?? []).includes(member),
+        );
+        return { ref, bound, unreadable: false };
+      } catch {
+        return { ref, bound: true, unreadable: true };
+      }
+    }),
+  );
+
+  const unreadable = verdicts.filter((verdict) => verdict.unreadable).length;
+  return {
+    unbound: verdicts.filter((verdict) => !verdict.bound).map((verdict) => verdict.ref),
+    ...(unreadable > 0
+      ? {
+          unavailable:
+            `${unreadable} of ${refs.size} credential policies could not be read, so this ` +
+            `check covered the rest. ${driver.tool} has to be installed and authorised for it.`,
+        }
+      : {}),
+  };
+}

--- a/src/deployments/gcp/dockerfile.test.ts
+++ b/src/deployments/gcp/dockerfile.test.ts
@@ -16,6 +16,7 @@ import { readFile } from 'node:fs/promises';
 
 const DOCKERFILE = new URL('./Dockerfile', import.meta.url).pathname;
 const GITIGNORE = new URL('../../../.gitignore', import.meta.url).pathname;
+const MANIFEST = new URL('../../../package.json', import.meta.url).pathname;
 
 /** The sources of every `COPY`, minus the destination and any flags. */
 function copySources(dockerfile: string): string[] {
@@ -93,6 +94,37 @@ describe('the deployed image', () => {
 
     expect(copySources(dockerfile)).not.toContain('data/');
     expect(dockerfile).not.toMatch(/^COPY\s+\.\s/m);
+  });
+
+  test('copies only what an npm install actually receives', async () => {
+    // The check `.gitignore` cannot make. A fresh clone and a published package
+    // are two different definitions of "the files are there", and this Dockerfile
+    // ships inside the package — `files` carries `src`, and the Dockerfile lives
+    // under it — so `lanes link deploy` builds from whatever npm sent.
+    //
+    // `bun.lock` and `bunfig.toml` were not in `files`. Every test above passed:
+    // both are tracked, neither is gitignored, the allowlist named them. Deploy
+    // from a checkout worked, which is where it is always tested. Deploy from a
+    // bun-global install — the only install method this CLI documents — died at
+    // `COPY package.json bun.lock bunfig.toml ./` with `stat bun.lock: file does
+    // not exist`, after pulling the base image and pushing a build context, so
+    // the failure arrived minutes in and named a file sitting in the repository.
+    const sources = copySources(await readFile(DOCKERFILE, 'utf8'));
+    const files: string[] = JSON.parse(await readFile(MANIFEST, 'utf8')).files;
+
+    // npm ships these whatever `files` says, so they need no entry.
+    const always = ['package.json', 'README.md', 'LICENSE', 'LICENCE'];
+
+    const missing = sources.filter((source) => {
+      const bare = source.replace(/\/$/, '');
+      if (always.includes(bare)) return false;
+      return !files.some((entry) => {
+        const listed = entry.replace(/^\.\//, '').replace(/\/$/, '');
+        return listed === bare || bare.startsWith(`${listed}/`);
+      });
+    });
+
+    expect({ missing, files }).toEqual({ missing: [], files });
   });
 
   test('the workspace root is not baked in', async () => {

--- a/src/deployments/gcp/driver.test.ts
+++ b/src/deployments/gcp/driver.test.ts
@@ -290,7 +290,11 @@ describe('first-run provisioning', () => {
     // — but by the anchored pattern only. A blanket `startsWith(".../data/")`
     // here would hand the revision read on every credential-adjacent object in
     // the profile, which is the narrowing this condition exists to make.
-    expect(condition).toContain('providers\\.d/');
+    // `[.]`, not `\\.`: this is a regex inside a CEL *string literal*, which CEL
+    // unescapes before the regex engine sees it, and `\\.` is not one of its
+    // escapes. The expression that produced failed to compile at Google, and the
+    // binding carries `tolerateFailure`, so the narrowing silently did not apply.
+    expect(condition).toContain('providers[.]d/');
     expect(condition).not.toMatch(/startsWith\("[^"]*\/objects\/data\/"\)/);
   });
 
@@ -314,7 +318,7 @@ describe('first-run provisioning', () => {
     expect(write).not.toContain('profiles/');
     expect(write).not.toContain('lanes-link.yaml');
     expect(write).toContain('!resource.name.matches(');
-    expect(write).toContain('providers\\.d/');
+    expect(write).toContain('providers[.]d/');
 
     expect(conditions.some((condition) => condition.includes('reads-its-config'))).toBe(true);
   });

--- a/src/deployments/gcp/provision.ts
+++ b/src/deployments/gcp/provision.ts
@@ -1,4 +1,4 @@
-import { VAULT_DOCUMENT_REF } from '#secrets';
+import { VAULT_DOCUMENT_REF, type SecretRef } from '#secrets';
 import type { DeployStep, ProvisionInput } from '../driver.ts';
 import { encodeRef } from '../adapters/gcp-secret-manager.ts';
 import { requireProject } from './gcloud.ts';
@@ -42,6 +42,109 @@ const REQUIRED_SERVICES = [
   'iam.googleapis.com',
   'cloudresourcemanager.googleapis.com',
 ];
+
+/**
+ * Who the grant is for, and on what.
+ *
+ * A named type because these two functions are now called from two places that
+ * must not disagree — see the note on `secretGrantSteps`.
+ */
+export interface SecretGrant {
+  readonly project: string;
+  readonly serviceAccount: string;
+  readonly refs: readonly SecretRef[];
+}
+
+/** Read, named one secret at a time, so the grant needs no condition to be scoped. */
+export function readSteps({ project, serviceAccount, refs }: SecretGrant): DeployStep[] {
+  return refs.map((ref) => ({
+    title: `let the revision read ${ref}`,
+    argv: [
+      'secrets',
+      'add-iam-policy-binding',
+      encodeRef(ref),
+      '--project',
+      project,
+      '--member',
+      `serviceAccount:${serviceAccount}`,
+      '--role',
+      'roles/secretmanager.secretAccessor',
+      // Bindings are printed as the whole policy otherwise, which is pages
+      // of YAML per deploy and buries everything after it.
+      '--condition',
+      'None',
+    ],
+    tolerateFailure: true,
+  }));
+}
+
+/**
+ * Write, two steps each, and the first is what keeps the second narrow: the
+ * secret is created here so the revision only ever needs to *add a version*,
+ * never `secrets.create`, which is a project-level permission that would let it
+ * mint credential references of its own.
+ */
+export function rotateSteps({ project, serviceAccount, refs }: SecretGrant): DeployStep[] {
+  return refs.flatMap((ref) => {
+    const id = encodeRef(ref);
+    return [
+      {
+        title: `create the secret ${id}, so the revision never needs secrets.create`,
+        argv: ['secrets', 'create', id, '--project', project, '--replication-policy', 'automatic'],
+        tolerateFailure: true,
+      },
+      {
+        title: `let the revision rewrite ${ref}, and nothing else in the store`,
+        argv: [
+          'secrets',
+          'add-iam-policy-binding',
+          id,
+          '--project',
+          project,
+          '--member',
+          `serviceAccount:${serviceAccount}`,
+          '--role',
+          'roles/secretmanager.secretVersionAdder',
+          '--condition',
+          'None',
+        ],
+        tolerateFailure: true,
+      },
+    ];
+  });
+}
+
+/**
+ * Both halves for one connection's credentials, for a caller that is not a deploy.
+ *
+ * **This exists because the grant was a deploy-time snapshot of a set that
+ * changes between deploys.** `provisionSteps` walks the config's connections and
+ * binds each secret it finds; `connect` then adds a connection, writes its
+ * credential, and binds nothing. The revision can read the new secret — an older
+ * deployment's project-wide `secretAccessor` covers it, and a current one does
+ * not — but it cannot add a version, so the first OAuth refresh 403s. The
+ * connection works for exactly as long as its initial access token lasts, which
+ * is about an hour, and then stops for a reason nothing on the connection says.
+ *
+ * So the same steps are reachable from `connect`, over one connection's refs
+ * rather than the whole config's. Deliberately the *same functions* rather than
+ * a second implementation: `reconcile.ts` makes the same argument for planning
+ * and applying, and it holds harder here, because a second spelling of a grant
+ * is not a wrong answer on screen, it is a permission that is missing in one
+ * path and present in the other.
+ */
+export function secretGrantSteps(
+  grant: Omit<SecretGrant, 'refs'> & {
+    readonly readable: readonly SecretRef[];
+    readonly rotatable: readonly SecretRef[];
+  },
+): DeployStep[] {
+  const { project, serviceAccount } = grant;
+  return [
+    ...readSteps({ project, serviceAccount, refs: grant.readable }),
+    ...rotateSteps({ project, serviceAccount, refs: grant.rotatable }),
+  ];
+}
 
 export function provisionSteps(input: ProvisionInput): Promise<DeployStep[]> {
   const cloudrun = requireProject(input.deploy, input.target);
@@ -116,27 +219,7 @@ export function provisionSteps(input: ProvisionInput): Promise<DeployStep[]> {
     // Affordable because the serving path reads by explicit ref: `list()` is a
     // CLI call, and `secretAccessor` never carried `secrets.list` anyway.
     // `readableRefs` derives the set from config and manifests at deploy time.
-    for (const ref of input.readable ?? []) {
-      steps.push({
-        title: `let the revision read ${ref}`,
-        argv: [
-          'secrets',
-          'add-iam-policy-binding',
-          encodeRef(ref),
-          '--project',
-          project,
-          '--member',
-          `serviceAccount:${serviceAccount}`,
-          '--role',
-          'roles/secretmanager.secretAccessor',
-          // Bindings are printed as the whole policy otherwise, which is pages
-          // of YAML per deploy and buries everything after it.
-          '--condition',
-          'None',
-        ],
-        tolerateFailure: true,
-      });
-    }
+    steps.push(...readSteps({ project, serviceAccount, refs: input.readable ?? [] }));
   }
 
   // What a revision rewrites in its own credential store, named one secret at a
@@ -165,32 +248,8 @@ export function provisionSteps(input: ProvisionInput): Promise<DeployStep[]> {
       ]
     : [];
 
-  for (const ref of writable) {
-    const id = encodeRef(ref);
-
-    steps.push({
-      title: `create the secret ${id}, so the revision never needs secrets.create`,
-      argv: ['secrets', 'create', id, '--project', project, '--replication-policy', 'automatic'],
-      tolerateFailure: true,
-    });
-
-    steps.push({
-      title: `let the revision rewrite ${ref}, and nothing else in the store`,
-      argv: [
-        'secrets',
-        'add-iam-policy-binding',
-        id,
-        '--project',
-        project,
-        '--member',
-        `serviceAccount:${serviceAccount}`,
-        '--role',
-        'roles/secretmanager.secretVersionAdder',
-        '--condition',
-        'None',
-      ],
-      tolerateFailure: true,
-    });
+  if (serviceAccount) {
+    steps.push(...rotateSteps({ project, serviceAccount, refs: writable }));
   }
 
   // Any target that addresses a bucket, which deployed means all of them:
@@ -241,8 +300,18 @@ export function provisionSteps(input: ProvisionInput): Promise<DeployStep[]> {
       // what the revision owns from what declares what it is. Anchored to the
       // profile segment rather than matched loosely: `contains("/providers.d/")`
       // would also catch a blob whose own key happened to spell it.
+      //
+      // The dot is a character class, not `\.`, and that is the fix rather than
+      // a style: this string is a *CEL string literal* holding a regex, so it is
+      // unescaped once by CEL before the regex engine ever sees it. `\.` is not
+      // a CEL escape sequence, so the whole expression failed to compile —
+      // `token recognition error at: '"^projects/_/buckets/...providers\.'` —
+      // and both bindings below carry `tolerateFailure`, so a deploy printed two
+      // warnings and carried on with the scoping silently not applied. `[.]` is
+      // the same regex and survives a layer of string unescaping unchanged,
+      // which is what keeps the next person from reintroducing it.
       const providerManifests =
-        `resource.name.matches("^projects/_/buckets/${bucket}/objects/data/[^/]+/providers\\.d/")`;
+        `resource.name.matches("^projects/_/buckets/${bucket}/objects/data/[^/]+/providers[.]d/")`;
 
       steps.push({
         title: 'let the revision write its own data, but not the manifests in it',

--- a/src/deployments/grants.test.ts
+++ b/src/deployments/grants.test.ts
@@ -122,15 +122,19 @@ const READS = {
   'a provider manifest': `${layout.providers(PROFILE)}/acme.yaml`,
 };
 
-async function writeCondition(): Promise<string> {
+/** The CEL of the one conditioned binding whose title carries `name`. */
+async function conditionTitled(name: string): Promise<string> {
   const steps = await provisionSteps({ deploy: cloudrun, declared: target, target: 'cloud' });
-  const step = steps.find((candidate) => candidate.argv.join(' ').includes('owns-its-data'));
+  const step = steps.find((candidate) => candidate.argv.join(' ').includes(name));
 
   // `title=…,expression=…`; only the expression is evaluable.
   const condition = step!.argv[step!.argv.indexOf('--condition') + 1]!;
   const marker = 'expression=';
   return condition.slice(condition.indexOf(marker) + marker.length);
 }
+
+const writeCondition = (): Promise<string> => conditionTitled('owns-its-data');
+const readCondition = (): Promise<string> => conditionTitled('reads-its-config');
 
 /**
  * Evaluate the shipped condition for one resource name.
@@ -164,6 +168,32 @@ describe('what the revision is granted, against what it writes', () => {
         what,
         key,
         permitted: true,
+      });
+    }
+  });
+
+  test('the condition is CEL a real API will accept, not just JavaScript', async () => {
+    // `permits` above runs the expression as JavaScript, which is what makes it
+    // an honest evaluator of *meaning*. It is a dishonest evaluator of *syntax*,
+    // and the gap is precisely one character wide.
+    //
+    // A CEL string literal is unescaped by CEL before the regex engine sees it,
+    // and CEL's escape table is not JavaScript's: `\.` is a no-op in a JS regex
+    // and a hard parse error in CEL. So `matches("…providers\\.d/")` evaluated
+    // correctly here and shipped an expression that Google answered with
+    // `HTTPError 400: Condition expression compilation failed`. Both bindings
+    // that carry it are `tolerateFailure`, so the deploy printed a warning and
+    // carried on with the read-scoping never applied — a security control that
+    // looked applied for as long as nobody read the warnings.
+    //
+    // The rule rather than the instance: no backslash at all. Every regex these
+    // conditions need can be written with a character class, `[.]` for a literal
+    // dot, which survives a layer of string unescaping unchanged and cannot
+    // acquire this bug back.
+    for (const condition of [await writeCondition(), await readCondition()]) {
+      expect({ condition, backslashes: condition.includes('\\') }).toEqual({
+        condition,
+        backslashes: false,
       });
     }
   });


### PR DESCRIPTION
## What broke

A deployed revision is granted each credential secret by name, at deploy time, over the connections the config held when the deploy ran. Nothing kept that true afterwards — `connect` writes a credential into the same store and binds nothing.

Read is unaffected, so the connection authorises, answers, and reconciles to `active`. Only the write on the far side of the first OAuth refresh is denied, about an hour later. `status` and `setup_overview` report "connected and reachable" the whole time, because both read the state store and the state store knows nothing about IAM.

Observed live: two connections made 23 minutes after a deploy, both holding valid credentials, both missing `secretVersionAdder`, both dead an hour in.

## What changed

**The grant is scoped to the connection, not to the deploy.** `deployments/bind.ts` binds one connection's refs from the same functions `provisionSteps` uses — extracted, not copied, for the reason `reconcile.ts` gives about planning and applying. Two spellings of a grant do not disagree on screen; they disagree about which permission exists.

It runs ahead of `connect`'s early return, because re-running `connect` is what an operator does to repair a connection and that run has no config changes to make. It is never fatal: the credential is already stored by then, and connecting against a deployed target from a machine without `gcloud` has to keep working.

Every path that writes a credential reaches that one call site — `connect custom` delegates to `runConnect`, `connectFamily` calls it per member. The reverse needs nothing: `disconnect` deletes the whole secret, and its IAM policy goes with it.

**`doctor` proves the invariant** instead of assuming it, as a problem rather than a warning. It asks IAM which rotatable refs the revision can actually write — a record this repo kept would only ever agree with itself. A policy it cannot read is reported as uncheckable, never as unbound.

## Two deploy bugs found on the way

Both had to be fixed for any of this to ship.

**`lanes link deploy` could not work from a bun/npm install.** `bun.lock` and `bunfig.toml` were not in `files`, while the Dockerfile that copies them ships under `src`. Deploy from a checkout worked, which is where it is always tested; deploy from a bun-global install died at `COPY package.json bun.lock bunfig.toml ./` after pulling the base image and pushing a build context. `dockerfile.test.ts` now checks COPY sources against what npm actually sends — the check `.gitignore` cannot make.

**The bucket conditions were invalid CEL.** `providers\.d/` inside a CEL string literal, where `\.` is not a valid escape, so both conditioned bindings failed to compile at Google. They carry `tolerateFailure`, so every deploy printed two warnings and carried on with the read-scoping never applied. `grants.test.ts` evaluates conditions as JavaScript — an honest evaluator of meaning, a permissive one of syntax — and the gap is exactly one character wide. The regex is a character class now, and the test asserts no backslash reaches the expression.

## Verification

`bun test` 2501 pass / 0 fail, `bun run typecheck` clean. Each fix was confirmed to fail its new test before the change.