### PR TITLE
fix: build the deployed image without a lockfile npm will not ship

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,6 @@
     "instructions",
     "README.md",
     "LICENSE",
-    "bun.lock",
     "bunfig.toml",
     ".dockerignore"
   ],

--- a/src/deployments/gcp/Dockerfile
+++ b/src/deployments/gcp/Dockerfile
@@ -18,9 +18,31 @@ WORKDIR /app
 # The manifest first, so a source-only change reuses the install layer. One
 # package now, rather than fifteen manifests copied ahead of the install to
 # satisfy workspace resolution.
-COPY package.json bun.lock bunfig.toml ./
+#
+# `bun.lock*`, not `bun.lock`, and the star is the whole point: **npm strips a
+# root lockfile out of a published tarball whatever `files` says.** Verified
+# against npm 12, which is what `release.yml` installs before publishing; npm
+# 11.6 still packs it, so a local `npm pack` says the opposite and the gap only
+# shows up in what people actually install.
+#
+# This image is built from whichever tree `lanes link deploy` is run against, and
+# there are two of them. From a checkout the lockfile is present and pins the
+# whole transitive set. From a bun-global install — the only install method this
+# CLI documents — it cannot be there at all, and naming it outright made deploy
+# impossible for every one of those users: the build pulled the base image,
+# pushed a context, and then died on `stat bun.lock: file does not exist`.
+COPY package.json bunfig.toml bun.lock* ./
 
-RUN bun install --frozen-lockfile
+# Not `--frozen-lockfile || bun install`: that swallows a genuine
+# lockfile-versus-manifest disagreement in a checkout build, which is the one
+# thing the frozen flag is for. The branch says which tree it is building and
+# holds the guarantee that tree can offer.
+#
+# What the fallback gives up is narrower than it looks. Every runtime dependency
+# in `package.json` is an exact version, so the direct set is identical either
+# way; the lockfile pins what those depend on in turn, and a published package
+# has never been able to carry one.
+RUN if [ -f bun.lock ]; then bun install --frozen-lockfile; else bun install; fi
 
 COPY src/ src/
 

--- a/src/deployments/gcp/dockerfile.test.ts
+++ b/src/deployments/gcp/dockerfile.test.ts
@@ -72,7 +72,7 @@ describe('the deployed image', () => {
     // that true as `.gitignore` changes.
     const sources = copySources(await readFile(DOCKERFILE, 'utf8'));
 
-    expect([...sources].sort()).toEqual(['bun.lock', 'bunfig.toml', 'package.json', 'src/']);
+    expect([...sources].sort()).toEqual(['bun.lock*', 'bunfig.toml', 'package.json', 'src/']);
   });
 
   test("does not copy the workspace, which is the operator's and not the image's", async () => {
@@ -96,35 +96,75 @@ describe('the deployed image', () => {
     expect(dockerfile).not.toMatch(/^COPY\s+\.\s/m);
   });
 
-  test('copies only what an npm install actually receives', async () => {
-    // The check `.gitignore` cannot make. A fresh clone and a published package
-    // are two different definitions of "the files are there", and this Dockerfile
-    // ships inside the package — `files` carries `src`, and the Dockerfile lives
-    // under it — so `lanes link deploy` builds from whatever npm sent.
+  test('requires nothing an npm install cannot receive', async () => {
+    // The check `.gitignore` cannot make, and the one that had to be rewritten.
     //
-    // `bun.lock` and `bunfig.toml` were not in `files`. Every test above passed:
-    // both are tracked, neither is gitignored, the allowlist named them. Deploy
-    // from a checkout worked, which is where it is always tested. Deploy from a
-    // bun-global install — the only install method this CLI documents — died at
-    // `COPY package.json bun.lock bunfig.toml ./` with `stat bun.lock: file does
-    // not exist`, after pulling the base image and pushing a build context, so
-    // the failure arrived minutes in and named a file sitting in the repository.
+    // A fresh clone and a published package are two different definitions of
+    // "the file is there", and this Dockerfile ships inside the package — `files`
+    // carries `src`, and it lives under it — so `lanes link deploy` builds from
+    // whatever npm sent. `bun.lock` and `bunfig.toml` were not in `files` at all;
+    // every other test here passed, because both are tracked and neither is
+    // gitignored, and deploy from a bun-global install died at `COPY`.
+    //
+    // Adding them to `files` fixed one of the two and *looked* like it fixed
+    // both. **npm removes a root lockfile from a tarball whatever `files`
+    // says** — npm 12, which `release.yml` installs, strips `bun.lock`; npm 11.6
+    // packs it. So a local `npm pack` confirmed a fix that had not shipped, and
+    // the published 0.6.3 tarball had no lockfile in it.
+    //
+    // Which is why this asserts the *rule* rather than shelling out to whichever
+    // npm happens to be on the machine — a test whose answer depends on that is
+    // the same trap one layer down. A source npm strips has to be written as a
+    // glob, so the build tolerates its absence; everything else has to be
+    // shipped by `files`.
     const sources = copySources(await readFile(DOCKERFILE, 'utf8'));
     const files: string[] = JSON.parse(await readFile(MANIFEST, 'utf8')).files;
 
     // npm ships these whatever `files` says, so they need no entry.
     const always = ['package.json', 'README.md', 'LICENSE', 'LICENCE'];
+    // …and removes these however hard you ask, but only at the package root.
+    const stripped = ['bun.lock', 'bun.lockb', 'package-lock.json', 'yarn.lock', 'pnpm-lock.yaml'];
 
-    const missing = sources.filter((source) => {
+    const problems: string[] = [];
+    for (const source of sources) {
       const bare = source.replace(/\/$/, '');
-      if (always.includes(bare)) return false;
-      return !files.some((entry) => {
+      if (bare.endsWith('*')) {
+        // Optional by construction. Only worth writing that way for something
+        // that can actually be missing.
+        const named = bare.slice(0, -1);
+        if (!stripped.includes(named)) problems.push(`${source} is optional but always ships`);
+        continue;
+      }
+      if (stripped.includes(bare)) {
+        problems.push(`${bare} is stripped from every tarball — copy it as "${bare}*"`);
+        continue;
+      }
+      if (always.includes(bare)) continue;
+      const shipped = files.some((entry) => {
         const listed = entry.replace(/^\.\//, '').replace(/\/$/, '');
         return listed === bare || bare.startsWith(`${listed}/`);
       });
-    });
+      if (!shipped) problems.push(`${bare} is copied but not in "files"`);
+    }
 
-    expect({ missing, files }).toEqual({ missing: [], files });
+    expect({ problems, sources, files }).toEqual({ problems: [], sources, files });
+  });
+
+  test('installs against the lockfile when there is one, and says so when there is not', async () => {
+    // The fallback must not be `--frozen-lockfile || bun install`: that turns a
+    // real lockfile-versus-manifest disagreement in a checkout build into a
+    // silent unpinned install, which is the one thing the frozen flag is for.
+    // Instructions only. The comment above the RUN line names the anti-pattern
+    // in order to rule it out, and a scan of the whole file reads that as the
+    // thing itself.
+    const instructions = (await readFile(DOCKERFILE, 'utf8'))
+      .split('\n')
+      .filter((line) => !line.trimStart().startsWith('#'))
+      .join('\n');
+
+    expect(instructions).toContain('--frozen-lockfile');
+    expect(instructions).not.toMatch(/--frozen-lockfile\s*\|\|/);
+    expect(instructions).toMatch(/if \[ -f bun\.lock \]/);
   });
 
   test('the workspace root is not baked in', async () => {


### PR DESCRIPTION
0.6.3 added `bun.lock` to `files` and did not fix the thing it was meant to.

**npm removes a root lockfile from a tarball whatever `files` says.** npm 12 — which `release.yml` installs before publishing — strips `bun.lock`; npm 11.6 packs it. So `npm pack` on the machine that wrote the fix confirmed a fix that had not shipped, and the published 0.6.3 tarball has no lockfile in it. `lanes link deploy` from a bun-global install still dies at `COPY`, which is the only install method this CLI documents.

Only at the package *root*, incidentally: a lockfile in a subdirectory packs normally. Mirroring one there would work, and would be a second copy of a generated file kept honest by a test — a worse trade than the one below.

## The change

The image tolerates its absence rather than requiring what cannot arrive:

```dockerfile
COPY package.json bunfig.toml bun.lock* ./
RUN if [ -f bun.lock ]; then bun install --frozen-lockfile; else bun install; fi
```

`bun.lock*` matches zero files without failing. The branch says which tree it is building and holds the guarantee that tree can offer: `--frozen-lockfile` against a checkout, where the lockfile pins the whole transitive set; plain `bun install` against a published package, which has never been able to carry one.

Deliberately **not** `--frozen-lockfile || bun install`. That turns a real lockfile-versus-manifest disagreement in a checkout build into a silent unpinned install, which is the one thing the flag is for.

What the fallback gives up is narrower than it reads: every runtime dependency in `package.json` is an exact version, so the direct set is identical either way. What floats is what those depend on in turn.

## The test that let it through

It compared the Dockerfile's COPY sources against `files` — a statement of intent, so it passed while the tarball was wrong. It encodes the rule now: a source npm strips must be written as a glob, everything else must be in `files`. Deliberately not by shelling out to `npm pack`, because whose npm answers is the same trap one layer down.

## Verification

`bun test` 2502 pass / 0 fail, `bun run typecheck` clean. The new tests fail against the old Dockerfile. Packed this tree with npm 12 and confirmed the tarball has `package.json` and `bunfig.toml`, no `bun.lock`, that the glob tolerates it, and that `bun install --production` resolves.