### PR TITLE
Release 0.6.7

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lanes-sh/link",
-  "version": "0.6.6",
+  "version": "0.6.7",
   "description": "A self-hostable MCP gateway for all your connections, memory, tasks, files, and secrets",
   "license": "Apache-2.0",
   "homepage": "https://lanes.sh/link",


### PR DESCRIPTION
Merging this publishes 0.6.7 to npm.

Since v0.6.6:

- fix: grant the listing the revision has always relied on (#100)