### PR TITLE
Release: grant the listing the revision has always relied on

### DIFF
--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -156,6 +156,10 @@ State, the audit log, memory, tasks, assets, skills, and your own provider manif
 one of them on an instance recycle without reporting anything, so the deploy configures the bucket
 for you rather than leaving it to a flag.
 
+A bucket it creates has Autoclass on, so an asset you have not opened in a year costs archive rates
+without you writing a lifecycle rule — and reading it back is free and immediate, which is the part
+that makes a cheaper class safe to sit under your own files.
+
 ---
 
 **Full reference:** [`detailed/deployment-cloudrun.md`](detailed/deployment-cloudrun.md) covers cold

--- a/docs/detailed/deployment-cloudrun.md
+++ b/docs/detailed/deployment-cloudrun.md
@@ -300,6 +300,20 @@ and every file kept as an asset. A deployment on the filesystem adapter is one t
 did — and for assets that is the only copy, since the point of keeping one is that the endpoint can
 reach it from anywhere.
 
+That mix is also why the deploy creates the bucket with **Autoclass**, terminal class `ARCHIVE`. The
+same bucket holds the config read on every boot and an attachment nobody opens twice, so no single
+storage class is right for it and a lifecycle rule would be a guess written by hand. Autoclass moves
+each object on its own access pattern — untouched for thirty days it cools to Nearline, and it keeps
+sinking to Archive from there — and inside such a bucket there are no retrieval fees and no
+early-deletion fees, so a read pulls the object back to Standard at no charge. That is what makes
+the colder floor safe rather than a bet on never needing the file again. Objects under 128 KiB never
+leave Standard at all, so the config, the state and the log rows are untouched by this; the saving
+is on assets and attachments.
+
+It applies to a bucket the deploy creates. A bucket from an earlier deploy is left exactly as it is
+— the create step finds it present and moves on — so turning Autoclass on for an existing one is a
+change you make yourself, in the console or with `gcloud storage buckets update`.
+
 ### The vault key, which the deploy now mints
 
 The vault document is sealed before it reaches Secret Manager, under `LANES_LINK_VAULT_KEY` — a

--- a/docs/detailed/deployment-cloudrun.md
+++ b/docs/detailed/deployment-cloudrun.md
@@ -223,7 +223,7 @@ Four bindings, each narrower than it looks:
 | `roles/secretmanager.secretAccessor` | **one binding per secret it reads** | Read at boot and while serving: OAuth refresh tokens, the endpoint's own bearer token, the vault key. |
 | `roles/secretmanager.secretVersionAdder` | **one binding per secret it rotates** | The vault document, and each connection's OAuth token. Add a version, never create — see below. |
 | `roles/storage.objectAdmin` | **conditioned** on `data/`, less each profile's `providers.d/` | What the endpoint owns and writes: state, the log, attachments, memory, and skills (writable under policy, ADR-014). Manifests are carved back out — they are config, and ADR-007 says a revision never rewrites its own. |
-| `roles/storage.objectViewer` | `profiles/`, `lanes-link.yaml`, and each `providers.d/` | Reading its own config. Deliberately *not* admin — see below. |
+| `roles/storage.objectViewer` | the bucket itself, plus `profiles/`, `lanes-link.yaml`, and each `providers.d/` | Reading its own config. Deliberately *not* admin — see below. The bucket is named as well because listing is granted there and nowhere else. |
 
 `deploy` creates the account and all of them on a first run; `--dry-run` shows them, and
 `--service-account` names a different one.
@@ -253,6 +253,22 @@ configuration. That used to be enforced by the config being baked into a read-on
 stopped being true when the workspace moved into the bucket (ADR-023). The condition is where that
 guarantee went: the revision may write what it owns and may only read what declares what it is. A
 blanket `objectAdmin` would silently undo it, which is why `driver.test.ts` asserts the shape.
+
+**Why the read grant also names the bucket.** `storage.objects.list` is checked against the
+*bucket*, never against an object — a prefixed listing is one call to the bucket carrying a filter,
+not a walk of matching resources — so no condition written in terms of `objects/…` can grant it, and
+Google says as much: IAM conditions cannot restrict object listing by prefix. The condition
+therefore admits `projects/_/buckets/<bucket>` as well as the three config paths.
+
+The only permission that can follow from it is `storage.objects.list`. Everything else in
+`objectViewer` is evaluated against an object, where the prefixes still decide, or is project-level
+and out of a bucket binding's reach. So the concession is the *names* of what is in the bucket;
+reading any of it stays where ADR-007 puts it.
+
+This was invisible for as long as the read binding sat at `expression=true`, which matches the
+bucket as readily as an object. The first deploy that actually removed that binding rolled a
+revision that could not list its own workspace, and `grants.test.ts` had not caught it because it
+evaluates the conditions against object keys — a listing has no object in it. It does now.
 
 **Why the Secret Manager write grant is per secret.** The line is not read versus write — the
 revision plainly writes — it is *rotating what exists* versus *bringing something into existence*.

--- a/src/deployments/gcp/bucket.ts
+++ b/src/deployments/gcp/bucket.ts
@@ -50,6 +50,31 @@ export function bucketGrants(bucket: string, profiles: readonly string[]): Condi
     `resource.name.startsWith("projects/_/buckets/${bucket}/objects/${path}")`;
   const objectIs = (path: string): string =>
     `resource.name == "projects/_/buckets/${bucket}/objects/${path}"`;
+  /**
+   * The bucket itself, which is a different resource from anything in it.
+   *
+   * **`storage.objects.list` is checked against the bucket, never against an
+   * object**, so no condition written in terms of `objects/…` can ever grant it
+   * — including a prefixed listing, which is one call with a filter rather than
+   * a walk of matching resources. Google says so outright: IAM conditions cannot
+   * restrict listing by prefix.
+   *
+   * This was invisible until the day the narrowing actually applied. The
+   * `reads-its-config` binding had been sitting at `expression=true` since the
+   * first deploy, and `true` matches the bucket resource as readily as an object
+   * — so listing worked, and every deploy that thought it had replaced that
+   * binding had in fact only added one beside it. The first deploy that removed
+   * the old one rolled a revision that could not list its own workspace, exited
+   * 1, and took the endpoint's listing with it: `objects.list` had never been
+   * granted by anything else.
+   *
+   * Only `storage.objects.list` can come of it. Every other permission in
+   * `objectViewer` is either evaluated against an object — where the prefixes
+   * below still decide — or is a project-level permission a binding on a bucket
+   * does not reach. So the concession is the names of the objects in this
+   * bucket, and reads stay scoped to the config.
+   */
+  const theBucket = `resource.name == "projects/_/buckets/${bucket}"`;
 
   const manifestPrefixes = profiles.map((profile) =>
     objectsUnder(`${layout.providers(profile)}/`),
@@ -73,7 +98,7 @@ export function bucketGrants(bucket: string, profiles: readonly string[]): Condi
       // and each profile's own manifests, so name exactly those.
       role: 'roles/storage.objectViewer',
       title: 'reads-its-config',
-      expression: `${objectsUnder('profiles/')} || ${objectIs('lanes-link.yaml')}${manifests ? ` || ${manifests}` : ''}`,
+      expression: `${theBucket} || ${objectsUnder('profiles/')} || ${objectIs('lanes-link.yaml')}${manifests ? ` || ${manifests}` : ''}`,
     },
   ];
 }

--- a/src/deployments/gcp/bucket.ts
+++ b/src/deployments/gcp/bucket.ts
@@ -108,6 +108,17 @@ export async function bucketSteps(input: {
         // served publicly; uniform access removes per-object ACLs as a way to
         // get that wrong.
         '--uniform-bucket-level-access',
+        // Autoclass rather than a lifecycle rule, because no one fixed class is
+        // right for this bucket: it holds the config the endpoint reads on every
+        // boot next to assets and audit rows nobody opens again. Inside an
+        // Autoclass bucket there are no retrieval and no early-deletion fees,
+        // which is what makes ARCHIVE safe as the floor rather than a bet on
+        // never reading the thing again — a read pulls the object back to
+        // Standard at no charge. Objects under 128 KiB never leave Standard, so
+        // this costs the config and the log nothing and saves on attachments.
+        '--enable-autoclass',
+        '--autoclass-terminal-storage-class',
+        'ARCHIVE',
       ],
       tolerateFailure: true,
     },

--- a/src/deployments/gcp/driver.test.ts
+++ b/src/deployments/gcp/driver.test.ts
@@ -333,6 +333,20 @@ describe('first-run provisioning', () => {
     expect(steps.flatMap((step) => step.argv)).toContain('buckets');
   });
 
+  test('the bucket is created with Autoclass, so cold assets stop costing Standard rates', async () => {
+    // The bucket holds the config read on every boot next to assets and audit
+    // rows nobody opens again, and it is created once — a class chosen here is
+    // the class those objects keep, because nothing revisits an existing bucket.
+    const create = (await provision({ adapter: 'gcs', bucket: 'lanes-link-blobs' })).find(
+      (step) => step.argv[0] === 'storage' && step.argv[2] === 'create',
+    )!;
+
+    expect(create.argv).toContain('--enable-autoclass');
+    expect(create.argv[create.argv.indexOf('--autoclass-terminal-storage-class') + 1]).toBe(
+      'ARCHIVE',
+    );
+  });
+
   test('no bucket is created for a target that declares no object storage', async () => {
     // Creating one it will never open is a resource nobody asked for and
     // nobody deletes.

--- a/src/deployments/grants.test.ts
+++ b/src/deployments/grants.test.ts
@@ -76,6 +76,12 @@ const AREAS: Record<string, [string | undefined, string]> = {
 
 const WRITES: Record<string, string> = {};
 
+/** The URL the store asks for a listing, captured from the adapter itself. */
+let LISTED = '';
+
+/** What IAM evaluates a listing against: the bucket, not anything in it. */
+const BUCKET_RESOURCE = `projects/_/buckets/${BUCKET}`;
+
 beforeAll(async () => {
   // Keeps `ApplicationDefaultCredentials` off the network and out of the
   // operator's own gcloud credentials: with this set it returns the override
@@ -104,6 +110,11 @@ beforeAll(async () => {
       await storage(area).put(key, new Uint8Array([1]));
       WRITES[what] = new URL(captured[0]!).searchParams.get('name')!;
     }
+
+    // And one listing, which is the call that has no object in it at all.
+    captured.length = 0;
+    await storage(layout.state(PROFILE)).list('connections.v1/');
+    LISTED = captured[0]!;
   } finally {
     globalThis.fetch = real;
   }
@@ -155,7 +166,11 @@ const readCondition = (): Promise<string> => conditionTitled('reads-its-config')
  * `resource.name == "…"` still compares equal by coercion.
  */
 function permits(condition: string, key: string): boolean {
-  const full = `${OBJECTS}${key}`;
+  return permitsResource(condition, `${OBJECTS}${key}`);
+}
+
+/** The same, for a resource name that is not an object under this bucket. */
+function permitsResource(condition: string, full: string): boolean {
   const name = Object.assign(new String(full), {
     contains: (needle: string) => full.includes(needle),
     matches: (pattern: string) => new RegExp(pattern).test(full),
@@ -163,6 +178,54 @@ function permits(condition: string, key: string): boolean {
 
   return new Function('resource', `return ${condition};`)({ name }) === true;
 }
+
+/**
+ * The permission no object prefix can carry.
+ *
+ * `storage.objects.list` is checked against the **bucket**, never against an
+ * object — a prefixed listing is one call to the bucket with a filter on it,
+ * not a walk of matching resources — so a condition written in terms of
+ * `objects/…` cannot grant it. Google documents the consequence outright: IAM
+ * conditions cannot restrict object listing by prefix.
+ *
+ * It stayed hidden for as long as the read binding said `expression=true`,
+ * which matches the bucket as readily as an object. The deploy that finally
+ * removed that binding rolled a revision which could not list its own
+ * workspace, exited 1 during the health check, and left the endpoint in front
+ * of it unable to list anything either — every `tasks`, `memory` and `assets`
+ * call 403'd, because listing had never been granted by anything else.
+ */
+describe('listing, which is checked against the bucket rather than an object', () => {
+  test('the store asks the bucket for it, with the prefix as a query parameter', async () => {
+    // Taken off the adapter rather than asserted about it: this is the fact
+    // that decides which resource IAM evaluates, and it is not visible in any
+    // object name.
+    const url = new URL(LISTED);
+
+    expect(url.pathname).toBe(`/storage/v1/b/${BUCKET}/o`);
+    expect(url.searchParams.get('prefix')).toContain('connections.v1/');
+  });
+
+  test('so the read grant has to admit the bucket itself, and does', async () => {
+    expect(permitsResource(await readCondition(), BUCKET_RESOURCE)).toBe(true);
+  });
+
+  test('and nothing else does, which is why removing that clause takes listing with it', async () => {
+    // The write grant is every other binding this deploy makes on the bucket.
+    // If this one ever passes, the clause above has a second source and the
+    // test above stops being load-bearing.
+    expect(permitsResource(await writeCondition(), BUCKET_RESOURCE)).toBe(false);
+  });
+
+  test('admitting the bucket does not admit an object outside the config', async () => {
+    // The whole concession is the *names* of what is in the bucket. Reads stay
+    // where ADR-007 puts them.
+    const condition = await readCondition();
+
+    expect(permitsResource(condition, `${OBJECTS}data/${PROFILE}/memory/main/note.md`)).toBe(false);
+    expect(permitsResource(condition, `${OBJECTS}data/${PROFILE}/credentials.enc`)).toBe(false);
+  });
+});
 
 describe('what the revision is granted, against what it writes', () => {
   test('every object the endpoint writes falls inside the write grant', async () => {


### PR DESCRIPTION
Merging this takes the **propose** path: the release run pushes `release/next` with the patch bump to 0.6.7, and merging that publishes.

Since v0.6.6:

- fix: grant the listing the revision has always relied on (#100)

0.6.6 removed the superseded bucket bindings and one of them was load-bearing: `reads-its-config` had sat at `expression=true` since the first deploy, and `storage.objects.list` is checked against the bucket rather than against an object — so no object-prefix condition can grant it. The read grant now names the bucket as well.

Merge commit, not a squash — the closing fast-forward of `develop` depends on it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
