### PR TITLE
entities: who and what everyone else is

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -104,10 +104,10 @@ selecting it (ADR-043). Everything acting on one account still names both. The t
 `src/cli/selection.ts` is the whole rule, and `selection.test.ts` reads the dispatch files to
 check a new command cannot be added without appearing in it.
 
-## The owner layer is seven ids, and `tasks` is not Google's
+## The owner layer is eight ids, and `tasks` is not Google's
 
-`RESERVED_PROVIDER_IDS` is `memory`, `tasks`, `assets`, `skills`, `vault`, `setup`, `identity`. Two
-things an agent gets wrong here:
+`RESERVED_PROVIDER_IDS` is `memory`, `tasks`, `assets`, `skills`, `vault`, `setup`, `identity`,
+`entities`. Three things an agent gets wrong here:
 
 - **`tasks` is the built-in task list; Google Tasks is `google_tasks`.** The rename was forced —
   `buildRegistry` registers the owner layer before `PROVIDERS`, so a manifest holding a reserved id
@@ -120,6 +120,19 @@ things an agent gets wrong here:
   `ensureOwnerLayer` in `src/cli/config-repair.ts` repairs an older profile from `start`, `connect`
   and `deploy`; the template in `config-edit.ts` and that repair must write a row in **one**
   spelling, which `config-edit.test.ts` checks by asserting a fresh profile needs no repair.
+- **`identity` and `entities` differ on writability and on the default grant, and the reason is one
+  test.** It is not "is it empty" — memory arrives empty and is granted. It is *can it be filled in
+  from here*: identity is configuration and changed in the CLI (ADR-007), so an agent able to edit
+  it could edit the one fact that stops it signing as the wrong person. Everyone else's details
+  accumulate on the same surface that reads them, so `entities` is agent-writable and granted like
+  memory (ADR-056). Do not "fix" the asymmetry.
+
+`entities.find` returns **every** match and sets no error on more than one, deliberately. If you
+change how it ranks, the rule to keep is that ordering is not selection: there is no scoring inside
+a rank, because a tiebreak that promoted one of two exact alias matches would turn a question for
+the owner into a silent pick. Its derived `_index.json` is a cache stamped with a `key:size`
+fingerprint of the entity files — not `key:size:mtime`, because the GitHub adapter reports the
+branch tip for every file and the stamp would never match twice.
 
 `src/architecture.test.ts` asserts the four rules the layout expresses: dependency
 direction between components, no vendor name in the code a request passes through, a

--- a/docs/detailed/adr/041-memory-and-skills-in-a-repository.md
+++ b/docs/detailed/adr/041-memory-and-skills-in-a-repository.md
@@ -160,3 +160,15 @@ wants to hear about.
 - **`#stores/blobs/conformance.ts` still holds every adapter to one contract.** The GitHub store
   passes the same suite the filesystem, S3, and in-memory stores do, twice: bare, and under a path
   prefix. A key one target refuses is still not one another accepts.
+
+---
+
+**Amended by [ADR-056](056-everyone-else-is-declared-too.md).** Entity files may move too. The
+exclusion in the title was never a count — its argument is a discriminator, an artefact of one
+installation stays and a document the owner wrote may move — and an entity file is a Markdown
+document with frontmatter, hand-editable, wanting history and review. The structural half is
+untouched: there is still no field here that could name the credential store or the vault, and
+that amendment adds none. What travels with the entity files that did not travel before is a
+derived `_index.json`, which is a cache landing in a documents repository and is the weaker half
+of that decision.
+

--- a/docs/detailed/adr/056-everyone-else-is-declared-too.md
+++ b/docs/detailed/adr/056-everyone-else-is-declared-too.md
@@ -68,6 +68,13 @@ using the first:
    it. When nothing distinguishes them the answer says so — that is a duplicate to merge, not a
    choice to make.
 
+   A draft withheld the *values* of differing attributes and named only their kinds. That is worse:
+   "these two differ by email" without saying how is the same ambiguity one level down, and it
+   discloses nothing to withhold, since `find` and `get` are both in the default read bundle and
+   either record can already be opened. The audit log is the separate question and is answered the
+   other way — the query is withheld there and only the matched ids are kept, because a response
+   goes to a caller that already has the grant while the log outlives the call.
+
 Exact matches suppress prefix and substring ones. That is a boundary between *kinds* of match, not
 a precedence among equals: two exact alias matches both survive and both are returned.
 

--- a/docs/detailed/adr/056-everyone-else-is-declared-too.md
+++ b/docs/detailed/adr/056-everyone-else-is-declared-too.md
@@ -1,0 +1,216 @@
+# ADR-056: Everyone else is declared too, and a lookup answers with all of them
+
+**Status:** accepted · **Follows from** [ADR-042](042-a-profile-declares-its-owner.md) ·
+**Amends** [ADR-041](041-memory-and-skills-in-a-repository.md) ·
+**Relates to** [ADR-050](050-the-owner-layer-is-granted-by-default.md),
+[ADR-051](051-tasks-and-assets-are-their-own-stores.md),
+[ADR-014](014-owner-layer-is-managed.md), [ADR-012](012-owner-layer-primitives.md)
+
+## Context
+
+ADR-042 exists because a profile said what was *reachable* and nothing about *whose* it was, so
+an agent writing as the owner inferred a name from whatever was in the conversation. The fix was
+to write it down.
+
+The same failure happens one step outward and nothing catches it. Asked to "email Jan about the
+invoice", an agent has no declared answer for who Jan is. It reaches for an address it saw in a
+thread, or asks, or guesses — and the guess is not obviously a guess, because an address that
+appeared in a mailbox this endpoint serves looks exactly like an address the owner uses for that
+person.
+
+The information is knowable. Nobody had written it down, because there was nowhere to write it.
+
+Memory is the store people reach for and it is the wrong shape for this. "Jan's email is
+jan@acme.test" written as a memory entry is findable only by substring, comes back as prose a
+model has to parse, and says nothing about which of two addresses to prefer. It is the same
+argument ADR-051 made for tasks and assets — the write succeeds, which is why it keeps happening —
+applied to a third thing memory is not.
+
+## Decision
+
+**An eighth owner-layer provider, `entities`**, holding the people, companies, projects and
+accounts the owner deals with. It is `identity`'s mirror: identity says who the owner is, this
+says who everyone else is.
+
+### One tool, and it never chooses
+
+`entities.find` takes structured criteria — a query matched against ids, names, aliases and
+attribute values; plus `type`, `tag`, `attr` and a one-hop `related` — and returns **every**
+match.
+
+Three outcomes, and **none of them is an error**:
+
+| | What comes back |
+|---|---|
+| one match | the whole entity, with a resource link |
+| several | all of them, ranked, showing only the fields that *differ* |
+| none | what was tried, and not to invent an address |
+
+An earlier draft refused on ambiguity: exactly one entity or an `isError` naming the candidates.
+It was rejected, and the reason is that it models the wrong thing. An assistant handed two people
+called Jan asks which one is meant; it does not fail. Several matches is a normal answer to a
+reasonable question, and returning it as an error makes every honest ambiguity look like a
+malfunction.
+
+What survives from that draft is the part that mattered: **the tool never picks.** Three rules
+carry it, because with no error there is nothing else standing between two candidates and an agent
+using the first:
+
+1. **Ordering is not selection.** Candidates are ranked so the list is legible — an exact id above
+   a substring — and nothing presents the first as the answer. There is deliberately no scoring
+   *inside* a rank: no most-recently-updated tiebreak that would quietly promote one of two exact
+   alias matches. This is the thing a later contributor will be tempted to improve.
+2. **The count comes first**, before any candidate, so a client that truncates the response has
+   still seen that there was more than one.
+3. **Several matches render what distinguishes them**, not two full records. Two Jans separated by
+   their employer is a question the surrounding context usually settles; two rows of identical
+   detail is not, and printing everything about both buries the one column that would have decided
+   it. When nothing distinguishes them the answer says so — that is a duplicate to merge, not a
+   choice to make.
+
+Exact matches suppress prefix and substring ones. That is a boundary between *kinds* of match, not
+a precedence among equals: two exact alias matches both survive and both are returned.
+
+A tag is never matched by the query. A tag is a category, not an identity, and `find("client")`
+returning one of eleven clients as if it were a name is the failure this component exists to
+prevent, wearing a different hat.
+
+### The model
+
+One entity is one Markdown file with YAML frontmatter — memory's shape exactly (ADR-014), so the
+directory stays one a person can open, edit and review.
+
+```yaml
+type: person
+name: Jan Bakker
+aliases: [Jan, JB]
+attributes:
+  - { kind: email, value: jan@acme.test, note: work }
+  - { kind: email, value: j.bakker@example.net, note: personal }
+relations:
+  - { predicate: works_at, entity: acme-bv, note: since 2023 }
+```
+
+**`attributes` is a list, not a map**, and the argument is identity's verbatim: a map cannot say
+*when* to use which, and the note is the whole point. A map also silently forbids two email
+addresses, which is the case that matters most. Order is preference order, so the first of a kind
+is the default — the same rule an agent already learned from `identity_list`, which is why the two
+shapes are deliberately the same.
+
+`type` and `predicate` are free-form. A closed vocabulary would need a release every time somebody
+wants `vessel` or `depends_on`, and identity refused an enum for the same reason.
+
+**Relations are one-sided.** An edge is written into the entity that declares it and nowhere else;
+the reverse is derived when the catalogue is built. Writing both sides is two files for one fact,
+and nothing in this codebase locks — an interrupted write would leave a half-edge that nothing
+detects. A dangling edge is legal and renders as a plain name: an entity referred to before it is
+declared is a fact the owner recorded, and hiding it would make the graph quietly wrong rather
+than visibly incomplete.
+
+`forget` does not cascade, for the same reason: a delete that rewrote five other people's files
+could not be reviewed as one change. It reports who still points at what it removed.
+
+### It is writable, and identity is not
+
+These look inconsistent and are not. ADR-007 makes identity CLI-only because an agent able to edit
+it could edit the one fact that stops it signing as the wrong person. Everyone else's details are
+ordinary owner material that accumulates in conversation, on the same surface that reads it — so
+`entities` follows `memory`: a default `read` bundle and a non-default `write` one (ADR-012 §2).
+
+The same distinction settles the default grant. `entities` is in `DEFAULT_SURFACES` and `identity`
+is not, and ADR-050's test is not "is it empty" — memory arrives empty and is granted — it is
+**can it be filled in from here**. Identity is configuration; a surface reporting an empty one
+could never do anything about it. Entities can.
+
+A note on the risk, because it is not quite memory's. ADR-012 §2 says text an agent authors is
+re-served to every later session. An entity is worse than re-served: it is *acted on*. An injected
+address is used to send something.
+
+### A derived index, stamped with what it was built from
+
+A read that opened every entity file is fine on a local directory and is a thousand HTTPS GETs
+against a bucket or a knowledge repository. So `_index.json` sits beside the entity files holding
+what a lookup needs, and a read that finds it valid opens no entity file at all.
+
+It is a **cache**, not a second source of truth, which is the distinction ADR-014 removed memory's
+index for failing. What makes this one different is that it carries a fingerprint of the exact
+listing it was built from: a file edited in an editor or on GitHub invalidates it structurally
+rather than by anybody remembering to. Absent, truncated, wrong-version and mismatched are one
+case, and all four rebuild from the files without throwing — `openRuntime` treats a corrupt
+discovery cache the same way, and never as a reason to fail startup.
+
+The fingerprint is `key:size`, not `key:size:mtime` as `skillFingerprint` uses. That one is a
+change detector for a two-second poll, where a false positive costs a reload; this is a validity
+stamp, where a false positive costs a full rebuild and, on a knowledge repository, a commit. The
+GitHub adapter reports the *branch tip* as `modifiedAt` for every file, so on the one backend where
+the index is worth the most, an mtime-bearing fingerprint would never match twice. Dropping mtime
+also lets a writer compute the fingerprint of the state it is about to create, since it knows the
+byte length before the put — no second listing, no read-back.
+
+**No read ever writes the index.** A read that finds it stale rebuilds in memory and serves the
+right answer; only the three write capabilities and `entities reindex` persist. So no read can
+move a branch tip, and therefore no read can invalidate the next read.
+
+**The hole this leaves, stated rather than hidden.** A hand-edited *index* whose fingerprint still
+matches untouched entity files is served. The fingerprint stamps the documents, not itself. It is
+pinned by a test, and closed where it matters: a single match — the only shape that gets acted on —
+is re-read from its file, and any disagreement rebuilds the whole catalogue and re-runs the search
+rather than patching the one row. Patching would answer with an entity that no longer matches what
+was asked for, and "here is your one result" is exactly the wrong sentence then. Re-running can
+legitimately return none, or several, and both are better than a confident wrong answer.
+
+## What this amends
+
+ADR-041 is titled "memory and skills may live in a repository, **and nothing else may**". Entity
+files may too.
+
+That exclusion was never a count. Its argument is a discriminator: an artefact of one installation
+stays, a document the owner wrote may move. State, the audit log, the credential store and the
+vault are excluded *structurally* — there is no field in `knowledgeTargetSchema` that could name
+them — and this amendment adds none. An entity file is a Markdown document with frontmatter,
+hand-editable, wanting history and review, reachable from more than one machine. It is on the same
+side of that line as a memory entry, by the same test, and "nothing else may" was a statement about
+what existed rather than about what qualifies.
+
+The derived index travels with the entity files, because it is derived from what travels. That is
+the weaker half of this argument and is worth saying plainly: it is a cache landing in a documents
+repository, it churns in every commit that changes an entity, and it is there only so a fresh clone
+does not pay a full rebuild on its first read.
+
+## Consequences
+
+**Where this stops being the right design.** Steady state on a bucket is one listing and one GET
+whatever the entity count, because a listing carries key and size only. A rebuild is one read per
+entity.
+
+| entities | listing requests | index | steady-state read | rebuild |
+|---|---|---|---|---|
+| 100 | 1 | ~35 KB | 2 requests | 100 GETs |
+| 1,000 | 1–2 | ~340 KB | 3 requests | 1,000 GETs |
+| 10,000 | 11 | ~3.4 MB | 12 requests | 10,000 GETs |
+
+A thousand is comfortably inside the design. Ten thousand is where it is the wrong design, and the
+answer then is not a larger index but a validity check that needs no listing — which needs an
+adapter reporting a per-object etag, and `BlobMetadata` carries none. On a local directory, which
+is what most people run, neither the index nor anything else here is worth a measurable amount.
+
+**Every write rewrites the whole index.** ~340 KB at a thousand entities. Unremarkable against a
+bucket; on a knowledge repository it is a blob in every commit. A bulk load of two hundred entities
+through two hundred calls rewrites it two hundred times, and `entities reindex` after the fact is
+the documented answer. A `--defer-index` flag was considered and rejected: a flag that leaves the
+index stale when a run fails is worse than the cost it avoids.
+
+**`MAX_INSTRUCTIONS` rises to 2900**, the fourth raise, certified at 2800 rather than guessed. The
+paragraph earns it on ADR-042's argument restated: an agent that resolves "email Jan" to the wrong
+address has already sent the message, before a skill would have loaded, and the client most in need
+of the rule is the one holding no skills directory. It also carries a rule nothing else can
+enforce — `find` sets no error on several matches, so between two candidates and a message sent to
+the wrong person there is only prose. It collapses with `IDENTITY` when both are reachable, on
+`MEMORY_AND_TASKS`'s argument, which is worth 161 characters as well as being the clearer sentence.
+
+**`RESERVED_PROVIDER_IDS` is eight**, and `entities` is appended rather than inserted
+alphabetically so it lands beside `identity` — the order is read, and the two collapse.
+
+**Multi-hop traversal is not in this decision.** `related` is one hop and free, because backlinks
+are derived anyway. Nothing in the storage or the schema precludes adding depth later, which is why
+the vocabulary was left free-form.

--- a/docs/detailed/adr/README.md
+++ b/docs/detailed/adr/README.md
@@ -63,6 +63,7 @@ Nothing in the codebase depends on it.
 | [053](053-the-page-a-person-reads-is-the-app.md) | The page a person reads is the desktop app, and the endpoint stops serving one |
 | [054](054-the-surface-in-front-of-the-gate.md) | The surface in front of the gate is metered, and does not name itself |
 | [055](055-a-connection-may-say-where-its-service-is.md) | A connection may say where its service is, so a self-hosted or multi-tenant host can be a built-in |
+| [056](056-everyone-else-is-declared-too.md) | Everyone else is declared too, and a lookup answers with all of them |
 
 Where an ADR departs from init.md, it says so at the top. Three are significant:
 
@@ -160,3 +161,19 @@ Where an ADR departs from init.md, it says so at the top. Three are significant:
   Google Tasks to `google_tasks`, which the reserved-id check forces, and the redaction keys that
   had to lengthen with it. Both are recorded there because a redaction key that misses withholds
   every argument and reads exactly like working redaction, which is not a thing to rediscover.
+
+- **ADR-056** follows from ADR-042 and amends ADR-041. The first is the interesting relationship:
+  it applies identity's argument to everybody who is not the owner, and then diverges from it
+  twice on purpose — `entities` is agent-writable and granted by default, where `identity` is
+  neither. Both differences turn on the same test, and it is not "is it empty": memory arrives
+  empty and is granted. It is *can it be filled in from here*, which configuration cannot be
+  (ADR-007) and an owner's own store can. The amendment to ADR-041 is smaller than its title makes
+  it look — that exclusion was a discriminator rather than a count, and the structural part, the
+  absence of any field that could name the credential store or the vault, is untouched.
+
+  Read the ambiguity rule if nothing else. An earlier draft refused on more than one match; this
+  one returns them all and errors on nothing, because an assistant handed two people called Jan
+  asks which is meant rather than failing. What replaces the refusal is three rules — ordering is
+  not selection, the count comes first, and several matches render only what tells them apart —
+  and they are load-bearing in a way a refusal was not: with no error, they are the only thing
+  between two candidates and a message sent to the wrong person.

--- a/instructions/skills/lanes-link/SKILL.md
+++ b/instructions/skills/lanes-link/SKILL.md
@@ -174,6 +174,31 @@ inventing something; they add one with `lanes link identity add <kind> <value> -
 --target <target>` — both flags, because neither has a fallback.
 Nothing you can call writes here, deliberately.
 
+## Who you are writing *to* is declared as well
+
+`entities_find` holds the people, companies and projects this owner deals with,
+with the addresses and handles to reach each of them. Call it before using
+anyone's address — do not recall one from earlier in the conversation, and do
+not lift one off a message you happen to have read.
+
+**It answers with every match and never chooses between them.** One match is an
+answer. More than one is a question: the reply shows what separates the
+candidates, so settle it from what you already know if that is genuinely
+unambiguous, and otherwise **ask**. Do not take the first — the order is not a
+ranking, and nothing about the reply is an error you need to work around.
+
+None matching is not a failure either. It means the owner has not written that
+person down, so ask rather than using an address from somewhere else.
+
+Where an entity holds two of a kind — a work address and a personal one — the
+first is the default and the notes say when to prefer the other, exactly as
+identity works.
+
+Writing is a separate grant. Where you have it, `entities_write` declares one
+and `entities_link` relates two; a field you do not send is left as it is.
+`entities_forget` does not clean up edges pointing at what it removed, and says
+which ones will dangle.
+
 ## Attachments are named, not carried
 
 Where a tool takes `attachments`, each entry names **one** source and the endpoint

--- a/src/architecture.test.ts
+++ b/src/architecture.test.ts
@@ -315,7 +315,35 @@ const MAX_LINES = 400;
  * `knowledge`, which is fourteen lines of the same shape as the twenty-seven
  * cases around it.
  */
+/**
+ * `server/mcp/instructions.ts` is the same case again, and the split it looks
+ * like it wants is the one thing that would damage it.
+ *
+ * The file is a list of paragraphs — one per owner surface an agent can reach,
+ * each carrying the story of the mistake it prevents — plus one assembler and
+ * one ceiling. Its length is a count of *surfaces*, which is `cli/main.ts`'s
+ * argument for being a count of *commands*.
+ *
+ * The obvious cut is prose into one module and assembly into another, and it is
+ * wrong here specifically: `MAX_INSTRUCTIONS` is a *measurement of the prose*,
+ * and its docstring carries the arithmetic that produced it. Putting the number
+ * in one file and the thing it measures in another is exactly how the two come
+ * to disagree — which that docstring records having already happened once, when
+ * the test asserted a literal while the code reserved room against a second,
+ * differently-derived number.
+ *
+ * It crossed the line adding `entities` (ADR-055): two paragraphs and a
+ * collapsed pair, the same shape as the eight around them. That is the
+ * concession, and it is worth naming as one — the alternative was a shorter
+ * paragraph, and a paragraph shortened to fit a line budget is a worse trade
+ * than a long file.
+ *
+ * What would earn a split is something here that is neither a paragraph nor its
+ * assembly: per-client branching, or prose built from configuration rather than
+ * declared. Both are visible in a diff.
+ */
 const KNOWN_LONG = new Set([
+  'server/mcp/instructions.ts',
   'cli/main.ts',
   'connectivity/transports/dav/ical.ts',
   'deployments/adapters/gcp-secret-manager.ts',

--- a/src/architecture.test.ts
+++ b/src/architecture.test.ts
@@ -332,7 +332,7 @@ const MAX_LINES = 400;
  * the test asserted a literal while the code reserved room against a second,
  * differently-derived number.
  *
- * It crossed the line adding `entities` (ADR-055): two paragraphs and a
+ * It crossed the line adding `entities` (ADR-056): two paragraphs and a
  * collapsed pair, the same shape as the eight around them. That is the
  * concession, and it is worth naming as one — the alternative was a shorter
  * paragraph, and a paragraph shortened to fit a line budget is a worse trade

--- a/src/cli/argv.ts
+++ b/src/cli/argv.ts
@@ -107,7 +107,7 @@ export function globalFlags(flags: Flags): GlobalFlags {
  * The kebab-case spellings live here and nowhere else, so the one place that
  * knows `--display-name` is the one place that parses argv.
  */
-export function ownerFlags(flags: Flags): OwnerFlags {
+export function ownerFlags(flags: Flags, argv: readonly string[] = []): OwnerFlags {
   return {
     ...globalFlags(flags),
     show: flags['show'] === true,
@@ -124,8 +124,21 @@ export function ownerFlags(flags: Flags): OwnerFlags {
     due: text(flags, 'due'),
     name: text(flags, 'name'),
     contentType: text(flags, 'content-type'),
+    type: text(flags, 'type'),
+    // Repeatable, so read from argv rather than from the parsed map: `parseArgv`
+    // keeps only the last value of a repeated flag, and two email addresses on
+    // one entity is the case entities exists for. `customFlags` does the same.
+    alias: list(argv, 'alias'),
+    attr: list(argv, 'attr'),
+    related: list(argv, 'related'),
     yes: flags['yes'] === true,
   };
+}
+
+/** A repeatable flag's values, or undefined when it was not passed at all. */
+function list(argv: readonly string[], name: string): string[] | undefined {
+  const values = all(argv, name);
+  return values.length > 0 ? values : undefined;
 }
 
 /**

--- a/src/cli/commands/knowledge/index.ts
+++ b/src/cli/commands/knowledge/index.ts
@@ -74,10 +74,17 @@ export async function knowledgeShow(flags: KnowledgeFlags): Promise<void> {
     const selection = ` --profile ${runtime.resolution.profile} --target ${runtime.target}`;
     const skills = (await runtime.skills.list()).length;
     const memory = (await runtime.storage.list(`${KNOWLEDGE_LAYOUT.memory}/`)).length;
+    const entities = (await runtime.storage.list(`${KNOWLEDGE_LAYOUT.entities}/`)).length;
     const where = runtime.knowledge?.describe;
 
     if (flags.json) {
-      print(JSON.stringify({ target: runtime.target, where: where ?? 'local', memory, skills }, null, 2));
+      print(
+        JSON.stringify(
+          { target: runtime.target, where: where ?? 'local', memory, skills, entities },
+          null,
+          2,
+        ),
+      );
       return;
     }
 
@@ -95,6 +102,16 @@ export async function knowledgeShow(flags: KnowledgeFlags): Promise<void> {
         '  skills',
         where ? `${where}/${KNOWLEDGE_LAYOUT.skills}` : layout.skills(profile),
         style.dim(`${skills} file${skills === 1 ? '' : 's'}`),
+      ],
+      // The count includes the derived `_index.json`, deliberately: it is a
+      // file in that directory and it is committed with the rest, so a number
+      // that quietly excluded it would not match what a person sees there.
+      [
+        '  entities',
+        where
+          ? `${where}/${KNOWLEDGE_LAYOUT.entities}`
+          : `${layout.blobs(profile)}/${KNOWLEDGE_LAYOUT.entities}`,
+        style.dim(`${entities} file${entities === 1 ? '' : 's'}`),
       ],
     ]);
 
@@ -266,8 +283,9 @@ async function useLocal(flags: KnowledgeFlags): Promise<void> {
       const moved = await moveOut(repository, knowledge, local.storage, local.skills);
       print(
         ok(
-          `wrote back ${moved.memory} memory entr${moved.memory === 1 ? 'y' : 'ies'} and ` +
-            `${moved.skills} skill file${moved.skills === 1 ? '' : 's'}`,
+          `wrote back ${moved.memory} memory entr${moved.memory === 1 ? 'y' : 'ies'}, ` +
+            `${moved.skills} skill file${moved.skills === 1 ? '' : 's'} and ` +
+            `${moved.entities} entity file${moved.entities === 1 ? '' : 's'}`,
         ),
       );
     }
@@ -275,7 +293,7 @@ async function useLocal(flags: KnowledgeFlags): Promise<void> {
     await writeBlock(runtime.config, runtime.resolution.workspaceRoot, undefined);
 
     print('');
-    print(ok('memory and skills are back on this target\'s own storage'));
+    print(ok('memory, skills and entities are back on this target\'s own storage'));
     print(
       style.dim(
         `  ${knowledge.repo} still holds everything — it is version control, so nothing was removed from it.`,

--- a/src/cli/commands/knowledge/knowledge.test.ts
+++ b/src/cli/commands/knowledge/knowledge.test.ts
@@ -50,6 +50,7 @@ policy:
 const SELECT = { profile: 'personal', target: 'local' } as const;
 
 const SKILL = '---\ndescription: Triage an inbox\n---\nOpen the inbox.\n';
+const ENTITY = '---\ntype: person\nname: Jan Bakker\n---\n\nPrefers email.\n';
 const ENTRY = '---\ntitle: A note\nupdated_at: 2026-01-01T00:00:00.000Z\n---\nBody.\n';
 
 async function workspace(seed = true): Promise<string> {
@@ -65,6 +66,9 @@ async function workspace(seed = true): Promise<string> {
     await writeFile(join(root, 'data/personal/memory/main/a-note.md'), ENTRY);
     await mkdir(join(root, 'data/personal/skills.d/triage'), { recursive: true });
     await writeFile(join(root, 'data/personal/skills.d/triage/SKILL.md'), SKILL);
+    await mkdir(join(root, 'data/personal/entities/main'), { recursive: true });
+    await writeFile(join(root, 'data/personal/entities/main/jan-bakker.md'), ENTITY);
+    await writeFile(join(root, 'data/personal/entities/main/_index.json'), '{"v":1}');
   }
 
   process.env['LANES_LINK_HOME'] = root;
@@ -110,12 +114,19 @@ describe('switching to a repository', () => {
     expect(github.files()).toEqual({
       'memory/main/a-note.md': ENTRY,
       'skills/triage/SKILL.md': SKILL,
+      'entities/main/jan-bakker.md': ENTITY,
+      // The derived index travels with the documents it describes. Asserted
+      // rather than tolerated: it is a cache in a documents repository, which
+      // is a real cost of committing it, and it should be a decision somebody
+      // made rather than something that happened.
+      'entities/main/_index.json': '{"v":1}',
     });
-    // One commit for both files, not one each.
+    // One commit for all of them, not one each.
     expect(github.calls.filter((call) => call.includes('/git/commits')).length).toBe(1);
 
     expect(existsSync(join(root, 'data/personal/memory/main/a-note.md'))).toBe(false);
     expect(existsSync(join(root, 'data/personal/skills.d/triage/SKILL.md'))).toBe(false);
+    expect(existsSync(join(root, 'data/personal/entities/main/jan-bakker.md'))).toBe(false);
   });
 
   test('writes one block, on the profile', async () => {
@@ -137,8 +148,9 @@ describe('switching to a repository', () => {
 
     await use({ migrate: true, keep: true });
 
-    expect(Object.keys(github.files())).toHaveLength(2);
+    expect(Object.keys(github.files())).toHaveLength(4);
     expect(existsSync(join(root, 'data/personal/memory/main/a-note.md'))).toBe(true);
+    expect(existsSync(join(root, 'data/personal/entities/main/jan-bakker.md'))).toBe(true);
   });
 
   test('--no-migrate switches and leaves what is stored where it is', async () => {
@@ -178,12 +190,14 @@ describe('switching to a repository', () => {
     expect(await readProfile(root)).toContain('repo: my-org/my-notes');
   });
 
-  test('a path prefix lands both areas under it', async () => {
+  test('a path prefix lands every area under it', async () => {
     await workspace();
 
     await use({ migrate: true, path: 'context' });
 
     expect(Object.keys(github.files()).sort()).toEqual([
+      'context/entities/main/_index.json',
+      'context/entities/main/jan-bakker.md',
       'context/memory/main/a-note.md',
       'context/skills/triage/SKILL.md',
     ]);
@@ -267,6 +281,9 @@ describe('coming back', () => {
 
     expect(await readFile(join(root, 'data/personal/memory/main/a-note.md'), 'utf8')).toBe(ENTRY);
     expect(await readFile(join(root, 'data/personal/skills.d/triage/SKILL.md'), 'utf8')).toBe(SKILL);
+    expect(await readFile(join(root, 'data/personal/entities/main/jan-bakker.md'), 'utf8')).toBe(
+      ENTITY,
+    );
     expect(await readProfile(root)).not.toContain('knowledge:');
   });
 
@@ -276,7 +293,7 @@ describe('coming back', () => {
 
     await knowledgeUse('local', { ...SELECT, fetch: github.fetch, migrate: true, yes: true });
 
-    expect(Object.keys(github.files())).toHaveLength(2);
+    expect(Object.keys(github.files())).toHaveLength(4);
   });
 
   test('a profile that never switched is told so rather than edited', async () => {
@@ -370,6 +387,9 @@ describe('knowledge show', () => {
       where: 'github:my-org/my-notes',
       memory: 1,
       skills: 1,
+      // Two: the entity document and its derived index, which is a file in that
+      // directory like any other and is counted as one.
+      entities: 2,
     });
   });
 });
@@ -488,9 +508,12 @@ describe('removing a profile does not reach into the repository', () => {
     // The routing that points memory at a repository lives in `openRuntime`;
     // this command opens the target's declared storage, so it cannot see one.
     expect(output).not.toContain('memory/main/a-note.md');
+    expect(output).not.toContain('entities/main/jan-bakker.md');
     expect(github.files()).toEqual({
       'memory/main/a-note.md': ENTRY,
       'skills/triage/SKILL.md': SKILL,
+      'entities/main/jan-bakker.md': ENTITY,
+      'entities/main/_index.json': '{"v":1}',
     });
   });
 });

--- a/src/cli/commands/knowledge/migrate.ts
+++ b/src/cli/commands/knowledge/migrate.ts
@@ -1,4 +1,10 @@
-import { ConfigError, KNOWLEDGE_LAYOUT, knowledgeRoot, type KnowledgeConfig } from '#profile';
+import {
+  ConfigError,
+  KNOWLEDGE_LAYOUT,
+  knowledgeRoot,
+  type KnowledgeArea,
+  type KnowledgeConfig,
+} from '#profile';
 import type { BlobStore } from '#stores/blobs';
 import { commitFiles, type CommitFile } from '#deployments/adapters/github-commit.ts';
 import type { GithubRepository } from '#deployments/adapters/github-repo.ts';
@@ -24,9 +30,30 @@ export interface Movable {
   readonly key: string;
   /** Where it goes in the repository. */
   readonly path: string;
-  readonly area: 'memory' | 'skills';
+  readonly area: KnowledgeArea;
   readonly data: Uint8Array;
 }
+
+/**
+ * Where each area lives locally, as one table.
+ *
+ * Two of the three are prefixes inside the profile's blob root and the third is
+ * a store of its own, and that asymmetry was written out three times before —
+ * once per direction — which is three places to forget a fourth area. Stating
+ * it once means `localContents`, `removeLocal` and `moveOut` each became a loop
+ * over this rather than a branch on a literal.
+ */
+type LocalArea = { readonly store: BlobStore; readonly prefix: string };
+
+function localAreas(storage: BlobStore, skills: BlobStore): Record<KnowledgeArea, LocalArea> {
+  return {
+    memory: { store: storage, prefix: `${KNOWLEDGE_LAYOUT.memory}/` },
+    skills: { store: skills, prefix: '' },
+    entities: { store: storage, prefix: `${KNOWLEDGE_LAYOUT.entities}/` },
+  };
+}
+
+const AREAS = ['memory', 'skills', 'entities'] as const;
 
 /**
  * Everything this profile has stored locally, ready to move.
@@ -42,30 +69,19 @@ export async function localContents(
   skills: BlobStore,
   knowledge: KnowledgeConfig,
 ): Promise<Movable[]> {
+  const areas = localAreas(storage, skills);
   const found: Movable[] = [];
-  const prefix = `${KNOWLEDGE_LAYOUT.memory}/`;
 
-  for (const entry of await storage.list(prefix)) {
-    const data = await storage.get(entry.key);
-    if (data === null) continue; // Listed then deleted; not worth failing over.
-    const key = entry.key.slice(prefix.length);
-    found.push({
-      key,
-      area: 'memory',
-      path: `${knowledgeRoot(knowledge, 'memory')}/${key}`,
-      data,
-    });
-  }
+  for (const area of AREAS) {
+    const { store, prefix } = areas[area];
 
-  for (const entry of await skills.list()) {
-    const data = await skills.get(entry.key);
-    if (data === null) continue;
-    found.push({
-      key: entry.key,
-      area: 'skills',
-      path: `${knowledgeRoot(knowledge, 'skills')}/${entry.key}`,
-      data,
-    });
+    for (const entry of await store.list(prefix)) {
+      const data = await store.get(entry.key);
+      if (data === null) continue; // Listed then deleted; not worth failing over.
+
+      const key = entry.key.slice(prefix.length);
+      found.push({ key, area, path: `${knowledgeRoot(knowledge, area)}/${key}`, data });
+    }
   }
 
   return found;
@@ -115,9 +131,11 @@ export async function removeLocal(
   skills: BlobStore,
   movable: readonly Movable[],
 ): Promise<void> {
+  const areas = localAreas(storage, skills);
+
   for (const item of movable) {
-    if (item.area === 'memory') await storage.delete(`${KNOWLEDGE_LAYOUT.memory}/${item.key}`);
-    else await skills.delete(item.key);
+    const { store, prefix } = areas[item.area];
+    await store.delete(`${prefix}${item.key}`);
   }
 }
 
@@ -135,24 +153,19 @@ export async function moveOut(
   knowledge: KnowledgeConfig,
   storage: BlobStore,
   skills: BlobStore,
-): Promise<{ memory: number; skills: number }> {
+): Promise<Record<KnowledgeArea, number>> {
   const { entries } = await repository.entries();
-  const roots = {
-    memory: `${knowledgeRoot(knowledge, 'memory')}/`,
-    skills: `${knowledgeRoot(knowledge, 'skills')}/`,
-  } as const;
-
-  const counts = { memory: 0, skills: 0 };
+  const areas = localAreas(storage, skills);
+  const counts: Record<KnowledgeArea, number> = { memory: 0, skills: 0, entities: 0 };
 
   for (const entry of entries.values()) {
-    for (const area of ['memory', 'skills'] as const) {
-      if (!entry.path.startsWith(roots[area])) continue;
+    for (const area of AREAS) {
+      const root = `${knowledgeRoot(knowledge, area)}/`;
+      if (!entry.path.startsWith(root)) continue;
 
-      const key = entry.path.slice(roots[area].length);
-      const data = await repository.blob(entry.sha);
-
-      if (area === 'memory') await storage.put(`${KNOWLEDGE_LAYOUT.memory}/${key}`, data);
-      else await skills.put(key, data);
+      const key = entry.path.slice(root.length);
+      const { store, prefix } = areas[area];
+      await store.put(`${prefix}${key}`, await repository.blob(entry.sha));
 
       counts[area] += 1;
     }
@@ -161,14 +174,19 @@ export async function moveOut(
   return counts;
 }
 
-/** `12 skills and 47 memory entries`, or whichever half of that is non-zero. */
+/** `12 skills and 47 memory entries`, or whichever parts of that are non-zero. */
 export function summarise(movable: readonly Movable[]): string {
-  const skills = movable.filter((item) => item.area === 'skills').length;
-  const memory = movable.length - skills;
+  const count = (area: KnowledgeArea) => movable.filter((item) => item.area === area).length;
+  const skills = count('skills');
+  const memory = count('memory');
+  const entities = count('entities');
 
+  // Skills and memory keep their existing wording and their existing order: a
+  // third clause is an addition to this sentence, not a rewrite of it.
   const parts = [
     ...(skills > 0 ? [`${skills} skill${skills === 1 ? '' : 's'}`] : []),
     ...(memory > 0 ? [`${memory} memory entr${memory === 1 ? 'y' : 'ies'}`] : []),
+    ...(entities > 0 ? [`${entities} entit${entities === 1 ? 'y' : 'ies'}`] : []),
   ];
   return parts.length === 0 ? 'nothing' : parts.join(' and ');
 }

--- a/src/cli/commands/owner.test.ts
+++ b/src/cli/commands/owner.test.ts
@@ -4,14 +4,16 @@ import { mkdtemp, mkdir, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { parseConfig } from '#profile';
-import { assetStorage, memoryStorage, taskStorage } from '#providers/owner.ts';
+import { assetStorage, entityStorage, memoryStorage, taskStorage } from '#providers/owner.ts';
 import { openRuntime, ownerPrincipal } from '../runtime.ts';
 import { memoryStore, ownerConnection } from './owner.ts';
 import { tasksStore } from './owner/tasks.ts';
 import { assetsStore } from './owner/assets.ts';
+import { entitiesStore } from './owner/entities.ts';
+import { openCatalogue } from '#providers/entities/catalogue.ts';
 
 /**
- * `lanes link memory` / `tasks` / `assets` / `skills` / `vault`.
+ * `lanes link memory` / `tasks` / `assets` / `skills` / `vault` / `entities`.
  *
  * The property worth a test is not the printing — it is that these commands and
  * the providers address the **same bytes**. A control plane that writes its own
@@ -41,6 +43,7 @@ connections:
   - { id: owner, provider: assets, account: Assets }
   - { id: owner, provider: skills, account: Skills }
   - { id: owner, provider: vault,  account: Vault }
+  - { id: owner, provider: entities, account: Entities }
 
 policy:
   allow: ['*']
@@ -65,6 +68,72 @@ afterAll(async () => {
 });
 
 describe('the CLI and the provider address the same bytes', () => {
+  test('an entity written the CLI way is what entities.find returns', async () => {
+    await workspace();
+    const runtime = await openRuntime({ profile: 'personal', target: 'local' });
+
+    try {
+      const store = entitiesStore(runtime, {});
+      await entityStorage.write(store, {
+        id: 'jan-bakker',
+        type: 'person',
+        name: 'Jan Bakker',
+        aliases: ['Jan'],
+        tags: [],
+        attributes: [{ kind: 'email', value: 'jan@acme.test' }],
+        relations: [],
+        updatedAt: new Date(0).toISOString(),
+        body: '',
+        bytes: 0,
+      });
+
+      const outcome = await runtime.dispatcher.invoke({
+        principal: ownerPrincipal('personal'),
+        capabilityId: 'entities.find',
+        connectionKey: 'entities.owner',
+        arguments: { query: 'Jan' },
+      });
+
+      expect(outcome.ok).toBe(true);
+      expect(JSON.stringify(outcome)).toContain('jan@acme.test');
+    } finally {
+      await runtime.close();
+    }
+  });
+
+  test('an entity written by entities.write is what the CLI reads, index and all', async () => {
+    await workspace();
+    const runtime = await openRuntime({ profile: 'personal', target: 'local' });
+
+    try {
+      await runtime.dispatcher.invoke({
+        principal: ownerPrincipal('personal'),
+        capabilityId: 'entities.write',
+        connectionKey: 'entities.owner',
+        arguments: {
+          name: 'Acme B.V.',
+          id: 'acme-bv',
+          type: 'company',
+          attributes: [{ kind: 'domain', value: 'acme.test' }],
+        },
+      });
+
+      const store = entitiesStore(runtime, {});
+      const entity = await entityStorage.read(store, 'acme-bv');
+      expect(entity?.name).toBe('Acme B.V.');
+      expect(entity?.attributes[0]?.value).toBe('acme.test');
+
+      // The derived index matters as much as the document here: a CLI that read
+      // the files but not `_index.json`, or a provider that wrote one the CLI
+      // could not read, would work until the two disagreed about who exists.
+      const catalogue = await openCatalogue(store);
+      expect(catalogue.fromIndex).toBe(true);
+      expect(catalogue.byId.get('acme-bv')?.type).toBe('company');
+    } finally {
+      await runtime.close();
+    }
+  });
+
   test('an entry written the CLI way is what memory.get returns', async () => {
     await workspace();
     const runtime = await openRuntime({ profile: 'personal', target: 'local' });

--- a/src/cli/commands/owner.ts
+++ b/src/cli/commands/owner.ts
@@ -1,6 +1,6 @@
 /**
- * `lanes link memory`, `tasks`, `assets`, `skills`, `vault` — the owner layer's
- * control plane.
+ * `lanes link memory`, `tasks`, `assets`, `skills`, `vault`, `entities` — the
+ * owner layer's control plane.
  *
  * The layer shipped in M4 with no CLI at all, so the two stores holding the
  * owner's *own* data were reachable only by an agent, and the one thing that
@@ -22,7 +22,7 @@
  * MCP because ADR-014 §1 decided a policy-gated grant beats a missing path.
  *
  * One noun per file — `memory.ts`, `tasks.ts`, `assets.ts`, `skills.ts`,
- * `vault.ts` — over the shape they all share in `shared.ts`: the flag type, the
+ * `vault.ts`, `entities.ts` — over the shape they all share in `shared.ts`: the flag type, the
  * open-announce-act-close wrapper, connection resolution, and the two prompts.
  */
 
@@ -39,6 +39,16 @@ export { tasksAdd, tasksGet, tasksList, tasksRemove, tasksUpdate } from './owner
 export { assetsAdd, assetsGet, assetsList, assetsRemove } from './owner/assets.ts';
 
 export { skillsAdd, skillsList, skillsRemove, skillsShow } from './owner/skills.ts';
+
+export {
+  entitiesFind,
+  entitiesForget,
+  entitiesGet,
+  entitiesLink,
+  entitiesReindex,
+  entitiesStore,
+  entitiesWrite,
+} from './owner/entities.ts';
 
 export {
   vaultGet,

--- a/src/cli/commands/owner/entities.test.ts
+++ b/src/cli/commands/owner/entities.test.ts
@@ -1,0 +1,156 @@
+import { afterAll, describe, expect, test } from 'bun:test';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { createProfile } from '../profile.ts';
+import { entitiesFind, entitiesForget, entitiesLink, entitiesWrite } from './entities.ts';
+
+/**
+ * `lanes link entities`, through what it actually prints.
+ *
+ * These exist because of a bug that no other kind of test would have caught.
+ * `warn` is a *formatter* — it returns a string, like `ok` — and calling it as
+ * a bare statement type-checks, runs, and silently prints nothing. Both places
+ * this command warns were written that way, so `forget` removed an entity that
+ * three others pointed at and said nothing about it, and `link` accepted an
+ * edge to an undeclared id in silence.
+ *
+ * Both of those warnings are the *entire* mitigation for a deliberate design
+ * choice: `forget` does not cascade, and a dangling edge is legal. A warning
+ * that does not print turns "we tell you so you can decide" into "it happens
+ * and you find out later", which is a different product.
+ *
+ * So what is asserted here is output, not return values. The unit tests in
+ * `#providers/entities` cover the behaviour; this covers whether a person is
+ * told about it.
+ */
+
+const WHERE = { profile: 'personal', target: 'local' } as const;
+
+const roots: string[] = [];
+const previousHome = process.env['LANES_LINK_HOME'];
+
+/**
+ * Pretend stdin is a terminal, which is the "no notes were piped" branch.
+ *
+ * `optionalStdin` reads `Bun.stdin.text()` when stdin is not a TTY, and under
+ * `bun test` stdin is neither a TTY nor ever closed — so the read never
+ * resolves and every test after the first hangs. Flipping the flag takes the
+ * branch these tests mean: `entities write` with its notes left out.
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const previousTty = (process.stdin as any).isTTY;
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+(process.stdin as any).isTTY = true;
+
+async function workspace(): Promise<string> {
+  const root = await mkdtemp(join(tmpdir(), 'lanes-link-entities-'));
+  roots.push(root);
+  process.env['LANES_LINK_HOME'] = root;
+  await createProfile('personal', { targets: ['local'] });
+  return root;
+}
+
+afterAll(async () => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (process.stdin as any).isTTY = previousTty;
+  if (previousHome === undefined) delete process.env['LANES_LINK_HOME'];
+  else process.env['LANES_LINK_HOME'] = previousHome;
+  await Promise.all(roots.map((root) => rm(root, { recursive: true, force: true })));
+});
+
+/** Everything written to stdout while `body` runs. */
+async function captureStdout(body: () => Promise<void>): Promise<string> {
+  const original = process.stdout.write.bind(process.stdout);
+  let captured = '';
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (process.stdout as any).write = (chunk: string | Uint8Array): boolean => {
+    captured += typeof chunk === 'string' ? chunk : new TextDecoder().decode(chunk);
+    return true;
+  };
+
+  try {
+    await body();
+  } finally {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (process.stdout as any).write = original;
+  }
+
+  return captured;
+}
+
+async function declareTwo(): Promise<void> {
+  await captureStdout(() =>
+    entitiesWrite('Acme B.V.', { ...WHERE, name: 'acme-bv', type: 'company' }),
+  );
+  await captureStdout(() =>
+    entitiesWrite('Jan Bakker', {
+      ...WHERE,
+      type: 'person',
+      alias: ['Jan'],
+      attr: ['email=jan@acme.test'],
+      related: ['works_at=acme-bv'],
+    }),
+  );
+}
+
+describe('what the command tells the person', () => {
+  test('forget says who still points at what it removed', async () => {
+    await workspace();
+    await declareTwo();
+
+    const output = await captureStdout(() => entitiesForget('acme-bv', { ...WHERE, yes: true }));
+
+    // The whole mitigation for not cascading. Without it, an entity vanishes
+    // and three other files quietly point at nothing.
+    expect(output).toContain('still referenced by jan-bakker');
+    expect(output).toContain('removed entity');
+  });
+
+  test('link says when the other end is not declared yet', async () => {
+    await workspace();
+    await declareTwo();
+
+    const output = await captureStdout(() =>
+      entitiesLink('jan-bakker', 'knows=nobody-yet', { ...WHERE }),
+    );
+
+    // Legal and kept — a name written before the person is — but silence here
+    // makes a typo in an id indistinguishable from a deliberate forward
+    // reference.
+    expect(output).toContain('not declared yet');
+  });
+
+  test('a listing of several says the order is not a ranking', async () => {
+    await workspace();
+    await declareTwo();
+    await captureStdout(() =>
+      entitiesWrite('Jan de Vries', { ...WHERE, type: 'person', alias: ['Jan'] }),
+    );
+
+    const output = await captureStdout(() => entitiesFind('Jan', { ...WHERE }));
+
+    expect(output).toContain('jan-bakker');
+    expect(output).toContain('jan-de-vries');
+    expect(output).toContain('the order is not a ranking');
+  });
+
+  test('one match does not claim to be a choice between several', async () => {
+    await workspace();
+    await declareTwo();
+
+    const output = await captureStdout(() => entitiesFind('Jan', { ...WHERE }));
+
+    expect(output).toContain('jan-bakker');
+    expect(output).not.toContain('the order is not a ranking');
+  });
+
+  test('an empty profile says how to declare the first one', async () => {
+    await workspace();
+
+    const output = await captureStdout(() => entitiesFind(undefined, { ...WHERE }));
+
+    expect(output).toContain('lanes link entities write');
+  });
+});

--- a/src/cli/commands/owner/entities.ts
+++ b/src/cli/commands/owner/entities.ts
@@ -7,6 +7,7 @@ import {
   rebuildCatalogue,
   writeCatalogue,
 } from '#providers/entities/catalogue.ts';
+import { forgetEntity, persistEntity } from '#providers/entities/writes.ts';
 import { matchEntities, type Criteria } from '#providers/entities/find.ts';
 import { describe, renderEntity } from '#providers/entities/render.ts';
 import { entityStorage, type Attribute, type Entity, type Relation } from '#providers/owner.ts';
@@ -144,7 +145,7 @@ export async function entitiesWrite(name: string | undefined, flags: OwnerFlags)
       bytes: 0,
     };
 
-    await persist(store, next);
+    await persistEntity(store, next);
     print(ok(`${existing ? 'updated' : 'declared'} entity ${style.bold(id)}`));
   });
 }
@@ -171,7 +172,7 @@ export async function entitiesLink(
       return;
     }
 
-    await persist(store, {
+    await persistEntity(store, {
       ...entity,
       relations: [...entity.relations, { predicate, entity: to }],
       updatedAt: new Date().toISOString(),
@@ -202,10 +203,7 @@ export async function entitiesForget(id: string | undefined, flags: OwnerFlags):
     }
     if (!(await agreed(flags, 'Remove this entity?'))) return;
 
-    await store.delete(entityStorage.key(entityId));
-    const remaining = catalogue.entities.filter((one) => one.id !== entityId);
-    const rebuilt = await rebuildCatalogue(store);
-    await writeCatalogue(store, remaining, rebuilt.fingerprint, new Date().toISOString());
+    await forgetEntity(store, catalogue, entityId, new Date().toISOString());
 
     print(ok(`removed entity ${style.bold(entityId)}`));
   });
@@ -232,13 +230,6 @@ export async function entitiesReindex(flags: OwnerFlags): Promise<void> {
     await writeCatalogue(store, catalogue.entities, catalogue.fingerprint, new Date().toISOString());
     print(ok(`rebuilt the index over ${catalogue.entities.length} entities — ${before.reason}`));
   });
-}
-
-/** Write one entity and leave the index describing what is now there. */
-async function persist(store: BlobStore, entity: Entity): Promise<void> {
-  await entityStorage.write(store, entity);
-  const rebuilt = await rebuildCatalogue(store);
-  await writeCatalogue(store, rebuilt.entities, rebuilt.fingerprint, entity.updatedAt);
 }
 
 /**

--- a/src/cli/commands/owner/entities.ts
+++ b/src/cli/commands/owner/entities.ts
@@ -1,0 +1,253 @@
+import { ConfigError } from '#profile';
+import { scopeNamespace } from '#dispatch';
+import { scopeBlobStore, type BlobStore } from '#stores/blobs';
+import {
+  indexState,
+  openCatalogue,
+  rebuildCatalogue,
+  writeCatalogue,
+} from '#providers/entities/catalogue.ts';
+import { matchEntities, type Criteria } from '#providers/entities/find.ts';
+import { describe, renderEntity } from '#providers/entities/render.ts';
+import { entityStorage, type Attribute, type Entity, type Relation } from '#providers/owner.ts';
+import { heading, ok, print, style, table, warn } from '../../output.ts';
+import type { Runtime } from '../../runtime.ts';
+import { agreed, optionalStdin, ownerConnection, required, withRuntime, type OwnerFlags } from './shared.ts';
+
+/**
+ * `lanes link entities` — who and what everyone else is.
+ *
+ * Reaches the same bytes the provider does, through the same two scoping
+ * functions and the same `entityStorage`, `catalogue` and `find` modules. Two
+ * spellings of one layout is how a control plane and its data plane drift
+ * apart, and here it would drift in a way nothing would notice: a CLI that
+ * wrote entity files without maintaining `_index.json` would leave every write
+ * costing the next reader a full rebuild.
+ */
+
+/** `--attr email=jan@example.test`, or `--attr github` for "has one at all". */
+function parseAttr(given: string): { kind: string; value?: string } {
+  const at = given.indexOf('=');
+  if (at === -1) return { kind: given.trim() };
+  return { kind: given.slice(0, at).trim(), value: given.slice(at + 1).trim() };
+}
+
+/** `--related works_at=acme-bv`, or `--related acme-bv` for any predicate. */
+function parseRelated(given: string): { predicate?: string; entity: string } {
+  const at = given.indexOf('=');
+  if (at === -1) return { entity: given.trim() };
+  return { predicate: given.slice(0, at).trim(), entity: given.slice(at + 1).trim() };
+}
+
+function criteriaFrom(query: string | undefined, flags: OwnerFlags): Criteria {
+  return {
+    query,
+    type: flags.type,
+    tag: flags.tag,
+    attr: flags.attr?.map(parseAttr),
+    related: flags.related?.map(parseRelated),
+    limit: 50,
+  };
+}
+
+export async function entitiesFind(query: string | undefined, flags: OwnerFlags): Promise<void> {
+  await withRuntime(flags, async (runtime) => {
+    const store = entitiesStore(runtime, flags);
+    const catalogue = await openCatalogue(store);
+    const criteria = criteriaFrom(query, flags);
+    const matches = matchEntities(catalogue, criteria);
+
+    if (matches.candidates.length === 0) {
+      heading('Entities (0)');
+      print(
+        style.dim(
+          catalogue.entities.length === 0
+            ? '  none — declare one with: lanes link entities write <name>'
+            : `  nothing matches ${describe(criteria)}`,
+        ),
+      );
+      return;
+    }
+
+    heading(`Entities (${matches.total})`);
+    table(
+      matches.candidates.map((candidate) => [
+        `  ${candidate.entity.id}`,
+        candidate.entity.name,
+        candidate.entity.type ? style.dim(candidate.entity.type) : '',
+        style.dim(candidate.entity.updatedAt.slice(0, 10)),
+      ]),
+    );
+
+    // The same sentence the tool result carries, for the same reason: the list
+    // is not a ranking, and the person reading it is about to pick from it.
+    if (matches.candidates.length > 1 && query !== undefined) {
+      print('');
+      print(style.dim('  more than one matches — the order is not a ranking'));
+    }
+  });
+}
+
+export async function entitiesGet(id: string | undefined, flags: OwnerFlags): Promise<void> {
+  const entityId = required(id, 'lanes link entities get <id>');
+
+  await withRuntime(flags, async (runtime) => {
+    const store = entitiesStore(runtime, flags);
+    const entity = await entityStorage.read(store, entityId);
+    if (!entity) throw new ConfigError(`No entity "${entityId}" in this profile.`);
+
+    const catalogue = await openCatalogue(store);
+    print('');
+    print(renderEntity(entity, catalogue, entity.body));
+  });
+}
+
+export async function entitiesWrite(name: string | undefined, flags: OwnerFlags): Promise<void> {
+  const given = required(name, 'lanes link entities write <name> [--type person] [--attr email=…]');
+  // Optional rather than required: an entity legitimately has no prose, and
+  // refusing an empty pipe would break every scripted invocation.
+  const notes = await optionalStdin();
+
+  await withRuntime(flags, async (runtime) => {
+    const store = entitiesStore(runtime, flags);
+    const id = flags.name ?? entityStorage.slugify(given);
+    const existing = await entityStorage.read(store, id);
+
+    const attributes = flags.attr?.map((one) => {
+      const { kind, value } = parseAttr(one);
+      if (value === undefined) {
+        throw new ConfigError(`--attr ${one} needs a value here: --attr ${kind}=<value>`);
+      }
+      return { kind, value } satisfies Attribute;
+    });
+
+    const relations = flags.related?.map((one) => {
+      const { predicate, entity } = parseRelated(one);
+      if (predicate === undefined) {
+        throw new ConfigError(`--related ${one} needs a predicate: --related <predicate>=${entity}`);
+      }
+      return { predicate, entity } satisfies Relation;
+    });
+
+    // A flag that was not passed keeps what is on disk, exactly as the tool
+    // does — `entities write` is how a person corrects one field.
+    const next: Entity = {
+      id,
+      name: given,
+      type: flags.type ?? existing?.type ?? '',
+      aliases: flags.alias ?? existing?.aliases ?? [],
+      tags: flags.tag ? [flags.tag] : (existing?.tags ?? []),
+      attributes: attributes ?? existing?.attributes ?? [],
+      relations: relations ?? existing?.relations ?? [],
+      updatedAt: new Date().toISOString(),
+      body: notes ?? existing?.body ?? '',
+      bytes: 0,
+    };
+
+    await persist(store, next);
+    print(ok(`${existing ? 'updated' : 'declared'} entity ${style.bold(id)}`));
+  });
+}
+
+export async function entitiesLink(
+  from: string | undefined,
+  edge: string | undefined,
+  flags: OwnerFlags,
+): Promise<void> {
+  const usage = 'lanes link entities link <from> <predicate>=<to>';
+  const given = required(from, usage);
+  const { predicate, entity: to } = parseRelated(required(edge, usage));
+  if (predicate === undefined) {
+    throw new ConfigError(`"${edge}" needs a predicate — ${usage}`);
+  }
+
+  await withRuntime(flags, async (runtime) => {
+    const store = entitiesStore(runtime, flags);
+    const entity = await entityStorage.read(store, given);
+    if (!entity) throw new ConfigError(`No entity "${given}" in this profile.`);
+
+    if (entity.relations.some((one) => one.predicate === predicate && one.entity === to)) {
+      print(style.dim(`  ${given} already ${predicate} ${to}`));
+      return;
+    }
+
+    await persist(store, {
+      ...entity,
+      relations: [...entity.relations, { predicate, entity: to }],
+      updatedAt: new Date().toISOString(),
+    });
+
+    const catalogue = await openCatalogue(store);
+    print(ok(`${style.bold(given)} ${predicate} ${style.bold(to)}`));
+    if (!catalogue.byId.has(to)) print(warn(`"${to}" is not declared yet — the edge is kept as written`));
+  });
+}
+
+export async function entitiesForget(id: string | undefined, flags: OwnerFlags): Promise<void> {
+  const entityId = required(id, 'lanes link entities forget <id>');
+
+  await withRuntime(flags, async (runtime) => {
+    const store = entitiesStore(runtime, flags);
+    const catalogue = await openCatalogue(store);
+    const entity = catalogue.byId.get(entityId);
+    if (!entity) throw new ConfigError(`No entity "${entityId}" in this profile.`);
+
+    const referencedBy = (catalogue.backlinks.get(entityId) ?? []).map((one) => one.from);
+
+    print(`  ${style.bold(entity.id)}  ${entity.name}`);
+    // Said before the prompt rather than after the delete: this is the fact
+    // that should change the answer, and `forget` deliberately does not cascade.
+    if (referencedBy.length > 0) {
+      print(warn(`still referenced by ${referencedBy.join(', ')} — those edges will dangle`));
+    }
+    if (!(await agreed(flags, 'Remove this entity?'))) return;
+
+    await store.delete(entityStorage.key(entityId));
+    const remaining = catalogue.entities.filter((one) => one.id !== entityId);
+    const rebuilt = await rebuildCatalogue(store);
+    await writeCatalogue(store, remaining, rebuilt.fingerprint, new Date().toISOString());
+
+    print(ok(`removed entity ${style.bold(entityId)}`));
+  });
+}
+
+/**
+ * Rebuild `_index.json` from the files, and say why it needed it.
+ *
+ * The index self-heals on the next write, so this exists for the case a write
+ * is not coming: a bulk edit made in an editor or pulled from a knowledge
+ * repository, where the next read would otherwise pay a full scan every time.
+ */
+export async function entitiesReindex(flags: OwnerFlags): Promise<void> {
+  await withRuntime(flags, async (runtime) => {
+    const store = entitiesStore(runtime, flags);
+    const before = await indexState(store);
+
+    if (before.current) {
+      print(style.dim(`  index is already current — ${before.reason}`));
+      return;
+    }
+
+    const catalogue = await rebuildCatalogue(store);
+    await writeCatalogue(store, catalogue.entities, catalogue.fingerprint, new Date().toISOString());
+    print(ok(`rebuilt the index over ${catalogue.entities.length} entities — ${before.reason}`));
+  });
+}
+
+/** Write one entity and leave the index describing what is now there. */
+async function persist(store: BlobStore, entity: Entity): Promise<void> {
+  await entityStorage.write(store, entity);
+  const rebuilt = await rebuildCatalogue(store);
+  await writeCatalogue(store, rebuilt.entities, rebuilt.fingerprint, entity.updatedAt);
+}
+
+/**
+ * The blob namespace core would scope this provider to.
+ *
+ * The same two functions `buildProviderContext` uses, for the reason
+ * `memoryStore` gives: a path spelled out again is a path that can differ.
+ */
+export function entitiesStore(runtime: Runtime, flags: OwnerFlags): BlobStore {
+  const connection = ownerConnection(runtime.config, 'entities', flags);
+  return scopeBlobStore(runtime.storage, scopeNamespace('entities', connection));
+}

--- a/src/cli/commands/owner/shared.ts
+++ b/src/cli/commands/owner/shared.ts
@@ -26,6 +26,20 @@ export interface OwnerFlags extends GlobalFlags {
   readonly name?: string | undefined;
   /** `assets`: for the file whose extension does not say what it is. */
   readonly contentType?: string | undefined;
+  /** `entities`: person, company, project — free-form, never a closed list. */
+  readonly type?: string | undefined;
+  /**
+   * `entities`: repeatable, which is why `ownerFlags` needs argv.
+   *
+   * `parseArgv` keeps only the last value of a repeated flag, and an entity
+   * with two email addresses is the case this whole component exists for — so
+   * these three read the raw argv through `all()`, as `customFlags` does.
+   */
+  readonly alias?: readonly string[] | undefined;
+  /** `entities`: `email=jan@example.test`, or `github` to mean "has one". */
+  readonly attr?: readonly string[] | undefined;
+  /** `entities`: `works_at=acme-bv`, or `acme-bv` for any predicate. */
+  readonly related?: readonly string[] | undefined;
   /** Reveal a vault value on a terminal. */
   readonly show?: boolean | undefined;
   /** Print only the value, for `$(…)`. */

--- a/src/cli/config-edit.test.ts
+++ b/src/cli/config-edit.test.ts
@@ -552,7 +552,7 @@ policy:
   deny: []
 `;
 
-  test('all six arrive, both halves each, in the order the template writes', async () => {
+  test('all seven arrive, both halves each, in the order the template writes', async () => {
     const { root } = await profileFile(OLD);
 
     const document = await ConfigDocument.open(root, 'personal');
@@ -566,12 +566,14 @@ policy:
       'connections += skills.main',
       'connections += vault.main',
       'connections += setup.main',
+      'connections += entities.main',
       'policy.allow += memory.*',
       'policy.allow += tasks.*',
       'policy.allow += assets.*',
       'policy.allow += skills.*',
       'policy.allow += vault.*',
       'policy.allow += setup.*',
+      'policy.allow += entities.*',
     ]);
   });
 
@@ -662,6 +664,6 @@ policy:
     const added = repairLines(ensureOwnerLayer(document));
 
     expect(added.filter((line) => line.startsWith('policy.allow'))).toEqual([]);
-    expect(added).toHaveLength(6);
+    expect(added).toHaveLength(7);
   });
 });

--- a/src/cli/config-edit.ts
+++ b/src/cli/config-edit.ts
@@ -282,7 +282,7 @@ oauth_apps: {}
 # reports — an address, a workspace — so this list says whose data is reachable
 # without having to look anything up.
 #
-# The six below hold no account, and that is why they are here already: they
+# The seven below hold no account, and that is why they are here already: they
 # reach your own material rather than anybody's API, so there was never anything
 # for a connect step to authorise (ADR-050). What each one is:
 #
@@ -292,6 +292,9 @@ oauth_apps: {}
 #   skills   procedures you have written, handed to an agent as instructions
 #   vault    passwords and API keys, released one at a time
 #   setup    what is connected here, and what connecting more would take
+#   entities the people, companies and projects you deal with, and how to
+#            reach each of them — so an agent looks an address up rather
+#            than recalling one
 #
 # Nothing is stored in any of them until you or an agent puts something there,
 # and none of them can read an account. To switch one off, deny it below —
@@ -304,6 +307,7 @@ connections:
   - { id: main, provider: skills, account: Skills }
   - { id: main, provider: vault, account: Vault }
   - { id: main, provider: setup, account: Setup }
+  - { id: main, provider: entities, account: Entities }
 
 # Only what is listed here is reachable, and an empty policy grants nothing.
 #
@@ -317,19 +321,25 @@ connections:
 #   allow: [notion.*, gmail.*]    two providers
 #   deny:  [gmail.send_message]   a deny always beats an allow
 #
-# The rules below grant each of the six its whole namespace, writes included —
+# The rules below grant each of the seven its whole namespace, writes included —
 # the same thing "connect memory" wrote when it was a command you had to run.
 # Narrowing is one line, and these are the three worth knowing:
 #
-#   deny: [memory.write]          memory becomes read-only
-#   deny: [skills.manage.*]       skills can be invoked but not authored
-#   deny: [vault.put, vault.remove]   nothing new can be stored
+#   deny: [memory.write, memory.forget]   memory becomes read-only
+#   deny: [skills.manage.*]               skills can be invoked but not authored
+#   deny: [vault.put, vault.remove]       nothing new can be stored
+#   deny: [entities.write, entities.link, entities.forget]
+#                                         entities becomes read-only
+#
+# Those lists are exhaustive on purpose: a namespace is read-only only when
+# every capability that changes something is named, so "deny: [memory.write]"
+# alone leaves "memory.forget" granted.
 #
 # A vault read is not granted by "vault.*" alone: each stored item is its own
 # "vault.get.<id>" capability and only appears after a restart, so a write can
 # never hand itself a read (ADR-012).
 policy:
-  allow: [memory.*, tasks.*, assets.*, skills.*, vault.*, setup.*]
+  allow: [memory.*, tasks.*, assets.*, skills.*, vault.*, setup.*, entities.*]
   deny: []
 `;
 }

--- a/src/cli/config-repair.ts
+++ b/src/cli/config-repair.ts
@@ -49,7 +49,7 @@ type ReservedSurface = keyof typeof RESERVED_SURFACES;
  * configuration, changed in the CLI under ADR-007, so a surface that reported
  * an empty one could never do anything about it. Entities accumulate on the
  * same surface that reads them, so an empty one is a store waiting to be used
- * rather than a tool with nothing to say (ADR-055).
+ * rather than a tool with nothing to say (ADR-056).
  *
  * Ordered as `RESERVED_PROVIDER_IDS` is, so a repair reports in the order the
  * template writes and a diff between the two reads as a diff.

--- a/src/cli/config-repair.ts
+++ b/src/cli/config-repair.ts
@@ -27,6 +27,7 @@ const RESERVED_SURFACES = {
   vault: 'Vault',
   setup: 'Setup',
   identity: 'Identity',
+  entities: 'Entities',
 } as const;
 
 type ReservedSurface = keyof typeof RESERVED_SURFACES;
@@ -42,6 +43,14 @@ type ReservedSurface = keyof typeof RESERVED_SURFACES;
  * which is ADR-050's whole argument — so a profile written before those existed
  * gets them on the next command rather than needing five of its own.
  *
+ * `entities` is on the list and `identity` is not, which reads as inconsistent
+ * until the test is stated exactly. It is not "is it empty" — memory arrives
+ * empty and is granted. It is **can it be filled in from here**: identity is
+ * configuration, changed in the CLI under ADR-007, so a surface that reported
+ * an empty one could never do anything about it. Entities accumulate on the
+ * same surface that reads them, so an empty one is a store waiting to be used
+ * rather than a tool with nothing to say (ADR-055).
+ *
  * Ordered as `RESERVED_PROVIDER_IDS` is, so a repair reports in the order the
  * template writes and a diff between the two reads as a diff.
  */
@@ -52,6 +61,7 @@ export const DEFAULT_SURFACES: readonly ReservedSurface[] = [
   'skills',
   'vault',
   'setup',
+  'entities',
 ];
 
 /**

--- a/src/cli/dispatch-owner.ts
+++ b/src/cli/dispatch-owner.ts
@@ -3,6 +3,12 @@ import {
   assetsGet,
   assetsList,
   assetsRemove,
+  entitiesFind,
+  entitiesForget,
+  entitiesGet,
+  entitiesLink,
+  entitiesReindex,
+  entitiesWrite,
   memoryForget,
   memoryGet,
   memoryList,
@@ -25,7 +31,8 @@ import {
 } from './commands/owner.ts';
 
 /**
- * The commands over the owner's own data: memory, tasks, assets, skills, vault.
+ * The commands over the owner's own data: memory, tasks, assets, skills, vault,
+ * entities.
  *
  * Split out of `main.ts` for the reason the budget in `src/architecture.test.ts`
  * exists to find, rather than to satisfy a line count. These are one subject —
@@ -123,6 +130,28 @@ export function dispatchOwner(
           return vaultKeyGenerate(owner);
         default:
           throw new Error(`Unknown: ${program} vault ${second}`);
+      }
+
+    case 'entities':
+      switch (second) {
+        // Bare `entities` is a listing, which is `find` with no criteria — one
+        // name for one concept rather than a `list` that would be the same code
+        // under a second word.
+        case 'find':
+        case undefined:
+          return entitiesFind(rest[0], owner);
+        case 'get':
+          return entitiesGet(rest[0], owner);
+        case 'write':
+          return entitiesWrite(rest[0], owner);
+        case 'link':
+          return entitiesLink(rest[0], rest[1], owner);
+        case 'forget':
+          return entitiesForget(rest[0], owner);
+        case 'reindex':
+          return entitiesReindex(owner);
+        default:
+          throw new Error(`Unknown: ${program} entities ${second}`);
       }
 
     default:

--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -58,7 +58,7 @@ export async function run(argv: readonly string[]): Promise<void> {
   const [first, second, ...rest] = command;
 
   const global = globalFlags(flags);
-  const owner = ownerFlags(flags);
+  const owner = ownerFlags(flags, argv);
 
   const show = flags['show'] === true;
   const raw = flags['raw'] === true;
@@ -260,6 +260,7 @@ export async function run(argv: readonly string[]): Promise<void> {
     case 'assets':
     case 'skills':
     case 'vault':
+    case 'entities':
       return dispatchOwner(first, second, rest, owner, PROGRAM);
 
     // Beside `memory` and `skills` because it is the question they raise next:

--- a/src/cli/runtime/knowledge.test.ts
+++ b/src/cli/runtime/knowledge.test.ts
@@ -42,9 +42,11 @@ async function open(overrides: Record<string, unknown> = {}) {
   const stores = await knowledgeStores(repository, config);
 
   // Exactly what `openRuntime` builds: the profile's blob root with `memory/`
-  // routed away, and skills taken from the repository rather than the profile.
+  // and `entities/` routed away, and skills taken from the repository rather
+  // than the profile.
   const storage = routeBlobStore(createMemoryBlobStore(), [
     { prefix: `${KNOWLEDGE_LAYOUT.memory}/`, store: stores.memory },
+    { prefix: `${KNOWLEDGE_LAYOUT.entities}/`, store: stores.entities },
   ]);
 
   return { github, storage, skills: stores.skills };
@@ -62,6 +64,28 @@ describe('a profile whose knowledge is in a repository', () => {
     });
 
     expect(Object.keys(github.files())).toEqual(['memory/main/a-note.md']);
+  });
+
+  test('an entity and its derived index both land in the repository', async () => {
+    const { github, storage } = await open();
+
+    const provider = scopeBlobStore(storage, scopeNamespace('entities', 'main'));
+    await provider.put(
+      'jan-bakker.md',
+      new TextEncoder().encode('---\nname: Jan Bakker\n---\n\n'),
+      { contentType: 'text/markdown' },
+    );
+    await provider.put('_index.json', new TextEncoder().encode('{"v":1}'), {
+      contentType: 'application/json',
+    });
+
+    // The index travels with the documents because it is derived from what
+    // travels — the weaker half of ADR-055's argument, and worth pinning so it
+    // is a decision rather than an accident.
+    expect(Object.keys(github.files()).sort()).toEqual([
+      'entities/main/_index.json',
+      'entities/main/jan-bakker.md',
+    ]);
   });
 
   test('the CLI and the provider address the same object', async () => {
@@ -144,16 +168,37 @@ describe('reading what somebody typed', () => {
 });
 
 describe('the repository layout', () => {
-  test('is two directories, and a prefix moves both', () => {
+  test('is three directories, and a prefix moves all of them', () => {
     expect(knowledgeRoot(knowledge(), 'memory')).toBe('memory');
     expect(knowledgeRoot(knowledge(), 'skills')).toBe('skills');
+    expect(knowledgeRoot(knowledge(), 'entities')).toBe('entities');
     expect(knowledgeRoot(knowledge({ path: 'context' }), 'memory')).toBe('context/memory');
+    expect(knowledgeRoot(knowledge({ path: 'context' }), 'entities')).toBe('context/entities');
   });
 
-  test('the memory directory is the provider namespace that routes into it', () => {
+  test('a directory name is the provider namespace that routes into it', () => {
     // If these ever differ, a write goes to one place and a read looks in
     // another, and nothing fails — the entry is simply not there.
     expect(KNOWLEDGE_LAYOUT.memory).toBe('memory');
     expect(scopeNamespace('memory', 'main').startsWith(`${KNOWLEDGE_LAYOUT.memory}/`)).toBe(true);
+    expect(KNOWLEDGE_LAYOUT.entities).toBe('entities');
+    expect(scopeNamespace('entities', 'main').startsWith(`${KNOWLEDGE_LAYOUT.entities}/`)).toBe(
+      true,
+    );
+  });
+
+  test('what may move is still what a document is, and nothing else', () => {
+    // ADR-041's exclusion is structural — there is no field that could name the
+    // credential store or the vault — and ADR-055 adds none. Asserted here
+    // because "and nothing else may" is the sentence a third area looks like it
+    // weakened, and the thing that makes it still true is the absence of a key.
+    expect(Object.keys(KNOWLEDGE_LAYOUT).sort()).toEqual(['entities', 'memory', 'skills']);
+    expect(Object.keys(knowledgeTargetSchema.shape).sort()).toEqual([
+      'adapter',
+      'branch',
+      'path',
+      'repo',
+      'token_ref',
+    ]);
   });
 });

--- a/src/cli/runtime/knowledge.test.ts
+++ b/src/cli/runtime/knowledge.test.ts
@@ -80,7 +80,7 @@ describe('a profile whose knowledge is in a repository', () => {
     });
 
     // The index travels with the documents because it is derived from what
-    // travels — the weaker half of ADR-055's argument, and worth pinning so it
+    // travels — the weaker half of ADR-056's argument, and worth pinning so it
     // is a decision rather than an accident.
     expect(Object.keys(github.files()).sort()).toEqual([
       'entities/main/_index.json',
@@ -189,7 +189,7 @@ describe('the repository layout', () => {
 
   test('what may move is still what a document is, and nothing else', () => {
     // ADR-041's exclusion is structural — there is no field that could name the
-    // credential store or the vault — and ADR-055 adds none. Asserted here
+    // credential store or the vault — and ADR-056 adds none. Asserted here
     // because "and nothing else may" is the sentence a third area looks like it
     // weakened, and the thing that makes it still true is the absence of a key.
     expect(Object.keys(KNOWLEDGE_LAYOUT).sort()).toEqual(['entities', 'memory', 'skills']);

--- a/src/cli/runtime/open.ts
+++ b/src/cli/runtime/open.ts
@@ -6,7 +6,6 @@ import type { BlobStore } from '#stores/blobs';
 import type { AnyConnector, ProviderManifest } from '#connectivity';
 import { RateLimiter, allowedConnections } from '#policy';
 import {
-  KNOWLEDGE_LAYOUT,
   layout,
   listProfiles,
   workspacePath,
@@ -26,7 +25,7 @@ import {
   type StorageFactory,
   type TargetInput,
 } from '#deployments/target.ts';
-import { openKnowledge, type FetchLike, type KnowledgeStores } from '#deployments/knowledge.ts';
+import { knowledgeRoutes, openKnowledge, type FetchLike, type KnowledgeStores } from '#deployments/knowledge.ts';
 import { routeBlobStore } from '#stores/blobs/route.ts';
 import { connectorFactory } from '#connectivity/transports';
 import { requestAuthorizer } from '#connectivity/auth/index.ts';
@@ -174,15 +173,7 @@ export async function openRuntime(
   // The audit log, `state.kv`, the credential store and the vault keep their
   // own roots on the target's own storage and are untouched.
   const knowledge = await openKnowledge(adapters, credentials, options.fetch);
-  const storage = knowledge
-    ? routeBlobStore(storageFor(), [
-        { prefix: `${KNOWLEDGE_LAYOUT.memory}/`, store: knowledge.memory },
-        // The prefixes are disjoint and `routeBlobStore` already handles a list,
-        // so a third area is one element rather than a second mechanism — which
-        // is the evidence the seam above was cut in the right place.
-        { prefix: `${KNOWLEDGE_LAYOUT.entities}/`, store: knowledge.entities },
-      ])
-    : storageFor();
+  const storage = knowledge ? routeBlobStore(storageFor(), knowledgeRoutes(knowledge)) : storageFor();
   const state = openState(storageFor, config.instance.profile);
 
   // The durable log, plus any copies the target declares. `sink` is what

--- a/src/cli/runtime/open.ts
+++ b/src/cli/runtime/open.ts
@@ -175,7 +175,13 @@ export async function openRuntime(
   // own roots on the target's own storage and are untouched.
   const knowledge = await openKnowledge(adapters, credentials, options.fetch);
   const storage = knowledge
-    ? routeBlobStore(storageFor(), [{ prefix: `${KNOWLEDGE_LAYOUT.memory}/`, store: knowledge.memory }])
+    ? routeBlobStore(storageFor(), [
+        { prefix: `${KNOWLEDGE_LAYOUT.memory}/`, store: knowledge.memory },
+        // The prefixes are disjoint and `routeBlobStore` already handles a list,
+        // so a third area is one element rather than a second mechanism — which
+        // is the evidence the seam above was cut in the right place.
+        { prefix: `${KNOWLEDGE_LAYOUT.entities}/`, store: knowledge.entities },
+      ])
     : storageFor();
   const state = openState(storageFor, config.instance.profile);
 

--- a/src/cli/runtime/registry.ts
+++ b/src/cli/runtime/registry.ts
@@ -13,6 +13,7 @@ import {
   createSetupProvider,
   createSkillsProvider,
   createVaultProvider,
+  entitiesProvider,
   memoryProvider,
   tasksProvider,
   type IdentityProviderOptions,
@@ -87,7 +88,7 @@ export interface OwnerLayerOptions {
  * from, which is what lets workspace YAML register alongside these.
  *
  * `allowReserved` is what admits `memory`, `tasks`, `assets`, `skills`, `vault`,
- * `setup`, and `identity`. The guard
+ * `setup`, `identity` and `entities`. The guard
  * stays rather than being retired: it exists so a *third-party* provider cannot
  * claim a namespace whose policy rules would then silently mean something else,
  * and that reason survives the owner layer shipping. Only this one construction
@@ -104,6 +105,10 @@ export function buildRegistry(owner: OwnerLayerOptions = {}): ProviderRegistry {
   registry.register(memoryProvider);
   registry.register(tasksProvider);
   registry.register(assetsProvider);
+  // `entities` is a fourth of the same shape: what it holds is the owner's, and
+  // its derived index lives in the same scoped store, so there is nothing to
+  // hand in here either.
+  registry.register(entitiesProvider);
   registry.register(skillsProviderFor(owner));
   registry.register(
     createVaultProvider({

--- a/src/cli/selection.test.ts
+++ b/src/cli/selection.test.ts
@@ -388,6 +388,18 @@ describe('every command is runnable in the spelling it demands', () => {
     // either was refused on a command documented as taking it.
     expect(() => assertKnownFlags('memory', 'list', { tag: 'x' })).not.toThrow();
     expect(() => assertKnownFlags('mcp', 'list', { name: 'x', scope: 'user' })).not.toThrow();
+    // Three of these are repeatable and read from argv rather than from the
+    // parsed map, which is exactly the shape that gets left out of the
+    // allowlist because the parser never complained about it.
+    expect(() =>
+      assertKnownFlags('entities', 'write', {
+        type: 'person',
+        alias: 'JB',
+        attr: 'email=jan@example.test',
+        related: 'works_at=acme-bv',
+        name: 'jan-bakker',
+      }),
+    ).not.toThrow();
   });
 });
 
@@ -397,7 +409,7 @@ describe('the grammar is read wherever it lives', () => {
     // only read `main.ts` it would pass by not looking.
     const dispatched = await dispatchedCommands();
 
-    for (const command of ['memory get', 'skills add', 'vault key']) {
+    for (const command of ['memory get', 'skills add', 'vault key', 'entities find']) {
       expect(dispatched.has(command)).toBe(true);
     }
   });

--- a/src/cli/selection.ts
+++ b/src/cli/selection.ts
@@ -168,6 +168,7 @@ export const SELECTION: Record<string, Requires> = {
   assets: 'profile+target',
   skills: 'profile+target',
   vault: 'profile+target',
+  entities: 'profile+target',
   // Both halves open the target's adapters — `show` counts what is in the
   // stores, and `use` migrates between them — and both edit the profile's
   // config. Neither can be answered without being told which.
@@ -198,6 +199,9 @@ const SUBCOMMANDS: Record<string, readonly string[]> = {
   assets: ['list', 'get', 'add', 'remove'],
   skills: ['list', 'show', 'add', 'remove'],
   vault: ['list', 'get', 'set', 'remove', 'key'],
+  // No `list`: a bare `entities` is a listing, which is `find` with no
+  // criteria. One concept, one word.
+  entities: ['find', 'get', 'write', 'link', 'forget', 'reindex'],
   mcp: ['skill', 'add', 'stdio', 'list'],
   secrets: ['push', 'set', 'list'],
   knowledge: ['show', 'use'],
@@ -309,6 +313,10 @@ const ACCEPTS: Record<string, readonly string[]> = {
   assets: ['connection', 'name', 'content-type', 'yes'],
   skills: ['connection', 'title', 'description', 'file'],
   vault: ['connection'],
+  // `alias`, `attr` and `related` are repeatable — see `ownerFlags`. `name`
+  // overrides the id derived from the positional name, which is how you get
+  // `acme-bv` rather than `acme-b-v`.
+  entities: ['connection', 'type', 'name', 'alias', 'attr', 'related', 'tag', 'yes'],
   // `no-migrate` is listed beside `migrate` because they are three states
   // rather than two: neither one asks, and a run with no terminal has to be
   // able to say which it meant (ADR-041).

--- a/src/cli/usage.ts
+++ b/src/cli/usage.ts
@@ -100,6 +100,17 @@ ${style.bold('Your own context')}
   ${PROGRAM} skills add <name> [--file f]             document on stdin
   ${PROGRAM} skills remove <name>
 
+  ${PROGRAM} entities                 who and what everyone else is
+  ${PROGRAM} entities find [query] [--type t] [--tag t] [--attr kind[=value]]
+                                 [--related predicate=id]   every match, never a choice
+  ${PROGRAM} entities get <id>                   with its relationships, both ways
+  ${PROGRAM} entities write <name> [--type t] [--name id] [--alias a]
+                                 [--attr kind=value] [--related predicate=id]
+                                 notes on stdin; a flag you omit keeps what is stored
+  ${PROGRAM} entities link <from> <predicate>=<to>       one edge, written on <from> only
+  ${PROGRAM} entities forget <id>
+  ${PROGRAM} entities reindex                    rebuild the lookup index from the files
+
   ${PROGRAM} knowledge show            where memory and skills are kept, and how many
   ${PROGRAM} knowledge use github --repo <owner/name> [--branch b] [--path p]
                                  keep both in a private repository, over the GitHub API
@@ -152,8 +163,8 @@ ${style.bold('Naming what a command acts on')}
                                  command that names neither refuses and lists what exists.
 
 ${style.bold('Other flags')}
-  --connection <id>              which memory/tasks/assets/skills/vault connection, where
-                                 a profile has several of one kind
+  --connection <id>              which memory/tasks/assets/skills/vault/entities
+                                 connection, where a profile has several of one kind
   --yes                          skip the confirmation a destructive command would ask for
   --json                         machine-readable output, where a command offers it
   --non-interactive              never prompt: connect refuses with what to store,

--- a/src/connectivity/manifest/provider.ts
+++ b/src/connectivity/manifest/provider.ts
@@ -78,6 +78,9 @@ export type ProviderManifest = z.infer<typeof providerManifestSchema>;
  *
  * The order is read: `#server/mcp`'s instructions emit one paragraph per
  * reachable id in this sequence, so it is the order an agent meets them in.
+ * `entities` is appended rather than inserted alphabetically so that it lands
+ * beside `identity`: the two answer the same question about different people,
+ * and the instructions collapse them into one paragraph when both are reachable.
  */
 export const RESERVED_PROVIDER_IDS: readonly string[] = [
   'memory',
@@ -87,6 +90,7 @@ export const RESERVED_PROVIDER_IDS: readonly string[] = [
   'vault',
   'setup',
   'identity',
+  'entities',
 ];
 
 /**

--- a/src/deployments/knowledge.ts
+++ b/src/deployments/knowledge.ts
@@ -1,6 +1,7 @@
 import type { SecretStore } from '#secrets';
 import type { BlobStore } from '#stores/blobs';
-import { knowledgeRoot, type KnowledgeArea, type KnowledgeConfig } from '#profile';
+import type { BlobRoute } from '#stores/blobs/route.ts';
+import { KNOWLEDGE_LAYOUT, knowledgeRoot, type KnowledgeArea, type KnowledgeConfig } from '#profile';
 import { requireSecret, type TargetInput } from './target.ts';
 import type { FetchLike } from './adapters/github-api.ts';
 // Type-only, so a target with no `knowledge` block never loads the adapter.
@@ -122,6 +123,22 @@ export async function knowledgeStores(
     });
 
   return { skills: build('skills'), memory: build('memory'), entities: build('entities') };
+}
+
+/**
+ * Which key prefixes of the profile's blob root lead to the repository.
+ *
+ * Here rather than at the call site because it is the same fact
+ * `KNOWLEDGE_LAYOUT` states: a directory name in the repository *is* the
+ * provider namespace that routes into it, and spelling the pair in two files is
+ * how they would come to disagree. `skills` is absent because it is not a
+ * prefix of that root — it is a store of its own, handed over whole.
+ */
+export function knowledgeRoutes(stores: KnowledgeStores): BlobRoute[] {
+  return [
+    { prefix: `${KNOWLEDGE_LAYOUT.memory}/`, store: stores.memory },
+    { prefix: `${KNOWLEDGE_LAYOUT.entities}/`, store: stores.entities },
+  ];
 }
 
 /** `github:owner/name#branch/path`, in one place so every reader agrees. */

--- a/src/deployments/knowledge.ts
+++ b/src/deployments/knowledge.ts
@@ -1,6 +1,6 @@
 import type { SecretStore } from '#secrets';
 import type { BlobStore } from '#stores/blobs';
-import { knowledgeRoot, type KnowledgeConfig } from '#profile';
+import { knowledgeRoot, type KnowledgeArea, type KnowledgeConfig } from '#profile';
 import { requireSecret, type TargetInput } from './target.ts';
 import type { FetchLike } from './adapters/github-api.ts';
 // Type-only, so a target with no `knowledge` block never loads the adapter.
@@ -14,13 +14,13 @@ import type { GithubRepository } from './adapters/github-repo.ts';
 export type { FetchLike } from './adapters/github-api.ts';
 
 /**
- * Opening the place a profile keeps its memory and its skills, when that is not
- * the place it keeps everything else.
+ * Opening the place a profile keeps its memory, skills and entities, when that
+ * is not the place it keeps everything else.
  *
  * Its own file rather than a fifth case in `target.ts`, because it is not the
  * same kind of decision. `target.ts` answers "where does this target run" —
  * credentials here, bytes there — and every consumer of a `BlobStore` rides
- * that one answer. This answers a narrower one: two directories of documents
+ * that one answer. This answers a narrower one: three directories of documents
  * the owner wrote have somewhere else to be, and nothing else moves with them.
  *
  * ADR-041 has the argument. `src/profile/knowledge.ts` has the contract, and
@@ -29,19 +29,22 @@ export type { FetchLike } from './adapters/github-api.ts';
  */
 
 /**
- * One repository client, two stores.
+ * One repository client, three stores.
  *
- * Memory and skills are two directories in one repository, and pointing both at
- * one client means one branch head, one tree, and one blob cache between them —
- * so the endpoint's two-second skill poll keeps memory's view current for free.
- * Two clients would each poll, each cache, and could disagree about which
- * commit is current.
+ * Memory, skills and entities are three directories in one repository, and
+ * pointing all of them at one client means one branch head, one tree, and one
+ * blob cache between them — so the endpoint's two-second skill poll keeps the
+ * other two views current for free. Three clients would each poll, each cache,
+ * and could disagree about which commit is current. The argument got stronger
+ * with a third area rather than weaker, which is why adding one is a line here.
  */
 export interface KnowledgeStores {
   readonly repository: GithubRepository;
   readonly skills: BlobStore;
   /** Rooted at the repository's memory directory; keys are `<connection>/<id>.md`. */
   readonly memory: BlobStore;
+  /** The same shape again, plus the derived `<connection>/_index.json`. */
+  readonly entities: BlobStore;
   /** One line for `target show` and `doctor`, so the config file is not the only witness. */
   readonly describe: string;
 }
@@ -88,7 +91,7 @@ export async function openKnowledge(
 }
 
 /**
- * The two stores a knowledge repository holds.
+ * The three stores a knowledge repository holds.
  *
  * Separate from `openKnowledge` because `lanes link knowledge use` builds these
  * against a repository it is still probing — before any of it has been written
@@ -98,21 +101,27 @@ export async function openKnowledge(
 export async function knowledgeStores(
   repository: GithubRepository,
   knowledge: KnowledgeConfig,
-): Promise<{ skills: BlobStore; memory: BlobStore }> {
+): Promise<{ skills: BlobStore; memory: BlobStore; entities: BlobStore }> {
   const { createGithubBlobStore } = await import('./adapters/github.ts');
 
-  const build = (area: 'memory' | 'skills'): BlobStore =>
+  // What the commit says it did. Named per area rather than left to the
+  // adapter's default, because "Store main/note.md" in a repository holding
+  // three of them is a line that does not say which one changed.
+  const noun: Record<KnowledgeArea, string> = {
+    memory: 'memory',
+    skills: 'skill',
+    entities: 'entity',
+  };
+
+  const build = (area: KnowledgeArea): BlobStore =>
     createGithubBlobStore({
       repository,
       root: knowledgeRoot(knowledge, area),
-      // What the commit says it did. Named per area rather than left to the
-      // adapter's default, because "Store main/note.md" in a repository holding
-      // both is a line that does not say which of them changed.
       message: (operation, key) =>
-        `${operation === 'store' ? 'Store' : 'Remove'} ${area === 'skills' ? 'skill' : 'memory'} ${key}`,
+        `${operation === 'store' ? 'Store' : 'Remove'} ${noun[area]} ${key}`,
     });
 
-  return { skills: build('skills'), memory: build('memory') };
+  return { skills: build('skills'), memory: build('memory'), entities: build('entities') };
 }
 
 /** `github:owner/name#branch/path`, in one place so every reader agrees. */

--- a/src/dispatch/control-plane.test.ts
+++ b/src/dispatch/control-plane.test.ts
@@ -15,6 +15,7 @@ import {
   createSetupProvider,
   createSkillsProvider,
   createVaultProvider,
+  entitiesProvider,
   memoryProvider,
   tasksProvider,
 } from '#providers/owner.ts';
@@ -81,6 +82,10 @@ function registryWithBuiltins(): ProviderRegistry {
   registry.register(
     createIdentityProvider({ profile: 'personal', target: 'local', entries: [] }),
   );
+  // Writable, unlike the two above, and still nothing here is a control-plane
+  // operation: what it changes is the owner's own record of other people, not
+  // what any agent is authorised to do next.
+  registry.register(entitiesProvider);
 
   return registry;
 }

--- a/src/profile/knowledge.ts
+++ b/src/profile/knowledge.ts
@@ -13,7 +13,7 @@ import { credentialRef } from './primitives.ts';
  * readable from more than one machine, and the backend that suits an object
  * nobody reads is not the backend that suits those.
  *
- * ADR-041 said "memory and skills, and nothing else", and ADR-055 amends the
+ * ADR-041 said "memory and skills, and nothing else", and ADR-056 amends the
  * count without touching the rule. That exclusion was never arithmetic: its
  * argument is a discriminator — an artefact of one installation stays, a
  * document the owner wrote may move — and an entity file is a Markdown document

--- a/src/profile/knowledge.ts
+++ b/src/profile/knowledge.ts
@@ -2,18 +2,25 @@ import { z } from 'zod';
 import { credentialRef } from './primitives.ts';
 
 /**
- * Where a profile's memory and skills live, when that is not where everything
- * else lives.
+ * Where a profile's memory, skills and entities live, when that is not where
+ * everything else lives.
  *
  * A target's `storage:` block names one backend for everything a profile holds
  * — runtime state, the audit log, memory entries, skills, cached attachments.
- * That is right for most of it and wrong for two: state and the log are
- * artefacts of one installation, and memory entries and skills are documents
- * the owner wrote. Documents want history, review, and to be readable from more
- * than one machine, and the backend that suits an object nobody reads is not
- * the backend that suits those.
+ * That is right for most of it and wrong for three: state and the log are
+ * artefacts of one installation, and memory entries, skills and entity files
+ * are documents the owner wrote. Documents want history, review, and to be
+ * readable from more than one machine, and the backend that suits an object
+ * nobody reads is not the backend that suits those.
  *
- * So this block moves exactly those two, and it is the whole of what it can
+ * ADR-041 said "memory and skills, and nothing else", and ADR-055 amends the
+ * count without touching the rule. That exclusion was never arithmetic: its
+ * argument is a discriminator — an artefact of one installation stays, a
+ * document the owner wrote may move — and an entity file is a Markdown document
+ * with frontmatter, hand-editable, wanting history and review. It is on the
+ * same side of that line as a memory entry, by the same test.
+ *
+ * So this block moves exactly those three, and it is the whole of what it can
  * move. There is no `credentials` or `vault` value here and there will not be:
  * a repository is a place to publish, and those two hold the material whose
  * entire value is that it is not published (`https://lanes.sh/docs/link/security`). The
@@ -89,8 +96,8 @@ export type KnowledgeConfig = z.infer<typeof knowledgeTargetSchema>;
 /**
  * Where each area sits inside the repository.
  *
- * Two directories, named after the two things that move. `memory` is also the
- * memory provider's own blob namespace — the prefix core scopes it into under
+ * Three directories, named after the three things that move. `memory` is also
+ * the memory provider's own blob namespace — the prefix core scopes it into under
  * the profile's blob root — which is why the same word does both jobs: the
  * route that redirects it and the directory it lands in are the same fact, and
  * spelling them separately is how they would come to disagree.
@@ -101,6 +108,7 @@ export type KnowledgeConfig = z.infer<typeof knowledgeTargetSchema>;
 export const KNOWLEDGE_LAYOUT = {
   memory: 'memory',
   skills: 'skills',
+  entities: 'entities',
 } as const;
 
 export type KnowledgeArea = keyof typeof KNOWLEDGE_LAYOUT;

--- a/src/providers/entities/catalogue.test.ts
+++ b/src/providers/entities/catalogue.test.ts
@@ -1,0 +1,359 @@
+import { describe, expect, test } from 'bun:test';
+import { createMemoryBlobStore } from '#stores/blobs/testing.ts';
+import type { BlobStore } from '#stores/blobs';
+import {
+  INDEX_KEY,
+  fingerprintAfter,
+  fingerprintOf,
+  indexState,
+  openCatalogue,
+  rebuildCatalogue,
+  writeCatalogue,
+  type CatalogueEntity,
+} from './catalogue.ts';
+import { entityKey, serialiseEntity, type Entity } from './store.ts';
+
+/**
+ * The index is a cache, and every test here is about that word.
+ *
+ * A cache may be absent, truncated, of the wrong version or simply behind, and
+ * in all four cases the right behaviour is the same: rebuild from the files and
+ * answer correctly. What it may never do is be *believed* when the files have
+ * moved on — which is what the fingerprint is for, and what most of this file
+ * measures.
+ *
+ * The counting proxy is the point of several of these. "Zero entity reads" is
+ * the entire claim the index makes, and asserting on a return value cannot
+ * distinguish an index that was used from one that was rebuilt behind it.
+ */
+
+const NOW = '2026-08-30T09:14:22.104Z';
+
+function counting(store: BlobStore): { store: BlobStore; reads: () => number } {
+  let reads = 0;
+
+  return {
+    reads: () => reads,
+    store: {
+      ...store,
+      async get(key) {
+        // The index itself is not an entity read: it is the thing being tested,
+        // and counting it would make "zero reads" impossible to state.
+        if (key !== INDEX_KEY) reads += 1;
+        return store.get(key);
+      },
+    },
+  };
+}
+
+function entity(id: string, overrides: Partial<Entity> = {}): Entity {
+  return {
+    id,
+    type: 'person',
+    name: id,
+    aliases: [],
+    tags: [],
+    attributes: [],
+    relations: [],
+    updatedAt: NOW,
+    body: '',
+    bytes: 0,
+    ...overrides,
+  };
+}
+
+async function storeOf(...entities: Entity[]): Promise<BlobStore> {
+  const store = createMemoryBlobStore();
+  for (const one of entities) {
+    const { id: _id, bytes: _bytes, ...rest } = one;
+    await store.put(entityKey(one.id), new TextEncoder().encode(serialiseEntity(rest)));
+  }
+  return store;
+}
+
+/** Build and persist an index that is correct for what is in the store. */
+async function indexed(store: BlobStore): Promise<void> {
+  const catalogue = await rebuildCatalogue(store);
+  await writeCatalogue(store, catalogue.entities, catalogue.fingerprint, NOW);
+}
+
+describe('a valid index is used, and costs no entity reads', () => {
+  test('the whole claim: zero reads when the fingerprint matches', async () => {
+    const store = await storeOf(
+      entity('jan-bakker', { name: 'Jan Bakker' }),
+      entity('acme-bv', { name: 'Acme B.V.', type: 'company' }),
+    );
+    await indexed(store);
+
+    const counted = counting(store);
+    const catalogue = await openCatalogue(counted.store);
+
+    expect(counted.reads()).toBe(0);
+    expect(catalogue.fromIndex).toBe(true);
+    expect(catalogue.byId.get('jan-bakker')?.name).toBe('Jan Bakker');
+    expect(catalogue.byId.get('acme-bv')?.type).toBe('company');
+  });
+
+  test('a rebuild reads every entity, so the counter measures something', async () => {
+    const store = await storeOf(entity('jan-bakker'), entity('acme-bv'));
+
+    const counted = counting(store);
+    const catalogue = await openCatalogue(counted.store);
+
+    expect(counted.reads()).toBe(2);
+    expect(catalogue.fromIndex).toBe(false);
+  });
+});
+
+describe('the index is not believed once the files move on', () => {
+  test('an entity edited to a different size invalidates it', async () => {
+    const store = await storeOf(entity('jan-bakker', { name: 'Jan' }));
+    await indexed(store);
+
+    // What a person does in an editor, or on GitHub — neither of which goes
+    // anywhere near the index.
+    const { id: _id, bytes: _b, ...rest } = entity('jan-bakker', { name: 'Jan Bakker Senior' });
+    await store.put(entityKey('jan-bakker'), new TextEncoder().encode(serialiseEntity(rest)));
+
+    const catalogue = await openCatalogue(store);
+    expect(catalogue.fromIndex).toBe(false);
+    expect(catalogue.byId.get('jan-bakker')?.name).toBe('Jan Bakker Senior');
+  });
+
+  test('a new entity invalidates it', async () => {
+    const store = await storeOf(entity('jan-bakker'));
+    await indexed(store);
+    const { id: _id, bytes: _b, ...rest } = entity('acme-bv');
+    await store.put(entityKey('acme-bv'), new TextEncoder().encode(serialiseEntity(rest)));
+
+    expect((await openCatalogue(store)).fromIndex).toBe(false);
+  });
+
+  test('a deleted entity invalidates it', async () => {
+    const store = await storeOf(entity('jan-bakker'), entity('acme-bv'));
+    await indexed(store);
+    await store.delete(entityKey('acme-bv'));
+
+    const catalogue = await openCatalogue(store);
+    expect(catalogue.fromIndex).toBe(false);
+    expect(catalogue.byId.has('acme-bv')).toBe(false);
+  });
+
+  test('a truncated index rebuilds silently and correctly', async () => {
+    const store = await storeOf(entity('jan-bakker', { name: 'Jan Bakker' }));
+    await indexed(store);
+    await store.put(INDEX_KEY, new TextEncoder().encode('{"v":1,"fingerpr'));
+
+    const catalogue = await openCatalogue(store);
+    expect(catalogue.fromIndex).toBe(false);
+    expect(catalogue.byId.get('jan-bakker')?.name).toBe('Jan Bakker');
+  });
+
+  test('an index from a future version rebuilds', async () => {
+    const store = await storeOf(entity('jan-bakker'));
+    await indexed(store);
+
+    const document = JSON.parse(new TextDecoder().decode((await store.get(INDEX_KEY))!));
+    await store.put(INDEX_KEY, new TextEncoder().encode(JSON.stringify({ ...document, v: 2 })));
+
+    expect((await openCatalogue(store)).fromIndex).toBe(false);
+  });
+
+  test('an index whose rows are malformed rebuilds rather than answering partially', async () => {
+    const store = await storeOf(entity('jan-bakker'));
+    await indexed(store);
+
+    const document = JSON.parse(new TextDecoder().decode((await store.get(INDEX_KEY))!));
+    await store.put(
+      INDEX_KEY,
+      new TextEncoder().encode(JSON.stringify({ ...document, entities: [{ id: 'jan-bakker' }] })),
+    );
+
+    // Unlike an entity document, this file is machine-written: a salvageable
+    // half of it is a partial answer with nothing saying so.
+    expect((await openCatalogue(store)).fromIndex).toBe(false);
+  });
+
+  test('a hand-written index with a matching fingerprint IS served — the known hole', async () => {
+    const store = await storeOf(entity('jan-bakker', { name: 'Jan Bakker' }));
+    const fingerprint = fingerprintOf(await store.list());
+
+    const wrong: CatalogueEntity[] = [
+      {
+        id: 'jan-bakker',
+        type: 'person',
+        name: 'Somebody Else',
+        aliases: [],
+        tags: [],
+        attributes: [{ kind: 'email', value: 'wrong@example.test' }],
+        relations: [],
+        updatedAt: NOW,
+      },
+    ];
+    await writeCatalogue(store, wrong, fingerprint, NOW);
+
+    // Pinned rather than pretended away. The fingerprint stamps the *entity
+    // files*, so an index edited on its own passes it. This is the cost of
+    // committing the index beside the documents, and it is why `find` confirms
+    // a single match against its file before an agent acts on it.
+    const catalogue = await openCatalogue(store);
+    expect(catalogue.fromIndex).toBe(true);
+    expect(catalogue.byId.get('jan-bakker')?.name).toBe('Somebody Else');
+  });
+});
+
+describe('the fingerprint', () => {
+  test('ignores the index file, so writing it does not invalidate it', async () => {
+    const store = await storeOf(entity('jan-bakker'));
+    const before = fingerprintOf(await store.list());
+
+    await indexed(store);
+    const after = fingerprintOf(await store.list());
+
+    // The loop, asserted directly: if `_index.json` were in its own
+    // fingerprint, the index would be stale the instant it was written.
+    expect(after).toBe(before);
+    expect((await openCatalogue(store)).fromIndex).toBe(true);
+  });
+
+  test('ignores mtime, so a backend reporting one timestamp for every file still matches', async () => {
+    const store = await storeOf(entity('jan-bakker'));
+    const before = fingerprintOf(await store.list());
+
+    // What the GitHub adapter does: `modifiedAt` is the branch tip, so every
+    // file's timestamp moves whenever anything on the branch is committed.
+    const listing = (await store.list()).map((blob) => ({
+      ...blob,
+      modifiedAt: new Date('2030-01-01T00:00:00.000Z'),
+    }));
+
+    expect(fingerprintOf(listing)).toBe(before);
+  });
+
+  test('fingerprintAfter predicts a put without listing again', async () => {
+    const store = await storeOf(entity('jan-bakker'));
+    const listing = await store.list();
+
+    const { id: _id, bytes: _b, ...rest } = entity('acme-bv', { name: 'Acme B.V.' });
+    const encoded = new TextEncoder().encode(serialiseEntity(rest));
+    const predicted = fingerprintAfter(listing, { key: entityKey('acme-bv'), size: encoded.byteLength });
+
+    await store.put(entityKey('acme-bv'), encoded);
+    expect(predicted).toBe(fingerprintOf(await store.list()));
+  });
+
+  test('fingerprintAfter predicts an overwrite', async () => {
+    const store = await storeOf(entity('jan-bakker', { name: 'Jan' }));
+    const listing = await store.list();
+
+    const { id: _id, bytes: _b, ...rest } = entity('jan-bakker', { name: 'Jan Bakker Senior' });
+    const encoded = new TextEncoder().encode(serialiseEntity(rest));
+    const predicted = fingerprintAfter(listing, {
+      key: entityKey('jan-bakker'),
+      size: encoded.byteLength,
+    });
+
+    await store.put(entityKey('jan-bakker'), encoded);
+    expect(predicted).toBe(fingerprintOf(await store.list()));
+  });
+
+  test('fingerprintAfter predicts a delete', async () => {
+    const store = await storeOf(entity('jan-bakker'), entity('acme-bv'));
+    const listing = await store.list();
+
+    const predicted = fingerprintAfter(listing, { key: entityKey('acme-bv'), deleted: true });
+
+    await store.delete(entityKey('acme-bv'));
+    expect(predicted).toBe(fingerprintOf(await store.list()));
+  });
+
+  test('a write predicted and persisted leaves the next read on the fast path', async () => {
+    const store = await storeOf(entity('jan-bakker'));
+    const catalogue = await openCatalogue(store);
+
+    const { id: _id, bytes: _b, ...rest } = entity('acme-bv', { name: 'Acme B.V.' });
+    const encoded = new TextEncoder().encode(serialiseEntity(rest));
+    await store.put(entityKey('acme-bv'), encoded);
+
+    const next = fingerprintAfter(catalogue.listing, {
+      key: entityKey('acme-bv'),
+      size: encoded.byteLength,
+    });
+    await writeCatalogue(
+      store,
+      [...catalogue.entities, { ...rest, id: 'acme-bv' }],
+      next,
+      NOW,
+    );
+
+    const counted = counting(store);
+    const after = await openCatalogue(counted.store);
+    expect(after.fromIndex).toBe(true);
+    expect(counted.reads()).toBe(0);
+    expect(after.byId.get('acme-bv')?.name).toBe('Acme B.V.');
+  });
+});
+
+describe('backlinks are derived, never stored', () => {
+  test('the reverse of a one-sided edge appears on the target', async () => {
+    const store = await storeOf(
+      entity('jan-bakker', {
+        name: 'Jan Bakker',
+        relations: [{ predicate: 'works_at', entity: 'acme-bv', note: 'since 2023' }],
+      }),
+      entity('acme-bv', { name: 'Acme B.V.', type: 'company' }),
+    );
+
+    const catalogue = await openCatalogue(store);
+
+    // Acme's own file says nothing about Jan.
+    expect(catalogue.byId.get('acme-bv')?.relations).toEqual([]);
+    expect(catalogue.backlinks.get('acme-bv')).toEqual([
+      { from: 'jan-bakker', predicate: 'works_at', note: 'since 2023' },
+    ]);
+  });
+
+  test('an edge to an entity that does not exist is kept, not dropped', async () => {
+    const store = await storeOf(
+      entity('jan-bakker', { relations: [{ predicate: 'works_at', entity: 'not-declared' }] }),
+    );
+
+    const catalogue = await openCatalogue(store);
+    expect(catalogue.byId.get('jan-bakker')?.relations).toHaveLength(1);
+    expect(catalogue.backlinks.get('not-declared')).toHaveLength(1);
+    expect(catalogue.byId.has('not-declared')).toBe(false);
+  });
+
+  test('the index path and the rebuild path derive the same backlinks', async () => {
+    const store = await storeOf(
+      entity('jan-bakker', { relations: [{ predicate: 'works_at', entity: 'acme-bv' }] }),
+      entity('marta-silva', { relations: [{ predicate: 'works_at', entity: 'acme-bv' }] }),
+      entity('acme-bv', { type: 'company' }),
+    );
+
+    const rebuilt = await rebuildCatalogue(store);
+    await indexed(store);
+    const served = await openCatalogue(store);
+
+    expect(served.fromIndex).toBe(true);
+    expect(served.backlinks.get('acme-bv')).toEqual(rebuilt.backlinks.get('acme-bv')!);
+  });
+});
+
+describe('indexState explains itself', () => {
+  test('it names each reason a rebuild was needed', async () => {
+    const store = await storeOf(entity('jan-bakker'));
+    expect(await indexState(store)).toEqual({ current: false, reason: 'no index file' });
+
+    await indexed(store);
+    expect((await indexState(store)).current).toBe(true);
+
+    await store.put(INDEX_KEY, new TextEncoder().encode('not json'));
+    expect((await indexState(store)).reason).toContain('could not be read');
+
+    await indexed(store);
+    const { id: _id, bytes: _b, ...rest } = entity('acme-bv');
+    await store.put(entityKey('acme-bv'), new TextEncoder().encode(serialiseEntity(rest)));
+    expect((await indexState(store)).reason).toContain('changed since the index was built');
+  });
+});

--- a/src/providers/entities/catalogue.ts
+++ b/src/providers/entities/catalogue.ts
@@ -1,0 +1,366 @@
+import { createHash } from 'node:crypto';
+import type { BlobMetadata, BlobStore } from '#connectivity';
+import { allEntities, idFromKey, type Attribute, type Entity, type Relation } from './store.ts';
+
+/**
+ * The derived index, and the rules that keep it from becoming a second source
+ * of truth.
+ *
+ * `_index.json` sits beside the entity files and holds what a lookup needs, so
+ * a read that finds it valid opens no entity file at all. It is a **cache**:
+ * absent, truncated, wrong-version and fingerprint-mismatched are all one case
+ * here, and all four rebuild from the files without throwing. The precedent is
+ * `openRuntime`'s treatment of a corrupt discovery cache — never a reason to
+ * fail startup.
+ *
+ * ADR-014 removed an index from memory because it could disagree with the file
+ * it described. What makes this one different is the fingerprint: it is a stamp
+ * of the exact listing the index was built from, so a file edited in an editor
+ * or on GitHub invalidates it structurally rather than by anybody remembering
+ * to. The hole that remains — a hand-edited *index* whose fingerprint still
+ * matches untouched entity files — is closed on the path that matters by the
+ * confirm-on-read rule in `find.ts`, and is pinned by a test rather than
+ * pretended away.
+ *
+ * **Why the fingerprint is `key:size` and not `key:size:mtime`.**
+ * `skillFingerprint` includes mtime and is right to: it is a change detector
+ * for a two-second poll, where a false positive costs a reload. This is a
+ * validity stamp, where a false positive costs a full rebuild and, on a
+ * knowledge repository, a commit. The GitHub adapter reports the *branch tip*
+ * as `modifiedAt` for every file, so on the one backend where this index is
+ * worth the most, an mtime-bearing fingerprint would never match twice. Sizes
+ * are per-file on every adapter.
+ *
+ * That choice buys a second property the write path depends on: because size is
+ * known before a put, a writer can compute the fingerprint of the state it is
+ * *about to create* (`fingerprintAfter`) rather than listing the store again
+ * afterwards. No read-back, no second `list()`, no ordering hazard.
+ *
+ * **No read ever writes this file.** A read that finds it stale rebuilds in
+ * memory and serves the right answer. Only `write`, `link`, `forget` and
+ * `entities reindex` persist. So no read can move a branch tip, and therefore
+ * no read can invalidate the next read.
+ *
+ * **What it costs, at scale.** Steady state on a bucket is one `list()` and one
+ * GET, whatever the entity count — a listing carries key and size only, so no
+ * body is transferred on that path. A rebuild is one read per entity, bounded
+ * 16 at a time.
+ *
+ *   entities   list() requests   index   steady-state read   rebuild
+ *   100        1                 ~35 KB  2 requests          100 GETs
+ *   1,000      1-2               ~340 KB 3 requests          1,000 GETs
+ *   10,000     11                ~3.4 MB 12 requests         10,000 GETs
+ *
+ * A thousand is comfortably inside the design. Ten thousand is where it is the
+ * wrong design, and the answer then is not a larger index but a validity check
+ * that needs no listing — which needs an adapter reporting a per-object etag,
+ * and `BlobMetadata` carries none today. On a local directory none of this is
+ * worth anything measurable; it is carried for the deployed and repository
+ * paths.
+ */
+
+export const INDEX_KEY = '_index.json';
+
+/**
+ * Bumping this invalidates every stored index without anyone remembering to.
+ *
+ * It is in the fingerprint's own prefix rather than checked separately, so a
+ * format change and a content change are one comparison.
+ */
+const INDEX_VERSION = 1;
+
+/**
+ * An entity as the index holds it: everything that matches or distinguishes,
+ * and nothing that only renders.
+ *
+ * No body, and no body summary. A summary would be the largest field per row
+ * and nothing consults it — a single match reads the file anyway under
+ * confirm-on-read, and several matches render the fields that *differ*, not
+ * prose. Dropping it is about a third of the file for no loss.
+ */
+export type CatalogueEntity = Omit<Entity, 'body' | 'bytes'>;
+
+/** An edge as the entity it points *at* sees it. Derived, never stored. */
+export interface Backlink {
+  readonly from: string;
+  readonly predicate: string;
+  readonly note?: string;
+}
+
+export interface Catalogue {
+  readonly entities: readonly CatalogueEntity[];
+  readonly byId: ReadonlyMap<string, CatalogueEntity>;
+  /** Reverse edges, derived in one pass. Keyed by the entity pointed at. */
+  readonly backlinks: ReadonlyMap<string, readonly Backlink[]>;
+  readonly fingerprint: string;
+  /**
+   * Whether this came from a valid index rather than from the files.
+   *
+   * `find` reads it to decide whether a single match needs confirming against
+   * its file: an answer rebuilt from the files is already confirmed.
+   */
+  readonly fromIndex: boolean;
+  /**
+   * The listing this was opened against.
+   *
+   * Carried so a write can compute `fingerprintAfter` without listing twice.
+   * It is the one piece of storage detail on this type and it is here rather
+   * than fetched again because the two calls could otherwise see different
+   * states.
+   */
+  readonly listing: readonly BlobMetadata[];
+}
+
+/**
+ * A stamp of exactly which entity files existed and how large each was.
+ *
+ * Filtered by `idFromKey`, which is what keeps `_index.json` out of its own
+ * fingerprint. Without that filter, writing the index would change the listing,
+ * which would invalidate the index the instant it was written.
+ */
+export function fingerprintOf(blobs: readonly BlobMetadata[]): string {
+  return hashLines(
+    blobs.flatMap((blob) => (idFromKey(blob.key) === null ? [] : [`${blob.key}:${blob.size}`])),
+  );
+}
+
+/** What `fingerprintOf` will return after this put or delete lands. */
+export function fingerprintAfter(
+  blobs: readonly BlobMetadata[],
+  change: { key: string; size: number } | { key: string; deleted: true },
+): string {
+  const lines = blobs.flatMap((blob) =>
+    idFromKey(blob.key) === null || blob.key === change.key ? [] : [`${blob.key}:${blob.size}`],
+  );
+
+  if (!('deleted' in change) && idFromKey(change.key) !== null) {
+    lines.push(`${change.key}:${change.size}`);
+  }
+
+  return hashLines(lines);
+}
+
+function hashLines(lines: readonly string[]): string {
+  return createHash('sha256')
+    .update(`entities/${INDEX_VERSION}\n${[...lines].sort().join('\n')}`)
+    .digest('hex');
+}
+
+/**
+ * The catalogue, from the index when it is valid and from the files when it is
+ * not.
+ *
+ * Never throws for a storage-shaped reason. The only thing that propagates is a
+ * failure to `list()` at all, which is the store being unreachable rather than
+ * this cache being wrong.
+ */
+export async function openCatalogue(storage: BlobStore): Promise<Catalogue> {
+  const listing = await storage.list();
+  const fingerprint = fingerprintOf(listing);
+
+  const indexed = await readIndex(storage, fingerprint);
+  if (indexed !== null) return assemble(indexed, fingerprint, true, listing);
+
+  const entities = (await allEntities(storage)).map(strip);
+  return assemble(entities, fingerprint, false, listing);
+}
+
+/** Rebuild from the files regardless of what the index says. */
+export async function rebuildCatalogue(storage: BlobStore): Promise<Catalogue> {
+  const listing = await storage.list();
+  const entities = (await allEntities(storage)).map(strip);
+
+  return assemble(entities, fingerprintOf(listing), false, listing);
+}
+
+export async function writeCatalogue(
+  storage: BlobStore,
+  entities: readonly CatalogueEntity[],
+  fingerprint: string,
+  now: string,
+): Promise<void> {
+  await storage.put(INDEX_KEY, new TextEncoder().encode(serialiseIndex(entities, fingerprint, now)), {
+    contentType: 'application/json',
+  });
+}
+
+/** Why a read had to rebuild, for `entities reindex` and a debug log line. */
+export async function indexState(
+  storage: BlobStore,
+): Promise<{ current: boolean; reason: string }> {
+  const fingerprint = fingerprintOf(await storage.list());
+  const bytes = await storage.get(INDEX_KEY);
+
+  if (bytes === null) return { current: false, reason: 'no index file' };
+
+  const parsed = parseIndex(bytes);
+  if (parsed === null) return { current: false, reason: 'the index file could not be read' };
+  if (parsed.fingerprint !== fingerprint) {
+    return { current: false, reason: 'the entity files changed since the index was built' };
+  }
+
+  return { current: true, reason: 'the index matches the entity files' };
+}
+
+function strip(entity: Entity): CatalogueEntity {
+  const { body: _body, bytes: _bytes, ...rest } = entity;
+  return rest;
+}
+
+/**
+ * A catalogue over entities already in hand, deriving the backlinks.
+ *
+ * The same assembly both open paths use, exposed so `find` can be exercised
+ * against literal arrays with no store at all — which is the point of keeping
+ * matching pure.
+ */
+export function catalogueFrom(entities: readonly CatalogueEntity[]): Catalogue {
+  return assemble(entities, '', false, []);
+}
+
+function assemble(
+  entities: readonly CatalogueEntity[],
+  fingerprint: string,
+  fromIndex: boolean,
+  listing: readonly BlobMetadata[],
+): Catalogue {
+  const byId = new Map(entities.map((one) => [one.id, one]));
+  const backlinks = new Map<string, Backlink[]>();
+
+  // One pass over the forward edges already loaded. Reverse edges are never
+  // stored: a second copy inside the same file could disagree with the first
+  // half of it, and this derivation is shared by both open paths so there is
+  // one implementation of "who points at this".
+  for (const entity of entities) {
+    for (const relation of entity.relations) {
+      const into = backlinks.get(relation.entity) ?? [];
+      into.push({
+        from: entity.id,
+        predicate: relation.predicate,
+        ...(relation.note === undefined ? {} : { note: relation.note }),
+      });
+      backlinks.set(relation.entity, into);
+    }
+  }
+
+  return { entities, byId, backlinks, fingerprint, fromIndex, listing };
+}
+
+/** The stored rows, or null for any reason at all. Every reason rebuilds. */
+async function readIndex(
+  storage: BlobStore,
+  fingerprint: string,
+): Promise<CatalogueEntity[] | null> {
+  const bytes = await storage.get(INDEX_KEY);
+  if (bytes === null) return null;
+
+  const parsed = parseIndex(bytes);
+  if (parsed === null || parsed.fingerprint !== fingerprint) return null;
+
+  return parsed.entities;
+}
+
+function parseIndex(
+  bytes: Uint8Array,
+): { fingerprint: string; entities: CatalogueEntity[] } | null {
+  let raw: unknown;
+  try {
+    raw = JSON.parse(new TextDecoder().decode(bytes));
+  } catch {
+    return null;
+  }
+
+  if (raw === null || typeof raw !== 'object' || Array.isArray(raw)) return null;
+  const document = raw as Record<string, unknown>;
+
+  if (document['v'] !== INDEX_VERSION) return null;
+  if (typeof document['fingerprint'] !== 'string') return null;
+  if (!Array.isArray(document['entities'])) return null;
+
+  const entities: CatalogueEntity[] = [];
+  for (const row of document['entities']) {
+    const entity = parseRow(row);
+    // One unreadable row is the whole file: unlike an entity document, this is
+    // machine-written and a partial one means a partial answer with nothing
+    // saying so. Rebuilding is cheap and correct.
+    if (entity === null) return null;
+    entities.push(entity);
+  }
+
+  return { fingerprint: document['fingerprint'], entities };
+}
+
+function parseRow(raw: unknown): CatalogueEntity | null {
+  if (raw === null || typeof raw !== 'object' || Array.isArray(raw)) return null;
+  const row = raw as Record<string, unknown>;
+
+  const id = row['id'];
+  const updatedAt = row['updated_at'];
+  if (typeof id !== 'string' || typeof updatedAt !== 'string') return null;
+
+  return {
+    id,
+    type: typeof row['type'] === 'string' ? row['type'] : '',
+    name: typeof row['name'] === 'string' ? row['name'] : id,
+    aliases: strings(row['aliases']),
+    tags: strings(row['tags']),
+    attributes: rows<Attribute>(row['attributes'], ['kind', 'value']),
+    relations: rows<Relation>(row['relations'], ['predicate', 'entity']),
+    updatedAt,
+  };
+}
+
+function strings(raw: unknown): string[] {
+  return Array.isArray(raw) ? raw.filter((one): one is string => typeof one === 'string') : [];
+}
+
+function rows<T>(raw: unknown, required: readonly [string, string]): T[] {
+  if (!Array.isArray(raw)) return [];
+
+  return raw.flatMap((item) => {
+    if (item === null || typeof item !== 'object' || Array.isArray(item)) return [];
+    const one = item as Record<string, unknown>;
+    if (required.some((key) => typeof one[key] !== 'string')) return [];
+
+    const note = one['note'];
+    return [
+      {
+        [required[0]]: one[required[0]],
+        [required[1]]: one[required[1]],
+        ...(typeof note === 'string' ? { note } : {}),
+      } as T,
+    ];
+  });
+}
+
+/**
+ * Sorted by id, fixed key order, two-space indent.
+ *
+ * Determinism is not cosmetic: this lands in a git diff on the owner's own
+ * notes repository, and a file that reorders itself makes a one-attribute
+ * change unreviewable.
+ */
+function serialiseIndex(
+  entities: readonly CatalogueEntity[],
+  fingerprint: string,
+  now: string,
+): string {
+  const rows = [...entities]
+    .sort((a, b) => a.id.localeCompare(b.id))
+    .map((entity) => ({
+      id: entity.id,
+      ...(entity.type ? { type: entity.type } : {}),
+      name: entity.name,
+      ...(entity.aliases.length > 0 ? { aliases: [...entity.aliases] } : {}),
+      ...(entity.tags.length > 0 ? { tags: [...entity.tags] } : {}),
+      ...(entity.attributes.length > 0
+        ? { attributes: entity.attributes.map((one) => ({ ...one })) }
+        : {}),
+      ...(entity.relations.length > 0
+        ? { relations: entity.relations.map((one) => ({ ...one })) }
+        : {}),
+      updated_at: entity.updatedAt,
+    }));
+
+  return `${JSON.stringify({ v: INDEX_VERSION, fingerprint, built_at: now, entities: rows }, null, 2)}\n`;
+}

--- a/src/providers/entities/find.test.ts
+++ b/src/providers/entities/find.test.ts
@@ -1,0 +1,340 @@
+import { describe, expect, test } from 'bun:test';
+import { catalogueFrom, type CatalogueEntity } from './catalogue.ts';
+import { distinguish, matchEntities, type Criteria } from './find.ts';
+import { describe as describeCriteria, renderCandidates, renderEntity } from './render.ts';
+
+/**
+ * What a name means, and what happens when it means more than one thing.
+ *
+ * The behaviour under test is a product decision as much as a technical one:
+ * several matches is a normal answer. So most of these assert that ambiguity is
+ * *preserved* — that nothing collapses two Jans into one — and the rest assert
+ * that when it happens, the answer carries enough to settle it.
+ *
+ * All pure, over literal arrays. That is the point of the seam: ambiguity,
+ * preference order and dangling edges are the cases worth covering and none of
+ * them needs a store.
+ */
+
+function entity(id: string, overrides: Partial<CatalogueEntity> = {}): CatalogueEntity {
+  return {
+    id,
+    type: 'person',
+    name: id,
+    aliases: [],
+    tags: [],
+    attributes: [],
+    relations: [],
+    updatedAt: '2026-08-30T09:00:00.000Z',
+    ...overrides,
+  };
+}
+
+const JAN = entity('jan-bakker', {
+  name: 'Jan Bakker',
+  aliases: ['Jan', 'JB'],
+  tags: ['client'],
+  attributes: [
+    { kind: 'email', value: 'jan@acme.test', note: 'work' },
+    { kind: 'email', value: 'j.bakker@example.net', note: 'personal' },
+    { kind: 'github', value: 'janb' },
+  ],
+  relations: [{ predicate: 'works_at', entity: 'acme-bv', note: 'since 2023' }],
+});
+
+const JAN_DE_VRIES = entity('jan-de-vries', {
+  name: 'Jan de Vries',
+  aliases: ['Jan'],
+  attributes: [{ kind: 'email', value: 'jdv@meridian.test' }],
+  relations: [{ predicate: 'works_at', entity: 'meridian' }],
+  updatedAt: '2026-08-31T09:00:00.000Z',
+});
+
+const ACME = entity('acme-bv', { name: 'Acme B.V.', type: 'company', tags: ['client'] });
+const MERIDIAN = entity('meridian', { name: 'Meridian Foundation', type: 'company' });
+const MARTA = entity('marta-silva', {
+  name: 'Marta Silva',
+  attributes: [{ kind: 'github', value: 'msilva' }],
+  relations: [{ predicate: 'works_at', entity: 'acme-bv' }],
+});
+
+const CATALOGUE = catalogueFrom([JAN, JAN_DE_VRIES, ACME, MERIDIAN, MARTA]);
+
+function ids(criteria: Criteria): string[] {
+  return matchEntities(CATALOGUE, criteria).candidates.map((one) => one.entity.id);
+}
+
+describe('the rank ladder', () => {
+  test('an id, a name, an alias and an attribute value each match exactly', () => {
+    expect(ids({ query: 'jan-bakker' })).toEqual(['jan-bakker']);
+    expect(ids({ query: 'Jan Bakker' })).toEqual(['jan-bakker']);
+    expect(ids({ query: 'JB' })).toEqual(['jan-bakker']);
+    expect(ids({ query: 'jan@acme.test' })).toEqual(['jan-bakker']);
+  });
+
+  test('matching is case- and whitespace-insensitive', () => {
+    expect(ids({ query: '  JAN BAKKER ' })).toEqual(['jan-bakker']);
+    expect(ids({ query: 'JAN@ACME.TEST' })).toEqual(['jan-bakker']);
+  });
+
+  test('an attribute match names its kind, so a wrong one is legible', () => {
+    const [candidate] = matchEntities(CATALOGUE, { query: 'janb' }).candidates;
+    expect(candidate?.rank).toBe('attribute');
+    expect(candidate?.matched).toBe('github');
+  });
+
+  test('an alias match names the alias it matched', () => {
+    const [candidate] = matchEntities(CATALOGUE, { query: 'JB' }).candidates;
+    expect(candidate?.matched).toBe('alias "JB"');
+  });
+
+  test('exact suppresses approximate', () => {
+    const catalogue = catalogueFrom([
+      entity('jan-bakker', { name: 'Jan Bakker', aliases: ['Jan'] }),
+      entity('janet-cole', { name: 'Janet Cole' }),
+    ]);
+
+    // "Janet Cole" starts with "jan" too. An exact alias match is a different
+    // *kind* of answer, so the approximate one is dropped rather than ranked
+    // below it — otherwise every lookup of a short name grows a tail.
+    expect(matchEntities(catalogue, { query: 'Jan' }).candidates.map((c) => c.entity.id)).toEqual([
+      'jan-bakker',
+    ]);
+  });
+
+  test('with nothing exact, prefix and substring still answer', () => {
+    const catalogue = catalogueFrom([
+      entity('janet-cole', { name: 'Janet Cole' }),
+      entity('marijana-b', { name: 'Marijana B' }),
+    ]);
+
+    expect(matchEntities(catalogue, { query: 'jan' }).candidates.map((c) => c.rank)).toEqual([
+      'prefix',
+      'substring',
+    ]);
+  });
+
+  test('a tag is never matched by query', () => {
+    // `find("client")` must not surface one of eleven clients as if it were a
+    // name. The tag filter is how you mean the category.
+    expect(ids({ query: 'client' })).toEqual([]);
+    expect(ids({ tag: 'client' }).sort()).toEqual(['acme-bv', 'jan-bakker']);
+  });
+
+  test('nothing matching is an empty list, not a throw', () => {
+    expect(matchEntities(CATALOGUE, { query: 'nobody at all' })).toEqual({
+      candidates: [],
+      total: 0,
+      scanned: 5,
+    });
+  });
+});
+
+describe('ambiguity is preserved, not resolved', () => {
+  test('two exact alias matches both come back', () => {
+    expect(ids({ query: 'Jan' }).sort()).toEqual(['jan-bakker', 'jan-de-vries']);
+  });
+
+  test('ordering within a rank does not promote one of them', () => {
+    const matches = matchEntities(CATALOGUE, { query: 'Jan' });
+
+    // Both are rank `alias`. `updatedAt` orders them, which is a presentation
+    // choice — and the assertion that matters is that both survive it.
+    expect(matches.candidates).toHaveLength(2);
+    expect(new Set(matches.candidates.map((one) => one.rank))).toEqual(new Set(['alias']));
+  });
+
+  test('a criterion narrows an ambiguity to one', () => {
+    expect(ids({ query: 'Jan', related: [{ predicate: 'works_at', entity: 'acme-bv' }] })).toEqual([
+      'jan-bakker',
+    ]);
+    expect(ids({ query: 'Jan', attr: [{ kind: 'github' }] })).toEqual(['jan-bakker']);
+  });
+
+  test('limit reports what it cut rather than hiding it', () => {
+    const matches = matchEntities(CATALOGUE, { query: 'Jan', limit: 1 });
+    expect(matches.candidates).toHaveLength(1);
+    expect(matches.total).toBe(2);
+  });
+});
+
+describe('criteria are AND-ed', () => {
+  test('type narrows', () => {
+    expect(ids({ type: 'company' }).sort()).toEqual(['acme-bv', 'meridian']);
+    expect(ids({ query: 'Jan', type: 'company' })).toEqual([]);
+  });
+
+  test('two criteria intersect rather than union', () => {
+    // `type: person` alone has three; `tag: client` alone has two. Together,
+    // one — which is the whole difference between AND and OR.
+    expect(ids({ type: 'person', tag: 'client' })).toEqual(['jan-bakker']);
+  });
+
+  test('attr matches a kind with or without a value', () => {
+    expect(ids({ attr: [{ kind: 'github' }] }).sort()).toEqual(['jan-bakker', 'marta-silva']);
+    expect(ids({ attr: [{ kind: 'github', value: 'msilva' }] })).toEqual(['marta-silva']);
+    expect(ids({ attr: [{ kind: 'github', value: 'nobody' }] })).toEqual([]);
+  });
+
+  test('no criteria at all lists everything', () => {
+    expect(ids({}).length).toBe(5);
+  });
+});
+
+describe('the related filter', () => {
+  test('out — who points at Acme, and not Acme itself', () => {
+    // The natural phrasing. "Who works at Acme" wants the employees; returning
+    // Acme as well would be a wrong answer wearing the same shape as a right one.
+    expect(ids({ related: [{ predicate: 'works_at', entity: 'acme-bv' }] }).sort()).toEqual([
+      'jan-bakker',
+      'marta-silva',
+    ]);
+  });
+
+  test('in — who Acme is pointed at by, read from the entity side', () => {
+    expect(ids({ related: [{ entity: 'jan-bakker', direction: 'in' }] })).toEqual(['acme-bv']);
+  });
+
+  test('any — either direction', () => {
+    expect(ids({ related: [{ entity: 'acme-bv', direction: 'any' }] }).sort()).toEqual([
+      'jan-bakker',
+      'marta-silva',
+    ]);
+    expect(ids({ related: [{ entity: 'marta-silva', direction: 'any' }] })).toEqual(['acme-bv']);
+  });
+
+  test('the predicate is optional', () => {
+    expect(ids({ related: [{ entity: 'meridian' }] })).toEqual(['jan-de-vries']);
+    expect(ids({ related: [{ predicate: 'knows', entity: 'meridian' }] })).toEqual([]);
+  });
+});
+
+describe('distinguish', () => {
+  test('it drops what every candidate shares and keeps what separates them', () => {
+    // Looked up by id rather than by position: the order within a rank is a
+    // presentation detail and asserting on it here would test the wrong thing.
+    const { candidates } = matchEntities(CATALOGUE, { query: 'Jan' });
+    const rows = new Map(
+      distinguish(candidates).map((facets, index) => [
+        candidates[index]!.entity.id,
+        facets.join(' '),
+      ]),
+    );
+
+    // Both are `type: person`, so type says nothing and is omitted.
+    expect(rows.get('jan-bakker')).not.toContain('person');
+    expect(rows.get('jan-de-vries')).not.toContain('person');
+
+    // The employer is what actually tells them apart.
+    expect(rows.get('jan-bakker')).toContain('acme-bv');
+    expect(rows.get('jan-de-vries')).toContain('meridian');
+  });
+
+  test('it reports nothing when nothing distinguishes', () => {
+    const catalogue = catalogueFrom([
+      entity('jan-one', { name: 'Jan', aliases: ['Jan'] }),
+      entity('jan-two', { name: 'Jan', aliases: ['Jan'] }),
+    ]);
+
+    expect(distinguish(matchEntities(catalogue, { query: 'Jan' }).candidates)).toEqual([[], []]);
+  });
+
+  test('a field only one candidate has still counts as distinguishing', () => {
+    const catalogue = catalogueFrom([
+      entity('a-one', { name: 'Same', aliases: ['Same'], tags: ['vip'] }),
+      entity('b-two', { name: 'Same', aliases: ['Same'] }),
+    ]);
+
+    const [first, second] = distinguish(matchEntities(catalogue, { query: 'Same' }).candidates);
+    expect(first).toEqual(['tags vip']);
+    expect(second).toEqual([]);
+  });
+});
+
+describe('rendering one entity', () => {
+  test('it prints attributes in file order and marks the preference rule', () => {
+    const text = renderEntity(JAN, CATALOGUE, 'Prefers email over calls.');
+
+    expect(text).toContain('Jan Bakker — person (jan-bakker)');
+    expect(text).toContain('Also known as Jan, JB.');
+    expect(text.indexOf('jan@acme.test')).toBeLessThan(
+      text.indexOf('j.bakker@example.net'),
+    );
+    expect(text).toContain('the first is the default');
+    expect(text).toContain('Prefers email over calls.');
+  });
+
+  test('the preference sentence is absent when no kind holds two', () => {
+    expect(renderEntity(MARTA, CATALOGUE, '')).not.toContain('the first is the default');
+  });
+
+  test('a forward edge names the entity it points at', () => {
+    expect(renderEntity(JAN, CATALOGUE, '')).toContain('works_at → Acme B.V. (acme-bv) — since 2023');
+  });
+
+  test('a backlink appears on the target without being stored there', () => {
+    const text = renderEntity(ACME, CATALOGUE, '');
+    expect(text).toContain('← works_at Jan Bakker (jan-bakker)');
+    expect(text).toContain('← works_at Marta Silva (marta-silva)');
+  });
+
+  test('a dangling edge renders as a plain name and says so', () => {
+    const catalogue = catalogueFrom([
+      entity('jan-bakker', {
+        name: 'Jan Bakker',
+        relations: [{ predicate: 'works_at', entity: 'not-declared' }],
+      }),
+    ]);
+
+    // Never a throw and never a dropped line: the owner recorded this, and
+    // hiding it would make the graph quietly wrong rather than visibly partial.
+    expect(renderEntity(catalogue.entities[0]!, catalogue, '')).toContain(
+      'works_at → not-declared (not a declared entity)',
+    );
+  });
+});
+
+describe('rendering several candidates', () => {
+  test('the count comes first, before any candidate', () => {
+    const matches = matchEntities(CATALOGUE, { query: 'Jan' });
+    const text = renderCandidates(matches, { query: 'Jan' }, 'entities.main');
+
+    // A client that truncates must still have seen that there was more than one.
+    expect(text.split('\n')[0]).toBe('2 entities match "Jan" on `entities.main`.');
+    expect(text.indexOf('2 entities match')).toBeLessThan(text.indexOf('jan-bakker'));
+  });
+
+  test('it says to ask, and says the order is not a ranking', () => {
+    const matches = matchEntities(CATALOGUE, { query: 'Jan' });
+    const text = renderCandidates(matches, { query: 'Jan' }, 'entities.main');
+
+    expect(text).toContain('ask before acting');
+    expect(text).toContain('the order is not a ranking');
+  });
+
+  test('two candidates that differ by nothing say so', () => {
+    const catalogue = catalogueFrom([
+      entity('jan-one', { name: 'Jan', aliases: ['Jan'] }),
+      entity('jan-two', { name: 'Jan', aliases: ['Jan'] }),
+    ]);
+    const matches = matchEntities(catalogue, { query: 'Jan' });
+
+    expect(renderCandidates(matches, { query: 'Jan' }, 'entities.main')).toContain(
+      'duplicate to merge',
+    );
+  });
+
+  test('a truncated list says how to see the rest', () => {
+    const matches = matchEntities(CATALOGUE, { query: 'Jan', limit: 1 });
+    expect(renderCandidates(matches, { query: 'Jan' }, 'entities.main')).toContain('raise `limit`');
+  });
+
+  test('criteria are described in the words the caller used', () => {
+    expect(describeCriteria({ query: 'Jan', type: 'person' })).toBe('"Jan", type person');
+    expect(describeCriteria({ attr: [{ kind: 'github' }] })).toBe('with a github');
+    expect(describeCriteria({ related: [{ predicate: 'works_at', entity: 'acme-bv' }] })).toBe(
+      'works_at → acme-bv',
+    );
+    expect(describeCriteria({})).toBe('no criteria');
+  });
+});

--- a/src/providers/entities/find.test.ts
+++ b/src/providers/entities/find.test.ts
@@ -239,6 +239,19 @@ describe('distinguish', () => {
     expect(distinguish(matchEntities(catalogue, { query: 'Jan' }).candidates)).toEqual([[], []]);
   });
 
+  test('it renders the differing value, not just the field name', () => {
+    const { candidates } = matchEntities(CATALOGUE, { query: 'Jan' });
+    const rows = new Map(
+      distinguish(candidates).map((facets, index) => [candidates[index]!.entity.id, facets.join(' ')]),
+    );
+
+    // A draft withheld these. "These two differ by email" without saying how is
+    // the same ambiguity one level down, and there is nothing to withhold —
+    // `find` and `get` are both in the default read bundle.
+    expect(rows.get('jan-bakker')).toContain('jan@acme.test');
+    expect(rows.get('jan-de-vries')).toContain('jdv@meridian.test');
+  });
+
   test('a field only one candidate has still counts as distinguishing', () => {
     const catalogue = catalogueFrom([
       entity('a-one', { name: 'Same', aliases: ['Same'], tags: ['vip'] }),

--- a/src/providers/entities/find.ts
+++ b/src/providers/entities/find.ts
@@ -1,0 +1,269 @@
+import type { Backlink, Catalogue, CatalogueEntity } from './catalogue.ts';
+
+/**
+ * What a name means, and what happens when it means more than one thing.
+ *
+ * This is the whole reason the component exists, so the rules are stated here
+ * rather than distributed through the handlers:
+ *
+ * **Several matches is a normal answer, not an error.** An assistant handed two
+ * people called Jan asks which one; it does not fail. So `find` returns every
+ * candidate and sets no error, and what it refuses to do is *choose*.
+ *
+ * **Ordering is not selection.** Candidates are ranked so the list is legible —
+ * an exact id above a substring — and nothing in the response presents the
+ * first as the answer. There is deliberately no scoring inside a rank: no
+ * most-recently-updated tiebreak that would quietly promote one of two exact
+ * alias matches. `updatedAt` orders *within* a rank and never across. This is
+ * the one thing a later contributor will be tempted to improve into a silent
+ * pick.
+ *
+ * **Exact suppresses approximate.** If anything matched exactly, prefix and
+ * substring candidates are dropped. That is a boundary between *kinds* of
+ * match, not a precedence among equals: two exact alias matches both survive,
+ * and both are returned.
+ *
+ * **A tag is never matched by `query`.** A tag is a category, not an identity,
+ * so `find("client")` must not surface one of eleven clients as if it were a
+ * name. Filter by `tag` to mean the category.
+ *
+ * Everything here is pure and synchronous over a catalogue already in memory,
+ * which is what lets the interesting cases — ambiguity, dangling edges,
+ * preference order — be tested with literal arrays and no I/O.
+ */
+
+export type Direction = 'out' | 'in' | 'any';
+
+export interface AttributeCriterion {
+  readonly kind: string;
+  /** Omitted means "has this kind at all", which is a useful browse. */
+  readonly value?: string | undefined;
+}
+
+export interface RelationCriterion {
+  /** Omitted means any predicate. */
+  readonly predicate?: string | undefined;
+  readonly entity: string;
+  /**
+   * `out` — the candidate declares an edge *to* `entity`. The default, because
+   * it is what the natural phrasing means: "who works at Acme" wants Acme's
+   * employees and not Acme.
+   */
+  readonly direction?: Direction | undefined;
+}
+
+/**
+ * Every field optional, and explicitly `| undefined`.
+ *
+ * The handler destructures its validated input and hands the pieces straight
+ * here, so a criterion the caller omitted arrives as `undefined` rather than
+ * being absent — writing that out is what lets the surface stay a one-line
+ * pass-through instead of six conditional spreads.
+ */
+export interface Criteria {
+  readonly query?: string | undefined;
+  readonly type?: string | undefined;
+  readonly tag?: string | undefined;
+  readonly attr?: readonly AttributeCriterion[] | undefined;
+  readonly related?: readonly RelationCriterion[] | undefined;
+  readonly limit?: number | undefined;
+}
+
+export const DEFAULT_LIMIT = 10;
+export const MAX_LIMIT = 50;
+
+/**
+ * How a candidate matched, in the order a list shows them.
+ *
+ * Ranks 1-4 are what a lookup means. 5 and 6 exist so a browse is useful, and
+ * are dropped entirely whenever anything above them matched.
+ */
+const RANKS = ['id', 'name', 'alias', 'attribute', 'prefix', 'substring'] as const;
+export type Rank = (typeof RANKS)[number];
+
+const APPROXIMATE: readonly Rank[] = ['prefix', 'substring'];
+
+export interface Candidate {
+  readonly entity: CatalogueEntity;
+  readonly rank: Rank;
+  /** The field that matched, as a person would say it: `alias "Jan"`, `email`. */
+  readonly matched: string;
+}
+
+export interface Matches {
+  readonly candidates: readonly Candidate[];
+  /** How many matched before `limit` cut the list. */
+  readonly total: number;
+  /** How many entities were considered, for the audit annotation. */
+  readonly scanned: number;
+}
+
+/**
+ * Normalised for comparison: trimmed, NFC, lowercased.
+ *
+ * NFC because a name typed with a combining accent in one place and precomposed
+ * in another is the same person, and this is the only comparison in the
+ * provider where that difference can decide an identity.
+ */
+function fold(text: string): string {
+  return text.trim().normalize('NFC').toLowerCase();
+}
+
+export function matchEntities(catalogue: Catalogue, criteria: Criteria): Matches {
+  const filtered = catalogue.entities.filter((entity) => passesFilters(catalogue, entity, criteria));
+
+  const query = criteria.query === undefined ? '' : fold(criteria.query);
+  const matched: Candidate[] = [];
+
+  for (const entity of filtered) {
+    if (query.length === 0) {
+      matched.push({ entity, rank: 'name', matched: 'listed' });
+      continue;
+    }
+    const candidate = rankOf(entity, query);
+    if (candidate !== null) matched.push(candidate);
+  }
+
+  const exact = matched.filter((one) => !APPROXIMATE.includes(one.rank));
+  const kept = exact.length > 0 ? exact : matched;
+
+  kept.sort(
+    (a, b) =>
+      RANKS.indexOf(a.rank) - RANKS.indexOf(b.rank) ||
+      b.entity.updatedAt.localeCompare(a.entity.updatedAt),
+  );
+
+  const limit = Math.min(Math.max(criteria.limit ?? DEFAULT_LIMIT, 1), MAX_LIMIT);
+
+  return { candidates: kept.slice(0, limit), total: kept.length, scanned: catalogue.entities.length };
+}
+
+/** All criteria present are AND-ed. None of them looks at `query`. */
+function passesFilters(
+  catalogue: Catalogue,
+  entity: CatalogueEntity,
+  criteria: Criteria,
+): boolean {
+  if (criteria.type !== undefined && fold(entity.type) !== fold(criteria.type)) return false;
+
+  if (criteria.tag !== undefined && !entity.tags.some((tag) => fold(tag) === fold(criteria.tag!))) {
+    return false;
+  }
+
+  for (const want of criteria.attr ?? []) {
+    const present = entity.attributes.some(
+      (attribute) =>
+        fold(attribute.kind) === fold(want.kind) &&
+        (want.value === undefined || fold(attribute.value) === fold(want.value)),
+    );
+    if (!present) return false;
+  }
+
+  for (const want of criteria.related ?? []) {
+    if (!relatedTo(catalogue, entity, want)) return false;
+  }
+
+  return true;
+}
+
+function relatedTo(
+  catalogue: Catalogue,
+  entity: CatalogueEntity,
+  want: RelationCriterion,
+): boolean {
+  const direction = want.direction ?? 'out';
+  const target = fold(want.entity);
+  const predicate = want.predicate === undefined ? null : fold(want.predicate);
+
+  const out = entity.relations.some(
+    (relation) =>
+      fold(relation.entity) === target &&
+      (predicate === null || fold(relation.predicate) === predicate),
+  );
+  if (direction === 'out') return out;
+
+  const into = (catalogue.backlinks.get(entity.id) ?? []).some(
+    (backlink) =>
+      fold(backlink.from) === target &&
+      (predicate === null || fold(backlink.predicate) === predicate),
+  );
+
+  return direction === 'in' ? into : out || into;
+}
+
+/** The strongest way this entity matches the query, or null. */
+function rankOf(entity: CatalogueEntity, query: string): Candidate | null {
+  if (fold(entity.id) === query) return { entity, rank: 'id', matched: 'id' };
+  if (fold(entity.name) === query) return { entity, rank: 'name', matched: 'name' };
+
+  const alias = entity.aliases.find((one) => fold(one) === query);
+  if (alias !== undefined) return { entity, rank: 'alias', matched: `alias "${alias}"` };
+
+  const attribute = entity.attributes.find((one) => fold(one.value) === query);
+  if (attribute !== undefined) {
+    return { entity, rank: 'attribute', matched: attribute.kind };
+  }
+
+  const prefixed = [entity.name, ...entity.aliases].find((one) => fold(one).startsWith(query));
+  if (prefixed !== undefined) return { entity, rank: 'prefix', matched: `starts with "${query}"` };
+
+  const haystack = [entity.name, ...entity.aliases, ...entity.attributes.map((one) => one.value)];
+  if (haystack.some((one) => fold(one).includes(query))) {
+    return { entity, rank: 'substring', matched: `contains "${query}"` };
+  }
+
+  return null;
+}
+
+/**
+ * The fields that actually differ across a set of candidates.
+ *
+ * This is what makes several matches a usable answer rather than a dump. Two
+ * people called Jan separated by their employer is a question the surrounding
+ * context usually settles; two rows of identical detail is not, and printing
+ * everything about both buries the one column that would have decided it.
+ *
+ * Fields shared by every candidate are omitted for that reason, not to save
+ * space. An attribute *value* that no criterion named is never rendered here —
+ * disambiguating two people by printing three people's phone numbers is worse
+ * than the ambiguity.
+ */
+export function distinguish(candidates: readonly Candidate[]): string[][] {
+  const facets = candidates.map(facetsOf);
+  const keys = [...new Set(facets.flatMap((one) => [...one.keys()]))];
+
+  const differing = keys.filter((key) => {
+    const values = facets.map((one) => one.get(key) ?? '');
+    return values.some((value) => value !== values[0]);
+  });
+
+  return facets.map((one) =>
+    differing.flatMap((key) => {
+      const value = one.get(key);
+      return value === undefined ? [] : [`${key} ${value}`];
+    }),
+  );
+}
+
+/** One candidate's comparable surface: type, tags, attribute kinds, edges. */
+function facetsOf(candidate: Candidate): Map<string, string> {
+  const facets = new Map<string, string>();
+  const { entity } = candidate;
+
+  if (entity.type) facets.set('type', entity.type);
+  if (entity.tags.length > 0) facets.set('tags', [...entity.tags].sort().join(', '));
+
+  for (const kind of new Set(entity.attributes.map((one) => one.kind))) {
+    const values = entity.attributes.filter((one) => one.kind === kind).map((one) => one.value);
+    facets.set(kind, values.join(', '));
+  }
+
+  for (const predicate of new Set(entity.relations.map((one) => one.predicate))) {
+    const targets = entity.relations
+      .filter((one) => one.predicate === predicate)
+      .map((one) => one.entity);
+    facets.set(`${predicate} →`, targets.join(', '));
+  }
+
+  return facets;
+}

--- a/src/providers/entities/find.ts
+++ b/src/providers/entities/find.ts
@@ -224,9 +224,19 @@ function rankOf(entity: CatalogueEntity, query: string): Candidate | null {
  * everything about both buries the one column that would have decided it.
  *
  * Fields shared by every candidate are omitted for that reason, not to save
- * space. An attribute *value* that no criterion named is never rendered here —
- * disambiguating two people by printing three people's phone numbers is worse
- * than the ambiguity.
+ * space: they cannot disambiguate, and they crowd out what can.
+ *
+ * Values *are* rendered, and that is a deliberate reversal of an earlier draft
+ * which withheld them. An address is usually the most distinguishing thing
+ * about a person, so withholding it leaves a row that says two people differ by
+ * their email without saying how — which is the ambiguity again, one level
+ * down. It discloses nothing either: `find` and `get` are both in the default
+ * read bundle, so anything that can see this list can already open either
+ * record. What it costs is verbosity, and only for fields that actually differ.
+ *
+ * The audit log is the separate question and is answered differently: the query
+ * is withheld there and only the ids that matched are recorded. A response goes
+ * to a caller that already has the read grant; the log outlives the call.
  */
 export function distinguish(candidates: readonly Candidate[]): string[][] {
   const facets = candidates.map(facetsOf);

--- a/src/providers/entities/provider.test.ts
+++ b/src/providers/entities/provider.test.ts
@@ -1,0 +1,390 @@
+import { describe, expect, test } from 'bun:test';
+import { harnessFor, linksOf, textOf } from '#providers/harness.ts';
+import { entitiesProvider } from './provider.ts';
+import { INDEX_KEY, fingerprintOf, writeCatalogue, type CatalogueEntity } from './catalogue.ts';
+import type { CapabilityResult } from '#connectivity';
+
+/**
+ * The surface, through the connector the runtime uses rather than by calling
+ * handlers directly.
+ *
+ * Two claims get most of the attention here because they are the ones the
+ * component exists for. **Several matches is a normal answer**: no `isError`,
+ * the count stated before any candidate, and nothing presenting one of them as
+ * the choice. And **what reaches the audit log**: this provider holds third
+ * parties' addresses, so the rules about what is kept are asserted against the
+ * redaction functions themselves rather than trusted to a comment.
+ */
+
+function harness() {
+  return harnessFor(entitiesProvider);
+}
+
+async function declare(
+  h: ReturnType<typeof harness>,
+  args: Record<string, unknown>,
+): Promise<CapabilityResult> {
+  return h.invoke('write', args);
+}
+
+const JAN = {
+  name: 'Jan Bakker',
+  type: 'person',
+  aliases: ['Jan'],
+  tags: ['client'],
+  attributes: [
+    { kind: 'email', value: 'jan@acme.test', note: 'work' },
+    { kind: 'email', value: 'j.bakker@example.net', note: 'personal' },
+    { kind: 'github', value: 'janb' },
+  ],
+  relations: [{ predicate: 'works_at', entity: 'acme-bv' }],
+  notes: 'Prefers email over calls.',
+};
+
+describe('the shape of the surface', () => {
+  test('reading and writing are different capabilities, and write is not default', () => {
+    const bundles = entitiesProvider.manifest.bundles ?? [];
+    const read = bundles.find((one) => one.name === 'read');
+    const write = bundles.find((one) => one.name === 'write');
+
+    expect(read?.default).toBe(true);
+    expect(read?.capabilities).toEqual(['entity', 'find', 'get']);
+
+    // ADR-012 §2. Not default, and it takes all three names to deny — there is
+    // no single rule that closes it, which the docs have to say.
+    expect(write?.default).toBeFalsy();
+    expect(write?.capabilities).toEqual(['write', 'link', 'forget']);
+  });
+
+  test('the capability list is exactly what was meant, and a resource is among it', () => {
+    expect(entitiesProvider.capabilities.map((one) => one.name)).toEqual([
+      'entity',
+      'find',
+      'get',
+      'write',
+      'link',
+      'forget',
+    ]);
+
+    // Without a resource template, `resourceLinkRouter` has no origin to route
+    // and every link below reaches the client unreadable.
+    const resource = entitiesProvider.capabilities.find((one) => one.kind === 'resource');
+    expect(resource?.name).toBe('entity');
+  });
+
+  test('no capability name trips the control-plane vocabulary', () => {
+    // The seven patterns `control-plane.test.ts` enforces, checked here too so
+    // a rename is caught in this file rather than three components away.
+    const forbidden = [/policy/i, /(^|[._])(token|bearer)/i, /credential|secret|password/i,
+      /(^|[._])config/i, /(^|[._])(connect|authorize|oauth)/i, /audit/i,
+      /(^|[._])(grant|revoke|allow|deny)/i];
+
+    for (const capability of entitiesProvider.capabilities) {
+      for (const pattern of forbidden) {
+        expect(`entities.${capability.name}`).not.toMatch(pattern);
+      }
+    }
+  });
+});
+
+describe('one match is an answer', () => {
+  test('it returns a link and the text, so a client that ignores links still reads it', async () => {
+    const h = harness();
+    await declare(h, JAN);
+
+    const result = await h.invoke('find', { query: 'Jan' });
+
+    expect(linksOf(result)).toEqual(['entities://entity/jan-bakker']);
+    const text = textOf(result);
+    expect(text).toContain('Jan Bakker — person (jan-bakker)');
+    expect(text).toContain('jan@acme.test');
+    expect(text).toContain('Prefers email over calls.');
+    expect('isError' in result && result.isError).toBeFalsy();
+  });
+
+  test('an address resolves to the entity that holds it', async () => {
+    const h = harness();
+    await declare(h, JAN);
+
+    expect(textOf(await h.invoke('find', { query: 'janb' }))).toContain('jan-bakker');
+  });
+});
+
+describe('several matches is a normal answer, not a failure', () => {
+  async function twoJans() {
+    const h = harness();
+    await declare(h, JAN);
+    await declare(h, {
+      name: 'Jan de Vries',
+      type: 'person',
+      aliases: ['Jan'],
+      attributes: [{ kind: 'email', value: 'jdv@meridian.test' }],
+      relations: [{ predicate: 'works_at', entity: 'meridian' }],
+    });
+    return h;
+  }
+
+  test('no error is set, and the count comes before any candidate', async () => {
+    const result = await (await twoJans()).invoke('find', { query: 'Jan' });
+
+    // An assistant handed two people called Jan asks which one. It does not
+    // fail, and a client that truncates must still have seen there were two.
+    expect('isError' in result && result.isError).toBeFalsy();
+    const text = textOf(result);
+    expect(text.split('\n')[0]).toContain('2 entities match');
+    expect(text.indexOf('2 entities match')).toBeLessThan(text.indexOf('jan-bakker'));
+  });
+
+  test('it says to ask, and that the order is not a ranking', async () => {
+    const text = textOf(await (await twoJans()).invoke('find', { query: 'Jan' }));
+
+    expect(text).toContain('ask before acting');
+    expect(text).toContain('the order is not a ranking');
+  });
+
+  test('it shows what separates them and not what they share', async () => {
+    const text = textOf(await (await twoJans()).invoke('find', { query: 'Jan' }));
+
+    expect(text).toContain('acme-bv');
+    expect(text).toContain('meridian');
+    // Both are people. Saying so twice crowds out the column that decides it.
+    expect(text).not.toContain('type person');
+  });
+
+  test('every candidate carries a link, so none is privileged', async () => {
+    expect(linksOf(await (await twoJans()).invoke('find', { query: 'Jan' })).sort()).toEqual([
+      'entities://entity/jan-bakker',
+      'entities://entity/jan-de-vries',
+    ]);
+  });
+
+  test('a criterion narrows the same query to one', async () => {
+    const h = await twoJans();
+    const result = await h.invoke('find', {
+      query: 'Jan',
+      related: [{ predicate: 'works_at', entity: 'acme-bv' }],
+    });
+
+    expect(linksOf(result)).toEqual(['entities://entity/jan-bakker']);
+  });
+});
+
+describe('no match', () => {
+  test('is not an error either, and says not to invent an address', async () => {
+    const h = harness();
+    await declare(h, JAN);
+
+    const result = await h.invoke('find', { query: 'Nobody Here' });
+
+    expect('isError' in result && result.isError).toBeFalsy();
+    expect(textOf(result)).toContain('Do not use an address that is not here');
+  });
+});
+
+describe('writing', () => {
+  test('a field that is not supplied keeps what is on disk', async () => {
+    const h = harness();
+    await declare(h, JAN);
+
+    // The lost-update case: a model updating one thing resends the entity
+    // without the attributes it forgot.
+    await declare(h, { id: 'jan-bakker', name: 'Jan Bakker', tags: ['client', 'vip'] });
+
+    const text = textOf(await h.invoke('get', { id: 'jan-bakker' }));
+    expect(text).toContain('jan@acme.test');
+    expect(text).toContain('janb');
+    expect(text).toContain('Tagged client, vip.');
+    expect(text).toContain('Prefers email over calls.');
+  });
+
+  test('an empty list clears deliberately', async () => {
+    const h = harness();
+    await declare(h, JAN);
+    await declare(h, { id: 'jan-bakker', name: 'Jan Bakker', attributes: [] });
+
+    expect(textOf(await h.invoke('get', { id: 'jan-bakker' }))).not.toContain('jan@acme.test');
+  });
+
+  test('a kind is refused rather than repaired', async () => {
+    const h = harness();
+    await expect(
+      declare(h, { name: 'Jan', attributes: [{ kind: 'E-Mail', value: 'x@example.test' }] }),
+    ).rejects.toThrow(/kind/);
+  });
+
+  test('link appends one edge without restating the entity', async () => {
+    const h = harness();
+    await declare(h, JAN);
+    await h.invoke('link', { from: 'jan-bakker', predicate: 'knows', to: 'marta-silva' });
+
+    const text = textOf(await h.invoke('get', { id: 'jan-bakker' }));
+    expect(text).toContain('works_at → acme-bv');
+    expect(text).toContain('knows → marta-silva');
+    expect(text).toContain('jan@acme.test');
+  });
+
+  test('an edge to an entity that does not exist is kept and said so', async () => {
+    const h = harness();
+    await declare(h, { name: 'Jan Bakker' });
+
+    const result = await h.invoke('link', {
+      from: 'jan-bakker',
+      predicate: 'works_at',
+      to: 'not-declared',
+    });
+
+    expect(textOf(result)).toContain('not declared yet');
+    expect(h.annotations()['dangling']).toBe(true);
+  });
+
+  test('the reverse of an edge is derived, never written to the other file', async () => {
+    const h = harness();
+    await declare(h, { id: 'acme-bv', name: 'Acme B.V.', type: 'company' });
+    await declare(h, JAN);
+
+    expect(textOf(await h.invoke('get', { id: 'acme-bv' }))).toContain(
+      '← works_at Jan Bakker (jan-bakker)',
+    );
+
+    // Acme's own document says nothing about Jan.
+    const raw = await h.context.storage.get('acme-bv.md');
+    expect(new TextDecoder().decode(raw!)).not.toContain('jan');
+  });
+});
+
+describe('forget does not cascade', () => {
+  test('it reports who still points at what it removed', async () => {
+    const h = harness();
+    await declare(h, { id: 'acme-bv', name: 'Acme B.V.', type: 'company' });
+    await declare(h, JAN);
+
+    const result = await h.invoke('forget', { id: 'acme-bv' });
+
+    // A delete that rewrote five other people's files could not be reviewed as
+    // one change. Naming them is what keeps the breakage from being silent.
+    expect(textOf(result)).toContain('Still referenced by jan-bakker');
+    expect(h.annotations()['referenced_by']).toBe(1);
+
+    const jan = textOf(await h.invoke('get', { id: 'jan-bakker' }));
+    expect(jan).toContain('works_at → acme-bv (not a declared entity)');
+  });
+
+  test('removing something absent is an error, and says so', async () => {
+    const result = await harness().invoke('forget', { id: 'nobody' });
+    expect('isError' in result && result.isError).toBe(true);
+  });
+});
+
+describe('the index is maintained by writes and trusted by reads', () => {
+  test('a write leaves an index that the next read uses', async () => {
+    const h = harness();
+    await declare(h, JAN);
+
+    const index = await h.context.storage.get(INDEX_KEY);
+    expect(index).not.toBeNull();
+
+    const document = JSON.parse(new TextDecoder().decode(index!));
+    expect(document.fingerprint).toBe(fingerprintOf(await h.context.storage.list()));
+    // What matches and what distinguishes, and nothing that only renders.
+    expect(JSON.stringify(document)).not.toContain('Prefers email over calls');
+  });
+
+  test('an index that disagrees with a file cannot produce a confident wrong answer', async () => {
+    const h = harness();
+    await declare(h, JAN);
+
+    // The hole the fingerprint cannot close: the index is edited on its own, so
+    // it still stamps the untouched entity files and is served.
+    const wrong: CatalogueEntity[] = [
+      {
+        id: 'jan-bakker',
+        type: 'person',
+        name: 'Jan Bakker',
+        aliases: ['Jan'],
+        tags: [],
+        attributes: [{ kind: 'email', value: 'attacker@example.test' }],
+        relations: [],
+        updatedAt: '2026-08-30T09:14:22.104Z',
+      },
+    ];
+    await writeCatalogue(
+      h.context.storage,
+      wrong,
+      fingerprintOf(await h.context.storage.list()),
+      '2026-08-30T09:14:22.104Z',
+    );
+
+    // One candidate, about to be acted on: the file is opened and compared, the
+    // catalogue is rebuilt, and the answer comes from the document on disk.
+    const text = textOf(await h.invoke('find', { query: 'Jan' }));
+    expect(text).toContain('jan@acme.test');
+    expect(text).not.toContain('attacker@example.test');
+  });
+});
+
+describe('what reaches the audit log', () => {
+  function redact(name: string, args: Record<string, unknown>): Record<string, unknown> {
+    const capability = entitiesProvider.capabilities.find((one) => one.name === name);
+    return capability!.redact!(args);
+  }
+
+  test('a lookup query is withheld, and the ids that came back are recorded', async () => {
+    const recorded = redact('find', { query: 'jan@acme.test', type: 'person', limit: 5 });
+
+    // The query is routinely a third party's address, typed by someone who
+    // never wrote it down — memory withholds its own for the same reason.
+    expect(JSON.stringify(recorded)).not.toContain('jan@acme.test');
+    expect(recorded['type']).toBe('person');
+    expect(recorded['limit']).toBe(5);
+
+    const h = harness();
+    await declare(h, JAN);
+    await h.invoke('find', { query: 'Jan' });
+
+    // The outcome is the useful record, and is stable across spellings.
+    expect(h.annotations()['candidates']).toEqual(['jan-bakker']);
+    expect(h.annotations()['matched']).toBe(1);
+  });
+
+  test('an attribute value never reaches the log, but its kind does', async () => {
+    const recorded = redact('write', {
+      id: 'jan-bakker',
+      name: 'Jan Bakker',
+      type: 'person',
+      tags: ['client'],
+      attributes: [{ kind: 'email', value: 'jan@acme.test' }],
+      notes: 'Prefers email over calls.',
+    });
+
+    const serialised = JSON.stringify(recorded);
+    expect(serialised).not.toContain('jan@acme.test');
+    expect(serialised).not.toContain('Prefers email over calls');
+    // The id and the name are addresses, and `id` is derived from `name` —
+    // keeping one while withholding the other would be theatre.
+    expect(recorded['id']).toBe('jan-bakker');
+    expect(recorded['name']).toBe('Jan Bakker');
+
+    const h = harness();
+    await declare(h, JAN);
+
+    // `redact` cannot express "keep the shape, drop the values"; `annotate`
+    // records what changed without putting an address in the chain. ADR-017.
+    expect(h.annotations()['kinds']).toEqual(['email', 'github']);
+    expect(h.annotations()['attributes']).toBe(3);
+    expect(h.annotations()['entity']).toBe('jan-bakker');
+  });
+
+  test('a relation is recorded by its ends, which are ids and not content', () => {
+    const recorded = redact('link', {
+      from: 'jan-bakker',
+      predicate: 'works_at',
+      to: 'acme-bv',
+      note: 'introduced by a mutual client',
+    });
+
+    expect(recorded['from']).toBe('jan-bakker');
+    expect(recorded['predicate']).toBe('works_at');
+    expect(recorded['to']).toBe('acme-bv');
+    expect(JSON.stringify(recorded)).not.toContain('mutual client');
+  });
+});

--- a/src/providers/entities/provider.ts
+++ b/src/providers/entities/provider.ts
@@ -1,0 +1,334 @@
+import { z } from 'zod';
+import {
+  defineLocalProvider,
+  keepKeys,
+  type BlobStore,
+  type ProviderDefinition,
+} from '#connectivity';
+import {
+  openCatalogue,
+  rebuildCatalogue,
+  type Catalogue,
+  type CatalogueEntity,
+} from './catalogue.ts';
+import { DEFAULT_LIMIT, MAX_LIMIT, matchEntities, type Criteria } from './find.ts';
+import { describe, renderCandidates, renderEntity } from './render.ts';
+import { readEntity, type Entity } from './store.ts';
+import { writeCapabilities } from './writes.ts';
+
+/**
+ * `entities` — who and what everyone else is.
+ *
+ * `identity` declares who the *owner* is, because an agent writing as them was
+ * otherwise inferring a name from whatever was in the conversation (ADR-042).
+ * The same failure happens one step outward and nothing catches it: asked to
+ * "email Jan about the invoice", an agent reaches for an address it saw in a
+ * thread. The information is knowable; there was nowhere to write it down.
+ *
+ * **`find` answers with everything that matches and never chooses.** One match
+ * is an answer; several is a question for the owner, and the response shows
+ * what *separates* the candidates so that question can usually be settled from
+ * context rather than asked. Several matches is a normal outcome and carries no
+ * error — an assistant handed two people called Jan asks which one, it does not
+ * fail. What is refused is silently picking one.
+ *
+ * **Reading and writing are separate capabilities**, following `memory` and
+ * ADR-012 §2. A writable store persists injections: an instruction written once
+ * is re-served to every later session, including to a different agent. That
+ * argument applies here with a twist worth naming — an entity is *acted on*, so
+ * a bad write is not only re-served, it is used to address a message. The write
+ * bundle is not default, and `deny` takes three rules to close
+ * (`entities.write`, `entities.link`, `entities.forget`), not one.
+ *
+ * Unlike `identity`, this **is** agent-writable, and the two are not
+ * inconsistent. ADR-050's test for a default grant is not "is it empty" but
+ * "can it be filled in from here": identity is configuration and changed in the
+ * CLI (ADR-007), so an agent able to edit it could edit the one fact that stops
+ * it signing as the wrong person. Everyone else's details are ordinary owner
+ * material, accumulated in conversation, on the same surface that reads them.
+ *
+ * Storage is `store.ts`, the derived index is `catalogue.ts`, matching is
+ * `find.ts` and wording is `render.ts`. This file is only the surface: schemas,
+ * bundles, redaction, and what reaches the audit log.
+ */
+
+const DESCRIPTION =
+  'The people, companies and projects the owner deals with, with their canonical addresses and ' +
+  'handles. Call entities.find before acting on a name: it returns every match and never chooses, ' +
+  'so more than one means ask rather than take the first.';
+
+export const entitiesProvider: ProviderDefinition = defineLocalProvider({
+  id: 'entities',
+  name: 'Entities',
+  version: '1.0.0',
+  description: DESCRIPTION,
+
+  configSchema: z.object({}),
+  connectionSchema: z.object({}),
+
+  bundles: [
+    {
+      name: 'read',
+      description: 'Look entities up and read them.',
+      oauth_scopes: [],
+      capabilities: ['entity', 'find', 'get'],
+      default: true,
+    },
+    {
+      // Not in the default bundle — see the provider docstring. Denying it
+      // takes all three names; there is no single rule that covers them.
+      name: 'write',
+      description: 'Declare, relate and remove entities.',
+      oauth_scopes: [],
+      capabilities: ['write', 'link', 'forget'],
+    },
+  ],
+
+  capabilities: [
+    /**
+     * Retrieval by address — a resource, not a tool (ADR-006).
+     *
+     * Not optional, and not decoration: `resourceLinkRouter` builds its set of
+     * routable origins from this provider's own `uriTemplate`s and returns the
+     * identity function when there are none. Without it every `resource_link`
+     * below would reach the client naming no profile and no connection, which
+     * no client can read.
+     */
+    {
+      kind: 'resource',
+      name: 'entity',
+      title: 'Entity',
+      description: 'One declared entity, addressed by its id.',
+      uriTemplate: 'entities://entity/{id}',
+      mimeType: 'text/markdown',
+      redact: keepKeys('uri'),
+
+      async list(context) {
+        const catalogue = await openCatalogue(context.storage);
+        return catalogue.entities.map((entity) => ({
+          uri: `entities://entity/${encodeURIComponent(entity.id)}`,
+          name: entity.name,
+        }));
+      },
+
+      async read(uri, params, context) {
+        const raw = params['id'];
+        if (!raw) throw new Error(`Malformed entities URI: ${uri}`);
+
+        const id = decodeURIComponent(raw);
+        const entity = await readEntity(context.storage, id);
+        if (entity === null) throw new Error(`No entity "${id}" on ${context.connection.key}`);
+
+        const catalogue = await openCatalogue(context.storage);
+        return { uri, mimeType: 'text/markdown', text: renderEntity(entity, catalogue, entity.body) };
+      },
+    },
+
+    {
+      kind: 'tool',
+      name: 'find',
+      title: 'Look up an entity',
+      description:
+        'Find entities by name, alias, address, type, tag, attribute or relationship. All criteria ' +
+        'given are combined. Returns every match: exactly one is an answer, several means ask which ' +
+        'is meant rather than taking the first, and the order is not a ranking. Call this before ' +
+        'using anyone’s address rather than recalling one.',
+      inputSchema: z.object({
+        query: z
+          .string()
+          .optional()
+          .describe('A name, alias, id or address. Matched exactly first, then by prefix and substring.'),
+        type: z.string().optional().describe('Restrict to one type, e.g. person, company, project'),
+        tag: z.string().optional().describe('Restrict to entities carrying this tag'),
+        attr: z
+          .array(
+            z.object({
+              kind: z.string().min(1).describe('Attribute kind, e.g. email, github'),
+              value: z.string().optional().describe('Omit to mean "has this kind at all"'),
+            }),
+          )
+          .optional()
+          .describe('Restrict to entities carrying these attributes'),
+        related: z
+          .array(
+            z.object({
+              predicate: z.string().optional().describe('Edge name, e.g. works_at. Omit for any.'),
+              entity: z.string().min(1).describe('The entity id on the other end'),
+              direction: z
+                .enum(['out', 'in', 'any'])
+                .optional()
+                .describe('out (default): this entity points at the named one'),
+            }),
+          )
+          .optional()
+          .describe('Restrict by relationship, one hop'),
+        limit: z
+          .number()
+          .int()
+          .min(1)
+          .max(MAX_LIMIT)
+          .optional()
+          .describe(`Maximum results (default ${DEFAULT_LIMIT})`),
+      }),
+      /**
+       * The query is withheld; the outcome is annotated instead.
+       *
+       * A lookup string here is frequently a third party's address, typed by
+       * someone who never wrote it down — the same class of thing
+       * `memory.search` withholds its query for. The ids that came back are the
+       * more useful record anyway: they are stable across spellings, and now
+       * that several matches is a normal outcome the log should show that two
+       * candidates were offered and which, so a later wrong message is
+       * traceable to the moment the choice was made.
+       */
+      redact: keepKeys('type', 'tag', 'limit'),
+      async handler({ query, type, tag, attr, related, limit }, context) {
+        const criteria: Criteria = { query, type, tag, attr, related, limit };
+
+        let catalogue = await openCatalogue(context.storage);
+        let matches = matchEntities(catalogue, criteria);
+
+        // Confirm-on-read: one candidate, served from an index, is the only
+        // shape where a wrong answer gets acted on. See `reconcile`.
+        const only = matches.candidates.length === 1 ? matches.candidates[0] : undefined;
+        if (catalogue.fromIndex && only !== undefined) {
+          const rebuilt = await reconcile(context.storage, catalogue, only.entity);
+          if (rebuilt !== null) {
+            context.log.debug('entities: index disagreed with a matched file, rebuilt');
+            catalogue = rebuilt;
+            matches = matchEntities(catalogue, criteria);
+          }
+        }
+
+        context.audit.annotate({
+          scanned: matches.scanned,
+          matched: matches.total,
+          candidates: matches.candidates.map((one) => one.entity.id),
+        });
+
+        if (matches.candidates.length === 0) {
+          return {
+            content: [
+              {
+                type: 'text',
+                text:
+                  `Nothing on ${context.connection.key} matches ${describe(criteria)}. ` +
+                  'Do not use an address that is not here — `entities.write` declares a new one, ' +
+                  'or ask the owner.',
+              },
+            ],
+          };
+        }
+
+        if (matches.candidates.length > 1) {
+          return {
+            content: [
+              { type: 'text', text: renderCandidates(matches, criteria, context.connection.key) },
+              ...matches.candidates.map((one) => ({
+                type: 'resource_link' as const,
+                uri: `entities://entity/${encodeURIComponent(one.entity.id)}`,
+                name: one.entity.name,
+              })),
+            ],
+          };
+        }
+
+        const found = matches.candidates[0]!.entity;
+        const file = await readEntity(context.storage, found.id);
+
+        return {
+          content: [
+            {
+              type: 'resource_link' as const,
+              uri: `entities://entity/${encodeURIComponent(found.id)}`,
+              name: found.name,
+            },
+            { type: 'text', text: renderEntity(found, catalogue, file?.body ?? '') },
+          ],
+        };
+      },
+    },
+
+    {
+      kind: 'tool',
+      name: 'get',
+      title: 'Read one entity',
+      description:
+        'Return one entity by id, with its relationships and everything pointing at it. The resource ' +
+        'entities://entity/{id} is the same content; this exists for clients that do not read resources.',
+      inputSchema: z.object({ id: z.string().min(1).describe('Entity id') }),
+      redact: keepKeys('id'),
+      async handler({ id }, context) {
+        const entity = await readEntity(context.storage, id);
+        if (entity === null) {
+          return {
+            content: [{ type: 'text', text: `No entity "${id}" on ${context.connection.key}.` }],
+            isError: true,
+          };
+        }
+
+        const catalogue = await openCatalogue(context.storage);
+        return { content: [{ type: 'text', text: renderEntity(entity, catalogue, entity.body) }] };
+      },
+    },
+
+    ...writeCapabilities,
+  ],
+});
+
+/**
+ * Re-check a single match against its own file before an agent acts on it.
+ *
+ * The index's fingerprint stamps the *entity files*, so an index edited on its
+ * own — by hand, or corrupted in a way that still parses — passes it and is
+ * served. That is the accepted cost of keeping the index beside the documents,
+ * and this is where it is paid back: on the one path where an answer is about
+ * to be used to address something, the file is opened and compared. One extra
+ * read, which `get` would have cost anyway.
+ *
+ * On any disagreement the whole catalogue is rebuilt and the search re-run,
+ * rather than the one row being patched. Patching would answer with an entity
+ * that no longer matches what was asked for — the index may have been the only
+ * reason it matched — and "here is your one result" is exactly the wrong thing
+ * to say then. Re-running can legitimately return none, or several; both are
+ * better answers than a confident wrong one.
+ *
+ * Not done when there are several candidates: nothing is being acted on yet,
+ * and `get` reads the file.
+ */
+async function reconcile(
+  storage: BlobStore,
+  catalogue: Catalogue,
+  candidate: CatalogueEntity,
+): Promise<Catalogue | null> {
+  const file = await readEntity(storage, candidate.id);
+  if (file !== null && canonical(strip(file)) === canonical(candidate)) return null;
+
+  return rebuildCatalogue(storage);
+}
+
+function strip(entity: Entity): CatalogueEntity {
+  const { body: _body, bytes: _bytes, ...row } = entity;
+  return row;
+}
+
+/**
+ * Everything about a row that could have decided the match, as one string.
+ *
+ * Written out field by field rather than `JSON.stringify(row)` so the
+ * comparison does not depend on two parsers inserting keys in the same order —
+ * a difference that would read as a disagreement and rebuild on every call.
+ */
+function canonical(row: CatalogueEntity): string {
+  return JSON.stringify([
+    row.type,
+    row.name,
+    [...row.aliases],
+    [...row.tags],
+    row.attributes.map((one) => [one.kind, one.value, one.note ?? '']),
+    row.relations.map((one) => [one.predicate, one.entity, one.note ?? '']),
+    row.updatedAt,
+  ]);
+}
+
+export default entitiesProvider;

--- a/src/providers/entities/render.ts
+++ b/src/providers/entities/render.ts
@@ -1,0 +1,142 @@
+import type { Catalogue, CatalogueEntity } from './catalogue.ts';
+import { distinguish, type Candidate, type Criteria, type Matches } from './find.ts';
+
+/**
+ * How an answer reads, kept apart from what an answer is.
+ *
+ * `find.ts` decides which entities match; this decides what a person or a model
+ * sees, and the two are separated because the interesting failures are
+ * different in kind. A matching bug returns the wrong entity. A rendering bug
+ * returns the right entity in a form that invites the wrong next move — a list
+ * of two that reads like a recommendation of one, or an edge to something
+ * undeclared silently omitted so the graph looks complete.
+ *
+ * Every function here is pure over a catalogue already in memory.
+ */
+
+/** One entity in full, for the answer an agent is about to act on. */
+export function renderEntity(
+  entity: CatalogueEntity,
+  catalogue: Catalogue,
+  body: string,
+): string {
+  const head = entity.type ? `${entity.name} — ${entity.type} (${entity.id})` : `${entity.name} (${entity.id})`;
+  const lines: string[] = [head];
+
+  if (entity.aliases.length > 0) lines.push(`Also known as ${entity.aliases.join(', ')}.`);
+  if (entity.tags.length > 0) lines.push(`Tagged ${entity.tags.join(', ')}.`);
+
+  if (entity.attributes.length > 0) {
+    const kinds = [...new Set(entity.attributes.map((one) => one.kind))];
+    const ordered = kinds.flatMap((kind) => entity.attributes.filter((one) => one.kind === kind));
+    const width = Math.max(...ordered.map((one) => one.kind.length));
+
+    lines.push('');
+    // The kind is repeated on every line rather than written once as a heading,
+    // for identity's reason: a line lifted out of this block on its own still
+    // says what it is, and a model quoting one line is what happens next.
+    for (const one of ordered) {
+      const head = `  ${one.kind.padEnd(width)}  ${one.value}`;
+      lines.push(one.note ? `${head}  — ${one.note}` : head);
+    }
+
+    if (kinds.some((kind) => entity.attributes.filter((one) => one.kind === kind).length > 1)) {
+      lines.push('');
+      lines.push(
+        'Where a kind holds more than one, the first is the default and the notes say when to ' +
+          'prefer another. If none of them fits what you are doing, ask rather than combining them.',
+      );
+    }
+  }
+
+  const edges = renderEdges(entity, catalogue);
+  if (edges.length > 0) lines.push('', ...edges);
+
+  if (body.trim().length > 0) lines.push('', body.trim());
+
+  return lines.join('\n');
+}
+
+function renderEdges(entity: CatalogueEntity, catalogue: Catalogue): string[] {
+  const lines: string[] = [];
+
+  for (const relation of entity.relations) {
+    lines.push(`  ${relation.predicate} → ${nameOf(catalogue, relation.entity)}${note(relation.note)}`);
+  }
+
+  for (const backlink of catalogue.backlinks.get(entity.id) ?? []) {
+    lines.push(`  ← ${backlink.predicate} ${nameOf(catalogue, backlink.from)}${note(backlink.note)}`);
+  }
+
+  return lines;
+}
+
+/**
+ * A declared entity by name and id; an undeclared one by id, said so.
+ *
+ * Never an error and never a dropped line: an edge to something not written
+ * down yet is a fact the owner recorded, and hiding it would make the graph
+ * quietly wrong rather than visibly incomplete.
+ */
+function nameOf(catalogue: Catalogue, id: string): string {
+  const entity = catalogue.byId.get(id);
+  return entity === undefined ? `${id} (not a declared entity)` : `${entity.name} (${id})`;
+}
+
+function note(text: string | undefined): string {
+  return text === undefined ? '' : ` — ${text}`;
+}
+
+/** Several candidates: the count first, then only what tells them apart. */
+export function renderCandidates(
+  matches: Matches,
+  criteria: Criteria,
+  connection: string,
+): string {
+  const { candidates, total } = matches;
+  const differing = distinguish(candidates);
+  const idWidth = Math.max(...candidates.map((one) => one.entity.id.length));
+  const nameWidth = Math.max(...candidates.map((one) => one.entity.name.length));
+
+  const rows = candidates.map((candidate, index) => {
+    const facets = differing[index] ?? [];
+    const head = `  ${candidate.entity.id.padEnd(idWidth)}  ${candidate.entity.name.padEnd(nameWidth)}  ${candidate.matched}`;
+    return facets.length > 0 ? `${head}  ·  ${facets.join('  ·  ')}` : head;
+  });
+
+  const nothing = differing.every((one) => one.length === 0);
+
+  return [
+    // The count leads, before any candidate: a client that truncates the
+    // response must still have seen that there was more than one.
+    `${total} entities match ${describe(criteria)} on \`${connection}\`.` +
+      (total > candidates.length ? ` The first ${candidates.length} are below; raise \`limit\` for more.` : ''),
+    '',
+    ...rows,
+    '',
+    nothing
+      ? 'Nothing here tells these apart beyond their ids — which usually means the owner has a ' +
+        'duplicate to merge. Ask which is meant; do not pick one.'
+      : 'If the context does not make it clear which is meant, ask before acting. Nothing here ' +
+        'chooses between them, and the order is not a ranking.',
+  ].join('\n');
+}
+
+/** What was asked for, in the words the caller used. */
+export function describe(criteria: Criteria): string {
+  const parts: string[] = [];
+
+  if (criteria.query !== undefined) parts.push(`"${criteria.query}"`);
+  if (criteria.type !== undefined) parts.push(`type ${criteria.type}`);
+  if (criteria.tag !== undefined) parts.push(`tag ${criteria.tag}`);
+
+  for (const one of criteria.attr ?? []) {
+    parts.push(one.value === undefined ? `with a ${one.kind}` : `${one.kind} ${one.value}`);
+  }
+  for (const one of criteria.related ?? []) {
+    const arrow = (one.direction ?? 'out') === 'in' ? '←' : '→';
+    parts.push(`${one.predicate ?? 'related'} ${arrow} ${one.entity}`);
+  }
+
+  return parts.length === 0 ? 'no criteria' : parts.join(', ');
+}

--- a/src/providers/entities/store.test.ts
+++ b/src/providers/entities/store.test.ts
@@ -1,0 +1,255 @@
+import { describe, expect, test } from 'bun:test';
+import { createMemoryBlobStore } from '#stores/blobs/testing.ts';
+import type { BlobStore } from '#stores/blobs';
+import {
+  allEntities,
+  assertEntityId,
+  assertKind,
+  idFromKey,
+  parseEntity,
+  readEntity,
+  serialiseEntity,
+  slugify,
+  writeEntity,
+  type Entity,
+} from './store.ts';
+
+/**
+ * The format, held to two rules that pull in opposite directions.
+ *
+ * **Tolerant read**: this is a directory the owner is invited to edit, so
+ * anything that can be salvaged is, and nothing throws. **Strict write**: a
+ * `kind` becomes part of how an attribute is matched and rendered, so the
+ * spellings that reach a file are held to one shape.
+ *
+ * The tolerance is tested one level deeper than memory's, because entities have
+ * lists inside their frontmatter and a bad row must cost that row rather than
+ * the file — and a file must never cost the directory.
+ */
+
+const EPOCH = new Date(0).toISOString();
+
+function entity(overrides: Partial<Entity> = {}): Entity {
+  return {
+    id: 'jan-bakker',
+    type: 'person',
+    name: 'Jan Bakker',
+    aliases: ['Jan'],
+    tags: ['client'],
+    attributes: [{ kind: 'email', value: 'jan@acme.test', note: 'work' }],
+    relations: [{ predicate: 'works_at', entity: 'acme-bv' }],
+    updatedAt: '2026-08-30T09:14:22.104Z',
+    body: 'Prefers email over calls.',
+    bytes: 0,
+    ...overrides,
+  };
+}
+
+async function storeWith(files: Record<string, string>): Promise<BlobStore> {
+  const store = createMemoryBlobStore();
+  for (const [key, text] of Object.entries(files)) {
+    await store.put(key, new TextEncoder().encode(text));
+  }
+  return store;
+}
+
+describe('the document round-trips', () => {
+  test('everything written is read back, in the order it was written', () => {
+    const original = entity({
+      aliases: ['Jan', 'JB'],
+      attributes: [
+        { kind: 'email', value: 'jan@acme.test', note: 'work' },
+        { kind: 'email', value: 'j.bakker@example.net', note: 'personal' },
+        { kind: 'github', value: 'janb' },
+      ],
+    });
+
+    const parsed = parseEntity('jan-bakker', serialiseEntity(original), EPOCH);
+
+    expect(parsed.type).toBe('person');
+    expect(parsed.name).toBe('Jan Bakker');
+    expect(parsed.aliases).toEqual(['Jan', 'JB']);
+    expect(parsed.tags).toEqual(['client']);
+    expect(parsed.body).toBe('Prefers email over calls.');
+    expect(parsed.updatedAt).toBe('2026-08-30T09:14:22.104Z');
+    // Preference order is the whole meaning of the list, so it is asserted as a
+    // sequence rather than as a set.
+    expect(parsed.attributes).toEqual([
+      { kind: 'email', value: 'jan@acme.test', note: 'work' },
+      { kind: 'email', value: 'j.bakker@example.net', note: 'personal' },
+      { kind: 'github', value: 'janb' },
+    ]);
+    expect(parsed.relations).toEqual([{ predicate: 'works_at', entity: 'acme-bv' }]);
+  });
+
+  test('empty lists are omitted from the file rather than written as []', () => {
+    const text = serialiseEntity(
+      entity({ aliases: [], tags: [], attributes: [], relations: [], body: '' }),
+    );
+
+    expect(text).not.toContain('aliases');
+    expect(text).not.toContain('tags');
+    expect(text).not.toContain('attributes');
+    expect(text).not.toContain('relations');
+    expect(text).toContain('name: Jan Bakker');
+  });
+
+  test('a relation names an entity that need not exist', () => {
+    const text = serialiseEntity(
+      entity({ relations: [{ predicate: 'works_at', entity: 'not-declared' }] }),
+    );
+
+    // No referential integrity at this layer, deliberately: a dangling edge
+    // renders as a plain name (see find.ts), and refusing it here would make
+    // declaration order matter.
+    expect(parseEntity('jan-bakker', text, EPOCH).relations).toEqual([
+      { predicate: 'works_at', entity: 'not-declared' },
+    ]);
+  });
+});
+
+describe('reading tolerates a directory a person edits', () => {
+  test('a file with no frontmatter is an entity named after its id', () => {
+    const parsed = parseEntity('acme-bv', 'Just some notes.\n', EPOCH);
+
+    expect(parsed.name).toBe('acme-bv');
+    expect(parsed.type).toBe('');
+    expect(parsed.attributes).toEqual([]);
+    expect(parsed.body).toBe('Just some notes.');
+  });
+
+  test('one malformed attribute is skipped and the rest of the file survives', () => {
+    const text = [
+      '---',
+      'name: Jan Bakker',
+      'attributes:',
+      '  - { kind: email, value: jan@acme.test }',
+      '  - just a string',
+      '  - { kind: github }',
+      '  - { value: no-kind }',
+      '  - { kind: phone, value: "" }',
+      '  - { kind: signal, value: janb }',
+      '---',
+      '',
+      'Notes.',
+    ].join('\n');
+
+    // The visible failure is an attribute that did not appear. The alternative
+    // is an exception that hides every other entity in the directory.
+    expect(parseEntity('jan-bakker', text, EPOCH).attributes).toEqual([
+      { kind: 'email', value: 'jan@acme.test' },
+      { kind: 'signal', value: 'janb' },
+    ]);
+  });
+
+  test('one malformed relation is skipped the same way', () => {
+    const text = [
+      '---',
+      'name: Jan Bakker',
+      'relations:',
+      '  - { predicate: works_at, entity: acme-bv }',
+      '  - works_at acme-bv',
+      '  - { predicate: knows }',
+      '  - { entity: marta-silva }',
+      '---',
+      '',
+    ].join('\n');
+
+    expect(parseEntity('jan-bakker', text, EPOCH).relations).toEqual([
+      { predicate: 'works_at', entity: 'acme-bv' },
+    ]);
+  });
+
+  test('attributes written as a mapping are ignored rather than half-read', () => {
+    const text = ['---', 'name: Jan', 'attributes:', '  email: jan@example.test', '---', ''].join(
+      '\n',
+    );
+
+    // Not tolerated, and the file still reads: the list form is what identity
+    // uses and what every example shows, and guessing a preference order out of
+    // a mapping would invent the one thing the list exists to record.
+    expect(parseEntity('jan-bakker', text, EPOCH).attributes).toEqual([]);
+    expect(parseEntity('jan-bakker', text, EPOCH).name).toBe('Jan');
+  });
+
+  test('a bare string in aliases reads as one alias', () => {
+    const text = ['---', 'name: Jan', 'aliases: JB', '---', ''].join('\n');
+
+    expect(parseEntity('jan-bakker', text, EPOCH).aliases).toEqual(['JB']);
+  });
+
+  test('a missing updated_at falls back to what the caller supplies', () => {
+    expect(parseEntity('jan-bakker', 'notes\n', '2026-01-01T00:00:00.000Z').updatedAt).toBe(
+      '2026-01-01T00:00:00.000Z',
+    );
+  });
+});
+
+describe('keys and ids', () => {
+  test('idFromKey accepts an entity file and refuses everything else', () => {
+    expect(idFromKey('jan-bakker.md')).toBe('jan-bakker');
+    expect(idFromKey('acme_bv.md')).toBe('acme_bv');
+
+    // The one predicate that keeps the derived index out of the entity listing,
+    // the fingerprint, the resource listing and the CLI listing.
+    expect(idFromKey('_index.json')).toBeNull();
+    expect(idFromKey('_index.md')).toBeNull();
+    expect(idFromKey('jan-bakker.md.meta')).toBeNull();
+    expect(idFromKey('Jan-Bakker.md')).toBeNull();
+    expect(idFromKey('notes.txt')).toBeNull();
+  });
+
+  test('an id is refused rather than repaired', () => {
+    expect(() => assertEntityId('jan-bakker')).not.toThrow();
+    expect(() => assertEntityId('Jan Bakker')).toThrow(/lowercase/);
+    expect(() => assertEntityId('-leading')).toThrow();
+  });
+
+  test('a kind is held to identity’s shape on write', () => {
+    expect(() => assertKind('email', 'kind')).not.toThrow();
+    expect(() => assertKind('works_at', 'predicate')).not.toThrow();
+    // Free-form within the shape: a new one must not need a release.
+    expect(() => assertKind('bluesky', 'kind')).not.toThrow();
+
+    expect(() => assertKind('Email', 'kind')).toThrow(/kind/);
+    expect(() => assertKind('e-mail', 'kind')).toThrow();
+    expect(() => assertKind('2fa', 'kind')).toThrow();
+  });
+
+  test('slugify derives an id from a name, and always derives something', () => {
+    expect(slugify('Jan Bakker')).toBe('jan-bakker');
+    expect(slugify('Acme B.V.')).toBe('acme-b-v');
+    expect(slugify('  ')).toBe('entity-2');
+    expect(slugify('北京公司')).toBe('entity-4');
+  });
+});
+
+describe('the store', () => {
+  test('a written entity reads back through the store', async () => {
+    const store = createMemoryBlobStore();
+    const bytes = await writeEntity(store, entity());
+
+    const read = await readEntity(store, 'jan-bakker');
+    expect(read).not.toBeNull();
+    expect(read?.name).toBe('Jan Bakker');
+    expect(read?.attributes[0]?.value).toBe('jan@acme.test');
+    // The byte length is returned so the catalogue can compute the fingerprint
+    // of the state it is creating without listing the store again.
+    expect(bytes).toBe(read?.bytes ?? -1);
+  });
+
+  test('a missing entity is null, not an error', async () => {
+    expect(await readEntity(createMemoryBlobStore(), 'nobody')).toBeNull();
+  });
+
+  test('allEntities reads only entity files, newest first', async () => {
+    const store = await storeWith({
+      'jan-bakker.md': '---\nname: Jan Bakker\nupdated_at: 2026-08-30T00:00:00.000Z\n---\n\n',
+      'acme-bv.md': '---\nname: Acme B.V.\nupdated_at: 2026-08-31T00:00:00.000Z\n---\n\n',
+      '_index.json': '{"v":1}',
+      'notes.txt': 'ignored',
+    });
+
+    expect((await allEntities(store)).map((one) => one.id)).toEqual(['acme-bv', 'jan-bakker']);
+  });
+});

--- a/src/providers/entities/store.ts
+++ b/src/providers/entities/store.ts
@@ -1,0 +1,276 @@
+import type { BlobStore } from '#connectivity';
+import {
+  splitOptionalFrontmatter,
+  stringList,
+  withFrontmatter,
+} from '#providers/shared/frontmatter.ts';
+import { slugify as slugifyText } from '#providers/shared/slug.ts';
+
+/**
+ * How an entity is stored, and the only place that knows.
+ *
+ * **One entity is one Markdown file**, exactly as a memory entry and a task
+ * are, and for the same reason (ADR-014): `lanes link entities` and a text
+ * editor reach the same bytes, and there is no row anywhere that can disagree
+ * with the file it describes. The document is frontmatter — type, name,
+ * aliases, tags, attributes, relations, timestamp — above a body that is the
+ * owner's notes on this person or thing.
+ *
+ * The `_index.json` beside these files is a *derived* artefact and is not a
+ * counter-example: it carries a fingerprint of the files it was built from and
+ * is rebuilt from them whenever that fingerprint disagrees. See `catalogue.ts`.
+ *
+ * **`attributes` is a list, not a map**, and the argument is identity's,
+ * verbatim (`#profile/identity.ts`): a map cannot say *when* to use which, and
+ * a map silently forbids two email addresses — the case that matters most.
+ * Order is preference order, so the first of a kind is the default.
+ *
+ * **`relations` is one-sided.** An edge is written into the entity that
+ * declares it and nowhere else; the reverse direction is derived when the
+ * catalogue is built. Writing both sides would be two files for one fact, and
+ * nothing in this codebase locks — an interrupted write would leave a half-edge
+ * that nothing detects.
+ *
+ * The store arrives scoped to `entities/<connection>` by core, so nothing here
+ * prefixes a key or thinks about isolation.
+ */
+
+/** One addressable fact about an entity: an address, a handle, a number. */
+export interface Attribute {
+  readonly kind: string;
+  readonly value: string;
+  /** When this one applies, in the owner's words. See `identityEntrySchema`. */
+  readonly note?: string;
+}
+
+/** A typed edge to another entity, as written on the entity that declares it. */
+export interface Relation {
+  readonly predicate: string;
+  /** An entity id. Not required to exist — see `parseEntity`. */
+  readonly entity: string;
+  readonly note?: string;
+}
+
+export interface Entity {
+  readonly id: string;
+  /** `person`, `company`, `project` — or anything else. Never a closed list. */
+  readonly type: string;
+  /** Falls back to the id, as a memory entry's title does. */
+  readonly name: string;
+  readonly aliases: readonly string[];
+  readonly tags: readonly string[];
+  /** Preference order: the first of a kind is the default. */
+  readonly attributes: readonly Attribute[];
+  readonly relations: readonly Relation[];
+  readonly updatedAt: string;
+  readonly body: string;
+  readonly bytes: number;
+}
+
+const ENTITY_ID = /^[a-z0-9][a-z0-9_-]*$/;
+
+/**
+ * What a `kind` or a `predicate` may be, enforced on write only.
+ *
+ * The same shape `identityEntrySchema.kind` holds, so an agent that has read
+ * `identity_list` recognises an entity's attributes without learning a second
+ * format. Free-form within that shape: `signal` and `bluesky` must not need a
+ * release, which is why this is a character class and not an enum.
+ */
+const IDENTIFIER = /^[a-z][a-z0-9_]*$/;
+
+export function entityKey(id: string): string {
+  return `${id}.md`;
+}
+
+/**
+ * The id a key holds, or null for a key that is not an entity.
+ *
+ * This one predicate is what keeps `_index.json` out of the entity listing, out
+ * of the fingerprint, out of the resource listing and out of the CLI listing —
+ * four places, no special case in any of them.
+ */
+export function idFromKey(key: string): string | null {
+  if (!key.endsWith('.md')) return null;
+  const id = key.slice(0, -'.md'.length);
+  return ENTITY_ID.test(id) ? id : null;
+}
+
+export function assertEntityId(id: string): void {
+  if (!ENTITY_ID.test(id)) {
+    throw new Error(
+      `Entity id ${JSON.stringify(id)} must be lowercase letters, digits, "_" or "-".`,
+    );
+  }
+}
+
+export function assertKind(kind: string, label: 'kind' | 'predicate'): void {
+  if (!IDENTIFIER.test(kind)) {
+    throw new Error(
+      `Attribute ${label} ${JSON.stringify(kind)} must be lowercase letters, digits and ` +
+        `underscores, starting with a letter — "email", "github", "works_at".`,
+    );
+  }
+}
+
+/** A stable id from a name, so writing does not demand one be invented. */
+export function slugify(name: string): string {
+  return slugifyText(name, 'entity');
+}
+
+/**
+ * Parse one stored entity, tolerating anything.
+ *
+ * Every field falls back and no fallback is an error, because this reads a
+ * directory the owner is invited to edit. A plain Markdown file dropped in
+ * there is an entity named after its filename, which is a better answer than an
+ * exception that hides every other entity behind it.
+ *
+ * A malformed row inside `attributes` or `relations` is **skipped rather than
+ * thrown**, and that is the same argument one level down: one bad list item
+ * must not cost the whole directory. The visible failure is an attribute that
+ * did not appear, which is diagnosable by opening the file; the alternative is
+ * a listing that will not render and does not say which file broke it.
+ */
+export function parseEntity(id: string, text: string, fallbackUpdatedAt: string): Entity {
+  const { frontmatter, body } = splitOptionalFrontmatter(text);
+
+  const type = frontmatter['type'];
+  const name = frontmatter['name'];
+  const updatedAt = frontmatter['updated_at'];
+
+  return {
+    id,
+    type: typeof type === 'string' && type.trim().length > 0 ? type.trim() : '',
+    name: typeof name === 'string' && name.trim().length > 0 ? name.trim() : id,
+    aliases: stringList(frontmatter['aliases']),
+    tags: stringList(frontmatter['tags']),
+    attributes: parseAttributes(frontmatter['attributes']),
+    relations: parseRelations(frontmatter['relations']),
+    updatedAt: typeof updatedAt === 'string' ? updatedAt : fallbackUpdatedAt,
+    body: body.trimEnd(),
+    bytes: new TextEncoder().encode(text).byteLength,
+  };
+}
+
+function parseAttributes(raw: unknown): Attribute[] {
+  if (!Array.isArray(raw)) return [];
+
+  return raw.flatMap((item) => {
+    const kind = field(item, 'kind');
+    const value = field(item, 'value');
+    if (kind === null || value === null) return [];
+
+    const note = field(item, 'note');
+    return [{ kind, value, ...(note === null ? {} : { note }) }];
+  });
+}
+
+function parseRelations(raw: unknown): Relation[] {
+  if (!Array.isArray(raw)) return [];
+
+  return raw.flatMap((item) => {
+    const predicate = field(item, 'predicate');
+    const entity = field(item, 'entity');
+    if (predicate === null || entity === null) return [];
+
+    const note = field(item, 'note');
+    return [{ predicate, entity, ...(note === null ? {} : { note }) }];
+  });
+}
+
+/** One non-empty string field off a frontmatter row, or null. */
+function field(item: unknown, key: string): string | null {
+  if (item === null || typeof item !== 'object' || Array.isArray(item)) return null;
+  const raw = (item as Record<string, unknown>)[key];
+  if (typeof raw !== 'string') return null;
+  const trimmed = raw.trim();
+  return trimmed.length > 0 ? trimmed : null;
+}
+
+export function serialiseEntity(entity: Omit<Entity, 'id' | 'bytes'>): string {
+  return withFrontmatter(
+    {
+      ...(entity.type ? { type: entity.type } : {}),
+      name: entity.name,
+      ...(entity.aliases.length > 0 ? { aliases: [...entity.aliases] } : {}),
+      ...(entity.tags.length > 0 ? { tags: [...entity.tags] } : {}),
+      ...(entity.attributes.length > 0
+        ? { attributes: entity.attributes.map((one) => ({ ...one })) }
+        : {}),
+      ...(entity.relations.length > 0
+        ? { relations: entity.relations.map((one) => ({ ...one })) }
+        : {}),
+      updated_at: entity.updatedAt,
+    },
+    `${entity.body.trimEnd()}\n`,
+  );
+}
+
+export async function readEntity(storage: BlobStore, id: string): Promise<Entity | null> {
+  const bytes = await storage.get(entityKey(id));
+  if (bytes === null) return null;
+
+  return parseEntity(id, new TextDecoder().decode(bytes), new Date(0).toISOString());
+}
+
+/** Write one entity, returning the byte length the catalogue's fingerprint needs. */
+export async function writeEntity(storage: BlobStore, entity: Entity): Promise<number> {
+  const { id: _id, bytes: _bytes, ...rest } = entity;
+  const encoded = new TextEncoder().encode(serialiseEntity(rest));
+
+  await storage.put(entityKey(entity.id), encoded, { contentType: 'text/markdown' });
+  return encoded.byteLength;
+}
+
+/**
+ * How many entities are read at once.
+ *
+ * The bound memory and tasks use, for the reason memory gives: against a bucket
+ * each read is an HTTPS request, and firing a thousand at once trades a slow
+ * rebuild for a rate-limited one.
+ */
+const READ_CONCURRENCY = 16;
+
+/**
+ * Every entity, newest first.
+ *
+ * **This reads every file**, and is the expensive path this provider exists to
+ * avoid taking twice: it runs when the catalogue's index is absent, stale or
+ * unreadable, and never on a read that found a valid one. `catalogue.ts` has
+ * the arithmetic for what that costs at a thousand entities on a bucket.
+ */
+export async function allEntities(storage: BlobStore): Promise<Entity[]> {
+  const blobs = (await storage.list()).flatMap((blob) => {
+    const id = idFromKey(blob.key);
+    return id === null ? [] : [{ blob, id }];
+  });
+
+  const entities: Entity[] = [];
+
+  for (let start = 0; start < blobs.length; start += READ_CONCURRENCY) {
+    const batch = await Promise.all(
+      blobs.slice(start, start + READ_CONCURRENCY).map(async ({ blob, id }) => {
+        const bytes = await storage.get(blob.key);
+        return bytes === null
+          ? null
+          : parseEntity(id, new TextDecoder().decode(bytes), blob.modifiedAt.toISOString());
+      }),
+    );
+    for (const entity of batch) if (entity) entities.push(entity);
+  }
+
+  return entities.sort((a, b) => b.updatedAt.localeCompare(a.updatedAt));
+}
+
+/** The pieces `lanes link entities` needs to reach the same bytes the provider does. */
+export const entityStorage = {
+  key: entityKey,
+  idFromKey,
+  parse: parseEntity,
+  serialise: serialiseEntity,
+  read: readEntity,
+  write: writeEntity,
+  all: allEntities,
+  slugify,
+};

--- a/src/providers/entities/writes.ts
+++ b/src/providers/entities/writes.ts
@@ -99,7 +99,7 @@ export const writeCapabilities: readonly Capability[] = [
           bytes: 0,
         };
 
-        await persist(context.storage, next);
+        await persistEntity(context.storage, next);
 
         // `redact` maps keys to keep-or-typemark and cannot express "keep the
         // shape of this list, drop its values" — left to it alone, the log
@@ -168,7 +168,7 @@ export const writeCapabilities: readonly Capability[] = [
           updatedAt: new Date().toISOString(),
         };
 
-        const catalogue = await persist(context.storage, next);
+        const catalogue = await persistEntity(context.storage, next);
 
         // Recorded because a dangling edge is legal and useful, and is also how
         // a typo in an id looks. The log is where that becomes visible.
@@ -211,15 +211,7 @@ export const writeCapabilities: readonly Capability[] = [
           };
         }
 
-        await context.storage.delete(entityKey(id));
-
-        const remaining = catalogue.entities.filter((one) => one.id !== id);
-        await writeCatalogue(
-          context.storage,
-          remaining,
-          fingerprintAfter(catalogue.listing, { key: entityKey(id), deleted: true }),
-          new Date().toISOString(),
-        );
+        await forgetEntity(context.storage, catalogue, id, new Date().toISOString());
 
         // Deliberately not a cascade: a delete that rewrote five other people's
         // files could not be reviewed as one change. Saying who still points
@@ -246,8 +238,14 @@ export const writeCapabilities: readonly Capability[] = [
  * The fingerprint is computed from the listing taken *before* the put plus the
  * byte length being written, so there is no second `list()` and no read-back —
  * see `catalogue.ts` for why `key:size` is what makes that possible.
+ *
+ * Exported because `lanes link entities write` needs exactly this and an
+ * earlier version of it had its own: a rebuild-then-write that read every file
+ * on every call, which is one extra pass by hand and a quadratic bulk load from
+ * a script. Two implementations of index maintenance is the same drift the
+ * shared `entityStorage` exists to prevent, one layer up.
  */
-async function persist(storage: BlobStore, entity: Entity): Promise<Catalogue> {
+export async function persistEntity(storage: BlobStore, entity: Entity): Promise<Catalogue> {
   const catalogue = await openCatalogue(storage);
   const bytes = await writeEntity(storage, entity);
 
@@ -262,4 +260,20 @@ async function persist(storage: BlobStore, entity: Entity): Promise<Catalogue> {
   );
 
   return catalogue;
+}
+
+/** Remove one entity and leave the index describing what is left. */
+export async function forgetEntity(
+  storage: BlobStore,
+  catalogue: Catalogue,
+  id: string,
+  now: string,
+): Promise<void> {
+  await storage.delete(entityKey(id));
+  await writeCatalogue(
+    storage,
+    catalogue.entities.filter((one) => one.id !== id),
+    fingerprintAfter(catalogue.listing, { key: entityKey(id), deleted: true }),
+    now,
+  );
 }

--- a/src/providers/entities/writes.ts
+++ b/src/providers/entities/writes.ts
@@ -1,0 +1,265 @@
+import { z } from 'zod';
+import { keepKeys, type BlobStore, type Capability } from '#connectivity';
+import { fingerprintAfter, openCatalogue, writeCatalogue, type Catalogue } from './catalogue.ts';
+import {
+  assertEntityId,
+  assertKind,
+  entityKey,
+  readEntity,
+  slugify,
+  writeEntity,
+  type Attribute,
+  type Entity,
+  type Relation,
+} from './store.ts';
+
+/**
+ * The three capabilities that change something, and the index maintenance they
+ * share.
+ *
+ * Their own file because the file boundary is the *bundle* boundary, and the
+ * bundle boundary is the security argument: `read` is default and this is not
+ * (ADR-012 §2). A reader deciding whether an agent should hold `entities.write`
+ * has one file to read, and a grep for what an agent with only the default
+ * bundle can do does not have to distinguish handlers inside one long list.
+ *
+ * All three go through `persist`, so there is one implementation of "write an
+ * entity and leave the index describing what is now there".
+ */
+
+export const writeCapabilities: readonly Capability[] = [
+    {
+      kind: 'tool',
+      name: 'write',
+      title: 'Declare or update an entity',
+      description:
+        'Create an entity, or update one that exists. A field you do not supply is left as it is — ' +
+        'send attributes: [] to clear them deliberately. Attribute order is preference order: the ' +
+        'first of a kind is the default. Separate from reading, because what is written here is used ' +
+        'to address messages in every later session.',
+      inputSchema: z.object({
+        name: z.string().min(1).describe('How the owner refers to this entity'),
+        id: z
+          .string()
+          .optional()
+          .describe('Entity id. Derived from the name when omitted; naming an existing one updates it.'),
+        type: z.string().optional().describe('person, company, project — or anything else'),
+        aliases: z.array(z.string()).optional().describe('Other names this is known by'),
+        tags: z.array(z.string()).optional().describe('Labels for filtering'),
+        attributes: z
+          .array(
+            z.object({
+              kind: z.string().min(1).describe('email, github, phone — lowercase, no spaces'),
+              value: z.string().min(1),
+              note: z.string().optional().describe('When to use this one rather than another'),
+            }),
+          )
+          .optional()
+          .describe('Addresses and handles, most-preferred first'),
+        relations: z
+          .array(
+            z.object({
+              predicate: z.string().min(1).describe('works_at, owns, part_of'),
+              entity: z.string().min(1).describe('The entity id on the other end'),
+              note: z.string().optional(),
+            }),
+          )
+          .optional()
+          .describe('Edges from this entity. Replaces the existing set; entities.link appends one.'),
+        notes: z.string().optional().describe('Free prose about this entity, as Markdown'),
+      }),
+      // The id, type and name are addresses — and `id` is `slugify(name)`, so
+      // keeping one while withholding the other would be theatre. Every value
+      // is withheld; `annotate` records the shape instead.
+      redact: keepKeys('id', 'type', 'name', 'tags'),
+      async handler(
+        { name, id: given, type, aliases, tags, attributes, relations, notes },
+        context,
+      ) {
+        const id = given ?? slugify(name);
+        assertEntityId(id);
+        for (const one of attributes ?? []) assertKind(one.kind, 'kind');
+        for (const one of relations ?? []) assertKind(one.predicate, 'predicate');
+
+        const existing = await readEntity(context.storage, id);
+        // A field that was not supplied keeps what is on disk. Spelled out
+        // rather than merged generically, because the alternative — a model
+        // resending an entity minus an attribute it forgot — is a lost update
+        // with a language model holding the pen.
+        const next: Entity = {
+          id,
+          name,
+          type: type ?? existing?.type ?? '',
+          aliases: aliases ?? existing?.aliases ?? [],
+          tags: tags ?? existing?.tags ?? [],
+          attributes: (attributes ?? existing?.attributes ?? []) as readonly Attribute[],
+          relations: (relations ?? existing?.relations ?? []) as readonly Relation[],
+          updatedAt: new Date().toISOString(),
+          body: notes ?? existing?.body ?? '',
+          bytes: 0,
+        };
+
+        await persist(context.storage, next);
+
+        // `redact` maps keys to keep-or-typemark and cannot express "keep the
+        // shape of this list, drop its values" — left to it alone, the log
+        // would record `<array:3>` and say nothing about what changed. The
+        // kinds are the reviewable fact; the addresses stay out of an
+        // append-only hash-chained log. ADR-017.
+        context.audit.annotate({
+          entity: id,
+          created: existing === null,
+          attributes: next.attributes.length,
+          kinds: [...new Set(next.attributes.map((one) => one.kind))],
+          relations: next.relations.length,
+        });
+
+        return {
+          content: [
+            {
+              type: 'text',
+              text: `${existing === null ? 'Declared' : 'Updated'} "${id}" on ${context.connection.key}.`,
+            },
+            { type: 'resource_link', uri: `entities://entity/${id}`, name },
+          ],
+        };
+      },
+    },
+
+    {
+      kind: 'tool',
+      name: 'link',
+      title: 'Relate one entity to another',
+      description:
+        'Add one edge to an entity, leaving everything else on it alone. The edge is written only on ' +
+        'the entity it comes from; the reverse direction is derived, so do not also write it the other ' +
+        'way. The other end need not exist yet.',
+      inputSchema: z.object({
+        from: z.string().min(1).describe('Entity id the edge comes from'),
+        predicate: z.string().min(1).describe('works_at, owns, part_of'),
+        to: z.string().min(1).describe('Entity id the edge points at'),
+        note: z.string().optional(),
+      }),
+      redact: keepKeys('from', 'predicate', 'to'),
+      async handler({ from, predicate, to, note }, context) {
+        assertKind(predicate, 'predicate');
+
+        const entity = await readEntity(context.storage, from);
+        if (entity === null) {
+          return {
+            content: [{ type: 'text', text: `No entity "${from}" on ${context.connection.key}.` }],
+            isError: true,
+          };
+        }
+
+        const already = entity.relations.some(
+          (one) => one.predicate === predicate && one.entity === to,
+        );
+        if (already) {
+          return {
+            content: [{ type: 'text', text: `"${from}" already ${predicate} "${to}".` }],
+          };
+        }
+
+        const relation: Relation = { predicate, entity: to, ...(note === undefined ? {} : { note }) };
+        const next: Entity = {
+          ...entity,
+          relations: [...entity.relations, relation],
+          updatedAt: new Date().toISOString(),
+        };
+
+        const catalogue = await persist(context.storage, next);
+
+        // Recorded because a dangling edge is legal and useful, and is also how
+        // a typo in an id looks. The log is where that becomes visible.
+        const dangling = !catalogue.byId.has(to);
+        context.audit.annotate({ dangling });
+
+        return {
+          content: [
+            {
+              type: 'text',
+              text:
+                `"${from}" ${predicate} "${to}".` +
+                (dangling ? ` "${to}" is not declared yet — the edge is kept as written.` : ''),
+            },
+          ],
+        };
+      },
+    },
+
+    {
+      kind: 'tool',
+      name: 'forget',
+      title: 'Remove an entity',
+      description:
+        'Delete an entity. Edges pointing at it from other entities are left alone and are reported, ' +
+        'so nothing else is rewritten behind your back — clean them up deliberately if you mean to.',
+      inputSchema: z.object({ id: z.string().min(1).describe('Entity id') }),
+      redact: keepKeys('id'),
+      async handler({ id }, context) {
+        const catalogue = await openCatalogue(context.storage);
+        const existed = catalogue.byId.has(id);
+        const referencedBy = (catalogue.backlinks.get(id) ?? []).map((one) => one.from);
+
+        context.audit.annotate({ existed, referenced_by: referencedBy.length });
+
+        if (!existed) {
+          return {
+            content: [{ type: 'text', text: `No entity "${id}" on ${context.connection.key}.` }],
+            isError: true,
+          };
+        }
+
+        await context.storage.delete(entityKey(id));
+
+        const remaining = catalogue.entities.filter((one) => one.id !== id);
+        await writeCatalogue(
+          context.storage,
+          remaining,
+          fingerprintAfter(catalogue.listing, { key: entityKey(id), deleted: true }),
+          new Date().toISOString(),
+        );
+
+        // Deliberately not a cascade: a delete that rewrote five other people's
+        // files could not be reviewed as one change. Saying who still points
+        // here is what keeps the breakage from being silent.
+        return {
+          content: [
+            {
+              type: 'text',
+              text:
+                `Removed "${id}" from ${context.connection.key}.` +
+                (referencedBy.length > 0
+                  ? ` Still referenced by ${referencedBy.join(', ')} — those edges now dangle.`
+                  : ''),
+            },
+          ],
+        };
+      },
+    },
+];
+
+/**
+ * Write one entity and the index that describes the store afterwards.
+ *
+ * The fingerprint is computed from the listing taken *before* the put plus the
+ * byte length being written, so there is no second `list()` and no read-back —
+ * see `catalogue.ts` for why `key:size` is what makes that possible.
+ */
+async function persist(storage: BlobStore, entity: Entity): Promise<Catalogue> {
+  const catalogue = await openCatalogue(storage);
+  const bytes = await writeEntity(storage, entity);
+
+  const { body: _body, bytes: _bytes, ...row } = entity;
+  const rows = [...catalogue.entities.filter((one) => one.id !== entity.id), row];
+
+  await writeCatalogue(
+    storage,
+    rows,
+    fingerprintAfter(catalogue.listing, { key: entityKey(entity.id), size: bytes }),
+    entity.updatedAt,
+  );
+
+  return catalogue;
+}

--- a/src/providers/memory/provider.ts
+++ b/src/providers/memory/provider.ts
@@ -1,5 +1,6 @@
 import { z } from 'zod';
 import { splitOptionalFrontmatter, stringList, withFrontmatter } from '#providers/shared/frontmatter.ts';
+import { slugify as slugifyText } from '#providers/shared/slug.ts';
 import {
   defineLocalProvider,
   keepKeys,
@@ -167,13 +168,7 @@ async function allEntries(storage: BlobStore): Promise<Entry[]> {
 
 /** A stable id from a title, so writing does not demand one be invented. */
 function slugify(title: string): string {
-  const slug = title
-    .toLowerCase()
-    .replace(/[^a-z0-9]+/g, '-')
-    .replace(/^-+|-+$/g, '')
-    .slice(0, 60);
-
-  return slug.length > 0 ? slug : `entry-${title.length}`;
+  return slugifyText(title, 'entry');
 }
 
 export const memoryProvider: ProviderDefinition = defineLocalProvider({

--- a/src/providers/owner.ts
+++ b/src/providers/owner.ts
@@ -41,7 +41,7 @@
  * consistent rather than in tension: identity is configuration, so an agent
  * able to edit it could edit the one fact that stops it signing as the wrong
  * person, while everyone else's details are ordinary owner material that
- * accumulates on the same surface that reads it (ADR-055).
+ * accumulates on the same surface that reads it (ADR-056).
  *
  * All eight ids are reserved (`RESERVED_PROVIDER_IDS`) and still refused by
  * default — the registry has to be built with `allowReserved` to hold them, so a

--- a/src/providers/owner.ts
+++ b/src/providers/owner.ts
@@ -1,7 +1,8 @@
 /**
- * The owner layer — memory, tasks, assets, skills, vault, setup, identity.
+ * The owner layer — memory, tasks, assets, skills, vault, setup, identity,
+ * entities.
  *
- * Seven providers that hold no third-party account: no OAuth, no vendor API, no
+ * Eight providers that hold no third-party account: no OAuth, no vendor API, no
  * rate limit anyone else imposes. They are ordinary `defineLocalProvider`
  * registrations, scoped by the same profiles and gated by the same policy
  * evaluation as everything else — which was the claim `docs/detailed/init.md`
@@ -33,7 +34,16 @@
  * naming the owner and describing what is connected are two policy decisions
  * instead of one.
  *
- * All seven ids are reserved (`RESERVED_PROVIDER_IDS`) and still refused by
+ * `entities` is its mirror: who and what *everyone else* is — the people,
+ * companies and projects the owner deals with, and their canonical addresses —
+ * so that a reference is looked up rather than inferred from whatever was in
+ * the conversation. It is writable where `identity` is not, and the two are
+ * consistent rather than in tension: identity is configuration, so an agent
+ * able to edit it could edit the one fact that stops it signing as the wrong
+ * person, while everyone else's details are ordinary owner material that
+ * accumulates on the same surface that reads it (ADR-055).
+ *
+ * All eight ids are reserved (`RESERVED_PROVIDER_IDS`) and still refused by
  * default — the registry has to be built with `allowReserved` to hold them, so a
  * third-party provider cannot claim a namespace whose policy rules would then
  * mean something else. `tasks` cost something to reserve: Google Tasks held that
@@ -57,6 +67,8 @@ export { createSkillsProvider, type SkillsProviderOptions } from './skills/provi
 export { createVaultProvider, type VaultProviderOptions } from './vault/provider.ts';
 export { createSetupProvider, type SetupProviderOptions } from './setup/provider.ts';
 export { createIdentityProvider, type IdentityProviderOptions } from './identity/provider.ts';
+export { entitiesProvider } from './entities/provider.ts';
+export { entityStorage, type Attribute, type Entity, type Relation } from './entities/store.ts';
 export { planAll, planFor, type PlanContext, type ProviderPlan } from './setup/plan.ts';
 // The vault's *store* is not here: it is `#secrets`, beside the system
 // credential store it must never become. What lives in `./vault/` is the

--- a/src/providers/shared/slug.ts
+++ b/src/providers/shared/slug.ts
@@ -1,0 +1,28 @@
+/**
+ * A stable id from something the owner typed, so writing does not demand one be
+ * invented.
+ *
+ * Three owner-layer stores derive an id this way — a memory entry from its
+ * title, a task from its title, an entity from its name — and they must derive
+ * it *identically*, because the id is the filename and a person who has learned
+ * what one store does with an apostrophe has learned what all three do.
+ *
+ * The 60-character cap is the whole of the length policy. It is not about any
+ * filesystem limit: it is that an id appears in a policy rule, a resource URI
+ * and an audit line, and a title-length one is unreadable in all three.
+ *
+ * `fallback` is the prefix for a name that slugifies to nothing — a title of
+ * only punctuation, or of a script this transliterates away. Producing
+ * `entry-14` rather than throwing is deliberate: the caller has content to
+ * store, and refusing it because its title is CJK would be a worse answer than
+ * an ugly id the owner can rename.
+ */
+export function slugify(text: string, fallback: string): string {
+  const slug = text
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .slice(0, 60);
+
+  return slug.length > 0 ? slug : `${fallback}-${text.length}`;
+}

--- a/src/providers/tasks/store.ts
+++ b/src/providers/tasks/store.ts
@@ -4,6 +4,7 @@ import {
   stringList,
   withFrontmatter,
 } from '#providers/shared/frontmatter.ts';
+import { slugify as slugifyText } from '#providers/shared/slug.ts';
 
 /**
  * How a task is stored, and the only place that knows.
@@ -99,13 +100,7 @@ export function assertTaskId(id: string): void {
 
 /** A stable id from a title, so adding a task does not demand one be invented. */
 export function slugify(title: string): string {
-  const slug = title
-    .toLowerCase()
-    .replace(/[^a-z0-9]+/g, '-')
-    .replace(/^-+|-+$/g, '')
-    .slice(0, 60);
-
-  return slug.length > 0 ? slug : `task-${title.length}`;
+  return slugifyText(title, 'task');
 }
 
 /**

--- a/src/server/mcp/instructions.test.ts
+++ b/src/server/mcp/instructions.test.ts
@@ -339,14 +339,53 @@ describe('the habits it teaches', () => {
         ),
       ]);
 
-    const everything = ['memory', 'tasks', 'assets', 'skills', 'vault', 'setup', 'identity'];
-    const withoutTasks = everything.filter((id) => id !== 'tasks');
+    const everything = [
+      'memory',
+      'tasks',
+      'assets',
+      'skills',
+      'vault',
+      'setup',
+      'identity',
+      'entities',
+    ];
+    const without = (...drop: string[]) => everything.filter((id) => !drop.includes(id));
+    const lengthOf = (ids: readonly string[]) =>
+      serverInstructions(profiles, owners(ids), true).length;
 
-    const paired = serverInstructions(profiles, owners(everything), true);
-    const unpaired = serverInstructions(profiles, owners(withoutTasks), true);
+    // Two independent pairs — memory/tasks and identity/entities — so there are
+    // four combinations and the widest is not the one with the most providers
+    // in it. Walking all four is the point: the last three raises to this
+    // ceiling were each certified against a case an endpoint does not serve.
+    const branches = [
+      lengthOf(everything),
+      lengthOf(without('tasks')),
+      lengthOf(without('entities')),
+      lengthOf(without('tasks', 'entities')),
+    ];
 
-    expect(unpaired.length).toBeGreaterThan(paired.length);
-    expect(unpaired.length).toBeLessThan(MAX_INSTRUCTIONS);
+    for (const length of branches) expect(length).toBeLessThan(MAX_INSTRUCTIONS);
+
+    // The maximum is memory *unpaired* while identity and entities are paired:
+    // it looks like the narrower configuration and costs the most, because
+    // `MEMORY_AND_TASKS` is shorter than `MEMORY` and `TASKS` apart.
+    expect(Math.max(...branches)).toBe(branches[1]!);
+  });
+
+  test('collapsing identity and entities is what keeps the ceiling where it is', () => {
+    const profiles = ['personal'];
+    const owners = (ids: readonly string[]) =>
+      new Map(ids.map((id) => [`${id}.list`, reaching({ personal: [`${id}.owner`] })]));
+
+    const neither = serverInstructions(profiles, owners(['memory']), true).length;
+    const identityOnly = serverInstructions(profiles, owners(['memory', 'identity']), true).length;
+    const entitiesOnly = serverInstructions(profiles, owners(['memory', 'entities']), true).length;
+    const both = serverInstructions(profiles, owners(['memory', 'identity', 'entities']), true).length;
+
+    // Written as an inequality rather than as four literals, so the assertion
+    // survives an edit to the prose while still failing if the collapse is
+    // removed — at which point `both` becomes the sum of the two halves.
+    expect(both).toBeLessThan(identityOnly + entitiesOnly - neither);
   });
 
   test('stays inside its budget', () => {

--- a/src/server/mcp/instructions.ts
+++ b/src/server/mcp/instructions.ts
@@ -127,6 +127,49 @@ const IDENTITY = `**Identity is declared, not inferred.** Where a name, address 
 owner's is needed, call \`identity_list\`: a profile may hold several, each with a
 note on when it applies.`;
 
+/**
+ * The one about addressing the wrong person.
+ *
+ * `IDENTITY` prevents an agent signing as the wrong person; this prevents it
+ * writing *to* the wrong one, which is the same mistake pointed outward and is
+ * the more expensive of the two — a message signed wrongly is embarrassing, a
+ * message sent to the wrong Jan has left.
+ *
+ * It carries two rules rather than one, because dropping the refusal made the
+ * second necessary. `entities_find` returns every match and sets no error, so a
+ * client is not stopped by anything: nothing but this sentence stands between
+ * "two candidates" and an agent using the first. The count and the wording of
+ * the tool result say it too, and this says it before the first call rather
+ * than after.
+ *
+ * Names nothing, for `IDENTITY`'s reason: a per-profile list inside a string
+ * with a fixed ceiling is summarised away first in exactly the workspace that
+ * has the most people to keep straight.
+ */
+const ENTITIES = `**Who you are writing to is declared.** Before using anyone's address or handle,
+call \`entities_find\` — the people, companies and projects this owner deals with
+are there. It returns every match and never chooses: more than one means ask
+which is meant, not take the first.`;
+
+/**
+ * The pair, when both are reachable.
+ *
+ * The same argument `MEMORY_AND_TASKS` makes. The mistake is a routing one —
+ * reaching for the wrong side of "the owner" and "everybody else" — and a
+ * routing rule is shorter and clearer said once, naming both, than implied by
+ * two paragraphs that each describe only themselves. It replaces `IDENTITY`
+ * rather than joining it, and measures 161 characters cheaper than the two
+ * apart (see `MAX_INSTRUCTIONS`).
+ *
+ * Worth noting which case is ordinary: `entities` is granted on a fresh profile
+ * and `identity` is not (ADR-050, ADR-055), so `ENTITIES` alone is the common
+ * form and this one arrives only once the owner has declared themselves.
+ */
+const IDENTITY_AND_ENTITIES = `**Who someone is, is declared rather than inferred.** For the owner's own name,
+address or handle, call \`identity_list\`. For anyone else — a person, a company,
+a project — call \`entities_find\`, which returns every match and never chooses:
+more than one means ask which is meant, not take the first.`;
+
 const FILES = `**Files are named, not carried.** Where a tool takes attachments, give a path, an
 HTTPS URL, or an attachment already on another message; the endpoint reads the
 bytes. Never encode a file into a call — that is the thing this replaces.`;
@@ -165,26 +208,34 @@ const OWNER_HABITS: Record<string, string> = {
   vault: VAULT,
   setup: SETUP,
   identity: IDENTITY,
+  entities: ENTITIES,
 };
 
 /**
  * The paragraphs this principal should be told, in `RESERVED_PROVIDER_IDS` order.
  *
  * A lookup per provider would be enough if every paragraph described exactly one
- * provider, and one does not: memory and tasks are only worth distinguishing
- * from each other, so when both are reachable they collapse into one. The
- * substitution is conditional rather than unconditional for the reason the
- * docstring at the top of this file gives — prose describing a tool that is not
- * there is worse than absent prose, and a profile carrying `deny: [tasks.*]` is
- * exactly the case that would produce it.
+ * provider, and two do not. Memory and tasks are only worth distinguishing from
+ * each other; identity and entities are the same question about different
+ * people. Each pair collapses into one paragraph when both halves are
+ * reachable. The substitutions are conditional rather than unconditional for
+ * the reason the docstring at the top of this file gives — prose describing a
+ * tool that is not there is worse than absent prose, and a profile carrying
+ * `deny: [tasks.*]` is exactly the case that would produce it.
+ *
+ * The two pairs are independent, which is why the budget below is certified
+ * against four combinations rather than two.
  */
 function habitsFor(reachable: readonly string[]): string[] {
   const present = new Set(reachable);
-  const paired = present.has('memory') && present.has('tasks');
+  const stores = present.has('memory') && present.has('tasks');
+  const people = present.has('identity') && present.has('entities');
 
   return reachable.flatMap((id) => {
-    if (paired && id === 'memory') return [MEMORY_AND_TASKS];
-    if (paired && id === 'tasks') return [];
+    if (stores && id === 'memory') return [MEMORY_AND_TASKS];
+    if (stores && id === 'tasks') return [];
+    if (people && id === 'identity') return [IDENTITY_AND_ENTITIES];
+    if (people && id === 'entities') return [];
     return OWNER_HABITS[id] ? [OWNER_HABITS[id]!] : [];
   });
 }
@@ -214,14 +265,33 @@ function habitsFor(reachable: readonly string[]): string[] {
  * has already done so by the time a skill would have been loaded. The client
  * that most needs the rule is the one holding no skills directory.
  *
- * The arithmetic, because the number is a measurement and not a round figure:
- * twenty profiles, twenty connections each, every owner provider reachable,
- * remote clients, is **2686**. That is the *unpaired* case — memory reachable
- * and tasks denied — which runs three characters longer than the ordinary one
- * (2683), because `MEMORY_AND_TASKS` is slightly shorter than `MEMORY` and
- * `TASKS` apart. Worth stating, because the last two raises were both certified
- * against a case an endpoint does not actually serve, and the widest case here
- * is the one that looks like the narrower configuration.
+ * Raised a fourth time, to 2900, for `entities` (ADR-055), and the answer is
+ * `IDENTITY`'s restated one step outward. An agent that resolves "email Jan" to
+ * the wrong address has already sent the message; the mistake happens at the
+ * instant of the send, before a skill would have been loaded, and the client
+ * most in need of the rule is again the one holding no skills directory. The
+ * paragraph also carries a rule nothing else can enforce: `entities_find` sets
+ * no error on an ambiguous result, so between "two candidates" and an agent
+ * using the first there is only prose.
+ *
+ * The arithmetic, because the number is a measurement and not a round figure.
+ * Twenty profiles, twenty connections each, every owner provider reachable,
+ * remote clients:
+ *
+ *   neither identity nor entities reachable   2500
+ *   + `IDENTITY` alone                        2686   (+186)
+ *   + `ENTITIES` alone                        2775   (+275)
+ *   + both, collapsed                         2800   (+300)
+ *   + both, if they were not collapsed        2961
+ *
+ * So the maximum is **2800**, and the collapse is worth 161 characters as well
+ * as being the clearer prose. Every figure above is the *unpaired* memory case
+ * — memory reachable and tasks denied — which runs three characters longer than
+ * the ordinary one, because `MEMORY_AND_TASKS` is shorter than `MEMORY` and
+ * `TASKS` apart. Worth stating again, because two earlier raises were certified
+ * against a case an endpoint does not actually serve, and the widest case is
+ * still the one that looks like the narrower configuration. There are now two
+ * independent pairs, so the test walks four combinations rather than two.
  *
  * Exported because the test asserted `2000` as a literal while the code
  * reserved room against a second, differently-derived number — so the two could
@@ -230,7 +300,7 @@ function habitsFor(reachable: readonly string[]): string[] {
  * exactly the final length, because `join` adds the same two characters the
  * reduce already counted.
  */
-export const MAX_INSTRUCTIONS = 2700;
+export const MAX_INSTRUCTIONS = 2900;
 
 /** Which of the owner-layer providers this principal can actually reach. */
 function ownerProviders(merged: ReadonlyMap<string, MergedCapability>): string[] {

--- a/src/server/mcp/instructions.ts
+++ b/src/server/mcp/instructions.ts
@@ -162,7 +162,7 @@ which is meant, not take the first.`;
  * apart (see `MAX_INSTRUCTIONS`).
  *
  * Worth noting which case is ordinary: `entities` is granted on a fresh profile
- * and `identity` is not (ADR-050, ADR-055), so `ENTITIES` alone is the common
+ * and `identity` is not (ADR-050, ADR-056), so `ENTITIES` alone is the common
  * form and this one arrives only once the owner has declared themselves.
  */
 const IDENTITY_AND_ENTITIES = `**Who someone is, is declared rather than inferred.** For the owner's own name,
@@ -265,7 +265,7 @@ function habitsFor(reachable: readonly string[]): string[] {
  * has already done so by the time a skill would have been loaded. The client
  * that most needs the rule is the one holding no skills directory.
  *
- * Raised a fourth time, to 2900, for `entities` (ADR-055), and the answer is
+ * Raised a fourth time, to 2900, for `entities` (ADR-056), and the answer is
  * `IDENTITY`'s restated one step outward. An agent that resolves "email Jan" to
  * the wrong address has already sent the message; the mistake happens at the
  * instant of the send, before a skill would have been loaded, and the client


### PR DESCRIPTION
`identity` (ADR-042) exists because a profile said what was *reachable* and nothing about *whose*
it was, so an agent writing as the owner inferred a name from whatever was in the conversation.

The same failure happens one step outward and nothing catches it. Asked to "email Jan about the
invoice", an agent has no declared answer for who Jan is — it reaches for an address it saw in a
thread, and the guess does not look like one. `entities` is identity's mirror: who and what
everyone else is, so a reference is looked up.

## The decision worth reviewing first

**`entities_find` returns every match and errors on none of them.** An earlier draft refused on
ambiguity — exactly one entity or an error naming the candidates. That models the wrong thing: an
assistant handed two people called Jan asks which is meant, it does not fail.

What survives is that the tool never *picks*, and with no error to stop a client, three rules carry
it alone:

- **ordering is not selection** — no scoring inside a rank, so no tiebreak quietly promotes one of
  two exact alias matches;
- **the count comes first**, before any candidate, so a client that truncates has still seen there
  were two;
- **several matches render only what differs**, values included, so the question can usually be
  settled from context instead of asked.

```
2 entities match "Jan" on `entities.main`.

  jan-de-vries  Jan de Vries  alias "Jan"  ·  email jdv@meridian.test  ·  works_at → meridian
  jan-bakker    Jan Bakker    alias "Jan"  ·  email jan@acme.test      ·  works_at → acme-bv

If the context does not make it clear which is meant, ask before acting. Nothing here
chooses between them, and the order is not a ranking.
```

## The rest, briefly

One Markdown file per entity, frontmatter above notes — memory's shape (ADR-014), so the directory
stays one a person can open. `attributes` is a list rather than a map for identity's reason: a map
cannot say *when* to use which, and silently forbids two email addresses. Relations are one-sided
and the reverse is derived, because two files for one fact cannot be written atomically here.

**It is agent-writable and granted by default, where `identity` is neither.** One test settles
both, and it is not "is it empty" — memory arrives empty and is granted. It is *can it be filled in
from here*: configuration cannot (ADR-007), an owner's own store can.

**A derived `_index.json`** so a lookup opens no files, stamped with a `key:size` fingerprint of the
entity files. Not `key:size:mtime` as `skillFingerprint` uses — the GitHub adapter reports the
branch tip for every file, so on the backend where the index is worth the most it would never match
twice. The hole it leaves (a hand-edited *index* still passing its own fingerprint) is pinned by a
test and closed where it matters: a single match is re-read from its file before an agent acts on
it, and disagreement rebuilds and re-runs rather than patching one row.

**ADR-056 amends ADR-041**, whose title is "and nothing else may". That exclusion was a
discriminator, not a count — an artefact of one installation stays, a document the owner wrote may
move — and the structural half, no field that could name the credential store or the vault, is
untouched.

`MAX_INSTRUCTIONS` rises to 2900, certified at 2800 by measurement across four branches rather than
guessed; the collapse with `IDENTITY` is worth 161 characters of that.

## ⚠️ Not done: the user-facing documentation

This branch was cut from `main`, and on `develop` the guide pages **moved to lanes.sh/docs/link**
(#121). Only the ADRs and `init.md` remain here, so the edits this change had made to
`providers.md`, `commands.md`, `configuration.md`, `workflow.md`, `quickstart.md`, `deploy.md` and
`creating-a-provider.md` are dropped from it rather than merged.

**Documenting `entities` for a reader is a separate change in the website repository and has not
been made.** What is in this PR is the ADR, `CLAUDE.md`, and the bundled agent skill. The dropped
edits still apply cleanly in spirit — a provider table entry, a commands section, a config row, and
a workflow walkthrough — and I have them saved if that change is wanted next.

Rebasing also surfaced that **ADR-055 was already taken** on develop ("a connection may say where
its service is"). Mine is **056**; filename, heading and index row moved together.

## Two things found by running it, not by testing it

- **`warn` is a formatter, and calling it bare prints nothing.** Both places this CLI warns were
  written that way, so `forget` removed an entity three others pointed at in silence. Those
  warnings are the whole mitigation for `forget` not cascading and dangling edges being legal. Now
  asserted on captured stdout; reverting either fix fails it.
- **`distinguish` prints the differing values**, while the docstring above it and the ADR both
  claimed it never did. The code was right — "these two differ by email" without saying how is the
  same ambiguity one level down — so the prose moved and the behaviour is pinned.

## Verification

`bun run typecheck` clean. `bun test` 2794 pass / 0 fail, and 2806 pass with `LANES_DOCS_DIR`
pointed at the website checkout. The two `readme.test.ts` failures that appear with it are
**pre-existing** — reproduced on a clean `origin/develop` worktree with the same checkout, where the
connect guide is behind the eighty-one providers #114 added.

Only this repo runs CI on a PR, so also driven by hand against a scratch endpoint: five tools
advertised, instructions arriving at 2485 of 2900, two matches with no error and the count first,
`--related works_at=acme-bv` returning the employee and not the employer, a file edited in an editor
invalidating the index and reading back correctly, a truncated index still answering, and
`deny: [entities.write, entities.link, entities.forget]` leaving exactly `entities_find` and
`entities_get` while memory keeps all four.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
