### PR TITLE
fix: scope the bucket bindings with CEL Cloud Storage implements

### DIFF
--- a/src/deployments/deploy.ts
+++ b/src/deployments/deploy.ts
@@ -157,6 +157,7 @@ export async function deploy(flags: DeployFlags): Promise<void> {
     target,
     rotatable,
     readable,
+    profiles: serving,
   });
 
   // Where the running instance will read its config. The bucket the target

--- a/src/deployments/driver.ts
+++ b/src/deployments/driver.ts
@@ -92,6 +92,20 @@ export interface ProvisionInput {
    * what a target with no profile to walk still needs.
    */
   readonly readable?: readonly string[];
+  /**
+   * The profiles this revision serves, so the bucket conditions can name each
+   * one's provider manifests.
+   *
+   * Needed because Cloud Storage IAM conditions cannot express "any profile
+   * segment": their CEL is a restricted subset with no `matches`, so the only
+   * way to carve out `data/<profile>/providers.d/` is to enumerate the profiles
+   * and write one `startsWith` each. `deploy.ts` already resolved the list.
+   *
+   * Absent leaves the carve-out off entirely rather than guessing, which is the
+   * safe direction: the revision keeps write on its own data and the manifests
+   * inside it, exactly as it did before the carve-out existed.
+   */
+  readonly profiles?: readonly string[];
 }
 
 export interface SurveyInput {

--- a/src/deployments/gcp/driver.test.ts
+++ b/src/deployments/gcp/driver.test.ts
@@ -219,6 +219,7 @@ describe('first-run provisioning', () => {
       declared: target(storage),
       target: 'cloud',
       readable,
+      profiles: ['personal'],
     });
 
   test('every step tolerates failure, because the second deploy finds them all present', async () => {
@@ -290,11 +291,12 @@ describe('first-run provisioning', () => {
     // — but by the anchored pattern only. A blanket `startsWith(".../data/")`
     // here would hand the revision read on every credential-adjacent object in
     // the profile, which is the narrowing this condition exists to make.
-    // `[.]`, not `\\.`: this is a regex inside a CEL *string literal*, which CEL
-    // unescapes before the regex engine sees it, and `\\.` is not one of its
-    // escapes. The expression that produced failed to compile at Google, and the
-    // binding carries `tolerateFailure`, so the narrowing silently did not apply.
-    expect(condition).toContain('providers[.]d/');
+    // One `startsWith` per served profile, not `matches`: Cloud Storage IAM
+    // conditions have no `matches`, and refused the whole expression. The
+    // binding carries `tolerateFailure`, so the narrowing silently did not apply
+    // and the bucket kept whatever condition was already on it.
+    expect(condition).toContain('/objects/data/personal/providers.d/');
+    expect(condition).not.toContain('matches(');
     expect(condition).not.toMatch(/startsWith\("[^"]*\/objects\/data\/"\)/);
   });
 
@@ -317,8 +319,9 @@ describe('first-run provisioning', () => {
     // is why the expression carries a negation at all.
     expect(write).not.toContain('profiles/');
     expect(write).not.toContain('lanes-link.yaml');
-    expect(write).toContain('!resource.name.matches(');
-    expect(write).toContain('providers[.]d/');
+    expect(write).toContain('!(resource.name.startsWith(');
+    expect(write).toContain('/objects/data/personal/providers.d/');
+    expect(write).not.toContain('matches(');
 
     expect(conditions.some((condition) => condition.includes('reads-its-config'))).toBe(true);
   });

--- a/src/deployments/gcp/provision.ts
+++ b/src/deployments/gcp/provision.ts
@@ -1,6 +1,7 @@
 import { VAULT_DOCUMENT_REF, type SecretRef } from '#secrets';
 import type { DeployStep, ProvisionInput } from '../driver.ts';
 import { encodeRef } from '../adapters/gcp-secret-manager.ts';
+import { layout } from '#profile';
 import { requireProject } from './gcloud.ts';
 
 /**
@@ -296,22 +297,34 @@ export function provisionSteps(input: ProvisionInput): Promise<DeployStep[]> {
         `resource.name == "projects/_/buckets/${bucket}/objects/${path}"`;
 
       // A provider manifest is configuration that happens to live inside the
-      // profile's directory (ADR-030), so `data/` alone no longer separates
-      // what the revision owns from what declares what it is. Anchored to the
-      // profile segment rather than matched loosely: `contains("/providers.d/")`
-      // would also catch a blob whose own key happened to spell it.
+      // profile's directory (ADR-030), so `data/` alone no longer separates what
+      // the revision owns from what declares what it is.
       //
-      // The dot is a character class, not `\.`, and that is the fix rather than
-      // a style: this string is a *CEL string literal* holding a regex, so it is
-      // unescaped once by CEL before the regex engine ever sees it. `\.` is not
-      // a CEL escape sequence, so the whole expression failed to compile —
-      // `token recognition error at: '"^projects/_/buckets/...providers\.'` —
-      // and both bindings below carry `tolerateFailure`, so a deploy printed two
-      // warnings and carried on with the scoping silently not applied. `[.]` is
-      // the same regex and survives a layer of string unescaping unchanged,
-      // which is what keeps the next person from reintroducing it.
+      // **One `startsWith` per profile, because Cloud Storage IAM conditions
+      // cannot express anything else.** Their CEL is a restricted subset —
+      // `resource.type`, `resource.name` with `startsWith`/`endsWith`/`==`, and
+      // the date functions — and it has no `matches`. This was a regex, and it
+      // was refused twice over: first because it spelled the dot `\.`, which is
+      // not a CEL escape, so the string literal would not parse; then, with that
+      // fixed, because `matches` is `undeclared` in this dialect.
+      //
+      // Both bindings carry `tolerateFailure`, so each attempt printed a warning
+      // and left whatever conditions the bucket already had. On a real
+      // deployment that was `expression=true` on the read binding — every object
+      // in the bucket, the exact opposite of the narrowing the step title claims,
+      // and the state ADR-007 says must not exist.
+      //
+      // Enumerating the served profiles is expressible in the subset that does
+      // exist, and it makes `grants.test.ts` honest as a side effect: that file
+      // evaluates these as JavaScript, where `startsWith` means what it means
+      // here and `matches` quietly did not.
+      const manifestPrefixes = (input.profiles ?? []).map((profile) =>
+        objectsUnder(`${layout.providers(profile)}/`),
+      );
+      // No profiles leaves the carve-out off rather than guessing at one: the
+      // revision keeps write on its own data, as it did before this existed.
       const providerManifests =
-        `resource.name.matches("^projects/_/buckets/${bucket}/objects/data/[^/]+/providers[.]d/")`;
+        manifestPrefixes.length > 0 ? `(${manifestPrefixes.join(' || ')})` : null;
 
       steps.push({
         title: 'let the revision write its own data, but not the manifests in it',
@@ -327,7 +340,7 @@ export function provisionSteps(input: ProvisionInput): Promise<DeployStep[]> {
           '--role',
           'roles/storage.objectAdmin',
           '--condition',
-          `title=owns-its-data,expression=${objectsUnder('data/')} && !${providerManifests}`,
+          `title=owns-its-data,expression=${objectsUnder('data/')}${providerManifests ? ` && !${providerManifests}` : ''}`,
         ],
         tolerateFailure: true,
       });
@@ -348,7 +361,7 @@ export function provisionSteps(input: ProvisionInput): Promise<DeployStep[]> {
           // The config the revision reads is the workspace file, the profiles
           // beside it, and each profile's own manifests, so name exactly those.
           '--condition',
-          `title=reads-its-config,expression=${objectsUnder('profiles/')} || ${objectIs('lanes-link.yaml')} || ${providerManifests}`,
+          `title=reads-its-config,expression=${objectsUnder('profiles/')} || ${objectIs('lanes-link.yaml')}${providerManifests ? ` || ${providerManifests}` : ''}`,
         ],
         tolerateFailure: true,
       });

--- a/src/deployments/grants.test.ts
+++ b/src/deployments/grants.test.ts
@@ -124,7 +124,12 @@ const READS = {
 
 /** The CEL of the one conditioned binding whose title carries `name`. */
 async function conditionTitled(name: string): Promise<string> {
-  const steps = await provisionSteps({ deploy: cloudrun, declared: target, target: 'cloud' });
+  const steps = await provisionSteps({
+    deploy: cloudrun,
+    declared: target,
+    target: 'cloud',
+    profiles: [PROFILE],
+  });
   const step = steps.find((candidate) => candidate.argv.join(' ').includes(name));
 
   // `title=…,expression=…`; only the expression is evaluable.
@@ -172,29 +177,49 @@ describe('what the revision is granted, against what it writes', () => {
     }
   });
 
-  test('the condition is CEL a real API will accept, not just JavaScript', async () => {
+  test('the condition uses only what Cloud Storage IAM actually implements', async () => {
     // `permits` above runs the expression as JavaScript, which is what makes it
-    // an honest evaluator of *meaning*. It is a dishonest evaluator of *syntax*,
-    // and the gap is precisely one character wide.
+    // an honest evaluator of *meaning*. It was a dishonest evaluator of
+    // *availability*, and this expression was refused twice on that gap.
     //
-    // A CEL string literal is unescaped by CEL before the regex engine sees it,
-    // and CEL's escape table is not JavaScript's: `\.` is a no-op in a JS regex
-    // and a hard parse error in CEL. So `matches("…providers\\.d/")` evaluated
-    // correctly here and shipped an expression that Google answered with
-    // `HTTPError 400: Condition expression compilation failed`. Both bindings
-    // that carry it are `tolerateFailure`, so the deploy printed a warning and
-    // carried on with the read-scoping never applied — a security control that
-    // looked applied for as long as nobody read the warnings.
+    // Cloud Storage IAM conditions take a restricted CEL subset: `resource.type`,
+    // `resource.name` with `startsWith`, `endsWith` and `==`, and the date
+    // functions. No `matches`. JavaScript has one, so a regex condition
+    // evaluated perfectly here and came back from Google as `undeclared
+    // reference to 'matches'`.
     //
-    // The rule rather than the instance: no backslash at all. Every regex these
-    // conditions need can be written with a character class, `[.]` for a literal
-    // dot, which survives a layer of string unescaping unchanged and cannot
-    // acquire this bug back.
+    // Before that it was refused for a second reason — the regex was written
+    // `providers\\.d/`, and `\\.` is not a CEL escape, so the string literal
+    // failed to parse. Two spellings, two errors, and the same silence either
+    // way: both bindings carry `tolerateFailure`, so a deploy printed a warning
+    // and left whatever conditions the bucket already had. On a real deployment
+    // that meant `expression=true` on the read binding — every object in the
+    // bucket, which is precisely the narrowing the step title claims to make.
+    //
+    // So this asserts the subset rather than the instance.
+    const allowed = /^(resource\.name\.(startsWith|endsWith)\(|resource\.name ==|resource\.type)/;
     for (const condition of [await writeCondition(), await readCondition()]) {
-      expect({ condition, backslashes: condition.includes('\\') }).toEqual({
+      // No escape can survive CEL's unescaping wrong if there is none.
+      expect({ condition, backslash: condition.includes('\\') }).toEqual({
         condition,
-        backslashes: false,
+        backslash: false,
       });
+
+      const calls = condition.match(/[a-z_]+(\.[a-z_]+)*\s*\(/gi) ?? [];
+      const unsupported = calls
+        .map((call) => call.replace(/\s*\($/, ''))
+        .filter((name) => !/^resource\.name\.(startsWith|endsWith)$/.test(name));
+      expect({ condition, unsupported }).toEqual({ condition, unsupported: [] });
+
+      // And every clause is one of the shapes the subset names.
+      for (const clause of condition.split(/\s*(?:\|\||&&)\s*/)) {
+        const bare = clause.replace(/^[!(]+/, '').replace(/\)+$/, '');
+        if (bare.startsWith('title=') || bare.startsWith('expression=')) continue;
+        expect({ clause: bare, allowed: allowed.test(bare) }).toEqual({
+          clause: bare,
+          allowed: true,
+        });
+      }
     }
   });
 
@@ -218,7 +243,7 @@ describe('what the revision is granted, against what it writes', () => {
 
 describe('the vault, which is the one thing a revision writes back to its store', () => {
   const provision = (declared: TargetConfig) =>
-    provisionSteps({ deploy: cloudrun, declared, target: 'cloud' });
+    provisionSteps({ deploy: cloudrun, declared, target: 'cloud', profiles: [PROFILE] });
 
   test('the document secret is created here, so the revision never needs secrets.create', async () => {
     // `secrets.create` is project-level: a revision holding it could mint


### PR DESCRIPTION
The two conditioned bucket bindings have **never applied**. Both carry `tolerateFailure`, so every deploy printed a warning and carried on, and what stayed on the bucket was whatever preceded the narrowing. On the live deployment that is:

```
roles/storage.objectViewer  | reads-its-config  | expression: true
```

Every object in the bucket, readable by the revision — the exact opposite of what the step title claims, and the state ADR-007 exists to prevent.

## Refused twice, and the second only visible once the first was fixed

The carve-out was a regex spelling the dot `\.`, which is not a CEL escape, so the string literal would not parse:

```
HTTPError 400: token recognition error at: '"^projects/_/buckets/…/providers\.'
```

Fixing that (#87) produced a different refusal:

```
HTTPError 400: undeclared reference to 'matches' (in container '')
```

Cloud Storage IAM conditions take a restricted subset of CEL — `resource.type`, `resource.name` with `startsWith`/`endsWith`/`==`, and the date functions. There is no `matches` in it at all, so no spelling of that regex could ever have worked.

## The change

The carve-out enumerates the served profiles: one `startsWith` per `data/<profile>/providers.d/`, which the subset does implement. `deploy.ts` already resolved that list for the upload and the repair, so it is threaded through `ProvisionInput`. With no profiles the carve-out is omitted rather than guessed at, leaving the revision writing its own data exactly as before.

```
resource.name.startsWith("…/objects/data/")
  && !(resource.name.startsWith("…/objects/data/personal/providers.d/"))
```

## Why the test did not catch it

`grants.test.ts` evaluates these by running them as JavaScript. That is an honest evaluator of *meaning* and a silent one of *availability*: JavaScript has `matches`, Cloud Storage does not, so the expression passed here and was rejected there.

It asserts the subset now — no backslash, no call that is not `resource.name.startsWith`/`endsWith`, every clause one of the shapes the dialect names. Restoring a regex fails it; so does removing the enumeration.

## Verification

`bun test` 2502 pass / 0 fail, `bun run typecheck` clean. Confirmed the new assertions fail against a reintroduced `matches(`.