### PR TITLE
Release 0.7.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lanes-sh/link",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "description": "A self-hostable MCP gateway for all your connections, memory, tasks, files, and secrets",
   "license": "Apache-2.0",
   "homepage": "https://lanes.sh/link",


### PR DESCRIPTION
Merging this publishes 0.7.2 to npm.

Since v0.7.1:

- fix: the consent page's own policy blocked the redirect that ends an authorization (#128)