### PR TITLE
Release 0.6.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lanes-sh/link",
-  "version": "0.6.3",
+  "version": "0.6.4",
   "description": "A self-hostable MCP gateway for all your connections, memory, tasks, files, and secrets",
   "license": "Apache-2.0",
   "homepage": "https://lanes.sh/link",


### PR DESCRIPTION
Merging this publishes 0.6.4 to npm.

Since v0.6.3:

- fix: build the deployed image without a lockfile npm will not ship (#90)

0.6.3's deploy fix did not take. npm strips a root lockfile from a tarball whatever `files` says, so the published tarball had none and the image build still died at `COPY`. The Dockerfile tolerates its absence now.