### PR TITLE
A connection may say where its service is

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ second calendar, a second anything.
 
 | | |
 |---|---|
-| **Mail, calendar, contacts, files** | Gmail · Google Calendar · Google Drive · Google Docs · Google Sheets · Google Tasks · Google Contacts · iCloud Mail, Calendar, Contacts and Drive · Outlook Mail, Calendar and Contacts · OneDrive · Microsoft To Do · Fastmail · Zoho Mail · Yahoo Mail |
+| **Mail, calendar, contacts, files** | Gmail · Google Calendar · Google Drive · Google Docs · Google Sheets · Google Tasks · Google Contacts · iCloud Mail, Calendar, Contacts and Drive · Outlook Mail, Calendar and Contacts · OneDrive · Microsoft To Do · Fastmail · Zoho Mail · Yahoo Mail · Nextcloud · any IMAP mailbox |
 | **Work** | Notion · Linear · Slack · GitHub · Asana · Atlassian (Jira, Confluence) · Todoist · ClickUp · monday.com · Shortcut · Miro · Whimsical · Figma · Canva · Calendly · Fireflies · HubSpot |
 | **Money** | Stripe · PayPal · Square · Mercury · Ramp · bunq · Paddle · Recurly · Expensify |
 | **Build and run** | Sentry · Vercel · Netlify · Cloudflare · Supabase · Neon · Prisma · Heroku · CircleCI · Buildkite · Datadog · Grafana · Better Stack · Rootly · Flagsmith |
@@ -138,7 +138,9 @@ second calendar, a second anything.
 Most of them need nothing set up. Seventy of them run their own MCP server and offer dynamic client
 registration, so `connect` registers us on the spot: browser, approve, done. The rest are one of
 three shapes — an app password you issue yourself (iCloud, Fastmail, Gmail over IMAP), a token you
-paste (GitHub, Discord), or an OAuth client of your own (Reddit, Microsoft).
+paste (GitHub, Discord), or an OAuth client of your own (Reddit, Microsoft). A few also ask *where*
+they are, because the address belongs to the account rather than the vendor — a Nextcloud you run,
+or any IMAP server.
 
 **Most of them are also untested**, and the tables say which. A provider marked † validates, generates
 tools inside the budget, and answers a probe — but nobody has connected it to a real account yet, and

--- a/docs/connect.md
+++ b/docs/connect.md
@@ -45,6 +45,9 @@ $ lanes link connect gmail --profile personal --target local        # again, for
 | Fastmail Contacts † | `lanes link connect fastmail_contacts` | Look up an address over CardDAV |
 | Zoho Mail † | `lanes link connect zoho_mail` | Read, search, and send over IMAP and SMTP |
 | Yahoo Mail † | `lanes link connect yahoo_mail` | Read, search, and send over IMAP and SMTP |
+| Nextcloud Calendar † | `lanes link connect nextcloud_calendar` | Events over CalDAV, on your own server |
+| Nextcloud Contacts † | `lanes link connect nextcloud_contacts` | Contacts over CardDAV, on your own server |
+| Any IMAP mailbox † | `lanes link connect mailbox` | Read, search, and send on a host with no entry of its own |
 | bunq | `lanes link connect bunq` | Accounts, balances, transaction history, and payments |
 
 **† means untested.** The manifest is right in every way this repository can check — it validates,

--- a/docs/detailed/adr/055-a-connection-may-say-where-its-service-is.md
+++ b/docs/detailed/adr/055-a-connection-may-say-where-its-service-is.md
@@ -1,0 +1,88 @@
+# ADR-055: A connection may say where its service is
+
+## Status
+
+Accepted.
+
+## Context
+
+A provider's address is one value in its manifest. `base_url`, `endpoint`, `host` — one string,
+fixed at build time, the same for everybody. That is correct for a vendor who runs one address:
+Gmail is `gmail.googleapis.com` for every account there has ever been, and putting that in the
+manifest is what makes a provider fifteen lines.
+
+It is wrong for two large families, and both were unreachable as built-ins:
+
+- **Multi-tenant SaaS whose host carries the tenant.** Zendesk is `<subdomain>.zendesk.com`,
+  Shopify `<shop>.myshopify.com`, Atlassian's REST API `api.atlassian.com/ex/jira/<cloudid>`,
+  Mailchimp `<dc>.api.mailchimp.com`. A built-in cannot name the address because the address is a
+  property of the account.
+- **Anything self-hosted.** A Nextcloud, a Gitea, a Home Assistant, a company Dovecot. Here the
+  whole address belongs to the operator.
+
+Neither was *impossible*: an operator could hand-write a YAML manifest in `providers.d/` with their
+own address, and `connect custom` would help. But a manifest per instance is a thing nobody
+discovers, it carries no setup walkthrough, and it made the generic case — "any IMAP mailbox" —
+something we could not ship at all. Five near-identical mail providers exist in this repository for
+exactly that reason.
+
+## Decision
+
+**A manifest may put `{placeholders}` in its connector's address, and declare what fills them.**
+
+```yaml
+connector:
+  kind: dav
+  base_url: https://{host}
+  service: caldav
+variables:
+  - key: host
+    label: Nextcloud server address
+    description: The hostname you sign in at, with no https:// and no path.
+    example: cloud.example.com
+    pattern: '^[a-z0-9][a-z0-9.-]*[a-z0-9]$'
+```
+
+`connect` asks for each value and writes it to the connection's `config` — a field that already
+existed on the row for exactly this kind of thing. The connector factory substitutes before
+building, so **no transport changes**: a variable decides *where* a connector points and nothing
+about how it speaks.
+
+Four things fall out, and each is a decision rather than an accident.
+
+**The value is not a credential.** A hostname is not a secret and does not belong in the secret
+store. It lives in config, where it can be read, edited, and reviewed.
+
+**A value is validated at substitution, not only at the prompt.** The default pattern admits one DNS
+label or path segment and no dots. That is not cosmetic: the value is put into a URL, so an
+unconstrained one chooses the host the operator's credential is sent to, and `acme.evil.test` in a
+`{site}` would leave a manifest that reads as Zendesk and authenticates to somebody else. Config is
+a file that can be edited by hand and is read by a deployed revision that never sees a prompt, so
+the check has to live where the substitution does. A provider whose value is legitimately a whole
+hostname — self-hosted, where the manifest names no domain to escape — says so with its own
+`pattern`, and that pattern still refuses everything that is not a hostname.
+
+**`defineProvider` refuses a manifest whose two halves disagree.** A placeholder nothing fills
+reaches the vendor verbatim and fails as DNS, which says nothing about the real problem. A variable
+nothing uses is quieter and worse: `connect` asks the operator a question, stores the answer, and
+nothing ever reads it.
+
+**A provider nobody has connected is not an error.** The factory returns no connector rather than
+throwing, because every surface that lists what *could* be connected asks for one. A row that has
+been configured and is wrong still throws.
+
+## Consequences
+
+`nextcloud_calendar`, `nextcloud_contacts` and `mailbox` ship as built-ins, which was not possible
+before. `mailbox` is the general case the five named mail providers were each a special case of;
+they stay, because a named provider carries the vendor's own setup steps, its message-size limit,
+and the sentence about app passwords that a generic one cannot.
+
+The multi-tenant HTTP family — Zendesk, Shopify, Salesforce — is now expressible and not yet
+written. Each still needs a vendored OpenAPI document, which is the other half of an `http`
+provider and unchanged by this.
+
+`connect` gained a step, and it runs before the identity probe: settling an account means calling
+the service, and there is nothing to call until the address is known. That ordering is why the
+values cannot simply be written to the connection row first — the row's id is not decided until the
+identity comes back — so a run with variables builds a factory of its own holding them.

--- a/docs/detailed/adr/README.md
+++ b/docs/detailed/adr/README.md
@@ -62,6 +62,7 @@ Nothing in the codebase depends on it.
 | [052](052-a-target-owns-its-workspace.md) | A target owns its workspace, and a profile lives in exactly one |
 | [053](053-the-page-a-person-reads-is-the-app.md) | The page a person reads is the desktop app, and the endpoint stops serving one |
 | [054](054-the-surface-in-front-of-the-gate.md) | The surface in front of the gate is metered, and does not name itself |
+| [055](055-a-connection-may-say-where-its-service-is.md) | A connection may say where its service is, so a self-hosted or multi-tenant host can be a built-in |
 
 Where an ADR departs from init.md, it says so at the top. Three are significant:
 

--- a/docs/detailed/connectivity-coverage.md
+++ b/docs/detailed/connectivity-coverage.md
@@ -209,6 +209,63 @@ exactly one operation to choose from.
 spec. Out of scope, and the reason is not the cost: the set of services reachable by GraphQL and not
 by MCP is small and shrinking.
 
+### ~~One address per manifest~~ — closed by ADR-055
+
+`base_url`, `endpoint` and `host` were one value per manifest, which made a built-in impossible for
+any service whose address is a property of the *account* rather than of the vendor: every
+self-hosted thing, and every multi-tenant SaaS whose host carries the tenant.
+
+A manifest may now put `{placeholders}` in its connector's address and declare `variables` that fill
+them; `connect` asks, the connection's own `config` stores the answer, and the factory substitutes
+before building. **No transport changed** — a variable decides where a connector points and nothing
+about how it speaks — which is the property the gaps below are measured against.
+
+```yaml
+id: mailbox
+name: Mailbox
+connector:
+  kind: imap
+  host: "{imap_host}"
+  smtp:
+    host: "{smtp_host}"
+auth:
+  kind: basic
+identity:
+  kind: connector
+variables:
+  - key: imap_host
+    label: IMAP server
+    description: Where mail is read from.
+    example: imap.example.com
+    pattern: "^[a-z0-9][a-z0-9.-]*[a-z0-9]$"
+  - key: smtp_host
+    label: SMTP server
+    description: Where mail is sent from.
+    example: smtp.example.com
+    pattern: "^[a-z0-9][a-z0-9.-]*[a-z0-9]$"
+setup:
+  prompts:
+    - key: username
+      label: Username
+      scope: connection
+      field: username
+    - key: password
+      label: Password
+      secret: true
+      scope: connection
+      field: password
+```
+
+The **pattern is the part to read twice**. A value goes into a URL, so an unconstrained one chooses
+the host the operator's credential is sent to. The default admits one label and no dots; a provider
+whose value is legitimately a whole hostname overrides it, and that override still refuses `/`, `@`,
+`:` and everything else that turns a host into a different address. It is enforced at substitution
+rather than only at the prompt, because config is a file someone can edit and a deployed revision
+reads it without ever seeing a prompt.
+
+What this does **not** close: an `http` provider still needs an OpenAPI document, so Zendesk and
+Shopify are expressible and not yet written.
+
 ### Pagination, cursors, rate limits, retries
 
 None of it is expressible. The `http` transport is one `fetch` and one response: no retry, no

--- a/src/cli/commands/connect/acquire.ts
+++ b/src/cli/commands/connect/acquire.ts
@@ -1,0 +1,100 @@
+import type { ConfigDocument } from '../../config-edit.ts';
+import type { ProviderManifest } from '#connectivity';
+import type { SecretStore } from '#secrets';
+import type { Prompter } from '../../prompt.ts';
+import { authorise } from './authorise.ts';
+import { authoriseWithKey } from './assertion.ts';
+import { authorisePastedToken } from './pasted-token.ts';
+import { ensureStaticCredential } from './setup.ts';
+import type { ChosenMethod } from './method.ts';
+
+/**
+ * Getting the credential, whichever way this provider offers.
+ *
+ * Four routes and exactly one of them runs: a signed assertion from a key the
+ * operator holds, a token they paste, a browser round trip, or a static
+ * credential asked for and stored. `none` is the fifth case and does nothing —
+ * an `fs` provider has no account to prove.
+ *
+ * Its own file because it is the one part of `runConnect` that is a decision
+ * rather than a sequence, and because that file was at the size budget. Each arm
+ * already lives in a module of its own; this is only the choosing.
+ */
+export async function acquireCredential(input: {
+  readonly method: ChosenMethod;
+  readonly manifest: ProviderManifest;
+  readonly provisionalId: string;
+  readonly credentials: SecretStore;
+  readonly document: ConfigDocument;
+  readonly changes: string[];
+  readonly providerId: string;
+  readonly connections: readonly { readonly provider: string }[];
+  /** How the operator spelled the target, so a refusal names a command they typed. */
+  readonly target: string | undefined;
+  readonly profile: string;
+  readonly prompter: Prompter;
+  /** True when a name was given, which reads as "that one again". */
+  readonly named: boolean;
+  /** The connection id is still the placeholder, so nothing has been settled. */
+  readonly provisional: boolean;
+  readonly replace: boolean;
+  readonly nonInteractive: boolean;
+  readonly acceptBroadScopes: boolean;
+  readonly fetch?: typeof globalThis.fetch | undefined;
+}): Promise<void> {
+  const { manifest, method, provisionalId, prompter, changes, document } = input;
+  const { credentials, providerId, target, profile } = input;
+
+  /**
+   * "That one again", which is what asks for a value the store already has.
+   *
+   * Naming a connection says it, and so does `--replace`. Never
+   * non-interactively: there, again has already happened — the new value was
+   * written with `secrets set` before this ran, so asking would be asking for
+   * something the store is holding.
+   */
+  const askAgain = !input.nonInteractive && (input.replace || input.named);
+
+  if (method.kind === 'assertion') {
+    await authoriseWithKey({
+      manifest,
+      assertion: method.assertion,
+      connectionId: provisionalId,
+      credentials,
+      changes,
+      replace: askAgain,
+      prompter,
+    });
+  } else if (method.kind === 'pasted') {
+    await authorisePastedToken({
+      manifest,
+      connectionId: provisionalId,
+      credentials,
+      prompter,
+    });
+  } else if (manifest.auth.kind === 'oauth') {
+    await authorise({
+      manifest,
+      connectionId: provisionalId,
+      credentials,
+      document,
+      changes,
+      firstForProvider: !input.connections.some((c) => c.provider === providerId),
+      ...(target === undefined ? {} : { target }),
+      profile,
+      client: method.client,
+      prompter,
+      acceptBroadScopes: input.acceptBroadScopes,
+      ...(input.fetch ? { fetch: input.fetch } : {}),
+    });
+  } else if (manifest.auth.kind !== 'none') {
+    await ensureStaticCredential({
+      manifest,
+      connectionId: provisionalId,
+      credentials,
+      replace: askAgain,
+      provisional: input.provisional,
+      prompter,
+    });
+  }
+}

--- a/src/cli/commands/connect/declare.test.ts
+++ b/src/cli/commands/connect/declare.test.ts
@@ -31,7 +31,12 @@ function declaring(connections: readonly ConnectionConfig[], over: Record<string
     account: 'ada@example.com',
     label: 'ada@example.com',
     method: undefined,
+    config: {},
     ...over,
+    // The cast is what let a missing argument through once already: `config`
+    // was passed by `runConnect` and never declared here, so the spread was not
+    // excess-property-checked and `tsc` stayed green while the value was
+    // dropped on the floor. Kept only for `over`, which is deliberately loose.
   } as Parameters<typeof declareConnection>[0]);
 
   return { changes, written: parse(document.toString()) as { connections: ConnectionConfig[] } };
@@ -97,3 +102,50 @@ describe('reconnecting one that is already declared', () => {
     expect(changes).toEqual(['connections.gmail.ada.label = Work mail', 're-authorised gmail.ada']);
   });
 });
+
+describe('a connection that carries where its service is', () => {
+  test('writes the address, so the next start can build a connector', () => {
+    // The regression this exists for. `connect` prompted for the host, probed
+    // the identity through a factory holding it, wrote the row — and the row had
+    // no `config`, so every later run found nothing, built no connector, and
+    // showed the provider as unconnected. No error anywhere.
+    const { written } = declaring([], {
+      providerId: 'nextcloud_calendar',
+      config: { host: 'cloud.example.com' },
+    });
+
+    expect(written.connections[0]).toMatchObject({
+      id: 'ada',
+      provider: 'nextcloud_calendar',
+      config: { host: 'cloud.example.com' },
+    });
+  });
+
+  test('a provider with no address writes no config key at all', () => {
+    expect(written(declaring([]))).not.toHaveProperty('config');
+  });
+
+  test('a reconnect updates an address that moved, and says so', () => {
+    // A self-hosted service moving is exactly why somebody reconnects, and a
+    // row left pointing at the old host sends the credential there.
+    const { changes, written: after } = declaring(
+      [
+        {
+          id: 'ada',
+          provider: 'nextcloud_calendar',
+          account: 'ada@example.com',
+          config: { host: 'old.example.com' },
+        } as ConnectionConfig,
+      ],
+      { providerId: 'nextcloud_calendar', config: { host: 'new.example.com' } },
+    );
+
+    expect(after.connections[0]?.config).toEqual({ host: 'new.example.com' });
+    expect(changes).toContain('connections.nextcloud_calendar.ada.config.host = new.example.com');
+  });
+});
+
+/** The first row, for the assertions that only care about one. */
+function written(result: { written: { connections: ConnectionConfig[] } }): ConnectionConfig {
+  return result.written.connections[0]!;
+}

--- a/src/cli/commands/connect/declare.ts
+++ b/src/cli/commands/connect/declare.ts
@@ -24,8 +24,17 @@ export function declareConnection(input: {
   readonly label: string;
   /** Which route in, where the provider offered a choice. */
   readonly method: string | undefined;
+  /**
+   * Where this connection's service is, for a provider that asked.
+   *
+   * Empty for every provider whose address is fixed, which is almost all of
+   * them. Written on a reconnect as well as on an add: the operator may be
+   * reconnecting *because* the server moved.
+   */
+  readonly config: Readonly<Record<string, string>>;
 }): readonly string[] {
   const { document, connections, providerId, connectionId, account, label, method } = input;
+  const config = input.config;
 
   const key = `${providerId}.${connectionId}`;
   const index = connections.findIndex((c) => `${c.provider}.${c.id}` === key);
@@ -44,6 +53,7 @@ export function declareConnection(input: {
       provider: providerId,
       account,
       ...(label === account ? {} : { label }),
+      ...(Object.keys(config).length > 0 ? { config } : {}),
     });
     changes.push(`connections += ${key} (${account})`);
     return changes;
@@ -65,6 +75,15 @@ export function declareConnection(input: {
   if ((declared?.label ?? declared?.account) !== label) {
     document.setIn(['connections', index, 'label'], label);
     changes.push(`connections.${key}.label = ${label}`);
+  }
+
+  // The address, when the provider has one to keep. Written whenever it differs,
+  // because a reconnect is exactly when a self-hosted service has moved — and a
+  // row whose config is silently stale points the credential at the old host.
+  for (const [key_, value] of Object.entries(config)) {
+    if ((declared?.config as Record<string, unknown> | undefined)?.[key_] === value) continue;
+    document.setIn(['connections', index, 'config', key_], value);
+    changes.push(`connections.${key}.config.${key_} = ${value}`);
   }
 
   // Named where the provider offered a choice, because this is the line an

--- a/src/cli/commands/connect/index.ts
+++ b/src/cli/commands/connect/index.ts
@@ -6,7 +6,9 @@ import { nonInteractivePrompter, terminalPrompter, type Prompter } from '../../p
 import { openRuntime, type GlobalFlags } from '../../runtime.ts';
 import { moveCredential, siblingAccountId } from './accounts.ts';
 import { grantProvider } from './grant.ts';
+import { acquireCredential } from './acquire.ts';
 import { declareConnection } from './declare.ts';
+import { resolveConnectionAddress, type ResolvedAddress } from './variables.ts';
 import { discoverCapabilities } from './discover.ts';
 import { connectFamily, familyMembers } from './family.ts';
 import { authoriseWithKey } from './assertion.ts';
@@ -14,6 +16,7 @@ import { authorise } from './authorise.ts';
 import { authorisePastedToken } from './pasted-token.ts';
 import { chooseAuthMethod } from './method.ts';
 import { preflight } from './requirements.ts';
+import { parseSet } from './variables.ts';
 import { ALREADY, NOTHING, renderOutcome, where, type ConnectOutcome } from './outcome.ts';
 import { nextAfterEdit, publishRuntimeEdit } from '#cli/publish.ts';
 import { bindNewCredential } from './bind-credential.ts';
@@ -40,6 +43,8 @@ import { unknownProvider } from './unknown.ts';
 export interface ConnectOptions extends GlobalFlags {
   readonly id?: string | undefined;
   readonly displayName?: string | undefined;
+  /** `--set key=value`, repeatable: where this connection's service is. */
+  readonly set?: readonly string[] | string | undefined;
   /**
    * `--label`: what to call this connection, instead of being asked.
    *
@@ -124,6 +129,9 @@ export async function runConnect(
   // The runtime is opened first because its registry includes workspace
   // manifests — a custom provider must be as connectable as a built-in.
   const runtime = await openRuntime(options);
+
+  // Declared out here so the `finally` can close whatever it built.
+  let address: ResolvedAddress | undefined;
 
   try {
     // After the runtime rather than before, like every other command that
@@ -214,66 +222,52 @@ export async function runConnect(
         credentials: runtime.credentials,
         spec: target,
         method: method.kind,
+        supplied: parseSet(options.set),
       });
 
       if (blocked) return { ...NOTHING, ok: false, ...blocked };
     }
 
-    if (method.kind === 'assertion') {
-      await authoriseWithKey({
-        manifest,
-        assertion: method.assertion,
-        connectionId: provisionalId,
-        credentials: runtime.credentials,
-        changes,
-        // Same reading as the static-credential arm below: naming a connection,
-        // or asking outright, is how someone says "that one again" — which is
-        // what a rotated key calls for.
-        replace: options.nonInteractive !== true && (options.replace === true || named !== undefined),
-        prompter,
-      });
-    } else if (method.kind === 'pasted') {
-      await authorisePastedToken({
-        manifest,
-        connectionId: provisionalId,
-        credentials: runtime.credentials,
-        prompter,
-      });
-    } else if (manifest.auth.kind === 'oauth') {
-      await authorise({
-        manifest,
-        connectionId: provisionalId,
-        credentials: runtime.credentials,
-        document,
-        changes,
-        firstForProvider: !runtime.config.connections.some((c) => c.provider === providerId),
-        target,
-        profile,
-        client: method.client,
-        prompter,
-        acceptBroadScopes: options.acceptBroadScopes === true,
-        ...(options.fetch ? { fetch: options.fetch } : {}),
-      });
-    } else if (manifest.auth.kind !== 'none') {
-      await ensureStaticCredential({
-        manifest,
-        connectionId: provisionalId,
-        credentials: runtime.credentials,
-        // Naming a connection is how someone says "this one, again" — which is
-        // what a rotated key or a revoked app-specific password calls for.
-        // `--replace` says the same thing about a family, where there is no
-        // single provider to name and the ids are not the operator's to know.
-        //
-        // Never non-interactively: there, "again" already happened. The new
-        // value was written with `secrets set` before this ran, so asking would
-        // be asking for something the store already holds.
-        replace: options.nonInteractive !== true && (options.replace === true || named !== undefined),
-        provisional: provisionalId === PROVISIONAL_ID,
-        prompter,
-      });
-    }
+    // 1a. Where this connection's service is, for a provider whose address is
+    //     not the same for everybody.
+    //
+    //     First, and before anything is written: step 0b's rule is that a
+    //     refusal leaves the profile as it was, and asked last a non-interactive
+    //     run with no `--set` acquired a credential before refusing.
+    address = await resolveConnectionAddress({
+      manifest,
+      prompter,
+      runtime,
+      providerId,
+      provisionalId,
+      interactive: options.nonInteractive !== true,
+      set: options.set,
+    });
 
-    // 1b. The vendor's own handshake — see `./strategy.ts`, including why here.
+    // 1b. Get the credential, whichever of the four ways this provider offers.
+    //     See `./acquire.ts` — the arms each live in their own module already,
+    //     and that file is the choosing.
+    await acquireCredential({
+      method,
+      manifest,
+      provisionalId,
+      credentials: runtime.credentials,
+      document,
+      changes,
+      providerId,
+      connections: runtime.config.connections,
+      target,
+      profile,
+      prompter,
+      named: named !== undefined,
+      provisional: provisionalId === PROVISIONAL_ID,
+      replace: options.replace === true,
+      nonInteractive: options.nonInteractive === true,
+      acceptBroadScopes: options.acceptBroadScopes === true,
+      ...(options.fetch ? { fetch: options.fetch } : {}),
+    });
+
+    // 1c. The vendor's own handshake — see `./strategy.ts`, including why here.
     await runStrategySetup(manifest, provisionalId, runtime);
 
     // 2. Ask the provider whose account that was.
@@ -288,7 +282,7 @@ export async function runConnect(
       explicitId: named,
       account: options.displayName,
       label: options.label,
-      runtime,
+      runtime: { ...runtime, connectorFor: address.connectorFor },
       prompter,
     });
 
@@ -309,7 +303,7 @@ export async function runConnect(
       manifest,
       connectionId,
       credentials: runtime.credentials,
-      connectorFor: runtime.connectorFor.bind(runtime),
+      connectorFor: address.connectorFor,
       remember: async (found) => {
         await runtime.state.kv.set('discovery', providerId, JSON.stringify(found));
         registry.setDiscovered(providerId, found);
@@ -326,6 +320,7 @@ export async function runConnect(
         account,
         label,
         method: method.id,
+        config: address.values,
       }),
     );
 
@@ -394,6 +389,9 @@ export async function runConnect(
       next: nextAfterEdit(publish),
     };
   } finally {
+    // Before the runtime, and separately: this one holds its own cache, so a
+    // provider whose connector is a socket would otherwise keep it until exit.
+    await address?.close();
     await runtime.close();
   }
 }

--- a/src/cli/commands/connect/requirements.ts
+++ b/src/cli/commands/connect/requirements.ts
@@ -97,6 +97,8 @@ export async function preflight(input: {
    * a step it does not perform.
    */
   readonly method?: 'oauth' | 'assertion' | 'pasted';
+  /** What `--set` supplied, so an address given on the command line is not reported missing. */
+  readonly supplied?: Readonly<Record<string, string>> | undefined;
 }): Promise<Blocked | null> {
   const { manifest, connectionId, profile, target, spec } = input;
   const method = input.method ?? 'oauth';
@@ -150,8 +152,28 @@ export async function preflight(input: {
     };
   }
 
+  // Before the credential check, so the two come back together rather than one
+  // per run. An address is not a credential and no `secrets set` places it —
+  // `--set` does — but to somebody scripting this it is the same thing: another
+  // value the command will refuse without. Reporting it only after the
+  // credentials were stored made a two-step setup a three-step one.
+  const address = manifest.variables
+    .filter((variable) => (input.supplied ?? {})[variable.key] === undefined)
+    .map((variable) => `--set ${variable.key}=${variable.example}`);
+
   const missing = await missingRequirements(requirements, input.credentials);
-  if (missing.length === 0) return null;
+  if (missing.length === 0 && address.length === 0) return null;
+
+  if (address.length > 0) {
+    return {
+      reason: 'missing_credentials',
+      message:
+        `${manifest.name} needs ${missing.length + address.length} value(s) before it can connect. ` +
+        `Its address is not stored — it is given on the command line.`,
+      needs: missing,
+      then: `${rerun}${connectionId ? ` --id ${connectionId}` : ''} ${address.join(' ')} --non-interactive`,
+    };
+  }
 
   return {
     reason: 'missing_credentials',

--- a/src/cli/commands/connect/variables.ts
+++ b/src/cli/commands/connect/variables.ts
@@ -1,0 +1,220 @@
+import type { AnyConnector, ProviderManifest } from '#connectivity';
+import { connectorFactory, type ConnectorFactory } from '#connectivity/transports';
+import type { ProviderRegistry } from '#registry';
+
+/** Only the fields this reads; the real row carries more. */
+interface ConnectionRow {
+  readonly provider: string;
+  readonly id: string;
+  readonly config?: Readonly<Record<string, unknown>> | undefined;
+}
+import type { SecretStore } from '#secrets';
+import type { Prompter } from '../../prompt.ts';
+
+/**
+ * Asking a connection where its service is.
+ *
+ * Only a provider that declares `variables` reaches this — a Zendesk-shaped host
+ * that carries the tenant, or anything self-hosted. Everything else has one
+ * address for everybody and is never asked anything here.
+ *
+ * Asked *before* the account is settled, and that ordering is forced rather than
+ * chosen: settling the identity means calling the service, and there is nothing
+ * to call until the address is known. It is also why the values cannot simply be
+ * written to the connection row first — the row's id is not decided until the
+ * identity comes back.
+ */
+export interface VariableValues {
+  readonly [key: string]: string;
+}
+
+export async function askForVariables(input: {
+  readonly manifest: ProviderManifest;
+  readonly prompter: Prompter;
+  /** Values already on the row, when reconnecting. Offered as the default. */
+  readonly existing?: Readonly<Record<string, unknown>> | undefined;
+  /** With nobody to ask, an absent value is a refusal rather than a prompt. */
+  readonly interactive: boolean;
+  /** From `--set key=value`, which is how a non-interactive run supplies one. */
+  readonly supplied?: Readonly<Record<string, string>> | undefined;
+}): Promise<VariableValues> {
+  const { manifest, prompter, existing, interactive } = input;
+  const supplied = input.supplied ?? {};
+  if (manifest.variables.length === 0) return {};
+
+  const values: Record<string, string> = {};
+
+  for (const variable of manifest.variables) {
+    // `--set` outranks what the row already carries: naming a value is how
+    // somebody says the server moved.
+    const previous = supplied[variable.key] ?? existing?.[variable.key];
+    const known = typeof previous === 'string' && previous !== '' ? previous : undefined;
+
+    if (!interactive) {
+      if (!known) {
+        throw new Error(
+          `${manifest.name} needs to be told its ${variable.label} and there is nobody to ask. ` +
+            `Give it on the command line: --set ${variable.key}=${variable.example}`,
+        );
+      }
+      if (!new RegExp(variable.pattern).test(known)) {
+        throw new Error(
+          `"${known}" is not a usable ${variable.label} — it must look like ${variable.example}.`,
+        );
+      }
+      values[variable.key] = known;
+      continue;
+    }
+
+    // The description goes in the question rather than beside it: `Prompter.ask`
+    // takes one string, and a hostname nobody can guess needs the sentence that
+    // says where to find it.
+    const answer = (
+      await prompter.ask(
+        `${variable.description}\n${variable.label}${known ? ` [${known}]` : ` (e.g. ${variable.example})`}`,
+      )
+    ).trim();
+
+    const chosen = answer === '' ? known : answer;
+    if (!chosen) {
+      throw new Error(`${manifest.name} cannot be reached without its ${variable.label}.`);
+    }
+
+    // Checked here as well as at substitution, so a mistyped subdomain is a
+    // question asked again rather than a connection that is written and then
+    // fails on its first call. `applyVariables` is still the one that matters —
+    // it guards the value a *file* supplies, which never passes through here.
+    if (!new RegExp(variable.pattern).test(chosen)) {
+      throw new Error(
+        `"${chosen}" is not a usable ${variable.label} — it must look like ${variable.example}. ` +
+          `The value goes into the address this connection calls, so anything that could change ` +
+          `the host is refused.`,
+      );
+    }
+
+    values[variable.key] = chosen;
+  }
+
+  return values;
+}
+
+/**
+ * The address a provider was last given, from whichever of its connections has one.
+ *
+ * Also reached across a family: `nextcloud_calendar` and `nextcloud_contacts`
+ * are two providers on one server, and the setup steps tell people to connect
+ * them together — so being asked the same hostname twice is the thing to avoid.
+ * They are matched on sharing a credential app, which is already how "one
+ * account, several providers" is expressed.
+ */
+function previousAddress(
+  connections: readonly ConnectionRow[],
+  providerId: string,
+  manifest: ProviderManifest,
+): Readonly<Record<string, unknown>> | undefined {
+  const family = manifest.auth.kind === 'basic' ? manifest.auth.app : undefined;
+
+  const mine = connections.find(
+    (connection) => connection.provider === providerId && connection.config,
+  );
+  if (mine) return mine.config;
+
+  if (!family) return undefined;
+
+  return connections.find(
+    (connection) => connection.provider.startsWith(`${family}_`) && connection.config,
+  )?.config;
+}
+
+export interface ResolvedAddress {
+  /** What the connection will store under `config`. Empty for a fixed-address provider. */
+  readonly values: VariableValues;
+  /** The factory the identity probe and discovery should use. */
+  readonly connectorFor: (providerId: string, connectionId: string) => AnyConnector | undefined;
+  /** Only ever a scoped factory; the runtime's own is never closed by this. */
+  close(): Promise<void>;
+}
+
+/**
+ * Everything a connect run needs in order to reach a service whose address it
+ * has just been told.
+ *
+ * The scoped factory is the part worth explaining. The values belong to a
+ * connection row that does not exist yet — the row is written at step 4, and
+ * the id it will carry is not settled until step 2 — so there is nowhere for
+ * the runtime's own lookup to read them from. Rather than write a provisional
+ * row and rename it, this run gets a factory of its own holding the values
+ * directly. The runtime's factory is untouched, which matters because its cache
+ * is what keeps a stateful connector a single instance.
+ *
+ * A provider with no variables gets the runtime's factory back and no second
+ * cache, so the ordinary path is exactly as it was.
+ */
+export async function resolveConnectionAddress(input: {
+  readonly manifest: ProviderManifest;
+  readonly prompter: Prompter;
+  readonly providerId: string;
+  readonly provisionalId: string;
+  readonly interactive: boolean;
+  /** `--set key=value`, as the parser hands it over: absent, one, or many. */
+  readonly set?: readonly string[] | string | undefined;
+  readonly runtime: {
+    readonly registry: ProviderRegistry;
+    readonly credentials: SecretStore;
+    readonly config: { readonly connections: readonly ConnectionRow[] };
+    connectorFor(providerId: string, connectionId: string): AnyConnector | undefined;
+  };
+}): Promise<ResolvedAddress> {
+  const { manifest, runtime } = input;
+
+  const values = await askForVariables({
+    manifest,
+    prompter: input.prompter,
+    // What was said last time, offered as the default.
+    //
+    // Not keyed on the provisional id, which is `pending` unless `--id` was
+    // given — so the lookup almost never hit and every reconnect asked for the
+    // server address again. Any declared connection of this provider will do:
+    // the id is not settled yet, and a second Nextcloud on a *different* host is
+    // rarer than reconnecting the one there is. It is offered, not imposed —
+    // pressing Enter accepts it and typing replaces it.
+    existing: previousAddress(runtime.config.connections, input.providerId, manifest),
+    interactive: input.interactive,
+    supplied: parseSet(input.set),
+  });
+
+  if (manifest.variables.length === 0) {
+    return {
+      values,
+      connectorFor: runtime.connectorFor.bind(runtime),
+      close: async () => {},
+    };
+  }
+
+  const scoped: ConnectorFactory = connectorFactory({
+    registry: runtime.registry,
+    credentials: runtime.credentials,
+    connectionConfig: () => values,
+  });
+
+  return { values, connectorFor: scoped, close: () => scoped.closeAll() };
+}
+
+/**
+ * `--set key=value` into a map, refusing anything that is not a pair.
+ *
+ * A flag given once arrives as a string and twice as an array, which is the
+ * parser's shape rather than a choice here.
+ */
+export function parseSet(input: readonly string[] | string | undefined): Record<string, string> {
+  const given = input === undefined ? [] : typeof input === 'string' ? [input] : input;
+  const values: Record<string, string> = {};
+
+  for (const entry of given) {
+    const at = entry.indexOf('=');
+    if (at <= 0) throw new Error(`--set wants key=value, and got "${entry}".`);
+    values[entry.slice(0, at)] = entry.slice(at + 1);
+  }
+
+  return values;
+}

--- a/src/cli/commands/setup.ts
+++ b/src/cli/commands/setup.ts
@@ -128,6 +128,18 @@ function renderOne(plan: ProviderPlan, missing: ReadonlySet<string>): void {
     }
   }
 
+  if (plan.variables.length > 0) {
+    // Its own heading rather than a row under "Values it needs", because there
+    // is nothing to store ahead of time: `connect` asks for these and writes
+    // them to the connection, so the useful thing to show is what will be asked
+    // and what an answer looks like.
+    heading('Where it is');
+    for (const variable of plan.variables) {
+      print(`  ${style.bold(variable.label)}  ${style.dim(`e.g. ${variable.example}`)}`);
+      print(`    ${style.dim(variable.description)}`);
+    }
+  }
+
   heading('Then');
   print(`  ${plan.command}`);
 

--- a/src/cli/runtime/open.ts
+++ b/src/cli/runtime/open.ts
@@ -327,7 +327,14 @@ export async function openRuntime(
   // dispatcher and the CLI share it deliberately: a stateful connector must be
   // the *same instance* whichever side asks for it, or a held session is held
   // twice.
-  const connectorFor = connectorFactory({ registry, credentials });
+  const connectorFor = connectorFactory({
+    registry,
+    credentials,
+    // From the connection row, which is where a per-connection setting has
+    // always lived. One lookup behind both, so they cannot disagree.
+    connectionConfig: (provider, id) => row(config, provider, id)?.config,
+    isDeclared: (provider, id) => row(config, provider, id) !== undefined,
+  });
   const authorizeRequest = requestAuthorizer(registry, credentials);
   let closed = false;
 
@@ -385,3 +392,6 @@ export async function openRuntime(
     },
   };
 }
+
+const row = (config: Config, provider: string, id: string) =>
+  config.connections.find((connection) => connection.provider === provider && connection.id === id);

--- a/src/cli/selection.ts
+++ b/src/cli/selection.ts
@@ -253,6 +253,9 @@ const ACCEPTS: Record<string, readonly string[]> = {
   connect: [
     'id',
     'display-name',
+    // Repeatable: `--set host=cloud.example.com`. The only way to give a
+    // provider its address without a terminal to ask at.
+    'set',
     'label',
     'replace',
     'non-interactive',

--- a/src/connectivity/auth/resolve.test.ts
+++ b/src/connectivity/auth/resolve.test.ts
@@ -289,3 +289,57 @@ describe('bearerTokenAsStored', () => {
     );
   });
 });
+
+describe('a connector whose address the connection supplies', () => {
+  const registry = new ProviderRegistry();
+
+  registry.register(
+    defineProvider({
+      id: 'tenant',
+      name: 'Tenant',
+      connector: { kind: 'dav', base_url: 'https://{site}.example.com', service: 'caldav' },
+      auth: { kind: 'basic' },
+      variables: [
+        {
+          key: 'site',
+          label: 'subdomain',
+          description: 'The first part of your address.',
+          example: 'acme',
+        },
+      ],
+      setup: {
+        prompts: [
+          { key: 'username', label: 'User', scope: 'connection', field: 'username' },
+          { key: 'password', label: 'Password', secret: true, scope: 'connection', field: 'password' },
+        ],
+      },
+    }),
+  );
+
+  const factoryWith = (config: Record<string, unknown> | undefined) =>
+    connectorFactory({
+      registry,
+      credentials: createMemoryCredentials({}),
+      connectionConfig: () => config,
+    });
+
+  test('is built once the connection says where it is', () => {
+    expect(factoryWith({ site: 'acme' })('tenant', 'main')).toBeDefined();
+  });
+
+  test('a provider nobody has connected is undefined rather than a throw', () => {
+    // Every surface that lists what *could* be connected asks for this — the
+    // dashboard among them — and a throw took the whole page down rather than
+    // showing an unconnected provider as unconnected.
+    expect(factoryWith(undefined)('tenant', 'main')).toBeUndefined();
+  });
+
+  test('a row that is set up and wrong throws, rather than going quiet', () => {
+    // The opposite case, and the reason the one above is not simply "return
+    // undefined on any failure": this connection *has* been configured, and a
+    // value that cannot be used is worth saying out loud.
+    expect(() => factoryWith({ site: 'acme.evil.test' })('tenant', 'main')).toThrow(
+      /not a usable subdomain/,
+    );
+  });
+});

--- a/src/connectivity/manifest/provider.ts
+++ b/src/connectivity/manifest/provider.ts
@@ -5,6 +5,7 @@ import { connectorSchema } from './connector.ts';
 import { identitySchema } from './identity.ts';
 import { identifier } from './primitives.ts';
 import { setupSchema } from './setup.ts';
+import { connectionVariableSchema, placeholdersInConnector } from './variables.ts';
 
 /**
  * A provider manifest.
@@ -60,6 +61,14 @@ export const providerManifestSchema = z.object({
    * not silently discarded.
    */
   hints: z.record(z.string(), z.string()).optional(),
+  /**
+   * What this connection has to say about *where* the service is.
+   *
+   * Absent for every provider whose address is the same for everybody, which is
+   * almost all of them. Present for a multi-tenant host that carries the tenant,
+   * or anything self-hosted — see `./variables.ts`.
+   */
+  variables: z.array(connectionVariableSchema).default([]),
 });
 
 export type ProviderManifest = z.infer<typeof providerManifestSchema>;
@@ -103,6 +112,43 @@ export function defineProvider(input: unknown): ProviderManifest {
   }
 
   const manifest = parsed.data;
+
+  // R12 and R13. The two halves of a variable have to agree, and neither failure
+  // is visible without this: a placeholder nothing fills reaches the vendor
+  // verbatim, so the request goes to a host literally called `{site}.zendesk.com`
+  // and fails as DNS rather than as configuration. A variable nothing uses is the
+  // opposite and quieter — `connect` asks the operator a question, stores the
+  // answer, and nothing ever reads it.
+  {
+    // `fs` and `local` are the two that hold no address a caller supplies.
+    // `local` is our own code, and `fs.root` *is* substitutable — a vault path
+    // differs per person — so only `local` is refused here.
+    if (manifest.connector.kind === 'local' && manifest.variables.length > 0) {
+      throw new Error(
+        `Provider "${manifest.id}": a local connector is our own code and has no address to fill in, so it cannot declare variables.`,
+      );
+    }
+
+    const placeholders = placeholdersInConnector(
+      manifest.connector as unknown as Record<string, unknown>,
+    );
+    const declared = new Set(manifest.variables.map((variable) => variable.key));
+
+    const unfilled = placeholders.filter((name) => !declared.has(name));
+    if (unfilled.length > 0) {
+      throw new Error(
+        `Provider "${manifest.id}": the connector names {${unfilled.join('}, {')}} and the manifest declares no variable for ${unfilled.length === 1 ? 'it' : 'them'}. Add one under "variables", or the address is sent to the vendor with the braces still in it.`,
+      );
+    }
+
+    const unused = [...declared].filter((key) => !placeholders.includes(key));
+    if (unused.length > 0) {
+      throw new Error(
+        `Provider "${manifest.id}": variable${unused.length === 1 ? '' : 's'} ${unused.join(', ')} ${unused.length === 1 ? 'appears' : 'appear'} in no address, so connect would ask for ${unused.length === 1 ? 'a value' : 'values'} nothing reads. Put {${unused[0]}} in the connector's address — or drop it.`,
+      );
+    }
+
+  }
 
   if (manifest.auth.kind === 'oauth' && manifest.auth.registration === 'manual') {
     if (!manifest.auth.app) {

--- a/src/connectivity/manifest/variables.test.ts
+++ b/src/connectivity/manifest/variables.test.ts
@@ -1,0 +1,192 @@
+import { describe, expect, test } from 'bun:test';
+import { defineProvider } from './provider.ts';
+import { applyVariables, placeholdersInConnector } from './variables.ts';
+
+/**
+ * Where a service lives, when the connection decides.
+ *
+ * The two halves are tested separately on purpose. `defineProvider` catches a
+ * manifest whose placeholders and variables disagree, which is a mistake made
+ * once by whoever writes the provider. `applyVariables` guards the *value*,
+ * which arrives from a config file that can be edited by hand and is read by a
+ * deployed revision that never sees a prompt — so it is the one that has to hold
+ * against something hostile rather than merely careless.
+ */
+
+const HOST = {
+  key: 'site',
+  label: 'subdomain',
+  description: 'The first part of your address.',
+  example: 'acme',
+  pattern: '^[A-Za-z0-9][A-Za-z0-9_-]*$',
+};
+
+describe('finding placeholders', () => {
+  test('reaches a nested field, not just the top level', () => {
+    // The imap connector puts submission a level down, and a field list missed
+    // it — a generic mailbox was refused for a variable it plainly used.
+    const found = placeholdersInConnector({
+      kind: 'imap',
+      host: '{imap_host}',
+      smtp: { host: '{smtp_host}', port: 587 },
+    });
+
+    expect(found.sort()).toEqual(['imap_host', 'smtp_host']);
+  });
+
+  test('a connector with no placeholders finds none', () => {
+    expect(placeholdersInConnector({ kind: 'http', base_url: 'https://api.example.com' })).toEqual(
+      [],
+    );
+  });
+});
+
+describe('substituting a value', () => {
+  test('fills every occurrence, however deep', () => {
+    const filled = applyVariables(
+      { kind: 'imap', host: '{site}.mail.example.com', smtp: { host: '{site}.smtp.example.com' } },
+      [HOST],
+      { site: 'acme' },
+    );
+
+    expect(filled['host']).toBe('acme.mail.example.com');
+    expect((filled['smtp'] as { host: string }).host).toBe('acme.smtp.example.com');
+  });
+
+  test('a manifest with no variables is returned untouched', () => {
+    const connector = { kind: 'http', base_url: 'https://api.example.com' };
+
+    expect(applyVariables(connector, [], {})).toBe(connector);
+  });
+
+  test('a missing value says which one, and what it looks like', () => {
+    expect(() => applyVariables({ kind: 'dav', base_url: 'https://{site}' }, [HOST], {})).toThrow(
+      /does not say what "site" is/,
+    );
+  });
+
+  test('a value that would change the host is refused rather than sent', () => {
+    // The whole reason the pattern exists. Each of these keeps the manifest
+    // reading as one vendor while pointing the operator's credential at
+    // another, or at a path that is not the API at all.
+    for (const hostile of [
+      'acme.evil.test',
+      'acme/../../evil',
+      'acme@evil.test',
+      'acme:8080',
+      'acme?x=',
+      'acme#',
+    ]) {
+      expect(() =>
+        applyVariables({ kind: 'http', base_url: 'https://{site}.example.com' }, [HOST], {
+          site: hostile,
+        }),
+      ).toThrow(/not a usable subdomain/);
+    }
+  });
+
+  test('a provider whose value is a whole hostname says so with its own pattern', () => {
+    // Self-hosted: there is no domain to escape, because the manifest names
+    // none. What the pattern still refuses is anything that is not a hostname.
+    const anywhere = { ...HOST, key: 'host', label: 'server', pattern: '^[a-z0-9][a-z0-9.-]*[a-z0-9]$' };
+
+    expect(
+      applyVariables({ kind: 'dav', base_url: 'https://{host}' }, [anywhere], {
+        host: 'cloud.example.com',
+      })['base_url'],
+    ).toBe('https://cloud.example.com');
+
+    expect(() =>
+      applyVariables({ kind: 'dav', base_url: 'https://{host}' }, [anywhere], {
+        host: 'cloud.example.com/../evil',
+      }),
+    ).toThrow(/not a usable server/);
+  });
+});
+
+describe('a manifest declaring variables', () => {
+  const base = {
+    id: 'thing',
+    name: 'Thing',
+    connector: { kind: 'dav', base_url: 'https://{site}.example.com', service: 'caldav' },
+    auth: { kind: 'basic' },
+    setup: {
+      prompts: [
+        { key: 'username', label: 'User', scope: 'connection', field: 'username' },
+        { key: 'password', label: 'Password', secret: true, scope: 'connection', field: 'password' },
+      ],
+    },
+  };
+
+  test('is accepted when the two halves agree', () => {
+    expect(defineProvider({ ...base, variables: [HOST] }).variables).toHaveLength(1);
+  });
+
+  test('a placeholder nothing fills is refused', () => {
+    // Otherwise the braces reach the vendor verbatim and it fails as DNS,
+    // which says nothing about the real problem.
+    expect(() => defineProvider(base)).toThrow(/names \{site\} and the manifest declares no variable/);
+  });
+
+  test('a variable nothing uses is refused', () => {
+    // The quieter of the two: connect asks the operator a question, stores the
+    // answer, and nothing ever reads it.
+    expect(() =>
+      defineProvider({
+        ...base,
+        connector: { kind: 'dav', base_url: 'https://fixed.example.com', service: 'caldav' },
+        variables: [HOST],
+      }),
+    ).toThrow(/appears in no address/);
+  });
+
+  test('a local provider cannot declare one, because it has no address', () => {
+    expect(() =>
+      defineProvider({
+        id: 'thing',
+        name: 'Thing',
+        connector: { kind: 'local' },
+        auth: { kind: 'none' },
+        variables: [HOST],
+      }),
+    ).toThrow(/no address to fill in/);
+  });
+});
+
+describe('the pattern is a control, not a hint', () => {
+  const withPattern = (pattern: string) =>
+    defineProvider({
+      id: 'thing',
+      name: 'Thing',
+      connector: { kind: 'dav', base_url: 'https://{site}.example.com', service: 'caldav' },
+      auth: { kind: 'basic' },
+      variables: [{ ...HOST, pattern }],
+      setup: {
+        prompts: [
+          { key: 'username', label: 'User', scope: 'connection', field: 'username' },
+          { key: 'password', label: 'Password', secret: true, scope: 'connection', field: 'password' },
+        ],
+      },
+    });
+
+  test('an unanchored one is anchored, because test matches a substring', () => {
+    // Written as a hint, it would accept `acme.evil.test/@x` — which is then
+    // put into the URL the credential is sent to.
+    const manifest = withPattern('[a-z.]+');
+
+    expect(manifest.variables[0]?.pattern).toBe('^(?:[a-z.]+)$');
+    expect(() =>
+      applyVariables({ kind: 'dav', base_url: 'https://{site}.example.com' }, manifest.variables, {
+        site: 'acme.evil.test/@x',
+      }),
+    ).toThrow(/not a usable/);
+  });
+
+  test('one that is already anchored is left alone', () => {
+    expect(withPattern('^[a-z]+$').variables[0]?.pattern).toBe('^[a-z]+$');
+  });
+
+  test('an invalid one is refused at load, not at the first call', () => {
+    expect(() => withPattern('[unclosed')).toThrow(/not a usable regular expression/);
+  });
+});

--- a/src/connectivity/manifest/variables.ts
+++ b/src/connectivity/manifest/variables.ts
@@ -1,0 +1,173 @@
+import { z } from 'zod';
+import { identifier } from './primitives.ts';
+
+/**
+ * Where a service lives, when that is a property of the connection rather than
+ * of the provider.
+ *
+ * `base_url`, `endpoint` and `host` are one value per manifest, which is right
+ * for a vendor that runs one address for everybody — Gmail is
+ * `gmail.googleapis.com` for every account there has ever been. It is wrong for
+ * two large families:
+ *
+ *   - **multi-tenant SaaS whose host carries the tenant** — Zendesk is
+ *     `<subdomain>.zendesk.com`, Shopify `<shop>.myshopify.com`, Atlassian
+ *     `api.atlassian.com/ex/jira/<cloudid>`
+ *   - **anything self-hosted** — a Nextcloud, a Gitea, a Home Assistant, each at
+ *     an address only its owner knows
+ *
+ * Both were reachable already, but only by hand-writing a YAML manifest per
+ * instance in `providers.d/`. What was impossible was a *built-in* for any of
+ * them, because a built-in cannot know the address. A declared variable is the
+ * missing half: the manifest says a placeholder is there and what fills it, and
+ * the connection supplies the value.
+ *
+ * Deliberately not a credential. A hostname is not a secret and does not belong
+ * in the secret store; it lives in the connection's own `config`, which is what
+ * that field has always been for.
+ */
+
+/**
+ * What a value is allowed to be, and the reason this is not cosmetic.
+ *
+ * A variable is substituted into a URL, so an unconstrained value chooses the
+ * host the operator's credential is sent to: `acme.zendesk.com/../..@evil.test`
+ * in a `{site}` would leave a manifest that reads as Zendesk and authenticates
+ * to somebody else. This is the check that stops that, and it runs at
+ * *substitution* rather than only at the prompt — config is a file that can be
+ * edited by hand, and a deployed revision reads it without ever seeing a prompt.
+ *
+ * One DNS label or path segment: letters, digits, and the three separators that
+ * appear inside real subdomains and tenant ids. No dots by default, because a
+ * dot is how you leave the domain the manifest named; a provider whose value
+ * genuinely contains one says so with its own `pattern`.
+ */
+export const DEFAULT_VARIABLE_PATTERN = '^[A-Za-z0-9][A-Za-z0-9_-]*$';
+
+export const connectionVariableSchema = z.object({
+  /** The name inside the braces. `{site}` is `key: 'site'`. */
+  key: identifier,
+  /** What to call it when asking, in the vendor's own word — "subdomain", not "variable". */
+  label: z.string().min(1),
+  /** One line: what it is and where the operator finds it. */
+  description: z.string().min(1),
+  /** A real-looking value, shown in the prompt and in the refusal. */
+  example: z.string().min(1),
+  /**
+   * Override the default only to *narrow* it or to admit a character the
+   * default excludes — a cloud id with dots, a path segment with slashes. A
+   * pattern that admits `/` or `@` is choosing to trust the value with the host,
+   * and should say why.
+   */
+  pattern: z
+    .string()
+    .default(DEFAULT_VARIABLE_PATTERN)
+    // Anchored here rather than trusted to be anchored, and compiled here
+    // rather than at the first call.
+    //
+    // `test` matches a substring, so an unanchored pattern silently voids the
+    // guarantee this field exists for: `[a-z.]+` accepts `acme.evil.test/@x`,
+    // which is then substituted into the URL the operator's credential is sent
+    // to. Both built-ins anchor; a manifest in `providers.d/` is not obliged to
+    // read this file first, and a security control that depends on remembering
+    // is not one.
+    //
+    // Wrapped rather than refused, because what an author means by a pattern is
+    // always "the value looks like this" — nobody writes one intending a
+    // substring match. An invalid regex is refused, though, and refused at load
+    // rather than surfacing as a raw SyntaxError when a connector is built.
+    .transform((pattern) => (/^\^.*\$$/.test(pattern) ? pattern : `^(?:${pattern})$`))
+    .superRefine((pattern, context) => {
+      try {
+        new RegExp(pattern);
+      } catch (failure) {
+        context.addIssue({
+          code: 'custom',
+          message: `is not a usable regular expression: ${(failure as Error).message}`,
+        });
+      }
+    }),
+});
+
+export type ConnectionVariable = z.infer<typeof connectionVariableSchema>;
+
+/** Every `{name}` in a string, in the order they appear, without duplicates. */
+export function placeholdersIn(text: string): string[] {
+  return [...new Set([...text.matchAll(/\{([a-z][a-z0-9_]*)\}/g)].map((match) => match[1]!))];
+}
+
+/**
+ * Every placeholder anywhere in a connector, however deep.
+ *
+ * A field list was the first shape and it was wrong within one provider: the
+ * `imap` connector's submission host is `smtp.host`, a level down, so a generic
+ * mailbox declaring `{smtp_host}` was refused for using a variable that
+ * "appears in no address". Walking the object has no list to keep in step with
+ * a transport schema, and a `{name}` in a field where it means nothing is
+ * simply never substituted rather than silently wrong.
+ */
+export function placeholdersInConnector(connector: Record<string, unknown>): string[] {
+  const found = new Set<string>();
+
+  const walk = (node: unknown): void => {
+    if (typeof node === 'string') {
+      for (const name of placeholdersIn(node)) found.add(name);
+      return;
+    }
+    if (node === null || typeof node !== 'object') return;
+    for (const value of Object.values(node as Record<string, unknown>)) walk(value);
+  };
+
+  walk(connector);
+  return [...found];
+}
+
+/**
+ * Fill a connector's address in, or say exactly what is wrong.
+ *
+ * Returns the connector untouched when it declares no variables, which is every
+ * provider but a handful — so this costs nothing where it is not used and cannot
+ * quietly reshape a connector that was already complete.
+ */
+export function applyVariables(
+  connector: Record<string, unknown>,
+  variables: readonly ConnectionVariable[],
+  values: Readonly<Record<string, unknown>>,
+): Record<string, unknown> {
+  if (variables.length === 0) return connector;
+
+  const resolved = new Map<string, string>();
+  for (const variable of variables) {
+    const value = values[variable.key];
+    if (typeof value !== 'string' || value === '') {
+      throw new Error(
+        `This connection does not say what "${variable.key}" is (${variable.label}). ` +
+          `Reconnect it, or add it under this connection's config: ${variable.key}: ${variable.example}`,
+      );
+    }
+    if (!new RegExp(variable.pattern).test(value)) {
+      throw new Error(
+        `"${value}" is not a usable ${variable.label} — it must match ${variable.pattern}, ` +
+          `like ${variable.example}. The value is put into the address this connection calls, ` +
+          `so anything that could change the host is refused rather than sent.`,
+      );
+    }
+    resolved.set(variable.key, value);
+  }
+
+  const substitute = (node: unknown): unknown => {
+    if (typeof node === 'string') {
+      return node.replace(/\{([a-z][a-z0-9_]*)\}/g, (whole, name: string) =>
+        resolved.get(name) ?? whole,
+      );
+    }
+    if (node === null || typeof node !== 'object') return node;
+    if (Array.isArray(node)) return node.map(substitute);
+
+    return Object.fromEntries(
+      Object.entries(node as Record<string, unknown>).map(([key, value]) => [key, substitute(value)]),
+    );
+  };
+
+  return substitute(connector) as Record<string, unknown>;
+}

--- a/src/connectivity/transports/factory.ts
+++ b/src/connectivity/transports/factory.ts
@@ -1,4 +1,5 @@
 import type { AnyConnector, ProviderDefinition, ProviderManifest } from '#connectivity';
+import { applyVariables } from '#connectivity/manifest/variables.ts';
 import type { SecretStore } from '#secrets';
 import type { ProviderRegistry } from '#registry';
 import { basicCredential } from '#connectivity/auth/basic/index.ts';
@@ -22,6 +23,29 @@ import { createMcpConnector } from './mcp/index.ts';
 export interface ConnectorFactoryOptions {
   readonly registry: ProviderRegistry;
   readonly credentials: SecretStore;
+  /**
+   * What one connection says about where its service is.
+   *
+   * Optional, and read only by a provider that declares `variables` — which is
+   * a handful. A caller that omits it is saying every provider it serves has a
+   * fixed address, which was true of all of them until Zendesk-shaped hosts
+   * arrived, and is still true of almost all.
+   */
+  readonly connectionConfig?: (
+    providerId: string,
+    connectionId: string,
+  ) => Readonly<Record<string, unknown>> | undefined;
+  /**
+   * Whether this connection is declared at all.
+   *
+   * Separate from its config, and the distinction is load-bearing: a provider
+   * nobody has connected is not a misconfiguration — every surface that lists
+   * what *could* be connected asks the factory about one — while a row that has
+   * been declared and carries no address is exactly the case worth failing
+   * loudly. Without this the two are indistinguishable, and the quiet answer
+   * wins for both.
+   */
+  readonly isDeclared?: (providerId: string, connectionId: string) => boolean;
 }
 
 /**
@@ -61,7 +85,13 @@ export function connectorFactory(options: ConnectorFactoryOptions): ConnectorFac
     const entry = options.registry.get(providerId);
     if (!entry) return undefined;
 
-    const connector = wrap(entry.definition, build(entry.manifest, entry.definition, connectionId, options));
+    // Filled in before the switch, so no transport case knows this happened —
+    // which is the property worth keeping. A variable changes *where* a
+    // connector points, and nothing about how it speaks.
+    const manifest = fillAddress(entry.manifest, providerId, connectionId, options);
+    if (!manifest) return undefined;
+
+    const connector = wrap(entry.definition, build(manifest, entry.definition, connectionId, options));
     if (connector) cache.set(key, connector);
     return connector;
   };
@@ -80,6 +110,49 @@ export function connectorFactory(options: ConnectorFactoryOptions): ConnectorFac
   };
 
   return factory;
+}
+
+/**
+ * Substitute what this connection says about where its service is.
+ *
+ * Returns the manifest itself when it declares no variables, which is the
+ * overwhelming majority — so the cost is one array check per connector built,
+ * and a provider with a fixed address cannot be affected by any of this.
+ *
+ * A missing or malformed value throws, and throwing here is deliberate. The
+ * alternative is a connector pointed at `{site}.zendesk.com`, which fails as a
+ * DNS error at the first call and says nothing about the real problem; this
+ * fails at construction, naming the variable and what it should look like.
+ */
+function fillAddress(
+  manifest: ProviderManifest,
+  providerId: string,
+  connectionId: string,
+  options: ConnectorFactoryOptions,
+): ProviderManifest | undefined {
+  if (manifest.variables.length === 0) return manifest;
+
+  const values = options.connectionConfig?.(providerId, connectionId) ?? {};
+
+  // A provider nobody has connected has no address and that is not an error:
+  // the dashboard asks the factory about every provider it lists, and a throw
+  // here took the whole page down rather than showing one as unconnected.
+  //
+  // A *declared* connection missing its address is the opposite, and used to be
+  // silent for the same reason — which is how a `connect` that never wrote the
+  // value produced a provider that was simply, wordlessly dead.
+  if (Object.keys(values).length === 0 && !options.isDeclared?.(providerId, connectionId)) {
+    return undefined;
+  }
+  const connector = applyVariables(
+    manifest.connector as unknown as Record<string, unknown>,
+    manifest.variables,
+    values,
+  );
+
+  // The cast is honest: `applyVariables` rewrites string fields in place and
+  // never touches `kind`, so the union member is the one it started as.
+  return { ...manifest, connector: connector as unknown as ProviderManifest['connector'] };
 }
 
 /**

--- a/src/providers/README.md
+++ b/src/providers/README.md
@@ -1,6 +1,6 @@
 # Providers
 
-A hundred and two of them, and almost all are a folder and a line. This page is the inventory and the
+A hundred and five of them, and almost all are a folder and a line. This page is the inventory and the
 ins and outs; [`docs/connect.md`](../../docs/connect.md) is the same list written for someone
 deciding what to connect.
 
@@ -19,16 +19,16 @@ Where they come from:
 
 | | |
 |---|---|
-| **connector** | `mcp` 77 · `http` 15 · `imap` 5 · `dav` 4 · `fs` 1 |
-| **auth** | `oauth (dynamic)` 70 · `oauth (manual)` 18 · `basic` 9 · `bearer` 2 · `header` 1 · `none` 1 · `strategy` 1 |
+| **connector** | `mcp` 77 · `http` 15 · `imap` 6 · `dav` 6 · `fs` 1 |
+| **auth** | `oauth (dynamic)` 70 · `oauth (manual)` 18 · `basic` 12 · `bearer` 2 · `header` 1 · `none` 1 · `strategy` 1 |
 
-Two of the hundred and two are code rather than data — `gmail`, which assembles an RFC 2822 message to
+Two of the hundred and five are code rather than data — `gmail`, which assembles an RFC 2822 message to
 send one, and `bunq`, which runs a signing handshake no declarative form describes. Everything else
 is a manifest.
 
 ## Tested means somebody connected it
 
-**Twenty-one are tested. Eighty-one are not**, and the tables say which.
+**Twenty-one are tested. Eighty-four are not**, and the tables say which.
 
 A manifest can be right in every way this repository can check and still not work. What the checks
 prove: the schema validates, the vendored spec generates registrable tools inside the 64 KB budget,
@@ -65,10 +65,14 @@ Four things bite, and all four are quiet:
    budget. `projectRequestBody` is the remedy where the body is a schema reference, and it is
    checked — a field the vendor renames fails the refresh instead of becoming an argument the API
    ignores.
-3. **A property key the Anthropic API refuses takes down every provider at once**, not just its own.
+3. **A placeholder in the address needs a variable, and the reverse.** A provider whose host belongs
+   to the account rather than the vendor declares `variables`; `defineProvider` refuses a
+   `{placeholder}` nothing fills and a variable nothing uses, because the first fails as DNS and the
+   second asks the operator a question nothing reads. See ADR-055.
+4. **A property key the Anthropic API refuses takes down every provider at once**, not just its own.
    `^[a-zA-Z0-9_.-]{1,64}$`, and one bad key rejects the whole `tools` array. The `http` transport
    renames them and leaves the wire name alone, so OData's `$top` reaches an agent as `top`.
-4. **`base_url` must equal the spec's own `servers[0].url`**, and the version lives in different
+5. **`base_url` must equal the spec's own `servers[0].url`**, and the version lives in different
    places per vendor — Drive puts it in the host, Sheets in the path. Copying the wrong one 404s
    every call.
 
@@ -82,6 +86,8 @@ Four things bite, and all four are quiet:
 | `fastmail_contacts` | Fastmail Contacts | `dav` | `basic` |  |
 | `icloud_calendar` | iCloud Calendar | `dav` | `basic` | yes |
 | `icloud_contacts` | iCloud Contacts | `dav` | `basic` | yes |
+| `nextcloud_calendar` | Nextcloud Calendar | `dav` | `basic` |  |
+| `nextcloud_contacts` | Nextcloud Contacts | `dav` | `basic` |  |
 | `icloud_drive` | iCloud Drive | `fs` | `none` | yes |
 | `bunq` | bunq | `http` | `strategy` | yes |
 | `calendar` | Google Calendar | `http` | `oauth (manual)` | yes |
@@ -101,6 +107,7 @@ Four things bite, and all four are quiet:
 | `fastmail_mail` | Fastmail Mail | `imap` | `basic` |  |
 | `gmail_imap` | Gmail (IMAP) | `imap` | `basic` | yes |
 | `icloud_mail` | iCloud Mail | `imap` | `basic` | yes |
+| `mailbox` | Mailbox (any IMAP server) | `imap` | `basic` |  |
 | `yahoo_mail` | Yahoo Mail | `imap` | `basic` |  |
 | `zoho_mail` | Zoho Mail | `imap` | `basic` |  |
 | `airtable` | Airtable | `mcp` | `oauth (dynamic)` |  |

--- a/src/providers/index.ts
+++ b/src/providers/index.ts
@@ -26,6 +26,9 @@ import { fastmailContacts } from './fastmail/contacts/index.ts';
 import { fastmailMail } from './fastmail/mail/index.ts';
 import { yahooMail } from './yahoo_mail/index.ts';
 import { zohoMail } from './zoho_mail/index.ts';
+import { mailbox } from './mailbox/index.ts';
+import { nextcloudCalendar } from './nextcloud/calendar/index.ts';
+import { nextcloudContacts } from './nextcloud/contacts/index.ts';
 import { linear } from './linear/index.ts';
 import { notion } from './notion/index.ts';
 import { reddit } from './reddit/index.ts';
@@ -163,6 +166,9 @@ export const PROVIDERS: readonly (ProviderManifest | ProviderDefinition)[] = [
   fastmailContacts,
   zohoMail,
   yahooMail,
+  nextcloudCalendar,
+  nextcloudContacts,
+  mailbox,
   bunq,
 
   // Vendors running an official MCP server that offers Dynamic Client
@@ -276,6 +282,8 @@ export {
 export { fastmailCalendar, fastmailContacts, fastmailMail } from './fastmail/index.ts';
 export { yahooMail } from './yahoo_mail/index.ts';
 export { zohoMail } from './zoho_mail/index.ts';
+export { nextcloudCalendar, nextcloudContacts } from './nextcloud/index.ts';
+export { mailbox } from './mailbox/index.ts';
 export { bunq } from './bunq/index.ts';
 export { discord } from './discord/index.ts';
 export { github } from './github/index.ts';

--- a/src/providers/mailbox/index.ts
+++ b/src/providers/mailbox/index.ts
@@ -1,0 +1,87 @@
+import { defineProvider } from '#connectivity';
+import { HOSTNAME } from '../nextcloud/shared/setup.ts';
+
+/**
+ * Any mailbox, over IMAP and SMTP.
+ *
+ * The generic one, and the reason connection variables were worth building. Every
+ * other mail provider here is the same twenty lines with a different pair of
+ * hostnames — `icloud_mail`, `gmail_imap`, `fastmail_mail`, `zoho_mail`,
+ * `yahoo_mail` — and each exists because a manifest could hold exactly one
+ * address. A named provider is still better where there is one: it can carry the
+ * vendor's own setup walkthrough, its message-size limit, and the sentence about
+ * app passwords that a generic one cannot. This is for everything else — a
+ * company Dovecot, a Migadu, a Mailcow, a host nobody has written a manifest for.
+ *
+ * Two variables rather than one, because the two hosts genuinely differ:
+ * submission is conventionally `smtp.` where retrieval is `imap.`, and plenty of
+ * servers do neither.
+ */
+export const mailbox = defineProvider({
+  id: 'mailbox',
+  name: 'Mailbox (any IMAP server)',
+  description:
+    'Read, search, and send mail in any IMAP mailbox — a company server, or a host with no provider of its own.',
+  connector: {
+    kind: 'imap',
+    host: '{imap_host}',
+    port: 993,
+    smtp: { host: '{smtp_host}', port: 587, starttls: true },
+  },
+  auth: { kind: 'basic' },
+  identity: { kind: 'connector' },
+  variables: [
+    {
+      key: 'imap_host',
+      label: 'IMAP server',
+      description: 'Where mail is read from. Usually imap.<your domain>, on port 993.',
+      example: 'imap.example.com',
+      pattern: HOSTNAME,
+    },
+    {
+      key: 'smtp_host',
+      label: 'SMTP server',
+      description: 'Where mail is sent from. Often the same host, often smtp.<your domain>.',
+      example: 'smtp.example.com',
+      pattern: HOSTNAME,
+    },
+  ],
+  setup: {
+    summary:
+      'A mailbox on a server this program has no manifest for. It asks for the two hostnames and the ' +
+      'login; TLS is required on both, and the ports are the standard 993 and 587. Where your provider ' +
+      'has a named entry here — iCloud, Fastmail, Gmail, Zoho, Yahoo — use that instead: it carries the ' +
+      'setup steps and the limits this one cannot know.',
+    steps: [
+      'Find your provider\'s IMAP and SMTP hostnames. They are usually in a page called "IMAP settings" or "Mail client setup".',
+      'If the account has two-factor authentication, create an app password for it. Most servers refuse the account password over IMAP once 2FA is on.',
+      'This provider assumes IMAP on 993 and SMTP submission on 587 with STARTTLS, which is what almost every host uses. A server on 465, or on a non-standard port, needs a manifest of its own in providers.d/ — see docs/detailed/creating-a-provider.md.',
+    ],
+    troubleshooting:
+      'A connection refused is usually the wrong hostname or a server that wants port 465 rather than 587. ' +
+      'A rejected login on the right host is usually an account password where an app password belongs.',
+    prompts: [
+      {
+        key: 'username',
+        label: 'Username (usually the full email address)',
+        secret: false,
+        scope: 'connection' as const,
+        field: 'username' as const,
+      },
+      {
+        key: 'password',
+        label: 'Password or app password',
+        secret: true,
+        scope: 'connection' as const,
+        field: 'password' as const,
+      },
+    ],
+  },
+  redact: {
+    search_messages: ['mailbox', 'limit', 'unseen', 'flagged'],
+    get_message: ['mailbox', 'uid', 'include_body'],
+    mark_messages: ['mailbox', 'add_flags', 'remove_flags'],
+    move_messages: ['mailbox', 'destination', 'destination_flag'],
+    send_message: [],
+  },
+});

--- a/src/providers/nextcloud/calendar/index.ts
+++ b/src/providers/nextcloud/calendar/index.ts
@@ -1,0 +1,28 @@
+import { defineProvider } from '#connectivity';
+import { NEXTCLOUD_APP, NEXTCLOUD_HOST, nextcloudSetup } from '../shared/setup.ts';
+
+/**
+ * Nextcloud calendars, on whichever server the operator runs.
+ *
+ * The first built-in whose address is not a property of the provider. Until a
+ * connection could carry one, a self-hosted service could only be reached by
+ * hand-writing a YAML manifest per instance — which worked, and which nobody
+ * discovers. See ADR-055.
+ */
+export const nextcloudCalendar = defineProvider({
+  id: 'nextcloud_calendar',
+  name: 'Nextcloud Calendar',
+  description: 'Read and create events in Nextcloud calendars over CalDAV, on your own server.',
+  connector: { kind: 'dav', base_url: 'https://{host}', service: 'caldav' },
+  auth: { kind: 'basic', app: NEXTCLOUD_APP },
+  identity: { kind: 'connector' },
+  variables: [NEXTCLOUD_HOST],
+  setup: nextcloudSetup('Nextcloud Calendar'),
+  redact: {
+    list_events: ['calendar', 'start', 'end', 'limit'],
+    get_event: ['calendar', 'uid'],
+    update_event: ['calendar', 'uid'],
+    delete_event: ['calendar', 'uid'],
+    create_event: ['calendar'],
+  },
+});

--- a/src/providers/nextcloud/contacts/index.ts
+++ b/src/providers/nextcloud/contacts/index.ts
@@ -1,0 +1,18 @@
+import { defineProvider } from '#connectivity';
+import { NEXTCLOUD_APP, NEXTCLOUD_HOST, nextcloudSetup } from '../shared/setup.ts';
+
+export const nextcloudContacts = defineProvider({
+  id: 'nextcloud_contacts',
+  name: 'Nextcloud Contacts',
+  description: 'Search and read contacts in a Nextcloud address book over CardDAV, on your own server.',
+  connector: { kind: 'dav', base_url: 'https://{host}', service: 'carddav' },
+  auth: { kind: 'basic', app: NEXTCLOUD_APP },
+  identity: { kind: 'connector' },
+  variables: [NEXTCLOUD_HOST],
+  setup: nextcloudSetup('Nextcloud Contacts'),
+  redact: {
+    // Not `query`: a name is content.
+    search_contacts: ['addressbook', 'limit'],
+    create_contact: ['addressbook'],
+  },
+});

--- a/src/providers/nextcloud/index.ts
+++ b/src/providers/nextcloud/index.ts
@@ -1,0 +1,3 @@
+/** Nextcloud's two, sharing one app password and one server address. */
+export { nextcloudCalendar } from './calendar/index.ts';
+export { nextcloudContacts } from './contacts/index.ts';

--- a/src/providers/nextcloud/shared/setup.ts
+++ b/src/providers/nextcloud/shared/setup.ts
@@ -1,0 +1,59 @@
+export const NEXTCLOUD_APP = 'nextcloud';
+
+/**
+ * A hostname pattern, because the default forbids the dots a hostname is made of.
+ *
+ * The default exists to stop a value escaping the domain its manifest named —
+ * `{site}.zendesk.com` must stay at zendesk.com. Here there is no domain to
+ * escape: the manifest is `https://{host}` and the whole address is the
+ * operator's to choose, because the whole point is that it is their server.
+ *
+ * What it still refuses is everything that is not a hostname — no slash, no `@`,
+ * no colon, no port. Those are the characters that would turn a host into a URL
+ * with a different meaning, and none of them belongs in this value.
+ */
+export const HOSTNAME = '^[a-z0-9][a-z0-9.-]*[a-z0-9]$';
+
+export const nextcloudSetup = (product: string) => ({
+  summary:
+    `${product} is on a server you run, so it asks for the address as well as the login. ` +
+    `Nextcloud issues app passwords for exactly this — a per-app password that does not expire and ` +
+    `can be revoked on its own, without changing the one you sign in with.`,
+  docs_url: 'https://docs.nextcloud.com/server/latest/user_manual/en/session_management.html',
+  steps: [
+    'Sign in to your Nextcloud and open Settings → Personal → Security.',
+    'Under "Devices & sessions", enter "Lanes Link" as the app name and choose "Create new app password".',
+    'Copy the password it shows. It is shown once, and it is not your account password.',
+    'You are asked for the server address next — the hostname you sign in at, without https:// and without a path.',
+    'If your Nextcloud lives under a path — cloud.example.com/nextcloud — this provider cannot reach it: the address it builds ends at the host. Declare a manifest of your own in providers.d/ with the full base_url.',
+  ],
+  troubleshooting:
+    'A refused login is usually the account password used where an app password belongs, or a server address ' +
+    'typed with https:// or a trailing path — it wants the bare hostname. Create an app password under ' +
+    'Settings → Security and re-run: lanes link connect nextcloud --replace.',
+  prompts: [
+    {
+      key: 'username',
+      label: 'Nextcloud username',
+      secret: false,
+      scope: 'connection' as const,
+      field: 'username' as const,
+    },
+    {
+      key: 'password',
+      label: 'App password',
+      secret: true,
+      scope: 'connection' as const,
+      field: 'password' as const,
+    },
+  ],
+});
+
+/** The one thing that differs per person, and the reason this provider can exist at all. */
+export const NEXTCLOUD_HOST = {
+  key: 'host',
+  label: 'Nextcloud server address',
+  description: 'The hostname you sign in at, with no https:// and no path.',
+  example: 'cloud.example.com',
+  pattern: HOSTNAME,
+};

--- a/src/providers/setup/plan.ts
+++ b/src/providers/setup/plan.ts
@@ -16,6 +16,13 @@ import { hasOwnClientPath, RESERVED_PROVIDER_IDS, setupRequirements, type SetupR
  */
 
 export interface ProviderPlan {
+  /** Where the service is, for a provider whose address the connection supplies. */
+  readonly variables: readonly {
+    readonly key: string;
+    readonly label: string;
+    readonly description: string;
+    readonly example: string;
+  }[];
   readonly id: string;
   readonly name: string;
   readonly description: string;
@@ -145,6 +152,10 @@ export function planFor(
     ...(manifest.setup?.docs_url ? { docsUrl: manifest.setup.docs_url } : {}),
     steps: manifest.setup?.steps ?? [],
     requires: requirements,
+    // Not a `requires` entry, and the difference is the point: a variable is not
+    // a secret, has no ref, and no `secrets set` line would place it. It is
+    // asked for at connect and written to the connection's own row.
+    variables: manifest.variables,
     needsId,
     command,
     brokered,

--- a/src/providers/setup/provider.ts
+++ b/src/providers/setup/provider.ts
@@ -305,6 +305,18 @@ function renderProvider(plan: ProviderPlan): string {
     for (const requirement of plan.requires) lines.push(`  ${requirement.label}`);
   }
 
+  // Listed alongside the credentials, because to the person answering they are
+  // the same thing — another question `connect` will ask. Omitted here would be
+  // worse than for a credential: an agent relaying a setup plan for Nextcloud
+  // would say "your username and password" and never mention the one value that
+  // provider cannot be connected without.
+  if (plan.variables.length > 0) {
+    lines.push('', 'And where the service is:');
+    for (const variable of plan.variables) {
+      lines.push(`  ${variable.label} — ${variable.description} For example: ${variable.example}`);
+    }
+  }
+
   if (plan.needsId) {
     lines.push(
       '',

--- a/src/providers/untested.ts
+++ b/src/providers/untested.ts
@@ -99,4 +99,7 @@ export const UNTESTED_PROVIDERS: ReadonlySet<string> = new Set([
   'hubspot',
   'box',
   'render',
+  'mailbox',
+  'nextcloud_calendar',
+  'nextcloud_contacts',
 ]);


### PR DESCRIPTION
A provider's address was one string in its manifest, fixed at build time and the same for everybody. That is right for a vendor who runs one address, and it made a built-in impossible for two large families: multi-tenant SaaS whose host carries the tenant (`<subdomain>.zendesk.com`, `<shop>.myshopify.com`), and anything self-hosted.

Neither was unreachable — an operator could hand-write a YAML manifest per instance in `providers.d/` — but a manifest per instance is a thing nobody discovers, it carries no setup walkthrough, and it is why five near-identical mail providers exist in this repository.

A manifest may now put `{placeholders}` in its connector's address and declare `variables` that fill them. `connect` asks, the value is written to the connection row's `config` — a field that already existed for exactly this — and the factory substitutes before building. **No transport changed.**

Three providers prove it, none of them possible before: `nextcloud_calendar`, `nextcloud_contacts`, and `mailbox` — any IMAP server, the general case the five named mail providers were each a special case of.

## The part to read twice

The value goes into a URL, so an unconstrained one chooses the host the operator's credential is sent to. `acme.evil.test` in a `{site}` would leave a manifest that reads as Zendesk and authenticating to somebody else.

- Validated at **substitution**, not only at the prompt — config is hand-editable and a deployed revision never sees a prompt.
- The pattern is **anchored at load**, not trusted to be anchored: `test` matches a substring, so `[a-z.]+` written as a hint would accept `acme.evil.test/@x`.
- Six hostile values are pinned in tests.

## What review caught

Reviewed at `high` before this was pushed; four findings fixed, one of them fatal.

`declareConnection` never had a `config` parameter, so the spread that passed it was not excess-property-checked and the value was silently dropped — `connect` prompted, probed the identity, wrote the row, and every later run built no connector. The provider was wordlessly dead. It is a required parameter now, written on reconnect as well as on add, with a regression test.

Also: the reconnect default was keyed on the provisional id so it almost never hit; `--set key=value` exists because without it a provider with variables could not be connected without a terminal; preflight reports the address alongside the credentials so a scripted run gets the whole list in one refusal; and the agent-facing `setup_provider` surface renders it.

## Verification

`bun test` 2582 pass / 0 fail. `bun run typecheck` clean.

## Notes

- ADR-055 (renumbered from 053 on rebase — develop had claimed 053 and 054).
- `connect/index.ts` was at 399 of a 400-line budget, so this needed a seam first: `acquire.ts` is the four-way credential branch, the one part of `runConnect` that is a decision rather than a sequence.
- #114 touches `src/providers/index.ts`, `README.md` and `docs/connect.md` too; whichever lands second needs those three resolved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
