### PR TITLE
Release 0.7.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lanes-sh/link",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "description": "A self-hostable MCP gateway for all your connections, memory, tasks, files, and secrets",
   "license": "Apache-2.0",
   "homepage": "https://lanes.sh/link",


### PR DESCRIPTION
Merging this publishes **0.7.1** to npm. The bump was pushed by the propose run on the previous
merge, so `package.json` here is untagged and this push takes the **publish** path.

## Since v0.7.0

- fix: two lines of copy that were wrong in front of the person reading them (#125)

A patch, and the workflow chose the number, which is right: this fixes two sentences and adds no
surface. Both were found by deploying 0.7.0 to a real endpoint and reading what it printed.

- A bare `entities_find` on a fresh profile returned *"Nothing on entities.main matches no
  criteria"*. An empty directory and a query that matched nothing are two sentences now.
- The owner-layer repair summary called the layer six surfaces, two lines under
  `connections += entities.main`. It reads `DEFAULT_SURFACES` now.

`ci` will show as never reporting: GitHub does not run workflows on a branch it pushed itself, which
is why this needs an admin merge. Both gates run again inside `release.yml` against the exact tree
being published.