### PR TITLE
Create deploy buckets with Autoclass

### DIFF
--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -156,6 +156,10 @@ State, the audit log, memory, tasks, assets, skills, and your own provider manif
 one of them on an instance recycle without reporting anything, so the deploy configures the bucket
 for you rather than leaving it to a flag.
 
+A bucket it creates has Autoclass on, so an asset you have not opened in a year costs archive rates
+without you writing a lifecycle rule — and reading it back is free and immediate, which is the part
+that makes a cheaper class safe to sit under your own files.
+
 ---
 
 **Full reference:** [`detailed/deployment-cloudrun.md`](detailed/deployment-cloudrun.md) covers cold

--- a/docs/detailed/deployment-cloudrun.md
+++ b/docs/detailed/deployment-cloudrun.md
@@ -300,6 +300,20 @@ and every file kept as an asset. A deployment on the filesystem adapter is one t
 did — and for assets that is the only copy, since the point of keeping one is that the endpoint can
 reach it from anywhere.
 
+That mix is also why the deploy creates the bucket with **Autoclass**, terminal class `ARCHIVE`. The
+same bucket holds the config read on every boot and an attachment nobody opens twice, so no single
+storage class is right for it and a lifecycle rule would be a guess written by hand. Autoclass moves
+each object on its own access pattern — untouched for thirty days it cools to Nearline, and it keeps
+sinking to Archive from there — and inside such a bucket there are no retrieval fees and no
+early-deletion fees, so a read pulls the object back to Standard at no charge. That is what makes
+the colder floor safe rather than a bet on never needing the file again. Objects under 128 KiB never
+leave Standard at all, so the config, the state and the log rows are untouched by this; the saving
+is on assets and attachments.
+
+It applies to a bucket the deploy creates. A bucket from an earlier deploy is left exactly as it is
+— the create step finds it present and moves on — so turning Autoclass on for an existing one is a
+change you make yourself, in the console or with `gcloud storage buckets update`.
+
 ### The vault key, which the deploy now mints
 
 The vault document is sealed before it reaches Secret Manager, under `LANES_LINK_VAULT_KEY` — a

--- a/src/deployments/gcp/bucket.ts
+++ b/src/deployments/gcp/bucket.ts
@@ -108,6 +108,17 @@ export async function bucketSteps(input: {
         // served publicly; uniform access removes per-object ACLs as a way to
         // get that wrong.
         '--uniform-bucket-level-access',
+        // Autoclass rather than a lifecycle rule, because no one fixed class is
+        // right for this bucket: it holds the config the endpoint reads on every
+        // boot next to assets and audit rows nobody opens again. Inside an
+        // Autoclass bucket there are no retrieval and no early-deletion fees,
+        // which is what makes ARCHIVE safe as the floor rather than a bet on
+        // never reading the thing again — a read pulls the object back to
+        // Standard at no charge. Objects under 128 KiB never leave Standard, so
+        // this costs the config and the log nothing and saves on attachments.
+        '--enable-autoclass',
+        '--autoclass-terminal-storage-class',
+        'ARCHIVE',
       ],
       tolerateFailure: true,
     },

--- a/src/deployments/gcp/driver.test.ts
+++ b/src/deployments/gcp/driver.test.ts
@@ -333,6 +333,20 @@ describe('first-run provisioning', () => {
     expect(steps.flatMap((step) => step.argv)).toContain('buckets');
   });
 
+  test('the bucket is created with Autoclass, so cold assets stop costing Standard rates', async () => {
+    // The bucket holds the config read on every boot next to assets and audit
+    // rows nobody opens again, and it is created once — a class chosen here is
+    // the class those objects keep, because nothing revisits an existing bucket.
+    const create = (await provision({ adapter: 'gcs', bucket: 'lanes-link-blobs' })).find(
+      (step) => step.argv[0] === 'storage' && step.argv[2] === 'create',
+    )!;
+
+    expect(create.argv).toContain('--enable-autoclass');
+    expect(create.argv[create.argv.indexOf('--autoclass-terminal-storage-class') + 1]).toBe(
+      'ARCHIVE',
+    );
+  });
+
   test('no bucket is created for a target that declares no object storage', async () => {
     // Creating one it will never open is a resource nobody asked for and
     // nobody deletes.


### PR DESCRIPTION
`lanes link deploy` created the target's bucket with no storage-class policy, so everything it ever held stayed in Standard forever — the config the endpoint reads on every boot and the assets, attachments and audit rows nobody opens again, all at the same rate.

This adds `--enable-autoclass --autoclass-terminal-storage-class ARCHIVE` to the create step:

```console
gcloud storage buckets create gs://your-bucket --project my-project --location europe-west1 \
  --uniform-bucket-level-access --enable-autoclass --autoclass-terminal-storage-class ARCHIVE
```

**Why Autoclass and not a lifecycle rule.** A lifecycle rule is a fixed guess about age, written by hand, that has to be kept in step with what the bucket holds — and a wrong guess is paid for at retrieval. Autoclass moves each object on its own access pattern, and inside such a bucket there are no retrieval and no early-deletion fees. That is what makes `ARCHIVE` safe as the floor rather than a bet on never needing the file again: a read pulls the object back to Standard at no charge. Objects under 128 KiB never leave Standard, so the config, the state and the log rows are unaffected — the saving lands on attachments.

**Fixed, not configurable.** It sits beside `--uniform-bucket-level-access` and is justified the same way, by a comment. A knob would mean a schema field, a survey answer and a default to explain, for a choice whose wrong answer costs more; the bucket stays editable afterwards.

**New buckets only.** No migration. The create step already tolerates finding a bucket present and never revisits it, so an existing deployment is untouched.

## Verification

- `bun test` — 2530 pass, 0 fail. (`src/cli/commands/mcp/list.test.ts` times out under full-suite load on some runs; it does so on an unmodified checkout too, and passes in isolation.)
- `bun run typecheck` — clean.
- One test in `driver.test.ts` pins the two flags on the create step.
- The rendered command above is the real `provisionSteps` output, not a hand-written example.
- `gcloud storage buckets create --help` on SDK 546.0.0 lists both flags under `AUTOCLASS FLAGS`.

Nothing was deployed — anything past the step list touches a real project and is the operator's call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)