### PR TITLE
feat: lanes link auth — whether each connection can still sign in

### DIFF
--- a/docs/detailed/workflow.md
+++ b/docs/detailed/workflow.md
@@ -383,7 +383,8 @@ Failures surface in the cheapest place first:
 
 ```console
 $ lanes link check --profile personal     # static: schema, validation rules, no external calls
-$ lanes link doctor --profile personal --target local    # read-only external: credentials resolve, database reachable
+$ lanes link doctor --profile personal --target local     # external: credentials still authenticate, database reachable
+$ lanes link auth --profile personal --target local       # just the credentials, per connection, as JSON
 $ lanes link plan --profile personal --target local      # what reconcile would change; no mutation
 $ lanes link start --profile personal --target local     # apply reconcile, then serve locally
 $ lanes link deploy --profile personal --target local    # apply to the cloud target

--- a/src/cli/commands/operate.ts
+++ b/src/cli/commands/operate.ts
@@ -2,10 +2,11 @@
  * Running an instance and looking at it — everything that is neither
  * `connect` nor the owner layer.
  *
- * Seven files, one per verb group, because every private helper here served
+ * Eight files, one per verb group, because every private helper here served
  * exactly one command and nothing crossed between them:
  *
  *   inspect.ts   check, plan, doctor — the gate order, cheapest failure first
+ *   auth.ts      whether each connection can still authenticate, by asking
  *   status.ts    connections, reachable capabilities, endpoint
  *   outputs.ts   what an agent harness needs, and proving the short form works
  *   dashboard.ts opening the page a local endpoint serves, with the key it needs
@@ -19,6 +20,7 @@
  */
 
 export { check, doctor, plan } from './operate/inspect.ts';
+export { auth, classifyOAuth, type AuthFlags, type AuthVerdict, type ConnectionAuth } from './operate/auth.ts';
 export { status } from './operate/status.ts';
 export { outputs, type OutputsFlags } from './operate/outputs.ts';
 export { tools, type ToolsFlags } from './operate/tools.ts';

--- a/src/cli/commands/operate/auth.test.ts
+++ b/src/cli/commands/operate/auth.test.ts
@@ -1,0 +1,151 @@
+import { describe, expect, test } from 'bun:test';
+import { ReauthRequired } from '#connectivity/auth/index.ts';
+import { defineProvider } from '#connectivity';
+import type { SecretRef, SecretStore } from '#secrets';
+import { classifyOAuth, probeConnections } from './auth.ts';
+import type { Runtime } from '../../runtime.ts';
+
+/**
+ * The mapping, on its own.
+ *
+ * Everything expensive about `lanes link auth` is I/O, and everything that
+ * could be *wrong* about it is this function. Both ways it can lie have a test
+ * here, because both are the kind of bug that ships quietly: one tells someone
+ * to sign in again when their network is simply down, and the other tells them
+ * a dead credential is fine.
+ */
+describe('classifyOAuth', () => {
+  test('a resolved credential is ok', () => {
+    expect(classifyOAuth({ outcome: 'resolved', staleAccessToken: false })).toBe('ok');
+  });
+
+  test('a resolved credential whose stored token is still expired needs a person', () => {
+    // `upstreamAccessToken` hands back the *stale* access token when there is
+    // no refresh token to renew with, and again when a refresh comes back
+    // without one. Both are deliberate on the serve path — a vendor 401 is the
+    // truthful instruction there — but a health check that called them ok would
+    // say the opposite of what the next real call finds.
+    expect(classifyOAuth({ outcome: 'resolved', staleAccessToken: true })).toBe('reauth');
+  });
+
+  test('a ReauthRequired is the signal this exists for', () => {
+    const error = new ReauthRequired('gmail.main', 'could not be refreshed (400)');
+    expect(classifyOAuth({ outcome: 'threw', error })).toBe('reauth');
+  });
+
+  test('any other throw is unknown, never reauth', () => {
+    // The wolf-crying guard. A 5xx, a DNS failure, or a bug in here must not
+    // send someone through a consent screen — a warning that is wrong once is a
+    // warning that gets scrolled past every time after.
+    expect(classifyOAuth({ outcome: 'threw', error: new Error('fetch failed') })).toBe('unknown');
+    expect(classifyOAuth({ outcome: 'threw', error: 'not even an Error' })).toBe('unknown');
+  });
+
+  test('a timeout is unknown — it is a statement about the network, not the grant', () => {
+    expect(classifyOAuth({ outcome: 'timeout' })).toBe('unknown');
+  });
+
+  test('nothing to resolve is missing', () => {
+    expect(classifyOAuth({ outcome: 'none' })).toBe('missing');
+  });
+});
+
+/**
+ * What the probe does *before* it reaches the resolver.
+ *
+ * The OAuth path is covered by `classifyOAuth` above and by the throw sites in
+ * `refresh.test.ts`; this is the dispatch in front of both, and it exists
+ * because the wrong branch here manufactures failures that are not there. The
+ * `strategy` case is the specific one: `credentialResolver` refuses that kind
+ * unconditionally, so a connection that signs its own requests would be
+ * reported as broken by a probe that simply asked the resolver about everything.
+ */
+describe('probeConnections, before the resolver', () => {
+  const forSelection = (command: string) => `${command} --profile p --target t`;
+
+  const store = (seed: Record<string, string> = {}): SecretStore => {
+    const map = new Map(Object.entries(seed));
+    return {
+      get: async (ref) => map.get(ref) ?? null,
+      set: async (ref, value) => void map.set(ref, value),
+      has: async (ref) => map.has(ref),
+      delete: async (ref) => void map.delete(ref),
+      list: async () => [...map.keys()] as SecretRef[],
+    };
+  };
+
+  const provider = (id: string, auth: Record<string, unknown>) =>
+    defineProvider({
+      id,
+      name: id,
+      connector: { kind: 'http', base_url: 'https://api.test', openapi: './t.json' },
+      auth: auth as never,
+    });
+
+  const runtimeWith = (manifests: ReturnType<typeof provider>[], secrets: SecretStore) =>
+    ({
+      credentials: secrets,
+      registry: { manifest: (id: string) => manifests.find((m) => m.id === id) ?? null },
+      manifestFor: (id: string) => manifests.find((m) => m.id === id),
+    }) as unknown as Runtime;
+
+  test('a strategy connection is answered from the store, never through the resolver', async () => {
+    // `credentialResolver` throws for `strategy` whatever is stored, so reaching
+    // it would report a working bunq connection as broken.
+    const manifest = provider('bunq', { kind: 'strategy', strategy: 'bunq' });
+    const runtime = runtimeWith([manifest], store({ 'bunq/joint': 'a-key' }));
+
+    const [result] = await probeConnections(
+      runtime,
+      [{ provider: 'bunq', id: 'joint' } as never],
+      forSelection,
+    );
+
+    expect(result!.verdict).toBe('stored');
+    expect(result!.method).toBe('strategy');
+    expect(result!.refreshed).toBe(false);
+  });
+
+  test('a static secret that is present is stored, not ok — nothing here exercised it', async () => {
+    const manifest = provider('icloud_mail', { kind: 'basic' });
+    const runtime = runtimeWith([manifest], store({ 'icloud_mail/main': 'user:pass' }));
+
+    const [result] = await probeConnections(
+      runtime,
+      [{ provider: 'icloud_mail', id: 'main' } as never],
+      forSelection,
+    );
+
+    expect(result!.verdict).toBe('stored');
+  });
+
+  test('a static secret that is absent is missing, and carries the command that fixes it', async () => {
+    const manifest = provider('icloud_mail', { kind: 'basic' });
+    const runtime = runtimeWith([manifest], store());
+
+    const [result] = await probeConnections(
+      runtime,
+      [{ provider: 'icloud_mail', id: 'main' } as never],
+      forSelection,
+    );
+
+    expect(result!.verdict).toBe('missing');
+    expect(result!.fix).toBe('lanes link connect icloud_mail.main --profile p --target t');
+  });
+
+  test('the owner layer needs no credential and costs no store read', async () => {
+    const manifest = provider('memory', { kind: 'none' });
+    let reads = 0;
+    const counted: SecretStore = { ...store(), has: async () => (reads++, false) };
+    const runtime = runtimeWith([manifest], counted);
+
+    const [result] = await probeConnections(
+      runtime,
+      [{ provider: 'memory', id: 'main' } as never],
+      forSelection,
+    );
+
+    expect(result!.verdict).toBe('none');
+    expect(reads).toBe(0);
+  });
+});

--- a/src/cli/commands/operate/auth.ts
+++ b/src/cli/commands/operate/auth.ts
@@ -1,0 +1,333 @@
+import { credentialResolver, ReauthRequired } from '#connectivity/auth/index.ts';
+import type { ResolvedCredential } from '#connectivity/auth/credential.ts';
+import { credentialRefFor } from '#registry';
+import { announce, emit, fail, ok, print, warn } from '../../output.ts';
+import { openRuntime, type GlobalFlags, type Runtime } from '../../runtime.ts';
+
+/**
+ * Whether each connection could still authenticate, asked rather than guessed.
+ *
+ * `doctor` used to answer a version of this from the *age* of a stored
+ * credential, which is wrong in both directions: it dates a credential from
+ * when its access token was last refreshed, so a healthy connection nobody has
+ * called in a fortnight reads as stale, and a grant revoked an hour ago reads
+ * as fresh because nothing has tried to use it since.
+ *
+ * So this attempts the renewal instead. That is the only thing that actually
+ * knows, and it is cheap in the case that matters: resolving an OAuth
+ * credential short-circuits on the stored `expires_at` (`oauth-authcode/provider.ts`),
+ * so a connection whose access token is still live costs no network at all. The
+ * cost is one token-endpoint round trip per connection that has genuinely
+ * lapsed — which is exactly the set worth asking about.
+ *
+ * **This command writes.** A successful refresh persists the new token, which on
+ * a deployed target is a secret-store version per refreshed connection. That is
+ * deliberate — it is the same write the serve path makes, and it warms the token
+ * for the next real call — but it is why the read-only wording `check`, `plan`
+ * and `doctor` carry does not appear here.
+ */
+
+/** What can be said about one connection's ability to authenticate. */
+export type AuthVerdict =
+  /** Resolved. The vendor accepted it just now, or its access token is still live. */
+  | 'ok'
+  /** Stored, and cannot be renewed without a person. The signal this exists for. */
+  | 'reauth'
+  /** Nothing at the credential ref. */
+  | 'missing'
+  /** A static secret is present, and nothing here can exercise it. */
+  | 'stored'
+  /** `auth.kind: none` — the owner layer. Can never need signing in. */
+  | 'none'
+  /** The probe could not complete: a timeout, a network fault, an unexpected throw. */
+  | 'unknown';
+
+export interface ConnectionAuth {
+  readonly key: string;
+  readonly provider: string;
+  readonly id: string;
+  /** The manifest's `auth.kind`, so a reader can tell why a verdict is what it is. */
+  readonly method: string;
+  readonly verdict: AuthVerdict;
+  /** Whether answering cost a token-endpoint round trip. */
+  readonly refreshed: boolean;
+  readonly detail?: string;
+  readonly fix?: string;
+}
+
+/**
+ * What the probe observed, before it means anything.
+ *
+ * Separated from the verdict so the classification can be tested without a
+ * network, a credential store, or a runtime — every interesting case here is a
+ * question about *mapping*, and the mapping is where the mistakes are.
+ */
+export type ProbeResult =
+  /** A credential came back. `staleAccessToken` is the silent-failure case below. */
+  | { readonly outcome: 'resolved'; readonly staleAccessToken: boolean }
+  /** The resolver returned `resolveNone()` — there was nothing to resolve. */
+  | { readonly outcome: 'none' }
+  | { readonly outcome: 'timeout' }
+  | { readonly outcome: 'threw'; readonly error: unknown };
+
+/**
+ * One OAuth probe result, as a verdict.
+ *
+ * The two rules worth stating out loud, because both are ways this feature
+ * could lie:
+ *
+ * **An unexpected throw is `unknown`, never `reauth`.** Only `ReauthRequired`
+ * means a person is needed. Anything else — DNS, a 500, a bug in here — must
+ * not send someone through a consent screen, and a warning that is wrong once
+ * is a warning that gets scrolled past every time after.
+ *
+ * **A resolved token is not automatically `ok`.** `upstreamAccessToken` hands
+ * back the *stale* access token when there is no refresh token to renew with,
+ * and again when a refresh returns no `access_token`. Both are deliberate on
+ * the serve path, where letting the vendor's own 401 surface is the truthful
+ * instruction — but a health check that reported them as working would be
+ * saying the opposite of what the next real call will find. So the stored
+ * expiry is checked here rather than that behaviour being changed.
+ */
+export function classifyOAuth(result: ProbeResult): AuthVerdict {
+  switch (result.outcome) {
+    case 'resolved':
+      return result.staleAccessToken ? 'reauth' : 'ok';
+    case 'none':
+      return 'missing';
+    case 'timeout':
+      return 'unknown';
+    case 'threw':
+      return result.error instanceof ReauthRequired ? 'reauth' : 'unknown';
+  }
+}
+
+/**
+ * How many connections to probe at once.
+ *
+ * Small on purpose. The work is mostly waiting on token endpoints, so some
+ * concurrency is free, but a profile with twenty Google connections hitting one
+ * endpoint at once is a rate limit rather than a speed-up.
+ */
+const CONCURRENCY = 6;
+
+/**
+ * How long one connection may take before it is reported as `unknown`.
+ *
+ * `refreshDirectly` takes no `AbortSignal`, so this races rather than cancels —
+ * the request finishes into nothing. That is acceptable for a read-shaped
+ * command and avoids threading a signal through the refresh path for the
+ * benefit of one caller.
+ */
+const PER_CONNECTION_TIMEOUT_MS = 8_000;
+
+/** `expires_at` from a stored OAuth blob, or null when it is not one. */
+function storedExpiry(raw: string | null): number | null {
+  if (!raw) return null;
+  try {
+    const parsed = JSON.parse(raw) as { expires_at?: number };
+    return typeof parsed.expires_at === 'number' ? parsed.expires_at : null;
+  } catch {
+    return null;
+  }
+}
+
+export interface AuthFlags extends GlobalFlags {
+  readonly json?: boolean | undefined;
+  /** Narrow to one connection, by `provider.id`. A filter, not a second subject. */
+  readonly connection?: string | undefined;
+}
+
+/**
+ * Every connection's verdict, probed concurrently.
+ *
+ * Exported because `doctor` asks the same question and must not answer it a
+ * second, differently-wrong way — that divergence is the bug this replaced.
+ */
+export async function probeConnections(
+  runtime: Runtime,
+  connections: readonly Runtime['config']['connections'][number][],
+  forSelection: (command: string) => string,
+): Promise<ConnectionAuth[]> {
+  const resolve = credentialResolver(runtime.registry, runtime.credentials);
+
+  const probe = async (
+    connection: Runtime['config']['connections'][number],
+  ): Promise<ConnectionAuth> => {
+    const key = `${connection.provider}.${connection.id}`;
+    const manifest = runtime.manifestFor(connection.provider);
+    const method = manifest?.auth.kind ?? 'unknown';
+    const base = { key, provider: connection.provider, id: connection.id, method };
+
+    // A provider holding nothing to authenticate with can never need signing
+    // in, and saying so is more useful than saying nothing: it is the whole
+    // owner layer, and "why is memory not checked" is a real question.
+    if (!manifest || manifest.auth.kind === 'none') {
+      return { ...base, method: 'none', verdict: 'none', refreshed: false };
+    }
+
+    const ref = credentialRefFor(connection, manifest);
+    if (!ref) return { ...base, verdict: 'none', refreshed: false };
+
+    const missing = (): ConnectionAuth => ({
+      ...base,
+      verdict: 'missing',
+      refreshed: false,
+      detail: `Nothing stored at ${ref}.`,
+      fix: forSelection(`lanes link connect ${key}`),
+    });
+
+    if (!(await runtime.credentials.has(ref))) return missing();
+
+    // Everything that is not authcode OAuth is a secret sitting in the store.
+    // There is nothing to renew and no cheap way to exercise it, so presence is
+    // the whole of what can be said — and `strategy` in particular *must* take
+    // this path, because `credentialResolver` refuses it unconditionally (it
+    // signs its own requests) and routing it through would manufacture a
+    // failure that is not there.
+    if (manifest.auth.kind !== 'oauth') {
+      return { ...base, verdict: 'stored', refreshed: false };
+    }
+
+    const before = storedExpiry(await runtime.credentials.get(ref));
+    const lapsed = before !== null && before <= Date.now();
+
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    const result = await Promise.race([
+      resolve(connection.provider, connection.id).then(
+        (credential: ResolvedCredential): ProbeResult =>
+          credential.kind === 'none'
+            ? { outcome: 'none' }
+            : { outcome: 'resolved', staleAccessToken: false },
+        (error: unknown): ProbeResult => ({ outcome: 'threw', error }),
+      ),
+      new Promise<ProbeResult>((settle) => {
+        timer = setTimeout(() => settle({ outcome: 'timeout' }), PER_CONNECTION_TIMEOUT_MS);
+      }),
+    ]);
+    if (timer) clearTimeout(timer);
+
+    // The silent-failure check. An expiry that is *still* in the past after
+    // resolving means the resolver went out and came back with nothing better,
+    // which is the case `classifyOAuth` documents.
+    const after = storedExpiry(await runtime.credentials.get(ref));
+    const stillLapsed = after !== null && after <= Date.now();
+
+    const settled: ProbeResult =
+      result.outcome === 'resolved'
+        ? { outcome: 'resolved', staleAccessToken: stillLapsed }
+        : result;
+
+    const verdict = classifyOAuth(settled);
+    const detail =
+      result.outcome === 'threw' && result.error instanceof Error
+        ? result.error.message
+        : result.outcome === 'timeout'
+          ? `Timed out after ${PER_CONNECTION_TIMEOUT_MS / 1000}s.`
+          : settled.outcome === 'resolved' && settled.staleAccessToken
+            ? 'The stored access token is expired and could not be renewed.'
+            : undefined;
+
+    return {
+      ...base,
+      verdict,
+      // Whether answering cost a round trip: a live token means the resolver
+      // short-circuited and never went out.
+      refreshed: lapsed,
+      ...(detail ? { detail } : {}),
+      ...(verdict === 'reauth' || verdict === 'missing'
+        ? { fix: forSelection(`lanes link connect ${key}`) }
+        : {}),
+    };
+  };
+
+  return mapWithLimit(connections, CONCURRENCY, probe);
+}
+
+export async function auth(flags: AuthFlags): Promise<void> {
+  const runtime = await openRuntime(flags);
+
+  try {
+    const { profile, target } = runtime.resolution;
+    const forSelection = (command: string) => `${command} --profile ${profile} --target ${target}`;
+
+    const wanted = flags.connection;
+    const connections = wanted
+      ? runtime.config.connections.filter((c) => `${c.provider}.${c.id}` === wanted)
+      : runtime.config.connections;
+
+    if (wanted && connections.length === 0) {
+      throw new Error(
+        `No connection "${wanted}" in profile ${profile}. Run: ${forSelection('lanes link status')}`,
+      );
+    }
+
+    const results = await probeConnections(runtime, connections, forSelection);
+    const needsSomeone = results.filter((r) => r.verdict === 'reauth' || r.verdict === 'missing');
+
+    // Always zero, and this is load-bearing rather than an oversight: the
+    // desktop app discards stdout when the CLI exits non-zero, which is exactly
+    // why it cannot read `doctor`. A connection needing a person is the answer
+    // this command was asked for, not a failure to produce one.
+    return emit(flags.json, { profile, target, ok: needsSomeone.length === 0, connections: results }, () => {
+      announce(runtime.resolution);
+
+      for (const result of results) {
+        const line = `${result.key} — ${describe(result.verdict)}`;
+        if (result.verdict === 'reauth') print(fail(`${line}\n      ${result.fix}`));
+        else if (result.verdict === 'missing') print(warn(`${line}\n      ${result.fix}`));
+        else print(ok(line));
+      }
+
+      if (needsSomeone.length > 0) {
+        print();
+        print(fail(`${needsSomeone.length} connection(s) need you to sign in again`));
+      }
+    });
+  } finally {
+    await runtime.close();
+  }
+}
+
+function describe(verdict: AuthVerdict): string {
+  switch (verdict) {
+    case 'ok':
+      return 'authenticated';
+    case 'reauth':
+      return 'signed out, and cannot renew itself';
+    case 'missing':
+      return 'no credential stored';
+    case 'stored':
+      return 'credential stored, not exercised';
+    case 'none':
+      return 'needs no credential';
+    case 'unknown':
+      return 'could not be checked';
+  }
+}
+
+/**
+ * `Promise.all` with a ceiling, in the ten lines it takes.
+ *
+ * A pool rather than chunks: chunking would make every batch wait for its
+ * slowest member, which is the shape this command is trying to avoid.
+ */
+async function mapWithLimit<T, R>(
+  items: readonly T[],
+  limit: number,
+  run: (item: T) => Promise<R>,
+): Promise<R[]> {
+  const results = new Array<R>(items.length);
+  let next = 0;
+
+  const worker = async (): Promise<void> => {
+    for (;;) {
+      const index = next++;
+      if (index >= items.length) return;
+      results[index] = await run(items[index]!);
+    }
+  };
+
+  await Promise.all(Array.from({ length: Math.min(limit, items.length) }, worker));
+  return results;
+}

--- a/src/cli/commands/operate/findings.ts
+++ b/src/cli/commands/operate/findings.ts
@@ -1,53 +1,24 @@
 import { ownerPrincipal } from '#auth';
 import type { DiscoveredCapability } from '#connectivity';
-import { BROKERED } from '#connectivity/auth/index.ts';
 import { allowedConnections } from '#policy';
 import { toPolicyDocument } from '#registry';
 import { capabilityDiff, discoveryProbe } from '../../runtime/discovery.ts';
 import type { openRuntime } from '../../runtime.ts';
 
 /**
- * The two things `doctor` has to work out rather than simply read.
+ * The one thing `doctor` has to work out rather than simply read.
  *
  * Everything else in `inspect.ts` is a lookup — is the token there, does the
- * credential resolve, does the connection name a provider that exists — and
- * these two are analyses: one dates a credential from what the OAuth provider
- * stamped on it, and the other diffs what an upstream now offers against what
- * the endpoint is serving. They are the length in that file, and they are the
- * part that changes for reasons the gate order has nothing to do with.
- */
-
-/**
- * How old a stored OAuth credential is.
+ * connection name a provider that exists — and this is an analysis: it diffs
+ * what an upstream now offers against what the endpoint is serving. It is the
+ * length in that file, and it is the part that changes for reasons the gate
+ * order has nothing to do with.
  *
- * Derived from the `expires_at` the OAuth provider stamps when saving tokens.
- * Returns null for anything that is not a token blob — an app password has no
- * meaningful age, and guessing one would produce a confusing warning.
+ * `credentialAge` used to sit beside it and date a credential from the OAuth
+ * provider's stamp. It is gone: dating a credential answers "when did this last
+ * refresh", which is not the question anyone was asking. `operate/auth.ts`
+ * asks the real one by attempting the renewal.
  */
-export async function credentialAge(
-  credentials: { get(ref: string): Promise<string | null> },
-  ref: string,
-): Promise<{ days: number; brokered: boolean } | null> {
-  const raw = await credentials.get(ref);
-  if (!raw) return null;
-
-  try {
-    const parsed = JSON.parse(raw) as {
-      expires_at?: number;
-      expires_in?: number;
-      authorized_via?: string;
-    };
-    if (typeof parsed.expires_at !== 'number') return null;
-
-    const issued = parsed.expires_at - (parsed.expires_in ?? 3600) * 1000;
-    return {
-      days: Math.floor((Date.now() - issued) / 86_400_000),
-      brokered: parsed.authorized_via === BROKERED,
-    };
-  } catch {
-    return null;
-  }
-}
 
 /**
  * Capabilities the upstream has grown since you connected.

--- a/src/cli/commands/operate/inspect.ts
+++ b/src/cli/commands/operate/inspect.ts
@@ -1,11 +1,12 @@
-import { credentialRefFor, formatPlan, planIsNoop, planReconcile } from '#registry';
+import { formatPlan, planIsNoop, planReconcile } from '#registry';
 import { DEFAULT_SURFACES } from '../../config-repair.ts';
 import { announce, announceProfile, emit, fail, ok, print, warn } from '../../output.ts';
 import { staleNudge } from '../../release.ts';
 import { openRuntime, resolveProfileOnly, type GlobalFlags, type Runtime } from '../../runtime.ts';
 import type { FetchLike } from '#deployments/knowledge.ts';
 import { unboundRotatableRefs } from '#deployments/bind.ts';
-import { credentialAge, reportCapabilityDrift } from './findings.ts';
+import { reportCapabilityDrift } from './findings.ts';
+import { probeConnections } from './auth.ts';
 import { migratedContract, migratedRenamedProviders } from './migrate.ts';
 
 /**
@@ -65,7 +66,16 @@ export interface DoctorFinding {
   readonly fix?: string;
 }
 
-/** Read-only external checks: credentials resolve, stores reachable. */
+/**
+ * External checks: credentials still authenticate, stores reachable.
+ *
+ * Not read-only, and that changed when the credential check stopped guessing
+ * from a stored date and started attempting the renewal. A refresh that
+ * succeeds persists the new token, which on a deployed target is a secret-store
+ * write. It is the same write serving a request makes, and it warms the token
+ * for the next real call — but `check` and `plan` above are still the two that
+ * touch nothing.
+ */
 export async function doctor(flags: DoctorFlags): Promise<void> {
   // The one check that cannot use a runtime, because it answers for the profiles
   // that cannot open one. A provider rename left in the config refuses at load,
@@ -108,47 +118,56 @@ export async function doctor(flags: DoctorFlags): Promise<void> {
       });
     }
 
-    for (const connection of runtime.config.connections) {
-      const key = `${connection.provider}.${connection.id}`;
-      const ref = credentialRefFor(connection, runtime.manifestFor(connection.provider));
-      if (!ref) {
-        checks.push(`${key} needs no credential`);
-        continue;
-      }
-      if (await runtime.credentials.has(ref)) {
-        const staleness = await credentialAge(runtime.credentials, ref);
+    // Whether each credential still works, asked rather than dated.
+    //
+    // This used to warn from the *age* of a stored credential, on the theory
+    // that a Google app left in "Testing" expires refresh tokens at seven days.
+    // The heuristic was wrong in both directions — it dated a credential from
+    // its last refresh, so an untouched healthy connection read as stale and a
+    // grant revoked an hour ago read as fresh — and its own guard made it worse:
+    // it skipped brokered credentials because "the hosted client is in
+    // production", which `providers/google/shared/oauth.ts` now says outright is
+    // not so. The hosted client is under review and carries the same weekly
+    // expiry, so the warning was silenced for exactly the population that has
+    // the problem.
+    //
+    // `probeConnections` answers it by attempting the renewal, which is the only
+    // thing that actually knows. Same classifier as `lanes link auth`, so the two
+    // cannot drift apart again.
+    const probed = await probeConnections(runtime, runtime.config.connections, forSelection);
 
-        // A Google project left in "Testing" expires refresh tokens after seven
-        // days. That is a policy setting rather than a fault, but it presents
-        // as an authentication failure mid-task — so say it before the call
-        // fails rather than after.
-        //
-        // Only for a client the operator registered. The hosted one is in
-        // production and does not expire refresh tokens weekly, so this warning
-        // would simply be false there — and a warning that is wrong once is a
-        // warning that gets scrolled past every time after.
-        if (staleness !== null && !staleness.brokered && staleness.days >= 7) {
+    for (const result of probed) {
+      switch (result.verdict) {
+        case 'reauth':
           warnings.push({
-            kind: 'stale_credential',
-            key,
+            kind: 'needs_reauth',
+            key: result.key,
             message:
-              `${key} credential is ${staleness.days} days old — a Google app in "Testing" expires at 7. ` +
-              `Run: lanes link connect ${key}`,
-            fix: forSelection(`lanes link connect ${key}`),
+              `${result.key} is signed out and cannot renew itself — run: lanes link connect ${result.key}` +
+              (result.detail ? `\n      ${result.detail}` : ''),
+            fix: forSelection(`lanes link connect ${result.key}`),
           });
-        } else {
-          const age = staleness
-            ? ` (${staleness.days}d old${staleness.brokered ? ', hosted client' : ''})`
-            : '';
-          checks.push(`${key} credential resolves${age}`);
-        }
-      } else {
-        problems.push({
-          kind: 'missing_credential',
-          key,
-          message: `${key} has no stored credential — run: lanes link connect ${key}`,
-          fix: forSelection(`lanes link connect ${key}`),
-        });
+          break;
+        case 'missing':
+          problems.push({
+            kind: 'missing_credential',
+            key: result.key,
+            message: `${result.key} has no stored credential — run: lanes link connect ${result.key}`,
+            fix: forSelection(`lanes link connect ${result.key}`),
+          });
+          break;
+        case 'none':
+          checks.push(`${result.key} needs no credential`);
+          break;
+        case 'unknown':
+          warnings.push({
+            kind: 'auth_uncheckable',
+            key: result.key,
+            message: `${result.key} could not be checked${result.detail ? `: ${result.detail}` : ''}`,
+          });
+          break;
+        default:
+          checks.push(`${result.key} credential resolves`);
       }
     }
 

--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -5,6 +5,7 @@ import {
   attachFile,
   auditTail,
   auditVerify,
+  auth,
   check,
   configShow,
   dashboard,
@@ -282,6 +283,11 @@ export async function run(argv: readonly string[]): Promise<void> {
       return plan(global);
     case 'doctor':
       return doctor({ ...global, json, fix: flags['fix'] === true });
+
+    // Beside `doctor` because it answers half of what `doctor` used to guess at,
+    // and answers it by asking rather than by dating a credential.
+    case 'auth':
+      return auth({ ...global, json, connection: text(flags, 'connection') });
     case 'status':
       return status({ ...global, json });
     case 'outputs':

--- a/src/cli/selection.ts
+++ b/src/cli/selection.ts
@@ -129,6 +129,7 @@ export const SELECTION: Record<string, Requires> = {
   secrets: 'profile+target',
   plan: 'profile+target',
   doctor: 'profile+target',
+  auth: 'profile+target',
   // Target-scoped: see the note above. `--profile` narrows each to one profile.
   status: 'target',
   outputs: 'profile+target',
@@ -267,6 +268,9 @@ const ACCEPTS: Record<string, readonly string[]> = {
   // it undoes a provider rename this project shipped, and every other finding
   // there is something only the operator can decide.
   doctor: ['fix'],
+  // A filter, not a second subject: it narrows the answer to one connection so
+  // a caller can re-ask about the row it just repaired. Same shape as `attach`.
+  auth: ['connection'],
   relabel: [],
   'target list': ['urls', 'target'],
   'target show': ['target'],

--- a/src/cli/usage.ts
+++ b/src/cli/usage.ts
@@ -129,6 +129,8 @@ ${style.bold('Inspection')}
   ${PROGRAM} doctor [--json]            credentials resolve, stores reachable
   ${PROGRAM} doctor --fix               apply a repair it can make itself, such as
                                         a provider this project renamed under you
+  ${PROGRAM} auth [--json]              whether each connection can still sign in
+  ${PROGRAM} auth --connection <key>    just this one
   ${PROGRAM} tools [--json]             what the endpoint advertises to a client
   ${PROGRAM} plan                       what reconcile would change
   ${PROGRAM} audit tail [--limit N] [--denied-only] [--format md]

--- a/src/connectivity/auth/index.ts
+++ b/src/connectivity/auth/index.ts
@@ -19,6 +19,7 @@
 
 export { credentialResolver, type ResolvedCredential } from './resolve.ts';
 export { requestAuthorizer } from './authorize.ts';
+export { ReauthRequired, statusMeansGrantIsDead } from './reauth.ts';
 export { basicCredential } from './basic/index.ts';
 export { bearerToken, bearerTokenAsStored } from './token.ts';
 export {

--- a/src/connectivity/auth/oauth-authcode/provider.ts
+++ b/src/connectivity/auth/oauth-authcode/provider.ts
@@ -1,5 +1,6 @@
 import type { SecretStore } from '#secrets';
 import type { ProviderManifest } from '#connectivity';
+import { ReauthRequired } from '../reauth.ts';
 
 /**
  * The SDK's `OAuthClientProvider`, backed by our `SecretStore`.
@@ -69,6 +70,20 @@ export class CredentialOAuthProvider {
     return `${this.#options.manifest.id}/${this.#options.connectionId}`;
   }
 
+  /**
+   * Which connection this provider speaks for, as `provider.id`.
+   *
+   * Public because a refusal has to name it: `refresh.ts` builds the same key
+   * for a `ReauthRequired`, and a caller holding several connections needs to
+   * know which one to send someone to rather than parsing it back out of a
+   * sentence. Note the separator differs from `#tokensRef` on purpose — that
+   * one is a credential ref (`gmail/main`), this one is the addressing form
+   * (`gmail.main`).
+   */
+  get connectionId(): string {
+    return this.#options.connectionId;
+  }
+
   // --- OAuthClientProvider ----------------------------------------------
 
   get redirectUrl(): string | undefined {
@@ -131,7 +146,8 @@ export class CredentialOAuthProvider {
 
   async redirectToAuthorization(authorizationUrl: URL): Promise<void> {
     if (!this.#options.openBrowser) {
-      throw new Error(
+      throw new ReauthRequired(
+        `${this.#options.manifest.id}.${this.#options.connectionId}`,
         `Connection ${this.#options.manifest.id}.${this.#options.connectionId} needs re-authorisation, ` +
           `which requires a browser. Connect ${this.#options.manifest.id}.${this.#options.connectionId} again for this profile and target.`,
       );

--- a/src/connectivity/auth/oauth-authcode/refresh.test.ts
+++ b/src/connectivity/auth/oauth-authcode/refresh.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from 'bun:test';
 import { defineProvider } from '#connectivity';
 import type { SecretRef, SecretStore } from '#secrets';
 import { refreshDirectly } from './refresh.ts';
+import { ReauthRequired } from '../reauth.ts';
 import type { CredentialOAuthProvider } from './provider.ts';
 
 /**
@@ -43,6 +44,7 @@ function stubProvider(initial: Record<string, unknown>) {
   let blob = { ...initial };
   return {
     provider: {
+      connectionId: 'main',
       tokens: async () => blob,
       saveTokens: async (next: Record<string, unknown>) => void (blob = { ...next }),
     } as unknown as CredentialOAuthProvider,
@@ -186,5 +188,91 @@ describe('refreshDirectly', () => {
       refreshDirectly(manifest(), provider, 'https://oauth2.example.com/token', store(), fetch),
     ).rejects.toThrow(/No refresh token stored/);
     expect(calls).toEqual([]);
+  });
+});
+
+/**
+ * Telling "this credential is dead" apart from "the server is unwell".
+ *
+ * Both used to throw the same `Error` with the same sentence, which meant
+ * anything reporting connection health had to either match on that text or
+ * treat an outage as a reason to send someone through a consent screen. The
+ * message is unchanged — what is new is the type, and that a 5xx no longer
+ * claims it.
+ */
+describe('refreshDirectly, on a refusal', () => {
+  const tokenUrl = 'https://oauth2.example.com/token';
+  const ownClient = store({ 'vendor/client_id': 'id', 'vendor/client_secret': 'secret' });
+
+  test('a 4xx from the token endpoint is a re-authorisation, and names the connection', async () => {
+    const { fetch } = recording(400, { error: 'invalid_grant' });
+    const { provider } = stubProvider({ refresh_token: 'rt' });
+
+    const refusal = await refreshDirectly(manifest(null), provider, tokenUrl, ownClient, fetch).catch(
+      (error: unknown) => error,
+    );
+
+    expect(refusal).toBeInstanceOf(ReauthRequired);
+    expect((refusal as ReauthRequired).connectionKey).toBe('vendor_mail.main');
+    expect((refusal as Error).message).toContain('could not be refreshed (400)');
+  });
+
+  test('a 5xx is not, because the server being unwell says nothing about the grant', async () => {
+    const { fetch } = recording(503, { error: 'unavailable' });
+    const { provider } = stubProvider({ refresh_token: 'rt' });
+
+    const refusal = await refreshDirectly(manifest(null), provider, tokenUrl, ownClient, fetch).catch(
+      (error: unknown) => error,
+    );
+
+    expect(refusal).toBeInstanceOf(Error);
+    expect(refusal).not.toBeInstanceOf(ReauthRequired);
+    // The sentence is unchanged from what it always said. Only the type moved.
+    expect((refusal as Error).message).toContain('could not be refreshed (503)');
+  });
+
+  test('a 429 is not either — "not now" is not "never again"', async () => {
+    const { fetch } = recording(429, { error: 'rate_limited' });
+    const { provider } = stubProvider({ refresh_token: 'rt' });
+
+    const refusal = await refreshDirectly(manifest(null), provider, tokenUrl, ownClient, fetch).catch(
+      (error: unknown) => error,
+    );
+
+    expect(refusal).not.toBeInstanceOf(ReauthRequired);
+  });
+
+  test('the broker refusing this credential is a re-authorisation', async () => {
+    const { fetch } = recording(400, { success: false, error: 'invalid_grant' });
+    const { provider } = stubProvider({ refresh_token: 'rt', authorized_via: 'broker' });
+
+    const refusal = await refreshDirectly(manifest(), provider, tokenUrl, store(), fetch).catch(
+      (error: unknown) => error,
+    );
+
+    expect(refusal).toBeInstanceOf(ReauthRequired);
+  });
+
+  test('the broker being down is not', async () => {
+    const { fetch } = recording(502, { success: false, error: 'bad_gateway' });
+    const { provider } = stubProvider({ refresh_token: 'rt', authorized_via: 'broker' });
+
+    const refusal = await refreshDirectly(manifest(), provider, tokenUrl, store(), fetch).catch(
+      (error: unknown) => error,
+    );
+
+    expect(refusal).not.toBeInstanceOf(ReauthRequired);
+  });
+
+  test('no refresh token stored is a re-authorisation — there is nothing to renew with', async () => {
+    const { fetch } = recording(200, {});
+    const { provider } = stubProvider({});
+
+    const refusal = await refreshDirectly(manifest(null), provider, tokenUrl, ownClient, fetch).catch(
+      (error: unknown) => error,
+    );
+
+    expect(refusal).toBeInstanceOf(ReauthRequired);
+    expect((refusal as Error).message).toContain('No refresh token stored');
   });
 });

--- a/src/connectivity/auth/oauth-authcode/refresh.ts
+++ b/src/connectivity/auth/oauth-authcode/refresh.ts
@@ -1,6 +1,7 @@
 import type { ProviderManifest } from '#connectivity';
 import type { SecretStore } from '#secrets';
 import { BROKERED, BrokerError, brokerRefresh } from './broker.ts';
+import { ReauthRequired, statusMeansGrantIsDead } from '../reauth.ts';
 import type { CredentialOAuthProvider } from './provider.ts';
 
 /** What a stored OAuth credential carries beyond the tokens themselves. */
@@ -23,7 +24,10 @@ export async function refreshDirectly(
   const refreshToken = existing?.refresh_token;
 
   if (!refreshToken) {
-    throw new Error(
+    // Nothing to renew with, so this can only be settled by signing in again —
+    // the same remedy as a dead grant, and reported as the same thing.
+    throw new ReauthRequired(
+      `${manifest.id}.${provider.connectionId}`,
       `No refresh token stored for ${manifest.id}. Connecting it again for this profile and target would store one.`,
     );
   }
@@ -38,9 +42,19 @@ export async function refreshDirectly(
   const broker = auth?.broker;
   const brokered = broker !== undefined && existing?.authorized_via === BROKERED;
 
+  const connectionKey = `${manifest.id}.${provider.connectionId}`;
+
   const refreshed = brokered
-    ? await viaBroker(manifest, broker.url, refreshToken, existing, fetchImpl)
-    : await viaStoredClient(manifest, auth?.app, tokenUrl, refreshToken, credentials, fetchImpl);
+    ? await viaBroker(manifest, connectionKey, broker.url, refreshToken, existing, fetchImpl)
+    : await viaStoredClient(
+        manifest,
+        connectionKey,
+        auth?.app,
+        tokenUrl,
+        refreshToken,
+        credentials,
+        fetchImpl,
+      );
 
   // `existing` first, so what the response does not mention survives it. Neither
   // the vendor nor the broker echoes `refresh_token`, `id_token`, or
@@ -53,6 +67,7 @@ export async function refreshDirectly(
 
 async function viaBroker(
   manifest: ProviderManifest,
+  connectionKey: string,
   url: string,
   refreshToken: string,
   existing: StoredTokens,
@@ -70,17 +85,27 @@ async function viaBroker(
     // next step. Same shape as the stored-client message below, deliberately:
     // where the credential came from is not the reader's problem here.
     const notice = cause instanceof BrokerError && cause.notice ? `\n${cause.notice}` : '';
-    throw new Error(
+    const message =
       `The credential for ${manifest.id} could not be refreshed. ` +
-        `Re-authorise ${manifest.id} for this profile and target.\n${String(
-          cause instanceof Error ? cause.message : cause,
-        ).slice(0, 200)}${notice}`,
-    );
+      `Re-authorise ${manifest.id} for this profile and target.\n${String(
+        cause instanceof Error ? cause.message : cause,
+      ).slice(0, 200)}${notice}`;
+
+    // Only the broker refusing *this* credential means a person is needed. A
+    // broker that is down, or rate-limiting, says nothing about the grant, and
+    // reporting it as "sign in again" would send someone through a consent
+    // screen to fix an outage. A `cause` that is not a `BrokerError` never
+    // reached the broker at all, so it is the same case.
+    if (cause instanceof BrokerError && statusMeansGrantIsDead(cause.status)) {
+      throw new ReauthRequired(connectionKey, message);
+    }
+    throw new Error(message);
   }
 }
 
 async function viaStoredClient(
   manifest: ProviderManifest,
+  connectionKey: string,
   app: string | undefined,
   tokenUrl: string,
   refreshToken: string,
@@ -108,10 +133,17 @@ async function viaStoredClient(
   if (!response.ok) {
     // A revoked or expired refresh token is the common case here, and the fix
     // is always the same, so say it rather than surfacing the raw grant error.
-    throw new Error(
+    const message =
       `The credential for ${manifest.id} could not be refreshed (${response.status}). ` +
-        `Re-authorise ${manifest.id} for this profile and target.\n${text.slice(0, 200)}`,
-    );
+      `Re-authorise ${manifest.id} for this profile and target.\n${text.slice(0, 200)}`;
+
+    // 4xx is the authorization server rejecting this credential; 5xx is it
+    // being unwell. Only the first is something a person can fix, and only the
+    // first may be reported as such.
+    if (statusMeansGrantIsDead(response.status)) {
+      throw new ReauthRequired(connectionKey, message);
+    }
+    throw new Error(message);
   }
 
   return JSON.parse(text) as Record<string, unknown>;

--- a/src/connectivity/auth/oauth-jwt/index.ts
+++ b/src/connectivity/auth/oauth-jwt/index.ts
@@ -1,4 +1,5 @@
 import type { ProviderManifest } from '#connectivity';
+import { ReauthRequired, statusMeansGrantIsDead } from '../reauth.ts';
 import type { SecretStore } from '#secrets';
 import { credentialRefForConnection } from '../../manifest/credential-ref.ts';
 import { parseAssertionKey, signAssertion } from './key.ts';
@@ -170,7 +171,17 @@ export async function resolveAssertionToken(input: {
   const body = (await response.json().catch(() => ({}))) as TokenResponse;
 
   if (!response.ok || !body.access_token) {
-    throw new Error(refusalMessage(manifest, stored, body, response.status));
+    const message = refusalMessage(manifest, stored, body, response.status);
+
+    // A key is refused for the same two reasons a refresh token is: the grant
+    // behind it is gone, or the token endpoint is unwell. The remedy differs
+    // from a consent screen — it is an admin grant in a console, or `connect
+    // --replace` — but "the owner has to re-authorise this connection" is the
+    // same claim, and `refusalMessage` already writes the specific sentence.
+    if (statusMeansGrantIsDead(response.status)) {
+      throw new ReauthRequired(`${manifest.id}.${connectionId}`, message);
+    }
+    throw new Error(message);
   }
 
   minted.set(cacheKey, {

--- a/src/connectivity/auth/reauth.ts
+++ b/src/connectivity/auth/reauth.ts
@@ -1,0 +1,48 @@
+/**
+ * The one failure a person has to fix, told apart from every other one.
+ *
+ * A stored credential stops working for two very different reasons, and until
+ * this existed they arrived as the same `Error`:
+ *
+ *   - the grant is gone — revoked, or expired because the client's publishing
+ *     status expires refresh tokens on a timer. Nothing retries its way out of
+ *     this; somebody has to sign in again.
+ *   - the token endpoint had a bad afternoon — a 502, a reset connection, DNS.
+ *     Retrying is exactly right, and telling the owner to re-authorise would be
+ *     a lie that costs them a consent screen.
+ *
+ * Both used to read as "could not be refreshed", so anything trying to *report*
+ * connection health had to match on the message text. That is why this is a
+ * class and not a string: `auth.ts` classifies on `instanceof`, and the messages
+ * stay free to be rewritten for whoever is reading them.
+ *
+ * The message is deliberately unchanged from what each throw site said before —
+ * this is a widening, not a rewrite. What is new is that the type now carries
+ * *which* connection, so a caller holding several can say which one to fix
+ * without parsing the sentence.
+ */
+export class ReauthRequired extends Error {
+  /** `provider.id`, e.g. `gmail.main`. The addressing form used everywhere. */
+  readonly connectionKey: string;
+
+  constructor(connectionKey: string, message: string) {
+    super(message);
+    this.name = 'ReauthRequired';
+    this.connectionKey = connectionKey;
+  }
+}
+
+/**
+ * Whether an HTTP status from a token endpoint means the grant itself is dead.
+ *
+ * 4xx is the authorization server saying no to *this credential* — `invalid_grant`
+ * for a revoked or expired refresh token, `invalid_client` for a client that no
+ * longer exists. Signing in again is the fix.
+ *
+ * 5xx is the server saying no to *everyone*, and 429 is it saying "not now".
+ * Neither is a statement about the credential, so neither may be reported as
+ * needing a human. 429 sits in the 4xx range and is excluded for that reason.
+ */
+export function statusMeansGrantIsDead(status: number): boolean {
+  return status >= 400 && status < 500 && status !== 429;
+}


### PR DESCRIPTION
## Why

A connection made through an OAuth client whose publishing status is **Testing** has every refresh token it issues expired after seven days, so the account silently stops working weekly. Nothing said so until the next call failed mid-task.

`doctor` tried to warn about this from the **age** of a stored credential, which is wrong in both directions: it dates a credential from its last refresh, so an untouched healthy connection reads as stale and a grant revoked an hour ago reads as fresh.

Its guard made it worse. It skipped brokered credentials because *"the hosted one is in production and does not expire refresh tokens weekly"* — which `src/providers/google/shared/oauth.ts:31-38` now says outright is not so:

> That expiry is a property of the client's publishing status rather than of its verification, and a client under review has the status it has — so a connection made this way is re-authorised weekly until the review lands, exactly like one made against a client of the operator's own that was left in "Testing".

So the warning was silenced for exactly the population that has the problem. On my own workspace that is all 14 connections.

## What

**Ask instead of guessing.** `lanes link auth [--json] [--connection <key>]` attempts the renewal, which is the only thing that actually knows. It is cheap where it matters: resolving an OAuth credential short-circuits on the stored `expires_at`, so a connection whose access token is still live costs no network at all.

Measured against 14 live connections on a deployed target: **9.5s**, against `doctor`'s 16.3s. Two needed a real refresh; the rest short-circuited.

Six verdicts, generic across all eight auth kinds:

| verdict | claim |
|---|---|
| `ok` | resolved — accepted just now, or its access token is still live |
| `reauth` | stored, and cannot be renewed without a person — **the new signal** |
| `missing` | nothing at the credential ref |
| `stored` | a static secret is present and nothing here can exercise it |
| `none` | `auth.kind: none` — the owner layer, can never need signing in |
| `unknown` | the probe could not complete: timeout, network down, unexpected throw |

**`ReauthRequired`** makes the one failure a person can fix distinguishable from the ones they cannot, without matching on message text. Messages are byte-identical to what each site said before — this is a widening, not a rewrite. Two refinements come with the type:

- A **4xx** from a token endpoint means the grant is dead; a **5xx or 429** means the server is unwell. Today they are lumped, so a token endpoint having a bad afternoon reads the same as a revoked grant.
- Same split for the broker, via `BrokerError.status`.

**`doctor` moves onto the same classifier** so the two cannot drift apart again — `needs_reauth` replaces `stale_credential`, `credentialAge` is deleted along with the `!brokered` guard. That is a `doctor --json` shape change, one warning `kind` for another.

## Notes for review

- **Exit code is always 0**, deliberately, and commented as such: the desktop app discards stdout on a non-zero exit, which is exactly why it cannot consume `doctor` (`inspect.ts` sets `process.exitCode = 1`). Verdicts live in the payload.
- **`strategy` is answered from the store, never through the resolver.** `resolve.ts:40` refuses that kind unconditionally — it signs its own requests — so probing it would have reported a working bunq connection as broken.
- **A resolved token is not automatically `ok`.** `upstreamAccessToken` hands back the *stale* access token when there is no refresh token, and again when a refresh returns none. Both are deliberate on the serve path, so the stored expiry is checked here rather than that behaviour being changed.
- **An unexpected throw is `unknown`, never `reauth`.** A warning that is wrong once is one that gets scrolled past every time after.
- **This command writes.** A successful refresh persists the new token — the same write the serve path makes. `doctor` is therefore no longer read-only and its wording now says so.
- `ConnectionRecord.credentialExpiresAt` is left alone. It is declared, serialized, and written by nothing; populating it would put a second, staler answer to the same question into the state store.

**Found while reading, not fixed here:** `refresh.ts:50` writes `{ ...existing, ...refreshed, refresh_token: refreshToken }`, which clobbers a rotated refresh token with the old one — against the stated intent of the comment above it. Benign for Google, which does not rotate; a probe makes refreshes more frequent and would surface it sooner on any server that does. Worth its own fix.

## Testing

`bun test` — 2552 pass, 0 fail. `tsc --noEmit` clean.

New coverage: the 4xx/5xx split at each throw site with messages byte-compared against today's; the classifier as a pure function, including the two ways it could lie (an unexpected throw must not become `reauth`, a stale-but-resolved token must not become `ok`); and the dispatch in front of the resolver, including the `strategy` bypass.

Verified live: `lanes link auth --profile personal --target cloud --json` over 14 real connections, all eight auth kinds classified correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)