### PR TITLE
Release 0.6.11

### DIFF
--- a/.gcloudignore
+++ b/.gcloudignore
@@ -12,9 +12,19 @@
 # method is a directory under `~/.bun` with no `.git` in it — so the safe
 # behaviour was being inherited from a coincidence.
 #
-# Keep the first block in step with `.dockerignore`. `data/` holds the encrypted
-# credential store *and* the key that opens it.
-data/
+# **Anchor every directory pattern with a leading slash.** This file is gitignore
+# syntax and `.dockerignore` is not: there, a pattern is relative to the context
+# root, so `docs/` means the one at the top. Here `docs/` means *any* directory
+# called `docs`, at any depth — which is `src/providers/google/docs/`, and
+# stripping it produced an image that built cleanly and died on its first import
+# with `Cannot find module './google/docs/index.ts'`. The two files must say the
+# same thing, not carry the same characters.
+#
+# The credential patterns below are deliberately *not* anchored: a stray `*.key`
+# is worth excluding wherever it turns up. `data/` is, because the credential
+# store is one known directory and a source directory called `data` would be a
+# legitimate part of the package.
+/data/
 *.key
 *.pem
 *.enc
@@ -23,28 +33,28 @@ data/
 .env.*
 
 # Not needed to build, and `.git` in particular carries every branch.
-.git/
+/.git/
 .gitignore
-.worktrees/
+/.worktrees/
 node_modules/
 **/node_modules/
-coverage/
-dist/
-build/
+/coverage/
+/dist/
+/build/
 *.tsbuildinfo
 
 # Tests, docs and tooling: the image runs the endpoint and nothing else.
 **/*.test.ts
 **/*.test.json
-docs/
-instructions/
+/docs/
+/instructions/
 **/README.md
-.lanes/
-.claude/
-.vscode/
-.idea/
+/.lanes/
+/.claude/
+/.vscode/
+/.idea/
 .DS_Store
-.playwright-mcp/
+/.playwright-mcp/
 
 # The compiled binary from `bun build --compile`, if one was made locally.
 /lanes

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lanes-sh/link",
-  "version": "0.6.10",
+  "version": "0.6.11",
   "description": "A self-hostable MCP gateway for all your connections, memory, tasks, files, and secrets",
   "license": "Apache-2.0",
   "homepage": "https://lanes.sh/link",

--- a/src/deployments/gcp/dockerfile.test.ts
+++ b/src/deployments/gcp/dockerfile.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from 'bun:test';
-import { readFile } from 'node:fs/promises';
+import { readdir, readFile } from 'node:fs/promises';
 
 /**
  * The image has to build from a clean checkout.
@@ -19,6 +19,7 @@ const GITIGNORE = new URL('../../../.gitignore', import.meta.url).pathname;
 const MANIFEST = new URL('../../../package.json', import.meta.url).pathname;
 const DOCKERIGNORE = new URL('../../../.dockerignore', import.meta.url).pathname;
 const GCLOUDIGNORE = new URL('../../../.gcloudignore', import.meta.url).pathname;
+const SRC = new URL('../../../src', import.meta.url).pathname;
 
 /**
  * What the credential store and its key look like, wherever they land.
@@ -212,16 +213,56 @@ describe('the deployed image', () => {
         .map((line) => line.trim())
         .filter((line) => line !== '' && !line.startsWith('#'));
 
-    const missing = SECRET_PATHS.filter((path) => !entries(gcloudignore).includes(path));
+    // Compared with the leading slash stripped, because the two files anchor
+    // differently — see the test below, which is the reason that matters.
+    const bare = (line: string): string => line.replace(/^\//, '');
+    const held = (text: string): string[] => entries(text).map(bare);
+
+    const missing = SECRET_PATHS.filter((path) => !held(gcloudignore).includes(path));
     expect({ missing, from: '.gcloudignore' }).toEqual({ missing: [], from: '.gcloudignore' });
 
     // And the two stay in step, so a path added to one is not silently absent
     // from the other.
-    const alsoMissing = SECRET_PATHS.filter((path) => !entries(dockerignore).includes(path));
+    const alsoMissing = SECRET_PATHS.filter((path) => !held(dockerignore).includes(path));
     expect({ missing: alsoMissing, from: '.dockerignore' }).toEqual({
       missing: [],
       from: '.dockerignore',
     });
+  });
+
+  test('no directory the package ships is excluded from the build upload', async () => {
+    // **The two files say the same thing and do not mean the same thing.**
+    // `.gcloudignore` is gitignore syntax, where `docs/` matches a directory
+    // called `docs` at *any* depth; `.dockerignore` is Docker's, where the same
+    // line is relative to the context root. Mirroring the patterns across
+    // stripped `src/providers/google/docs/` out of the tarball
+    // `gcloud builds submit` uploads — so the image built cleanly, started, and
+    // exited 1 on `Cannot find module './google/docs/index.ts'`. Cloud Run kept
+    // serving the previous revision, which is the only reason it was not an
+    // outage.
+    //
+    // Asserted against the real tree rather than by reading the patterns,
+    // because the failure is a *collision* between a pattern and a directory
+    // name, and neither side is wrong on its own.
+    const gcloudignore = await readFile(GCLOUDIGNORE, 'utf8');
+
+    const unanchored = gcloudignore
+      .split('\n')
+      .map((line) => line.trim())
+      .filter((line) => line.endsWith('/') && !line.startsWith('/') && !line.startsWith('**/'))
+      .map((line) => line.slice(0, -1));
+
+    // `node_modules` is the one directory name that *should* match at any depth.
+    const risky = unanchored.filter((name) => name !== 'node_modules');
+
+    const shipped = new Set(
+      (await readdir(SRC, { recursive: true, withFileTypes: true }))
+        .filter((entry) => entry.isDirectory())
+        .map((entry) => entry.name),
+    );
+
+    const collisions = risky.filter((name) => shipped.has(name));
+    expect({ collisions, risky }).toEqual({ collisions: [], risky });
   });
 
   test('the workspace root is not baked in', async () => {


### PR DESCRIPTION
Fixes a packaging bug in 0.6.10 that made every Cloud Run deploy roll a revision
that could not start: `.gcloudignore`'s `docs/` matched `src/providers/google/docs/`
and stripped it from the build upload. See #116.

Merge with `--merge`, not `--squash`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
