### PR TITLE
Release 0.6.9

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lanes-sh/link",
-  "version": "0.6.8",
+  "version": "0.6.9",
   "description": "A self-hostable MCP gateway for all your connections, memory, tasks, files, and secrets",
   "license": "Apache-2.0",
   "homepage": "https://lanes.sh/link",


### PR DESCRIPTION
Merging this publishes 0.6.9 to npm.

Since v0.6.8:

- feat: lanes link auth — whether each connection can still sign in (#107)
- Open the Lanes app instead of serving a dashboard (#103)

This pull request carries no `ci` run of its own — GitHub does not run workflows on branches it
pushed itself. Both gates run inside the publish job against the exact tree that reaches the
registry, and they were also verified locally against this tree before #108 was merged
(2542 pass, 0 fail; `tsc --noEmit` clean).