### PR TITLE
Release: the 0.7.0 copy fixes

### DIFF
--- a/src/cli/config-edit.test.ts
+++ b/src/cli/config-edit.test.ts
@@ -5,7 +5,9 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { ConfigDocument, newProfileTemplate } from './config-edit.ts';
 import {
+  DEFAULT_SURFACES,
   ensureOwnerLayer,
+  repairOwnerLayer,
   ensureReservedConnection,
   repairLines,
   type SurfaceRepair,
@@ -607,6 +609,24 @@ policy:
       account: 'ada.lovelace@example.com',
     });
     expect(config.policy.allow).toContain('gmail.*');
+  });
+
+  test('the prose after a repair names every surface it wrote', async () => {
+    // The summary line was typed out, and still named six after a seventh had
+    // been added: a deploy printed `connections += entities.main` and then said
+    // the layer was six things. Read out of the report rather than out of
+    // `repairLines`, because it was the *prose* that drifted and the lines were
+    // right all along.
+    const { root } = await profileFile(OLD);
+
+    const lines: string[] = [];
+    await repairOwnerLayer(root, ['personal'], { report: (line) => lines.push(line) });
+
+    const summary = lines.find((line) => line.includes('your own material'));
+    expect(summary).toBeDefined();
+    for (const surface of DEFAULT_SURFACES) {
+      expect(summary).toContain(surface);
+    }
   });
 
   test('a fresh profile from the template needs no repair at all', async () => {

--- a/src/cli/config-repair.ts
+++ b/src/cli/config-repair.ts
@@ -156,6 +156,13 @@ export function ensureReservedConnection(
 }
 
 /** Whether a repair did anything, without a caller adding up two lists. */
+/** `memory, tasks, assets, skills, vault, setup and entities`, in repair order. */
+function listSurfaces(): string {
+  const names = [...DEFAULT_SURFACES];
+  const last = names.pop();
+  return names.length === 0 ? String(last) : `${names.join(', ')} and ${last}`;
+}
+
 export function repaired(repair: SurfaceRepair): boolean {
   return repair.changes.length > 0 || repair.granted.length > 0;
 }
@@ -293,9 +300,11 @@ export async function repairOwnerLayer(
 
       say(ok(`gave ${style.bold(name)} its own owner layer`));
       for (const change of repairLines(repair)) say(`      ${style.dim(change)}`);
-      say(
-        `      ${style.dim('memory, tasks, assets, skills, vault and setup — your own material, no account behind any of them')}`,
-      );
+      // Built from `DEFAULT_SURFACES` rather than typed out. The typed-out
+      // version still named six after a seventh had been added, so a person
+      // watching a deploy was told entities had arrived on the line above and
+      // that the layer was six things on the line below.
+      say(`      ${style.dim(`${listSurfaces()} — your own material, no account behind any of them`)}`);
     } catch (error) {
       say(
         warn(

--- a/src/providers/entities/provider.test.ts
+++ b/src/providers/entities/provider.test.ts
@@ -170,6 +170,26 @@ describe('several matches is a normal answer, not a failure', () => {
 });
 
 describe('no match', () => {
+  test('an empty directory says so, rather than "matches no criteria"', async () => {
+    // What a bare `entities_find` returned on a fresh profile. `describe({})`
+    // is "no criteria", so the sentence read "Nothing on entities.main matches
+    // no criteria", which tells a caller nothing and reads like a parser error.
+    const result = await harness().invoke('find', {});
+
+    expect('isError' in result && result.isError).toBeFalsy();
+    expect(textOf(result)).toContain('No entities are declared');
+    expect(textOf(result)).not.toContain('matches no criteria');
+  });
+
+  test('a query that matched nothing is a different sentence from an empty one', async () => {
+    const h = harness();
+    await declare(h, JAN);
+
+    const text = textOf(await h.invoke('find', { query: 'Nobody Here' }));
+    expect(text).toContain('matches "Nobody Here"');
+    expect(text).not.toContain('No entities are declared');
+  });
+
   test('is not an error either, and says not to invent an address', async () => {
     const h = harness();
     await declare(h, JAN);

--- a/src/providers/entities/provider.ts
+++ b/src/providers/entities/provider.ts
@@ -207,17 +207,21 @@ export const entitiesProvider: ProviderDefinition = defineLocalProvider({
         });
 
         if (matches.candidates.length === 0) {
-          return {
-            content: [
-              {
-                type: 'text',
-                text:
-                  `Nothing on ${context.connection.key} matches ${describe(criteria)}. ` +
-                  'Do not use an address that is not here — `entities.write` declares a new one, ' +
-                  'or ask the owner.',
-              },
-            ],
-          };
+          // An empty directory and a query that matched nothing are different
+          // answers and a caller does something different with each. Told
+          // "matches no criteria" it learns neither: that is what `describe({})`
+          // produces when a bare listing finds an empty store, and it reads like
+          // a parser error rather than an empty one.
+          const text =
+            matches.scanned === 0
+              ? `No entities are declared on ${context.connection.key} yet. ` +
+                '`entities.write` declares one. Until then there is nothing here to address ' +
+                'anyone by, so ask rather than using an address from somewhere else.'
+              : `Nothing on ${context.connection.key} matches ${describe(criteria)}. ` +
+                'Do not use an address that is not here — `entities.write` declares a new one, ' +
+                'or ask the owner.';
+
+          return { content: [{ type: 'text', text }] };
         }
 
         if (matches.candidates.length > 1) {


### PR DESCRIPTION
Takes the **propose** path, not publish: `package.json` still reads 0.7.0 and `v0.7.0` is tagged, so
the release run pushes `release/next` carrying the patch bump rather than publishing from here. That
is the intended shape for a patch, and the judgement it defers is exactly the one that does not need
making: this fixes two sentences and adds no surface.

## Since v0.7.0

- fix: two lines of copy that were wrong in front of the person reading them (#125)

Both were found by deploying 0.7.0 to a real Cloud Run endpoint and reading what it printed, which
is the only place either could have appeared.

- A bare `entities_find` on a fresh profile returned *"Nothing on entities.main matches no
  criteria"*, assembled from `describe({})`, which answers nothing and reads like a parser error.
  An empty directory and a query that matched nothing are two sentences now.
- The owner-layer repair summary called the layer six surfaces, two lines under
  `connections += entities.main`. It reads `DEFAULT_SURFACES` now rather than a hand-written list.

## Merge method

Merge commit, not squash, so `develop`'s tip stays an ancestor of `main` and the closing
fast-forward is possible.

Verified on `develop`: `bun test` 2797 passing, 0 failing; `bun run typecheck` clean.