### PR TITLE
Bound what an IMAP server can make the reader hold

### DIFF
--- a/src/connectivity/transports/imap/parser.test.ts
+++ b/src/connectivity/transports/imap/parser.test.ts
@@ -1,5 +1,12 @@
 import { describe, expect, test } from 'bun:test';
-import { asText, itemValue, ResponseAssembler, tokenize, type ImapToken } from './parser.ts';
+import {
+  asText,
+  itemValue,
+  MAX_RESPONSE_BYTES,
+  ResponseAssembler,
+  tokenize,
+  type ImapToken,
+} from './parser.ts';
 
 /** The items of a token that must be a list, so the tests read as assertions. */
 const items = (token: ImapToken | undefined): readonly ImapToken[] => {
@@ -146,5 +153,92 @@ describe('tokenising', () => {
 
     expect(asText(tokens[2])).toContain('IMAP4rev1');
     expect(asText(tokens[2])).toContain('AUTH=PLAIN');
+  });
+});
+
+/**
+ * What the server is allowed to make this allocate.
+ *
+ * A literal's length is a number the server writes and the reader waits for.
+ * With no ceiling that is an allocation the far end decides the size of — and
+ * the far end is not always one this endpoint chose, because a connector names
+ * its own host.
+ */
+describe('bounds', () => {
+  const line = (text: string): Uint8Array => new TextEncoder().encode(text);
+
+  test('refuses a literal larger than the limit, on the announcement', () => {
+    // Before the bytes arrive, not after: believing the number is what makes
+    // waiting for it expensive.
+    const assembler = new ResponseAssembler();
+    assembler.push(line(`* 1 FETCH (BODY[] {${MAX_RESPONSE_BYTES + 1}}\r\n`));
+
+    expect(() => assembler.next()).toThrow(/over the .* limit/);
+  });
+
+  test('accepts a literal at the limit', () => {
+    const assembler = new ResponseAssembler();
+    assembler.push(line(`* 1 FETCH (BODY[] {${MAX_RESPONSE_BYTES}}\r\n`));
+
+    // Not complete — the bytes have not arrived — but not refused either.
+    expect(assembler.next()).toBeUndefined();
+  });
+
+  test('refuses a server that never completes a response', () => {
+    // The other half, and it is not the same check: a response may announce
+    // several literals, each individually reasonable, and a server that simply
+    // never finishes would otherwise grow this without bound.
+    const assembler = new ResponseAssembler();
+    const megabyte = new Uint8Array(1024 * 1024);
+
+    expect(() => {
+      for (let sent = 0; sent <= MAX_RESPONSE_BYTES; sent += megabyte.length) {
+        assembler.push(megabyte);
+      }
+    }).toThrow(/without completing a response/);
+  });
+
+  test('a large body still assembles, and does so in one piece', () => {
+    // The bound has to leave the legitimate case alone. Four mebibytes in
+    // sixty-four-kilobyte chunks is an ordinary mail with an attachment.
+    const size = 4 * 1024 * 1024;
+    const body = new Uint8Array(size).fill(0x61);
+    const assembler = new ResponseAssembler();
+
+    const response = [
+      line(`* 1 FETCH (BODY[] {${size}}\r\n`),
+      body,
+      line(')\r\n'),
+    ];
+
+    const stream = new Uint8Array(response.reduce((total, part) => total + part.length, 0));
+    let at = 0;
+    for (const part of response) {
+      stream.set(part, at);
+      at += part.length;
+    }
+
+    for (let offset = 0; offset < stream.length; offset += 65536) {
+      assembler.push(stream.subarray(offset, offset + 65536));
+      if (offset + 65536 < stream.length) expect(assembler.next()).toBeUndefined();
+    }
+
+    const assembled = assembler.next();
+    expect(assembled?.length).toBe(stream.length);
+    expect(assembler.pending).toBe(0);
+  });
+
+  test('bytes survive being shifted down after a response is taken', () => {
+    // `next` returns a copy and compacts in place. A view would be rewritten by
+    // the compaction, so this pins that the first response is still intact
+    // after the second one has been read.
+    const assembler = new ResponseAssembler();
+    assembler.push(line('* OK first\r\n* OK second\r\n'));
+
+    const first = assembler.next()!;
+    const second = assembler.next()!;
+
+    expect(new TextDecoder().decode(first)).toBe('* OK first\r\n');
+    expect(new TextDecoder().decode(second)).toBe('* OK second\r\n');
   });
 });

--- a/src/connectivity/transports/imap/parser.ts
+++ b/src/connectivity/transports/imap/parser.ts
@@ -16,6 +16,30 @@
 const CR = 0x0d;
 const LF = 0x0a;
 
+/**
+ * The most this will accumulate before refusing a response.
+ *
+ * A literal's length is a number the *server* writes — `{1234}` — and the
+ * reader's job is to wait until that many bytes have arrived. With no ceiling
+ * that is an allocation an upstream decides the size of, and the upstream is
+ * not always one this endpoint chose: a connector names its own host, so a
+ * connection pointed at a hostile or compromised server could announce a
+ * literal of any size and be believed.
+ *
+ * Sixty-four mebibytes because that is already the ceiling on the other side of
+ * the same journey — `MAX_UPLOAD_BYTES` in `server/attachments.ts` — and a
+ * message larger than the largest attachment this endpoint will accept is not
+ * one it can do anything useful with. Every mail host's own limit is well below
+ * it, so this is never what refuses a legitimate read.
+ *
+ * Applied twice, and both are needed. The announced length is refused up front,
+ * so an absurd number costs nothing rather than being discovered after the
+ * bytes arrive. The accumulated buffer is refused too, because one response may
+ * announce several literals and a server that never completes a response would
+ * otherwise grow this without ever announcing anything unreasonable.
+ */
+export const MAX_RESPONSE_BYTES = 64 * 1024 * 1024;
+
 /** A parsed element of a response. */
 export type ImapToken =
   | { readonly kind: 'atom'; readonly value: string }
@@ -32,27 +56,56 @@ export type ImapToken =
  */
 export class ResponseAssembler {
   #buffer = new Uint8Array(0);
+  /** Bytes in use. The buffer is grown ahead of this and is not a length. */
+  #length = 0;
 
+  /**
+   * Take a chunk off the socket.
+   *
+   * Capacity doubles rather than growing to fit. It used to allocate exactly
+   * `held + chunk` and copy everything across on every chunk, which is
+   * quadratic in the size of a response — a thirty-megabyte message arriving in
+   * sixty-four-kilobyte pieces copied several gigabytes to assemble, and that
+   * was the *legitimate* case. Doubling makes each byte move a constant number
+   * of times.
+   */
   push(chunk: Uint8Array): void {
-    const merged = new Uint8Array(this.#buffer.length + chunk.length);
-    merged.set(this.#buffer);
-    merged.set(chunk, this.#buffer.length);
-    this.#buffer = merged;
+    const needed = this.#length + chunk.length;
+    if (needed > MAX_RESPONSE_BYTES) {
+      throw new Error(
+        `The server sent more than ${MAX_RESPONSE_BYTES} bytes without completing a response.`,
+      );
+    }
+
+    if (needed > this.#buffer.length) {
+      let capacity = Math.max(this.#buffer.length, 8192);
+      while (capacity < needed) capacity *= 2;
+
+      const grown = new Uint8Array(Math.min(capacity, MAX_RESPONSE_BYTES));
+      grown.set(this.#buffer.subarray(0, this.#length));
+      this.#buffer = grown;
+    }
+
+    this.#buffer.set(chunk, this.#length);
+    this.#length = needed;
   }
 
   /** The next complete response, or undefined while more bytes are needed. */
   next(): Uint8Array | undefined {
-    const end = completeResponseEnd(this.#buffer);
+    const end = completeResponseEnd(this.#buffer.subarray(0, this.#length));
     if (end === undefined) return undefined;
 
-    const response = this.#buffer.subarray(0, end);
-    this.#buffer = this.#buffer.slice(end);
+    // A copy, not a view: the remainder is shifted down in place below, which
+    // would otherwise rewrite the bytes underneath the response just returned.
+    const response = this.#buffer.slice(0, end);
+    this.#buffer.copyWithin(0, end, this.#length);
+    this.#length -= end;
     return response;
   }
 
   /** Whatever has arrived but does not yet form a response. For diagnostics. */
   get pending(): number {
-    return this.#buffer.length;
+    return this.#length;
   }
 }
 
@@ -66,6 +119,14 @@ function completeResponseEnd(buffer: Uint8Array): number | undefined {
 
     const announced = literalLength(buffer, cursor, crlf);
     if (announced === undefined) return crlf + 2;
+
+    // Refused on the announcement rather than after the bytes turn up: the
+    // number is the server's, and believing an absurd one means waiting for it.
+    if (announced > MAX_RESPONSE_BYTES) {
+      throw new Error(
+        `The server announced a ${announced}-byte literal, over the ${MAX_RESPONSE_BYTES}-byte limit.`,
+      );
+    }
 
     const afterLiteral = crlf + 2 + announced;
     if (buffer.length < afterLiteral) return undefined;


### PR DESCRIPTION
How much the IMAP reader accumulates was decided by the far end rather than by
this code, and a connector names its own host — so that is not always a server
this endpoint picked.

Two limits, because one does not imply the other: one on what a single response
may announce, refused up front rather than after the bytes arrive, and one on
what the reader will hold in total, for the case where nothing individually
unreasonable is ever announced.

The ceiling is the one already applied on the other side of the same journey
(`MAX_UPLOAD_BYTES` in `server/attachments.ts`). Every mail host's own message
limit sits well below it, so it should never be what refuses a real read.

The same change removes an amplification in the ordinary case: the buffer grew
by exact reallocation on every chunk, which is quadratic in the size of a
response. Capacity doubles now and the buffer compacts in place, which is why
`next` returns a copy rather than a view.

Both guards are verified as load-bearing — removing either fails exactly the
test written for it and leaves the other nineteen passing.

Found while auditing the transports.

🤖 Generated with [Claude Code](https://claude.com/claude-code)