### PR TITLE
fix: the consent page's policy blocked the redirect that ends an authorization

### DIFF
--- a/docs/detailed/adr/054-the-surface-in-front-of-the-gate.md
+++ b/docs/detailed/adr/054-the-surface-in-front-of-the-gate.md
@@ -88,9 +88,28 @@ request going somewhere else, and a proxy that genuinely rewrites it — a domai
 `Host` too. The scheme still comes from `X-Forwarded-Proto` because that is what the header is for
 here, and it is checked against `http` and `https` rather than echoed.
 
-`form-action 'self'` joins the page CSP as the second lock on the one form that carries the
-owner's token. It has to be named explicitly: `form-action` does not fall back to `default-src`,
-so the `'none'` already there said nothing about where a form may post.
+`form-action` joins the page CSP as the second lock on the one form that carries the owner's
+token. It has to be named explicitly: it does not fall back to `default-src`, so the `'none'`
+already there said nothing about where a form may post.
+
+**Amended.** It was written as `form-action 'self'`, and `'self'` alone cannot end an OAuth flow.
+Chrome and Safari check this directive against the *redirect* a submission produces as well as
+against the `action`, and the consent form exists to end in a 302 to the client that asked. So the
+POST was accepted, the code was minted, and the browser then refused to deliver it — a page that
+hangs on its spinner, with a console error naming this endpoint's own `/authorize` rather than the
+blocked destination, because a violation report deliberately names the pre-redirect URL. Firefox
+does not enforce it on redirects, so it failed in half the browsers and worked in the other half.
+Whether the directive *should* apply to redirects has been open since
+[w3c/webappsec-csp#8](https://github.com/w3c/webappsec-csp/issues/8); the browsers that ship it are
+the ones that decide.
+
+The consent page now names the redirect target of the request it is rendering, beside `'self'` —
+taken from the request rather than from the registration, since a native client registers
+`http://localhost/callback` and binds a port. This widens nothing that matters. The origin admitted
+is the one already printed on the page as where the code will be sent, it has been checked against
+the registration before the page renders and again before anything is minted, and `form-action`
+only ever *refuses* a destination: the `action` that carries the token is still built server-side
+from `Host`, so no source added here can move it.
 
 ## Consequences
 

--- a/src/cli/brand.ts
+++ b/src/cli/brand.ts
@@ -150,6 +150,19 @@ a { color: inherit; }
 .footer a { text-decoration: underline; }
 `.trim();
 
+/** What a page may widen its policy by, for the two pages that need to. */
+export interface PagePolicy {
+  /** The page carries an inline script, and has to say so. */
+  readonly script?: boolean;
+  /**
+   * Where this page's form is allowed to end up, beyond `'self'`.
+   *
+   * A source expression, not a URL: an origin (`https://client.example`) or a
+   * bare scheme (`vscode:`) for a native client's redirect.
+   */
+  readonly formAction?: readonly string[];
+}
+
 /**
  * What every page these modules serve loads, and nothing else.
  *
@@ -158,16 +171,32 @@ a { color: inherit; }
  * a page here has no script by default — the consent screen, which has one
  * listener for its submit spinner, extends this rather than replacing it.
  */
-export const PAGE_CSP =
-  "frame-ancestors 'none'; default-src 'none'; " +
-  // `form-action` does **not** fall back to `default-src`, so `'none'` above
-  // says nothing about where a form may post. One page here posts the owner's
-  // endpoint token, and its `action` is built from the request's own `Host` —
-  // this is the second lock on that, so a form target that ever came from
-  // somewhere else is refused by the browser rather than followed.
-  "form-action 'self'; " +
-  "style-src 'unsafe-inline' https://fonts.googleapis.com; " +
-  'font-src https://fonts.gstatic.com';
+export function pageCsp(policy: PagePolicy = {}): string {
+  return [
+    "frame-ancestors 'none'",
+    "default-src 'none'",
+    // `form-action` does **not** fall back to `default-src`, so `'none'` above
+    // says nothing about where a form may post. One page here posts the owner's
+    // endpoint token, and its `action` is built from the request's own `Host` —
+    // this is the second lock on that, so a form target that ever came from
+    // somewhere else is refused by the browser rather than followed.
+    //
+    // It takes sources beyond `'self'` because Chrome and Safari re-check this
+    // directive against the *redirect* a submission produces, not only against
+    // the `action` — and the consent form's whole purpose is to end in a 302 to
+    // the client that asked. Named nothing else, the directive accepts the
+    // POST, mints the code, and then blocks the browser from delivering it,
+    // which is indistinguishable from a hung page. Firefox does not do this, so
+    // it stays broken in exactly half the browsers. See ADR-054.
+    ["form-action 'self'", ...(policy.formAction ?? [])].join(' '),
+    "style-src 'unsafe-inline' https://fonts.googleapis.com",
+    'font-src https://fonts.gstatic.com',
+    ...(policy.script ? ["script-src 'unsafe-inline'"] : []),
+  ].join('; ');
+}
+
+/** The policy a page with nothing to widen answers with. */
+export const PAGE_CSP = pageCsp();
 
 /**
  * Headers every page here answers with.

--- a/src/cli/callback-page.test.ts
+++ b/src/cli/callback-page.test.ts
@@ -181,6 +181,42 @@ describe('approving', () => {
     expect(withScript.headers.get('content-security-policy')).toContain("script-src 'unsafe-inline'");
     expect(without.headers.get('content-security-policy')).not.toContain('script-src');
   });
+
+  test('the policy admits the destination named on the page, and only that one', () => {
+    // `form-action` is checked against the redirect the approval produces, not
+    // just the `action` — so the one origin this page tells the reader about is
+    // the one origin it has to admit. Anything else and the browser refuses to
+    // deliver a code that has already been minted.
+    const csp =
+      approvalPage({
+        client: 'C',
+        redirectHost: 'client.example',
+        formAction: 'https://client.example',
+        fields: {},
+        action: '/authorize',
+        retry: false,
+        target: 'local',
+      }).headers.get('content-security-policy') ?? '';
+
+    expect(csp).toContain("form-action 'self' https://client.example;");
+    expect(csp).not.toContain('https://other.example');
+  });
+
+  test('a page given no destination keeps the narrow policy', () => {
+    // A redirect this endpoint could not parse never reaches consent, so the
+    // absence is a real state rather than a caller forgetting the field.
+    const csp =
+      approvalPage({
+        client: 'C',
+        redirectHost: 'client.example',
+        fields: {},
+        action: '/authorize',
+        retry: false,
+        target: 'local',
+      }).headers.get('content-security-policy') ?? '';
+
+    expect(csp).toContain("form-action 'self';");
+  });
 });
 
 describe('untrusted text', () => {

--- a/src/cli/callback-page.ts
+++ b/src/cli/callback-page.ts
@@ -26,7 +26,7 @@
  * else — not on emphasis, and not on the heading.
  */
 
-import { escapeHtml, FONTS, FOOTER, PAGE_CSP, PAGE_HEADERS, TOKENS } from './brand.ts';
+import { escapeHtml, FONTS, FOOTER, pageCsp, PAGE_HEADERS, TOKENS } from './brand.ts';
 
 export interface CallbackPage {
   /** The focal line, set in Lora. A provider name, or the outcome itself. */
@@ -74,6 +74,11 @@ export interface ApprovalPage {
   readonly client: string;
   /** Where the code would be sent. The part of the request that cannot be faked. */
   readonly redirectHost: string;
+  /**
+   * The same destination as a CSP source, so the browser will follow the
+   * redirect this form's approval ends in rather than blocking it.
+   */
+  readonly formAction?: string;
   /** Hidden fields carrying the authorization request through the POST. */
   readonly fields: Readonly<Record<string, string>>;
   readonly action: string;
@@ -121,7 +126,10 @@ ${hidden}
 </form>
 <p class="small"><code>lanes link outputs --show --target ${escapeHtml(page.target)}</code></p>`;
 
-  return shell(body, 'Authorise', page.retry ? 401 : 200, '', SUBMIT_SPINNER);
+  return shell(body, 'Authorise', page.retry ? 401 : 200, '', {
+    script: SUBMIT_SPINNER,
+    ...(page.formAction ? { formAction: [page.formAction] } : {}),
+  });
 }
 
 /**
@@ -152,8 +160,9 @@ function shell(
   title: string,
   status: number,
   cardClass = '',
-  script = '',
+  policy: { readonly script?: string; readonly formAction?: readonly string[] } = {},
 ): Response {
+  const script = policy.script ?? '';
   return new Response(
     `<!doctype html>
 <html lang="en">
@@ -182,7 +191,10 @@ ${script ? `<script>\n${script}\n</script>` : ''}
       status,
       headers: {
         ...PAGE_HEADERS,
-        ...(script ? { 'content-security-policy': `${PAGE_CSP}; script-src 'unsafe-inline'` } : {}),
+        'content-security-policy': pageCsp({
+          ...(script ? { script: true } : {}),
+          ...(policy.formAction ? { formAction: policy.formAction } : {}),
+        }),
       },
     },
   );

--- a/src/server/oauth.test.ts
+++ b/src/server/oauth.test.ts
@@ -95,6 +95,22 @@ async function authorise(
   });
 }
 
+/**
+ * The `form-action` sources a page was served with.
+ *
+ * Parsed rather than matched as a substring because what matters is the list a
+ * browser checks a navigation against, and `'self'` alone passing a
+ * `toContain('form-action')` is exactly the assertion that missed this.
+ */
+function formActionOf(response: Response): string[] {
+  const directive = (response.headers.get('content-security-policy') ?? '')
+    .split(';')
+    .map((part) => part.trim())
+    .find((part) => part.startsWith('form-action '));
+
+  return directive ? directive.split(/\s+/).slice(1) : [];
+}
+
 async function codeFrom(response: Response): Promise<string> {
   return new URL(response.headers.get('location')!).searchParams.get('code')!;
 }
@@ -404,6 +420,42 @@ describe('the authorization code flow', () => {
 
     expect(response.status).toBe(302);
     expect(response.headers.get('location')).toStartWith('http://localhost:51763/callback?');
+  });
+
+  test('the consent page permits the redirect its own approval performs', async () => {
+    // Chrome and Safari re-check `form-action` when a form submission redirects,
+    // so a policy naming only `'self'` blocks the 302 that ends the flow: the
+    // POST is accepted, the code is minted, and the browser then refuses to
+    // deliver it. Nothing about that is visible in the page or the response —
+    // the spinner simply never stops.
+    //
+    // So this asks the policy the consent page was served with about the
+    // destination that page's own approval produces, rather than asserting a
+    // string. The string was right; what it named was not enough.
+    const clientId = await register();
+    const consent = await fetch(
+      `${origin}/authorize?response_type=code&client_id=${clientId}` +
+        `&redirect_uri=${encodeURIComponent(REDIRECT)}` +
+        `&code_challenge=${pkceChallengeFor(VERIFIER)}&code_challenge_method=S256`,
+    );
+    const approved = await authorise(clientId);
+
+    expect(approved.status).toBe(302);
+    expect(formActionOf(consent)).toContain(new URL(approved.headers.get('location')!).origin);
+  });
+
+  test('a native client on loopback is permitted the port it actually bound', async () => {
+    // The registered URI has no port and the redirect has one, so a policy
+    // built from what was registered would name an origin the browser never
+    // navigates to. It has to come from the request being approved.
+    const clientId = await register(['http://localhost/callback']);
+    const consent = await fetch(
+      `${origin}/authorize?response_type=code&client_id=${clientId}` +
+        `&redirect_uri=${encodeURIComponent('http://localhost:51763/callback')}` +
+        `&code_challenge=${pkceChallengeFor(VERIFIER)}&code_challenge_method=S256`,
+    );
+
+    expect(formActionOf(consent)).toContain('http://localhost:51763');
   });
 });
 

--- a/src/server/oauth.ts
+++ b/src/server/oauth.ts
@@ -168,6 +168,9 @@ function render(result: OAuthResult, request: Request, target: string): Response
         // anything, but it cannot change where the code is sent.
         client: result.clientName ?? result.request.clientId,
         redirectHost: hostOf(result.request.redirectUri),
+        // The page's policy has to admit the redirect the page's own approval
+        // ends in, or the browser blocks it. See `formActionFor`.
+        ...formActionFor(result.request.redirectUri),
         action: `${publicOrigin(request)}${AUTHORIZE_PATH}`,
         fields: formFromRequest(result.request),
         retry: result.retry,
@@ -216,6 +219,37 @@ function hostOf(uri: string): string {
     return new URL(uri).host;
   } catch {
     return uri;
+  }
+}
+
+/**
+ * The redirect target as a CSP source, for the consent page's `form-action`.
+ *
+ * Chrome and Safari check that directive against the redirect a form submission
+ * produces, so the page has to name where its own approval is about to send the
+ * browser — `'self'` alone mints the code and then blocks its delivery.
+ *
+ * Taken from the request being approved rather than from what the client
+ * registered, because the two legitimately differ: a native client registers
+ * `http://localhost/callback` and binds whatever port it got (RFC 8252), and
+ * the origin the browser navigates to is the one carrying that port. It is
+ * already checked against the registration — by `authorize` before this page is
+ * rendered, and again by `approve` before anything is minted — and it cannot
+ * move the token, because the form's `action` is built here rather than read
+ * from the request.
+ *
+ * An origin and nothing else, because `isSafeRedirect` registers nothing else:
+ * https, or http on loopback. A private-use scheme — `vscode:`, the other shape
+ * RFC 8252 allows — would need a scheme-source here, and is refused two steps
+ * earlier, so a branch for it would be a branch nothing can reach.
+ */
+function formActionFor(uri: string): { formAction?: string } {
+  try {
+    const { protocol, origin } = new URL(uri);
+    if (protocol !== 'http:' && protocol !== 'https:') return {};
+    return { formAction: origin };
+  } catch {
+    return {};
   }
 }
 


### PR DESCRIPTION
A deployed endpoint on 0.6.10 or later cannot complete an OAuth authorization in
Chrome or Safari. The consent screen accepts the token, mints the code, and then
the browser refuses to deliver it — the spinner never stops.

`form-action 'self'` arrived in #111 (ADR-054) as a second lock on the one form
that carries the owner's endpoint token. Chrome and Safari check that directive
against the **redirect** a submission produces as well as against the `action`,
and this form exists to end in a 302 to the client that asked. Firefox does not,
so it broke in half the browsers. Whether it should apply to redirects has been
open since [w3c/webappsec-csp#8](https://github.com/w3c/webappsec-csp/issues/8);
the browsers that ship it decide.

The reported error names the endpoint's own `/authorize` rather than the blocked
destination, because a CSP violation report deliberately reports the pre-redirect
URL. That is why it reads as if the same-origin POST were refused.

## The change

The consent response names the redirect target of the request it is rendering,
beside `'self'` — from the request rather than the registration, since a native
client registers `http://localhost/callback` and binds an ephemeral port
(RFC 8252).

This widens nothing that matters. The origin admitted is the one already printed
on the page as where the code will be sent; it is checked against the
registration by `authorize` before the page renders and again by `approve`
before anything is minted; and `form-action` only ever *refuses* a destination —
the `action` carrying the token is still built server-side from `Host`, so no
source added here can move it.

## Verified

Locally, since only `lanes-sh/link` runs CI on a PR:

- `bun test` — 2801 pass, 0 fail
- `bun run typecheck` — clean

And in Chrome 151 against the real served page, on a routable bind so the
loopback rebinding check is off and the shape matches Cloud Run:

- **Before** (policy reverted to `'self'` alone): the page does not navigate, the
  button stays disabled mid-spinner, and the console reads *"Sending form data to
  'http://127.0.0.1:7401/authorize' violates the following Content Security Policy
  directive: `form-action 'self'`. The request has been blocked."* — word for word
  the reported failure.
- **After**: Chrome follows the 302 to `https://example.com/cb?code=…&state=…`,
  no CSP violation logged.

The regression test asks the policy the consent page was served with about the
destination that page's own approval produces. Asserting the header string is
what missed this: the string was right, and what it named was not enough.

## Noted separately, not fixed here

On a **loopback** bind the same form is refused before it reaches any of this,
with `Invalid Origin header: null`: the page's `Referrer-Policy: no-referrer`
makes Chrome send `Origin: null`, which the DNS-rebinding check rejects. Both
headers date to the first commit, so it is not a regression and it does not
affect a deployed endpoint, where that check is off by design. Worth its own
change.