### PR TITLE
One containment rule for every blob adapter

### DIFF
--- a/src/deployments/adapters/filesystem.ts
+++ b/src/deployments/adapters/filesystem.ts
@@ -1,7 +1,7 @@
 import { mkdir, readdir, readFile, rename, rm, rmdir, stat, writeFile } from 'node:fs/promises';
 import { existsSync } from 'node:fs';
 import { dirname, join, relative, resolve, sep } from 'node:path';
-import type { BlobKey, BlobMetadata, BlobStore } from '#stores/blobs';
+import { containedKey, type BlobKey, type BlobMetadata, type BlobStore } from '#stores/blobs';
 
 /**
  * Filesystem blob store — the `local` target's adapter.
@@ -54,12 +54,27 @@ export function createFilesystemBlobStore(options: FilesystemBlobStoreOptions): 
    * this adapter is also usable directly, and a containment check belongs at
    * the point where a path actually becomes a filesystem operation. Defence in
    * depth is cheap; a provider escaping its directory is not.
+   *
+   * **The rule is `containedKey`'s, not this file's.** It used to be a copy,
+   * and the copy did not agree: it tested `rel.startsWith('..')` where it meant
+   * "the first segment is `..`", so a key beginning with two dots and
+   * continuing — an ordinary name — was refused here and accepted by every
+   * other adapter. That is the divergence `conformance.ts` exists to prevent,
+   * and it was reachable from an ordinary argument, because a provider passes
+   * a caller's name straight through as a key.
+   *
+   * Kept as a resolve-then-join rather than deferring the whole path: the
+   * shared rule answers "does this land inside", and this adapter still has to
+   * turn the answer into a filesystem path.
    */
   const pathFor = (key: BlobKey): string => {
-    const resolved = resolve(root, key);
+    const resolved = resolve(root, containedKey(key));
     const rel = relative(root, resolved);
 
-    if (rel === '' || rel.startsWith('..') || rel.startsWith(`..${sep}`)) {
+    // Unreachable once `containedKey` has answered, and kept because this is
+    // the line where a path becomes a filesystem operation: a future change to
+    // either side should fail here rather than escape.
+    if (rel === '' || rel === '..' || rel.startsWith(`..${sep}`)) {
       throw new Error(`Blob key resolves outside the store root: ${key}`);
     }
     return resolved;

--- a/src/stores/blobs/conformance.ts
+++ b/src/stores/blobs/conformance.ts
@@ -177,6 +177,25 @@ export function describeBlobStoreContract(
       });
     });
 
+    test('allows a name that merely begins with dots', async () => {
+      await use(async (store) => {
+        // Not a traversal — an ordinary name that happens to start with two
+        // dots, which a provider will hand over verbatim because it is a
+        // caller's to choose. One adapter refused these and the rest stored
+        // them, so the same workspace behaved differently depending on which
+        // target it was opened against. That is the divergence this whole
+        // suite exists to catch, and it caught nothing until there was a case
+        // for it.
+        // Distinct names, because a filesystem cannot hold `x` as a file and
+        // `x/y` beneath it at once — a real difference between an object store
+        // and a directory tree, and not the one under test here.
+        for (const key of ['..config', '...rc', '..nested/inner.txt']) {
+          await store.put(key, bytes(key));
+          expect(text(await store.get(key))).toBe(key);
+        }
+      });
+    });
+
     test('allows a traversal that stays inside, normalised', async () => {
       await use(async (store) => {
         // Weaker than `scopeBlobStore`'s rule on purpose: the namespace


### PR DESCRIPTION
`containedKey` exists so every blob adapter answers containment identically —
the filesystem adapter carried its own copy instead, and the copy was stricter
in one case than the rest. The result was that the same workspace could behave
differently depending on which target it was opened against.

Neither rule was unsafe, and namespace scoping refuses traversal before either
is reached. This is about the two agreeing.

The adapter now defers to the shared rule and keeps its own check as a
belt-and-braces at the point a key becomes a filesystem path. The conformance
suite gains the case it was missing — it covered traversal thoroughly and had
nothing for a name that merely resembles one, which is how the divergence
survived inside a suite written to catch exactly this.

Verified by reverting the adapter change: the new conformance case fails, and
passes again with it.

Found while auditing the stores.

🤖 Generated with [Claude Code](https://claude.com/claude-code)