### PR TITLE
Release 0.6.10

### DIFF
--- a/.gcloudignore
+++ b/.gcloudignore
@@ -1,0 +1,50 @@
+# What `gcloud builds submit` uploads, and what it must not.
+#
+# **This file exists because `.dockerignore` is not consulted for the upload.**
+# The build context is packed and sent to a Cloud Build staging bucket before any
+# Dockerfile is read, so the first block of `.dockerignore` — which its own
+# comment calls "a security control, not an image-size optimisation" — governs
+# what reaches the *image* and says nothing about what reaches Google.
+#
+# Absent this file, gcloud derives its exclusions from `.gitignore` when the
+# context happens to be a git checkout, and from nothing at all when it is not.
+# `lanes link deploy` sends `installRoot`, which for the documented install
+# method is a directory under `~/.bun` with no `.git` in it — so the safe
+# behaviour was being inherited from a coincidence.
+#
+# Keep the first block in step with `.dockerignore`. `data/` holds the encrypted
+# credential store *and* the key that opens it.
+data/
+*.key
+*.pem
+*.enc
+*.p12
+.env
+.env.*
+
+# Not needed to build, and `.git` in particular carries every branch.
+.git/
+.gitignore
+.worktrees/
+node_modules/
+**/node_modules/
+coverage/
+dist/
+build/
+*.tsbuildinfo
+
+# Tests, docs and tooling: the image runs the endpoint and nothing else.
+**/*.test.ts
+**/*.test.json
+docs/
+instructions/
+**/README.md
+.lanes/
+.claude/
+.vscode/
+.idea/
+.DS_Store
+.playwright-mcp/
+
+# The compiled binary from `bun build --compile`, if one was made locally.
+/lanes

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,3 +39,19 @@ jobs:
 
       - run: bun test
       - run: bun run typecheck
+
+      # The third command, and the one that was written down without being run.
+      #
+      # `SECURITY.md` has claimed a lockfile CVE check since the first release
+      # and the script behind it was `bun pm scan`, which does nothing at all
+      # without `[install.security] scanner` configured in `bunfig.toml` — it
+      # prints how to configure one and exits zero. So a project that holds live
+      # OAuth refresh tokens had a supply-chain control that was documented,
+      # scripted, and inert.
+      #
+      # `bun audit` needs no scanner package: it resolves the lockfile against
+      # npm's advisory database directly. Blocking rather than advisory, because
+      # a security check nobody has to act on is the state this replaces. If a
+      # transitive advisory with no fix available ever holds up unrelated work,
+      # the lever is `--audit-level`, not deleting the step.
+      - run: bun run audit

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -43,4 +43,6 @@ If you are unsure whether something is in scope, report it.
 
 Dependency compromise is a live threat for a project holding long-lived credentials.
 `bunfig.toml` sets a seven-day `minimumReleaseAge`, so a version published and yanked within hours
-cannot enter the lockfile. Reports about a dependency are welcome; please also report them upstream.
+cannot enter the lockfile. `bun run audit` resolves the lockfile against npm's advisory database and
+runs in CI. The deployed image's base is pinned by digest, not only by tag. Reports about a
+dependency are welcome; please also report them upstream.

--- a/docs/detailed/adr/054-the-surface-in-front-of-the-gate.md
+++ b/docs/detailed/adr/054-the-surface-in-front-of-the-gate.md
@@ -1,0 +1,113 @@
+# ADR-054: The surface in front of the gate is metered, and does not name itself
+
+**Status:** accepted · **Follows from** [ADR-018](018-the-gate-is-in-the-application.md),
+[ADR-036](036-a-client-is-told-this-endpoint-keeps-it-signed-in.md),
+[ADR-039](039-cross-origin-access-is-a-deployment-only-grant.md)
+
+## Context
+
+ADR-018 put the gate in the application, because a target a remote MCP client can reach has to
+be `--allow-unauthenticated` at the platform: Cloud Run IAM admits only a caller holding a
+Google-signed identity token for the service, and no agent harness can mint one. So a deployed
+endpoint is a routable address that anybody can send a request to, and everything it does about
+who is calling, it does itself.
+
+That was reasoned about carefully for the paths *behind* the bearer check. A failed comparison
+costs a re-read of the credential store — a Secret Manager call on a deployed target, and two of
+them when the presented value does not match what the process cached, because a mismatch against
+a cached value is what forces the re-read that makes a rotation take effect within five seconds.
+`FAILED_AUTH_PER_MINUTE` exists for exactly that.
+
+It was not reasoned about for the paths in *front* of it, and there are four:
+
+| | what it costs, once, unauthenticated |
+|---|---|
+| `GET /health` with a credential | one credential-store read, two on a cache mismatch |
+| `POST /register` | one object written to the workspace bucket, then two namespaces listed |
+| `POST /authorize` | one credential-store read, per attempt at the owner's token |
+| `POST /token` | bucket objects read and written |
+
+The ceiling lived inside the `if (!outcome.ok)` branch of the request handler, which is reached
+only after the 404 gate — so none of the four ever passed through it. `/health` in particular is
+answered and returned several lines earlier, and it calls the authenticator on the way.
+
+Two smaller things were wrong in the same region, and they are the same subject rather than a
+second one.
+
+**The limiter's key map was unbounded.** `callerKey` is the first `X-Forwarded-For` hop, which is
+the only address that means anything on Cloud Run — the socket peer there is Google's frontend,
+identical for every caller — and which anybody talking to the endpoint writes as they please.
+`RateLimiter` had a `prune` that nothing called; the comment above the limiter said idle callers
+were dropped so keys would not accumulate, and they were not.
+
+**And the endpoint let the request decide its own name.** `publicOrigin` preferred
+`X-Forwarded-Host` over `Host`. Four documents are built from it: both discovery documents, the
+`resource_metadata` pointer on every `401` that ADR-036 made load-bearing, and the `action` of
+the consent form that asks the owner to paste their endpoint token. The justification written
+beside it is entirely about the *scheme* — Cloud Run terminates TLS, so a URL built from the
+incoming request says `http` — and nothing ever needed the other header.
+
+## Decision
+
+**1. The pre-authentication surface is metered, and the meter is a property of the bind address.**
+
+Two buckets, both taken on every costly request. One is keyed on the caller and stops a single
+noisy client spending everything. The other is keyed on nothing at all, and is the one that
+actually holds: a per-caller limit alone bounds only a caller who is not trying, because rotating
+a header walks straight through it.
+
+An endpoint-wide bucket has the failure mode that whoever spends it locks everyone else out,
+which is precisely why the *failed-auth* ceiling is not keyed that way. The trade is different
+here, and it is worth naming rather than assuming. What is behind these four paths is not the
+owner's ability to use their endpoint — a client that has authorised holds a token and never
+returns through them — it is a discovery document, a registration, and a consent screen. Losing
+those for a minute is an authorization retried. Not losing them is a stranger's unbounded spend
+against the credential store.
+
+`/health` presented with **no** credential is deliberately free. It reads nothing, and it is what
+a platform probe, `lanes link deploy` and `lanes link outputs` send; a health check that answers
+`429` during an attack is an outage the attack did not have to cause.
+
+Off on loopback, decided in the same three lines of `serve()` that decide CORS, the dashboard and
+the rebinding allowlist — because it is the same kind of fact. What the ceiling protects is a
+network call and an object in a bucket; on loopback both are a local file belonging to whoever is
+already standing at the machine, and `rebinding.ts` refuses the one caller who is not.
+
+**2. A limiter is bounded by construction, not by a caller remembering to prune it.**
+
+Idle buckets go first, because dropping one costs nothing — an untouched bucket has refilled to
+full, so re-creating it returns exactly what was discarded. Only when that is not enough is a live
+caller evicted, oldest by last use, in batches so the sort is amortised rather than run per
+request. Evicting a live caller does forgive what it had spent; that is the honest cost of a
+bounded map, and it is why the endpoint-wide bucket above is not optional.
+
+**3. The host is `Host`. `X-Forwarded-Host` is not read.**
+
+Cloud Run sets `Host` and routes on it, so it is the one value a caller cannot invent without the
+request going somewhere else, and a proxy that genuinely rewrites it — a domain mapping — rewrites
+`Host` too. The scheme still comes from `X-Forwarded-Proto` because that is what the header is for
+here, and it is checked against `http` and `https` rather than echoed.
+
+`form-action 'self'` joins the page CSP as the second lock on the one form that carries the
+owner's token. It has to be named explicitly: `form-action` does not fall back to `default-src`,
+so the `'none'` already there said nothing about where a form may post.
+
+## Consequences
+
+A deployed endpoint has a bound on what an unauthenticated stranger can make it spend, which it
+did not have. Combined with `max_instances`, which the rollout now always sends, the aggregate is
+bounded too — `limits.requests_per_minute` has always been per instance, and with no ceiling on
+instances the aggregate had no value at all.
+
+The numbers are ordinary rate limits and not a security boundary; `#policy` says so about the
+limits beside them and it is equally true here. Guessing the token is hopeless because it is 256
+bits, not because it is slow.
+
+A test drives the deployed behaviour by asking for the meter explicitly, because a harness binds
+loopback where it is off. That is the same shape as every other property of the bind address and
+it means the thing under test is the thing that ships.
+
+An operator running an unusual proxy in front of the endpoint — one that rewrites `Host` and
+expects `X-Forwarded-Host` to be honoured — will find the discovery documents naming the inner
+hostname. That configuration was never supported and is not documented; a domain mapping, which
+is, sets `Host` correctly.

--- a/docs/detailed/adr/README.md
+++ b/docs/detailed/adr/README.md
@@ -61,6 +61,7 @@ Nothing in the codebase depends on it.
 | [051](051-tasks-and-assets-are-their-own-stores.md) | A task and a file are each their own store, not a memory entry |
 | [052](052-a-target-owns-its-workspace.md) | A target owns its workspace, and a profile lives in exactly one |
 | [053](053-the-page-a-person-reads-is-the-app.md) | The page a person reads is the desktop app, and the endpoint stops serving one |
+| [054](054-the-surface-in-front-of-the-gate.md) | The surface in front of the gate is metered, and does not name itself |
 
 Where an ADR departs from init.md, it says so at the top. Three are significant:
 

--- a/docs/detailed/deployment-cloudrun.md
+++ b/docs/detailed/deployment-cloudrun.md
@@ -330,6 +330,29 @@ It applies to a bucket the deploy creates. A bucket from an earlier deploy is le
 — the create step finds it present and moves on — so turning Autoclass on for an existing one is a
 change you make yourself, in the console or with `gcloud storage buckets update`.
 
+### What protects the bucket, on every deploy rather than only the first
+
+Three things, and they are applied by a `buckets update` step precisely because of the paragraph
+above: a flag on the create reaches a bucket made after the change and no other, and every
+deployment that already exists is the one holding an audit log worth keeping.
+
+- **Public access prevention, enforced.** Nothing here is served to a browser, so the useful setting
+  is the one that makes granting anonymous read impossible rather than merely absent. Uniform
+  bucket-level access already removed per-object ACLs; this removes the bucket-level route.
+- **Soft delete, thirty days.** The revision holds `objectAdmin` on everything under `data/`, and
+  `objectAdmin` contains `storage.objects.delete`. That grant is right — the endpoint writes state,
+  memory, tasks, assets and the log, and rewriting an object is deleting the old one — but it means
+  the process most exposed to the internet is also the one that can erase the record of what it did.
+  Thirty rather than the platform's seven, because the gap this closes is noticing late.
+- **Object versioning**, with a lifecycle rule that bounds it (`src/deployments/gcp/lifecycle.json`:
+  noncurrent versions go at thirty days or ten newer copies, whichever comes first). This covers what
+  soft delete does not — an object *overwritten* in place, where the previous content is the thing
+  worth keeping — and state is the one thing here that is rewritten rather than appended.
+
+None of this makes a deletion *detectable*. `audit.tamper-evident` in
+[`security.md`](security.md) is explicit that deleting a run whole is not, and that has not changed.
+It makes it undoable.
+
 ### The vault key, which the deploy now mints
 
 The vault document is sealed before it reaches Secret Manager, under `LANES_LINK_VAULT_KEY` — a
@@ -510,15 +533,70 @@ account it has; which of them is *you* is not something it knows.
 
 **Rate limits are per instance.** `limits.requests_per_minute` is enforced by an in-memory counter, so
 a service running N instances enforces N times the configured limit in aggregate. A shared counter
-store would be needed for a global limit, and that is not in scope. If the limit matters to you as a
-ceiling rather than as a guard against a runaway agent, cap `--max-instances` accordingly.
+store would be needed for a global limit, and that is not in scope. What bounds the aggregate instead
+is `max_instances`, below — this used to say "cap `--max-instances` accordingly" and nothing in
+`deploy` ever sent the flag, so the aggregate had no ceiling at all.
+
+### The ceilings a revision runs under
+
+Five settings the rollout sends on every deploy, defaults included, for the reason `min_instances`
+is also always sent: config decides, and a flag passed only when it differs from a default lets a
+value be raised and never lowered. Absent, each fell to the platform's own default — a hundred
+instances, eighty concurrent requests each, and 512 MiB to stage a 64 MiB upload in.
+
+```yaml
+targets:
+  cloud:
+    deploy:
+      platform: cloudrun
+      # ...
+      min_instances: 0
+      max_instances: 4     # instances
+      concurrency: 40      # requests per instance
+      timeout_seconds: 300
+      memory: 1Gi
+      cpu: "1"
+```
+
+You do not write these either — the survey carries them through, and pressing return changes
+nothing. They are here because they are worth being able to find.
+
+`max_instances` is the one that matters on a `public` target. That is a routable address anyone can
+send a request to, and every instance that starts reads the credential store and lists the bucket —
+so scaling out multiplies cost *and* traffic against the two things this endpoint most wants kept
+quiet. Four is a single-user endpoint's ceiling; a fifth concurrent instance is an agent in a loop.
+Raise it if you are genuinely serving that much.
+
+`memory` is a gigabyte because 512 MiB is not enough for what the endpoint already accepts: an
+attachment is capped at 64 MiB and staging one costs roughly twice that at peak, so the platform
+default is one upload away from an out-of-memory kill — which is a 503 for every other request that
+instance was serving.
+
+### What answers before the token does
+
+Four things answer without a credential, and on a `public` target that means to anybody:
+`/health`, `/register`, `/authorize`, `/token`. Each costs a read of the credential store or an
+object written to the bucket, so each is metered — two buckets, one per caller and one for the
+endpoint, because the per-caller key is a forwarded address a stranger can rewrite. A `/health`
+carrying **no** credential is free and stays free: it reads nothing, and it is what the platform's
+probe and `lanes link outputs` send.
+
+None of this applies to `lanes link start`. A loopback endpoint's credential store is a local file
+belonging to whoever is already at the machine, and the cross-origin refusal covers the one caller
+who is not. See [ADR-054](adr/054-the-surface-in-front-of-the-gate.md).
 
 ---
 
 ## The image
 
 `src/deployments/gcp/Dockerfile`, built from the repository root through
-`src/deployments/gcp/cloudbuild.yaml`. Two things about it are worth knowing.
+`src/deployments/gcp/cloudbuild.yaml`. Three things about it are worth knowing.
+
+**It is pinned by digest.** `FROM oven/bun:<version>@sha256:<digest>`, with the tag kept beside it so
+the next bump is legible. A tag is a pointer its publisher can move, so it is not a promise about
+bytes: a rebuild months from now can pull a base image nobody reviewed, into a container holding live
+refresh tokens. To bump it, change the tag and resolve it with
+`docker buildx imagetools inspect oven/bun:<tag> --format '{{.Manifest.Digest}}'`.
 
 **The config is not in it.** The image carries no `lanes-link.yaml` and no `profiles/`; `deploy`
 uploads them to the bucket and passes `LANES_LINK_HOME=gs://<bucket>` at rollout, so one image
@@ -534,10 +612,18 @@ authored directories inside the profile, `data/<profile>/skills.d/` and
 reason `.dockerignore` excludes it.
 
 **Everything else under `data/` is excluded, and that exclusion is load bearing.** The local
-encrypted credential store and its key live there. The root `.dockerignore` keeps them out of the build context; a credential baked
-into an image is pushed to a registry, cached on every builder that touched it, and readable by anyone
-who can pull the tag. The deployed target reads credentials from Secret Manager and wants nothing from
-that directory.
+encrypted credential store and its key live there. A credential baked into an image is pushed to a
+registry, cached on every builder that touched it, and readable by anyone who can pull the tag. The
+deployed target reads credentials from Secret Manager and wants nothing from that directory.
+
+It takes **two** files, because there are two things to stay out of. The root `.dockerignore` keeps
+them out of the image. `.gcloudignore` keeps them out of the tarball `gcloud builds submit` uploads
+to a Cloud Build staging bucket, which is packed and sent before any Dockerfile is read — so
+`.dockerignore` has nothing to say about it. Without the second file gcloud derives its exclusions
+from `.gitignore` when the context happens to be a git checkout and from nothing at all when it is
+not, and `deploy` sends the *installed package*, which for the documented install method is a
+directory under `~/.bun` with no `.git` in it. The safe behaviour was being inherited from a
+coincidence. Keep the first block of the two files in step; `dockerfile.test.ts` checks that you did.
 
 The entrypoint is `src/server/container.ts`, not `lanes link start`. It logs plain lines to stdout for
 Cloud Logging, handles SIGTERM, listens on `$PORT`, and — importantly — **refuses to start when the

--- a/docs/detailed/security.md
+++ b/docs/detailed/security.md
@@ -107,6 +107,10 @@ limitation. `RESERVED` names a compatibility slot with no implementation.
 | `oauth.refresh-replay-is-refused-and-recorded` | ENFORCED **outside a 30-second reuse interval** | a spent refresh token is tombstoned rather than deleted, so presenting it again is detectable; within 30 seconds of being spent it still answers, because a client whose refresh response was lost has no other move and the reference client rethrows `invalid_grant` rather than recovering ([ADR-036](adr/036-a-client-is-told-this-endpoint-keeps-it-signed-in.md) has the client-side reasoning). After that the replayed token is refused, the replay is logged, and the family it belongs to keeps working — tested over real HTTP in `src/server/oauth.test.ts` from any depth in the chain. Revoking the whole family instead is what [ADR-035](adr/035-a-replayed-refresh-token-must-not-log-the-owner-out.md) reversed, and what it gives up is stated there: a family is minted once and never rotates, so the old answer logged an approved client out roughly daily and a thief never |
 | `token.rotation-takes-effect` | ENFORCED **within a five-second window** | `src/auth/index.test.ts` covers both halves against a real credential store: the replacement is accepted on its first call, and the rotated-away token stops working once the window passes. Both caches are dropped together — the authenticator's and the credential store's — because dropping only one re-reads the same stale value |
 | `limits.per-profile` | ENFORCED per instance | rate limit tests |
+| `edge.pre-auth-metered` | ENFORCED (deployed target) | the four things that answer before the bearer check — `/health` presented with a credential, `/register`, `/authorize`, `/token` — each cost a credential-store read or a bucket write, and until [ADR-054](adr/054-the-surface-in-front-of-the-gate.md) none of them passed through any ceiling: the limit lived inside the `401` branch, which is reached after the 404 gate. Two buckets are now taken on each, one keyed on the caller and one keyed on nothing — the second is the one that holds, because the caller key is the first `X-Forwarded-For` hop and a stranger writes that. `/health` with **no** credential stays free: it reads nothing, and it is what a platform probe sends. Off on loopback, decided beside CORS and the dashboard in `serve()`, for the reason ADR-054 gives. `src/server/index.test.ts` drives it over real HTTP |
+| `limits.map-is-bounded` | ENFORCED | a rate-limiter key is the caller's forwarded address, which on a public URL is a header a stranger writes. `RateLimiter` evicts — idle buckets first, then oldest-by-last-use in batches — rather than relying on a `prune` a caller remembers to call, which for most of this file's life nothing did. `src/policy/limits.test.ts` |
+| `deployed.data-recoverable` | ENFORCED (deployed target) | the revision holds `objectAdmin` on `data/`, which contains `storage.objects.delete` — so the process most exposed to the internet can erase the record of what it did. The bucket carries a 30-day soft-delete window and object versioning with a lifecycle rule bounding it, applied by `buckets update` on **every** deploy rather than as flags on the create, which is refused as `ALREADY_EXISTS` from the second deploy onwards and so would never reach a bucket that already exists. This does not make deletion *detectable* — see `audit.tamper-evident` — it makes it undoable |
+| `deployed.not-publicly-shareable` | ENFORCED (deployed target) | public access prevention is enforced on the bucket, so anonymous read cannot be granted rather than merely not being granted. Uniform bucket-level access already removed per-object ACLs; this removes the bucket-level route to the same place |
 | `audit.every-invocation` | ENFORCED **with two documented exceptions** | see below |
 | `credentials.client-secret-never-local` | ENFORCED (hosted client) | there is no client secret on the machine to hold. `resolveSecretRefs` grants no client reference at all for a connection authorised this way, asserted in `src/dispatch/context.test.ts` |
 | `credentials.exchange-is-local` | **NOT-GUARANTEED for a connection authorised against the hosted client** | see below |
@@ -290,9 +294,14 @@ weekly schedule — so `invalid_grant` is detected specifically and the error na
   token. It does mean an unauthenticated caller can write rows, so the list is capped at 200 and the
   oldest without a live token are evicted — a connector in use is never dropped to make room.
 - **Rate limits are per instance.** On a horizontally scaled deployment they are not global.
-  This now includes a ceiling on *failed* authentication at the HTTP edge, which exists to bound
-  the credential-store re-read a mismatch triggers rather than to make guessing harder — 256 bits
-  already does that. Only a failure spends the budget, so a valid token is never refused by it.
+  What bounds the aggregate instead is `max_instances`, which the rollout now always sends and
+  which defaults to four — with no ceiling on instances the aggregate had no value at all, and
+  `docs/detailed/deployment-cloudrun.md` told the reader to set one themselves because nothing did.
+  Two ceilings sit at the HTTP edge. One is on *failed* authentication, and exists to bound the
+  credential-store re-read a mismatch triggers rather than to make guessing harder — 256 bits
+  already does that; only a failure spends it, so a valid token is never refused by it. The other
+  is on the surface that answers *before* authentication, and is the subject of
+  [ADR-054](adr/054-the-surface-in-front-of-the-gate.md). Neither is a security boundary.
 - **No egress control**, no provider sandbox, no secret scanning on write.
 - **Content leaving the boundary is not recoverable.** Lanes Link governs what an agent may fetch,
   not what happens to it afterwards.
@@ -306,9 +315,20 @@ compromised version and yank it within hours; a release-age floor keeps a versio
 the lockfile entirely. This is verified rather than assumed: `bun add hono` resolves to the newest
 release older than the floor, not to `latest`.
 
-Also: `bun pm scan` for lockfile CVEs, `bun install --frozen-lockfile` in CI, a pinned Bun version in
-`.bun-version`, and a committed lockfile. An urgent security fix can be pulled in ahead of the window
-by installing an exact version explicitly.
+Also: `bun run audit` for lockfile CVEs, `bun install --frozen-lockfile` in CI, a pinned Bun version
+in `.bun-version`, and a committed lockfile. An urgent security fix can be pulled in ahead of the
+window by installing an exact version explicitly.
+
+**That line used to say `bun pm scan`, and `bun pm scan` did nothing.** Without an
+`[install.security] scanner` configured in `bunfig.toml` it prints how to configure one and exits
+zero — so the check was documented, scripted, and inert, on a project holding live OAuth refresh
+tokens. `bun audit` needs no scanner package: it resolves the lockfile against npm's advisory
+database directly. It runs in CI now rather than only in the script, because a control nobody has
+to act on is the state this replaces.
+
+The base image is pinned by digest as well as by tag. A tag is a pointer its publisher can move,
+so it is not a promise about bytes — the release-age floor above protects the npm half of the
+supply chain, and the base image is the larger half and had nothing.
 
 The runtime dependency set is deliberately small — MCP SDK v2 (`core` has one dependency), `zod`, and
 `yaml`. Argument parsing is hand-rolled rather than delegated, because a dependency that parses argv

--- a/package.json
+++ b/package.json
@@ -44,13 +44,14 @@
     "README.md",
     "LICENSE",
     "bunfig.toml",
-    ".dockerignore"
+    ".dockerignore",
+    ".gcloudignore"
   ],
   "scripts": {
     "test": "bun test",
     "typecheck": "tsc --noEmit",
     "lanes": "bun run ./src/cli/lanes.ts",
-    "audit": "bun pm scan",
+    "audit": "bun audit",
     "vendor:bunq": "bun run ./src/providers/bunq/specs/vendor.ts",
     "vendor:discord": "bun run ./src/providers/discord/specs/vendor.ts",
     "vendor:google": "bun run ./src/providers/google/specs/vendor.ts"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lanes-sh/link",
-  "version": "0.6.9",
+  "version": "0.6.10",
   "description": "A self-hostable MCP gateway for all your connections, memory, tasks, files, and secrets",
   "license": "Apache-2.0",
   "homepage": "https://lanes.sh/link",

--- a/src/auth/oidc.test.ts
+++ b/src/auth/oidc.test.ts
@@ -134,6 +134,89 @@ describe('when the issuer cannot answer', () => {
     await expect(blind.verify('t')).rejects.toThrow(/introspection_endpoint/);
   });
 
+  test('a discovery document may not send the token somewhere else', async () => {
+    // The issuer is config and the operator chose it. The endpoint named inside
+    // its metadata is a value fetched over the network, and following it
+    // unchecked means a compromised or misconfigured discovery document
+    // redirects this endpoint's tokens to a host of its choosing.
+    const stub: FetchLike = (input) =>
+      Promise.resolve(
+        String(input).endsWith('/.well-known/openid-configuration')
+          ? Response.json({ introspection_endpoint: 'https://attacker.example/tokeninfo' })
+          : Response.json(VALID),
+      );
+
+    const elsewhere = new OidcVerifier({
+      issuer: ISSUER,
+      audience: 'this-application',
+      allowedSubjects: ['you@example.com'],
+      fetch: stub,
+      now: () => 1_000_000,
+    });
+
+    await expect(elsewhere.verify('t')).rejects.toThrow(/introspection_endpoint/);
+  });
+
+  test('a discovered endpoint is never asked with the token in the query string', async () => {
+    // RFC 7662 is a form POST, and a discovered endpoint is one publishing
+    // itself as RFC 7662. The query-string shape exists for issuers that ship a
+    // non-standard equivalent, and those have to be named in config anyway — so
+    // trying it here could only put a credential in a URL, and in the issuer's
+    // access log, for an issuer that never asked for it.
+    const { stub, calls } = stubIssuer({ active: false });
+
+    const discovered = new OidcVerifier({
+      issuer: ISSUER,
+      audience: 'this-application',
+      allowedSubjects: ['you@example.com'],
+      fetch: stub,
+      now: () => 1_000_000,
+    });
+
+    await discovered.verify('super-secret-token');
+    expect(calls.some((url) => url.includes('super-secret-token'))).toBe(false);
+  });
+
+  test('an endpoint the operator named keeps the fallback, because Google needs it', async () => {
+    // `oauth2.googleapis.com/tokeninfo` is the documented `oidc` setup and it
+    // answers a GET with `access_token` in the query. Dropping the shape
+    // outright would break the one configuration the docs walk through; keeping
+    // it behind an explicit setting is the operator choosing the cost.
+    const calls: string[] = [];
+    const stub: FetchLike = (input, init) => {
+      calls.push(String(input));
+      // Refuse the POST, as a tokeninfo-shaped endpoint does.
+      return Promise.resolve(
+        init?.method === 'POST' ? new Response('bad request', { status: 400 }) : Response.json(VALID),
+      );
+    };
+
+    const named = new OidcVerifier({
+      issuer: ISSUER,
+      audience: 'this-application',
+      allowedSubjects: ['you@example.com'],
+      introspectionEndpoint: INTROSPECTION,
+      fetch: stub,
+      now: () => 1_000_000,
+    });
+
+    expect(await named.verify('t')).not.toBeNull();
+    expect(calls.some((url) => url.includes('access_token=t'))).toBe(true);
+  });
+
+  test('an introspection endpoint that is not https is refused before a token reaches it', async () => {
+    const insecure = new OidcVerifier({
+      issuer: ISSUER,
+      audience: 'this-application',
+      allowedSubjects: ['you@example.com'],
+      introspectionEndpoint: 'http://issuer.example/tokeninfo',
+      fetch: () => Promise.reject(new Error('should never be called')),
+      now: () => 1_000_000,
+    });
+
+    await expect(insecure.verify('t')).rejects.toThrow(/not https/);
+  });
+
   test('an unreachable issuer is not an authorisation', async () => {
     const failing = new OidcVerifier({
       issuer: ISSUER,

--- a/src/auth/oidc.ts
+++ b/src/auth/oidc.ts
@@ -108,8 +108,27 @@ export class OidcVerifier {
     return verified;
   }
 
-  async #endpoint(): Promise<string | null> {
-    if (this.#options.introspectionEndpoint) return this.#options.introspectionEndpoint;
+  /**
+   * Where to ask about a token, and whether the operator chose it.
+   *
+   * The second half decides one thing: whether the non-standard GET shape below
+   * is attempted at all. A discovered endpoint is one the issuer publishes as
+   * RFC 7662, and RFC 7662 is a form POST — so an issuer that answers discovery
+   * and then needs its token in a query string is not a case that exists. The
+   * shape is for issuers that ship an equivalent without advertising one, and
+   * those have to be named in config regardless.
+   */
+  async #endpoint(): Promise<{ url: string; explicit: boolean } | null> {
+    const named = this.#options.introspectionEndpoint;
+    if (named) {
+      if (!isHttps(named)) {
+        throw new Error(
+          `auth.authorization.introspection_endpoint is ${named}, which is not https. ` +
+            'A token is sent to it on every call.',
+        );
+      }
+      return { url: named, explicit: true };
+    }
 
     this.#discovered ??= this.#fetch(
       `${this.#options.issuer.replace(/\/$/, '')}/.well-known/openid-configuration`,
@@ -120,16 +139,33 @@ export class OidcVerifier {
 
     const metadata = await this.#discovered;
     const endpoint = metadata['introspection_endpoint'];
-    return typeof endpoint === 'string' ? endpoint : null;
+    if (typeof endpoint !== 'string') return null;
+
+    // **A discovery document decides where a credential is sent, so what it
+    // names is checked rather than followed.** The issuer is config and the
+    // operator chose it; the endpoint inside its metadata is a value fetched
+    // over the network, and until now anything there — any host, any scheme —
+    // received this endpoint's tokens. Same origin as the issuer is what a
+    // conforming document says anyway.
+    if (!isHttps(endpoint) || !sameOrigin(endpoint, this.#options.issuer)) return null;
+
+    return { url: endpoint, explicit: false };
   }
 
   /**
    * Two request shapes, because two are in the wild.
    *
    * RFC 7662 is a form POST of `token`. The other common spelling is a GET with
-   * the token in the query string, which several issuers ship instead. Trying
-   * the standard one first and the other on failure covers both without either
-   * being named in a conditional.
+   * the token in the query string, which several issuers ship instead — Google's
+   * `tokeninfo` among them, which is why the second shape exists at all.
+   *
+   * **The GET is attempted only for an endpoint the operator named.** A token in
+   * a query string is a credential in the issuer's access logs and in every
+   * proxy between here and it, which is a cost worth paying for the issuer whose
+   * documented setup requires it and worth paying for no other. A discovered
+   * endpoint publishes itself as RFC 7662 and RFC 7662 is the POST, so trying
+   * the query-string shape against one could only ever put a credential in a URL
+   * for an issuer that did not ask for it.
    */
   async #introspect(token: string): Promise<Introspection | null> {
     const endpoint = await this.#endpoint();
@@ -138,20 +174,21 @@ export class OidcVerifier {
       // audience would leave the confused-deputy hole open while looking like
       // it verified something.
       throw new Error(
-        `The issuer ${this.#options.issuer} publishes no introspection_endpoint. ` +
-          'Set auth.authorization.introspection_endpoint to the URL that answers ' +
-          'questions about a token, or this endpoint cannot check who a token was issued to.',
+        `The issuer ${this.#options.issuer} publishes no introspection_endpoint this endpoint ` +
+          'will use — it is absent, not https, or not on the issuer\'s own origin. Set ' +
+          'auth.authorization.introspection_endpoint to the URL that answers questions about a ' +
+          'token, or this endpoint cannot check who a token was issued to.',
       );
     }
 
-    const posted = await this.#ask(endpoint, {
+    const posted = await this.#ask(endpoint.url, {
       method: 'POST',
       headers: { 'content-type': 'application/x-www-form-urlencoded' },
       body: new URLSearchParams({ token }).toString(),
     });
-    if (posted) return posted;
+    if (posted || !endpoint.explicit) return posted;
 
-    const url = new URL(endpoint);
+    const url = new URL(endpoint.url);
     url.searchParams.set('access_token', token);
     return this.#ask(url.toString(), { method: 'GET' });
   }
@@ -164,6 +201,22 @@ export class OidcVerifier {
     } catch {
       return null;
     }
+  }
+}
+
+function isHttps(candidate: string): boolean {
+  try {
+    return new URL(candidate).protocol === 'https:';
+  } catch {
+    return false;
+  }
+}
+
+function sameOrigin(candidate: string, issuer: string): boolean {
+  try {
+    return new URL(candidate).origin === new URL(issuer).origin;
+  } catch {
+    return false;
   }
 }
 

--- a/src/cli/brand.test.ts
+++ b/src/cli/brand.test.ts
@@ -182,6 +182,10 @@ describe('what a browser actually receives', () => {
       expect(response.headers.get('referrer-policy')).toBe('no-referrer');
       expect(csp).toContain("frame-ancestors 'none'");
       expect(csp).toContain("default-src 'none'");
+      // Named separately because it has to be: `form-action` does not fall back
+      // to `default-src`, so `'none'` above says nothing about where a form may
+      // post — and one of these pages posts the owner's endpoint token.
+      expect(csp).toContain("form-action 'self'");
       expect(csp).toContain('https://fonts.googleapis.com');
       expect(csp).toContain('https://fonts.gstatic.com');
       // Script is allowed exactly where there is one: the consent screen has a

--- a/src/cli/brand.ts
+++ b/src/cli/brand.ts
@@ -160,6 +160,12 @@ a { color: inherit; }
  */
 export const PAGE_CSP =
   "frame-ancestors 'none'; default-src 'none'; " +
+  // `form-action` does **not** fall back to `default-src`, so `'none'` above
+  // says nothing about where a form may post. One page here posts the owner's
+  // endpoint token, and its `action` is built from the request's own `Host` —
+  // this is the second lock on that, so a form target that ever came from
+  // somewhere else is refused by the browser rather than followed.
+  "form-action 'self'; " +
   "style-src 'unsafe-inline' https://fonts.googleapis.com; " +
   'font-src https://fonts.gstatic.com';
 

--- a/src/deployments/bind.test.ts
+++ b/src/deployments/bind.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from 'bun:test';
 import { defineProvider } from '#connectivity';
-import type { ConnectionConfig, DeployConfig } from '#profile';
+import { DEPLOY_DEFAULTS, type ConnectionConfig, type DeployConfig } from '#profile';
 import type { CommandResult, DeployDriver } from './driver.ts';
 import { bindConnectionCredentials, unboundRotatableRefs } from './bind.ts';
 
@@ -27,6 +27,7 @@ const cloudrun = {
   access: 'public',
   service_account: 'lanes-link-run@my-project.iam.gserviceaccount.com',
   min_instances: 0,
+  ...DEPLOY_DEFAULTS,
 } as const satisfies DeployConfig;
 
 const connection: ConnectionConfig = {

--- a/src/deployments/gcp/Dockerfile
+++ b/src/deployments/gcp/Dockerfile
@@ -11,7 +11,21 @@
 # There is no build step: Bun runs TypeScript directly, so the image holds
 # source, and `bun install` only fetches the third-party dependencies.
 
-FROM oven/bun:1.3.11-slim
+# Pinned by digest, with the tag kept beside it so the next bump is legible.
+#
+# A tag is a pointer its publisher can move. `1.3.11-slim` is not a promise about
+# bytes — it resolves to whatever was last pushed under that name — so a rebuild
+# months from now can ship a base image nobody here reviewed, in a container that
+# holds live OAuth refresh tokens. The digest is the bytes.
+#
+# `bunfig.toml` already makes this argument about npm packages, with a seven-day
+# release-age floor; the base image is the larger half of the same supply chain
+# and had nothing.
+#
+# To bump: change the tag, then resolve it —
+#   docker buildx imagetools inspect oven/bun:<tag> --format '{{.Manifest.Digest}}'
+# The digest below is the multi-arch index, so it still resolves per architecture.
+FROM oven/bun:1.3.11-slim@sha256:478281fdd196871c7e51ba6a820b7803a8ae97042ec86cdbc2e1c6b6626442d9
 
 WORKDIR /app
 
@@ -42,7 +56,18 @@ COPY package.json bunfig.toml bun.lock* ./
 # in `package.json` is an exact version, so the direct set is identical either
 # way; the lockfile pins what those depend on in turn, and a published package
 # has never been able to carry one.
-RUN if [ -f bun.lock ]; then bun install --frozen-lockfile; else bun install; fi
+#
+# The fallback says so out loud. An unfrozen resolve is a real difference in what
+# ships and it used to be silent — the build log looked identical either way, so
+# "which transitive versions did this image get" was answerable only by opening
+# the image. One line makes it answerable from the build.
+RUN if [ -f bun.lock ]; then \
+      bun install --frozen-lockfile; \
+    else \
+      echo "no bun.lock in the build context: resolving transitive dependencies fresh." >&2; \
+      echo "Direct dependencies are exact in package.json, so the direct set is unchanged." >&2; \
+      bun install; \
+    fi
 
 COPY src/ src/
 

--- a/src/deployments/gcp/bucket.ts
+++ b/src/deployments/gcp/bucket.ts
@@ -1,4 +1,5 @@
-import { layout } from '#profile';
+import { join } from 'node:path';
+import { installRoot, layout } from '#profile';
 import type { DeployStep } from '../driver.ts';
 import {
   removalStep,
@@ -103,6 +104,68 @@ export function bucketGrants(bucket: string, profiles: readonly string[]): Condi
   ];
 }
 
+/**
+ * How long a deleted or overwritten object can still be recovered.
+ *
+ * The revision holds `objectAdmin` on everything under `data/`, and
+ * `objectAdmin` contains `storage.objects.delete`. That grant is correct — the
+ * endpoint writes state, memory, tasks, assets and the audit log, and rewriting
+ * an object is deleting the old one — but it means the process most exposed to
+ * the internet is also the one that can erase the record of what it did.
+ * `audit.tamper-evident` already says deleting a run whole is not *detectable*;
+ * without this it was not *recoverable* either.
+ *
+ * Thirty days rather than the platform's default seven, because the gap this
+ * closes is noticing late. A compromise found the same afternoon needs no
+ * retention policy at all.
+ */
+const SOFT_DELETE_DURATION = '30d';
+
+/**
+ * The three protections a deploy applies to the bucket every time it runs.
+ *
+ * `update` rather than flags on `create`, so they reach a bucket that already
+ * exists — see the call site. Idempotent: setting a policy to what it already is
+ * is a no-op that costs one API call.
+ *
+ * - **Public access prevention**, enforced. Nothing in this bucket is served to
+ *   a browser and nothing in it should ever be anonymous-readable, so the useful
+ *   setting is the one that makes granting that impossible rather than merely
+ *   absent. Uniform bucket-level access already removes per-object ACLs; this
+ *   removes the bucket-level way to do the same thing.
+ * - **Soft delete**, so a deletion is recoverable — see above.
+ * - **Object versioning**, with the lifecycle rule that bounds it. Versioning
+ *   covers what soft delete does not: an object *overwritten* in place, where
+ *   the previous content is the thing worth keeping. The rule is a file shipped
+ *   beside this one rather than written at plan time, because `--dry-run` writes
+ *   nothing and prints what it would run — a temporary file would break both.
+ */
+function durabilitySteps(bucket: string): DeployStep[] {
+  const lifecycle = join(installRoot(import.meta.dir), 'src/deployments/gcp/lifecycle.json');
+
+  return [
+    {
+      title: 'make the bucket unable to be shared publicly, and its deletions recoverable',
+      argv: [
+        'storage',
+        'buckets',
+        'update',
+        `gs://${bucket}`,
+        '--public-access-prevention',
+        '--soft-delete-duration',
+        SOFT_DELETE_DURATION,
+        '--versioning',
+        // Without this, versioning keeps every prior copy of every state key
+        // forever, and state is the one thing here that is rewritten rather than
+        // appended. The rule bounds it by age and by count.
+        '--lifecycle-file',
+        lifecycle,
+      ],
+      tolerateFailure: true,
+    },
+  ];
+}
+
 const TITLES: Record<string, string> = {
   'owns-its-data': 'let the revision write its own data, but not the manifests in it',
   'reads-its-config': 'let the revision read its config, and only read it',
@@ -133,20 +196,30 @@ export async function bucketSteps(input: {
         // served publicly; uniform access removes per-object ACLs as a way to
         // get that wrong.
         '--uniform-bucket-level-access',
-        // Autoclass rather than a lifecycle rule, because no one fixed class is
-        // right for this bucket: it holds the config the endpoint reads on every
-        // boot next to assets and audit rows nobody opens again. Inside an
-        // Autoclass bucket there are no retrieval and no early-deletion fees,
-        // which is what makes ARCHIVE safe as the floor rather than a bet on
-        // never reading the thing again — a read pulls the object back to
-        // Standard at no charge. Objects under 128 KiB never leave Standard, so
-        // this costs the config and the log nothing and saves on attachments.
+        // Autoclass rather than a storage-class lifecycle rule, because no one
+        // fixed class is right for this bucket: it holds the config the endpoint
+        // reads on every boot next to assets and audit rows nobody opens again.
+        // Inside an Autoclass bucket there are no retrieval and no
+        // early-deletion fees, which is what makes ARCHIVE safe as the floor
+        // rather than a bet on never reading the thing again — a read pulls the
+        // object back to Standard at no charge. Objects under 128 KiB never
+        // leave Standard, so this costs the config and the log nothing and saves
+        // on attachments.
         '--enable-autoclass',
         '--autoclass-terminal-storage-class',
         'ARCHIVE',
       ],
       tolerateFailure: true,
     },
+    // Everything about durability, applied separately from the create.
+    //
+    // **Not folded into the flags above, and that is the whole point.** Every
+    // step here tolerates failure, so the create is refused as `ALREADY_EXISTS`
+    // on the second deploy onwards — which means a protection added to that
+    // argv reaches a bucket made after this commit and no other. Every
+    // deployment that already exists is exactly the one that has an audit log
+    // worth keeping.
+    ...durabilitySteps(input.bucket),
   ];
 
   if (!input.serviceAccount) return steps;

--- a/src/deployments/gcp/dockerfile.test.ts
+++ b/src/deployments/gcp/dockerfile.test.ts
@@ -17,6 +17,17 @@ import { readFile } from 'node:fs/promises';
 const DOCKERFILE = new URL('./Dockerfile', import.meta.url).pathname;
 const GITIGNORE = new URL('../../../.gitignore', import.meta.url).pathname;
 const MANIFEST = new URL('../../../package.json', import.meta.url).pathname;
+const DOCKERIGNORE = new URL('../../../.dockerignore', import.meta.url).pathname;
+const GCLOUDIGNORE = new URL('../../../.gcloudignore', import.meta.url).pathname;
+
+/**
+ * What the credential store and its key look like, wherever they land.
+ *
+ * The same list has to be excluded from two different things — the image, and
+ * the tarball `gcloud builds submit` uploads — and they are governed by two
+ * files that do not know about each other.
+ */
+const SECRET_PATHS = ['data/', '*.key', '*.pem', '*.enc', '*.p12', '.env', '.env.*'];
 
 /** The sources of every `COPY`, minus the destination and any flags. */
 function copySources(dockerfile: string): string[] {
@@ -165,6 +176,52 @@ describe('the deployed image', () => {
     expect(instructions).toContain('--frozen-lockfile');
     expect(instructions).not.toMatch(/--frozen-lockfile\s*\|\|/);
     expect(instructions).toMatch(/if \[ -f bun\.lock \]/);
+
+    // And the fallback says so. An unfrozen resolve is a real difference in
+    // what ships, and it used to leave a build log identical to a frozen one.
+    expect(instructions).toMatch(/echo "no bun\.lock in the build context/);
+  });
+
+  test('the base image is pinned by digest, not only by tag', async () => {
+    // A tag is a pointer its publisher can move, so it is not a promise about
+    // bytes: a rebuild months from now can pull a base image nobody here
+    // reviewed, into a container holding live OAuth refresh tokens. `bunfig.toml`
+    // already makes this argument about npm packages with a release-age floor;
+    // the base image is the larger half of the same supply chain.
+    const from = (await readFile(DOCKERFILE, 'utf8'))
+      .split('\n')
+      .find((line) => line.startsWith('FROM '))!;
+
+    expect(from).toMatch(/^FROM oven\/bun:[\w.-]+@sha256:[0-9a-f]{64}$/);
+  });
+
+  test('the build upload excludes the credential store, not only the image', async () => {
+    // `.dockerignore` is not consulted by `gcloud builds submit`: the context is
+    // packed and sent to a Cloud Build staging bucket before any Dockerfile is
+    // read. Without a `.gcloudignore` gcloud derives exclusions from
+    // `.gitignore` when the context is a git checkout and from nothing when it
+    // is not — and `lanes link deploy` sends `installRoot`, which for the
+    // documented install method is a directory under `~/.bun` with no `.git`.
+    // So the safe behaviour was inherited from a coincidence.
+    const gcloudignore = await readFile(GCLOUDIGNORE, 'utf8');
+    const dockerignore = await readFile(DOCKERIGNORE, 'utf8');
+
+    const entries = (text: string): string[] =>
+      text
+        .split('\n')
+        .map((line) => line.trim())
+        .filter((line) => line !== '' && !line.startsWith('#'));
+
+    const missing = SECRET_PATHS.filter((path) => !entries(gcloudignore).includes(path));
+    expect({ missing, from: '.gcloudignore' }).toEqual({ missing: [], from: '.gcloudignore' });
+
+    // And the two stay in step, so a path added to one is not silently absent
+    // from the other.
+    const alsoMissing = SECRET_PATHS.filter((path) => !entries(dockerignore).includes(path));
+    expect({ missing: alsoMissing, from: '.dockerignore' }).toEqual({
+      missing: [],
+      from: '.dockerignore',
+    });
   });
 
   test('the workspace root is not baked in', async () => {

--- a/src/deployments/gcp/driver.test.ts
+++ b/src/deployments/gcp/driver.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from 'bun:test';
-import type { DeployConfig, TargetConfig } from '#profile';
+import { DEPLOY_DEFAULTS, type DeployConfig, type TargetConfig } from '#profile';
 import { cloudRunDriver, deployPlan, imageReference } from './driver.ts';
 import { provisionSteps } from './provision.ts';
 
@@ -18,6 +18,7 @@ const cloudrun = {
   service: 'lanes-link',
   access: 'iam',
   min_instances: 0,
+  ...DEPLOY_DEFAULTS,
 } as const satisfies DeployConfig;
 
 const plan = (overrides: Partial<DeployConfig> = {}, rest: { profile?: string } = {}) =>
@@ -168,8 +169,48 @@ describe('who can reach the endpoint', () => {
     );
   });
 
-  test('no --set-secrets at all for a target that needs none', () => {
+  test('a target that needs no secret clears the mounts rather than omitting the flag', () => {
+    // Omitting it is not "mount nothing" — `gcloud run deploy` leaves a setting
+    // it is not told about exactly as the previous revision had it. So removing
+    // a vault from config used to leave its secret resolved into the new
+    // revision's environment indefinitely, with nothing in the config saying so.
     expect(rollout().argv).not.toContain('--set-secrets');
+    expect(rollout().argv).toContain('--clear-secrets');
+  });
+
+  test('the ceilings are stated on every rollout, at their defaults', () => {
+    // Absent, each of these fell to a platform default: a hundred instances,
+    // eighty concurrent requests each, and 512 MiB to stage a 64 MiB upload in.
+    // On a `public` target those defaults are what an unauthenticated caller
+    // gets to spend, so they are config here and always sent — same argument
+    // `--min-instances` makes about passing the zero.
+    const argv = rollout().argv;
+    const valueOf = (flag: string): string | undefined => argv[argv.indexOf(flag) + 1];
+
+    expect(valueOf('--max-instances')).toBe('4');
+    expect(valueOf('--concurrency')).toBe('40');
+    expect(valueOf('--timeout')).toBe('300');
+    expect(valueOf('--memory')).toBe('1Gi');
+    expect(valueOf('--cpu')).toBe('1');
+    expect(valueOf('--execution-environment')).toBe('gen2');
+  });
+
+  test('a raised ceiling is what gets sent', () => {
+    const argv = rollout({ max_instances: 20, memory: '2Gi' }).argv;
+    expect(argv[argv.indexOf('--max-instances') + 1]).toBe('20');
+    expect(argv[argv.indexOf('--memory') + 1]).toBe('2Gi');
+  });
+
+  test('ingress follows access, so an iam target has no internet-facing listener', () => {
+    // An `iam` target cannot be reached by an MCP client at all — no agent
+    // harness can mint the identity token Cloud Run wants — so the listener it
+    // would present to the internet answers nobody and is one more thing to
+    // probe.
+    const closed = rollout({ access: 'iam' }).argv;
+    expect(closed[closed.indexOf('--ingress') + 1]).toBe('internal-and-cloud-load-balancing');
+
+    const open = rollout({ access: 'public' }).argv;
+    expect(open[open.indexOf('--ingress') + 1]).toBe('all');
   });
 
   test('a service account is passed through, and omitted when not given', () => {
@@ -345,6 +386,52 @@ describe('first-run provisioning', () => {
     expect(create.argv[create.argv.indexOf('--autoclass-terminal-storage-class') + 1]).toBe(
       'ARCHIVE',
     );
+  });
+
+  test('durability is applied by an update, so it reaches a bucket that already exists', async () => {
+    // The create step tolerates failure and is refused as ALREADY_EXISTS from
+    // the second deploy onwards, so a protection expressed as a flag on it
+    // reaches new buckets only — and every deployment that already exists is
+    // exactly the one holding an audit log worth keeping.
+    const update = (await provision({ adapter: 'gcs', bucket: 'lanes-link-blobs' })).find(
+      (step) => step.argv[0] === 'storage' && step.argv[2] === 'update',
+    )!;
+
+    expect(update).toBeDefined();
+    expect(update.argv).toContain('gs://lanes-link-blobs');
+    // Nothing here is served to a browser, so the useful setting is the one that
+    // makes granting anonymous read impossible rather than merely absent.
+    expect(update.argv).toContain('--public-access-prevention');
+    // The revision holds objectAdmin on data/, which contains objects.delete —
+    // so the process most exposed to the internet can erase the record of what
+    // it did. Soft delete is what makes that recoverable.
+    expect(update.argv[update.argv.indexOf('--soft-delete-duration') + 1]).toBe('30d');
+    // And versioning for the other half: an object overwritten in place, where
+    // soft delete does not help and the previous content is the thing worth
+    // keeping.
+    expect(update.argv).toContain('--versioning');
+  });
+
+  test('versioning ships with the rule that bounds it', async () => {
+    // Unbounded, versioning keeps every prior copy of every state key forever,
+    // and state is the one thing here rewritten rather than appended. The rule
+    // is a file beside the driver rather than one written at plan time, because
+    // `--dry-run` writes nothing.
+    const update = (await provision({ adapter: 'gcs', bucket: 'b' })).find(
+      (step) => step.argv[0] === 'storage' && step.argv[2] === 'update',
+    )!;
+
+    const lifecycle = update.argv[update.argv.indexOf('--lifecycle-file') + 1]!;
+    expect(lifecycle.endsWith('src/deployments/gcp/lifecycle.json')).toBe(true);
+
+    const rules = (await Bun.file(lifecycle).json()) as {
+      rule: { action: { type: string }; condition: Record<string, number> }[];
+    };
+    expect(rules.rule.every((entry) => entry.action.type === 'Delete')).toBe(true);
+    expect(rules.rule.map((entry) => Object.keys(entry.condition)[0])).toEqual([
+      'daysSinceNoncurrentTime',
+      'numNewerVersions',
+    ]);
   });
 
   test('no bucket is created for a target that declares no object storage', async () => {

--- a/src/deployments/gcp/driver.ts
+++ b/src/deployments/gcp/driver.ts
@@ -126,12 +126,43 @@ export function deployPlan(input: PlanInput): DeployStep[] {
         // harness can mint one — so a target reached by a remote MCP client
         // declares `public` and gates the request in the application instead.
         cloudrun.access === 'iam' ? '--no-allow-unauthenticated' : '--allow-unauthenticated',
-        // Always passed, including the zero. Config is the source of truth here
-        // (ADR-004), and a flag sent only when non-zero would let a value be
-        // raised and never lowered — the revision would keep whatever the last
-        // deploy that bothered to mention it had set.
+        // What the platform will accept a connection from at all, which is a
+        // different question from who it lets through. An `iam` target is by
+        // definition not reached by an MCP client — no agent harness can mint the
+        // identity token Cloud Run wants — so it is reached by other cloud
+        // workloads or by nothing, and neither needs an internet-facing listener.
+        // `public` is the case where the listener *is* the point.
+        '--ingress',
+        cloudrun.access === 'iam' ? 'internal-and-cloud-load-balancing' : 'all',
+        // Always passed, including the zero and including every default below
+        // it. Config is the source of truth here (ADR-004), and a flag sent only
+        // when non-zero would let a value be raised and never lowered — the
+        // revision would keep whatever the last deploy that bothered to mention
+        // it had set.
         '--min-instances',
         String(cloudrun.min_instances),
+        // The five that used to be absent, and absent meant the platform's own
+        // defaults: a hundred instances, eighty concurrent requests each, and
+        // 512 MiB to serve a 64 MiB upload in. Each one is argued at its field in
+        // `deployTargetSchema`; what they have in common is that a public URL
+        // with no ceiling on any of them is an endpoint whose cost and whose
+        // credential-store traffic are decided by whoever is calling it.
+        '--max-instances',
+        String(cloudrun.max_instances),
+        '--concurrency',
+        String(cloudrun.concurrency),
+        '--timeout',
+        String(cloudrun.timeout_seconds),
+        '--memory',
+        cloudrun.memory,
+        '--cpu',
+        cloudrun.cpu,
+        // Named rather than inherited, like the five above. gen2 is the current
+        // default and the one this image is tested on; pinning it means a
+        // platform migration is a commit here rather than a change under a
+        // running endpoint.
+        '--execution-environment',
+        'gen2',
       ],
     },
   ];
@@ -151,7 +182,14 @@ export function deployPlan(input: PlanInput): DeployStep[] {
  */
 function secretMounts(secretEnv: PlanInput['secretEnv']): string[] {
   const entries = Object.entries(secretEnv ?? {});
-  if (entries.length === 0) return [];
+
+  // `--clear-secrets`, not nothing. `gcloud run deploy` leaves a setting it is
+  // not told about exactly as the last revision had it, so an empty map used to
+  // mean "keep whatever is mounted" rather than "mount nothing" — and removing a
+  // vault from config left its secret still resolved into the new revision's
+  // environment, indefinitely, with nothing in the config saying so. The same
+  // argument `--min-instances` makes about always passing the zero.
+  if (entries.length === 0) return ['--clear-secrets'];
 
   return [
     '--set-secrets',

--- a/src/deployments/gcp/iam.test.ts
+++ b/src/deployments/gcp/iam.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from 'bun:test';
-import type { DeployConfig, TargetConfig } from '#profile';
+import { DEPLOY_DEFAULTS, type DeployConfig, type TargetConfig } from '#profile';
 import { conditionFlag, removalStep, supersededBindings, type PolicyBinding, type PolicyReader } from './iam.ts';
 import { bucketGrants } from './bucket.ts';
 import { provisionSteps } from './provision.ts';
@@ -168,6 +168,7 @@ const cloudrun = {
   access: 'public',
   service_account: SERVICE_ACCOUNT,
   min_instances: 0,
+  ...DEPLOY_DEFAULTS,
 } as const satisfies DeployConfig;
 
 const target: TargetConfig = {

--- a/src/deployments/gcp/lifecycle.json
+++ b/src/deployments/gcp/lifecycle.json
@@ -1,0 +1,12 @@
+{
+  "rule": [
+    {
+      "action": { "type": "Delete" },
+      "condition": { "daysSinceNoncurrentTime": 30 }
+    },
+    {
+      "action": { "type": "Delete" },
+      "condition": { "numNewerVersions": 10 }
+    }
+  ]
+}

--- a/src/deployments/gcp/survey.ts
+++ b/src/deployments/gcp/survey.ts
@@ -1,4 +1,4 @@
-import { ConfigError, type DeployConfig, type TargetConfig } from '#profile';
+import { ConfigError, DEPLOY_DEFAULTS, type DeployConfig, type TargetConfig } from '#profile';
 import { heading, print, style, waiting } from '#cli/output.ts';
 import { ask, confirm } from '#cli/prompt.ts';
 import type { SurveyInput, SurveyResult } from '../driver.ts';
@@ -130,6 +130,17 @@ export async function surveyCloudRun(input: SurveyInput): Promise<SurveyResult> 
     // Not asked about. Zero is right for almost every target and the question
     // would cost every operator a decision to buy one of them a knob.
     min_instances: current.min_instances ?? 0,
+    // Not asked about either, and for a stronger version of the same reason: a
+    // ceiling is only interesting to somebody who has already hit it, and the
+    // defaults are the ones a single-user endpoint wants. Carried through from
+    // what the target already says so that an operator who *has* edited them
+    // keeps their edit — pressing return through the survey changes nothing,
+    // which is the property every other field here has too.
+    max_instances: current.max_instances ?? DEPLOY_DEFAULTS.max_instances,
+    concurrency: current.concurrency ?? DEPLOY_DEFAULTS.concurrency,
+    timeout_seconds: current.timeout_seconds ?? DEPLOY_DEFAULTS.timeout_seconds,
+    memory: current.memory ?? DEPLOY_DEFAULTS.memory,
+    cpu: current.cpu ?? DEPLOY_DEFAULTS.cpu,
     project,
     region,
     service,

--- a/src/deployments/grants.test.ts
+++ b/src/deployments/grants.test.ts
@@ -6,7 +6,7 @@ import {
   type ProviderManifest,
 } from '#connectivity';
 import { CredentialOAuthProvider } from '#connectivity/auth/index.ts';
-import { layout, type Config, type DeployConfig, type TargetConfig } from '#profile';
+import { DEPLOY_DEFAULTS, layout, type Config, type DeployConfig, type TargetConfig } from '#profile';
 import { ownClientRefsFor } from '#registry';
 import { encodeRef } from './adapters/gcp-secret-manager.ts';
 import { provisionSteps } from './gcp/provision.ts';
@@ -45,6 +45,7 @@ const cloudrun = {
   access: 'public',
   service_account: 'lanes-link-run@my-project.iam.gserviceaccount.com',
   min_instances: 0,
+  ...DEPLOY_DEFAULTS,
 } as const satisfies DeployConfig;
 
 const target: TargetConfig = {

--- a/src/policy/limits.test.ts
+++ b/src/policy/limits.test.ts
@@ -96,3 +96,71 @@ describe('rate limiting', () => {
     expect(limiter.take('personal', 5).allowed).toBe(false);
   });
 });
+
+/**
+ * The bound on the map itself.
+ *
+ * A key here is not always one the endpoint chose: at the HTTP edge a caller is
+ * identified by the first `X-Forwarded-For` hop, which on a public deployment is
+ * a header a stranger writes. Without a cap that is an unbounded allocation
+ * driven from outside the process.
+ */
+describe('the key map', () => {
+  test('holds no more keys than its cap, however many distinct callers arrive', () => {
+    const time = clock();
+    const limiter = new RateLimiter(time.now, 100);
+
+    for (let i = 0; i < 5_000; i++) {
+      time.advance(1);
+      limiter.take(`caller-${i}`, 30);
+    }
+
+    expect(limiter.size).toBeLessThanOrEqual(100);
+  });
+
+  test('an idle caller goes before a live one', () => {
+    const time = clock();
+    const limiter = new RateLimiter(time.now, 10);
+
+    // Nine callers that arrive and stop.
+    for (let i = 0; i < 9; i++) limiter.take(`idle-${i}`, 30);
+
+    // Long past the idle window for those nine. `busy` arrives now and spends
+    // twice, so it is the one caller whose bucket is both live and not full.
+    time.advance(400_000);
+    limiter.take('busy', 30);
+    limiter.take('busy', 30);
+
+    // The insert that overflows: the nine idle buckets are dropped, and nothing
+    // live is touched.
+    limiter.take('newcomer', 30);
+    expect(limiter.size).toBeLessThanOrEqual(10);
+
+    // Two of thirty spent. Had `busy` been evicted, re-creating it would hand
+    // back a full bucket and this would read thirty — so the number is the
+    // assertion that its spend survived the eviction going on around it.
+    let remaining = 0;
+    while (limiter.take('busy', 30).allowed) remaining += 1;
+    expect(remaining).toBe(28);
+  });
+
+  test('eviction is amortised rather than one key per overflow', () => {
+    // A single eviction per insert would run a sort on every request once the
+    // map is full, which turns the bound into its own denial of service. A batch
+    // means most inserts past the cap do no sorting at all.
+    const time = clock();
+    const limiter = new RateLimiter(time.now, 100);
+
+    for (let i = 0; i < 100; i++) {
+      time.advance(1);
+      limiter.take(`caller-${i}`, 30);
+    }
+    expect(limiter.size).toBe(100);
+
+    // The insert that overflows drops a tenth, so there is room for nine more
+    // before the next one has to.
+    time.advance(1);
+    limiter.take('overflows', 30);
+    expect(limiter.size).toBe(91);
+  });
+});

--- a/src/policy/limits.ts
+++ b/src/policy/limits.ts
@@ -28,6 +28,29 @@ interface Bucket {
 }
 
 /**
+ * How many keys one limiter will hold.
+ *
+ * The bound exists because a key is not always something the endpoint chose. At
+ * the HTTP edge a caller is identified by the first `X-Forwarded-For` hop, which
+ * on a public deployment is a header a stranger writes — so an unbounded map is
+ * an unbounded allocation driven from outside, in a container that now has an
+ * explicit memory limit to exceed.
+ *
+ * Ten thousand is far above any real caller count for a single-user endpoint and
+ * far below a problem: a bucket is two numbers and a string key.
+ */
+const DEFAULT_MAX_KEYS = 10_000;
+
+/**
+ * How many go at once when the cap is reached.
+ *
+ * A batch rather than one, so the sort that finds them is amortised. Evicting a
+ * single key per overflow would run an O(n log n) pass on every request once the
+ * map is full, which turns the bound into its own denial of service.
+ */
+const EVICTION_FRACTION = 10;
+
+/**
  * Token bucket, refilled continuously rather than on a fixed window boundary.
  *
  * A fixed window lets a caller spend the whole budget in the last instant of
@@ -37,9 +60,16 @@ interface Bucket {
 export class RateLimiter {
   readonly #buckets = new Map<string, Bucket>();
   readonly #now: () => number;
+  readonly #maxKeys: number;
 
-  constructor(now: () => number = Date.now) {
+  constructor(now: () => number = Date.now, maxKeys: number = DEFAULT_MAX_KEYS) {
     this.#now = now;
+    this.#maxKeys = maxKeys;
+  }
+
+  /** How many callers are currently held. For tests, and for nothing else. */
+  get size(): number {
+    return this.#buckets.size;
   }
 
   /**
@@ -52,7 +82,13 @@ export class RateLimiter {
 
     const now = this.#now();
     const refillPerMs = perMinute / 60_000;
-    const bucket = this.#buckets.get(key) ?? { tokens: perMinute, lastRefill: now };
+    const existing = this.#buckets.get(key);
+
+    // Before the insert, not after: the cap is on what this map holds, and
+    // checking afterwards means it is briefly one over on every overflow.
+    if (!existing) this.#makeRoom();
+
+    const bucket = existing ?? { tokens: perMinute, lastRefill: now };
 
     bucket.tokens = Math.min(perMinute, bucket.tokens + (now - bucket.lastRefill) * refillPerMs);
     bucket.lastRefill = now;
@@ -67,11 +103,48 @@ export class RateLimiter {
     return { allowed: true, retryAfterMs: 0 };
   }
 
-  /** Drop idle buckets so a long-lived process does not accumulate keys forever. */
+  /**
+   * Drop idle buckets so a long-lived process does not accumulate keys forever.
+   *
+   * Public because it reads as the obvious lever, and because the tests drive it
+   * directly. It is **not** what bounds the map, and nothing's correctness may
+   * depend on a caller remembering it: for most of this file's life nothing did
+   * call it, `edge.ts` claimed idle callers were dropped, and the map grew for
+   * as long as the process lived. `#makeRoom` is the bound now, and it runs on
+   * the insert path where it cannot be forgotten.
+   */
   prune(idleMs = 300_000): void {
     const cutoff = this.#now() - idleMs;
     for (const [key, bucket] of this.#buckets) {
       if (bucket.lastRefill < cutoff) this.#buckets.delete(key);
     }
+  }
+
+  /**
+   * Make space for one more key, if the map is full.
+   *
+   * Idle callers first, because dropping one costs nothing — a bucket that has
+   * not been touched in five minutes has refilled to full, so re-creating it
+   * gives back exactly what was discarded.
+   *
+   * Only when that is not enough does this evict a live caller, oldest first by
+   * last use. That *does* forgive whatever the evicted caller had spent, which
+   * is the honest cost of a bounded map: an attacker who can mint ten thousand
+   * distinct keys can push their own bucket out and start again. What they
+   * cannot do is grow the map, and on the paths this limiter guards there is a
+   * second bucket keyed on nothing at all — see `edge.ts` — which is the one
+   * that holds when the per-caller key is worthless.
+   */
+  #makeRoom(): void {
+    if (this.#buckets.size < this.#maxKeys) return;
+
+    this.prune();
+    if (this.#buckets.size < this.#maxKeys) return;
+
+    const oldest = [...this.#buckets.entries()]
+      .sort((a, b) => a[1].lastRefill - b[1].lastRefill)
+      .slice(0, Math.max(1, Math.ceil(this.#maxKeys / EVICTION_FRACTION)));
+
+    for (const [key] of oldest) this.#buckets.delete(key);
   }
 }

--- a/src/profile/index.ts
+++ b/src/profile/index.ts
@@ -12,6 +12,7 @@
  */
 
 export {
+  DEPLOY_DEFAULTS,
   SUPPORTED_CONTRACT,
   configSchema,
   declaredTarget,

--- a/src/profile/legacy.ts
+++ b/src/profile/legacy.ts
@@ -2,6 +2,7 @@ import { z } from 'zod';
 import {
   auditTargetSchema,
   credentialsTargetSchema,
+  DEPLOY_DEFAULTS,
   deployTargetSchema,
   storageTargetSchema,
   vaultTargetSchema,
@@ -54,14 +55,18 @@ export const legacyTargetSchema = z
       ? target
       : {
           ...target,
-          // The pre-`deploy` spelling predates both of these, so it gets the
-          // same defaults the current one would: the closed door, and no
-          // instance kept warm.
+          // The pre-`deploy` spelling predates all of these, so it gets the
+          // same defaults the current one would: the closed door, no instance
+          // kept warm, and the ceilings a public URL is deployed under. Built by
+          // hand here rather than parsed, so `DEPLOY_DEFAULTS` is spread rather
+          // than left to zod — a block that reaches `deployPlan` without them
+          // sends `undefined` to `gcloud` as the string "undefined".
           deploy: {
             ...cloudrun,
             platform: 'cloudrun' as const,
             access: 'iam' as const,
             min_instances: 0,
+            ...DEPLOY_DEFAULTS,
           },
         },
   );

--- a/src/profile/load.test.ts
+++ b/src/profile/load.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, test } from 'bun:test';
 import { parse as parseYaml } from 'yaml';
 import { ConfigError, parseConfig, validateConfig } from './load.ts';
 import { legacyTargetSchema } from './legacy.ts';
-import { workspaceSchema } from './schema.ts';
+import { DEPLOY_DEFAULTS, workspaceSchema } from './schema.ts';
 
 /** A minimal valid config; each test overrides the part it is about. */
 const VALID = `
@@ -344,6 +344,11 @@ describe('where a target deploys', () => {
       // Scaling to zero is the default, and stays the default: a cold start is
       // under three seconds and the platform queues the request behind it.
       min_instances: 0,
+      // And the ceilings, which a target that says nothing also gets. That is
+      // the whole point of them being defaults rather than prompts: an operator
+      // who never opens this block still deploys behind a bound on what a public
+      // URL can spend.
+      ...DEPLOY_DEFAULTS,
     });
   });
 
@@ -366,6 +371,10 @@ describe('where a target deploys', () => {
       service: 'lanes-link',
       access: 'iam',
       min_instances: 0,
+      // The pre-`deploy` spelling predates these too, so `legacy.ts` supplies
+      // them by hand — a migrated block that reached `deployPlan` without them
+      // would send the string "undefined" to gcloud.
+      ...DEPLOY_DEFAULTS,
     });
   });
 

--- a/src/profile/schema.ts
+++ b/src/profile/schema.ts
@@ -158,6 +158,25 @@ export const vaultTargetSchema = z.object({
  * discriminated union per platform — buys precision this file cannot use and
  * costs a schema edit on every field any host ever adds.
  */
+/**
+ * The ceilings a deployed revision runs under, in one place.
+ *
+ * A named constant rather than five literals inside `z.default()` because two
+ * callers need the same numbers and neither can read a zod default out of a
+ * schema: the survey writes a target's block field by field, and the deploy plan
+ * sends every one of them on every rollout. Two spellings of a ceiling is a
+ * ceiling that is one value in a fresh profile and another in a surveyed one.
+ *
+ * Each is argued at its own field below.
+ */
+export const DEPLOY_DEFAULTS = {
+  max_instances: 4,
+  concurrency: 40,
+  timeout_seconds: 300,
+  memory: '1Gi',
+  cpu: '1',
+} as const;
+
 export const deployTargetSchema = z.object({
   platform: z.enum(['cloudrun']),
   // Non-empty here rather than in a referential check further down. Under
@@ -210,6 +229,52 @@ export const deployTargetSchema = z.object({
    * Raise it if a re-authorization ever lines up with a cold `/token`.
    */
   min_instances: z.number().int().min(0).max(10).default(0),
+  /**
+   * The ceiling on instances, and the only thing bounding what a public URL can
+   * spend.
+   *
+   * Four, not the platform's hundred. `access: public` is a routable address on
+   * the internet, and every instance that starts reads the credential store and
+   * lists the bucket — so scaling out multiplies cost *and* traffic against the
+   * two things this endpoint most wants kept quiet. A single-user endpoint that
+   * genuinely needs a fifth concurrent instance has an agent in a loop, which is
+   * the case the ceiling is for.
+   *
+   * It is also what makes `limits.requests_per_minute` mean something in
+   * aggregate. Those limits are per instance and always were; with no ceiling
+   * the aggregate had no value at all, and `docs/detailed/deployment-cloudrun.md`
+   * told the reader to cap this themselves because nothing here did.
+   */
+  max_instances: z.number().int().min(1).max(100).default(DEPLOY_DEFAULTS.max_instances),
+  /**
+   * Requests one instance serves at once.
+   *
+   * Forty rather than the platform's eighty, paired with `memory` below: an
+   * attachment upload is capped at 64 MiB and is buffered before it is written,
+   * so what bounds this is memory per instance rather than CPU.
+   */
+  concurrency: z.number().int().min(1).max(1000).default(DEPLOY_DEFAULTS.concurrency),
+  /**
+   * How long one request may run before the platform cuts it.
+   *
+   * The platform's own default, stated rather than inherited — the point is that
+   * it is written down and always sent, so a platform changing its default is
+   * not a silent change to what this serves.
+   */
+  timeout_seconds: z.number().int().min(1).max(3600).default(DEPLOY_DEFAULTS.timeout_seconds),
+  /**
+   * Memory per instance.
+   *
+   * A gigabyte because 512 MiB is not enough for what the endpoint already
+   * accepts: `MAX_UPLOAD_BYTES` is 64 MiB, and staging one costs roughly twice
+   * that at peak — the chunks as they arrive, and the single buffer they are
+   * copied into. At the platform default that is one upload away from an
+   * out-of-memory kill, and an OOM is a 503 for every request the instance was
+   * also serving.
+   */
+  memory: z.string().min(1).default(DEPLOY_DEFAULTS.memory),
+  /** CPU per instance. Explicit for the same reason `timeout_seconds` is. */
+  cpu: z.string().min(1).default(DEPLOY_DEFAULTS.cpu),
 });
 
 /**

--- a/src/profile/targets.test.ts
+++ b/src/profile/targets.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from 'bun:test';
+import { DEPLOY_DEFAULTS } from './schema.ts';
 import { noTargetNamed, notInRegistry, requireTarget, type Registry } from './targets.ts';
 
 /**
@@ -21,7 +22,16 @@ const declared = (name: string, deploy = false): Registry[string] => ({
   credentials: { adapter: 'file' },
   storage: { adapter: 'filesystem' },
   ...(deploy
-    ? { deploy: { platform: 'cloudrun' as const, region: 'r', service: 's', access: 'iam' as const, min_instances: 0 } }
+    ? {
+        deploy: {
+          platform: 'cloudrun' as const,
+          region: 'r',
+          service: 's',
+          access: 'iam' as const,
+          min_instances: 0,
+          ...DEPLOY_DEFAULTS,
+        },
+      }
     : {}),
 });
 

--- a/src/server/edge.ts
+++ b/src/server/edge.ts
@@ -1,3 +1,4 @@
+import { challenge, type AuthOutcome, type ChallengeError } from '#auth';
 import { RateLimiter } from '#policy';
 
 /**
@@ -14,6 +15,56 @@ import { RateLimiter } from '#policy';
  * a sustained probe a shape in the log rather than an unbroken run of 401s.
  */
 export const FAILED_AUTH_PER_MINUTE = 30;
+
+/**
+ * A ceiling on the surface that answers *before* authentication.
+ *
+ * The limit above sits behind the bearer gate, and for a long time that was the
+ * whole of it — which left the four things that answer in front of the gate with
+ * no ceiling at all. On a `public` deployment every one of them costs the owner
+ * something, and none of them needs a credential to reach:
+ *
+ *   - `/health` presented with a credential re-reads the credential store, which
+ *     on a deployed target is a Secret Manager call — two, when the value the
+ *     process cached does not match, because a mismatch against a cached value
+ *     forces the re-read that makes a rotation take effect.
+ *   - `/register` writes an object to the workspace bucket, then lists two
+ *     namespaces to decide whether anything needs evicting.
+ *   - `/authorize` compares against the endpoint token, which is another read of
+ *     the credential store.
+ *   - `/token` reads and writes bucket objects.
+ *
+ * `/health` presented with *no* credential is deliberately free: it reads
+ * nothing, and it is what a platform probe and `lanes link outputs` send.
+ * Metering it would put a ceiling on the one request that costs nothing to
+ * answer.
+ */
+export const UNAUTHENTICATED_PER_MINUTE = 30;
+
+/**
+ * The same ceiling for the endpoint as a whole, keyed on nothing.
+ *
+ * **This is the one that actually holds.** The per-caller key below is the first
+ * `X-Forwarded-For` hop, which anyone talking to the endpoint directly can write
+ * as they please — so a per-caller limit alone bounds only a caller who is not
+ * trying, and rotating the header walks straight through it.
+ *
+ * A shared bucket has the opposite problem: whoever is spending it locks
+ * everyone else out, which is why `index.ts` refuses to key the *failed-auth*
+ * limit that way. Here the trade is different, because what is behind these
+ * paths is not the owner's ability to use their endpoint — a client that has
+ * already authorised holds a token and never comes back through them — it is a
+ * discovery document, a registration, and a consent screen. Losing those for a
+ * minute is an authorization that has to be retried. Not losing them costs a
+ * stranger's arbitrary spend against the credential store.
+ *
+ * Two hundred a minute is far above what an authorization flow uses: a connector
+ * being added is a handful of requests, once.
+ */
+export const UNAUTHENTICATED_TOTAL_PER_MINUTE = 200;
+
+/** The key the endpoint-wide bucket is held under. Constant on purpose. */
+const EVERYONE = 'endpoint';
 
 /**
  * Who an attempt is counted against.
@@ -47,7 +98,143 @@ export function tooManyAttempts(retryAfterMs: number): Response {
   );
 }
 
-/** One bucket set per endpoint. Idle callers are dropped so keys do not accumulate. */
+/**
+ * One bucket set per endpoint.
+ *
+ * The map is bounded by `RateLimiter` itself rather than by a caller
+ * remembering to prune it. This comment used to say idle callers were dropped
+ * "so keys do not accumulate", and nothing anywhere called `prune` — so on a
+ * public URL the map grew one entry per distinct `X-Forwarded-For` for as long
+ * as the process lived, which is a header a stranger writes.
+ */
 export function failedAuthLimiter(): RateLimiter {
   return new RateLimiter();
+}
+
+/** The same, for the pre-authentication surface. Separate so one cannot spend the other. */
+export function unauthenticatedLimiter(): RateLimiter {
+  return new RateLimiter();
+}
+
+/**
+ * The refusal for a pre-authentication request over budget, or `undefined` to
+ * let it through.
+ *
+ * One function rather than a branch in the router, for the reason `./cors.ts`
+ * and `./oauth.ts` are their own files: `index.ts` gains a delegation instead of
+ * the whole of this behaviour, and it stays inside the size budget that would
+ * otherwise be the rule relaxed to fit this in.
+ *
+ * `isAuthorizationPath` is passed rather than imported so this file does not
+ * reach back into the router's path constants — `corsAware` takes the same shape
+ * for the same reason.
+ *
+ * Two buckets are taken rather than one short-circuiting the other, so a caller
+ * that has exhausted its own budget still counts against the endpoint's: the
+ * alternative lets a flood of distinct forwarded-for values leave the shared
+ * bucket untouched, which is precisely the case the shared bucket exists for.
+ */
+export function unauthenticatedRefusal(input: {
+  readonly request: Request;
+  readonly pathname: string;
+  readonly limiter: RateLimiter;
+  readonly healthPath: string;
+  readonly isAuthorizationPath: (pathname: string) => boolean;
+  readonly authorizationEnabled: boolean;
+}): Response | undefined {
+  // A `/health` carrying no credential reads nothing and is deliberately free —
+  // it is what a platform probe and `lanes link outputs` send, and a ceiling on
+  // the one request that costs nothing to answer is an outage waiting for an
+  // attack that did not have to cause one.
+  const costly =
+    input.pathname === input.healthPath
+      ? input.request.headers.get('authorization') !== null
+      : input.authorizationEnabled && input.isAuthorizationPath(input.pathname);
+
+  if (!costly) return undefined;
+
+  const caller = callerKey(input.request);
+  const mine = input.limiter.take(`caller:${caller}`, UNAUTHENTICATED_PER_MINUTE);
+  const everyone = input.limiter.take(EVERYONE, UNAUTHENTICATED_TOTAL_PER_MINUTE);
+  if (mine.allowed && everyone.allowed) return undefined;
+
+  return tooManyAttempts(Math.max(mine.retryAfterMs, everyone.retryAfterMs));
+}
+
+type RefusalReason = Extract<AuthOutcome, { ok: false }>['reason'];
+
+/**
+ * What a caller should do about each refusal.
+ *
+ * `invalid` is the only one a client can act on by itself: it presented a
+ * credential and this endpoint did not accept it, which is what a refresh is
+ * for. RFC 6750 §3.1 has a name for that and clients branch on it; the others
+ * mean there is nothing to refresh, and §3 says to stay quiet rather than send
+ * a client after a token it does not hold. `malformed` says nothing either —
+ * `invalid_request` carries a SHOULD of a 400 status, and changing that path's
+ * status is a larger question than this answers.
+ */
+const CHALLENGE: Partial<Record<RefusalReason, ChallengeError>> = {
+  invalid: {
+    code: 'invalid_token',
+    description: 'The credential is expired, revoked, or not one this endpoint issued.',
+  },
+};
+
+/** The same four, for whoever is reading the body rather than the header. */
+const HINTS: Record<RefusalReason, string> = {
+  missing: 'Present the profile token as: Authorization: Bearer <token>',
+  malformed: 'Present the profile token as: Authorization: Bearer <token>',
+  invalid: 'Refresh the credential. Authorize again only if the refresh is refused too.',
+  not_configured: 'This profile has no token yet. Run: lanes link token rotate',
+};
+
+/**
+ * The `401`, with whatever the caller can act on.
+ *
+ * Here rather than in the router because it is the same subject as the two
+ * ceilings above — what this endpoint does about a caller who has not
+ * authenticated — and because the router was over its size budget carrying both.
+ * The vocabulary is RFC 6750's on the header and plain English in the body, so
+ * whoever is reading a terminal and whoever is writing a client each get the
+ * version they can use.
+ */
+function unauthorized(reason: RefusalReason, metadataUrl: string | null): Response {
+  return new Response(
+    JSON.stringify({ error: 'unauthorized', reason, hint: HINTS[reason] }),
+    {
+      status: 401,
+      headers: {
+        'content-type': 'application/json',
+        'www-authenticate': challenge(metadataUrl, CHALLENGE[reason]),
+      },
+    },
+  );
+}
+
+/**
+ * What a caller who failed authentication gets: the `401`, or the `429` once
+ * they have failed too often.
+ *
+ * The ceiling is spent **after** the attempt rather than before it. Keyed on the
+ * caller alone, anyone able to reach the endpoint could spend the owner's budget
+ * and lock them out, which trades a cost problem for a worse availability one.
+ * Only a failure consumes a token, so a valid credential is never refused by
+ * this.
+ *
+ * `metadataUrl` is the whole handshake for a remote client: it reads the named
+ * document, finds the authorization server, and starts a flow. Without it the
+ * client has to guess the document's location, and a client that guesses wrong
+ * reports the endpoint as unreachable.
+ */
+export function authRefusal(input: {
+  readonly request: Request;
+  readonly reason: RefusalReason;
+  readonly limiter: RateLimiter;
+  readonly metadataUrl: string | null;
+}): Response {
+  const budget = input.limiter.take(callerKey(input.request), FAILED_AUTH_PER_MINUTE);
+  return budget.allowed
+    ? unauthorized(input.reason, input.metadataUrl)
+    : tooManyAttempts(budget.retryAfterMs);
 }

--- a/src/server/harness.ts
+++ b/src/server/harness.ts
@@ -116,6 +116,15 @@ export interface HarnessOptions {
    * serving the old generation" case is reached; absent means nothing new.
    */
   reopen?: () => Promise<ReadonlyMap<string, ProfileRuntime>>;
+  /**
+   * Meter the pre-authentication surface, as a routable deployment does.
+   *
+   * A harness binds loopback, where `serve()` leaves this off — the ceiling
+   * protects a credential-store call over the network and an object written to a
+   * bucket, and on loopback both are a local file. Set it to drive the deployed
+   * behaviour without a deployment.
+   */
+  meterUnauthenticated?: boolean;
 }
 
 /**
@@ -254,6 +263,7 @@ export function startHarness(options: HarnessOptions): Harness {
     primary: options.profile,
     authenticator: gate ? new AuthenticatorChain([bearer, gate.authenticator]) : bearer,
     ...(gate ? { authorization: gate.surface } : {}),
+    ...(options.meterUnauthenticated ? { meterUnauthenticated: true } : {}),
     log,
   });
 

--- a/src/server/index.test.ts
+++ b/src/server/index.test.ts
@@ -1018,6 +1018,116 @@ describe('the authentication edge', () => {
   });
 });
 
+/**
+ * The ceiling in front of authentication, which is a different one.
+ *
+ * `the authentication edge` above covers the limit behind the bearer gate. This
+ * covers the four things that answer without ever reaching it, each of which
+ * costs the owner a read of the credential store or a write to the workspace
+ * bucket: `/health` presented with a credential, `/register`, `/authorize` and
+ * `/token`. On a `public` deployment all four are reachable by anyone with the
+ * hostname, and until this existed none of them had any ceiling at all.
+ */
+describe('the pre-authentication edge', () => {
+  const metered = startHarness({
+    profile: 'personal',
+    port: allocatePort(),
+    policy: `  allow:
+    - "example.*"`,
+    authorization: true,
+    // The ceiling is off on loopback, where what it protects is a local file
+    // rather than a network call and a bucket write. This harness asks for the
+    // deployed behaviour so the thing under test is the thing that ships.
+    meterUnauthenticated: true,
+  });
+
+  const origin = (): string => new URL(metered.server.url).origin;
+
+  afterAll(async () => {
+    await metered.stop();
+  });
+
+  test('a credentialed /health burst is eventually refused', async () => {
+    // A `/health` carrying a credential is not the free request an uncredentialed
+    // one is: it compares against the credential store, and a value that does
+    // not match what the process cached forces a re-read — a Secret Manager call
+    // on a deployed target, twice over, for a caller holding nothing.
+    const statuses: number[] = [];
+    for (let attempt = 0; attempt < 40; attempt += 1) {
+      const response = await fetch(`${origin()}/health`, {
+        headers: {
+          authorization: `Bearer llk_wrong_${attempt}`,
+          'x-forwarded-for': '198.51.100.7',
+        },
+      });
+      statuses.push(response.status);
+    }
+
+    expect(statuses[0]).toBe(200);
+    expect(statuses.at(-1)).toBe(429);
+  });
+
+  test('the authorization surface is metered on the same budget', async () => {
+    // Registration is open by design — it yields an identifier and nothing else
+    // — but open was never meant to mean free. Each call writes an object to the
+    // workspace bucket and then lists two namespaces to decide what to evict.
+    const statuses: number[] = [];
+    for (let attempt = 0; attempt < 40; attempt += 1) {
+      const response = await fetch(`${origin()}/register`, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json', 'x-forwarded-for': '198.51.100.8' },
+        body: JSON.stringify({ redirect_uris: ['https://client.example/callback'] }),
+      });
+      statuses.push(response.status);
+    }
+
+    expect(statuses[0]).toBe(201);
+    expect(statuses.at(-1)).toBe(429);
+
+    // A refusal a client can act on. `Retry-After` is already in the CORS
+    // expose list for exactly this.
+    const refused = await fetch(`${origin()}/register`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json', 'x-forwarded-for': '198.51.100.8' },
+      body: JSON.stringify({ redirect_uris: ['https://client.example/callback'] }),
+    });
+    expect(refused.status).toBe(429);
+    expect(refused.headers.get('retry-after')).not.toBeNull();
+  });
+
+  test('rotating the forwarded-for header does not evade the ceiling', async () => {
+    // The point of the second bucket. `x-forwarded-for` is a header anyone
+    // talking to the endpoint directly writes as they please, so a per-caller
+    // limit alone bounds only a caller who is not trying. The endpoint-wide
+    // bucket is keyed on nothing and cannot be rotated out of.
+    let last = 0;
+    for (let attempt = 0; attempt < 220; attempt += 1) {
+      const response = await fetch(`${origin()}/health`, {
+        headers: {
+          authorization: 'Bearer llk_wrong',
+          // A fresh caller every single time.
+          'x-forwarded-for': `203.0.113.${attempt % 254}, 10.0.0.1`,
+        },
+      });
+      last = response.status;
+    }
+
+    expect(last).toBe(429);
+  });
+
+  test('an uncredentialed /health still answers while everything else is refused', async () => {
+    // Deliberately free, and this is the assertion that says so. It reads
+    // nothing, and it is what a platform probe, `lanes link deploy` and
+    // `lanes link outputs` send — metering it would put a ceiling on the one
+    // request that costs nothing to answer, and a health check that 429s during
+    // an attack is an outage the attack did not have to cause.
+    const response = await fetch(`${origin()}/health`);
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({ status: 'ok' });
+  });
+});
+
 describe('operational logging', () => {
   test('a rejected request is reported to the logger', async () => {
     // The warning existed and went nowhere: every caller of `serve()` passed a

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -1,4 +1,4 @@
-import { challenge, type Authenticator, type AuthOutcome, type ChallengeError } from '#auth';
+import type { Authenticator } from '#auth';
 import type { Logger } from '#connectivity';
 import { capabilityIdForToolName } from '#server/mcp';
 import { ATTACHMENTS_PATH, stageAttachment } from './attachments.ts';
@@ -6,7 +6,12 @@ import { allowedHostnamesFor, rebindingRefusal } from './rebinding.ts';
 import { ANY_ORIGIN, corsAware, type CorsPolicy } from './cors.ts';
 import type { Generation } from './generation.ts';
 import type { Generations } from './generations.ts';
-import { callerKey, failedAuthLimiter, FAILED_AUTH_PER_MINUTE, tooManyAttempts } from './edge.ts';
+import {
+  authRefusal,
+  failedAuthLimiter,
+  unauthenticatedLimiter,
+  unauthenticatedRefusal,
+} from './edge.ts';
 import {
   handleAuthorization,
   isAuthorizationPath,
@@ -50,38 +55,29 @@ export interface ServerOptions {
   readonly authorization?: AuthorizationSurface | undefined;
   /** Hostnames this endpoint answers to. See `./rebinding.ts`. */
   readonly allowedHostnames?: readonly string[] | undefined;
+  /**
+   * Meter the surface that answers before authentication.
+   *
+   * A property of what this is bound to, exactly as `cors` and
+   * `allowedHostnames` are, and decided in the same lines of `serve()`. Off on
+   * loopback, and that is not a gap: what the ceiling protects is a
+   * credential-store call over the network and an object written to a bucket,
+   * and on loopback both are a local file belonging to whoever is already
+   * standing at the machine. `./rebinding.ts` refuses the one caller that is not
+   * — a page the owner happens to be visiting — before this would be reached.
+   */
+  readonly meterUnauthenticated?: boolean | undefined;
 }
-
-type RefusalReason = Extract<AuthOutcome, { ok: false }>['reason'];
-
-/**
- * What a caller should do about each refusal.
- *
- * `invalid` is the only one a client can act on by itself: it presented a
- * credential and this endpoint did not accept it, which is what a refresh is
- * for. RFC 6750 §3.1 has a name for that and clients branch on it; the others
- * mean there is nothing to refresh, and §3 says to stay quiet rather than send
- * a client after a token it does not hold. `malformed` says nothing either —
- * `invalid_request` carries a SHOULD of a 400 status, and changing that path's
- * status is a larger question than this answers.
- */
-const CHALLENGE: Partial<Record<RefusalReason, ChallengeError>> = {
-  invalid: {
-    code: 'invalid_token',
-    description: 'The credential is expired, revoked, or not one this endpoint issued.',
-  },
-};
-
-/** The same four, for whoever is reading the body rather than the header. */
-const HINTS: Record<RefusalReason, string> = {
-  missing: 'Present the profile token as: Authorization: Bearer <token>',
-  malformed: 'Present the profile token as: Authorization: Bearer <token>',
-  invalid: 'Refresh the credential. Authorize again only if the refresh is refused too.',
-  not_configured: 'This profile has no token yet. Run: lanes link token rotate',
-};
 
 export const MCP_PATH = '/mcp';
 export const RELOAD_PATH = '/reload';
+/**
+ * Named rather than inline, because two places now decide about it: the branch
+ * that answers it, and the ceiling in front of that branch which has to know
+ * that a `/health` carrying a credential is not the free request the other one
+ * is.
+ */
+export const HEALTH_PATH = '/health';
 
 /**
  * Loopback addresses. What binding to one changes is the browser threat model,
@@ -111,6 +107,7 @@ export interface RequestHandler {
 export function createRequestHandler(options: ServerOptions): RequestHandler {
   let probedAt = 0;
   const failedAuth = failedAuthLimiter();
+  const unauthenticated = options.meterUnauthenticated ? unauthenticatedLimiter() : null;
 
   /**
    * Re-read the config because a call named a tool we do not serve.
@@ -144,6 +141,27 @@ export function createRequestHandler(options: ServerOptions): RequestHandler {
 
       const url = new URL(request.url);
 
+      // Ahead of every path that answers without a credential, because the
+      // ceiling further down is inside the `401` branch and so has never covered
+      // any of them. Each costs a read of the credential store or a write to the
+      // workspace bucket, and none of them asks who is calling first. See
+      // `./edge.ts` for which ones, and for why `/health` is only sometimes
+      // among them.
+      if (unauthenticated) {
+        const refusal = unauthenticatedRefusal({
+          request,
+          pathname: url.pathname,
+          limiter: unauthenticated,
+          healthPath: HEALTH_PATH,
+          isAuthorizationPath,
+          authorizationEnabled: options.authorization !== undefined,
+        });
+        if (refusal) {
+          options.log.warn('rejected request', { reason: 'unauthenticated_rate' });
+          return refusal;
+        }
+      }
+
       // Before authentication, deliberately: a client's first request is the
       // one that discovers how to authenticate, so requiring a token to read
       // the document that says where tokens come from would close the loop it
@@ -152,7 +170,7 @@ export function createRequestHandler(options: ServerOptions): RequestHandler {
         return await handleAuthorization(request, options.authorization);
       }
 
-      if (url.pathname === '/health') {
+      if (url.pathname === HEALTH_PATH) {
         // `status` is unauthenticated because the platform's own probe reads it
         // and a deploy waits on it. The profile *names* are not: on a public URL
         // that is a list of what this endpoint holds, handed to anyone who asks,
@@ -182,37 +200,17 @@ export function createRequestHandler(options: ServerOptions): RequestHandler {
         request.headers.get('authorization'),
       );
 
+      // The refusal, and the ceiling on how often one may be provoked. Both in
+      // `./edge.ts`, which is the subject: what this endpoint does about a
+      // caller who has not authenticated.
       if (!outcome.ok) {
         options.log.warn('rejected request', { reason: outcome.reason });
-
-        // After the attempt rather than before it: keyed on the caller alone,
-        // anyone able to reach the endpoint could spend the owner's budget and
-        // lock them out, which trades a cost problem for a worse availability
-        // one. Only a failure consumes a token, so a valid credential is never
-        // refused by this.
-        const budget = failedAuth.take(callerKey(request), FAILED_AUTH_PER_MINUTE);
-        if (!budget.allowed) return tooManyAttempts(budget.retryAfterMs);
-
-        // The pointer is the whole handshake for a remote client: it reads the
-        // named document, finds the authorization server, and starts a flow.
-        // Without it the client has to guess the document's location, and a
-        // client that guesses wrong reports the endpoint as unreachable.
-        const metadata = options.authorization ? resourceMetadataUrl(request) : null;
-
-        return new Response(
-          JSON.stringify({
-            error: 'unauthorized',
-            reason: outcome.reason,
-            hint: HINTS[outcome.reason],
-          }),
-          {
-            status: 401,
-            headers: {
-              'content-type': 'application/json',
-              'www-authenticate': challenge(metadata, CHALLENGE[outcome.reason]),
-            },
-          },
-        );
+        return authRefusal({
+          request,
+          reason: outcome.reason,
+          limiter: failedAuth,
+          metadataUrl: options.authorization ? resourceMetadataUrl(request) : null,
+        });
       }
 
       // Behind the same bearer check as everything else, and deliberately not a
@@ -348,6 +346,10 @@ export function serve(options: ServeOptions): RunningServer {
     : { allowedOrigins: primary.config.auth.allowed_origins ?? [ANY_ORIGIN] };
   const handler = createRequestHandler({
     ...options,
+    // Off on loopback for the same reason `cors` is undefined there, and decided
+    // here so every property of the bind address is decided together. An
+    // explicit `true` wins, which is how a test drives the deployed behaviour.
+    meterUnauthenticated: options.meterUnauthenticated ?? !loopback,
     ...(allowedHostnames ? { allowedHostnames } : {}),
   });
 

--- a/src/server/oauth.test.ts
+++ b/src/server/oauth.test.ts
@@ -180,13 +180,40 @@ describe('discovery', () => {
     // document built from the incoming request would say `http`, which fails
     // the exact match the client makes against the URL its user typed.
     const response = await fetch(`${origin}/.well-known/oauth-protected-resource`, {
-      headers: { 'x-forwarded-proto': 'https', 'x-forwarded-host': 'link.example.run.app' },
+      headers: { 'x-forwarded-proto': 'https' },
     });
 
+    const secure = origin.replace('http://', 'https://');
     expect(await response.json()).toMatchObject({
-      resource: 'https://link.example.run.app/mcp',
-      authorization_servers: ['https://link.example.run.app'],
+      resource: `${secure}/mcp`,
+      authorization_servers: [secure],
     });
+  });
+
+  test('a forwarded host is ignored, so a caller cannot steer the documents', async () => {
+    // `X-Forwarded-Host` used to be preferred over `Host`, and nothing needed it
+    // — the argument for reading headers at all is about the *scheme*. What it
+    // cost is that a caller decided what four documents said: both discovery
+    // documents, the `resource_metadata` pointer on every `401`, and the form
+    // action on the page that asks the owner for their endpoint token.
+    const response = await fetch(`${origin}/.well-known/oauth-protected-resource`, {
+      headers: { 'x-forwarded-proto': 'https', 'x-forwarded-host': 'attacker.example' },
+    });
+
+    const body = (await response.json()) as Record<string, unknown>;
+    expect(JSON.stringify(body)).not.toContain('attacker.example');
+    expect(body['resource']).toBe(`${origin.replace('http://', 'https://')}/mcp`);
+  });
+
+  test('a forwarded scheme that is neither http nor https is not echoed into a URL', async () => {
+    // Smaller than the host — naming a nonsense scheme downgrades nothing, it
+    // just makes the client's exact match fail — but a header that decides part
+    // of a URL should not accept an arbitrary string.
+    const response = await fetch(`${origin}/.well-known/oauth-protected-resource`, {
+      headers: { 'x-forwarded-proto': 'javascript' },
+    });
+
+    expect(await response.json()).toMatchObject({ resource: `${origin}/mcp` });
   });
 
   test('the authorization server advertises S256, which a client checks before starting', async () => {

--- a/src/server/oauth.ts
+++ b/src/server/oauth.ts
@@ -62,11 +62,30 @@ export function isAuthorizationPath(pathname: string): boolean {
  * `http` and every metadata document would name a resource no client asked for
  * — which fails the exact-match the specification requires. Config cannot help
  * either: the hostname carries a project hash assigned at deploy time.
+ *
+ * **The host is `Host`, and `X-Forwarded-Host` is not consulted.** It used to
+ * be, ahead of `Host`, and the justification above is entirely about the
+ * *scheme* — nothing ever needed the other header. What it cost is that four
+ * documents were steerable per request by whoever sent it: both discovery
+ * documents, the `resource_metadata` pointer on every `401`, and the `action` of
+ * the consent form that asks the owner to paste their endpoint token. Cloud Run
+ * sets `Host` and routes on it, so it is the one value a caller cannot invent
+ * without the request going somewhere else; a proxy that genuinely rewrites it
+ * rewrites `Host` too, which is what a domain mapping does.
+ *
+ * The scheme is checked rather than trusted for the same reason, and it is a
+ * smaller hole — naming `http` in a document downgrades nothing, it just makes
+ * the exact-match fail — but a header that decides part of a URL should not
+ * accept an arbitrary string.
  */
 export function publicOrigin(request: Request): string {
   const url = new URL(request.url);
-  const host = request.headers.get('x-forwarded-host') ?? request.headers.get('host') ?? url.host;
-  const proto = request.headers.get('x-forwarded-proto') ?? url.protocol.replace(':', '');
+  const host = request.headers.get('host') ?? url.host;
+
+  const forwarded = request.headers.get('x-forwarded-proto');
+  const proto =
+    forwarded === 'https' || forwarded === 'http' ? forwarded : url.protocol.replace(':', '');
+
   return `${proto}://${host}`;
 }
 


### PR DESCRIPTION
Endpoint hardening. `package.json` is already at `0.6.10` on `develop` and the
tag does not exist, so this merge takes the *publish* path and both branches end
up on the same tree.

**Merge with `--merge`, not `--squash`.** A squash writes a new commit onto
`main`, `develop`'s tip stops being an ancestor, and the fast-forward that
finishes the release is then rejected as non-fast-forward even though the trees
are identical.

## What ships

- Five Cloud Run ceilings as config, sent on every rollout: `max_instances: 4`,
  `concurrency: 40`, `timeout_seconds: 300`, `memory: 1Gi`, `cpu: 1`. Absent,
  each fell to a platform default — a hundred instances, and 512 MiB to stage a
  64 MiB upload in.
- `--ingress` follows `access`; `--clear-secrets` replaces an omitted
  `--set-secrets`, which used to leave a removed vault's secret mounted.
- A ceiling on the surface that answers before authentication — `/health` with a
  credential, `/register`, `/authorize`, `/token` — none of which passed through
  any limit before, and each of which costs a credential-store read or a bucket
  write. `/health` with no credential stays free.
- `RateLimiter` bounds its own key map. The key is the first `X-Forwarded-For`
  hop, and `prune` was never called by anything.
- `publicOrigin` reads `Host` rather than `X-Forwarded-Host`, so a caller no
  longer decides what the discovery documents and the consent form's action say.
  `form-action 'self'` added to the page CSP.
- Bucket: public-access prevention, 30-day soft delete, versioning with a
  bounding lifecycle rule — applied by `buckets update` so they reach a bucket
  that already exists.
- Base image pinned by digest; `.gcloudignore` ships; `bun audit` replaces a
  `bun pm scan` that did nothing without a configured scanner, and runs in CI.
- `OidcVerifier` requires a discovered introspection endpoint to be https and on
  the issuer's own origin.

[ADR-054](docs/detailed/adr/054-the-surface-in-front-of-the-gate.md).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
