### PR TITLE
Release 0.6.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lanes-sh/link",
-  "version": "0.6.2",
+  "version": "0.6.3",
   "description": "A self-hostable MCP gateway for all your connections, memory, tasks, files, and secrets",
   "license": "Apache-2.0",
   "homepage": "https://lanes.sh/link",


### PR DESCRIPTION
Merging this publishes 0.6.3 to npm.

Since v0.6.2:

- fix: bind a credential to the revision that serves it, at connect time (#87)
- docs: Lanes Link in Lanes Desktop (#66)

The version is set here, so the push to `main` arrives untagged and takes the
publish path.