### PR TITLE
0.6.10

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lanes-sh/link",
-  "version": "0.6.9",
+  "version": "0.6.10",
   "description": "A self-hostable MCP gateway for all your connections, memory, tasks, files, and secrets",
   "license": "Apache-2.0",
   "homepage": "https://lanes.sh/link",


### PR DESCRIPTION
Patch bump, set on `develop` before the release pull request to `main` — a merge
whose version is already tagged runs the *propose* path instead of publishing,
which leaves `develop` behind by a version commit.

Carries #111: the deployed endpoint's perimeter hardening.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
