### PR TITLE
ci: run the documentation checks against the published pages

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,97 @@
+# Does the published documentation still name everything this code ships?
+#
+# `sheets` and `docs` once shipped complete and unreachable, because nothing
+# told anyone `lanes link connect sheets` existed. Three test files exist to
+# stop that recurring, and when the documentation moved to lanes.sh they were
+# left reading `LANES_DOCS_DIR` and skipping when it is unset. In `ci` it is
+# unset, so they skip: the guards are written down and not run, which is the
+# state `bun run audit` was added to this repository to end.
+#
+# This runs them, against the pages a reader actually receives.
+#
+# Why fetch rather than check out the website repository: `ci` grants its job
+# nothing but tree read, and gives a fork PR the same gate as a branch PR. A
+# token for a private repository breaks both, since fork PRs receive no secrets
+# and would silently get a weaker check. The site publishes every page as
+# Markdown, so nothing here needs a credential at all.
+#
+# Why on a schedule rather than on a pull request: the subject is the *published*
+# documentation, which is deployed from another repository and lags a merge here
+# by however long that takes. Gating a PR on it would redden branches for a
+# deploy that is simply in flight. Daily is soon enough to catch drift and never
+# blocks anybody. `workflow_dispatch` is here for when you want the answer now.
+#
+# There is no event payload anywhere in this file: it runs on a timer or on a
+# button, and the only interpolation is an output this workflow itself wrote.
+name: docs
+
+on:
+  schedule:
+    # 07:00 UTC, before the working day in the timezone this is maintained from.
+    - cron: "0 7 * * *"
+  workflow_dispatch:
+
+concurrency:
+  group: docs
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  docs:
+    name: published docs name everything
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.3.11
+
+      - run: bun install --frozen-lockfile
+
+      # The article list comes from llms.txt rather than being spelled here, so
+      # a page added to the section is fetched without editing this file.
+      - name: Fetch the published documentation
+        id: fetch
+        run: |
+          set -euo pipefail
+          docs="${RUNNER_TEMP}/link-docs"
+          mkdir -p "$docs"
+
+          slugs=$(curl -fsS --retry 3 --retry-delay 5 https://lanes.sh/llms.txt \
+            | grep -oE 'https://lanes\.sh/docs/link/[a-z0-9-]+' \
+            | sed 's|.*/||' | sort -u)
+
+          if [ -z "$slugs" ]; then
+            echo "::error::llms.txt named no /docs/link pages. Has the section shipped?"
+            exit 1
+          fi
+
+          for slug in $slugs; do
+            # Saved as .mdx because that is what LANES_DOCS_DIR means: the
+            # section's source directory. The .md twin is the same document.
+            curl -fsS --retry 3 --retry-delay 5 \
+              "https://lanes.sh/docs/link/${slug}.md" -o "${docs}/${slug}.mdx"
+          done
+
+          echo "fetched $(find "$docs" -name '*.mdx' | wc -l | tr -d ' ') pages"
+
+          # A page that 404s into an HTML error body would otherwise reach the
+          # tests as prose that happens to name no providers.
+          grep -q 'lanes link connect' "${docs}/connect.mdx" \
+            || { echo "::error::connect.mdx carries no connect commands"; exit 1; }
+
+          echo "dir=${docs}" >> "$GITHUB_OUTPUT"
+
+      # Only the three files that read the documentation. `ci` already runs the
+      # rest, and running them twice would just double the time to a red X.
+      - name: Check the documentation against the code
+        env:
+          LANES_DOCS_DIR: ${{ steps.fetch.outputs.dir }}
+        run: |
+          bun test \
+            src/readme.test.ts \
+            src/profile/docs.test.ts \
+            src/providers/google/specs/specs.test.ts

--- a/docs/README.md
+++ b/docs/README.md
@@ -24,13 +24,24 @@ Those are engineering history rather than documentation, so they stay with the s
 
 ## Editing the docs
 
-The pages above are authored in the website repository, under `src/content/docs/link/`. Two test
-suites here read them, so point them at your checkout when you change a config example or the
-Google scope justifications:
+The pages above are authored in the website repository, under `src/content/docs/link/`. Three test
+files here read them, so point them at your checkout when you add a provider, change a config
+example, or edit the Google scope justifications:
 
 ```console
 $ LANES_DOCS_DIR=/path/to/web/src/content/docs/link bun test
 ```
 
-Without it, `src/profile/docs.test.ts` and the verification checks in
-`src/providers/google/specs/specs.test.ts` skip rather than passing by not looking.
+| | Reads | Checks |
+|---|---|---|
+| `src/readme.test.ts` | `connect.mdx` | Every provider manifest has a `lanes link connect` command, and the untested markers agree with `untested.ts` |
+| `src/profile/docs.test.ts` | `configuration.mdx`, `deployment-cloudrun.mdx`, `creating-a-provider.mdx`, `connectivity-coverage.mdx` | The documented config examples and provider manifests parse against the real schema |
+| `src/providers/google/specs/specs.test.ts` | `google-verification.mdx` | The Google scopes the code requests are the ones the page justifies to reviewers |
+
+Without `LANES_DOCS_DIR` those checks skip rather than passing by not looking, which is what happens
+in the `ci` workflow: it has no access to the website repository, which is private.
+
+They are run instead by the **`docs` workflow**, daily and on demand, against the pages as published
+on lanes.sh. That is the honest subject anyway, since what matters is whether the documentation a
+reader receives still names everything this code ships. If it goes red after you add a provider, the
+website side has not caught up yet.


### PR DESCRIPTION
Three test files assert that the documentation still describes what this code ships. #121 left all three reading `LANES_DOCS_DIR` and skipping when it is unset, and in `ci` it is unset. So they are currently written down and not run, which is exactly the state `bun run audit` was added to this repository to end.

This runs them, daily and on demand.

| Reads | Checks |
|---|---|
| `connect.mdx` | Every provider manifest has a `lanes link connect` command, and the untested markers agree with `untested.ts` |
| `configuration.mdx`, `deployment-cloudrun.mdx`, `creating-a-provider.mdx`, `connectivity-coverage.mdx` | The documented config examples and provider manifests parse against the real schema |
| `google-verification.mdx` | The Google scopes the code requests are the ones the page justifies to reviewers |

## Two design choices, both argued from what `ci` says about itself

**It fetches the pages rather than checking out the website repository.** `ci` grants its job nothing but tree read, and gives a fork PR the same gate as a branch PR, "which is the point: the contributor does not have to be trusted for the check to mean something." The website repository is private, so reaching it needs a token, and a token breaks both of those: fork PRs receive no secrets, so they would silently get the weaker check. Every page is published as Markdown at `lanes.sh/docs/link/<slug>.md`, so nothing here needs a credential at all.

**It runs on a schedule rather than on a pull request.** The subject is the *published* documentation, which is deployed from another repository and lags a merge here by however long that takes. Gating a PR on it would redden branches for a deploy that is simply in flight. Daily catches drift soon enough and blocks nobody; `workflow_dispatch` is there for when you want the answer now.

There is no event payload anywhere in the workflow. It runs on a timer or a button, and the only interpolation is an output the workflow itself wrote.

## Verification

- The three files run against Markdown twins generated by the website's own renderer, which is byte-for-byte what the fetch step will pull: **62 pass, 0 fail**. The twins preserve everything the tests need, including the YAML fences, the `†` untested markers, and the `{/* scopes:begin */}` JSX comments.
- The slug list the fetch derives from `llms.txt` resolves to exactly the 27 pages in the section, with no bogus entries from the bare `/docs/link` link that also appears there.
- `bash -n` on the run blocks, and the YAML parses to the intended triggers and `permissions: contents: read`.

## Before the first run

`/docs/link` had not finished deploying when this was written, so `lanes.sh/docs/link/connect.md` still 404s and the fetch step would fail its own guard with `llms.txt named no /docs/link pages`. Trigger it manually once the website deploy lands, or let the 07:00 UTC run pick it up.

## Not in here

Adding `docs` to the required checks on `develop` is a separate decision. This only makes the check exist and report.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LhKKxruNLmX7eXz6GgoZJb
