### PR TITLE
Release 0.6.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lanes-sh/link",
-  "version": "0.6.4",
+  "version": "0.6.5",
   "description": "A self-hostable MCP gateway for all your connections, memory, tasks, files, and secrets",
   "license": "Apache-2.0",
   "homepage": "https://lanes.sh/link",


### PR DESCRIPTION
Merging this publishes 0.6.5 to npm.

Since v0.6.4:

- fix: scope the bucket bindings with CEL Cloud Storage implements (#93)

The two conditioned bucket bindings had never applied — Cloud Storage IAM conditions have no `matches`, so the carve-out was rejected and the bucket kept `expression=true` on the read binding.