### PR TITLE
feat!: 0.8.0 — connections belong to the workspace, a caller is a person

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,7 +193,7 @@ the whole inventory by connector and credential type:
 
 The same code, the same config, in all three. Only the storage adapters change.
 
-| | **Local** | **Your own cloud** | **Lanes Cloud** |
+| | **Local** | **Self-Hosted** | **Lanes Cloud** |
 |---|---|---|---|
 | Runs on | your machine | your GCP project, on Cloud Run | managed for you |
 | Needs | Bun, nothing else | a Google Cloud billing account | — |
@@ -201,7 +201,7 @@ The same code, the same config, in all three. Only the storage adapters change.
 | Reachable from | that machine | anywhere, including your phone | anywhere |
 | Status | ready | ready | **coming soon** |
 
-**Local** is the fastest way to start, and where most people stay. **Your own cloud** is what you
+**Local** is the fastest way to start, and where most people stay. **Self-Hosted** is what you
 want if you need to reach it from claude.ai, ChatGPT, or a phone — `lanes link deploy` creates the
 project, the bucket, the service account, and the revision on its first run. **Lanes Cloud** is the
 managed version; because it is the same data model, a workspace you build today moves across rather

--- a/README.md
+++ b/README.md
@@ -51,12 +51,14 @@ middle of your data.
 
 ## Quickstart
 
-Needs [Bun](https://bun.com) 1.3.11+. Nothing else — no account anywhere.
+Needs [Bun](https://bun.com) 1.3.11+, and a Lanes sign-in.
 
 ```console
 $ bun install -g @lanes-sh/link                # puts `lanes` on your PATH
-$ lanes link profile add personal --target local
-$ lanes link start --profile personal --target local
+$ lanes auth login                             # opens a browser once
+$ lanes link profile add personal --workspace local
+$ lanes link profile members add --me --profile personal --workspace local
+$ lanes link start --profile personal --workspace local
 ok    serving http://127.0.0.1:7337/mcp
       profiles: personal
 ```
@@ -64,7 +66,7 @@ ok    serving http://127.0.0.1:7337/mcp
 Then, in another shell:
 
 ```console
-$ lanes link mcp add --profile personal --target local                           # every agent installed; or name one: claude, codex
+$ lanes link mcp add --profile personal --workspace local     # every agent installed; or name one: claude, codex
 ok    registered lanes-link with Claude Code (user scope)
 ok    registered lanes-link with Codex
 ```
@@ -73,14 +75,22 @@ Your agents can now use it. Memory, tasks, files, skills, and the vault hold you
 rather than an account, so they are already there — nothing to connect, no credentials, no browser.
 Mail and calendar are the next step. **[Full quickstart →](https://lanes.sh/docs/link/quickstart)**
 
+**Why the sign-in.** A profile declares who may consume it, and there is nothing to check that
+against if the endpoint has no idea who is asking. That is a real dependency for a self-hostable
+tool and worth stating plainly; what it is not is a dependency per request. The network is needed
+to sign in and to refresh, and a machine offline for a day keeps serving. `lanes link token
+show` still mints a static token for CI, which has no browser to sign in with.
+
 ## In the Lanes desktop app
 
 Prefer not to use a terminal? The [Lanes desktop app](https://lanes.sh/desktop) drives this CLI from
-a settings page. **Settings → Integrations → Lanes Link** installs it, holds the profile and target
-every command runs against, connects your accounts, starts and stops the endpoint, and registers it
-with Claude Code or Codex.
+a settings page. **Settings → Integrations → Lanes Link** installs it, holds the profile and
+workspace every command runs against, starts and stops the endpoint, and registers it with Claude
+Code or Codex. From 0.8.0 your connections, profiles and audit log are on the
+[Lanes dashboard](https://lanes.sh/dashboard/link) instead, which reads your endpoint directly over
+loopback: run `lanes link pair` once to let it.
 
-![The Lanes Link page in the Lanes desktop app: the CLI status card and its version, the target and profile selectors, the endpoint row with its running state, and the list of connected accounts.](docs/images/lanes-link-desktop.png)
+![The Lanes Link page in the Lanes desktop app: the CLI status card and its version, the workspace and profile selectors, the endpoint row with its running state, and the list of connected accounts.](docs/images/lanes-link-desktop.png)
 
 It runs the commands above rather than reimplementing them, so consent and the token stay here where
 they belong, and an endpoint set up in the app is the same one you get from a shell. Available from

--- a/docs/detailed/adr/012-owner-layer-primitives.md
+++ b/docs/detailed/adr/012-owner-layer-primitives.md
@@ -138,6 +138,24 @@ the item id is recorded verbatim, because a log that cannot say *which* item was
 very little, and the value records `<withheld>` and nothing else. Redaction resolves before the
 policy decision, so a denied vault call is redacted exactly like an allowed one.
 
+**Amendment (0.8.0): a search query is the question, not the answer, and it is kept.**
+`memory.search` withheld its `query`, on the argument that a memory query is at least as revealing as
+a Gmail search query. That is true, and it is an argument about the wrong thing. A search term is not
+the owner's material; it is what an *agent* went looking for in that material, which is the question
+the log exists to answer. Withheld, every search read alike: memory was searched, twice, and matched
+nothing, with no way to tell a calendar lookup from a rummage through someone's medical notes.
+
+The pairing is what makes this safe rather than a loosening. The question is recorded and the answer
+is not: `entry` keeps a `uri`, `get` keeps an `id`, `write` keeps `id`, `title` and `tags`, and no
+capability on this provider keeps a body. A reader of the log learns what was asked and still cannot
+learn what came back.
+
+The old rule was reasoning about [`audit/fanout.ts`](../../../src/audit/fanout.ts): a workspace may
+declare secondary sinks, and copies sent to stdout or an OTLP collector leave the machine. That
+exposure is real and it is the operator's to weigh, which is exactly what declaring a sink is. It was
+never a reason to withhold from the durable log on the operator's own disk, where the only reader is
+the person the entries are about.
+
 ---
 
 ## What M4 had to change in core, contradicting `docs/detailed/init.md`

--- a/docs/detailed/adr/057-a-connection-belongs-to-the-workspace.md
+++ b/docs/detailed/adr/057-a-connection-belongs-to-the-workspace.md
@@ -1,0 +1,122 @@
+# ADR-057: A connection belongs to the workspace, and a profile selects it
+
+**Status:** accepted · **Supersedes** [ADR-003](003-auth-model.md)'s granularity argument ·
+**Amends** [ADR-009](009-one-endpoint-per-workspace.md), [ADR-030](030-a-profile-owns-its-skills-and-manifests.md) ·
+**Follows from** [ADR-052](052-a-target-owns-its-workspace.md)
+
+## Context
+
+A connection has lived inside one profile since M1. `profiles/<name>.yaml` carries a
+`connections:` array, and a sibling profile cannot see a row in it. ADR-009 stated the boundary as
+an invariant — profiles share no database and no credential store — and ADR-030 finished the job
+by moving skills and manifests in beside them.
+
+The isolation is real. What it costs is that **authorising an account and deciding what may be
+done with it are the same act**, and only one of the two is a property of the account.
+
+An owner who wants a mailbox read by one agent and written by another authorises the mailbox
+twice. Two OAuth round trips, two refresh tokens, two grants the vendor lists on its security
+page, and revoking one does not revoke the other. Every further combination — a third profile
+that reads mail and edits the calendar — is another full pass through a browser. The workspace
+this was written against holds fifteen connections across seven vendors; a second profile wanting
+half of them costs seven browser sign-ins to express a permission change.
+
+Two smaller things point the same way.
+
+**The credential store was never actually per profile on a deployment.** `credentialRef` is
+`gmail/main`, flat within one target's store, and `deploy` carries a `collidingRefs` preflight
+precisely because two profiles deployed into one project share that namespace. ADR-043 records
+what the collision does: it is "silent until one profile is reading the other's account". So the
+boundary a profile claims is, on the path that matters most, enforced by a refusal at deploy time
+rather than by the model.
+
+**A profile is a statement about scope, not about inventory.** "Personal assistant — read my mail,
+edit my calendar" describes what may be done. It does not describe which accounts exist, and it
+was never the natural place to record that a mailbox was authorised.
+
+## Decision
+
+**Connections move up to the workspace.**
+
+```
+~/.lanes-link/
+├── lanes-link.yaml         the workspace registry
+├── connections.yaml        every authorised account in this workspace
+└── profiles/<name>.yaml    which of them, and what may be done with each
+```
+
+`connections.yaml` carries the `connectionSchema` rows unchanged, and `oauth_apps` with them — a
+registered client is a property of an account, not of a selection.
+
+**A profile names connections in `grants:`**, one row per connection.
+[ADR-058](058-a-grant-names-a-connection.md) covers the scopes half; this decision is only about
+where a connection lives.
+
+**One credential store per workspace**, at `data/credentials.enc`. Refs are unique by
+construction, so `collidingRefs` and its preflight are deleted rather than kept as a guard for a
+state that can no longer occur.
+
+**Provider manifests move with them**, to `data/providers.d/`. This reverses half of ADR-030 and
+follows from it rather than contradicting it: a manifest *defines a connection* — a host, an
+OpenAPI document, and the credential refs that reach them — so once connections are
+workspace-level, a manifest scoped to one profile describes something that does not live there.
+
+## Why this is not the retreat it looks like
+
+ADR-030's argument was about *content*: a work incident-review skill "is a description of how a
+particular employer runs incidents", and is exactly as private as the knowledge it operates on.
+That argument is untouched. It is answered by
+[ADR-059](059-the-owner-layer-is-instances.md), which keeps memory, skills and entities as
+instances a profile chooses — so two profiles can still share nothing, deliberately, by choosing
+different ones.
+
+ADR-009's "a note written through `personal` is simply absent in `work`" survives for the same
+reason. What does not survive is the claim that a *refresh token* is private to a profile, and
+that claim was already false on a deployment.
+
+## What this costs, stated plainly
+
+**The workspace is now the only isolation boundary.** Before, `rm -r data/work` was the whole
+answer to "what could work reach". It is not any more: removing a profile removes a selection, and
+the accounts outlive it. That is the correct answer for an account — you did not stop having the
+mailbox — but "remove the work profile" no longer means "revoke what work could reach", and
+`profile remove` therefore prints the connections that outlive it rather than letting the
+difference go unnoticed.
+
+**Two profiles referencing one connection share one credential.** They share its rate limit, its
+reconcile state, and its revocation: `disconnect` takes the account away from every profile
+naming it. `disconnect` consequently reports which profiles reference the row and refuses without
+`--yes`, where before it could only ever affect the one profile it was run against.
+
+**A leaked workspace is a wider leak than a leaked profile was.** One credential document now
+holds every account rather than one profile's share. It is the same document, under the same key,
+in the same place — but it is worth saying that the blast radius of the file grew, because the
+`data/<profile>/` split used to bound it and no longer does.
+
+## Consequences
+
+**`connect` and `disconnect` become workspace-scoped.** Both drop `--profile`: there is no profile
+to write into. A newly connected account belongs to the workspace and is reachable from no profile
+until one grants it, which is default deny arriving one step earlier than before.
+
+**The deploy preflight goes.** `collidingRefs` existed for two profiles sharing a namespace. There
+is one namespace now, and a duplicate id is refused at config load by the schema rather than
+minutes into a rollout.
+
+**A profile file gets shorter and says only what it is for** — a name, a description, a set of
+grants, and the people who may use it. That is what makes ADR-058 and
+[ADR-060](060-a-caller-is-a-person.md) expressible; neither would fit in a file that was also an
+account inventory.
+
+**Migration has one interesting case**, and it is not the common one: two profiles each holding a
+row that is spelled `gmail.main` but names a different account. Keyed on `(provider, account)` the
+common case merges silently; the divergent case suffixes the id and reports the rename, because
+picking either row would be the silent wrong answer this project keeps refusing to give.
+
+## What this does not do
+
+It does not make a connection reachable by default — a connection with no grant is not advertised
+and not callable, which is ADR-003's default deny unchanged. It does not merge the credential
+store with the vault; ADR-022's separation is untouched and is the one thing here that must never
+be collapsed. And it does not give a profile any way to authorise an account itself: connecting
+remains a control-plane act performed by the owner in a terminal (ADR-007, ADR-019).

--- a/docs/detailed/adr/058-a-grant-names-a-connection.md
+++ b/docs/detailed/adr/058-a-grant-names-a-connection.md
@@ -1,0 +1,119 @@
+# ADR-058: A grant names a connection, so scopes differ per account
+
+**Status:** accepted · **Supersedes** [ADR-003](003-auth-model.md)'s "rules name capabilities,
+never connections" · **Follows from** [ADR-057](057-a-connection-belongs-to-the-workspace.md)
+
+## Context
+
+A policy rule has never named an account. `policySchema` is one `allow` list and one `deny` list
+for the whole profile, and the schema says why:
+
+> Rules name capabilities, never connections. Every account of a provider in a profile is governed
+> identically, and granularity comes from running a narrower profile.
+
+`allowedConnections` implements exactly that, and is explicit about it — it filters to the
+capability's own provider and then goes all-or-nothing:
+
+```ts
+// All or nothing beyond that, since rules do not discriminate between
+// accounts. The list shape is kept because it is what the `connection` enum
+// wants, and because a future principal-scoped rule would restore the
+// filtering without touching any caller.
+```
+
+That was a good trade while a connection lived in exactly one profile, because **the second
+profile was the granularity**. Two mailboxes governed differently meant two profiles, and two
+profiles shared no store and no credential, which ADR-003 correctly calls a stronger boundary than
+a policy row.
+
+ADR-057 removes the mechanism that made it work. A connection now lives in the workspace and any
+profile may select it, so "run a narrower profile" no longer produces a narrower *grant* — it
+produces a second selection of the same account, with the same flat rule set applied to it. The
+granularity has to move into the rule, because there is nowhere else left for it to be.
+
+The thing this makes expressible is the thing the product is for: one profile that reads a mailbox
+and writes a calendar, and another that reads the calendar and sends as the mailbox, over the same
+two accounts, authorised once.
+
+## Decision
+
+**A profile's policy is a list of rows, each naming one connection.**
+
+```yaml
+grants:
+  - connection: gmail.personal
+    allow: [gmail.users.messages.list, gmail.users.messages.get, gmail.users.threads.*]
+  - connection: gmail.work
+    allow: [gmail.*]
+    deny:  [gmail.send_message]
+  - connection: calendar.personal
+    allow: [calendar.*]
+```
+
+Everything load-bearing from ADR-003 survives unchanged, and is worth listing because a change to
+the policy engine invites reading more into it than is there:
+
+- **Default deny.** A connection with no row is not reachable and not advertised. An empty
+  `grants:` grants nothing at all.
+- **Deny wins**, regardless of order, within the row that governs the call.
+- **Tighten only.** The instance floor is still evaluated first and its denial is still final.
+  Composition can narrow and can never widen.
+- **`approval_required` is still reserved** and still treated as `deny` until an approval engine
+  exists.
+
+**There is no profile-wide `allow` beside the rows**, and that is deliberate. A second place a
+connection could be granted is a second answer to "may this call proceed", and the whole shape of
+ADR-052 is that two answers to one question is the defect rather than the convenience.
+
+**`PolicyRequest.connection` becomes load-bearing.** It has been carried since M1 "for audit, not
+for the decision"; the field does not change, the reason it is there does.
+
+**`allowedConnections` stays the single implementation.** It evaluates each candidate connection
+rather than answering once per provider, and discovery (`server/mcp/visibility.ts`) and
+enforcement (`dispatch/dispatch.ts`) keep calling the same function. Computing visibility a second
+way is how a filter and a gate come to disagree, and a leak in discovery is still a leak.
+
+## What this costs, stated plainly
+
+**A profile file is longer, and repetitive by construction.** Eight connections is eight rows,
+and a profile that genuinely wants the same rules everywhere now writes them eight times. That is
+the honest cost of removing the shorthand, and it is not worked around with a wildcard row: a
+`connection: '*'` would be exactly the second grant path this decision refuses.
+
+**`policy allow` and `policy deny` require `--connection`.** A rule has to land somewhere, and
+there is no longer a single block to append to. The refusal names the connections the profile
+holds, so the flag is discoverable from the error rather than from the docs.
+
+**`connect` no longer writes a grant**, because it no longer writes into a profile at all
+(ADR-057). The first-impression argument ADR-003 made for `allow: ['*']` moves to `profile add`
+and to `lanes link grant <connection>`, which writes the row and the wildcard together.
+
+**A denial reads differently in the log.** `denied_by_policy` used to mean "this provider is not
+permitted here"; it can now mean "not for this account". The event already records the connection,
+so nothing is lost — but anyone reading old and new events together should know the predicate
+changed.
+
+## What was considered and rejected
+
+**Keeping the flat block and adding per-connection overrides.** Two places, precedence rules
+between them, and the same "which one answered" question ADR-037 spent a whole decision removing.
+
+**Rules that name a connection pattern** — `gmail.*` on the connection axis as well as the
+capability axis. It reads as symmetry and is not: a capability pattern narrows a vendor's own
+namespace, which the operator does not control, while a connection id is a name the operator
+chose. A pattern over names they chose buys brevity and costs the property that you can read a
+profile and see exactly which accounts it reaches.
+
+**Per-capability grants on the connection row instead of allow/deny lists.** Rejected on grounds
+of parity: `capabilityPattern` and the `allow`/`deny` pair are what `policy list`, the audit log,
+the instance floor and every existing profile already speak. Changing the rule grammar and its
+location in one release would make the migration two changes instead of one.
+
+## What this does not do
+
+It does not add a principal to a rule. Who may call is decided one layer up, by the profile's
+members ([ADR-060](060-a-caller-is-a-person.md)), and a grant row is about the account rather than
+the person. It does not introduce ordering between rows — a row governs exactly its connection and
+rows cannot interact. And it does not change what a capability *is*: the vendor still names the
+operations, and `capabilityPattern` still admits `*`, `gmail.*`, and a trailing `.*` at any depth,
+and nothing else.

--- a/docs/detailed/adr/059-the-owner-layer-is-instances.md
+++ b/docs/detailed/adr/059-the-owner-layer-is-instances.md
@@ -1,0 +1,140 @@
+# ADR-059: The owner layer is instances, and two profiles may share one
+
+**Status:** accepted · **Amends** [ADR-009](009-one-endpoint-per-workspace.md)'s "profiles share
+nothing", [ADR-014](014-owner-layer-is-managed.md), [ADR-030](030-a-profile-owns-its-skills-and-manifests.md),
+[ADR-050](050-the-owner-layer-is-granted-by-default.md) · **Follows from**
+[ADR-057](057-a-connection-belongs-to-the-workspace.md)
+
+## Context
+
+Memory, tasks, assets, skills, vault and entities are providers with no vendor, no credential and
+no account. What they have is bytes, and ADR-030 put those bytes inside the profile —
+`data/<profile>/memory/main/<id>.md` — which is what made ADR-009's "profiles share no database"
+true without exceptions.
+
+ADR-057 moves every *account* up to the workspace. That leaves the owner layer as the only thing
+still declared inside a profile, and it cannot stay there: a profile is now a selection of
+connections, and `memory` is reached exactly the way `gmail` is — a `connection` argument, a
+capability, a policy decision. A surface that is a connection at the MCP boundary and not one in
+the config is two models for one thing.
+
+There is a second reason, and it is the one an owner feels. A note taken while doing work is
+useful when reading personal mail — "the flight is booked on the other card" does not belong to a
+profile. Under ADR-030 the only way to have it in both places is to write it twice, and the two
+copies then diverge. The isolation was chosen deliberately and it is right for a *work* note in a
+*personal* profile; it is wrong for the large middle where the same person is the same person.
+
+## Decision
+
+**An owner-layer surface is a connection like any other, and there may be more than one.**
+
+```yaml
+# connections.yaml
+- { id: main, provider: memory,   account: Memory }
+- { id: acme, provider: memory,   account: Memory (Acme) }
+- { id: main, provider: entities, account: Entities }
+- { id: main, provider: vault,    account: Vault }
+```
+
+```yaml
+# profiles/personal.yaml            # profiles/work.yaml
+grants:                             grants:
+  - { connection: memory.main,        - { connection: memory.acme,
+      allow: [memory.*] }                 allow: [memory.*] }
+```
+
+Bytes follow the connection rather than the profile:
+
+```
+data/
+├── memory/main/<id>.md      shared by every profile granting memory.main
+├── memory/acme/<id>.md
+├── vault/<id>.enc           one sealed document per vault connection
+├── skills.d/<id>/<name>/    one directory per skills connection
+└── providers.d/             the operator's own manifests (ADR-057)
+```
+
+**Sharing is a choice the owner makes, and separation is still available.** Two profiles granting
+`memory.main` genuinely share it — one note, one place, visible from both. Two profiles granting
+different instances share nothing at all, which is ADR-030's isolation, obtained by naming rather
+than by structure.
+
+**`identity` stays out of this.** It is not a store; it is a block in the profile YAML, edited in
+the CLI, read through one capability (ADR-042). A profile declares who *it* is written as, and two
+profiles exist precisely because that answer differs. Nothing about it becomes an instance.
+
+**The default is unchanged in effect.** A new workspace gets one instance of each of the six, and
+a new profile is created granting all of them, exactly as ADR-050 arranged — `ensureOwnerLayer`
+moves from repairing a profile to repairing a workspace and a profile together. Someone who wants
+two memories creates the second deliberately; nobody is asked to think about it to get started.
+
+## Two of them may only be granted once per profile
+
+`skills` and `vault` are instances like the rest, and a workspace may hold as
+many as anyone makes. A **profile** may grant one of each, refused at load if it
+grants two.
+
+That is not a limitation of the store. It comes from the surface, and from the
+protocol rather than from a choice made here. Every other owner-layer tool takes
+a `connection` argument, so two memory instances are two routes through one tool
+and the caller names which. These two have nowhere to put that:
+
+- **A skill is surfaced as a prompt** (ADR-012), and a prompt is selected by name
+  with no arguments to route on. Two `triage` skills in one profile would be one
+  name for two procedures.
+- **A vault item becomes its own `vault.get.<id>` capability**, and capability
+  ids are flat for the same reason. Two instances holding `stripe_key` would be
+  one capability naming two secrets — the worst of the three collisions, because
+  the wrong answer is a credential.
+
+Refusing at load names both rows. Resolving at call time would let one win
+silently, which for the vault is indistinguishable from working.
+
+Someone who wants two sets of procedures has two profiles, and that is now cheap:
+neither of them re-authorises an account to get there.
+
+## What this costs, stated plainly
+
+**ADR-009's invariant is now a default rather than a guarantee.** "A note written through
+`personal` is simply absent in `work`" is true only while the two name different instances, and
+the shipped default names the same one. Anyone reading that sentence should read this decision
+next, which is why ADR-009 is amended rather than left to age.
+
+**A shared skill is a shared instruction.** ADR-014 §1 treats authoring a skill as a grant worth
+governing, because a skill is instructions an agent will later be handed. Two profiles on one
+`skills` instance means an agent writing under one authors a procedure the other is offered. That
+is the intended behaviour and it is the sharpest edge here; the narrowing is one documented line,
+`deny: [skills.manage.*]` on the row, and the template says so where it already says the other
+two.
+
+**`rm -r data/<profile>` is gone as a concept.** ADR-030's "one profile, one directory" was worth
+having and does not survive: a profile owns no bytes at all now. What replaces it is
+`lanes link disconnect memory.acme`, which removes an instance and every profile's grant on it,
+and reports which profiles it emptied.
+
+**Migrating two profiles that both hold `memory.main` cannot merge them.** Interleaving two sets
+of notes is not reversible and not reviewable. The second becomes `memory.<profile>` and the
+rename is reported, which leaves the owner with two instances and one `lanes link` command if they
+did want them joined.
+
+## Why this is not a reversal of ADR-030
+
+ADR-030's argument is that a procedure "names things: which mailbox to file into, which people to
+copy, which of the owner's conventions apply", so it is exactly as private as the knowledge it
+operates on. That is still true, and this decision does not contradict it — it changes what
+expresses it. Under ADR-030 privacy came from the file path, and the owner had no say. Here it
+comes from which instance a profile is granted, and the owner has exactly the say the argument
+implies they should.
+
+The half of ADR-030 that does not survive is the reasoning about *manifests*, and that is handled
+in ADR-057 rather than here.
+
+## What this does not do
+
+It does not give an agent any way to create an instance — that is `lanes link connect memory
+--id acme` in a terminal, and ADR-007's wall is unmoved. It does not change what any capability
+does or what `vault.get.<id>` means. It does not merge the vault into the credential store, which
+remains the one collapse this project will not make (ADR-022). And it does not make the number of
+instances visible to a caller: `setup_overview` reports the connections a profile can reach, as it
+always has, and a `memory` instance the profile was not granted is absent rather than listed as
+denied.

--- a/docs/detailed/adr/060-a-caller-is-a-person.md
+++ b/docs/detailed/adr/060-a-caller-is-a-person.md
@@ -1,0 +1,117 @@
+# ADR-060: A caller is a person, and a profile declares who may consume it
+
+**Status:** accepted · **Fills the seam kept by** [ADR-003](003-auth-model.md) ·
+**Closes most of** [ADR-009](009-one-endpoint-per-workspace.md)'s stated gap ·
+**Amends** [ADR-018](018-the-gate-is-in-the-application.md)
+
+## Context
+
+ADR-003 built policy around `(principal, capability, connection)` and then always passed the same
+principal. It said why:
+
+> That is one parameter, and it is what keeps init.md's `delegation.external-clients` slot honest:
+> adding delegated principals later becomes new rows rather than a new signature on the dispatch
+> path.
+
+The slot has been empty since M1, and ADR-009 named what the emptiness costs. One token opens
+every profile in the workspace, and the mitigation — "origin or client binding, so that a token
+plus a caller identity determines the reachable profiles" — is recorded there as **unbuilt**, with
+the instruction to treat the endpoint as trusting whoever holds the token with everything the
+workspace holds.
+
+Two things have changed that make this the moment.
+
+**A profile is now worth sharing.** ADR-057 and ADR-058 turn a profile into a named capability
+grant over accounts that exist independently of it. "Read the shared mailbox, do not send" is a
+thing to hand somebody. Under the old model handing it over meant handing over a token that also
+opened everything else.
+
+**Lanes already knows who people are.** Workspaces, members and roles exist end to end — the
+tables, the invitations, `GET /v1/me`. There is an identity to name, and it is the one the person
+already signed in with.
+
+## Decision
+
+**A profile declares its members, and a caller is authenticated as a person.**
+
+```yaml
+members:
+  - { subject: <lanes uid>, role: owner }
+  - { subject: <lanes uid>, role: member }
+```
+
+```ts
+export interface Principal {
+  readonly id: string;                     // the Lanes subject
+  readonly kind: 'owner' | 'member' | 'machine';
+  readonly profiles: readonly string[];    // every profile whose members list this subject
+}
+```
+
+**Identity comes from a Lanes sign-in, on every endpoint including loopback.** How a client
+obtains one is [ADR-062](062-the-consent-page-asks-lanes-who-you-are.md); what this decision adds
+is that the resulting subject is matched against `members:` before anything else happens.
+
+**The check is one line, ahead of policy.** `Dispatcher.invoke` refuses when the named `profile`
+is not in `principal.profiles`, and `server/mcp/visibility.ts` filters the `profile` enum from the
+same list — so a member does not merely fail to call a profile they are not on, they never see it
+exists. Discovery and enforcement share the answer, which is the same rule ADR-003 set for
+capabilities and for the same reason.
+
+**Roles are `owner` and `member`, and they decide nothing at the MCP boundary.** Both reach
+exactly what the profile's grants allow. `owner` is who may edit the member list, and that is a
+CLI act (ADR-007). A role that changed what an agent could call would be a second policy system
+beside ADR-058's, and there is no question the first one cannot answer.
+
+**`kind: 'machine'` is the one principal not backed by a person.** The static `llk_` token
+resolves to it, it reaches every profile in the workspace, and it exists for a headless runner
+with no browser. That is ADR-009's gap, surviving in exactly one place instead of in every
+registration.
+
+## What this costs, stated plainly
+
+**Running this now requires a Lanes account.** A local, self-hosted, Apache-2.0 MCP server cannot
+start signed out. That is a real change in what the project is, and it is not softened by calling
+it optional somewhere: the member list is how a profile decides who may consume it, and a member
+list with no identities to match is not a mechanism.
+
+What bounds it is that the dependency is on **sign-in and refresh, not on every call**. A session
+is cached; a machine offline for a day keeps serving. `lanes auth status` reports when the session
+expires and whether it can still refresh, because the failure this produces — an endpoint that
+worked yesterday — deserves a command that explains it rather than a 401.
+
+**A revoked member is not instantly locked out.** Access tokens live for their configured TTL
+(twelve hours by default, ADR-035's reasoning unchanged) and membership is read from the profile
+file at request time. Removing a member takes effect on the next token exchange, or immediately on
+`lanes link token rotate`. Stating it plainly is the point: this is delegation, not a session
+manager.
+
+**A workspace bound to a Lanes workspace inherits its membership as a source of truth.**
+`profile members add` validates a subject against `GET /v1/workspaces/{id}/members`, so a person
+removed from the Lanes workspace can no longer be added — but the rows already written are not
+revoked by that removal. Nothing reconciles the two automatically, and pretending otherwise would
+be worse than the gap.
+
+## What was considered and rejected
+
+**Per-profile tokens** — the other half of ADR-009's mitigation. It closes the same gap for the
+static token and it is genuinely smaller work. Rejected as the *answer* rather than as an
+addition: a token is still a bearer string, so per-profile tokens buy isolation without buying
+attribution, and the audit log would still record which profile rather than which person. It
+remains available and is not in this release.
+
+**Roles that narrow capabilities** — `member` gets read, `owner` gets write. It reads as obviously
+right and it is a second grammar for what ADR-058 already expresses per connection, with
+precedence rules between them. If two people need different scopes, that is two profiles, which
+is now cheap.
+
+**Reading membership from the API on every request.** Correct, and it makes the endpoint's
+availability depend on ours. The profile file is the source of truth and the API is consulted when
+the list is *edited*, which is the same shape as every other piece of configuration here.
+
+## What this does not do
+
+It does not let an agent edit a member list, add itself, or read one it is not on. It does not
+attribute a call to a client — MCP `clientInfo` is still self-reported and still observability
+only (ADR-003). It does not change what a grant means: who may call and what they may call are two
+questions, answered in two places, and this is only the first.

--- a/docs/detailed/adr/061-a-workspace-is-the-only-word.md
+++ b/docs/detailed/adr/061-a-workspace-is-the-only-word.md
@@ -1,0 +1,111 @@
+# ADR-061: A workspace is the only word, and a default may be sticky where nothing is destroyed
+
+**Status:** accepted · **Completes** [ADR-052](052-a-target-owns-its-workspace.md) ·
+**Amends** [ADR-037](037-a-command-names-what-it-acts-on.md),
+[ADR-043](043-a-target-scoped-command-acts-on-the-target.md)
+
+## Context
+
+ADR-052 decided that a workspace *is* a target. It said so in those words, and the note appended
+to ADR-009 says the two "now coincide exactly". What it did not do is finish the sentence: the
+config key stayed `targets:`, the flag stayed `--target`, and `workspace` went on being used for
+the directory in prose while `target` was used for the same thing in commands.
+
+That is one concept with two names, which this repository treats as the defect everywhere else it
+appears — two spellings of a reserved row, two sources for one adapter set, two answers to where a
+target's bytes are. It survived because renaming is churn and the meanings had only just merged.
+
+There is now a second reason to finish it. A remote workspace is about to be bound to a **Lanes**
+workspace, which is what carries the members a profile delegates to ([ADR-060](060-a-caller-is-a-person.md)).
+Three words for two things — target, workspace, Lanes workspace — is not a vocabulary anyone can
+hold.
+
+The second half of this decision is harder, because it reopens something that was argued and won.
+
+ADR-037 removed every implicit selection and deleted `lanes link target use`, on reasoning worth
+quoting rather than summarising:
+
+> Persisted context state is the standard way operators run destructive commands against the wrong
+> target, and the version of it that bites is the dotfile nothing prints.
+
+That is correct about destructive commands. Applied to all of them it produces `lanes link status
+--profile personal --workspace local` typed forty times a day, and a flag typed reflexively has
+stopped being a guard — which is the same over-reach ADR-043 found and fixed for a different
+reason.
+
+## Decision
+
+**`target` is retired as a word.** `targets:` becomes `workspaces:`; `--target` becomes
+`--workspace`; `target list|show` become `workspace list|show`. The pointer key inside an entry
+becomes `at:`, because `workspaces.<name>.workspace` names the concept twice and reads as a typo.
+
+`--target` is accepted for one minor as a deprecated alias that warns on use. The desktop app
+spells it in Rust argument arrays and in a persisted, serde-mirrored settings field, and cutting
+it in the same release would break the app for anyone who updates the CLI first.
+
+**`default_workspace` is read.** `lanes set-workspace <name>` writes it, and every command that
+resolves a workspace prints which one it used and where the value came from:
+
+```console
+$ lanes link status
+workspace  local  (default)
+```
+
+**The echo is the decision, not a nicety.** ADR-037's objection is precisely to "the dotfile
+nothing prints", and a default that announces itself on every command is not that dotfile. If the
+line is ever dropped for tidiness, this decision has been reversed.
+
+**A command that publishes or destroys refuses the default.** `deploy`, `sync`, `secrets push`,
+`profile remove`, `disconnect` and `token rotate` require `--workspace` to be typed, and say so:
+
+```console
+$ lanes link deploy
+error  --workspace is required. This command publishes; the default is not
+       used for commands that change something outside this machine.
+```
+
+That is the exact hazard ADR-037 names, kept, while the forty-times-a-day commands stop paying for
+it.
+
+**`connect` is deliberately not in that set.** It creates rather than destroys, it is the command
+someone runs while learning the tool, and it prints the workspace it wrote to. Requiring a flag
+there is the ceremony ADR-043 identified as the way a required flag stops being a guard.
+
+## Why this is not the chain ADR-037 removed
+
+The chain was `--profile`, then `LANES_LINK_PROFILE`, then `default_profile` — three sources, and
+nothing on screen saying which had answered. This is **one** source, read only when the flag is
+absent, printed every time, and refused outright by the commands that can do damage.
+`LANES_LINK_TARGET` and `LANES_LINK_PROFILE` stay unread, and their refusal messages are retained.
+
+The distinction is the same one ADR-052 drew for pointers: a single declaration followed to exactly
+one place is not a resolution chain, however much it resembles one from a distance.
+
+## What this costs, stated plainly
+
+**Every command in a year of notes, scripts and documentation says `--target`.** The alias covers
+the transition and then stops, which means it breaks later rather than never. The deprecation
+warning names the release that removes it.
+
+**A sticky default is a state someone can forget.** The echo bounds it and does not eliminate it:
+somebody piping `--json` sees no banner, because the banner is not in the JSON. That is the honest
+hole in this decision. `--json` output therefore carries the resolved workspace as a field, so the
+answer is in the payload for anyone reading it programmatically.
+
+**`profile add` and `profile remove` still name their profile positionally** and still reject
+`--profile`. Nothing about the default reaches the profile axis: there is no `default_profile`,
+it stays parsed and ignored, and this decision does not reopen it. A profile is the thing a
+mistake is most expensive against.
+
+## Consequences
+
+**`workspace list` is the command you run to find out what `--workspace` accepts**, so it stays at
+`'none'` and keeps working when every other command is failing — the reasoning ADR-052 gave for
+`target list`, unchanged apart from the word.
+
+**`lanes set-workspace` is a top-level command, not `lanes link set-workspace`.** It selects which
+workspace *the* CLI acts in, and a second area added to `lanes` later will want the same answer.
+
+**The refusal text changes shape.** ADR-043's "--target is required" listing every target in the
+workspace becomes the same listing under the new word, and gains a line naming the default when
+one is set and the command refused it anyway.

--- a/docs/detailed/adr/062-the-consent-page-asks-lanes-who-you-are.md
+++ b/docs/detailed/adr/062-the-consent-page-asks-lanes-who-you-are.md
@@ -1,6 +1,6 @@
 # ADR-062: The consent page asks Lanes who you are, and the pasted token is for CI
 
-**Status:** proposed — the endpoint still asks for a pasted token; the federation described here is not built · **Amends** [ADR-018](018-the-gate-is-in-the-application.md),
+**Status:** accepted · **Amends** [ADR-018](018-the-gate-is-in-the-application.md),
 [ADR-036](036-a-client-is-told-this-endpoint-keeps-it-signed-in.md),
 [ADR-054](054-the-surface-in-front-of-the-gate.md) · **Retires**
 [ADR-003](003-auth-model.md)'s "the token is the identity" · **Requires**

--- a/docs/detailed/adr/062-the-consent-page-asks-lanes-who-you-are.md
+++ b/docs/detailed/adr/062-the-consent-page-asks-lanes-who-you-are.md
@@ -1,0 +1,113 @@
+# ADR-062: The consent page asks Lanes who you are, and the pasted token is for CI
+
+**Status:** proposed — the endpoint still asks for a pasted token; the federation described here is not built · **Amends** [ADR-018](018-the-gate-is-in-the-application.md),
+[ADR-036](036-a-client-is-told-this-endpoint-keeps-it-signed-in.md),
+[ADR-054](054-the-surface-in-front-of-the-gate.md) · **Retires**
+[ADR-003](003-auth-model.md)'s "the token is the identity" · **Requires**
+[ADR-060](060-a-caller-is-a-person.md)
+
+## Context
+
+ADR-018 made this endpoint its own authorization server, and the machinery is complete: dynamic
+client registration, mandatory PKCE, a consent screen, codes, access tokens, refresh families, and
+the reuse grace ADR-035 added. One step in it is not what it appears to be.
+
+The consent screen asks the owner to **paste their endpoint bearer token**. `approve(request,
+token)` compares it and mints a code. That is a proof of possession of a shared secret, and it is
+the only proof anywhere in the flow — the whole OAuth apparatus resolves to "whoever can read the
+credential store is the owner".
+
+Three things follow, and the third is why this is being changed now.
+
+**It cannot answer the question ADR-060 asks.** A pasted secret says *the holder has the secret*.
+It cannot say which person is at the browser, so a member list has nothing to match against and
+delegation is not expressible.
+
+**Locally, the flow is skipped entirely.** `lanes link mcp add` writes
+`--header "Authorization: Bearer $(lanes link token show --raw …)"`, so every local registration
+bypasses consent, PKCE and expiry, and ends with the endpoint's long-lived credential sitting in a
+harness config file in plaintext. ADR-003 records that limitation; ADR-060 makes it the ordinary
+case rather than an edge.
+
+**The form is the most valuable thing on the endpoint.** ADR-039 names it directly when explaining
+why a loopback endpoint refuses every cross-origin request: what such a page reaches is
+"`/health`, the discovery documents, `/register`, and the `/authorize` consent form **that asks the
+owner for their token**".
+
+## Decision
+
+**`/authorize` asks Lanes who the person is, instead of asking them for a secret.**
+
+1. `/authorize` validates the client and redirect as it does today, mints a single-use nonce into
+   `OAuthStore`, and redirects the browser to `https://lanes.sh/link/authorize` carrying the
+   resource, the nonce, and the endpoint's return address.
+2. That page signs the person in with their existing Lanes session, shows what is being granted —
+   the client's name, the redirect host, the endpoint, and the profiles the subject is a member of
+   — and asks the Lanes API for an assertion.
+3. It redirects back to `/authorize/callback?assertion=<jwt>`.
+4. The endpoint verifies the assertion against the API's published keys: RS256, `aud` equal to its
+   own resource URL, the nonce single-use from `OAuthStore`, sixty seconds of validity. It resolves
+   `sub` to the profiles whose `members:` list it, and mints the code.
+
+**Every endpoint runs this, loopback included.** `auth.authorization` stops being optional and a
+new profile is written with `{ mode: self }`. The discovery documents are already served ahead of
+the auth gate on loopback, so a client pointed at `http://127.0.0.1:7337/mcp` discovers the
+authorization server and completes the flow with nothing configured.
+
+**`lanes link mcp add` stops writing a header.** It registers the bare URL. The client discovers
+`/.well-known/oauth-protected-resource` from the `401` and runs the flow, which is what ADR-036
+built the challenge for and what every remote client already does.
+
+**The static token becomes CI's credential and nothing else.** `token show` and `token rotate`
+survive, their help says what they are for, and `kind: 'machine'` is the principal they resolve to
+(ADR-060). A headless runner has no browser and needs a way in; a person has a browser and no
+longer needs a secret.
+
+**`mode: oidc` is untouched**, and it is now the documented answer for anyone who does not want
+Lanes in their authorization path. An issuer of your own, `allowed_subjects`, no change.
+
+## What this costs, stated plainly
+
+**A browser authorization now depends on lanes.sh being reachable.** A self-hosted endpoint's
+sign-in leg runs through infrastructure the operator does not control. Bounded three ways, and
+worth being precise: an *existing* session refreshes against the endpoint's own `/token` and does
+not touch Lanes; only a first authorization or a lapsed refresh family does; and `mode: oidc`
+removes the dependency entirely for anyone who wants it gone.
+
+**A local endpoint is no longer usable with no account at all.** That is ADR-060's cost, arriving
+here as the mechanism.
+
+**The assertion is a new trust relationship.** The endpoint believes what the Lanes API signs about
+a subject. The API can therefore mint an assertion for any subject, for any endpoint that trusts
+it — which is what "identity provider" means, and is stated rather than left to be discovered. The
+`aud` binding is what stops an assertion minted for one endpoint opening another; the nonce is what
+stops one being replayed into a second authorization.
+
+**One thing gets safer, and it is the thing ADR-039 was most worried about.** There is no longer a
+form on the endpoint that asks the owner for their token, so the highest-value target on a loopback
+bind no longer exists.
+
+## Consequences
+
+**The CSP fix from the 0.7.2 consent-page regression carries over with a different destination.**
+`formActionFor` derives `form-action` from the redirect the page's own approval produces; that
+redirect is now to lanes.sh rather than to the client, and `oauth.test.ts` asserts the served
+policy admits it. The mechanism is unchanged and the regression it prevents is the same one.
+
+**The return leg is a top-level navigation**, so it carries no `Origin` header and no
+mixed-content rule applies to it — which is what lets an HTTPS page hand control back to
+`http://127.0.0.1`. `server/rebinding.ts` validates `Origin` as well as `Host` and must admit an
+absent one on that path; the API's Slack broker already performs this exact bounce against a
+loopback listener, so the shape is proven rather than assumed.
+
+**`approve()` loses its token parameter** and gains an assertion. The form, its hidden fields and
+the round trip through them go with it — the request is carried in the redirect to Lanes and back,
+and is re-validated against the registration before anything is minted, exactly as before.
+
+## What this does not do
+
+It does not make Lanes the authorization server. This endpoint still issues every token a client
+holds, still owns expiry and revocation, and still answers `/token`; Lanes answers one question,
+once, at the start. It does not change what a token may reach — that is the profile's grants and
+its member list. And it does not give the API any way to call this endpoint: the trust is one
+signature, verified offline, in one direction.

--- a/docs/detailed/adr/063-one-origin-may-read-a-loopback-endpoint.md
+++ b/docs/detailed/adr/063-one-origin-may-read-a-loopback-endpoint.md
@@ -1,6 +1,6 @@
 # ADR-063: One origin may read a loopback endpoint, over a certificate it installs
 
-**Status:** proposed — there is no read listener and no `lanes link pair`; nothing described here is built · **Narrows** [ADR-039](039-cross-origin-access-is-a-deployment-only-grant.md) ·
+**Status:** accepted · **Narrows** [ADR-039](039-cross-origin-access-is-a-deployment-only-grant.md) ·
 **Reopens for a different audience** [ADR-053](053-the-page-a-person-reads-is-the-app.md) ·
 **Constrained by** the loopback guard in `src/server/rebinding.ts`
 

--- a/docs/detailed/adr/063-one-origin-may-read-a-loopback-endpoint.md
+++ b/docs/detailed/adr/063-one-origin-may-read-a-loopback-endpoint.md
@@ -1,0 +1,103 @@
+# ADR-063: One origin may read a loopback endpoint, over a certificate it installs
+
+**Status:** proposed — there is no read listener and no `lanes link pair`; nothing described here is built · **Narrows** [ADR-039](039-cross-origin-access-is-a-deployment-only-grant.md) ·
+**Reopens for a different audience** [ADR-053](053-the-page-a-person-reads-is-the-app.md) ·
+**Constrained by** the loopback guard in `src/server/rebinding.ts`
+
+## Context
+
+The audience for a page about this endpoint has now moved twice. It was a page the endpoint served
+at `/dashboard`; ADR-053 retired that and sent people to the Lanes desktop app, which shells out to
+the CLI and therefore works whether the endpoint is local or deployed. It is moving again, to the
+Lanes web dashboard, for reasons outside this repository — one place for connections, profiles and
+the audit log, on any machine, beside the rest of the product.
+
+The difference that matters is that the desktop app is *on the machine* and a web page is not.
+`lanes.sh` reaching a local endpoint is a cross-origin request to `127.0.0.1`, and ADR-039 refuses
+that deliberately and says so in terms that anticipate this decision:
+
+> A reader who later notices that `lanes link start` cannot be given an allowed origin should read
+> this paragraph rather than close the gap.
+
+The paragraph's argument is sound and is not being discarded. A deployment's wildcard grant is safe
+because the endpoint is *already publicly reachable* — "the wildcard grants a browser exactly what
+`curl` already has". None of that holds on loopback, where a hostile page reaching `127.0.0.1` is
+stealing something no attacker otherwise has: reachability.
+
+So the gap is closed, but not by relaxing the rule that protects it.
+
+## Decision
+
+**A second listener, for reading, on its own port, over TLS.**
+
+```
+http://127.0.0.1:7337/mcp          the endpoint. Unchanged. No CORS. No new route.
+https://127.0.0.1:7338/state       connections, profiles, health
+https://127.0.0.1:7338/audit       the log, most recent first
+```
+
+Five constraints, and each of them answers a specific sentence in ADR-039:
+
+- **One origin, named, never `*`.** `https://lanes.sh` and nothing else, echoed rather than
+  wildcarded, with `Vary: Origin`. A deployment's default may be a wildcard because it is already
+  public; this is not, so it is not.
+- **A different credential, which cannot call a tool.** A pairing token minted by
+  `lanes link pair`, stored under its own ref, rotatable and revocable on its own. It is not the
+  MCP bearer and it is not an OAuth token, and the surface it opens has no mutation on it at all.
+  ADR-039's "an origin is not a permission" is the same point from the other side.
+- **The credential is still never ambient.** No cookie, no session — an `Authorization` header the
+  page must already possess, obtained by the owner running a command and pasting a link.
+- **Reads only, ever.** Editing a connection or a profile from a browser would put control-plane
+  mutation behind a CORS grant, and ADR-007 is not moving for a convenience.
+- **The MCP listener is untouched.** No CORS on it, no new route, no change to the rebinding guard
+  for `/mcp`. Everything ADR-039 protects on the endpoint stays protected, because the endpoint is
+  not what answers the dashboard.
+
+**TLS, because of Safari.** Chrome, Edge and Firefox treat `127.0.0.1` as a potentially trustworthy
+origin and let an HTTPS page fetch it. Safari does not, and there is no header, flag or opt-in that
+changes that — an `http://` read surface simply does not exist for a Safari user. So the read
+listener terminates TLS with a locally trusted certificate. This is the whole reason for a second
+port: the MCP listener must keep answering `http://127.0.0.1:7337` for every registration that
+already exists.
+
+**`lanes link pair` provisions it, and asks first.** It prefers **mkcert**, which is the one tool
+that installs into the system trust store *and* Firefox's separate NSS store across macOS, Linux
+and Windows; where it is absent the command offers `brew install mkcert` and stops if declined.
+This is ADR-053's precedent applied unchanged — installing something on the machine is the largest
+side effect a command here has and the one a person is most entitled to decline — and a run with
+nobody at the terminal is refused rather than assumed.
+
+**The pairing token travels in a fragment.** `lanes link pair` prints
+`https://lanes.sh/dashboard/link#pair=<token>`. A fragment is not sent to the server, so the
+credential does not reach a Lanes access log, a proxy, or a referrer header on the way to a page
+whose entire purpose is that Lanes does not see this data.
+
+## What this costs, stated plainly
+
+**A certificate in the machine's trust store.** That is a real, persistent change to the machine,
+made by a CLI, and it is worth naming as the largest thing in this decision. mkcert's local CA is
+the same one it installs for any other project, its private key sits in the user's own directory,
+and anyone who does not want it has `lanes link pair --print` and the deployed endpoint instead.
+
+**A certificate expires.** `status` reports the expiry and `pair` renews. An expired certificate
+fails in the browser with an error the page cannot read, which is the failure mode ADR-036 reversed
+elsewhere, so the dashboard shows the `lanes link pair` command whenever the local read fails for
+any reason rather than only when it is unpaired.
+
+**A second port, and a second thing that can be occupied.** `outputs` already reports when
+something else holds the MCP port, for the reason that calling it "running" would point someone at
+another workspace's accounts; the read port gets the same treatment.
+
+**A pairing token is a read of everything.** It lists every connection, every profile and the whole
+audit log for the workspace. It does not call a tool and it cannot change anything — but "read
+only" is not "harmless", and the log in particular is a record of what the owner's agents have
+done. It rotates with one command and the page is told to re-pair when it is refused.
+
+## What this does not do
+
+It does not add CORS to `/mcp`, on loopback or anywhere. It does not make the endpoint itself
+browser-reachable — ADR-039's closing line stands, and this is a different surface rather than a
+relaxation of that one. It does not let the dashboard change anything: every mutation is still a
+command the owner runs, which is what ADR-053 gave up the served page's copyable line for and what
+ADR-007 has required since M1. And it does not send anything to Lanes: the page runs in the
+owner's browser, the fetch goes to their own machine, and no local state transits a Lanes server.

--- a/docs/detailed/adr/064-a-deployed-endpoint-is-read-over-its-own-url.md
+++ b/docs/detailed/adr/064-a-deployed-endpoint-is-read-over-its-own-url.md
@@ -1,0 +1,130 @@
+# ADR-064: A deployed endpoint is read over its own URL, and pairing stops meaning a certificate
+
+**Status:** accepted · **Amends** [ADR-063](063-one-origin-may-read-a-loopback-endpoint.md) ·
+**Constrained by** [ADR-039](039-cross-origin-access-is-a-deployment-only-grant.md),
+[ADR-054](054-the-surface-in-front-of-the-gate.md)
+
+## Context
+
+ADR-063 gave the dashboard a surface to read and was careful about what it was giving away. Its
+five properties — one named origin, a credential that cannot call a tool, nothing ambient, reads
+only, TLS — were each answering a specific sentence in ADR-039, which refuses cross-origin access
+on loopback and had anticipated exactly this decision being reopened.
+
+It was also explicit that a deployed endpoint was not in scope, and said why:
+
+> a deployed endpoint is already reachable by URL and `lanes link pair` refuses to provision one
+
+That refusal shipped in two places. `pair` threw for a non-loopback `instance.host`, and
+`openReadListener` returned `null` for a non-loopback bind before reading a single credential —
+the latter for a sharp reason recorded in its own comment: a deployed revision that asked Secret
+Manager for refs no IAM binding covered got a **403**, not a 404, the rejection escaped the try
+block wrapping only `serveRead`, and the revision never went healthy.
+
+**What that argument actually establishes is narrower than what it was used for.** Read it again
+and every clause is about the *certificate*: pairing "would mean installing a certificate for an
+address this machine does not answer on". That is true, and it is still true. A deployed endpoint
+terminates TLS with a certificate a browser already trusts, so there is nothing to install and
+nobody to ask.
+
+But the certificate was never the point of pairing. The point is a credential that reads a
+workspace and an address to present it to, and a deployed endpoint has both — it simply had no
+way to hand either to a browser. So half the people running this could see their connections,
+their profiles and their audit log in the dashboard, and the half who had done the thing the
+product recommends for reaching an endpoint from a phone could not. That is the same shape of gap
+ADR-053 named when the served page was local-only, and it is closed the same way: by looking at
+what the audience needs rather than at where the last decision left them.
+
+## Decision
+
+**The read routes are one implementation, bound two ways.**
+
+```
+loopback    https://127.0.0.1:7338/state     a second listener, TLS via mkcert
+deployed    https://<service>/state          the endpoint's own port and certificate
+```
+
+`src/server/read/routes.ts` decides four of ADR-063's five properties and both binds go through
+it. The fifth — TLS — belongs to the bind rather than to the routes, which is why it is the one
+that differs: Cloud Run routes exactly one port, so a second listener is not available there and
+is not needed.
+
+**Four constraints carry over unchanged, and one is tightened.**
+
+- **One origin, named, never `*`.** This is the tightening, and it is worth stating because
+  "stricter is safer" would be a bad reason and is not the reason. `cors.ts` justifies a wildcard
+  on the credentialed surface with three conjuncts, and all three hold here: the endpoint is
+  already publicly reachable, the credential is never ambient, and `Access-Control-Allow-Credentials`
+  is never sent. A wildcard would be *safe*. What it was buying, in `cors.ts`'s own words, was the
+  absence of "a required setup step per user" — and there is no setup step here to avoid. The
+  consumer is one known product surface and `READ_ORIGINS` is already a compile-time constant, so
+  naming it costs nothing. It also buys something real: a pairing token reads every connection,
+  profile and audit entry, and ADR-063 says plainly that "read only" is not "harmless". Named, a
+  token that leaks through a screenshot has to be replayed from `lanes.sh`.
+- **A credential that cannot call a tool**, and the routes never pass through
+  `options.authenticator`. One shared check would make the MCP bearer able to open the dashboard
+  and the pairing token able to call a tool.
+- **Never ambient**, **reads only**: unchanged, and now tested on both binds.
+
+**`lanes link pair` refuses the certificate, not the pairing.** For a workspace declaring a
+deployment it skips `ensureCertificate` entirely, mints the token into that workspace's store,
+resolves the address the platform assigned, and prints
+`…/dashboard/link#pair=<token>&at=<url>`. The address rides in the fragment beside the token
+rather than in a query parameter, for the token's reason and one of its own: a query parameter
+would put a workspace's public address in a Lanes access log.
+
+A link with no `at=` is a local one, so every link minted before this decision still works.
+
+**A deploy binds the token, and creates it empty.** `PAIR_TOKEN_REF` joins `readableRefs`
+unconditionally — for every deploy, paired or not. This is the whole of the fix for the failure
+ADR-063 recorded, and it turns on the difference between two error codes: Secret Manager answers
+a *missing binding* with 403 and a *secret that exists with no version* with 404, and the adapter
+throws on the first and returns `null` for the second. Bound, the never-paired case becomes an
+ordinary `401 {error:'unpaired'}` instead of a revision that will not boot.
+
+Deciding it by asking whether a workspace is paired is the thing that cannot happen: that means
+opening a credential store inside `readableRefs`, which `--dry-run` reaches and must not do.
+
+It is deliberately **not** in `rotatableRefs`. The revision never writes this token — minting is
+`lanes link pair`, from the operator's machine — and `secretVersionAdder` here would let a
+compromised revision issue itself a credential that reads the whole workspace. The cert and key
+refs are absent for a different reason: nothing on a deployed endpoint reads them.
+
+**The read paths are metered.** ADR-054's four costly pre-gate paths gain a fifth kind. `/health`
+without a credential is free because a platform probe sends exactly that; `/state` gets no such
+exemption, because nothing legitimate calls it without a credential and so there is no free
+request to protect.
+
+## What this costs, stated plainly
+
+**A credential that reads the whole workspace now exists on a public URL.** On loopback the
+surface was unreachable to anyone not already at the machine. Here it is reachable by anyone, and
+what stands in front of it is a 256-bit token, a named origin, and a rate limit. That is the same
+posture `/mcp` has had since ADR-018 and it is a real widening of what a leaked pairing token can
+do — which is why `pair` says out loud what the token reads, and why rotating it is one command.
+
+**A rotation takes up to five seconds to be refused.** `GcpSecretManagerStore` holds nothing
+between calls, so verifying per request would be a network round trip per poll — and per *wrong*
+guess, which is ADR-054's hazard exactly. So the deployed bind caches for five seconds, the same
+window and the same trade `BearerAuthenticator` already takes over a stronger credential. A token
+rotated *in* still works on its first presentation, because a mismatch against a cached value
+buys exactly one re-read. A token rotated *away* keeps reading until the window ends. `pair
+--rotate` says so on a deployed workspace rather than repeating loopback's unqualified promise.
+
+**A full-workspace read from the internet leaves no trace in the log it is reading.** The read
+surface records nothing about itself, which was defensible when the only caller was someone
+already standing at the machine and is less so now. Not changed here, and named rather than left
+implied.
+
+**`src/cli/commands/operate/pair.ts` was cut in half.** The certificate machinery moved to
+`pair-certificate.ts`. That is the seam the file-size budget pointed at rather than a split by
+line count: it is the half of pairing that only loopback has.
+
+## What this does not do
+
+It does not add CORS to `/mcp`, on loopback or anywhere. It does not make the read surface
+reachable on a loopback bind — `serve()` discards it there exactly as it discards `cors`, and a
+test drives that, because a deployment-only grant that leaked onto `127.0.0.1` is precisely what
+ADR-039 refuses. It does not let the dashboard change anything: every mutation is still a command
+the owner runs. And it does not send anything to Lanes — the page runs in the owner's browser and
+the fetch goes to their own endpoint.

--- a/docs/detailed/adr/README.md
+++ b/docs/detailed/adr/README.md
@@ -3,14 +3,14 @@
 These decisions were made in `docs/detailed/init.md` and are transcribed here with their reasoning. They are
 not open questions; changing one means revisiting the reasoning, not re-litigating the choice.
 
-The exceptions are marked as such. **ADR-025 and ADR-063 are proposed rather than accepted** —
-each is a question with the case already argued, filed here so the next person to ask does not
-start from nothing. Nothing in the codebase depends on either yet.
+The exceptions are marked as such. **ADR-025 is proposed rather than accepted** — a question with
+the case already argued, filed here so the next person to ask does not start from nothing. Nothing
+in the codebase depends on it.
 
-ADR-063 is the last piece of 0.8.0 still unbuilt: there is no read listener and no `lanes link
-pair`. ADR-062 was proposed alongside it and is now accepted and shipped — `/authorize` redirects
-to lanes.sh, `/authorize/callback` verifies the assertion it comes back with, and the consent form
-that asked for a pasted token is gone.
+ADR-062 and ADR-063 were both filed as proposals while 0.8.0's first half was being shaped around
+them. Both are now accepted and built: `/authorize` redirects to lanes.sh and the consent form that
+asked for a pasted token is gone, and `lanes link pair` provisions a TLS read listener one port
+above the endpoint that exactly one browser origin may read.
 
 | | Decision |
 |---|---|
@@ -75,7 +75,7 @@ that asked for a pasted token is gone.
 | [060](060-a-caller-is-a-person.md) | A caller is a person, and a profile declares who may consume it |
 | [061](061-a-workspace-is-the-only-word.md) | A workspace is the only word, and a default may be sticky where nothing is destroyed |
 | [062](062-the-consent-page-asks-lanes-who-you-are.md) | The consent page asks Lanes who you are, and the pasted token is for CI |
-| [063](063-one-origin-may-read-a-loopback-endpoint.md) | *(proposed)* One origin may read a loopback endpoint, over a certificate it installs |
+| [063](063-one-origin-may-read-a-loopback-endpoint.md) | One origin may read a loopback endpoint, over a certificate it installs |
 
 Where an ADR departs from init.md, it says so at the top. Three are significant:
 

--- a/docs/detailed/adr/README.md
+++ b/docs/detailed/adr/README.md
@@ -10,7 +10,10 @@ in the codebase depends on it.
 ADR-062 and ADR-063 were both filed as proposals while 0.8.0's first half was being shaped around
 them. Both are now accepted and built: `/authorize` redirects to lanes.sh and the consent form that
 asked for a pasted token is gone, and `lanes link pair` provisions a TLS read listener one port
-above the endpoint that exactly one browser origin may read.
+above the endpoint that exactly one browser origin may read. **ADR-064 is accepted and built too**,
+and finishes that sentence for the other half of the audience: the same two routes now answer on a
+deployed endpoint's own URL, so `pair` works whether the workspace is on this machine or on Cloud
+Run.
 
 | | Decision |
 |---|---|
@@ -76,6 +79,7 @@ above the endpoint that exactly one browser origin may read.
 | [061](061-a-workspace-is-the-only-word.md) | A workspace is the only word, and a default may be sticky where nothing is destroyed |
 | [062](062-the-consent-page-asks-lanes-who-you-are.md) | The consent page asks Lanes who you are, and the pasted token is for CI |
 | [063](063-one-origin-may-read-a-loopback-endpoint.md) | One origin may read a loopback endpoint, over a certificate it installs |
+| [064](064-a-deployed-endpoint-is-read-over-its-own-url.md) | A deployed endpoint is read over its own URL, and pairing stops meaning a certificate |
 
 Where an ADR departs from init.md, it says so at the top. Three are significant:
 
@@ -217,6 +221,19 @@ Where an ADR departs from init.md, it says so at the top. Three are significant:
   refuses in a paragraph written to be read by whoever tried this. It is closed on a separate
   listener, with a separate credential, on a surface with no mutation, rather than by relaxing the
   rule.
+
+- **ADR-064 amends ADR-063, and the amendment is a lesson in reading one's own refusal.** ADR-063
+  declined to pair a deployed endpoint, and every clause of the reason it gave was about the
+  *certificate* — installing one for an address the machine does not answer on. That was correct
+  and is still correct; a deployed endpoint needs no certificate because the platform terminates
+  TLS. What the argument never established is that the *credential* and the *address* should be
+  withheld, and withholding them left half the people running this unable to see their own
+  workspace. The four properties that were not about TLS are kept, one of them tightened: the
+  deployed bind names its origin rather than taking the wildcard `cors.ts` would have allowed it,
+  because the wildcard's justification is the absence of a setup step and there is no setup step
+  here to avoid. Read the 403-versus-404 paragraph if nothing else — the whole of the boot failure
+  ADR-063 recorded turns on which of the two Secret Manager returns, and one IAM binding is what
+  moves it from the first to the second.
 
 - **ADR-056** follows from ADR-042 and amends ADR-041. The first is the interesting relationship:
   it applies identity's argument to everybody who is not the owner, and then diverges from it

--- a/docs/detailed/adr/README.md
+++ b/docs/detailed/adr/README.md
@@ -3,9 +3,14 @@
 These decisions were made in `docs/detailed/init.md` and are transcribed here with their reasoning. They are
 not open questions; changing one means revisiting the reasoning, not re-litigating the choice.
 
-The exception is marked as one. **ADR-025 is proposed rather than accepted** — it is a question
-with the case already argued, filed here so the next person to ask does not start from nothing.
-Nothing in the codebase depends on it.
+The exceptions are marked as such. **ADR-025, ADR-062 and ADR-063 are proposed rather than
+accepted** — each is a question with the case already argued, filed here so the next person to ask
+does not start from nothing. Nothing in the codebase depends on any of them yet.
+
+The two new ones are the second half of 0.8.0 and are recorded now because the first half was
+shaped around them: `members:`, `Principal.profiles` and `lanes auth` all exist so that ADR-062 has
+somewhere to land. Reading them as shipped would be wrong — the endpoint still asks for a pasted
+token, and there is no read listener.
 
 | | Decision |
 |---|---|
@@ -64,6 +69,13 @@ Nothing in the codebase depends on it.
 | [054](054-the-surface-in-front-of-the-gate.md) | The surface in front of the gate is metered, and does not name itself |
 | [055](055-a-connection-may-say-where-its-service-is.md) | A connection may say where its service is, so a self-hosted or multi-tenant host can be a built-in |
 | [056](056-everyone-else-is-declared-too.md) | Everyone else is declared too, and a lookup answers with all of them |
+| [057](057-a-connection-belongs-to-the-workspace.md) | A connection belongs to the workspace, and a profile selects it |
+| [058](058-a-grant-names-a-connection.md) | A grant names a connection, so scopes differ per account |
+| [059](059-the-owner-layer-is-instances.md) | The owner layer is instances, and two profiles may share one |
+| [060](060-a-caller-is-a-person.md) | A caller is a person, and a profile declares who may consume it |
+| [061](061-a-workspace-is-the-only-word.md) | A workspace is the only word, and a default may be sticky where nothing is destroyed |
+| [062](062-the-consent-page-asks-lanes-who-you-are.md) | *(proposed)* The consent page asks Lanes who you are, and the pasted token is for CI |
+| [063](063-one-origin-may-read-a-loopback-endpoint.md) | *(proposed)* One origin may read a loopback endpoint, over a certificate it installs |
 
 Where an ADR departs from init.md, it says so at the top. Three are significant:
 
@@ -161,6 +173,50 @@ Where an ADR departs from init.md, it says so at the top. Three are significant:
   Google Tasks to `google_tasks`, which the reserved-id check forces, and the redaction keys that
   had to lengthen with it. Both are recorded there because a redaction key that misses withholds
   every argument and reads exactly like working redaction, which is not a thing to rediscover.
+
+- **ADR-057 and ADR-058 are one change in two halves**, and reading either alone misleads. The
+  first moves a connection out of the profile and into the workspace; the second moves the
+  granularity that move destroys back into the rule. Taken together they retire ADR-003's central
+  trade — "a narrower grant is a narrower profile" — which was sound only while a second profile
+  was the only way to hold a second set of rules over one account.
+
+  What survives is every invariant anyone relies on: default deny, deny-wins, tighten-only, and
+  one implementation shared by discovery and enforcement. What is given up is stated in ADR-057
+  under its own heading, and the load-bearing sentence is that a workspace is now the only
+  isolation boundary — `rm -r data/work` stopped being the whole answer to "what could work
+  reach", and `profile remove` prints what outlives it because of that.
+
+- **ADR-059** is what keeps ADR-030 true after ADR-057 moved everything else out of the profile.
+  Read the two together or the second reads as a retreat. ADR-030 argued that a procedure is as
+  private as the knowledge it operates on, and that argument is untouched — what changes is that
+  privacy is now expressed by which instance a profile is granted rather than by a file path the
+  owner had no say in. The sentence to carry away is that ADR-009's "profiles share nothing"
+  becomes a default rather than a guarantee, and the shipped default shares.
+
+- **ADR-060 fills the slot ADR-003 kept empty on purpose.** That decision passed one principal
+  everywhere and said, in as many words, that carrying it explicitly was what would make delegated
+  access additive rather than a rewrite. This is the addition, and the seam held — it is new rows
+  and one check ahead of policy, not a new signature on the dispatch path.
+
+  It also closes most of what ADR-009 admitted was open. Not all: `kind: 'machine'` still reaches
+  every profile behind one string, because a headless runner has no browser. The gap moved from
+  every registration to one credential, which is a narrowing rather than a fix, and ADR-009 stays
+  the place it is described.
+
+- **ADR-061 finishes ADR-052 and reopens a piece of ADR-037.** The first half is bookkeeping: that
+  decision made a workspace *be* a target and left two words for it. The second half is not, and
+  should be read as the trade it is. ADR-037's objection was to "the dotfile nothing prints", and
+  the answer here is a default that prints itself on every command and is refused outright by every
+  command that publishes or destroys. If the echo is ever dropped for tidiness, the decision has
+  been reversed.
+
+- **ADR-062 and ADR-063 both take something back from a decision that was right when it was made.**
+  ADR-062 replaces the consent form's pasted token, which ADR-018 shipped and ADR-039 named as the
+  most valuable thing on a loopback bind — so the endpoint gets safer and gains a dependency in the
+  same change. ADR-063 grants one browser origin a read of a loopback endpoint, which ADR-039
+  refuses in a paragraph written to be read by whoever tried this. It is closed on a separate
+  listener, with a separate credential, on a surface with no mutation, rather than by relaxing the
+  rule.
 
 - **ADR-056** follows from ADR-042 and amends ADR-041. The first is the interesting relationship:
   it applies identity's argument to everybody who is not the owner, and then diverges from it

--- a/docs/detailed/adr/README.md
+++ b/docs/detailed/adr/README.md
@@ -3,14 +3,14 @@
 These decisions were made in `docs/detailed/init.md` and are transcribed here with their reasoning. They are
 not open questions; changing one means revisiting the reasoning, not re-litigating the choice.
 
-The exceptions are marked as such. **ADR-025, ADR-062 and ADR-063 are proposed rather than
-accepted** — each is a question with the case already argued, filed here so the next person to ask
-does not start from nothing. Nothing in the codebase depends on any of them yet.
+The exceptions are marked as such. **ADR-025 and ADR-063 are proposed rather than accepted** —
+each is a question with the case already argued, filed here so the next person to ask does not
+start from nothing. Nothing in the codebase depends on either yet.
 
-The two new ones are the second half of 0.8.0 and are recorded now because the first half was
-shaped around them: `members:`, `Principal.profiles` and `lanes auth` all exist so that ADR-062 has
-somewhere to land. Reading them as shipped would be wrong — the endpoint still asks for a pasted
-token, and there is no read listener.
+ADR-063 is the last piece of 0.8.0 still unbuilt: there is no read listener and no `lanes link
+pair`. ADR-062 was proposed alongside it and is now accepted and shipped — `/authorize` redirects
+to lanes.sh, `/authorize/callback` verifies the assertion it comes back with, and the consent form
+that asked for a pasted token is gone.
 
 | | Decision |
 |---|---|
@@ -74,7 +74,7 @@ token, and there is no read listener.
 | [059](059-the-owner-layer-is-instances.md) | The owner layer is instances, and two profiles may share one |
 | [060](060-a-caller-is-a-person.md) | A caller is a person, and a profile declares who may consume it |
 | [061](061-a-workspace-is-the-only-word.md) | A workspace is the only word, and a default may be sticky where nothing is destroyed |
-| [062](062-the-consent-page-asks-lanes-who-you-are.md) | *(proposed)* The consent page asks Lanes who you are, and the pasted token is for CI |
+| [062](062-the-consent-page-asks-lanes-who-you-are.md) | The consent page asks Lanes who you are, and the pasted token is for CI |
 | [063](063-one-origin-may-read-a-loopback-endpoint.md) | *(proposed)* One origin may read a loopback endpoint, over a certificate it installs |
 
 Where an ADR departs from init.md, it says so at the top. Three are significant:
@@ -211,7 +211,7 @@ Where an ADR departs from init.md, it says so at the top. Three are significant:
   been reversed.
 
 - **ADR-062 and ADR-063 both take something back from a decision that was right when it was made.**
-  ADR-062 replaces the consent form's pasted token, which ADR-018 shipped and ADR-039 named as the
+  ADR-062 replaced the consent form's pasted token, which ADR-018 shipped and ADR-039 named as the
   most valuable thing on a loopback bind — so the endpoint gets safer and gains a dependency in the
   same change. ADR-063 grants one browser origin a read of a loopback endpoint, which ADR-039
   refuses in a paragraph written to be read by whoever tried this. It is closed on a separate

--- a/docs/detailed/init.md
+++ b/docs/detailed/init.md
@@ -146,23 +146,58 @@ Credentials follow the target, because each target has its own credential store.
 ### Example (`config/personal.example.yaml`)
 
 ```yaml
-contract: 2
+contract: 3
 
 instance:
   profile: personal
 
-# Adapter selection is per target. Everything below targets is
-# target-independent and declared exactly once.
+# Adapter selection is per workspace. Everything below is workspace-independent
+# and declared exactly once.
 
 limits:
   requests_per_minute: 120        # per profile
   upstream_calls_per_minute: 60   # per connection, protects vendor quota
 
-# App registrations. Shared by every connection of that vendor.
-oauth_apps:
-  google:
-    client_id_ref: google/client_id
-    client_secret_ref: google/client_secret
+# One row per connection this profile may reach, and what it may do with each.
+#
+# The accounts themselves are in connections.yaml beside this file: authorising
+# an account and deciding what may be done with it are two acts, and only the
+# second belongs to a profile (ADR-057). A row here *is* the grant — naming a
+# connection is what makes it reachable, and the allow list is what makes any of
+# its capabilities callable. An account the workspace holds and this file does
+# not name is simply absent.
+#
+# Rules name capabilities of the row's own provider, which is what lets the two
+# mailboxes below differ (ADR-058).
+grants:
+  - connection: gmail.ada_lovelace
+    allow: ['gmail.*']
+    deny:  [gmail.users.drafts.send]
+  - connection: gmail.rin_shaw
+    allow: [gmail.users.messages.list, gmail.users.messages.get]
+    deny:  []
+  - connection: example.local
+    allow: ['example.*']
+    deny:  []
+
+# Who may consume this profile. Empty is nobody, not everybody — default deny on
+# the identity axis (ADR-060).
+members:
+  - { subject: lanes:SUBJECT, role: owner }
+
+# The bearer token is for CI. A person signs in instead: a client that asks for
+# authorization is sent to the Lanes login and comes back as somebody (ADR-062).
+auth:
+  mode: bearer
+  token_ref: profile/token
+  authorization:
+    mode: self
+```
+
+### Example (`connections.yaml`)
+
+```yaml
+contract: 3
 
 # One entry per authorised account. "account" is the identity the provider
 # reports, resolved at connect time, and the id derives from it — so this list
@@ -184,24 +219,17 @@ connections:
     provider: example
     account: Scratch
 
-# One token for the endpoint this profile serves — which since ADR-009 is every
-# profile in the workspace. A narrower grant is a narrower profile, not a
-# narrower client (ADR-003); a boundary that must hold against the agent itself
-# is a second workspace.
-auth:
-  mode: bearer
-  token_ref: profile/token
-
-# Default deny. Only listed rules grant access, and an absent policy block
-# grants nothing at all.
-policy:
-  allow: ['*']
-  deny:  [gmail.users.drafts.send]
+# App registrations. Shared by every connection of that vendor.
+oauth_apps:
+  google:
+    client_id_ref: google/client_id
+    client_secret_ref: google/client_secret
 ```
 
-Rules name capabilities, never connections: `gmail.*` covers every Gmail account in the profile.
-Three forms — `*`, `gmail.*`, `gmail.users.drafts.send` — and a trailing `.*` at any depth is the
-only wildcard. Do not build a policy expression language.
+A rule names a capability of its row's own provider: `gmail.*` covers everything Gmail offers *for
+that one account*, which is what lets the two mailboxes above differ (ADR-058). Three forms — `*`,
+`gmail.*`, `gmail.users.drafts.send` — and a trailing `.*` at any depth is the only wildcard. Do not
+build a policy expression language.
 
 ### Validation rules
 

--- a/instructions/agents/lanes-link-scout.md
+++ b/instructions/agents/lanes-link-scout.md
@@ -67,8 +67,8 @@ to every future session.
 stops a write is policy on the endpoint:
 
 ```console
-$ lanes link policy deny memory.write --profile <name> --target <name>
-$ lanes link policy list --profile <name> --target <name>
+$ lanes link policy deny memory.write --connection memory.main --profile <name> --workspace <name>
+$ lanes link policy list --profile <name> --workspace <name>
 ```
 
 If you are running against a profile that grants writes, that is the owner's

--- a/instructions/skills/lanes-link/SKILL.md
+++ b/instructions/skills/lanes-link/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: lanes-link
-description: Use when the user refers to their own accounts, knowledge, procedures, or secrets through Lanes Link — "check my mail", "what do I know about X", "remember this", "which profile am I in" — or asks to connect, register, or set up their Lanes Link MCP server with this agent. Also covers operating the workspace from a shell — adding or removing a profile, checking what a target serves, deploying an endpoint or recovering a lost deployment — and what to do when a Lanes Link call is refused, or when the endpoint is not running.
+description: Use when the user refers to their own accounts, knowledge, procedures, or secrets through Lanes Link — "check my mail", "what do I know about X", "remember this", "which profile am I in" — or asks to connect, register, or set up their Lanes Link MCP server with this agent. Also covers operating the workspace from a shell — signing in, adding a connection, granting it to a profile, adding or removing a profile, deciding who may consume one, deploying an endpoint or recovering a lost deployment — and what to do when a Lanes Link call is refused, or when the endpoint is not running.
 ---
 
 # Lanes Link
@@ -8,42 +8,63 @@ description: Use when the user refers to their own accounts, knowledge, procedur
 A self-hostable gateway to one person's own context: the accounts they have
 connected, the knowledge they have accumulated, the procedures they have
 written down, and their secrets. One endpoint serves every profile in a
-workspace under one token, and each call names which profile it means.
+workspace, and each call names which profile it means.
 
 The endpoint describes its own live state when you connect — which profiles
-exist, what is reachable in each. This file is the part that does not change:
-how to behave with it.
+exist, what is reachable in each — and serves the long form of this at
+`lanes://instructions`. This file is the part that does not change: how to
+behave with it.
+
+## Three words, and they changed in 0.8.0
+
+A **connection** is one authorised account, and it belongs to the **workspace**.
+A **profile** is a selection: which connections it includes, what it allows on
+each, and who may consume it.
+
+That ordering is the change. A connection used to live inside one profile, so
+reaching the same mailbox from two of them meant authorising it twice, and every
+account of a provider within a profile was governed identically. Now the account
+is authorised once and each profile decides what it may do with it, which is what
+makes "read this mailbox, write that calendar" something a person can write down.
+
+**"Target" is gone.** It named the thing a workspace already was. `--workspace`
+is the flag; `--target` still works for one minor and warns.
 
 ## Profiles are a boundary, not a setting
 
 Every tool takes `profile` and `connection`. Profiles are how someone keeps work
-and personal apart; they share no database and no credential store.
+and personal apart; a connection they do not grant is not visible in one at all.
 
 **Ask which profile is meant when it is ambiguous. Do not default to whichever
 is listed first.** Quietly picking one crosses the line the profile exists to
 draw. There is no "current profile" to switch — the choice is made per call, and
-`lanes link profile list --workspace <name>` shows what exists *in that target*. A
-profile lives in exactly one, so `personal` on `local` and `personal` on `cloud`
-are two profiles that share a name rather than one profile in two places.
+`lanes link profile list --workspace <name>` shows what exists *in that
+workspace*. A profile lives in exactly one, so `personal` on `local` and
+`personal` on `cloud` are two profiles that share a name rather than one profile
+in two places.
 
-**What a command must be told is never inferred — but it is not always both.**
-Nothing resolves from an environment variable or a config default, so a command
-missing what it needs refuses rather than acting somewhere else. Passing a flag a
+**What a command must be told is never inferred from a profile — but the
+workspace may have a default.** `lanes set-workspace <name>` writes one, every
+command that uses it echoes the name it resolved, and the commands where being
+wrong is expensive refuse it and demand the flag: `deploy`, `sync`,
+`secrets push`, `profile remove`, `disconnect`, `token rotate`. Passing a flag a
 command does not read is refused too, which makes "add both to be safe" its own
 failure. Four levels:
 
-- **Neither.** `lanes link target list`, `lanes link mcp list`,
-  `lanes link version`.
+- **Neither.** `lanes link workspace list`, `lanes link mcp list`,
+  `lanes link version`, `lanes link mcp install-instructions`.
 - **`--workspace` alone.** `lanes link profile list`, `lanes link profile add`,
-  `lanes link profile remove`, `lanes link target show`. A profile lives inside
-  one target's workspace, so listing or creating one names which workspace.
+  `lanes link profile remove`, `lanes link workspace show`,
+  `lanes link connection list`. A connection and a profile both live inside one
+  workspace, so listing or creating either names which.
 - **`--workspace`, with the profiles derived from it.** `lanes link status`,
-  `lanes link deploy` and `lanes link sync targets` act on one endpoint serving
-  every profile that declares that target. `--profile` is accepted and *narrows*
+  `lanes link deploy` and `lanes link sync workspaces` act on one endpoint
+  serving every profile in that workspace. `--profile` is accepted and *narrows*
   the answer; it does not choose the subject.
 - **Both.** Everything acting on one account, and everything reaching the
   owner's own stores: `lanes link connect`, `lanes link token rotate`,
-  `lanes link secrets set`, `lanes link policy allow`, `lanes link memory list`,
+  `lanes link secrets set`, `lanes link policy allow`, `lanes link grant add`,
+  `lanes link profile members`, `lanes link memory list`,
   `lanes link tasks list`, `lanes link assets list`, `lanes link mcp add`.
 
 `lanes link profile add` and `lanes link profile remove` **reject** `--profile`.
@@ -53,9 +74,12 @@ disagree with it.
 When you write a command out for the owner, fill in what that command needs or
 leave it as `<name>` for them to complete — never drop a required one.
 
-A `connection` names an account within that profile. One profile may hold
-several of the same kind, and naming a connection belonging to a *different*
-profile is refused rather than guessed at.
+A `connection` names an account the profile grants. One profile may grant
+several of the same kind and govern each differently, so `gmail.work` may be
+readable where `gmail.personal` is writable. Naming a connection the profile does
+not grant is refused rather than guessed at, and a connection it does not grant
+is absent from the enum entirely: if you cannot see it there, it was not
+withheld by accident.
 
 ## Which store a thing goes in
 
@@ -171,7 +195,7 @@ crossing is the specific mistake this exists to prevent.
 
 If the tool is not there, the profile has declared nothing. Ask rather than
 inventing something; they add one with `lanes link identity add <kind> <value> --profile <profile>
---workspace <target>` — both flags, because neither has a fallback.
+--workspace <name>` — both flags, because neither has a fallback.
 Nothing you can call writes here, deliberately.
 
 ## Who you are writing *to* is declared as well
@@ -267,6 +291,21 @@ one is missing, it was switched off with a `deny`, which is their decision; do n
 offer to connect it. What setup is for is accounts: mail, calendar, files,
 issues.
 
+**Connecting authorises once; a grant is what a second profile needs.**
+`lanes link connect <provider> --profile <name> --workspace <name>` authorises
+the account into the workspace *and* grants it to the profile you named. Reaching
+the same account from another profile is then a grant rather than a second
+consent screen, which is the point of connections belonging to the workspace:
+
+```
+lanes link grant add gmail.<id> --profile work --workspace local
+lanes link policy allow gmail.users.messages.list --connection gmail.<id> --profile work --workspace local
+```
+
+`lanes link connection list --workspace <name>` shows every connection with the
+profiles that grant it, which is the answer when an owner says an account they
+connected is not showing up somewhere.
+
 **Take the command from `setup_provider`; never compose one yourself.** It carries
 the right profile and, where the provider stores a credential per account, the
 `--id` it needs. A command you assembled is one the owner pastes and watches fail.
@@ -286,7 +325,7 @@ the line.
 it needs, print the scopes and let the owner add the flag. Deciding that is theirs.
 
 **A new connection is served at once; the tools you were handed are not.**
-Connecting publishes the config to wherever that target's endpoint reads it and
+Connecting publishes the config to wherever that workspace's endpoint reads it and
 asks the endpoint to re-read it, so a `setup_overview` straight after connecting
 *does* show the account. What has not changed is the set of tools this session
 was given when it connected — the endpoint does not announce that its tools
@@ -302,15 +341,15 @@ endpoint restarted before the new token opens anything.
 
 If you have a shell, the commands that only *read* are yours to run without
 asking: `lanes link status`, `lanes link check`, `lanes link plan`,
-`lanes link doctor`, `lanes link profile list`, `lanes link target list`,
-`lanes link target show`, `lanes link tools`, `lanes link config show` and
+`lanes link doctor`, `lanes link profile list`, `lanes link workspace list`,
+`lanes link workspace show`, `lanes link tools`, `lanes link config show` and
 `lanes link audit tail`. None writes config, opens a browser, or costs anything,
 and running one beats asking the owner to paste its output back. Give each what
 its own level requires — they are not all the same, and the four levels are at
 the top of this file.
 
 **A command that writes runs `--dry-run` first, where it has one.** Show what it
-reported and wait for an answer. `lanes link deploy`, `lanes link sync targets`,
+reported and wait for an answer. `lanes link deploy`, `lanes link sync workspaces`,
 `lanes link profile remove`, `lanes link secrets push` and `lanes link mcp add`
 all take it. For a write with no dry run — `lanes link token rotate`,
 `lanes link policy allow`, `lanes link secrets set` — say in one sentence what it
@@ -320,27 +359,63 @@ whoever owns the account, as above.
 **`--json` is not everywhere.** It parses on every command and is read by only
 some, so one that ignores it prints its ordinary output and gives you nothing to
 key on — do not treat the absence of JSON as a failure. `status`, `doctor`,
-`tools`, `outputs`, `sync targets`, `target list`, `target show`, `profile list`,
+`tools`, `outputs`, `sync workspaces`, `workspace list`, `workspace show`, `profile list`,
 `connect` and `setup plan` implement it. `deploy`, `check`, `plan`,
 `config show`, `audit tail` and every `mcp` subcommand do not.
 
 **A profile is created and removed, never switched.** `lanes link profile add
-<name> --workspace <name>` writes a new one *into that target's workspace* — one
-target, not a list, because a profile lives in exactly one.
+<name> --workspace <name>` writes a new one *into that workspace* — one
+workspace, not a list, because a profile lives in exactly one.
 `lanes link profile remove <name> --workspace <name>` takes `--dry-run` and then
 `--yes`, and removes the profile itself along with its stores: the file is in
 that workspace, so there is nowhere left for it to survive. Neither reads
 `--profile`; both name the profile positionally.
 
-There is no current profile and no default target. `lanes link profile default`
-and `lanes link target use` are gone and now refuse with an explanation — if you
+There is no current profile. There *is* a default workspace, written by
+`lanes set-workspace`, echoed by every command that uses it and refused by every
+command that publishes or destroys. The two commands that used to pin a
+profile or a workspace are gone and refuse with an explanation — if you
 meet one of those refusals, it is not a broken install, and there is no
 replacement to find. The choice is made per command, on purpose.
+
+## Signing in, and who may consume a profile
+
+Every human caller signs in with Lanes, on a local endpoint as much as a deployed
+one. `lanes auth login` opens a browser once; `lanes auth status` says who this
+machine is and when the session lapses. The network is needed to sign in and to
+refresh, not per call, so a machine offline for a day keeps serving.
+
+`lanes link start` refuses without a session, and names the command.
+
+A profile declares who may consume it, and **empty means nobody**:
+
+```
+lanes link profile members add --me --profile assistant --workspace local
+lanes link profile members list --profile assistant --workspace local
+```
+
+That list is a selection from the Lanes workspace rather than a second list
+beside it, so `members list` shows both who may consume this profile and who is
+in the workspace and could be given it. Somebody with an unaccepted invitation
+has no subject yet, so they are listed, marked, and refused; the answer there is
+for them to accept, not for anyone to invent a subject.
+
+Removing somebody does not end a session they already hold: membership is read
+when a token is minted. Rotating the endpoint token closes that
+window now, and it names both flags: `lanes link token rotate --profile <name>
+--workspace <name>`.
+
+**A client is not given a token any more.** `lanes link mcp add` registers the
+bare URL, and the client discovers the endpoint, sends its owner to sign in, and
+comes back with a token of its own. The static token is for CI, which has no
+browser, and `--headless` is what writes it into a registration. If you are
+writing a registration command for somebody, do not add an `Authorization`
+header: it is no longer how a client connects.
 
 ## Deploying, and what it decides
 
 `lanes link deploy` builds an image and rolls a revision. Its subject is a
-**target**, and the profiles behind it are every profile *in* that target's
+**workspace**, and the profiles behind it are every profile *in* that
 workspace, so one deploy serves all of them — there is no per-profile deploy to
 run and no reason to loop over them.
 
@@ -352,9 +427,9 @@ avoidable.
 Two things it refuses to guess, and both are the owner's to answer:
 
 - **Whose bearer token opens the endpoint.** One token reaches every profile
-  behind that target, so this decides who gets in. With several candidates and
+  behind that workspace, so this decides who gets in. With several candidates and
   nothing recorded, it refuses and prints the command that names one.
-- **A first deploy.** A target that does not exist yet has no workspace to derive
+- **A first deploy.** A workspace that does not exist yet has nothing to derive
   a set from, so `--profile` is required there. It may be repeated, and the first
   one named is the primary.
 
@@ -368,13 +443,13 @@ connected and not how a config change lands; both of those publish themselves.
 
 ## When a machine has lost track of a deployment
 
-A workspace holds a *pointer* to each target it does not itself hold, and a
+A workspace holds a *pointer* to each workspace it does not itself hold, and a
 machine can lose one — a new laptop, a reinstall, a workspace file restored from
 something older. The endpoint is still serving; what went missing is the line
 saying where it lives. The symptom is a `lanes link status` that reports nothing
-for a target you know is up.
+for a workspace you know is up.
 
-`lanes link sync targets` adopts it. `--discover` looks for a deployment the
+`lanes link sync workspaces` adopts it. `--discover` looks for a deployment the
 workspace has no pointer to, `--from <location>` names one directly, and
 `--dry-run` reports what it would write without writing it. Run the dry run and
 show it.

--- a/instructions/skills/lanes-link/SKILL.md
+++ b/instructions/skills/lanes-link/SKILL.md
@@ -22,7 +22,7 @@ and personal apart; they share no database and no credential store.
 **Ask which profile is meant when it is ambiguous. Do not default to whichever
 is listed first.** Quietly picking one crosses the line the profile exists to
 draw. There is no "current profile" to switch — the choice is made per call, and
-`lanes link profile list --target <name>` shows what exists *in that target*. A
+`lanes link profile list --workspace <name>` shows what exists *in that target*. A
 profile lives in exactly one, so `personal` on `local` and `personal` on `cloud`
 are two profiles that share a name rather than one profile in two places.
 
@@ -34,10 +34,10 @@ failure. Four levels:
 
 - **Neither.** `lanes link target list`, `lanes link mcp list`,
   `lanes link version`.
-- **`--target` alone.** `lanes link profile list`, `lanes link profile add`,
+- **`--workspace` alone.** `lanes link profile list`, `lanes link profile add`,
   `lanes link profile remove`, `lanes link target show`. A profile lives inside
   one target's workspace, so listing or creating one names which workspace.
-- **`--target`, with the profiles derived from it.** `lanes link status`,
+- **`--workspace`, with the profiles derived from it.** `lanes link status`,
   `lanes link deploy` and `lanes link sync targets` act on one endpoint serving
   every profile that declares that target. `--profile` is accepted and *narrows*
   the answer; it does not choose the subject.
@@ -90,7 +90,7 @@ try more than one wording before deciding it is not there.
 Writing is a separate grant, and it should be. What you write is served back to
 every later session, including to a different agent, so **write when you are
 asked to remember something, not as a habit.** The owner reaches the same
-entries with `lanes link memory list --profile <name> --target <name>` and a text editor.
+entries with `lanes link memory list --profile <name> --workspace <name>` and a text editor.
 
 ## Tasks have a status, so finish them rather than deleting them
 
@@ -116,7 +116,7 @@ being suggested again next week. Remove is for something recorded by mistake.
 Do not mute a task on your own initiative. It means "stop telling me about
 this", which is the owner's judgement, not yours.
 
-They manage these with `lanes link tasks list --profile <name> --target <name>`.
+They manage these with `lanes link tasks list --profile <name> --workspace <name>`.
 
 ## Assets are files kept by name
 
@@ -131,11 +131,11 @@ no form of a read that hands you a PDF, and a megabyte of base64 in the
 conversation would not help you if there were.
 
 To attach a stored file to something you are sending, ask the owner to run
-`lanes link attach <file> --profile <name> --target <name> --connection <provider>.<account>`,
+`lanes link attach <file> --profile <name> --workspace <name> --connection <provider>.<account>`,
 which prints a handle the send tools take. An asset's own store is not reachable
 from a mailbox's, deliberately.
 
-They manage these with `lanes link assets list --profile <name> --target <name>`.
+They manage these with `lanes link assets list --profile <name> --workspace <name>`.
 
 ## Skills are theirs, not yours
 
@@ -145,7 +145,7 @@ cannot read a skill's body; that is deliberate, not a gap to work around.
 
 So when a task has a skill for it, **say the skill exists and let them invoke
 it** rather than improvising your own version of their procedure. They manage
-these with `lanes link skills list --profile <name> --target <name>` and `lanes link skills show <skill> --profile <name> --target <name>`.
+these with `lanes link skills list --profile <name> --workspace <name>` and `lanes link skills show <skill> --profile <name> --workspace <name>`.
 
 ## Vault values are credentials
 
@@ -171,7 +171,7 @@ crossing is the specific mistake this exists to prevent.
 
 If the tool is not there, the profile has declared nothing. Ask rather than
 inventing something; they add one with `lanes link identity add <kind> <value> --profile <profile>
---target <target>` — both flags, because neither has a fallback.
+--workspace <target>` — both flags, because neither has a fallback.
 Nothing you can call writes here, deliberately.
 
 ## Who you are writing *to* is declared as well
@@ -228,7 +228,7 @@ its content.
 
 **If the endpoint is not on the same machine as the file**, `path` names the
 *server's* filesystem rather than theirs, and will not find it. Ask them to run
-`lanes link attach <file> --profile <name> --target <name> --connection <provider>.<account>`, which prints a
+`lanes link attach <file> --profile <name> --workspace <name> --connection <provider>.<account>`, which prints a
 handle to use instead.
 
 **`draft_only: true`** saves instead of sending, where they should see it before
@@ -248,9 +248,9 @@ granted, and retrying will not reveal it. A call that *is* refused was refused b
 policy on purpose.
 
 Report it plainly and let the owner decide whether to widen the grant —
-`lanes link policy list --profile <name> --target <name>` shows the rules, `lanes link policy allow <capability> --profile <name> --target <name>`
+`lanes link policy list --profile <name> --workspace <name>` shows the rules, `lanes link policy allow <capability> --connection <provider>.<id> --profile <name> --workspace <name>`
 changes them, and that is their call, not yours. **Do not look for another route
-to the same data.** Every call is audited either way; `lanes link audit tail --profile <name> --target <name>`
+to the same data.** Every call is audited either way; `lanes link audit tail --profile <name> --workspace <name>`
 shows what was attempted, refusals included.
 
 ## Setting something up
@@ -276,9 +276,9 @@ credential — those are `lanes link` in a terminal, deliberately. What you can 
 know exactly what to hand over, and say what it will ask for before they start.
 
 If you have a shell, you can run it yourself for anything that does *not* need a
-browser: `lanes link setup plan <provider> --profile <name> --target <name> --json` lists what to store,
-`lanes link secrets set <ref> --profile <name> --target <name>` takes the value on stdin, and
-`lanes link connect <provider> --profile <name> --target <name> --id <id> --non-interactive --json` finishes.
+browser: `lanes link setup plan <provider> --profile <name> --workspace <name> --json` lists what to store,
+`lanes link secrets set <ref> --profile <name> --workspace <name>` takes the value on stdin, and
+`lanes link connect <provider> --profile <name> --workspace <name> --id <id> --non-interactive --json` finishes.
 Anything with a browser sign-in belongs to whoever owns the account — give them
 the line.
 
@@ -325,9 +325,9 @@ key on — do not treat the absence of JSON as a failure. `status`, `doctor`,
 `config show`, `audit tail` and every `mcp` subcommand do not.
 
 **A profile is created and removed, never switched.** `lanes link profile add
-<name> --target <name>` writes a new one *into that target's workspace* — one
+<name> --workspace <name>` writes a new one *into that target's workspace* — one
 target, not a list, because a profile lives in exactly one.
-`lanes link profile remove <name> --target <name>` takes `--dry-run` and then
+`lanes link profile remove <name> --workspace <name>` takes `--dry-run` and then
 `--yes`, and removes the profile itself along with its stores: the file is in
 that workspace, so there is nowhere left for it to survive. Neither reads
 `--profile`; both name the profile positionally.
@@ -386,10 +386,10 @@ existed in two copies that could disagree, and there is one copy now.
 
 ## Registering it, and re-registering it
 
-`lanes link mcp add --profile <name> --target <name>` runs each harness's own registration command and installs
+`lanes link mcp add --profile <name> --workspace <name>` runs each harness's own registration command and installs
 this skill where that harness keeps them. With no argument it does every harness
 installed; name one (`claude`, `codex`) to be specific. Run it again after
-`lanes link token rotate --profile <name> --target <name>` — add `--force`, since Claude Code stores the token as
+`lanes link token rotate --profile <name> --workspace <name>` — add `--force`, since Claude Code stores the token as
 a value rather than a command.
 
 **Never paste the token.** There is a right way and a wrong way, and the
@@ -398,7 +398,7 @@ difference matters:
 ```bash
 # RIGHT — the token goes from the CLI to the harness. You never see it.
 claude mcp add --transport http lanes-link http://127.0.0.1:7337/mcp \
-  --header "Authorization: Bearer $(lanes link token show --raw --profile <name> --target <name>)"
+  --header "Authorization: Bearer $(lanes link token show --raw --profile <name> --workspace <name>)"
 
 # WRONG — the token is now in your context, and in the transcript, forever.
 lanes link token show --show          # then copying the value into the command
@@ -406,12 +406,12 @@ lanes link token show --show          # then copying the value into the command
 
 The token reaches every account of every profile the endpoint serves. Use the
 substitution form. If you have already printed one by accident, say so and offer
-`lanes link token rotate --profile <name> --target <name>`.
+`lanes link token rotate --profile <name> --workspace <name>`.
 
-Prefer `lanes link mcp add --profile <name> --target <name>` to writing the command yourself: it checks the
+Prefer `lanes link mcp add --profile <name> --workspace <name>` to writing the command yourself: it checks the
 endpoint is reachable, refuses to silently shadow an existing registration, and
 cannot mistype the token. For a harness it does not know, take the command from
-`lanes link outputs --profile <name> --target <name>` rather than writing it blind — that command checks whether
+`lanes link outputs --profile <name> --workspace <name>` rather than writing it blind — that command checks whether
 `lanes` resolves on this machine and prints a longer working form if it does
 not, where guessing gives you an empty substitution, a `Bearer ` header, and a
 401 that reads as a bad token.
@@ -420,7 +420,7 @@ If you register Codex, tell the user to export the token — Codex stores only t
 variable name, so nothing works until it is set:
 
 ```bash
-export LANES_LINK_TOKEN="$(lanes link token show --raw --profile <name> --target <name>)"
+export LANES_LINK_TOKEN="$(lanes link token show --raw --profile <name> --workspace <name>)"
 ```
 
 One registration covers every profile. Do not add one per profile; they share a
@@ -433,12 +433,12 @@ copy means the rules you are reading are not the ones that shipped.
 
 Claude Desktop cannot be handed a URL, so it spawns the endpoint over stdio
 instead. That one is named in the client's own config file rather than registered
-by a command, as `lanes link mcp stdio --profile <name> --target <name>`; both
+by a command, as `lanes link mcp stdio --profile <name> --workspace <name>`; both
 flags are required, and nothing may be written to stdout.
 
 ## When it is not running
 
-`lanes link start --profile <name> --target <name>` runs in the foreground and
+`lanes link start --profile <name> --workspace <name>` runs in the foreground and
 serves until stopped. Tell the
 user the command rather than backgrounding it silently on their behalf.
 Registration works while it is down — the harness simply cannot reach it yet,

--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "#audit": "./src/audit/index.ts",
     "#audit/*": "./src/audit/*",
     "#auth": "./src/auth/index.ts",
+    "#auth/*": "./src/auth/*",
     "#cli/*": "./src/cli/*",
     "#connectivity": "./src/connectivity/index.ts",
     "#connectivity/*": "./src/connectivity/*",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lanes-sh/link",
-  "version": "0.7.2",
+  "version": "0.8.0",
   "description": "A self-hostable MCP gateway for all your connections, memory, tasks, files, and secrets",
   "license": "Apache-2.0",
   "homepage": "https://lanes.sh/link",

--- a/src/audit/index.ts
+++ b/src/audit/index.ts
@@ -58,11 +58,18 @@ export interface AuditEvent {
   readonly principal: string;
 
   /**
-   * The MCP `clientInfo` name, when the caller supplied one.
+   * The MCP `clientInfo` name, when the caller repeated it on the request.
    *
    * OBSERVABILITY ONLY. This is self-reported by the client and is never
    * consulted for authorization — it exists so you can see which agent made a
    * call, not to decide what that agent may do.
+   *
+   * "On the request" is load-bearing and was wrong for this field's whole life:
+   * it claimed to hold the `clientInfo` name and read an `x-mcp-client` header
+   * that no MCP client sends, so it was empty on every event ever written. The
+   * name arrives in the request envelope now (`mcp/client-info.ts`). A client
+   * that announces itself only at `initialize` and never repeats it is still
+   * anonymous here, which is the honest answer rather than one inferred.
    */
   readonly clientLabel?: string;
 

--- a/src/auth/delegation.test.ts
+++ b/src/auth/delegation.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from 'bun:test';
-import { mayReach, memberPrincipal, ownerPrincipal } from './index.ts';
+import { forProfile, mayReach, memberPrincipal, ownerPrincipal } from './index.ts';
 
 /**
  * Who may act within a profile — ADR-060.
@@ -66,5 +66,32 @@ describe('the callers that are not people', () => {
     expect(
       mayReach({ id: 'x', profile: 'personal', kind: 'member', profiles: [] }, 'anything'),
     ).toBe(false);
+  });
+});
+
+describe('acting within a profile that is not the one the endpoint booted with', () => {
+  const member = memberPrincipal(SUBJECT, 'personal', ['personal', 'shared']);
+
+  test('carries the profile the call named, because that is what gets recorded', () => {
+    // A principal is built once, from the endpoint's primary profile, and an
+    // endpoint serves several. Without this the audit event and the `mayReach`
+    // check both read the profile the connection was opened under rather than
+    // the one the caller asked for.
+    expect(forProfile(member, 'shared').profile).toBe('shared');
+    expect(forProfile(member, 'shared').id).toBe(SUBJECT);
+  });
+
+  test('widens nothing — a profile they may not reach is still refused', () => {
+    const elsewhere = forProfile(member, 'work');
+
+    expect(elsewhere.profiles).toEqual(['personal', 'shared']);
+    expect(mayReach(elsewhere, elsewhere.profile)).toBe(false);
+  });
+
+  test('is the same object when the profile has not changed', () => {
+    // Not an optimisation worth having on its own; it is here so that the
+    // overwhelmingly common single-profile case cannot be told apart from the
+    // code that predates this.
+    expect(forProfile(member, 'personal')).toBe(member);
   });
 });

--- a/src/auth/delegation.test.ts
+++ b/src/auth/delegation.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, test } from 'bun:test';
+import { mayReach, memberPrincipal, ownerPrincipal } from './index.ts';
+
+/**
+ * Who may act within a profile — ADR-060.
+ *
+ * The slot ADR-003 kept open on purpose. Policy has always been evaluated
+ * against `(principal, capability, connection)` and always been handed the same
+ * principal; this is the first release where the first of those three is a
+ * person, and the check that reads it is one line ahead of policy in the
+ * dispatcher.
+ *
+ * Two properties, and the second is the one worth having tests for. Being
+ * refused is obvious. Being *invisible* is not: a member does not fail to call a
+ * profile they are not on, they never see it in the `profile` enum — and a
+ * filter that ever disagreed with the gate would be a leak in discovery, which
+ * is still a leak.
+ */
+
+const SUBJECT = 'lanes:3QBmAxJLLrYSMTVUIeCN1SKFbdD3';
+
+describe('a member reaches exactly the profiles that name them', () => {
+  const member = memberPrincipal(SUBJECT, 'personal', ['personal', 'shared']);
+
+  test('reaches a profile on the list', () => {
+    expect(mayReach(member, 'personal')).toBe(true);
+    expect(mayReach(member, 'shared')).toBe(true);
+  });
+
+  test('does not reach one that is not', () => {
+    expect(mayReach(member, 'work')).toBe(false);
+  });
+
+  test('an empty list reaches nothing, because empty is nobody', () => {
+    // Default deny on the identity axis. A profile whose `members:` is empty is
+    // not "open to everyone" — it is a profile nobody may consume, which is the
+    // state a hand-edit produces rather than one anybody is handed.
+    const nobody = memberPrincipal(SUBJECT, 'personal', []);
+    expect(mayReach(nobody, 'personal')).toBe(false);
+  });
+
+  test('carries the subject as its id, so the log names a person', () => {
+    // The audit log records `principal`, and the whole point of this release is
+    // that the value is a person rather than "whoever held the token".
+    expect(member.id).toBe(SUBJECT);
+    expect(member.kind).toBe('member');
+  });
+});
+
+describe('the callers that are not people', () => {
+  test('the owner principal reaches everything, as it always has', () => {
+    // Unchanged behaviour, stated as a test because it is what every existing
+    // registration relies on and what the CLI itself uses.
+    const owner = ownerPrincipal('personal');
+
+    expect(mayReach(owner, 'personal')).toBe(true);
+    expect(mayReach(owner, 'work')).toBe(true);
+  });
+
+  test('an undefined list means the whole workspace, not an empty one', () => {
+    // The distinction that would be a security hole if it inverted: `undefined`
+    // is the machine token and the stdio pipe, both of which reach everything;
+    // `[]` is a person delegated nothing. Reading one as the other in either
+    // direction is the bug this pins.
+    expect(mayReach({ id: 'ci', profile: 'personal', kind: 'machine' }, 'anything')).toBe(true);
+    expect(
+      mayReach({ id: 'x', profile: 'personal', kind: 'member', profiles: [] }, 'anything'),
+    ).toBe(false);
+  });
+});

--- a/src/auth/index.ts
+++ b/src/auth/index.ts
@@ -61,6 +61,23 @@ export function memberPrincipal(
   return { id: subject, profile, kind: 'member', profiles };
 }
 
+/**
+ * The same caller, acting within a different profile.
+ *
+ * An endpoint serves several profiles and a principal is built once, from the
+ * primary — so the profile on it is where the *connection* was opened, not
+ * where this call is going. Every dispatch has to say which, because
+ * `principal.profile` is what the audit event records and what `mayReach` is
+ * checked against; without this the log attributes a member's call to a profile
+ * they may never have been able to reach.
+ *
+ * It does not widen anything. `profiles` carries over untouched, so a name this
+ * caller may not reach is still refused — one step later, by the check below.
+ */
+export function forProfile(principal: Principal, profile: string): Principal {
+  return principal.profile === profile ? principal : { ...principal, profile };
+}
+
 /** Whether this caller may act within the named profile. */
 export function mayReach(principal: Principal, profile: string): boolean {
   return principal.profiles === undefined || principal.profiles.includes(profile);
@@ -246,7 +263,15 @@ export {
   type ChallengeError,
   type ResourceIdentity,
 } from './oauth/metadata.ts';
-export { OAuthServer, pkceChallengeFor, type AuthorizeRequest, type OAuthResult } from './oauth/server.ts';
+export {
+  OAuthServer,
+  pkceChallengeFor,
+  type EndpointIdentity,
+  type Federation,
+  type OAuthResult,
+} from './oauth/server.ts';
+export { AssertionVerifier, type Assertion } from './lanes/assertion.ts';
+export { lanesFederation, DEFAULT_WEB_URL, type FederationOptions } from './lanes/federation.ts';
 export { matchesRegistered } from './oauth/redirects.ts';
 export { OAuthStore, hashToken, randomToken } from './oauth/store.ts';
 export { OidcVerifier, type OidcVerifierOptions, type VerifiedSubject } from './oidc.ts';

--- a/src/auth/index.ts
+++ b/src/auth/index.ts
@@ -28,11 +28,42 @@ import type { SecretRef, SecretStore } from '#secrets';
 export interface Principal {
   readonly id: string;
   readonly profile: string;
-  readonly kind: 'owner';
+  readonly kind: 'owner' | 'member' | 'machine';
+  /**
+   * Every profile this caller may reach, or `undefined` for "all of them".
+   *
+   * `undefined` is the machine token and the stdio pipe: neither is a person,
+   * both reach the whole workspace, and saying so explicitly is better than
+   * enumerating a list that would then need keeping in step. A `member` always
+   * carries a list, because the list *is* the delegation (ADR-060).
+   */
+  readonly profiles?: readonly string[] | undefined;
 }
 
 export function ownerPrincipal(profile: string): Principal {
   return { id: `${profile}:owner`, profile, kind: 'owner' };
+}
+
+/**
+ * A person, and the profiles whose `members:` name them.
+ *
+ * `profile` carries the one this call is acting within, which is what the audit
+ * log records and what policy is evaluated against. `profiles` is the whole set
+ * they may choose from, and `mayReach` is the check — kept here rather than in
+ * the dispatcher so discovery and enforcement cannot answer it differently,
+ * which is the same rule `allowedConnections` follows on the capability axis.
+ */
+export function memberPrincipal(
+  subject: string,
+  profile: string,
+  profiles: readonly string[],
+): Principal {
+  return { id: subject, profile, kind: 'member', profiles };
+}
+
+/** Whether this caller may act within the named profile. */
+export function mayReach(principal: Principal, profile: string): boolean {
+  return principal.profiles === undefined || principal.profiles.includes(profile);
 }
 
 export type AuthOutcome =

--- a/src/auth/lanes/assertion.test.ts
+++ b/src/auth/lanes/assertion.test.ts
@@ -1,0 +1,243 @@
+import { beforeAll, describe, expect, test } from 'bun:test';
+import { AssertionVerifier } from './assertion.ts';
+
+/**
+ * Believing lanes.sh about who is at the browser.
+ *
+ * Signed with a real key pair rather than stubbed, because every check here is
+ * about a token somebody else could have written. A double that returns "valid"
+ * would exercise the branches and prove nothing about the one property this
+ * file exists for.
+ *
+ * The negative cases are the file. A verifier that accepts a good token and
+ * nothing else is the whole requirement; each `expect(…).toBeNull()` below
+ * corresponds to a way an endpoint could be made to believe the wrong person.
+ */
+
+const ISSUER = 'https://api.example.com';
+const JWKS_URL = `${ISSUER}/.well-known/jwks.json`;
+const RESOURCE = 'https://link.example.com/mcp';
+const KID = 'a-key-id';
+
+let keys: CryptoKeyPair;
+let jwks: { keys: unknown[] };
+
+beforeAll(async () => {
+  keys = (await crypto.subtle.generateKey(
+    { name: 'RSASSA-PKCS1-v1_5', modulusLength: 2048, publicExponent: new Uint8Array([1, 0, 1]), hash: 'SHA-256' },
+    true,
+    ['sign', 'verify'],
+  )) as CryptoKeyPair;
+
+  const jwk = await crypto.subtle.exportKey('jwk', keys.publicKey);
+  jwks = { keys: [{ ...jwk, kid: KID, alg: 'RS256', use: 'sig' }] };
+});
+
+function encode(value: unknown): string {
+  return Buffer.from(JSON.stringify(value)).toString('base64url');
+}
+
+/** A token as the API would mint it, with anything overridden for a test. */
+async function assertion(
+  claims: Record<string, unknown> = {},
+  header: Record<string, unknown> = {},
+  signWith?: CryptoKey,
+): Promise<string> {
+  const now = Math.floor(Date.now() / 1000);
+  const body =
+    `${encode({ alg: 'RS256', typ: 'JWT', kid: KID, ...header })}.` +
+    `${encode({
+      iss: ISSUER,
+      aud: RESOURCE,
+      sub: 'FIREBASEUID000000000000000000',
+      email: 'someone@example.com',
+      nonce: 'a-nonce',
+      iat: now,
+      exp: now + 60,
+      ...claims,
+    })}`;
+
+  const signature = await crypto.subtle.sign(
+    { name: 'RSASSA-PKCS1-v1_5' },
+    signWith ?? keys.privateKey,
+    new TextEncoder().encode(body),
+  );
+
+  return `${body}.${Buffer.from(signature).toString('base64url')}`;
+}
+
+type Call = (input: string | URL | Request, init?: RequestInit) => Promise<Response>;
+
+function verifier(overrides: { fetch?: Call; now?: () => number } = {}): AssertionVerifier {
+  return new AssertionVerifier({
+    jwksUrl: JWKS_URL,
+    issuer: ISSUER,
+    fetch: overrides.fetch ?? (async () => Response.json(jwks)),
+    ...(overrides.now ? { now: overrides.now } : {}),
+  });
+}
+
+const EXPECTED = { audience: RESOURCE, nonce: 'a-nonce' };
+
+describe('a token the API signed', () => {
+  test('names the person, prefixed so a profile can hold the subject', async () => {
+    const verified = await verifier().verify(await assertion(), EXPECTED);
+
+    expect(verified?.subject).toBe('lanes:FIREBASEUID000000000000000000');
+    expect(verified?.email).toBe('someone@example.com');
+  });
+
+  test('an already-prefixed subject is not prefixed twice', async () => {
+    // The API may reasonably sign either. Doing this in one place means the
+    // client and the server cannot disagree about what a subject looks like.
+    const verified = await verifier().verify(await assertion({ sub: 'lanes:ABC123' }), EXPECTED);
+
+    expect(verified?.subject).toBe('lanes:ABC123');
+  });
+});
+
+describe('a token nobody should believe', () => {
+  test('signed by a different key', async () => {
+    const impostor = (await crypto.subtle.generateKey(
+      { name: 'RSASSA-PKCS1-v1_5', modulusLength: 2048, publicExponent: new Uint8Array([1, 0, 1]), hash: 'SHA-256' },
+      true,
+      ['sign', 'verify'],
+    )) as CryptoKeyPair;
+
+    expect(await verifier().verify(await assertion({}, {}, impostor.privateKey), EXPECTED)).toBeNull();
+  });
+
+  test('with the payload edited after signing', async () => {
+    const [header, , signature] = (await assertion()).split('.');
+    const now = Math.floor(Date.now() / 1000);
+    const swapped = encode({
+      iss: ISSUER, aud: RESOURCE, sub: 'SOMEBODYELSE', nonce: 'a-nonce', iat: now, exp: now + 60,
+    });
+
+    expect(await verifier().verify(`${header}.${swapped}.${signature}`, EXPECTED)).toBeNull();
+  });
+
+  test('claiming alg none, which is the oldest way to skip the signature', async () => {
+    const now = Math.floor(Date.now() / 1000);
+    const unsigned =
+      `${encode({ alg: 'none', kid: KID })}.` +
+      `${encode({ iss: ISSUER, aud: RESOURCE, sub: 'X', nonce: 'a-nonce', iat: now, exp: now + 60 })}.`;
+
+    expect(await verifier().verify(unsigned, EXPECTED)).toBeNull();
+  });
+
+  test('minted for somebody else’s endpoint', async () => {
+    // The confused-deputy case. The signature is genuine and the person is
+    // real; the only thing wrong is that the assertion was for another
+    // resource, and this check is the only thing that notices.
+    const other = await assertion({ aud: 'https://someone-else.example.com/mcp' });
+
+    expect(await verifier().verify(other, EXPECTED)).toBeNull();
+  });
+
+  test('carrying a nonce this endpoint did not mint', async () => {
+    expect(await verifier().verify(await assertion({ nonce: 'a-different-nonce' }), EXPECTED)).toBeNull();
+  });
+
+  test('signed by an issuer we do not trust', async () => {
+    expect(await verifier().verify(await assertion({ iss: 'https://evil.example' }), EXPECTED)).toBeNull();
+  });
+
+  test('that has expired', async () => {
+    const now = Math.floor(Date.now() / 1000);
+    const stale = await assertion({ iat: now - 600, exp: now - 300 });
+
+    expect(await verifier().verify(stale, EXPECTED)).toBeNull();
+  });
+
+  test('whose own lifetime is longer than a redirect', async () => {
+    // Checked here as well as at the issuer. A deployment that widened its
+    // expiry would turn a redirect-scoped assertion into a bearer credential
+    // sitting in a browser history, and this endpoint is what lives with that.
+    const now = Math.floor(Date.now() / 1000);
+    const long = await assertion({ iat: now, exp: now + 86_400 });
+
+    expect(await verifier().verify(long, EXPECTED)).toBeNull();
+  });
+
+  test('signed with a key id that is not published', async () => {
+    expect(await verifier().verify(await assertion({}, { kid: 'not-published' }), EXPECTED)).toBeNull();
+  });
+
+  test('that is not three parts', async () => {
+    expect(await verifier().verify('nonsense', EXPECTED)).toBeNull();
+  });
+});
+
+describe('the key set', () => {
+  test('is fetched once and reused', async () => {
+    let fetches = 0;
+    const one = verifier({
+      fetch: async () => {
+        fetches += 1;
+        return Response.json(jwks);
+      },
+    });
+
+    await one.verify(await assertion(), EXPECTED);
+    await one.verify(await assertion(), EXPECTED);
+
+    expect(fetches).toBe(1);
+  });
+
+  test('a key id that is not in the cache refetches, which is what rotation looks like', async () => {
+    // The real sequence: the cache is warm and correct, the API publishes a new
+    // key, and a token signed with it arrives before the cache lapses. Without
+    // the refetch every endpoint refuses until its cache times out.
+    const rotated = (await crypto.subtle.generateKey(
+      { name: 'RSASSA-PKCS1-v1_5', modulusLength: 2048, publicExponent: new Uint8Array([1, 0, 1]), hash: 'SHA-256' },
+      true,
+      ['sign', 'verify'],
+    )) as CryptoKeyPair;
+    const rotatedJwk = await crypto.subtle.exportKey('jwk', rotated.publicKey);
+
+    let fetches = 0;
+    const one = verifier({
+      fetch: async () => {
+        fetches += 1;
+        return Response.json(
+          fetches === 1
+            ? jwks
+            : { keys: [...jwks.keys, { ...rotatedJwk, kid: 'the-next-key', alg: 'RS256' }] },
+        );
+      },
+    });
+
+    expect(await one.verify(await assertion(), EXPECTED)).not.toBeNull();
+    expect(fetches).toBe(1);
+
+    const next = await assertion({}, { kid: 'the-next-key' }, rotated.privateKey);
+    expect(await one.verify(next, EXPECTED)).not.toBeNull();
+    expect(fetches).toBe(2);
+  });
+
+  test('a key id nobody publishes does not refetch on every call', async () => {
+    // The other half of the rule above. A token naming a key that does not
+    // exist is what a flood looks like, and answering each one with a round
+    // trip to the API would make this endpoint the amplifier.
+    let fetches = 0;
+    const one = verifier({
+      fetch: async () => {
+        fetches += 1;
+        return Response.json(jwks);
+      },
+    });
+
+    await one.verify(await assertion(), EXPECTED);
+    await one.verify(await assertion({}, { kid: 'invented' }), EXPECTED);
+    await one.verify(await assertion({}, { kid: 'invented' }), EXPECTED);
+
+    expect(fetches).toBeLessThanOrEqual(2);
+  });
+
+  test('an unreachable JWKS refuses rather than admitting anything', async () => {
+    const one = verifier({ fetch: async () => new Response('nope', { status: 503 }) });
+
+    expect(await one.verify(await assertion(), EXPECTED)).toBeNull();
+  });
+});

--- a/src/auth/lanes/assertion.ts
+++ b/src/auth/lanes/assertion.ts
@@ -1,0 +1,256 @@
+import type { FetchLike } from './login.ts';
+
+/**
+ * Verifying that lanes.sh vouched for the person at the browser.
+ *
+ * This is what replaces the pasted endpoint token on the consent screen
+ * (ADR-062). The endpoint no longer asks "do you hold the owner's credential" —
+ * it asks lanes.sh "who is this", and gets back a signed statement it can check
+ * without trusting the browser that carried it.
+ *
+ * Four checks, and each of them is load-bearing:
+ *
+ *  - **Signature**, against the API's published JWKS. Without it the assertion
+ *    is a string the browser handed us and anyone could write one.
+ *  - **Audience**, which must be *this endpoint's own resource URL*. An
+ *    assertion minted for somebody else's endpoint is a valid assertion; using
+ *    it here is the confused-deputy case the MCP authorization spec calls out,
+ *    and this is the only thing that stops it.
+ *  - **Nonce**, single-use, minted by this endpoint when the flow began. It
+ *    binds the assertion to *this* authorization request, so one captured on a
+ *    different endpoint of ours cannot be replayed into this one.
+ *  - **Expiry**, tight. The assertion crosses one redirect, so a minute is
+ *    generous and anything longer is a bearer credential in a browser history.
+ *
+ * Verification is intentionally a public-key check and not a call back to the
+ * API. The endpoint may be behind somebody's firewall; it must be able to
+ * verify while only ever having *fetched* a key, and a cached JWKS makes the
+ * whole flow work with the API unreachable for the length of the cache.
+ *
+ * No JWT library. RS256 over a JWK is `crypto.subtle.importKey` plus
+ * `crypto.subtle.verify`, which is 30 lines and no supply chain — the same
+ * reasoning that has `connectivity/auth/oauth-jwt/key.ts` signing with subtle
+ * rather than pulling one in.
+ */
+
+/** What an assertion says once it has been believed. */
+export interface Assertion {
+  /** `lanes:<uid>`, the same string `lanes auth login` stores and `members:` names. */
+  readonly subject: string;
+  readonly email: string | null;
+}
+
+export interface AssertionVerifierOptions {
+  /** Where the signing keys are published. */
+  readonly jwksUrl: string;
+  /** Who is allowed to have signed. Checked against `iss`. */
+  readonly issuer: string;
+  readonly fetch?: FetchLike | undefined;
+  readonly now?: (() => number) | undefined;
+  /** How long a fetched key set is reused. */
+  readonly cacheTtlMs?: number | undefined;
+}
+
+/**
+ * One published key, as it arrives.
+ *
+ * Loose on purpose: `importKey` is the thing that decides whether a JWK is
+ * usable, and re-deciding that here with a stricter type would mean a key the
+ * platform accepts being dropped by our own schema.
+ */
+type Jwk = Record<string, unknown> & { kid?: unknown; kty?: unknown; alg?: unknown };
+
+/** An hour. A key rotation is noticed within it, and a miss refetches anyway. */
+const DEFAULT_CACHE_TTL_MS = 60 * 60_000;
+
+/**
+ * The shortest interval between two refetches provoked by an unknown key id.
+ *
+ * Without it, a token naming a key that does not exist costs a round trip to
+ * the API — and since anyone can send one unauthenticated, every endpoint
+ * becomes an amplifier pointed at us. A minute bounds that at one request per
+ * endpoint per minute while still letting a genuine rotation land promptly.
+ */
+const MISS_REFETCH_MS = 60_000;
+
+/** Assertions cross one redirect; more than this is a credential left lying about. */
+const MAX_LIFETIME_MS = 120_000;
+
+/** Clocks differ. Small enough that it does not extend the window meaningfully. */
+const CLOCK_SKEW_MS = 30_000;
+
+/** What `importKey('jwk', …)` takes, without depending on a lib.dom global. */
+type JsonWebKeyLike = Parameters<typeof crypto.subtle.importKey>[1] extends infer T
+  ? Extract<T, { kty?: string | undefined }>
+  : never;
+
+export class AssertionVerifier {
+  readonly #options: AssertionVerifierOptions;
+  readonly #fetch: FetchLike;
+  readonly #now: () => number;
+  #keys: { at: number; byKid: Map<string, CryptoKey> } | null = null;
+  #missedAt = Number.NEGATIVE_INFINITY;
+
+  constructor(options: AssertionVerifierOptions) {
+    this.#options = options;
+    this.#fetch = options.fetch ?? ((input, init) => globalThis.fetch(input, init));
+    this.#now = options.now ?? Date.now;
+  }
+
+  /**
+   * The person this assertion names, or null.
+   *
+   * Null rather than a reason. The caller renders an error page to whoever is
+   * at the browser, and "the signature did not verify" versus "the audience was
+   * wrong" tells an attacker which of their attempts got closer while telling a
+   * legitimate user nothing they can act on. What *is* actionable — expiry — is
+   * the one case the caller can infer by retrying.
+   */
+  async verify(token: string, expected: { audience: string; nonce: string }): Promise<Assertion | null> {
+    const parts = token.split('.');
+    if (parts.length !== 3) return null;
+
+    const [encodedHeader, encodedPayload, encodedSignature] = parts as [string, string, string];
+
+    const header = decodeJson(encodedHeader);
+    const payload = decodeJson(encodedPayload);
+    if (header === null || payload === null) return null;
+
+    // Pinned, not read. `alg` arrives inside the token, so honouring it is how
+    // the `none` algorithm and the HMAC-with-the-public-key confusions work.
+    if (header['alg'] !== 'RS256') return null;
+
+    const kid = typeof header['kid'] === 'string' ? header['kid'] : null;
+    if (kid === null) return null;
+
+    const key = await this.#key(kid);
+    if (key === null) return null;
+
+    const signed = new TextEncoder().encode(`${encodedHeader}.${encodedPayload}`);
+    const signature = base64url(encodedSignature);
+    if (signature === null) return null;
+
+    const valid = await crypto.subtle.verify(
+      { name: 'RSASSA-PKCS1-v1_5' },
+      key,
+      signature,
+      signed,
+    );
+    if (!valid) return null;
+
+    return this.#claims(payload, expected);
+  }
+
+  /** Everything that is true of a verified signature but not yet of this token. */
+  #claims(payload: Record<string, unknown>, expected: { audience: string; nonce: string }): Assertion | null {
+    if (payload['iss'] !== this.#options.issuer) return null;
+
+    // Exact match, per RFC 8707. A prefix or suffix comparison here would admit
+    // an assertion minted for a different endpoint on the same host.
+    const audience = payload['aud'];
+    const audiences = Array.isArray(audience) ? audience : [audience];
+    if (!audiences.includes(expected.audience)) return null;
+
+    if (payload['nonce'] !== expected.nonce) return null;
+
+    const now = this.#now();
+    const exp = typeof payload['exp'] === 'number' ? payload['exp'] * 1000 : 0;
+    const iat = typeof payload['iat'] === 'number' ? payload['iat'] * 1000 : 0;
+
+    if (exp <= now - CLOCK_SKEW_MS) return null;
+    if (iat > now + CLOCK_SKEW_MS) return null;
+
+    // Checked here as well as trusted from the issuer. A deployment that
+    // widened its own expiry would silently turn a redirect-scoped assertion
+    // into a long-lived bearer token, and this endpoint is the party that has
+    // to live with that.
+    if (exp - iat > MAX_LIFETIME_MS + CLOCK_SKEW_MS) return null;
+
+    const subject = payload['sub'];
+    if (typeof subject !== 'string' || subject.length === 0) return null;
+
+    return {
+      // The API signs the raw uid; the prefix is added at exactly one place in
+      // the client, here and in `login.ts`, so the two cannot disagree about
+      // what a subject looks like.
+      subject: subject.startsWith('lanes:') ? subject : `lanes:${subject}`,
+      email: typeof payload['email'] === 'string' ? payload['email'] : null,
+    };
+  }
+
+  /**
+   * The signing key with that id.
+   *
+   * A miss against a warm cache refetches, because that is what a key rotation
+   * looks like from here and the alternative is every endpoint refusing until
+   * its cache lapses. It refetches at most once a minute, because the *other*
+   * thing a miss looks like is an invented key id, and those arrive
+   * unauthenticated and as fast as anyone cares to send them.
+   */
+  async #key(kid: string): Promise<CryptoKey | null> {
+    const ttl = this.#options.cacheTtlMs ?? DEFAULT_CACHE_TTL_MS;
+    const now = this.#now();
+    const fresh = this.#keys !== null && now - this.#keys.at < ttl;
+
+    if (fresh) {
+      const hit = this.#keys?.byKid.get(kid);
+      if (hit) return hit;
+      if (now - this.#missedAt < MISS_REFETCH_MS) return null;
+      this.#missedAt = now;
+    }
+
+    const loaded = await this.#load();
+    return loaded.get(kid) ?? null;
+  }
+
+  async #load(): Promise<Map<string, CryptoKey>> {
+    const byKid = new Map<string, CryptoKey>();
+
+    const response = await this.#fetch(this.#options.jwksUrl).catch(() => null);
+    if (response === null || !response.ok) {
+      // Left uncached, so the next attempt tries again rather than treating an
+      // outage as "there are no keys" for an hour. Whatever was already known
+      // still answers, which is what keeps a verified endpoint working while
+      // the API is down.
+      return this.#keys?.byKid ?? byKid;
+    }
+
+    const body = (await response.json().catch(() => ({}))) as { keys?: Jwk[] };
+
+    for (const jwk of body.keys ?? []) {
+      if (jwk.kty !== 'RSA' || (jwk.alg !== undefined && jwk.alg !== 'RS256')) continue;
+      if (typeof jwk.kid !== 'string') continue;
+
+      const key = await crypto.subtle
+        .importKey('jwk', jwk as JsonWebKeyLike, { name: 'RSASSA-PKCS1-v1_5', hash: 'SHA-256' }, false, [
+          'verify',
+        ])
+        .catch(() => null);
+
+      if (key !== null) byKid.set(jwk.kid, key);
+    }
+
+    this.#keys = { at: this.#now(), byKid };
+    return byKid;
+  }
+}
+
+function base64url(value: string): ArrayBuffer | null {
+  try {
+    const bytes = Buffer.from(value, 'base64url');
+    return bytes.buffer.slice(bytes.byteOffset, bytes.byteOffset + bytes.byteLength) as ArrayBuffer;
+  } catch {
+    return null;
+  }
+}
+
+function decodeJson(value: string): Record<string, unknown> | null {
+  const bytes = base64url(value);
+  if (bytes === null) return null;
+  try {
+    const parsed: unknown = JSON.parse(new TextDecoder().decode(bytes));
+    return typeof parsed === 'object' && parsed !== null ? (parsed as Record<string, unknown>) : null;
+  } catch {
+    return null;
+  }
+}

--- a/src/auth/lanes/callback.ts
+++ b/src/auth/lanes/callback.ts
@@ -1,0 +1,135 @@
+/**
+ * The loopback listener a browser comes back to, and nothing else.
+ *
+ * Split from `login.ts` because the two have one value between them — an
+ * authorization code — and everything else they know is disjoint. This file
+ * knows about sockets, `state`, and the page somebody is left looking at; it
+ * knows nothing about Google, Firebase, or where a session is stored.
+ */
+
+/** What the browser should be told, for whoever is rendering it. */
+export interface LandingPage {
+  readonly ok: boolean;
+  /** One line. The reason, when something went wrong. */
+  readonly detail: string;
+}
+
+/**
+ * Serve exactly one callback, then stop.
+ *
+ * Bound to `127.0.0.1` on a port the kernel picks, which is RFC 8252's loopback
+ * redirect. Google matches loopback by host and ignores the port, so nothing
+ * has to be registered per machine — the property `link_auth.py`'s
+ * `_is_loopback_redirect` relies on at the other end.
+ */
+export async function awaitCallback(
+  state: string,
+  onListening: (redirectUri: string) => Promise<void>,
+  render: (outcome: LandingPage) => Response,
+): Promise<{ code: string; redirectUri: string }> {
+  const page = (outcome: LandingPage): Response => closing(render(outcome));
+  const { promise, resolve, reject } = Promise.withResolvers<string>();
+
+  const server = Bun.serve({
+    hostname: '127.0.0.1',
+    port: 0,
+    fetch(request) {
+      const url = new URL(request.url);
+      // Anything else, including the favicon a browser asks for unprompted.
+      // It closes its connection too, so a stray request cannot keep the server
+      // alive past the redirect it is waiting for.
+      if (url.pathname !== '/callback') {
+        return closing(new Response('Not found', { status: 404 }));
+      }
+
+      const error = url.searchParams.get('error');
+      if (error) {
+        reject(new Error(`Google refused the sign-in: ${error}`));
+        return page({ ok: false, detail: `Google refused the sign-in: ${error}` });
+      }
+
+      // Checked before the code is read. `state` is the only thing standing
+      // between this listener and a page on the machine feeding it a code from
+      // somebody else's authorization.
+      if (url.searchParams.get('state') !== state) {
+        reject(new Error('The sign-in came back with the wrong state, so it was discarded.'));
+        return page({
+          ok: false,
+          detail: 'That sign-in came back with the wrong state, so it was discarded.',
+        });
+      }
+
+      const code = url.searchParams.get('code');
+      if (!code) {
+        reject(new Error('The sign-in came back without a code.'));
+        return page({ ok: false, detail: 'That sign-in came back without a code.' });
+      }
+
+      resolve(code);
+      return page({ ok: true, detail: 'You can close this tab and go back to your terminal.' });
+    },
+  });
+
+  const timeout = setTimeout(
+    () => reject(new Error('Timed out waiting for the browser. Nothing was changed.')),
+    300_000,
+  );
+
+  // The redirect URI is returned rather than stashed. Google checks that the
+  // exchange sends back the *same* one, and a module-level variable holding it
+  // would be shared by two logins running at once — which is not hypothetical
+  // on a machine where somebody re-runs a command that seemed to hang.
+  const redirectUri = `http://127.0.0.1:${server.port}/callback`;
+
+  try {
+    await onListening(redirectUri);
+    return { code: await promise, redirectUri };
+  } finally {
+    clearTimeout(timeout);
+
+    // Graceful, and this is the whole of the fix for a login that worked and
+    // looked like it had not. `stop(true)` closes active connections
+    // immediately, and the active connection is the one carrying the page the
+    // person is waiting to see: `resolve` runs inside the handler, before Bun
+    // has written the response, so forcing here raced the browser and won every
+    // time. What they got was a connection error on a sign-in that had already
+    // succeeded, which is the worst possible way for this to fail.
+    //
+    // Nothing can hold a graceful stop open, because every response closes its
+    // own connection — see `closing`. That is what makes this safe to await
+    // rather than force.
+    await server.stop();
+  }
+}
+
+/**
+ * `Connection: close` on whatever was rendered.
+ *
+ * Applied here rather than asked of the renderer, because it is a property of
+ * *this* listener rather than of the page. The server is torn down the moment
+ * the code arrives, and a keep-alive connection would either hold the graceful
+ * stop open or be severed mid-response — the second is what used to happen.
+ * Telling the browser not to reuse the socket makes "respond, then stop" a
+ * sequence rather than a race.
+ */
+function closing(response: Response): Response {
+  const headers = new Headers(response.headers);
+  headers.set('connection', 'close');
+  return new Response(response.body, { status: response.status, headers });
+}
+
+/**
+ * The page when nobody supplied one.
+ *
+ * Deliberately plain, and deliberately not what a person sees: `lanes auth
+ * login` passes the branded card. This is for tests, and for a caller that has
+ * no opinion about presentation.
+ */
+export function plainPage(outcome: LandingPage): Response {
+  return new Response(
+    `<!doctype html><meta charset="utf-8"><title>Lanes</title>` +
+      `<body style="font:16px system-ui;display:grid;place-items:center;height:100vh;margin:0">` +
+      `<p>${outcome.ok ? 'Signed in.' : 'That did not work.'} ${outcome.detail}</p></body>`,
+    { headers: { 'content-type': 'text/html; charset=utf-8' } },
+  );
+}

--- a/src/auth/lanes/federation.ts
+++ b/src/auth/lanes/federation.ts
@@ -1,0 +1,50 @@
+import { AssertionVerifier } from './assertion.ts';
+import { DEFAULT_API_URL } from './login.ts';
+import type { Federation } from '../oauth/server.ts';
+
+/**
+ * The Lanes side of an endpoint's authorization, assembled.
+ *
+ * Three URLs and a membership lookup. It lives here rather than in
+ * `server/endpoint.ts` so that "who does this endpoint believe about identity"
+ * is one file with one answer, and so that a self-hoster changing it changes
+ * one thing — which is the same reasoning that keeps `oidc` a URL in config
+ * rather than a branch in the code.
+ *
+ * **Both URLs are overridable and neither is a vendor name in the request
+ * path.** `LANES_API_URL` and `LANES_WEB_URL` are what a self-hosted
+ * deployment sets, and they are also what makes `lanes dev` work against the
+ * API running on this machine.
+ */
+
+/** Where the consent page lives, unless told otherwise. */
+export const DEFAULT_WEB_URL = 'https://lanes.sh';
+
+export interface FederationOptions {
+  /** Which profiles a subject may consume, read at the moment a token is minted. */
+  readonly profilesFor: (subject: string) => Promise<readonly string[]>;
+  readonly apiUrl?: string | undefined;
+  readonly webUrl?: string | undefined;
+  /** Injected for tests. Nothing in production passes one. */
+  readonly fetch?: ConstructorParameters<typeof AssertionVerifier>[0]['fetch'];
+}
+
+export function lanesFederation(options: FederationOptions): Federation {
+  const apiUrl = options.apiUrl ?? process.env['LANES_API_URL'] ?? DEFAULT_API_URL;
+  const webUrl = options.webUrl ?? process.env['LANES_WEB_URL'] ?? DEFAULT_WEB_URL;
+
+  const verifier = new AssertionVerifier({
+    jwksUrl: `${apiUrl}/.well-known/jwks.json`,
+    // The API is the issuer of the assertion, and the audience is *us*. Getting
+    // these the wrong way round is the mistake that makes both checks
+    // decorative, so they are named rather than positional.
+    issuer: apiUrl,
+    ...(options.fetch ? { fetch: options.fetch } : {}),
+  });
+
+  return {
+    consentUrl: `${webUrl}/link/authorize`,
+    verify: (assertion, expected) => verifier.verify(assertion, expected),
+    profilesFor: options.profilesFor,
+  };
+}

--- a/src/auth/lanes/login.test.ts
+++ b/src/auth/lanes/login.test.ts
@@ -210,3 +210,67 @@ describe('an API that cannot sign anybody in', () => {
     );
   });
 });
+
+describe('the page the browser is left on', () => {
+  test('actually arrives, on a sign-in that worked', async () => {
+    // The regression this file exists to hold from here on. `awaitCallback` used
+    // to tear the listener down with `stop(true)`, which force-closes active
+    // connections — and the active connection is the one carrying this page.
+    // `resolve` runs inside the handler, before Bun has written the response, so
+    // the teardown raced the browser and won every time.
+    //
+    // What that looked like was a connection error on a sign-in that had already
+    // succeeded: the code was captured, the exchange happened, the session was
+    // written, and the person was looking at "This site can't be reached".
+    //
+    // Every other test here fires the callback with `void fetch(...).catch()`,
+    // which is what let this through. This one waits for the answer.
+    const { fetch: call, recorded } = harness();
+
+    let delivered: Response | null = null;
+    const open = async (raw: string): Promise<void> => {
+      const url = new URL(raw);
+      recorded.authorizeUrl = url;
+
+      const back = new URL(url.searchParams.get('redirect_uri')!);
+      back.searchParams.set('code', 'an-authorization-code');
+      back.searchParams.set('state', url.searchParams.get('state')!);
+
+      // Not awaited: `login` is not listening for the answer yet. Captured so
+      // the assertion below can wait for it.
+      void fetch(back).then((response) => void (delivered = response));
+    };
+
+    await login({ apiUrl: 'https://api.example.com', fetch: call, open, home: await home() });
+
+    // The listener is stopped by now, so this is asking whether the response
+    // escaped before it went.
+    await Bun.sleep(50);
+
+    expect(delivered).not.toBeNull();
+    expect(delivered!.status).toBe(200);
+    expect(await delivered!.text()).toContain('Signed in');
+  });
+
+  test('closes its connection, so the graceful stop cannot hang on keep-alive', async () => {
+    // What makes "respond, then stop" a sequence rather than a race. Without it
+    // the choice is a forced close, which is the bug above, or a stop that waits
+    // on a socket the browser is holding open.
+    const { fetch: call, recorded } = harness();
+
+    let delivered: Response | null = null;
+    const open = async (raw: string): Promise<void> => {
+      const url = new URL(raw);
+      recorded.authorizeUrl = url;
+      const back = new URL(url.searchParams.get('redirect_uri')!);
+      back.searchParams.set('code', 'an-authorization-code');
+      back.searchParams.set('state', url.searchParams.get('state')!);
+      void fetch(back).then((response) => void (delivered = response));
+    };
+
+    await login({ apiUrl: 'https://api.example.com', fetch: call, open, home: await home() });
+    await Bun.sleep(50);
+
+    expect(delivered!.headers.get('connection')).toBe('close');
+  });
+});

--- a/src/auth/lanes/login.test.ts
+++ b/src/auth/lanes/login.test.ts
@@ -1,0 +1,212 @@
+import { afterAll, describe, expect, test } from 'bun:test';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { login } from './login.ts';
+
+/**
+ * Signing in, without a browser or a network.
+ *
+ * Everything outside this process is injected — the fetch, the "open a browser"
+ * step, and *where the session is written* — so the flow is exercised as a
+ * sequence of values. The last of those is not fastidiousness: without it these
+ * tests sign the developer's own machine in as a fixture, which is how it was
+ * discovered.
+ *
+ * What is pinned is the part that is easy to get wrong and impossible to notice:
+ * PKCE is sent, `state` is checked, the *same* redirect URI goes to the
+ * exchange, and the token that gets stored is the Lanes one rather than
+ * Google's.
+ */
+
+const homes: string[] = [];
+
+/** A throwaway `$HOME`, so no test writes a session into the real one. */
+async function home(): Promise<string> {
+  const root = await mkdtemp(join(tmpdir(), 'lanes-login-'));
+  homes.push(root);
+  return root;
+}
+
+afterAll(async () => {
+  await Promise.all(homes.map((one) => rm(one, { recursive: true, force: true })));
+});
+
+const CONFIG = {
+  data: {
+    client_id: 'a-client-id.apps.googleusercontent.com',
+    firebase_api_key: 'a-web-api-key',
+    firebase_project_id: 'a-project',
+  },
+};
+
+interface Recorded {
+  authorizeUrl: URL;
+  exchange: Record<string, unknown>;
+  signIn: Record<string, unknown>;
+}
+
+/**
+ * What the code actually needs, rather than `typeof fetch`.
+ *
+ * Bun's `fetch` carries a `preconnect` property, so a plain function is not
+ * assignable to it — and a test double growing a method it never calls, to
+ * satisfy a type, is a double that has stopped standing for anything.
+ */
+type Call = (input: string | URL | Request, init?: RequestInit) => Promise<Response>;
+
+/**
+ * A fetch that plays every leg, and a browser that answers the callback.
+ *
+ * `open` is where the pretend user lives: it receives the authorize URL, reads
+ * the redirect and the state out of it, and calls back exactly as Google would.
+ */
+function harness(
+  overrides: { state?: string; idToken?: string } = {},
+): { fetch: Call; open: (url: string) => Promise<void>; recorded: Partial<Recorded> } {
+  const recorded: Partial<Recorded> = {};
+
+  const call: Call = async (input, init) => {
+    const url = String(input);
+
+    if (url.endsWith('/v1/auth/google/config')) {
+      return Response.json(CONFIG);
+    }
+
+    if (url.endsWith('/v1/auth/google/exchange')) {
+      recorded.exchange = JSON.parse(String(init?.body)) as Record<string, unknown>;
+      return Response.json({ data: { id_token: overrides.idToken ?? 'google-id-token' } });
+    }
+
+    if (url.includes('accounts:signInWithIdp')) {
+      recorded.signIn = JSON.parse(String(init?.body)) as Record<string, unknown>;
+      return Response.json({
+        localId: 'FIREBASEUID000000000000000000',
+        email: 'someone@example.com',
+        idToken: 'lanes-id-token',
+        refreshToken: 'lanes-refresh-token',
+        expiresIn: '3600',
+      });
+    }
+
+    throw new Error(`unexpected fetch: ${url}`);
+  };
+
+  const open = async (raw: string): Promise<void> => {
+    const url = new URL(raw);
+    recorded.authorizeUrl = url;
+
+    const redirect = new URL(url.searchParams.get('redirect_uri')!);
+    redirect.searchParams.set('code', 'an-authorization-code');
+    redirect.searchParams.set('state', overrides.state ?? url.searchParams.get('state')!);
+
+    // Fired without awaiting: the listener is only serving once `login` is
+    // waiting on it, and awaiting here would deadlock the two.
+    void fetch(redirect).catch(() => {});
+  };
+
+  return { fetch: call, open, recorded };
+}
+
+describe('the browser leg', () => {
+  test('asks for a code with PKCE, offline access, and a fresh consent screen', async () => {
+    const { fetch: call, open, recorded } = harness();
+    await login({ apiUrl: 'https://api.example.com', fetch: call, open, home: await home() });
+
+    const url = recorded.authorizeUrl!;
+    expect(url.origin + url.pathname).toBe('https://accounts.google.com/o/oauth2/v2/auth');
+    expect(url.searchParams.get('response_type')).toBe('code');
+    expect(url.searchParams.get('code_challenge_method')).toBe('S256');
+    expect(url.searchParams.get('code_challenge')).toBeTruthy();
+
+    // Both, or Google returns no refresh token on a second sign-in and the
+    // session quietly lasts an hour instead of indefinitely.
+    expect(url.searchParams.get('access_type')).toBe('offline');
+    expect(url.searchParams.get('prompt')).toBe('consent');
+  });
+
+  test('redirects to loopback on a port the kernel picked', async () => {
+    const { fetch: call, open, recorded } = harness();
+    await login({ apiUrl: 'https://api.example.com', fetch: call, open, home: await home() });
+
+    const redirect = new URL(recorded.authorizeUrl!.searchParams.get('redirect_uri')!);
+    expect(redirect.hostname).toBe('127.0.0.1');
+    expect(Number(redirect.port)).toBeGreaterThan(0);
+  });
+
+  test('refuses a callback whose state does not match', async () => {
+    // The only thing standing between this listener and a page on the machine
+    // feeding it somebody else's authorization code.
+    const { fetch: call, open } = harness({ state: 'not-the-state-we-sent' });
+
+    await expect(
+      login({ apiUrl: 'https://api.example.com', fetch: call, open, home: await home() }),
+    ).rejects.toThrow(/wrong state/);
+  });
+});
+
+describe('the exchange', () => {
+  test('sends the verifier and the same redirect the browser was given', async () => {
+    // Google checks the redirect matches, and a mismatch is a failure with a
+    // message about the client rather than about the URI — so this is pinned
+    // rather than left to be rediscovered.
+    const { fetch: call, open, recorded } = harness();
+    await login({ apiUrl: 'https://api.example.com', fetch: call, open, home: await home() });
+
+    const sent = recorded.exchange!;
+    expect(sent['code']).toBe('an-authorization-code');
+    expect(sent['code_verifier']).toBeTruthy();
+    expect(sent['redirect_uri']).toBe(
+      recorded.authorizeUrl!.searchParams.get('redirect_uri'),
+    );
+  });
+
+  test("hands Google's id token to Firebase, and stores the Lanes one", async () => {
+    // The distinction the whole file exists for: Google's token says who signed
+    // in to Google, and no part of Lanes accepts it. The subject a profile's
+    // members list names comes from the Firebase exchange.
+    const { fetch: call, open, recorded } = harness();
+    const session = await login({ apiUrl: 'https://api.example.com', fetch: call, open, home: await home() });
+
+    expect(String(recorded.signIn!['postBody'])).toContain('id_token=google-id-token');
+    expect(session.idToken).toBe('lanes-id-token');
+    expect(session.refreshToken).toBe('lanes-refresh-token');
+  });
+
+  test('prefixes the subject, so it can be written into a profile at all', async () => {
+    // `secret-detection.ts` refuses a bare Firebase uid as a high-entropy blob,
+    // and `subjectRef` requires the prefix. A session storing the raw id would
+    // produce a subject that `members:` cannot hold — see `profile/primitives.ts`.
+    const { fetch: call, open } = harness();
+    const session = await login({ apiUrl: 'https://api.example.com', fetch: call, open, home: await home() });
+
+    expect(session.subject).toBe('lanes:FIREBASEUID000000000000000000');
+  });
+
+  test('records which API issued it', async () => {
+    // A session is not portable between deployments: the subject means
+    // something only to the identity provider that minted it.
+    const { fetch: call, open } = harness();
+    const session = await login({ apiUrl: 'https://api.example.com', fetch: call, open, home: await home() });
+
+    expect(session.apiUrl).toBe('https://api.example.com');
+  });
+});
+
+describe('an API that cannot sign anybody in', () => {
+  test('says which setting is missing rather than failing at Google', async () => {
+    const call: Call = async () => Response.json({ data: { client_id: '' } });
+
+    await expect(login({ apiUrl: 'https://api.example.com', fetch: call })).rejects.toThrow(
+      /GOOGLE_OAUTH_CLIENT_ID or FIREBASE_API_KEY/,
+    );
+  });
+
+  test('names the override when the API is unreachable', async () => {
+    const call: Call = async () => new Response('nope', { status: 503 });
+
+    await expect(login({ apiUrl: 'https://api.example.com', fetch: call })).rejects.toThrow(
+      /LANES_API_URL/,
+    );
+  });
+});

--- a/src/auth/lanes/login.ts
+++ b/src/auth/lanes/login.ts
@@ -1,4 +1,5 @@
 import { createHash, randomBytes } from 'node:crypto';
+import { awaitCallback, plainPage, type LandingPage } from './callback.ts';
 import { isFresh, readSession, writeSession, type LanesSession } from './session.ts';
 
 /**
@@ -51,6 +52,18 @@ export interface LoginOptions {
    * of it has to either skip or damage something to run.
    */
   readonly home?: string | undefined;
+  /**
+   * How the page the browser lands on is rendered.
+   *
+   * Injected because this component may not reach the CLI's, and the layering is
+   * right rather than merely enforced: signing somebody in has no business
+   * knowing what a page looks like. `lanes auth login` passes the same branded
+   * card a provider connect flow ends on, so the two look like one product.
+   *
+   * The fallback below is deliberately plain and exists for tests and for any
+   * caller that has no opinion. It is not what a person sees.
+   */
+  readonly page?: ((outcome: LandingPage) => Response) | undefined;
 }
 
 interface BrokerConfig {
@@ -98,110 +111,6 @@ async function brokerConfig(
   return { clientId, firebaseApiKey, firebaseProjectId };
 }
 
-/**
- * Serve exactly one callback, then stop.
- *
- * Bound to `127.0.0.1` on a port the kernel picks, which is RFC 8252's loopback
- * redirect. Google matches loopback by host and ignores the port, so nothing
- * has to be registered per machine — the property `link_auth.py`'s
- * `_is_loopback_redirect` relies on at the other end.
- */
-async function awaitCallback(
-  state: string,
-  onListening: (redirectUri: string) => Promise<void>,
-): Promise<{ code: string; redirectUri: string }> {
-  const { promise, resolve, reject } = Promise.withResolvers<string>();
-
-  const server = Bun.serve({
-    hostname: '127.0.0.1',
-    port: 0,
-    fetch(request) {
-      const url = new URL(request.url);
-      // Anything else, including the favicon a browser asks for unprompted.
-      // It closes its connection too, so a stray request cannot keep the server
-      // alive past the redirect it is waiting for.
-      if (url.pathname !== '/callback') {
-        return closingPage('Not found.', 404);
-      }
-
-      const error = url.searchParams.get('error');
-      if (error) {
-        reject(new Error(`Google refused the sign-in: ${error}`));
-        return closingPage('That did not work. You can close this tab.');
-      }
-
-      // Checked before the code is read. `state` is the only thing standing
-      // between this listener and a page on the machine feeding it a code from
-      // somebody else's authorization.
-      if (url.searchParams.get('state') !== state) {
-        reject(new Error('The sign-in came back with the wrong state, so it was discarded.'));
-        return closingPage('That did not work. You can close this tab.');
-      }
-
-      const code = url.searchParams.get('code');
-      if (!code) {
-        reject(new Error('The sign-in came back without a code.'));
-        return closingPage('That did not work. You can close this tab.');
-      }
-
-      resolve(code);
-      return closingPage('Signed in. You can close this tab.');
-    },
-  });
-
-  const timeout = setTimeout(
-    () => reject(new Error('Timed out waiting for the browser. Nothing was changed.')),
-    300_000,
-  );
-
-  // The redirect URI is returned rather than stashed. Google checks that the
-  // exchange sends back the *same* one, and a module-level variable holding it
-  // would be shared by two logins running at once — which is not hypothetical
-  // on a machine where somebody re-runs a command that seemed to hang.
-  const redirectUri = `http://127.0.0.1:${server.port}/callback`;
-
-  try {
-    await onListening(redirectUri);
-    return { code: await promise, redirectUri };
-  } finally {
-    clearTimeout(timeout);
-
-    // Graceful, and this is the whole of the fix for a login that worked and
-    // looked like it had not. `stop(true)` closes active connections
-    // immediately, and the active connection is the one carrying the page the
-    // person is waiting to see: `resolve` runs inside the handler, before Bun
-    // has written the response, so forcing here raced the browser and won every
-    // time. What they got was a connection error on a sign-in that had already
-    // succeeded, which is the worst possible way for this to fail.
-    //
-    // Nothing can hold a graceful stop open, because every response closes its
-    // own connection — see `closingPage`. That is what makes this safe to await
-    // rather than force.
-    await server.stop();
-  }
-}
-
-/**
- * The page the browser lands on, and the last thing this listener does.
- *
- * `Connection: close` on every response, including the 404s. The listener is
- * torn down the moment the code arrives, and a keep-alive connection would
- * either hold the graceful stop open or be severed mid-response — the second is
- * what used to happen. Telling the browser not to reuse the socket makes
- * "respond, then stop" a sequence rather than a race.
- */
-function closingPage(message: string, status = 200): Response {
-  return new Response(
-    `<!doctype html><meta charset="utf-8"><title>Lanes</title>` +
-      `<body style="font:16px system-ui;display:grid;place-items:center;height:100vh;margin:0">` +
-      `<p>${message}</p></body>`,
-    {
-      status,
-      headers: { 'content-type': 'text/html; charset=utf-8', connection: 'close' },
-    },
-  );
-}
-
 export async function login(options: LoginOptions = {}): Promise<LanesSession> {
   const apiUrl = options.apiUrl ?? process.env['LANES_API_URL'] ?? DEFAULT_API_URL;
   const call = options.fetch ?? globalThis.fetch;
@@ -210,24 +119,28 @@ export async function login(options: LoginOptions = {}): Promise<LanesSession> {
   const { verifier, challenge } = pkce();
   const state = randomBytes(16).toString('base64url');
 
-  const { code, redirectUri } = await awaitCallback(state, async (redirectUri) => {
-    const url = new URL('https://accounts.google.com/o/oauth2/v2/auth');
-    url.searchParams.set('client_id', config.clientId);
-    url.searchParams.set('redirect_uri', redirectUri);
-    url.searchParams.set('response_type', 'code');
-    url.searchParams.set('scope', 'email profile openid');
-    url.searchParams.set('code_challenge', challenge);
-    url.searchParams.set('code_challenge_method', 'S256');
-    url.searchParams.set('state', state);
-    // Google issues a refresh token only when asked, and only on a consent
-    // screen it has actually shown. Without both, a second sign-in on the same
-    // machine returns no refresh token and the session lasts an hour.
-    url.searchParams.set('access_type', 'offline');
-    url.searchParams.set('prompt', 'consent');
+  const { code, redirectUri } = await awaitCallback(
+    state,
+    async (redirectUri) => {
+      const url = new URL('https://accounts.google.com/o/oauth2/v2/auth');
+      url.searchParams.set('client_id', config.clientId);
+      url.searchParams.set('redirect_uri', redirectUri);
+      url.searchParams.set('response_type', 'code');
+      url.searchParams.set('scope', 'email profile openid');
+      url.searchParams.set('code_challenge', challenge);
+      url.searchParams.set('code_challenge_method', 'S256');
+      url.searchParams.set('state', state);
+      // Google issues a refresh token only when asked, and only on a consent
+      // screen it has actually shown. Without both, a second sign-in on the same
+      // machine returns no refresh token and the session lasts an hour.
+      url.searchParams.set('access_type', 'offline');
+      url.searchParams.set('prompt', 'consent');
 
-    options.onUrl?.(url.toString());
-    await options.open?.(url.toString());
-  });
+      options.onUrl?.(url.toString());
+      await options.open?.(url.toString());
+    },
+    options.page ?? plainPage,
+  );
 
   const google = await exchangeWithBroker(apiUrl, call, {
     code,
@@ -377,3 +290,5 @@ export async function currentIdToken(
   await writeSession(refreshed, options.home);
   return refreshed.idToken;
 }
+
+export type { LandingPage };

--- a/src/auth/lanes/login.ts
+++ b/src/auth/lanes/login.ts
@@ -1,0 +1,350 @@
+import { createHash, randomBytes } from 'node:crypto';
+import { isFresh, readSession, writeSession, type LanesSession } from './session.ts';
+
+/**
+ * Signing in to Lanes, from a terminal.
+ *
+ * The same flow the desktop app runs, and deliberately not a second one: a
+ * loopback listener on a port the kernel picks, PKCE, Google's consent screen,
+ * and the exchange brokered by the Lanes API so no client holds the client
+ * secret. `core/src/auth/store.ts` is the reference implementation; this is it
+ * without a webview.
+ *
+ * **Nothing about the identity provider is hardcoded here.** The client id, the
+ * Firebase project and its web API key all come from `/v1/auth/google/config`.
+ * That is partly hygiene — this repository is public and a real Google Cloud
+ * project id must never be committed to it — and partly that a client which
+ * discovers its configuration cannot drift from the service that issues it.
+ *
+ * There are two tokens and they are not interchangeable. Google's `id_token`
+ * proves who signed in *to Google*; exchanging it at Firebase produces the Lanes
+ * session, whose `sub` is what a profile's `members:` names (ADR-060). Storing
+ * the first would be storing a token no part of Lanes accepts.
+ */
+
+/** Where the API is, unless told otherwise. */
+export const DEFAULT_API_URL = 'https://api.lanes.sh';
+
+/** The half of `fetch` this module uses. */
+export type FetchLike = (input: string | URL | Request, init?: RequestInit) => Promise<Response>;
+
+export interface LoginOptions {
+  readonly apiUrl?: string | undefined;
+  /**
+   * Injected for tests, and for nothing else.
+   *
+   * Typed as what is called rather than as `typeof fetch`: Bun's carries a
+   * `preconnect` property, and requiring a double to grow one is requiring it
+   * to stop standing for the thing it replaces.
+   */
+  readonly fetch?: FetchLike | undefined;
+  /** Opens the consent screen. Injected so a test never launches a browser. */
+  readonly open?: ((url: string) => Promise<void>) | undefined;
+  /** Called with the URL, so a headless run can be told where to go. */
+  readonly onUrl?: ((url: string) => void) | undefined;
+  /**
+   * Where the session is written. Injected for tests, and only for tests.
+   *
+   * It exists because the alternative was found the hard way: without it, the
+   * test suite signs the developer's own machine in as a fixture. A function
+   * that writes to `$HOME` and takes no way to say otherwise is one every test
+   * of it has to either skip or damage something to run.
+   */
+  readonly home?: string | undefined;
+}
+
+interface BrokerConfig {
+  readonly clientId: string;
+  readonly firebaseApiKey: string;
+  readonly firebaseProjectId: string;
+}
+
+/** RFC 7636 S256. The verifier never leaves this process until the exchange. */
+function pkce(): { verifier: string; challenge: string } {
+  const verifier = randomBytes(32).toString('base64url');
+  const challenge = createHash('sha256').update(verifier).digest('base64url');
+  return { verifier, challenge };
+}
+
+async function brokerConfig(
+  apiUrl: string,
+  call: FetchLike,
+): Promise<BrokerConfig> {
+  const response = await call(`${apiUrl}/v1/auth/google/config`);
+  if (!response.ok) {
+    throw new Error(
+      `${apiUrl} would not say how to sign in (${response.status}). ` +
+        'If this is a self-hosted API, set LANES_API_URL to reach it.',
+    );
+  }
+
+  const body = (await response.json()) as { data?: Record<string, unknown> };
+  const data = body.data ?? {};
+
+  const clientId = typeof data['client_id'] === 'string' ? data['client_id'] : '';
+  const firebaseApiKey =
+    typeof data['firebase_api_key'] === 'string' ? data['firebase_api_key'] : '';
+  const firebaseProjectId =
+    typeof data['firebase_project_id'] === 'string' ? data['firebase_project_id'] : '';
+
+  if (!clientId || !firebaseApiKey) {
+    throw new Error(
+      `${apiUrl} is not configured for sign-in. It answered without a client id or a ` +
+        'Firebase key, which means the deployment is missing GOOGLE_OAUTH_CLIENT_ID or ' +
+        'FIREBASE_API_KEY.',
+    );
+  }
+
+  return { clientId, firebaseApiKey, firebaseProjectId };
+}
+
+/**
+ * Serve exactly one callback, then stop.
+ *
+ * Bound to `127.0.0.1` on a port the kernel picks, which is RFC 8252's loopback
+ * redirect. Google matches loopback by host and ignores the port, so nothing
+ * has to be registered per machine — the property `link_auth.py`'s
+ * `_is_loopback_redirect` relies on at the other end.
+ */
+async function awaitCallback(
+  state: string,
+  onListening: (redirectUri: string) => Promise<void>,
+): Promise<{ code: string; redirectUri: string }> {
+  const { promise, resolve, reject } = Promise.withResolvers<string>();
+
+  const server = Bun.serve({
+    hostname: '127.0.0.1',
+    port: 0,
+    fetch(request) {
+      const url = new URL(request.url);
+      if (url.pathname !== '/callback') return new Response('Not found', { status: 404 });
+
+      const error = url.searchParams.get('error');
+      if (error) {
+        reject(new Error(`Google refused the sign-in: ${error}`));
+        return closingPage('That did not work. You can close this tab.');
+      }
+
+      // Checked before the code is read. `state` is the only thing standing
+      // between this listener and a page on the machine feeding it a code from
+      // somebody else's authorization.
+      if (url.searchParams.get('state') !== state) {
+        reject(new Error('The sign-in came back with the wrong state, so it was discarded.'));
+        return closingPage('That did not work. You can close this tab.');
+      }
+
+      const code = url.searchParams.get('code');
+      if (!code) {
+        reject(new Error('The sign-in came back without a code.'));
+        return closingPage('That did not work. You can close this tab.');
+      }
+
+      resolve(code);
+      return closingPage('Signed in. You can close this tab.');
+    },
+  });
+
+  const timeout = setTimeout(
+    () => reject(new Error('Timed out waiting for the browser. Nothing was changed.')),
+    300_000,
+  );
+
+  // The redirect URI is returned rather than stashed. Google checks that the
+  // exchange sends back the *same* one, and a module-level variable holding it
+  // would be shared by two logins running at once — which is not hypothetical
+  // on a machine where somebody re-runs a command that seemed to hang.
+  const redirectUri = `http://127.0.0.1:${server.port}/callback`;
+
+  try {
+    await onListening(redirectUri);
+    return { code: await promise, redirectUri };
+  } finally {
+    clearTimeout(timeout);
+    await server.stop(true);
+  }
+}
+
+function closingPage(message: string): Response {
+  return new Response(
+    `<!doctype html><meta charset="utf-8"><title>Lanes</title>` +
+      `<body style="font:16px system-ui;display:grid;place-items:center;height:100vh;margin:0">` +
+      `<p>${message}</p></body>`,
+    { headers: { 'content-type': 'text/html; charset=utf-8' } },
+  );
+}
+
+export async function login(options: LoginOptions = {}): Promise<LanesSession> {
+  const apiUrl = options.apiUrl ?? process.env['LANES_API_URL'] ?? DEFAULT_API_URL;
+  const call = options.fetch ?? globalThis.fetch;
+
+  const config = await brokerConfig(apiUrl, call);
+  const { verifier, challenge } = pkce();
+  const state = randomBytes(16).toString('base64url');
+
+  const { code, redirectUri } = await awaitCallback(state, async (redirectUri) => {
+    const url = new URL('https://accounts.google.com/o/oauth2/v2/auth');
+    url.searchParams.set('client_id', config.clientId);
+    url.searchParams.set('redirect_uri', redirectUri);
+    url.searchParams.set('response_type', 'code');
+    url.searchParams.set('scope', 'email profile openid');
+    url.searchParams.set('code_challenge', challenge);
+    url.searchParams.set('code_challenge_method', 'S256');
+    url.searchParams.set('state', state);
+    // Google issues a refresh token only when asked, and only on a consent
+    // screen it has actually shown. Without both, a second sign-in on the same
+    // machine returns no refresh token and the session lasts an hour.
+    url.searchParams.set('access_type', 'offline');
+    url.searchParams.set('prompt', 'consent');
+
+    options.onUrl?.(url.toString());
+    await options.open?.(url.toString());
+  });
+
+  const google = await exchangeWithBroker(apiUrl, call, {
+    code,
+    codeVerifier: verifier,
+    redirectUri,
+  });
+
+  const session = await firebaseSession(config, call, google.idToken, apiUrl);
+  await writeSession(session, options.home);
+  return session;
+}
+
+async function exchangeWithBroker(
+  apiUrl: string,
+  call: FetchLike,
+  input: { code: string; codeVerifier: string; redirectUri: string },
+): Promise<{ idToken: string }> {
+  const response = await call(`${apiUrl}/v1/auth/google/exchange`, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({
+      code: input.code,
+      code_verifier: input.codeVerifier,
+      redirect_uri: input.redirectUri,
+    }),
+  });
+
+  const body = (await response.json().catch(() => ({}))) as {
+    data?: { id_token?: unknown };
+    error?: unknown;
+  };
+
+  if (!response.ok || typeof body.data?.id_token !== 'string') {
+    throw new Error(
+      `The sign-in could not be completed: ${String(body.error ?? response.status)}`,
+    );
+  }
+
+  return { idToken: body.data.id_token };
+}
+
+/**
+ * Google's id token, exchanged for the Lanes one.
+ *
+ * Firebase's `signInWithIdp` over REST, because there is no browser here to run
+ * the web SDK in. The API key is a public identifier rather than a secret —
+ * it is in the web bundle — which is why it can be served to a CLI at all.
+ */
+async function firebaseSession(
+  config: BrokerConfig,
+  call: FetchLike,
+  googleIdToken: string,
+  apiUrl: string,
+): Promise<LanesSession> {
+  const response = await call(
+    `https://identitytoolkit.googleapis.com/v1/accounts:signInWithIdp?key=${config.firebaseApiKey}`,
+    {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        postBody: `id_token=${googleIdToken}&providerId=google.com`,
+        requestUri: 'http://127.0.0.1',
+        returnSecureToken: true,
+        returnIdpCredential: true,
+      }),
+    },
+  );
+
+  const body = (await response.json().catch(() => ({}))) as {
+    localId?: unknown;
+    email?: unknown;
+    idToken?: unknown;
+    refreshToken?: unknown;
+    expiresIn?: unknown;
+    error?: { message?: unknown };
+  };
+
+  if (
+    !response.ok ||
+    typeof body.localId !== 'string' ||
+    typeof body.idToken !== 'string' ||
+    typeof body.refreshToken !== 'string'
+  ) {
+    throw new Error(
+      `Lanes would not accept the Google sign-in: ${String(body.error?.message ?? response.status)}`,
+    );
+  }
+
+  const seconds = Number(body.expiresIn ?? 3600);
+
+  return {
+    // The prefix is what keeps a subject out of `secret-detection.ts`'s
+    // high-entropy rule and says which provider vouched for it — see
+    // `profile/primitives.ts`, where both halves are one decision.
+    subject: `lanes:${body.localId}`,
+    email: typeof body.email === 'string' ? body.email : null,
+    idToken: body.idToken,
+    refreshToken: body.refreshToken,
+    expiresAt: new Date(Date.now() + seconds * 1000).toISOString(),
+    apiUrl,
+  };
+}
+
+/**
+ * A token this machine can present, refreshing it if it has lapsed.
+ *
+ * The refresh is against Google's secure-token endpoint rather than the Lanes
+ * API, which is what the Firebase SDK does in the desktop app and web — the API
+ * verifies tokens and does not mint them.
+ */
+export async function currentIdToken(
+  options: { fetch?: FetchLike; apiUrl?: string } = {},
+): Promise<string | null> {
+  const session = await readSession();
+  if (session === null) return null;
+  if (isFresh(session)) return session.idToken;
+
+  const call = options.fetch ?? globalThis.fetch;
+  const config = await brokerConfig(session.apiUrl, call).catch(() => null);
+  if (config === null) return null;
+
+  const response = await call(
+    `https://securetoken.googleapis.com/v1/token?key=${config.firebaseApiKey}`,
+    {
+      method: 'POST',
+      headers: { 'content-type': 'application/x-www-form-urlencoded' },
+      body: `grant_type=refresh_token&refresh_token=${encodeURIComponent(session.refreshToken)}`,
+    },
+  );
+
+  const body = (await response.json().catch(() => ({}))) as {
+    id_token?: unknown;
+    refresh_token?: unknown;
+    expires_in?: unknown;
+  };
+
+  if (!response.ok || typeof body.id_token !== 'string') return null;
+
+  const refreshed: LanesSession = {
+    ...session,
+    idToken: body.id_token,
+    refreshToken:
+      typeof body.refresh_token === 'string' ? body.refresh_token : session.refreshToken,
+    expiresAt: new Date(Date.now() + Number(body.expires_in ?? 3600) * 1000).toISOString(),
+  };
+
+  await writeSession(refreshed);
+  return refreshed.idToken;
+}

--- a/src/auth/lanes/login.ts
+++ b/src/auth/lanes/login.ts
@@ -117,7 +117,12 @@ async function awaitCallback(
     port: 0,
     fetch(request) {
       const url = new URL(request.url);
-      if (url.pathname !== '/callback') return new Response('Not found', { status: 404 });
+      // Anything else, including the favicon a browser asks for unprompted.
+      // It closes its connection too, so a stray request cannot keep the server
+      // alive past the redirect it is waiting for.
+      if (url.pathname !== '/callback') {
+        return closingPage('Not found.', 404);
+      }
 
       const error = url.searchParams.get('error');
       if (error) {
@@ -160,16 +165,40 @@ async function awaitCallback(
     return { code: await promise, redirectUri };
   } finally {
     clearTimeout(timeout);
-    await server.stop(true);
+
+    // Graceful, and this is the whole of the fix for a login that worked and
+    // looked like it had not. `stop(true)` closes active connections
+    // immediately, and the active connection is the one carrying the page the
+    // person is waiting to see: `resolve` runs inside the handler, before Bun
+    // has written the response, so forcing here raced the browser and won every
+    // time. What they got was a connection error on a sign-in that had already
+    // succeeded, which is the worst possible way for this to fail.
+    //
+    // Nothing can hold a graceful stop open, because every response closes its
+    // own connection — see `closingPage`. That is what makes this safe to await
+    // rather than force.
+    await server.stop();
   }
 }
 
-function closingPage(message: string): Response {
+/**
+ * The page the browser lands on, and the last thing this listener does.
+ *
+ * `Connection: close` on every response, including the 404s. The listener is
+ * torn down the moment the code arrives, and a keep-alive connection would
+ * either hold the graceful stop open or be severed mid-response — the second is
+ * what used to happen. Telling the browser not to reuse the socket makes
+ * "respond, then stop" a sequence rather than a race.
+ */
+function closingPage(message: string, status = 200): Response {
   return new Response(
     `<!doctype html><meta charset="utf-8"><title>Lanes</title>` +
       `<body style="font:16px system-ui;display:grid;place-items:center;height:100vh;margin:0">` +
       `<p>${message}</p></body>`,
-    { headers: { 'content-type': 'text/html; charset=utf-8' } },
+    {
+      status,
+      headers: { 'content-type': 'text/html; charset=utf-8', connection: 'close' },
+    },
   );
 }
 

--- a/src/auth/lanes/login.ts
+++ b/src/auth/lanes/login.ts
@@ -310,9 +310,9 @@ async function firebaseSession(
  * verifies tokens and does not mint them.
  */
 export async function currentIdToken(
-  options: { fetch?: FetchLike; apiUrl?: string } = {},
+  options: { fetch?: FetchLike; apiUrl?: string; home?: string } = {},
 ): Promise<string | null> {
-  const session = await readSession();
+  const session = await readSession(options.home);
   if (session === null) return null;
   if (isFresh(session)) return session.idToken;
 
@@ -345,6 +345,6 @@ export async function currentIdToken(
     expiresAt: new Date(Date.now() + Number(body.expires_in ?? 3600) * 1000).toISOString(),
   };
 
-  await writeSession(refreshed);
+  await writeSession(refreshed, options.home);
   return refreshed.idToken;
 }

--- a/src/auth/lanes/members.test.ts
+++ b/src/auth/lanes/members.test.ts
@@ -1,0 +1,133 @@
+import { afterAll, describe, expect, test } from 'bun:test';
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { describeMember, workspaceMembers } from './members.ts';
+import { sessionPath } from './session.ts';
+
+/**
+ * Asking the Lanes workspace who it holds.
+ *
+ * The point of this file is that a profile's `members:` is a *selection from*
+ * that list rather than a second list beside it — so the two properties worth
+ * pinning are the mapping (a `user_uid` becomes the same `lanes:` subject that
+ * `lanes auth login` stores) and the failure behaviour (a workspace that cannot
+ * be reached says why, rather than reading as "holds nobody").
+ */
+
+const homes: string[] = [];
+
+/** A `$HOME` holding a session, so the fetch has a token to present. */
+async function signedIn(): Promise<string> {
+  const root = await mkdtemp(join(tmpdir(), 'lanes-members-'));
+  homes.push(root);
+  await mkdir(join(root, '.lanes'), { recursive: true });
+  await writeFile(
+    sessionPath(root),
+    JSON.stringify({
+      subject: 'lanes:AAAAAAAAAAAAAAAAAAAAAAAAAAAA',
+      email: 'owner@example.com',
+      refreshToken: 'a-refresh-token',
+      idToken: 'an-id-token',
+      expiresAt: new Date(Date.now() + 3_600_000).toISOString(),
+      apiUrl: 'https://api.example.com',
+    }),
+  );
+  return root;
+}
+
+afterAll(async () => {
+  await Promise.all(homes.map((one) => rm(one, { recursive: true, force: true })));
+});
+
+type Call = (input: string | URL | Request, init?: RequestInit) => Promise<Response>;
+
+describe('a workspace that is not bound', () => {
+  test('says so, rather than reporting an empty workspace', async () => {
+    // The distinction a caller has to make: `local` has no member list to ask,
+    // which is not the same as a Lanes workspace that holds nobody.
+    const result = await workspaceMembers(undefined);
+
+    expect(result.members).toEqual([]);
+    expect(result.unavailable).toContain('not bound');
+  });
+});
+
+describe('the mapping', () => {
+  test('a uid becomes the subject a profile can name', async () => {
+    // The one fact both halves depend on. `lanes auth login` derives the
+    // subject the same way, so a member added on the dashboard and a member
+    // signing in on this machine are the same string.
+    const call: Call = async () =>
+      Response.json({
+        data: [
+          { user_uid: 'BBBBBBBBBBBBBBBBBBBBBBBBBBBB', email: 'her@example.com', role: 'admin', status: 'active' },
+        ],
+      });
+
+    const result = await workspaceMembers('a-workspace', { fetch: call, home: await signedIn() });
+
+    expect(result.unavailable).toBeNull();
+    expect(result.members[0]?.subject).toBe('lanes:BBBBBBBBBBBBBBBBBBBBBBBBBBBB');
+    expect(result.members[0]?.role).toBe('admin');
+  });
+
+  test('an unaccepted invitation has no subject, and is marked rather than dropped', async () => {
+    // Listed, because the operator can see the person on the dashboard and
+    // would otherwise be told to invite somebody who is already invited. Not
+    // delegatable, because there is no subject yet to write into a profile.
+    const call: Call = async () =>
+      Response.json({ data: [{ email: 'pending@example.com', role: 'editor', status: 'pending' }] });
+
+    const result = await workspaceMembers('a-workspace', { fetch: call, home: await signedIn() });
+
+    expect(result.members[0]?.subject).toBeNull();
+    expect(result.members[0]?.status).toBe('pending');
+    expect(describeMember(result.members[0]!)).toBe('pending@example.com');
+  });
+
+  test('presents the token the API issued, not the workspace id', async () => {
+    let seen: string | undefined;
+    const call: Call = async (input, init) => {
+      seen = String((init?.headers as Record<string, string>)['authorization']);
+      expect(String(input)).toBe('https://api.example.com/v1/workspaces/a-workspace/members');
+      return Response.json({ data: [] });
+    };
+
+    await workspaceMembers('a-workspace', { fetch: call, home: await signedIn() });
+
+    expect(seen).toBe('Bearer an-id-token');
+  });
+});
+
+describe('when the answer cannot be had', () => {
+  test('not signed in reads as unavailable, not as empty', async () => {
+    const empty = await mkdtemp(join(tmpdir(), 'lanes-members-'));
+    homes.push(empty);
+
+    const result = await workspaceMembers('a-workspace', { home: empty });
+
+    expect(result.unavailable).toBe('not signed in');
+  });
+
+  test('a refusal names the status, so the reason reaches the operator', async () => {
+    const call: Call = async () => new Response('nope', { status: 403 });
+
+    const result = await workspaceMembers('a-workspace', { fetch: call, home: await signedIn() });
+
+    expect(result.unavailable).toContain('403');
+  });
+
+  test('an unreachable API is a reason rather than a throw', async () => {
+    // Deliberate: this is consulted while editing a local file, and a network
+    // failure there should warn rather than block. The endpoint verifies the
+    // subject when it mints a token regardless.
+    const call: Call = async () => {
+      throw new Error('getaddrinfo ENOTFOUND');
+    };
+
+    const result = await workspaceMembers('a-workspace', { fetch: call, home: await signedIn() });
+
+    expect(result.unavailable).toContain('unreachable');
+  });
+});

--- a/src/auth/lanes/members.ts
+++ b/src/auth/lanes/members.ts
@@ -1,0 +1,103 @@
+import { currentIdToken, type FetchLike } from './login.ts';
+import { readSession } from './session.ts';
+
+/**
+ * The people a Lanes workspace already holds.
+ *
+ * A profile's `members:` is a *selection from* this list, not a second list
+ * beside it. Membership of a workspace is managed on the dashboard — invited,
+ * accepted, given a role, removed — and reproducing any of that here would be a
+ * second place to say who somebody is, which is the failure this whole release
+ * is about on the connection axis.
+ *
+ * So the flow is: somebody is added to the workspace on the dashboard, and they
+ * appear here the moment they accept. Granting them a profile is then a local
+ * edit naming a subject the server already vouches for.
+ *
+ * **A pending invitation is not delegatable, and that is the useful part.** An
+ * invited person has an email and no `user_uid` until they accept, so there is
+ * no subject to write into a profile — and a `members:` entry naming a guess
+ * would look like a working delegation right up until they tried to use it.
+ * They are listed, marked pending, and refused.
+ */
+
+export interface WorkspaceMember {
+  /** `lanes:<uid>`, or null while the invitation is unaccepted. */
+  readonly subject: string | null;
+  readonly email: string | null;
+  readonly role: string;
+  readonly status: 'pending' | 'active';
+  readonly displayName: string | null;
+}
+
+export interface MembersResult {
+  readonly members: readonly WorkspaceMember[];
+  /** Why the list is empty, when it is, so a caller can say something useful. */
+  readonly unavailable: string | null;
+}
+
+/**
+ * Everyone in the Lanes workspace this one is bound to.
+ *
+ * Returns a reason rather than throwing when it cannot answer. Every caller is a
+ * listing or a validation that has something to say either way, and a network
+ * failure while editing a local file should not be fatal — the endpoint checks
+ * the subject at token time regardless.
+ */
+export async function workspaceMembers(
+  lanesWorkspace: string | undefined,
+  options: { fetch?: FetchLike; home?: string } = {},
+): Promise<MembersResult> {
+  if (lanesWorkspace === undefined) {
+    return {
+      members: [],
+      unavailable: 'this workspace is not bound to a Lanes workspace',
+    };
+  }
+
+  const session = await readSession(options.home);
+  if (session === null) return { members: [], unavailable: 'not signed in' };
+
+  const token = await currentIdToken({ ...(options.fetch ? { fetch: options.fetch } : {}), ...(options.home ? { home: options.home } : {}) });
+  if (token === null) return { members: [], unavailable: 'the session could not be refreshed' };
+
+  const call = options.fetch ?? globalThis.fetch;
+
+  const response = await call(`${session.apiUrl}/v1/workspaces/${lanesWorkspace}/members`, {
+    headers: { authorization: `Bearer ${token}` },
+  }).catch(() => null);
+
+  if (response === null) return { members: [], unavailable: `${session.apiUrl} is unreachable` };
+  if (!response.ok) {
+    return { members: [], unavailable: `${session.apiUrl} answered ${response.status}` };
+  }
+
+  const body = (await response.json().catch(() => ({}))) as {
+    data?: {
+      user_uid?: unknown;
+      email?: unknown;
+      role?: unknown;
+      status?: unknown;
+      display_name?: unknown;
+    }[];
+  };
+
+  return {
+    members: (body.data ?? []).map((row) => ({
+      // The subject a profile names is the uid with the prefix `subjectRef`
+      // requires — the same string `lanes auth login` stores, derived the same
+      // way so the two cannot disagree about who somebody is.
+      subject: typeof row.user_uid === 'string' ? `lanes:${row.user_uid}` : null,
+      email: typeof row.email === 'string' ? row.email : null,
+      role: typeof row.role === 'string' ? row.role : 'member',
+      status: row.status === 'active' ? 'active' : 'pending',
+      displayName: typeof row.display_name === 'string' ? row.display_name : null,
+    })),
+    unavailable: null,
+  };
+}
+
+/** How to show somebody whose subject is the only thing known about them. */
+export function describeMember(member: WorkspaceMember): string {
+  return member.displayName ?? member.email ?? member.subject ?? 'unknown';
+}

--- a/src/auth/lanes/session.test.ts
+++ b/src/auth/lanes/session.test.ts
@@ -1,0 +1,117 @@
+import { afterAll, describe, expect, test } from 'bun:test';
+import { mkdtemp, rm, stat, writeFile, mkdir } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import {
+  clearSession,
+  isFresh,
+  readSession,
+  sessionPath,
+  writeSession,
+  type LanesSession,
+} from './session.ts';
+
+/**
+ * The file holding this machine's Lanes session.
+ *
+ * Two properties, and both are about failing safely rather than about the happy
+ * path. It holds a refresh token, so its mode is part of its correctness; and it
+ * is read before every command that consumes a profile, so a damaged one has to
+ * read as "signed out" rather than throw a JSON error out of an unrelated
+ * command.
+ */
+
+const homes: string[] = [];
+
+async function home(): Promise<string> {
+  const root = await mkdtemp(join(tmpdir(), 'lanes-session-'));
+  homes.push(root);
+  return root;
+}
+
+afterAll(async () => {
+  await Promise.all(homes.map((one) => rm(one, { recursive: true, force: true })));
+});
+
+const SESSION: LanesSession = {
+  subject: 'lanes:3QBmAxJLLrYSMTVUIeCN1SKFbdD3',
+  email: 'someone@example.com',
+  refreshToken: 'a-refresh-token',
+  idToken: 'an-id-token',
+  expiresAt: new Date(Date.now() + 3_600_000).toISOString(),
+  apiUrl: 'https://api.example.com',
+};
+
+describe('the session file', () => {
+  test('round-trips what was written', async () => {
+    const root = await home();
+    await writeSession(SESSION, root);
+
+    expect(await readSession(root)).toEqual(SESSION);
+  });
+
+  test('is written 0600, because it holds a refresh token', async () => {
+    const root = await home();
+    await writeSession(SESSION, root);
+
+    const mode = (await stat(sessionPath(root))).mode & 0o777;
+    expect(mode).toBe(0o600);
+  });
+
+  test('reads as signed out when it is not there', async () => {
+    expect(await readSession(await home())).toBeNull();
+  });
+
+  test('reads as signed out when it is damaged, rather than throwing', async () => {
+    // The property that matters most. This is read before commands that have
+    // nothing to do with auth, and a JSON parse error surfacing out of
+    // `lanes link memory list` would send somebody to entirely the wrong place.
+    const root = await home();
+    await mkdir(join(root, '.lanes'), { recursive: true });
+    await writeFile(sessionPath(root), '{ not json');
+
+    expect(await readSession(root)).toBeNull();
+  });
+
+  test('reads as signed out when a field is missing', async () => {
+    // Shape-checked rather than cast. A file with a subject and no refresh
+    // token would otherwise present as signed in and fail on the first refresh,
+    // which is the same failure one step later and harder to read.
+    const root = await home();
+    await mkdir(join(root, '.lanes'), { recursive: true });
+    await writeFile(sessionPath(root), JSON.stringify({ subject: 'lanes:x' }));
+
+    expect(await readSession(root)).toBeNull();
+  });
+
+  test('signing out leaves a file that reads as signed out', async () => {
+    const root = await home();
+    await writeSession(SESSION, root);
+    await clearSession(root);
+
+    expect(await readSession(root)).toBeNull();
+  });
+});
+
+describe('whether a token is still worth presenting', () => {
+  test('a token an hour out is fresh', () => {
+    expect(isFresh(SESSION)).toBe(true);
+  });
+
+  test('one that has passed is not', () => {
+    const stale = { ...SESSION, expiresAt: new Date(Date.now() - 1000).toISOString() };
+    expect(isFresh(stale)).toBe(false);
+  });
+
+  test('one about to pass is not, because the request has to arrive too', () => {
+    // A minute of slack. Refreshing slightly early costs a round trip;
+    // refreshing slightly late costs a failed command, and the failure lands on
+    // whatever the operator was actually doing.
+    const soon = { ...SESSION, expiresAt: new Date(Date.now() + 30_000).toISOString() };
+    expect(isFresh(soon)).toBe(false);
+  });
+
+  test('an unparseable expiry is not fresh, which fails closed', () => {
+    expect(isFresh({ ...SESSION, expiresAt: 'whenever' })).toBe(false);
+  });
+});

--- a/src/auth/lanes/session.ts
+++ b/src/auth/lanes/session.ts
@@ -1,0 +1,97 @@
+import { chmod, mkdir, readFile, writeFile } from 'node:fs/promises';
+import { homedir } from 'node:os';
+import { dirname, join } from 'node:path';
+
+/**
+ * The Lanes identity this machine is signed in as.
+ *
+ * Its own store, beside the desktop app's `~/.lanes/auth.json` rather than
+ * inside it: that file holds a uid, an email and a photo URL and no credential,
+ * and merging a refresh token into it would change what an existing file means.
+ * Two files, one of which is `0600`, is the honest arrangement.
+ *
+ * **Not in the workspace.** A workspace is a set of accounts and profiles and
+ * may be a bucket; who is at the keyboard is neither. Putting this in
+ * `~/.lanes-link` would also mean a second workspace signs you out of the
+ * first, and would upload the session to a bucket on the next deploy.
+ */
+
+/** Where the session lives. Overridable for tests, and for nothing else. */
+export function sessionPath(home = homedir()): string {
+  return join(home, '.lanes', 'credentials.json');
+}
+
+export interface LanesSession {
+  /** The Firebase subject, which is what a profile's `members:` names. */
+  readonly subject: string;
+  readonly email: string | null;
+  /** Exchanged for a fresh id token; the long-lived half. */
+  readonly refreshToken: string;
+  /** The current id token, and when it stops being accepted. */
+  readonly idToken: string;
+  readonly expiresAt: string;
+  /** Which API issued it, so a session cannot be replayed against another. */
+  readonly apiUrl: string;
+}
+
+export async function readSession(home?: string): Promise<LanesSession | null> {
+  try {
+    const text = await readFile(sessionPath(home), 'utf8');
+    const parsed = JSON.parse(text) as Partial<LanesSession>;
+
+    // Shape-checked rather than trusted. This file is written by us and read on
+    // every command, so a half-written or hand-edited one should read as "not
+    // signed in" and send somebody to `lanes auth login` — not throw a JSON
+    // error out of a command that was about to list their memory.
+    if (
+      typeof parsed.subject !== 'string' ||
+      typeof parsed.refreshToken !== 'string' ||
+      typeof parsed.idToken !== 'string' ||
+      typeof parsed.expiresAt !== 'string' ||
+      typeof parsed.apiUrl !== 'string'
+    ) {
+      return null;
+    }
+
+    return {
+      subject: parsed.subject,
+      email: typeof parsed.email === 'string' ? parsed.email : null,
+      refreshToken: parsed.refreshToken,
+      idToken: parsed.idToken,
+      expiresAt: parsed.expiresAt,
+      apiUrl: parsed.apiUrl,
+    };
+  } catch {
+    return null;
+  }
+}
+
+export async function writeSession(session: LanesSession, home?: string): Promise<void> {
+  const path = sessionPath(home);
+  await mkdir(dirname(path), { recursive: true });
+
+  // `0600` before the content, and again after: the file holds a refresh token,
+  // and a token written world-readable for the instant between two syscalls is
+  // still a token that was world-readable.
+  await writeFile(path, `${JSON.stringify(session, null, 2)}\n`, { mode: 0o600 });
+  await chmod(path, 0o600);
+}
+
+export async function clearSession(home?: string): Promise<void> {
+  // Overwritten rather than deleted. An absent file and an empty one both read
+  // as signed out, and writing is the operation that cannot half-succeed on a
+  // store somebody else is reading.
+  await writeFile(sessionPath(home), '{}\n', { mode: 0o600 }).catch(() => {});
+}
+
+/**
+ * Whether the id token is still worth presenting.
+ *
+ * A minute of slack, because the thing being avoided is a request that leaves
+ * here valid and arrives expired. Refreshing slightly early costs one round
+ * trip; refreshing slightly late costs a failed command.
+ */
+export function isFresh(session: LanesSession, now = Date.now()): boolean {
+  const expires = Date.parse(session.expiresAt);
+  return Number.isFinite(expires) && expires - now > 60_000;
+}

--- a/src/auth/oauth/grant.ts
+++ b/src/auth/oauth/grant.ts
@@ -1,0 +1,173 @@
+import { grantableScope, MCP_SCOPE } from './metadata.ts';
+import { invalid, type OAuthResult } from './result.ts';
+import { randomToken, type OAuthStore } from './store.ts';
+
+/**
+ * Turning a code, or a refresh token, into an access token.
+ *
+ * Split from the browser leg because the two halves have nothing to say to each
+ * other: this one never sees a person, a redirect or a consent screen, and the
+ * other never mints a token. What passes between them is an `AuthorizationCode`
+ * row, which is the whole interface.
+ *
+ * Free functions over a context rather than methods, so the split is a real one
+ * — this file cannot reach the server's state except through what it is handed.
+ */
+
+const REFRESH_TTL_MS = 30 * 24 * 60 * 60 * 1000;
+
+/**
+ * How long a spent refresh token still answers.
+ *
+ * A client whose refresh succeeded but whose *response* was lost holds a token
+ * the server has already spent, and retrying with it is the only move it has.
+ * Without a window that retry is `invalid_grant`, and the reference MCP client
+ * rethrows every `OAuthError` but `server_error` rather than recovering — so
+ * the connector dies and its owner is sent to a browser, over a network blip.
+ *
+ * Thirty seconds is the band Auth0's reuse interval (0–60 s) and Okta's grace
+ * period occupy. What it costs: a captured refresh token keeps working for up
+ * to this long after the real client next rotates it.
+ */
+const REFRESH_REUSE_MS = 30_000;
+
+export interface GrantContext {
+  readonly store: OAuthStore;
+  readonly accessTokenTtlMs: number;
+  /** Where a replayed refresh token is recorded. */
+  readonly log?: { warn(message: string, detail?: Record<string, unknown>): void } | undefined;
+  readonly now: () => number;
+}
+
+export async function exchangeCode(
+  form: URLSearchParams,
+  context: GrantContext,
+): Promise<OAuthResult> {
+  const record = await context.store.takeCode(form.get('code') ?? '');
+  if (!record) return invalid('invalid_grant', 'That code is unknown, used, or expired.');
+
+  if (record.clientId !== form.get('client_id')) {
+    return invalid('invalid_grant', 'That code was issued to a different client.');
+  }
+  // Checked even though the code is already bound to it: a client that sends a
+  // different redirect_uri here than it started with is not the client that
+  // started, and the spec requires the comparison.
+  if (record.redirectUri !== form.get('redirect_uri')) {
+    return invalid('invalid_grant', 'redirect_uri does not match the authorization request.');
+  }
+
+  const verifier = form.get('code_verifier') ?? '';
+  if (!verifier || pkceChallengeFor(verifier) !== record.codeChallenge) {
+    return invalid('invalid_grant', 'code_verifier does not match the code_challenge.');
+  }
+
+  return issue(context, record.clientId, record.scope, randomToken('llr'), undefined, who(record));
+}
+
+export async function refresh(
+  form: URLSearchParams,
+  context: GrantContext,
+): Promise<OAuthResult> {
+  const presented = form.get('refresh_token') ?? '';
+  const record = await context.store.token(presented);
+
+  if (!record || record.kind === 'access') {
+    return invalid('invalid_grant', 'That refresh token is unknown or expired.');
+  }
+
+  // A spent token presented again used to take its whole family with it, on
+  // the reading that a replay is a theft. Against a real connector that was
+  // wrong twice over, and ADR-035 has the evidence. Two answers replace it,
+  // and the tombstone's age is what tells them apart.
+  if (record.kind === 'consumed') {
+    // Inside the window it is a retry of a request already answered, and the
+    // client is owed the answer rather than a dead connector. Not re-consumed:
+    // a client retrying twice is still retrying.
+    const spentAt = record.consumedAt;
+    if (spentAt !== undefined && context.now() - spentAt <= REFRESH_REUSE_MS) {
+      return issue(context, record.clientId, record.scope, randomToken('llr'), record.family, who(record));
+    }
+
+    // Outside it, refused on its own — and the family survives, which is the
+    // half that was taking live sessions down with it.
+    context.log?.warn('refresh token replayed', {
+      clientId: record.clientId,
+      family: record.family,
+    });
+    return invalid('invalid_grant', 'That refresh token has already been used.');
+  }
+
+  if (record.clientId !== form.get('client_id')) {
+    return invalid('invalid_grant', 'That refresh token was issued to a different client.');
+  }
+
+  await context.store.consumeToken(presented);
+  return issue(context, record.clientId, record.scope, randomToken('llr'), record.family, who(record));
+}
+
+/**
+ * Mint an access token and the refresh that replaces it.
+ *
+ * `holder` rides along unchanged through every rotation. A refresh is the same
+ * authorization continuing, so re-deciding who it belongs to would mean a
+ * client silently changing identity between two requests — and re-reading
+ * membership here would revoke a live session on a config edit, which is
+ * exactly what ADR-060 says rotation is for instead.
+ */
+async function issue(
+  context: GrantContext,
+  clientId: string,
+  scope: string,
+  refreshToken: string,
+  family = randomToken('llf'),
+  holder: Holder = {},
+): Promise<OAuthResult> {
+  const accessToken = randomToken('lla');
+  const expiresIn = Math.floor(context.accessTokenTtlMs / 1000);
+
+  await context.store.putToken(accessToken, {
+    clientId,
+    kind: 'access',
+    scope: grantableScope(scope) || MCP_SCOPE,
+    family,
+    ...holder,
+    expiresAt: context.now() + context.accessTokenTtlMs,
+  });
+  await context.store.putToken(refreshToken, {
+    clientId,
+    kind: 'refresh',
+    scope: grantableScope(scope) || MCP_SCOPE,
+    family,
+    ...holder,
+    expiresAt: context.now() + REFRESH_TTL_MS,
+  });
+
+  return {
+    kind: 'json',
+    status: 200,
+    body: {
+      access_token: accessToken,
+      token_type: 'Bearer',
+      expires_in: expiresIn,
+      refresh_token: refreshToken,
+      scope,
+    },
+  };
+}
+
+type Holder = { subject?: string | undefined; profiles?: readonly string[] | undefined };
+
+/** The identity half of a stored record, in the shape `issue` spreads. */
+function who(record: Holder): Holder {
+  return {
+    ...(record.subject !== undefined ? { subject: record.subject } : {}),
+    ...(record.profiles !== undefined ? { profiles: record.profiles } : {}),
+  };
+}
+
+/** `base64url(sha256(verifier))`, which is what S256 means. */
+export function pkceChallengeFor(verifier: string): string {
+  return Buffer.from(
+    new Bun.CryptoHasher('sha256').update(verifier, 'utf8').digest(),
+  ).toString('base64url');
+}

--- a/src/auth/oauth/grant.ts
+++ b/src/auth/oauth/grant.ts
@@ -80,6 +80,16 @@ export async function refresh(
   // wrong twice over, and ADR-035 has the evidence. Two answers replace it,
   // and the tombstone's age is what tells them apart.
   if (record.kind === 'consumed') {
+    // The client first, before the window is even considered. A spent token
+    // presented by a *different* client is not a retry however recent it is,
+    // and accepting one meant a captured refresh token needed only a single
+    // request inside the window to be turned into a fresh 30-day chain member
+    // carrying the original holder's subject and profiles. The retry this
+    // window exists for always comes from the client that spent it.
+    if (record.clientId !== form.get('client_id')) {
+      return invalid('invalid_grant', 'That refresh token was issued to a different client.');
+    }
+
     // Inside the window it is a retry of a request already answered, and the
     // client is owed the answer rather than a dead connector. Not re-consumed:
     // a client retrying twice is still retrying.

--- a/src/auth/oauth/result.ts
+++ b/src/auth/oauth/result.ts
@@ -1,0 +1,27 @@
+/**
+ * What an authorization step decided, before it is HTTP.
+ *
+ * Its own file because both halves of the flow produce one — the browser leg in
+ * `server.ts` and the grant in `grant.ts` — and a shared type that lives in
+ * either would make the other import it, which is a cycle rather than a
+ * dependency.
+ */
+export type OAuthResult =
+  | { readonly kind: 'json'; readonly status: number; readonly body: unknown }
+  | { readonly kind: 'redirect'; readonly location: string }
+  /**
+   * Show this to whoever is at the browser.
+   *
+   * The only page this server renders now. There was a second — the approval
+   * form that asked for the endpoint token — and its removal is the point of
+   * ADR-062: nothing on loopback asks for a credential any more, so there is
+   * nothing there worth phishing.
+   */
+  | { readonly kind: 'error'; readonly status: number; readonly message: string };
+
+export function invalid(error: string, description: string): OAuthResult {
+  // RFC 6749 codes exactly. A client refreshing on a 401 branches on
+  // `invalid_grant` specifically; anything else and it retries forever or gives
+  // up without re-authorising.
+  return { kind: 'json', status: 400, body: { error, error_description: description } };
+}

--- a/src/auth/oauth/server.ts
+++ b/src/auth/oauth/server.ts
@@ -1,5 +1,7 @@
+import { exchangeCode, pkceChallengeFor, refresh, type GrantContext } from './grant.ts';
 import { grantableScope, MCP_SCOPE } from './metadata.ts';
 import { isSafeRedirect, matchesRegistered } from './redirects.ts';
+import { invalid, type OAuthResult } from './result.ts';
 import {
   hashToken,
   randomToken,
@@ -19,63 +21,70 @@ import {
  * Deliberately small. This implements one grant and one refresh, for public
  * clients, with PKCE required. It is not a general authorization server and
  * should not grow into one: no client credentials grant, no implicit flow, no
- * consent scoping, no user directory. There is exactly one user here, and the
- * proof of being them is the endpoint token they already have.
+ * consent scoping, no user directory.
+ *
+ * **It does not authenticate anybody, and that is the change in 0.8.0.** It used
+ * to: `/authorize` rendered a form and the proof of being the owner was pasting
+ * the endpoint's own bearer token into it. Two things were wrong with that. A
+ * page on loopback asking for the one credential that opens everything is the
+ * most valuable thing a hostile local page could reach (ADR-039), and a
+ * credential is not a person — so a profile could not say *who* may consume it.
+ *
+ * Now the browser is sent to lanes.sh, which knows who is signed in, and comes
+ * back with a signed assertion this endpoint verifies against a published key
+ * (ADR-062). The endpoint learns a subject rather than a secret, and there is no
+ * form on loopback to phish.
  */
 
 /** Codes live about as long as a redirect takes. */
 const CODE_TTL_MS = 60_000;
-const REFRESH_TTL_MS = 30 * 24 * 60 * 60 * 1000;
+
+/** A person finding a password manager, not a redirect completing. */
+const PENDING_TTL_MS = 10 * 60_000;
 
 /**
- * How long a spent refresh token still answers.
+ * Where this endpoint sends people to be identified, and how it checks the answer.
  *
- * A client whose refresh succeeded but whose *response* was lost holds a token
- * the server has already spent, and retrying with it is the only move it has.
- * Without a window that retry is `invalid_grant`, and the reference MCP client
- * rethrows every `OAuthError` but `server_error` rather than recovering — so
- * the connector dies and its owner is sent to a browser, over a network blip.
- *
- * Thirty seconds is the band Auth0's reuse interval (0–60 s) and Okta's grace
- * period occupy. What it costs: a captured refresh token keeps working for up
- * to this long after the real client next rotates it.
+ * Every field is injected rather than built here, which is what keeps this file
+ * about the grant. It also means the whole federation can be replaced by a
+ * self-hoster's own — `mode: oidc` is the supported way to do that, and this is
+ * the same shape one layer down.
  */
-const REFRESH_REUSE_MS = 30_000;
+export interface Federation {
+  /** The page that knows who is signed in. `https://lanes.sh/link/authorize`. */
+  readonly consentUrl: string;
+  /**
+   * Believe an assertion, or do not.
+   *
+   * Returns the person, or null. Deliberately no reason: whoever is at the
+   * browser cannot act on "the audience was wrong", and an attacker can.
+   */
+  readonly verify: (
+    assertion: string,
+    expected: { audience: string; nonce: string },
+  ) => Promise<{ subject: string; email: string | null } | null>;
+  /**
+   * The profiles that subject may consume here.
+   *
+   * Empty is a real answer and the common one for a stranger: they signed in
+   * successfully, and no profile names them. It is refused with that reason,
+   * because "sign in again" would be advice that cannot work.
+   */
+  readonly profilesFor: (subject: string) => Promise<readonly string[]>;
+}
 
-export type OAuthResult =
-  | { readonly kind: 'json'; readonly status: number; readonly body: unknown }
-  | { readonly kind: 'redirect'; readonly location: string }
-  /** Render the approval page. The parameters are carried through it. */
-  | {
-      readonly kind: 'consent';
-      readonly request: AuthorizeRequest;
-      readonly retry: boolean;
-      /**
-       * What the client calls itself, if it said.
-       *
-       * Self-reported and therefore not evidence — registration is open, so
-       * anything may claim any name. It is shown because a name is what makes
-       * the screen legible, and shown *beside the redirect host*, which is the
-       * part that cannot be faked: an impostor calling itself Claude still has
-       * to send the code somewhere, and that somewhere is on the screen.
-       */
-      readonly clientName?: string | undefined;
-    }
-  | { readonly kind: 'error'; readonly status: number; readonly message: string };
-
-export interface AuthorizeRequest {
-  readonly clientId: string;
-  readonly redirectUri: string;
-  readonly codeChallenge: string;
-  readonly state: string | undefined;
-  readonly scope: string;
-  readonly resource: string | undefined;
+/** Who this endpoint is, from the point of view of the request being served. */
+export interface EndpointIdentity {
+  /** What an assertion must name as its audience — the MCP URL clients call. */
+  readonly resource: string;
+  /** Where lanes.sh sends the browser back to. */
+  readonly callbackUrl: string;
 }
 
 export interface OAuthServerOptions {
   readonly store: OAuthStore;
-  /** Proof of being the owner. The same token the endpoint already accepts. */
-  readonly verifyOwner: (presented: string) => Promise<boolean>;
+  /** Where the person is identified. See `Federation`. */
+  readonly federation: Federation;
   readonly accessTokenTtlMs: number;
   /** Where a replayed refresh token is recorded. Structural, because this layer
    * may not import `#connectivity`; the endpoint's own logger satisfies it. */
@@ -145,7 +154,7 @@ export class OAuthServer {
    * that failed validation is how an open redirector is built, so a bad
    * `client_id` or `redirect_uri` ends at this endpoint and goes no further.
    */
-  async authorize(params: URLSearchParams): Promise<OAuthResult> {
+  async authorize(params: URLSearchParams, endpoint: EndpointIdentity): Promise<OAuthResult> {
     if (params.get('response_type') !== 'code') {
       return { kind: 'error', status: 400, message: 'Only response_type=code is supported.' };
     }
@@ -173,193 +182,157 @@ export class OAuthServer {
       return { kind: 'error', status: 400, message: 'code_challenge is required.' };
     }
 
-    return {
-      kind: 'consent',
-      retry: false,
-      ...(client.clientName ? { clientName: client.clientName } : {}),
-      request: {
-        clientId,
-        redirectUri,
-        codeChallenge: challenge,
-        state: params.get('state') ?? undefined,
-        // The grantable part of what was asked for, not the request verbatim.
-        // Echoing it back through `#issue` was granting by echo, which was inert
-        // while `mcp` was the only scope and stops being inert now that there is
-        // a second one that means something.
-        scope: grantableScope(params.get('scope')) || MCP_SCOPE,
-        resource: params.get('resource') ?? undefined,
-      },
-    };
+    // Minted here and stored here. Everything the client asked for is kept
+    // server-side under this nonce, so nothing coming back through the browser
+    // is trusted — see `PendingAuthorization`.
+    const nonce = randomToken('lln');
+
+    await this.#options.store.putPending(nonce, {
+      clientId,
+      redirectUri,
+      codeChallenge: challenge,
+      ...(params.get('state') !== null ? { state: params.get('state')! } : {}),
+      // The grantable part of what was asked for, not the request verbatim.
+      // Echoing it back through `#issue` was granting by echo, which was inert
+      // while `mcp` was the only scope and stops being inert now that there is
+      // a second one that means something.
+      scope: grantableScope(params.get('scope')) || MCP_SCOPE,
+      ...(params.get('resource') !== null ? { resource: params.get('resource')! } : {}),
+      expiresAt: this.#now() + PENDING_TTL_MS,
+    });
+
+    const consent = new URL(this.#options.federation.consentUrl);
+    consent.searchParams.set('resource', endpoint.resource);
+    consent.searchParams.set('nonce', nonce);
+    consent.searchParams.set('return', endpoint.callbackUrl);
+    // Both shown to the person, and the second is the one that cannot be
+    // faked: a client may call itself anything, but the code still goes where
+    // its registration says, and that host is on the screen beside the name.
+    if (client.clientName) consent.searchParams.set('client', client.clientName);
+    consent.searchParams.set('redirect_host', hostOf(redirectUri));
+
+    return { kind: 'redirect', location: consent.toString() };
   }
 
   /**
-   * The owner approving, by presenting the endpoint token.
+   * The browser coming back from lanes.sh, carrying an assertion.
    *
-   * A wrong token re-renders the form rather than redirecting an error back to
-   * the client: the client has no business being told whether the owner typed
-   * their token correctly, and a redirect would end the flow on the first typo.
+   * This is where a person becomes a principal. Nothing in the query decides
+   * anything except *which* pending request this is: the client, the redirect
+   * URI and the PKCE challenge all come from the stored record, so a callback
+   * fabricated wholesale can at most spend a nonce it does not have.
+   *
+   * Errors are rendered rather than redirected, for the reason `authorize`
+   * gives: the redirect target is only trustworthy once the record it came
+   * from has been read, and by then the interesting failures have happened.
    */
-  async approve(request: AuthorizeRequest, presented: string): Promise<OAuthResult> {
-    const registered = await this.#options.store.client(request.clientId);
+  async callback(params: URLSearchParams, endpoint: EndpointIdentity): Promise<OAuthResult> {
+    const nonce = params.get('nonce') ?? '';
+    const assertion = params.get('assertion') ?? '';
 
-    if (!presented || !(await this.#options.verifyOwner(presented))) {
+    if (!nonce || !assertion) {
+      const refused = params.get('error');
       return {
-        kind: 'consent',
-        request,
-        retry: true,
-        ...(registered?.clientName ? { clientName: registered.clientName } : {}),
+        kind: 'error',
+        status: 400,
+        message: refused
+          ? `Sign-in was not completed: ${refused}. Nothing was authorised.`
+          : 'That sign-in came back without an assertion. Start again from your client.',
       };
     }
 
-    const client = registered;
-    if (!client || !matchesRegistered(request.redirectUri, client.redirectUris)) {
+    const pending = await this.#options.store.takePending(nonce);
+    if (!pending) {
+      return {
+        kind: 'error',
+        status: 400,
+        message: 'That sign-in has expired or was already used. Start again from your client.',
+      };
+    }
+
+    const person = await this.#options.federation.verify(assertion, {
+      audience: endpoint.resource,
+      nonce,
+    });
+    if (!person) {
+      return {
+        kind: 'error',
+        status: 403,
+        message: 'That sign-in could not be verified, so nothing was authorised.',
+      };
+    }
+
+    // Read once, at the moment the credential is minted. A profile that stops
+    // naming this person later does not reach back and revoke a live session —
+    // `lanes link token rotate` is what does that, and `profile members remove`
+    // says so (ADR-060).
+    const profiles = await this.#options.federation.profilesFor(person.subject);
+    if (profiles.length === 0) {
+      return {
+        kind: 'error',
+        status: 403,
+        message:
+          `You are signed in as ${person.email ?? person.subject}, and no profile on this ` +
+          'endpoint lists you as a member.\n\n' +
+          'Its owner can add you with:\n' +
+          `  lanes link profile members add ${person.subject} --profile <name>`,
+      };
+    }
+
+    // Re-checked against the registration, not taken on trust from the record.
+    // The record was written by this endpoint, so this is belt and braces — but
+    // a client deregistered mid-flow is a real sequence, and minting a code for
+    // a redirect nobody claims any more is not something to do quietly.
+    const client = await this.#options.store.client(pending.clientId);
+    if (!client || !matchesRegistered(pending.redirectUri, client.redirectUris)) {
       return { kind: 'error', status: 400, message: 'This approval no longer matches a client.' };
     }
 
     const code = randomToken('llx');
-    const record: AuthorizationCode = {
-      clientId: request.clientId,
-      redirectUri: request.redirectUri,
-      codeChallenge: request.codeChallenge,
-      // Narrowed here as well as in `authorize`, and this is the one that
-      // matters: the request arrives back through hidden form fields, so a
-      // caller can post any scope it likes straight to this endpoint. Nothing
-      // round-tripped through the form is trusted — the client and the redirect
-      // URI are re-checked above for the same reason.
-      scope: grantableScope(request.scope) || MCP_SCOPE,
-      ...(request.resource ? { resource: request.resource } : {}),
+    await this.#options.store.putCode(code, {
+      clientId: pending.clientId,
+      redirectUri: pending.redirectUri,
+      codeChallenge: pending.codeChallenge,
+      scope: grantableScope(pending.scope) || MCP_SCOPE,
+      ...(pending.resource ? { resource: pending.resource } : {}),
+      subject: person.subject,
+      profiles,
       expiresAt: this.#now() + CODE_TTL_MS,
-    };
-    await this.#options.store.putCode(code, record);
+    });
 
-    const location = new URL(request.redirectUri);
+    const location = new URL(pending.redirectUri);
     location.searchParams.set('code', code);
-    if (request.state !== undefined) location.searchParams.set('state', request.state);
+    if (pending.state !== undefined) location.searchParams.set('state', pending.state);
     return { kind: 'redirect', location: location.toString() };
   }
 
   /** Both grants. Form-encoded in, JSON out, RFC 6749 error codes throughout. */
   async token(form: URLSearchParams): Promise<OAuthResult> {
+    const context: GrantContext = {
+      store: this.#options.store,
+      accessTokenTtlMs: this.#options.accessTokenTtlMs,
+      ...(this.#options.log ? { log: this.#options.log } : {}),
+      now: this.#now,
+    };
+
     switch (form.get('grant_type')) {
       case 'authorization_code':
-        return this.#exchangeCode(form);
+        return exchangeCode(form, context);
       case 'refresh_token':
-        return this.#refresh(form);
+        return refresh(form, context);
       default:
         return invalid('unsupported_grant_type', 'Use authorization_code or refresh_token.');
     }
   }
+}
 
-  async #exchangeCode(form: URLSearchParams): Promise<OAuthResult> {
-    const record = await this.#options.store.takeCode(form.get('code') ?? '');
-    if (!record) return invalid('invalid_grant', 'That code is unknown, used, or expired.');
-
-    if (record.clientId !== form.get('client_id')) {
-      return invalid('invalid_grant', 'That code was issued to a different client.');
-    }
-    // Checked even though the code is already bound to it: a client that sends a
-    // different redirect_uri here than it started with is not the client that
-    // started, and the spec requires the comparison.
-    if (record.redirectUri !== form.get('redirect_uri')) {
-      return invalid('invalid_grant', 'redirect_uri does not match the authorization request.');
-    }
-
-    const verifier = form.get('code_verifier') ?? '';
-    if (!verifier || pkceChallengeFor(verifier) !== record.codeChallenge) {
-      return invalid('invalid_grant', 'code_verifier does not match the code_challenge.');
-    }
-
-    return this.#issue(record.clientId, record.scope, randomToken('llr'));
-  }
-
-  async #refresh(form: URLSearchParams): Promise<OAuthResult> {
-    const presented = form.get('refresh_token') ?? '';
-    const record = await this.#options.store.token(presented);
-
-    if (!record || record.kind === 'access') {
-      return invalid('invalid_grant', 'That refresh token is unknown or expired.');
-    }
-
-    // A spent token presented again used to take its whole family with it, on
-    // the reading that a replay is a theft. Against a real connector that was
-    // wrong twice over, and ADR-035 has the evidence. Two answers replace it,
-    // and the tombstone's age is what tells them apart.
-    if (record.kind === 'consumed') {
-      // Inside the window it is a retry of a request already answered, and the
-      // client is owed the answer rather than a dead connector. Not re-consumed:
-      // a client retrying twice is still retrying.
-      const spentAt = record.consumedAt;
-      if (spentAt !== undefined && this.#now() - spentAt <= REFRESH_REUSE_MS) {
-        return this.#issue(record.clientId, record.scope, randomToken('llr'), record.family);
-      }
-
-      // Outside it, refused on its own — and the family survives, which is the
-      // half that was taking live sessions down with it.
-      this.#options.log?.warn('refresh token replayed', {
-        clientId: record.clientId,
-        family: record.family,
-      });
-      return invalid('invalid_grant', 'That refresh token has already been used.');
-    }
-
-    if (record.clientId !== form.get('client_id')) {
-      return invalid('invalid_grant', 'That refresh token was issued to a different client.');
-    }
-
-    await this.#options.store.consumeToken(presented);
-    return this.#issue(record.clientId, record.scope, randomToken('llr'), record.family);
-  }
-
-  async #issue(
-    clientId: string,
-    scope: string,
-    refreshToken: string,
-    family = randomToken('llf'),
-  ): Promise<OAuthResult> {
-    const accessToken = randomToken('lla');
-    const expiresIn = Math.floor(this.#options.accessTokenTtlMs / 1000);
-
-    await this.#options.store.putToken(accessToken, {
-      clientId,
-      kind: 'access',
-      scope,
-      family,
-      expiresAt: this.#now() + this.#options.accessTokenTtlMs,
-    });
-    await this.#options.store.putToken(refreshToken, {
-      clientId,
-      kind: 'refresh',
-      scope,
-      family,
-      expiresAt: this.#now() + REFRESH_TTL_MS,
-    });
-
-    return {
-      kind: 'json',
-      status: 200,
-      body: {
-        access_token: accessToken,
-        token_type: 'Bearer',
-        expires_in: expiresIn,
-        refresh_token: refreshToken,
-        scope,
-      },
-    };
+function hostOf(uri: string): string {
+  try {
+    return new URL(uri).host;
+  } catch {
+    return uri;
   }
 }
 
-/** `base64url(sha256(verifier))`, which is what S256 means. */
-export function pkceChallengeFor(verifier: string): string {
-  return Buffer.from(
-    new Bun.CryptoHasher('sha256').update(verifier, 'utf8').digest(),
-  ).toString('base64url');
-}
-
-function invalid(error: string, description: string): OAuthResult {
-  // RFC 6749 codes exactly. A client refreshing on a 401 branches on
-  // `invalid_grant` specifically; anything else and it retries forever or gives
-  // up without re-authorising.
-  return { kind: 'json', status: 400, body: { error, error_description: description } };
-}
-
-export { hashToken };
+export { hashToken, pkceChallengeFor };
+export type { OAuthResult };

--- a/src/auth/oauth/store.ts
+++ b/src/auth/oauth/store.ts
@@ -23,6 +23,7 @@ import type { KeyValueStore } from '#stores/state';
 const CLIENTS = 'oauth/clients';
 const CODES = 'oauth/codes';
 const TOKENS = 'oauth/tokens';
+const PENDING = 'oauth/pending';
 
 /** Far above any real number of connectors, and far below a problem. */
 const MAX_CLIENTS = 200;
@@ -40,6 +41,41 @@ export interface AuthorizationCode {
   /** The S256 challenge. The verifier never leaves the client. */
   readonly codeChallenge: string;
   readonly scope: string;
+  readonly resource?: string | undefined;
+  readonly expiresAt: number;
+  /**
+   * Who authorised this, and what they may reach.
+   *
+   * Absent on a code minted before delegation existed, which reads as the
+   * owner — the one caller every endpoint had. Present, it is a `lanes:`
+   * subject and the profiles whose `members:` named it *at the moment the flow
+   * completed*. Resolved once, here, rather than on every request: membership
+   * is a decision about issuing a credential, and re-reading it per call would
+   * make a profile edit silently revoke a live session (ADR-060).
+   */
+  readonly subject?: string | undefined;
+  readonly profiles?: readonly string[] | undefined;
+}
+
+/**
+ * An authorization request waiting for the person to come back.
+ *
+ * The flow leaves this endpoint entirely — the browser goes to lanes.sh, signs
+ * in, and returns with an assertion — so what the client asked for has to
+ * survive the round trip somewhere. It is held here rather than in the redirect
+ * because everything in a redirect is attacker-supplied on the way back: the
+ * client id, the redirect URI and the PKCE challenge are read from this record
+ * and never from the callback's query string.
+ *
+ * Keyed by a nonce this endpoint minted, single-use, which is also what binds
+ * the returning assertion to *this* request.
+ */
+export interface PendingAuthorization {
+  readonly clientId: string;
+  readonly redirectUri: string;
+  readonly codeChallenge: string;
+  readonly scope: string;
+  readonly state?: string | undefined;
   readonly resource?: string | undefined;
   readonly expiresAt: number;
 }
@@ -64,6 +100,9 @@ export interface IssuedToken {
   readonly kind: TokenKind;
   readonly scope: string;
   readonly expiresAt: number;
+  /** Carried from the code, and from one refresh to the next. See `AuthorizationCode`. */
+  readonly subject?: string | undefined;
+  readonly profiles?: readonly string[] | undefined;
   /**
    * Which refresh chain this belongs to.
    *
@@ -145,6 +184,32 @@ export class OAuthStore {
 
   async client(clientId: string): Promise<RegisteredClient | null> {
     return this.#read<RegisteredClient>(CLIENTS, clientId);
+  }
+
+  /**
+   * Remember an authorization request while its owner is away signing in.
+   *
+   * Ten minutes, which is a person finding a password manager rather than a
+   * redirect completing. Long enough that a real sign-in is not raced, short
+   * enough that an abandoned flow does not leave a usable slot.
+   */
+  async putPending(nonce: string, record: PendingAuthorization): Promise<void> {
+    await this.#state.set(PENDING, hashToken(nonce), JSON.stringify(record));
+  }
+
+  /**
+   * Read a pending request and consume it in the same step.
+   *
+   * Single-use for the same reason a code is: the nonce travels through a
+   * browser redirect, so it reaches history, referrers and anything watching
+   * the address bar. Consuming it here is what stops one assertion being
+   * presented twice.
+   */
+  async takePending(nonce: string): Promise<PendingAuthorization | null> {
+    const key = hashToken(nonce);
+    const record = await this.#read<PendingAuthorization>(PENDING, key);
+    await this.#state.delete(PENDING, key);
+    return record && record.expiresAt > this.#now() ? record : null;
   }
 
   async putCode(code: string, record: AuthorizationCode): Promise<void> {

--- a/src/auth/remote.test.ts
+++ b/src/auth/remote.test.ts
@@ -1,0 +1,135 @@
+import { describe, expect, test } from 'bun:test';
+import { IssuedTokenAuthenticator } from './remote.ts';
+import { OAuthStore } from './oauth/store.ts';
+import type { KeyValueStore } from '#stores/state';
+
+/**
+ * A key-value store in a Map.
+ *
+ * The real one is built over a blob store, and standing one of those up here
+ * would make this a test of the storage adapter. What is under test is the four
+ * lines that turn a row into a principal.
+ */
+function memoryStore(): KeyValueStore {
+  const rows = new Map<string, string>();
+  const at = (namespace: string, key: string): string => `${namespace}\u0000${key}`;
+
+  return {
+    get: async (namespace, key) => rows.get(at(namespace, key)) ?? null,
+    set: async (namespace, key, value) => void rows.set(at(namespace, key), value),
+    delete: async (namespace, key) => void rows.delete(at(namespace, key)),
+    keys: async (namespace) =>
+      [...rows.keys()]
+        .filter((row) => row.startsWith(`${namespace}\u0000`))
+        .map((row) => row.slice(namespace.length + 1)),
+    clearNamespace: async (namespace) => {
+      for (const row of [...rows.keys()]) {
+        if (row.startsWith(`${namespace}\u0000`)) rows.delete(row);
+      }
+    },
+  };
+}
+
+/**
+ * What a token this endpoint issued turns into.
+ *
+ * The crux of delegation, and the one step where a stored row becomes a
+ * principal the dispatcher will act on. Three cases, and the middle one is the
+ * whole release: a token that names a person reaches the profiles that named
+ * them back, and nothing else.
+ */
+
+function authenticator(): { store: OAuthStore; auth: IssuedTokenAuthenticator } {
+  const store = new OAuthStore(memoryStore());
+  return { store, auth: new IssuedTokenAuthenticator(store, 'personal') };
+}
+
+const HOUR = Date.now() + 3_600_000;
+
+describe('a token that names nobody', () => {
+  test('is the owner, so one minted before this release keeps working', async () => {
+    // Not a fallback to be tidied away. Every token issued by 0.7 has no
+    // subject, and reading that as "no profiles" would log every connector out
+    // on upgrade.
+    const { store, auth } = authenticator();
+    await store.putToken('lla_old', {
+      clientId: 'llc_x',
+      kind: 'access',
+      scope: 'mcp',
+      family: 'llf_x',
+      expiresAt: HOUR,
+    });
+
+    const outcome = await auth.authenticate('Bearer lla_old');
+
+    expect(outcome.ok).toBe(true);
+    expect(outcome.ok && outcome.principal.kind).toBe('owner');
+    expect(outcome.ok && outcome.principal.profiles).toBeUndefined();
+  });
+});
+
+describe('a token that names a person', () => {
+  test('carries the profiles resolved when it was minted', async () => {
+    const { store, auth } = authenticator();
+    await store.putToken('lla_hers', {
+      clientId: 'llc_x',
+      kind: 'access',
+      scope: 'mcp',
+      family: 'llf_x',
+      subject: 'lanes:HER',
+      profiles: ['personal', 'shared'],
+      expiresAt: HOUR,
+    });
+
+    const outcome = await auth.authenticate('Bearer lla_hers');
+
+    expect(outcome.ok && outcome.principal.kind).toBe('member');
+    expect(outcome.ok && outcome.principal.id).toBe('lanes:HER');
+    expect(outcome.ok && outcome.principal.profiles).toEqual(['personal', 'shared']);
+  });
+
+  test('a subject with no profiles reaches nothing, rather than everything', async () => {
+    // The direction this has to fail in. `profiles: undefined` means "the whole
+    // workspace" — so a row that lost its list must not read as one that never
+    // had one.
+    const { store, auth } = authenticator();
+    await store.putToken('lla_nobody', {
+      clientId: 'llc_x',
+      kind: 'access',
+      scope: 'mcp',
+      family: 'llf_x',
+      subject: 'lanes:NOBODY',
+      profiles: [],
+      expiresAt: HOUR,
+    });
+
+    const outcome = await auth.authenticate('Bearer lla_nobody');
+
+    expect(outcome.ok && outcome.principal.profiles).toEqual([]);
+  });
+});
+
+describe('a credential that is not an access token', () => {
+  test('a refresh token does not open the resource', async () => {
+    // They are indistinguishable as strings, so the `kind` check is the only
+    // thing separating a credential for the token endpoint from one for this.
+    const { store, auth } = authenticator();
+    await store.putToken('llr_refresh', {
+      clientId: 'llc_x',
+      kind: 'refresh',
+      scope: 'mcp',
+      family: 'llf_x',
+      subject: 'lanes:HER',
+      profiles: ['personal'],
+      expiresAt: HOUR,
+    });
+
+    expect(await auth.authenticate('Bearer llr_refresh')).toEqual({ ok: false, reason: 'invalid' });
+  });
+
+  test('nothing at all is missing, not invalid, so the chain can rank it', async () => {
+    const { auth } = authenticator();
+
+    expect(await auth.authenticate(null)).toEqual({ ok: false, reason: 'missing' });
+  });
+});

--- a/src/auth/remote.ts
+++ b/src/auth/remote.ts
@@ -1,17 +1,31 @@
-import { ownerPrincipal, parseBearer, type AuthOutcome, type Authenticator } from './index.ts';
+import {
+  memberPrincipal,
+  ownerPrincipal,
+  parseBearer,
+  type AuthOutcome,
+  type Authenticator,
+} from './index.ts';
 import type { OAuthStore } from './oauth/store.ts';
 import type { OidcVerifier } from './oidc.ts';
 
 /**
  * The two ways a remote client's token becomes a principal.
  *
- * Both resolve to the **owner** principal, and that is a deliberate limit rather
- * than an omission. There is one person behind this endpoint; what a caller may
- * do is decided by the profile's policy per capability per call, not by which
- * credential opened the door. Delegated principals are additive later — the
- * dispatch path already takes a principal rather than assuming the owner — and
- * inventing a second kind now would mean inventing the policy axis to go with
- * it before anything needed one.
+ * A token this endpoint issued now carries *who completed the flow* and which
+ * profiles named them, so it resolves to a member principal (ADR-060). Both were
+ * the owner until 0.8.0, on the reading that there is one person behind an
+ * endpoint — which stopped being true the moment a profile could declare
+ * somebody else may consume it.
+ *
+ * **A token without a subject is still the owner**, and that is not a fallback
+ * to be tidied away: it is what a token minted before this release is, and
+ * every one of them keeps working until it expires rather than logging its
+ * holder out on upgrade.
+ *
+ * `OidcAuthenticator` still resolves to the owner, deliberately. A self-hoster
+ * pointing at their own issuer has an allowlist of subjects and no `members:`
+ * to map them onto — the delegation model is the Lanes one, and pretending
+ * otherwise would mean inventing a mapping nobody configured.
  *
  * Neither of these ever reports `missing` for a credential it simply does not
  * recognise. That is what the chain's ranking is for: a token this link cannot
@@ -39,7 +53,16 @@ export class IssuedTokenAuthenticator implements Authenticator {
     // check is the only thing separating them.
     if (!record || record.kind !== 'access') return { ok: false, reason: 'invalid' };
 
-    return { ok: true, principal: ownerPrincipal(this.#profile) };
+    if (record.subject === undefined) return { ok: true, principal: ownerPrincipal(this.#profile) };
+
+    // The list resolved when the code was minted, not now. Re-reading it here
+    // would mean a profile edit silently ending a live session, which ADR-060
+    // deliberately does not do — `lanes link token rotate` is the way to close
+    // that window, and `profile members remove` says so out loud.
+    return {
+      ok: true,
+      principal: memberPrincipal(record.subject, this.#profile, record.profiles ?? []),
+    };
   }
 }
 

--- a/src/cli/accepts.ts
+++ b/src/cli/accepts.ts
@@ -65,6 +65,7 @@ export const ACCEPTS: Record<string, readonly string[]> = {
   'target list': ['urls', 'workspace'],
   'workspace show': ['workspace'],
   'target show': ['workspace'],
+  'mcp install-instructions': ['client'],
   pair: ['print', 'rotate', 'yes'],
   'token show': ['show', 'raw'],
   'token rotate': ['show', 'raw', 'yes'],

--- a/src/cli/accepts.ts
+++ b/src/cli/accepts.ts
@@ -1,0 +1,106 @@
+import { CONNECT_CUSTOM_FLAGS } from './commands/connect/custom/spec.ts';
+
+/**
+ * The flags each command reads, beyond the universal set and its own selection.
+ *
+ * Split from `selection.ts` so that file stays inside the size budget, and on
+ * the seam it already had: that file answers *what a command must be told*, and
+ * this answers *what it will listen to*. Both are read by `assertKnownFlags`,
+ * and a flag missing from here is refused rather than ignored — which is the
+ * defect the whole arrangement exists to prevent.
+ */
+
+/**
+ * What each command accepts beyond the universal set and its own selection.
+ *
+ * Only commands with flags of their own appear. Anything absent accepts the
+ * universal set plus whatever `SELECTION` says it must be told.
+ */
+export const ACCEPTS: Record<string, readonly string[]> = {
+  // Imported rather than written out. Thirty-odd entries here would take this
+  // file past the size budget for a data literal, and the command's own
+  // `spec.ts` already derives most of them from the per-kind field tables — so
+  // a flag added there cannot be forgotten here.
+  'connect custom': CONNECT_CUSTOM_FLAGS,
+  // `own-client` is the older spelling of one of the routes `auth` names, kept
+  // because it is in scripts and a year of documentation (ADR-038).
+  connect: [
+    'id',
+    'display-name',
+    // Repeatable: `--set host=cloud.example.com`. The only way to give a
+    // provider its address without a terminal to ask at.
+    'set',
+    'label',
+    'replace',
+    'non-interactive',
+    'accept-broad-scopes',
+    'own-client',
+    'auth',
+  ],
+  setup: ['id'],
+  'profile add': ['workspace', 'non-interactive'],
+  // `--target` decommissions one target's stores and leaves the profile file in
+  // place (`removal.ts`). It is documented in `usage.ts` and read by
+  // `removalPlan`, and was refused here — the flag existed everywhere except in
+  // the list that decides whether it may be typed.
+  'profile remove': ['dry-run', 'yes', 'workspace'],
+  'profile members': ['me', 'role'],
+  disconnect: ['yes', 'keep-credential'],
+  // The one repair `doctor` can apply rather than only name. Narrow on purpose:
+  // it undoes a provider rename this project shipped, and every other finding
+  // there is something only the operator can decide.
+  doctor: ['fix'],
+  // A filter, not a second subject: it narrows the answer to one connection so
+  // a caller can re-ask about the row it just repaired. Same shape as `attach`.
+  auth: ['connection'],
+  relabel: [],
+  // A rule lands in a grant row, and a row names one connection (ADR-058), so
+  // the flag is required rather than optional. It is listed here as well as
+  // enforced in the command because `assertKnownFlags` refuses anything absent
+  // from this table — the flag existing everywhere except the allowlist is the
+  // exact defect this file was written for.
+  'policy allow': ['connection'],
+  'policy deny': ['connection'],
+  'workspace list': ['urls', 'workspace'],
+  'target list': ['urls', 'workspace'],
+  'workspace show': ['workspace'],
+  'target show': ['workspace'],
+  'token show': ['show', 'raw'],
+  'token rotate': ['show', 'raw', 'yes'],
+  'audit tail': ['limit', 'denied-only', 'format'],
+  'audit verify': ['limit', 'format'],
+  attach: ['connection'],
+  outputs: ['show'],
+  start: ['port', 'only'],
+  'mcp stdio': ['only'],
+  'mcp add': ['name', 'scope', 'token-env', 'dry-run', 'force', 'no-skill'],
+  'mcp skill': ['print', 'force'],
+  'mcp list': ['name', 'scope'],
+  // `--yes` because it installs the app when nothing answers the scheme, and
+  // that is the one prompt in this CLI that puts an application on the machine.
+  dashboard: ['print', 'yes'],
+  desktop: ['print', 'yes'],
+  skill: ['print', 'force'],
+  deploy: ['dry-run', 'iam', 'access', 'service-account', 'tag', 'yes', 'non-interactive'],
+  'secrets push': ['from', 'to', 'overwrite', 'dry-run'],
+  sync: ['dry-run', 'from', 'discover', 'prefer'],
+  'sync targets': ['dry-run', 'from', 'discover', 'prefer'],
+  'sync workspaces': ['dry-run', 'from', 'discover', 'prefer'],
+  update: ['check'],
+  'identity add': ['note'],
+  memory: ['connection', 'title', 'description', 'file', 'tag'],
+  // `--yes` on both, because both have a delete that asks first.
+  tasks: ['connection', 'title', 'status', 'due', 'tag', 'yes'],
+  assets: ['connection', 'name', 'content-type', 'yes'],
+  skills: ['connection', 'title', 'description', 'file'],
+  vault: ['connection'],
+  // `alias`, `attr` and `related` are repeatable — see `ownerFlags`. `name`
+  // overrides the id derived from the positional name, which is how you get
+  // `acme-bv` rather than `acme-b-v`.
+  entities: ['connection', 'type', 'name', 'alias', 'attr', 'related', 'tag', 'yes'],
+  // `no-migrate` is listed beside `migrate` because they are three states
+  // rather than two: neither one asks, and a run with no terminal has to be
+  // able to say which it meant (ADR-041).
+  knowledge: ['repo', 'branch', 'path', 'migrate', 'no-migrate', 'keep', 'allow-public', 'replace', 'yes'],
+};
+

--- a/src/cli/accepts.ts
+++ b/src/cli/accepts.ts
@@ -73,7 +73,7 @@ export const ACCEPTS: Record<string, readonly string[]> = {
   outputs: ['show'],
   start: ['port', 'only'],
   'mcp stdio': ['only'],
-  'mcp add': ['name', 'scope', 'token-env', 'dry-run', 'force', 'no-skill'],
+  'mcp add': ['name', 'scope', 'token-env', 'dry-run', 'force', 'no-skill', 'headless'],
   'mcp skill': ['print', 'force'],
   'mcp list': ['name', 'scope'],
   // `--yes` because it installs the app when nothing answers the scheme, and

--- a/src/cli/accepts.ts
+++ b/src/cli/accepts.ts
@@ -65,6 +65,7 @@ export const ACCEPTS: Record<string, readonly string[]> = {
   'target list': ['urls', 'workspace'],
   'workspace show': ['workspace'],
   'target show': ['workspace'],
+  pair: ['print', 'rotate', 'yes'],
   'token show': ['show', 'raw'],
   'token rotate': ['show', 'raw', 'yes'],
   'audit tail': ['limit', 'denied-only', 'format'],

--- a/src/cli/argv.test.ts
+++ b/src/cli/argv.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from 'bun:test';
-import { globalFlags, ownerFlags, parseArgv, text } from './argv.ts';
+import { globalFlags, normaliseWorkspace, ownerFlags, parseArgv, text } from './argv.ts';
 import { PROGRAM, USAGE } from './usage.ts';
 
 /**
@@ -82,5 +82,49 @@ describe('the program name', () => {
     const runTogether = ['lanes', 'link'].join('');
     expect(USAGE.toLowerCase()).not.toContain(runTogether);
     expect(USAGE).not.toContain('lanes-link');
+  });
+});
+
+describe('the old spelling of --workspace', () => {
+  test('is read as the new one', () => {
+    const said: string[] = [];
+    expect(normaliseWorkspace({ target: 'cloud' }, (line) => said.push(line))).toEqual({
+      workspace: 'cloud',
+    });
+  });
+
+  test('says so, because a deprecation nobody sees is one nobody acts on', () => {
+    // It has one minor to live, and the desktop app still passes it. The
+    // warning is what tells an operator their tooling needs updating before it
+    // stops working.
+    const said: string[] = [];
+    normaliseWorkspace({ target: 'cloud' }, (line) => said.push(line));
+
+    expect(said.join('\n')).toContain('--target is now --workspace');
+    expect(said.join('\n')).toContain('--workspace cloud');
+  });
+
+  test('says nothing when only the new spelling is used', () => {
+    const said: string[] = [];
+    normaliseWorkspace({ workspace: 'cloud' }, (line) => said.push(line));
+
+    expect(said).toEqual([]);
+  });
+
+  test('both spellings agreeing is not an error', () => {
+    // Redundant rather than wrong, and refusing it would break a script that
+    // passes both while migrating.
+    const said: string[] = [];
+    expect(
+      normaliseWorkspace({ target: 'cloud', workspace: 'cloud' }, (line) => said.push(line)),
+    ).toEqual({ workspace: 'cloud' });
+  });
+
+  test('both spellings disagreeing is refused rather than resolved', () => {
+    // Picking either would be a guess, and the two name different sets of
+    // accounts.
+    expect(() => normaliseWorkspace({ target: 'cloud', workspace: 'staging' }, () => {})).toThrow(
+      /name different things/,
+    );
   });
 });

--- a/src/cli/argv.ts
+++ b/src/cli/argv.ts
@@ -50,7 +50,38 @@ export function parseArgv(argv: readonly string[]): Parsed {
     }
   }
 
-  return { command, flags };
+  return { command, flags: normaliseWorkspace(flags) };
+}
+
+/**
+ * `--target` is the old spelling of `--workspace`, accepted for one minor.
+ *
+ * A workspace *is* a target and has been since ADR-052; contract 3 finishes the
+ * rename (ADR-061). The alias exists because the word is in a year of notes and
+ * in the desktop app's hardcoded argument arrays, and cutting it in the same
+ * release would break the app for anyone who updates the CLI first.
+ *
+ * Normalised here rather than in `selection.ts` so exactly one table knows the
+ * new word. A command reading `flags['target']` after this would be reading a
+ * key that is never set, which is the kind of silent miss `assertKnownFlags`
+ * exists to prevent.
+ *
+ * Both spellings is a mistake rather than a preference, so it is refused: they
+ * could name different workspaces, and picking either would be a guess.
+ */
+export function normaliseWorkspace(flags: Flags): Flags {
+  const legacy = flags['target'];
+  if (legacy === undefined) return flags;
+
+  if (flags['workspace'] !== undefined && flags['workspace'] !== legacy) {
+    throw new Error(
+      `--target and --workspace name different things ("${String(legacy)}" and ` +
+        `"${String(flags['workspace'])}"). --target is the old spelling of --workspace; pass one.`,
+    );
+  }
+
+  const { target: _legacy, ...rest } = flags;
+  return { ...rest, workspace: legacy };
 }
 
 /**
@@ -91,11 +122,20 @@ export function all(argv: readonly string[], name: string): string[] {
   return values.flatMap((value) => value.split(',').map((part) => part.trim())).filter(Boolean);
 }
 
-/** The flags every command accepts. */
+/**
+ * The flags every command accepts.
+ *
+ * Read from `workspace`, which is what `parseArgv` normalises both spellings
+ * into. The field it lands on is still called `target` and that is deliberate
+ * rather than missed: `#profile` resolves a *target* — an adapter set, a
+ * credential store, a bucket — and renaming the internal identifier is a
+ * separate change from renaming the word an operator types (ADR-061). The
+ * boundary is here, in one function, rather than scattered.
+ */
 export function globalFlags(flags: Flags): GlobalFlags {
   return {
     profile: text(flags, 'profile'),
-    target: text(flags, 'target'),
+    target: text(flags, 'workspace'),
     quiet: flags['quiet'] === true,
   };
 }

--- a/src/cli/argv.ts
+++ b/src/cli/argv.ts
@@ -68,8 +68,17 @@ export function parseArgv(argv: readonly string[]): Parsed {
  *
  * Both spellings is a mistake rather than a preference, so it is refused: they
  * could name different workspaces, and picking either would be a guess.
+ *
+ * **It says so, on stderr.** A deprecation nobody sees is one nobody acts on,
+ * and the alias has exactly one minor to live. Stderr rather than stdout because
+ * `--json` and `--raw` callers parse the other stream, and a deprecation notice
+ * that broke a script would be a worse way to make the point. `notify` is
+ * injectable so a test can read what was said without capturing a global.
  */
-export function normaliseWorkspace(flags: Flags): Flags {
+export function normaliseWorkspace(
+  flags: Flags,
+  notify: (line: string) => void = (line) => void process.stderr.write(`${line}\n`),
+): Flags {
   const legacy = flags['target'];
   if (legacy === undefined) return flags;
 
@@ -79,6 +88,11 @@ export function normaliseWorkspace(flags: Flags): Flags {
         `"${String(flags['workspace'])}"). --target is the old spelling of --workspace; pass one.`,
     );
   }
+
+  notify(
+    `warn  --target is now --workspace, and this spelling goes in the next minor. ` +
+      `Read it as: --workspace ${String(legacy)}`,
+  );
 
   const { target: _legacy, ...rest } = flags;
   return { ...rest, workspace: legacy };

--- a/src/cli/audit-change.test.ts
+++ b/src/cli/audit-change.test.ts
@@ -1,0 +1,140 @@
+import { afterAll, describe, expect, test } from 'bun:test';
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { workspaceYaml } from '#profile/testing.ts';
+import { openAudit } from '#deployments/target.ts';
+import { openTarget, loadProfileConfig, type Config } from '#profile';
+import { openSecrets, openStorage } from '#deployments/target.ts';
+import { PROVIDERS } from '#providers/index.ts';
+import { CONFIG_CAPABILITIES, CONFIG_PROVIDER, recordConfigChange } from './audit-change.ts';
+import { createProfile } from './commands/profile.ts';
+
+/**
+ * Config changes reach the same log as the calls they permit.
+ *
+ * The test that matters is the round trip, not the call: a config event is
+ * useless if `tail` cannot read it back, and the two sit either side of a chain
+ * encoder that has never had to carry a row with no connection on it.
+ */
+
+const roots: string[] = [];
+const previousHome = process.env['LANES_LINK_HOME'];
+
+async function workspace(): Promise<{ root: string; config: Config }> {
+  const root = await mkdtemp(join(tmpdir(), 'lanes-link-audit-'));
+  roots.push(root);
+  process.env['LANES_LINK_HOME'] = root;
+  await writeFile(join(root, 'lanes-link.yaml'), workspaceYaml(['local']));
+
+  const created = await createProfile('personal', { targets: ['local'], nonInteractive: true });
+  void created;
+  const { config } = await loadProfileConfig(root, 'personal');
+  return { root, config };
+}
+
+async function tail(root: string, config: Config) {
+  const resolved = await openTarget(root, 'local');
+  const input = { declared: resolved.declared, config, root: resolved.workspaceRoot, target: 'local' };
+  return openAudit(await openStorage(input, await openSecrets(input))).tail({ limit: 50 });
+}
+
+afterAll(async () => {
+  if (previousHome === undefined) delete process.env['LANES_LINK_HOME'];
+  else process.env['LANES_LINK_HOME'] = previousHome;
+  await Promise.all(roots.map((root) => rm(root, { recursive: true, force: true })));
+});
+
+describe('recordConfigChange', () => {
+  test('a change is readable back through the same tail that reads tool calls', async () => {
+    const { root, config } = await workspace();
+
+    await recordConfigChange(config, root, 'local', {
+      capability: 'config.member.add',
+      scope: 'personal',
+      arguments: { subject: 'lanes:someone', role: 'member' },
+    });
+
+    const events = await tail(root, config);
+    expect(events).toHaveLength(1);
+
+    const event = events[0]!;
+    expect(event.capability).toBe('config.member.add');
+    expect(event.provider).toBe(CONFIG_PROVIDER);
+    expect(event.profile).toBe('personal');
+    expect(event.arguments).toEqual({ subject: 'lanes:someone', role: 'member' });
+    // Recorded after the fact, so there is no denial to express and none to read
+    // as one — a config row that said "denied" would describe nothing.
+    expect(event.authorization).toBe('allowed');
+    expect(event.status).toBe('ok');
+  });
+
+  test('a workspace-scoped change carries the connection it was about', async () => {
+    const { root, config } = await workspace();
+
+    await recordConfigChange(config, root, 'local', {
+      capability: 'config.connection.create',
+      scope: 'local',
+      connection: 'gmail.work',
+      arguments: { account: 'someone@example.com' },
+    });
+
+    const [event] = await tail(root, config);
+    expect(event?.connection).toBe('gmail.work');
+    expect(event?.profile).toBe('local');
+  });
+
+  test('several changes chain, and verify', async () => {
+    const { root, config } = await workspace();
+
+    for (const capability of ['config.profile.add', 'config.policy.allow'] as const) {
+      await recordConfigChange(config, root, 'local', { capability, scope: 'personal' });
+    }
+
+    const resolved = await openTarget(root, 'local');
+    const input = { declared: resolved.declared, config, root: resolved.workspaceRoot, target: 'local' };
+    const store = openAudit(await openStorage(input, await openSecrets(input)));
+
+    expect((await store.tail({ limit: 50 })).map((event) => event.capability)).toEqual(
+      expect.arrayContaining(['config.profile.add', 'config.policy.allow']),
+    );
+
+    // Each call is its own run, which is what the chain is per (`audit/chain.ts`)
+    // — so two of them must still verify rather than read as a broken sequence.
+    const verified = await store.verify();
+    expect(verified.ok).toBe(true);
+    expect(verified.breaks).toEqual([]);
+  });
+
+  test('a log that cannot be written does not fail the command', async () => {
+    const { config } = await workspace();
+    const notes: string[] = [];
+
+    // A workspace that is not in the registry: `openTarget` throws, which is
+    // the shape of every real failure here — an unreachable bucket, a missing
+    // credential. The change is already on disk by now, so this must warn.
+    await recordConfigChange(config, '/nonexistent', 'nowhere', {
+      capability: 'config.member.add',
+      scope: 'personal',
+    }, (note) => notes.push(note));
+
+    expect(notes).toHaveLength(1);
+    expect(notes[0]).toContain('not recorded');
+  });
+});
+
+describe('the config pseudo-provider', () => {
+  test('no provider may claim it', () => {
+    // The whole value of a `config` row is that it cannot be confused with a
+    // provider's. A manifest with this id would make the two indistinguishable
+    // in the log, so the reservation is a test rather than a comment.
+    const ids = PROVIDERS.map((entry) => ('manifest' in entry ? entry.manifest.id : entry.id));
+    expect(ids).not.toContain(CONFIG_PROVIDER);
+  });
+
+  test('every capability is namespaced under it', () => {
+    for (const capability of CONFIG_CAPABILITIES) {
+      expect(capability.startsWith(`${CONFIG_PROVIDER}.`)).toBe(true);
+    }
+  });
+});

--- a/src/cli/audit-change.ts
+++ b/src/cli/audit-change.ts
@@ -1,0 +1,140 @@
+import { openAudit, openSecrets, openStorage } from '#deployments/target.ts';
+import { openTarget, type Config } from '#profile';
+import { readSession } from '#auth/lanes/session.ts';
+
+/**
+ * Config changes, in the same log as the calls they permit.
+ *
+ * The audit log recorded capability invocations and nothing else, which meant
+ * it could answer "what did this agent try to do" and could not answer "who
+ * changed what it was allowed to do". Those are halves of one investigation. A
+ * member added by hand at 14:02 and the first call that member made at 14:03
+ * are one story, and keeping them in two places means reconstructing the join
+ * by timestamp across two formats — so they go in one chain, in order, and
+ * `audit verify` covers both.
+ *
+ * **The event shape does not change.** A config change is written as an
+ * invocation of a capability that only the CLI can invoke, which is true rather
+ * than a convenient fiction: `config.member.add` is a thing that was done, by
+ * someone, to something, with arguments worth keeping. Adding a second record
+ * type would fork every reader, the chain encoding, and `tail`'s filters, to
+ * express something the existing five fields already carry.
+ *
+ * **`provider: 'config'` is not a provider**, and `config.test.ts` asserts no
+ * manifest may claim that id — the guarantee is a test rather than a comment,
+ * because the day someone writes `providers.d/config.yaml` the two kinds of row
+ * become indistinguishable in a log whose value is that they are not.
+ *
+ * **None of this is reachable over MCP.** These capabilities are not in the
+ * registry, no profile can grant them, and `control-plane.test.ts` is the
+ * standing check that config never becomes a surface an agent can call. Writing
+ * a row about a change is not the same as offering to make one.
+ *
+ * **Failing to log never fails the command.** The change is already on disk by
+ * the time this is called; throwing here would report failure for something
+ * that succeeded, and leave the operator to guess which half happened. It warns
+ * and returns.
+ */
+
+/**
+ * The vocabulary, in one place so it cannot drift command by command.
+ *
+ * `<area>.<verb>`, with the area named for the thing that changed rather than
+ * for the command that changed it — `lanes link connect` and a hand-edited
+ * `connections.yaml` are the same event, and a log that called them different
+ * things would be reporting the route rather than the change.
+ */
+export const CONFIG_CAPABILITIES = [
+  'config.connection.create',
+  'config.connection.remove',
+  'config.connection.relabel',
+  'config.profile.add',
+  'config.profile.remove',
+  'config.member.add',
+  'config.member.remove',
+  'config.policy.allow',
+  'config.policy.deny',
+  'config.pair.mint',
+  'config.pair.rotate',
+] as const;
+
+export type ConfigCapability = (typeof CONFIG_CAPABILITIES)[number];
+
+/** The pseudo-provider every config row carries. Reserved by `config.test.ts`. */
+export const CONFIG_PROVIDER = 'config';
+
+export interface ConfigChange {
+  readonly capability: ConfigCapability;
+  /**
+   * The scope of the change: the profile it altered, or the workspace where it
+   * altered something the whole workspace shares.
+   *
+   * A connection belongs to the workspace now (ADR-057), so `connect` has no
+   * profile to name and naming one would be a guess. The workspace's own name
+   * goes here instead — informative, and never mistakable for a profile,
+   * because a reader who filters by a profile they have gets rows about it and
+   * a reader who does not gets the workspace's.
+   */
+  readonly scope: string;
+  /** `<provider>.<id>`, where the change was about one connection. */
+  readonly connection?: string | undefined;
+  /**
+   * What changed, and it is the operator's own config rather than anybody's
+   * content — so unlike a provider's arguments there is nothing here to redact.
+   * Names, ids, subjects and capability patterns are the whole point of the
+   * record. Do not put a credential in it.
+   */
+  readonly arguments?: Readonly<Record<string, unknown>> | undefined;
+}
+
+export async function recordConfigChange(
+  config: Config,
+  root: string,
+  target: string,
+  change: ConfigChange,
+  warn?: (message: string) => void,
+): Promise<void> {
+  try {
+    const resolved = await openTarget(root, target);
+    const input = { declared: resolved.declared, config, root: resolved.workspaceRoot, target };
+    const audit = openAudit(await openStorage(input, await openSecrets(input)));
+
+    try {
+      await audit.append({
+        profile: change.scope,
+        principal: await principal(),
+        provider: CONFIG_PROVIDER,
+        ...(change.connection ? { connection: change.connection } : {}),
+        capability: change.capability,
+        arguments: change.arguments ?? {},
+        // Every one of these is written after the change is on disk, so there
+        // is no denied case to record and no duration worth measuring: the
+        // number would be how long a file write took, which answers nothing.
+        authorization: 'allowed',
+        status: 'ok',
+        durationMs: 0,
+      });
+    } finally {
+      await audit.close();
+    }
+  } catch (error) {
+    warn?.(`the change was made but not recorded in the audit log: ${message(error)}`);
+  }
+}
+
+/**
+ * Who made the change.
+ *
+ * The signed-in Lanes subject, which since ADR-060 is a real person rather than
+ * whoever held a token. `cli:unsigned` is the honest answer where there is no
+ * session — some commands do not require one, and attributing their changes to
+ * the last person who signed in on this machine would be worse than saying so.
+ */
+async function principal(): Promise<string> {
+  const session = await readSession().catch(() => null);
+  return session?.subject ?? 'cli:unsigned';
+}
+
+function message(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}

--- a/src/cli/brand.test.ts
+++ b/src/cli/brand.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, test } from 'bun:test';
 import { readFile } from 'node:fs/promises';
 import { join } from 'node:path';
-import { approvalPage, completionPage } from './callback-page.ts';
+import { completionPage, noticePage } from './callback-page.ts';
 
 /**
  * Every page this repository serves, held to the design system.
@@ -148,17 +148,7 @@ describe('type comes from the tokens', () => {
 describe('what a browser actually receives', () => {
   const PAGES: ReadonlyArray<[string, Response]> = [
     ['completion', completionPage({ heading: 'Connected', detail: '.', ok: true })],
-    [
-      'approval',
-      approvalPage({
-        client: 'A client',
-        redirectHost: 'example.com',
-        fields: {},
-        action: '/authorize',
-        retry: false,
-        target: 'local',
-      }),
-    ],
+    ['notice', noticePage('No profile on this endpoint lists you.', 403)],
   ];
 
   for (const [name, response] of PAGES) {
@@ -188,9 +178,10 @@ describe('what a browser actually receives', () => {
       expect(csp).toContain("form-action 'self'");
       expect(csp).toContain('https://fonts.googleapis.com');
       expect(csp).toContain('https://fonts.gstatic.com');
-      // Script is allowed exactly where there is one: the consent screen has a
-      // submit spinner, and the page a connect flow lands on has nothing.
-      expect(csp.includes('script-src')).toBe(name !== 'completion');
+      // No page here runs script any more. The one that did was the consent
+      // form, whose submit spinner was the only thing that widening bought —
+      // and identity moved to lanes.sh with it (ADR-062).
+      expect(csp).not.toContain('script-src');
     });
   }
 });

--- a/src/cli/callback-page.test.ts
+++ b/src/cli/callback-page.test.ts
@@ -140,9 +140,9 @@ describe('approving', () => {
     // and a trailing period is a character that gets copied with it.
     const body = await html(page());
 
-    expect(body).toContain('<code>lanes link outputs --show --target local</code>');
+    expect(body).toContain('<code>lanes link outputs --show --workspace local</code>');
     expect(body).not.toContain('Printed by');
-    expect(body).not.toContain('--target local</code>.');
+    expect(body).not.toContain('--workspace local</code>.');
   });
 
   test('the button becomes busy, and stops accepting clicks', async () => {
@@ -256,14 +256,14 @@ describe('the approval page', () => {
     // will refuse or holds none and has one minted on the spot.
     const body = await html(approval('cloud'));
 
-    expect(body).toContain('lanes link outputs --show --target cloud');
+    expect(body).toContain('lanes link outputs --show --workspace cloud');
     expect(body).not.toContain('outputs --show</code>');
   });
 
   test('names it even when it is the default, so the flag is never ambiguous', async () => {
     const body = await html(approval('local'));
 
-    expect(body).toContain('lanes link outputs --show --target local');
+    expect(body).toContain('lanes link outputs --show --workspace local');
   });
 
   test('a target name cannot inject markup', async () => {

--- a/src/cli/callback-page.test.ts
+++ b/src/cli/callback-page.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from 'bun:test';
-import { approvalPage, completionPage } from './callback-page.ts';
+import { completionPage, noticePage } from './callback-page.ts';
 
 /**
  * The page nobody sees until the one moment it is the whole product.
@@ -124,98 +124,53 @@ describe('light and dark', () => {
   });
 });
 
-describe('approving', () => {
-  const page = () =>
-    approvalPage({
-      client: 'Claude',
-      redirectHost: 'claude.ai',
-      fields: {},
-      action: '/authorize',
-      retry: false,
-      target: 'local',
-    });
+describe('a refusal, read by the person it happened to', () => {
+  test('says what to do next, which is the whole reason it is a page', async () => {
+    // The message that matters: somebody signed in successfully and no profile
+    // on this endpoint lists them. Returned as bare text it read as a protocol
+    // error to a client; the audience is a person at a browser who needs to
+    // know what to ask their operator for.
+    const body = await html(
+      noticePage(
+        'You are signed in as her@example.com, and no profile on this endpoint lists ' +
+          'you as a member.\n\nIts owner can add you with:\n  lanes link profile members add lanes:ABC --profile <name>',
+        403,
+      ),
+    );
 
-  test('names the command and nothing around it', async () => {
-    // No lead-in and no full stop: the line is there to be selected and run,
-    // and a trailing period is a character that gets copied with it.
-    const body = await html(page());
-
-    expect(body).toContain('<code>lanes link outputs --show --workspace local</code>');
-    expect(body).not.toContain('Printed by');
-    expect(body).not.toContain('--workspace local</code>.');
+    expect(body).toContain('Not authorised');
+    expect(body).toContain('no profile on this endpoint lists you');
+    expect(body).toContain('lanes link profile members add lanes:ABC');
   });
 
-  test('the button becomes busy, and stops accepting clicks', async () => {
-    // Approving is a round trip. Until it returns the page looks untouched,
-    // which reads as "nothing happened" — and the second click is the one that
-    // sends a duplicate. Disabling is the half that matters; the spinner says why.
-    const body = await html(page());
-
-    expect(body).toContain("addEventListener('submit'");
-    expect(body).toContain("classList.add('busy')");
-    expect(body).toContain('button.disabled = true');
-    expect(body).toContain('.go.busy::after');
-    expect(body).toContain('animation: spin');
+  test('keeps the status, so a client following the redirect still sees a failure', () => {
+    expect(noticePage('nope', 403).status).toBe(403);
+    expect(noticePage('nope', 400).status).toBe(400);
   });
 
-  test('the spinner is monochrome, because a request in flight is not a verdict', async () => {
-    const body = await html(page());
+  test('is the error card, not the success one', async () => {
+    const body = await html(noticePage('nope', 400));
 
-    expect(body).toContain('border-top-color: var(--foreground)');
-    expect(body).not.toContain('border-top-color: var(--accent-gold)');
+    expect(body).toContain('card surface err');
   });
 
-  test('a page with script says so in its policy, and one without does not', () => {
-    // The consent screen is the page that asks for the endpoint token, so the
-    // inline listener it now carries is the one place this widening is spent.
-    const withScript = approvalPage({
-      client: 'C',
-      redirectHost: 'example.com',
-      fields: {},
-      action: '/authorize',
-      retry: false,
-      target: 'local',
-    });
-    const without = completionPage({ heading: 'Connected', detail: '.', ok: true });
+  test('carries no script, so the policy stays narrow', () => {
+    // The page this replaces asked for the endpoint token and ran an inline
+    // listener to disable its button. Nothing here submits anything, so the
+    // widening that paid for goes away with it (ADR-062).
+    const csp = noticePage('nope', 400).headers.get('content-security-policy') ?? '';
 
-    expect(withScript.headers.get('content-security-policy')).toContain("script-src 'unsafe-inline'");
-    expect(without.headers.get('content-security-policy')).not.toContain('script-src');
-  });
-
-  test('the policy admits the destination named on the page, and only that one', () => {
-    // `form-action` is checked against the redirect the approval produces, not
-    // just the `action` — so the one origin this page tells the reader about is
-    // the one origin it has to admit. Anything else and the browser refuses to
-    // deliver a code that has already been minted.
-    const csp =
-      approvalPage({
-        client: 'C',
-        redirectHost: 'client.example',
-        formAction: 'https://client.example',
-        fields: {},
-        action: '/authorize',
-        retry: false,
-        target: 'local',
-      }).headers.get('content-security-policy') ?? '';
-
-    expect(csp).toContain("form-action 'self' https://client.example;");
-    expect(csp).not.toContain('https://other.example');
-  });
-
-  test('a page given no destination keeps the narrow policy', () => {
-    // A redirect this endpoint could not parse never reaches consent, so the
-    // absence is a real state rather than a caller forgetting the field.
-    const csp =
-      approvalPage({
-        client: 'C',
-        redirectHost: 'client.example',
-        fields: {},
-        action: '/authorize',
-        retry: false,
-        target: 'local',
-      }).headers.get('content-security-policy') ?? '';
-
+    expect(csp).not.toContain('script-src');
     expect(csp).toContain("form-action 'self';");
+  });
+
+  test('cannot be made to carry markup', async () => {
+    // The subject in that message comes from an assertion, and the email from
+    // whatever the person signed in with.
+    const body = await html(noticePage('<script>alert(1)</script>', 403));
+
+    expect(body).not.toContain('<script>alert(1)</script>');
+    expect(body).toContain('&lt;script&gt;');
   });
 });
 
@@ -238,41 +193,3 @@ describe('untrusted text', () => {
   });
 });
 
-describe('the approval page', () => {
-  const approval = (target: string) =>
-    approvalPage({
-      client: 'Claude',
-      redirectHost: 'claude.ai',
-      action: 'https://endpoint.example/authorize',
-      fields: { client_id: 'abc' },
-      retry: false,
-      target,
-    });
-
-  test('names the target whose store holds the token it is asking for', async () => {
-    // The reader runs this in a shell that resolves a target of its own, and
-    // credentials are per-target. A bare `--show` sends the owner of a deployed
-    // endpoint to the local store, which either holds a token this endpoint
-    // will refuse or holds none and has one minted on the spot.
-    const body = await html(approval('cloud'));
-
-    expect(body).toContain('lanes link outputs --show --workspace cloud');
-    expect(body).not.toContain('outputs --show</code>');
-  });
-
-  test('names it even when it is the default, so the flag is never ambiguous', async () => {
-    const body = await html(approval('local'));
-
-    expect(body).toContain('lanes link outputs --show --workspace local');
-  });
-
-  test('a target name cannot inject markup', async () => {
-    // It comes from config rather than from a request, but everything else on
-    // this page is escaped and a value reaching HTML is not where to make an
-    // exception.
-    const body = await html(approval('<script>alert(1)</script>'));
-
-    expect(body).not.toContain('<script>alert(1)</script>');
-    expect(body).toContain('&lt;script&gt;alert(1)&lt;/script&gt;');
-  });
-});

--- a/src/cli/callback-page.ts
+++ b/src/cli/callback-page.ts
@@ -69,100 +69,44 @@ const ICON =
   'stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">' +
   '<path d="M20 6 9 17l-5-5"/></svg>';
 
-export interface ApprovalPage {
-  /** What is asking. A client's self-reported name, or a stand-in. */
-  readonly client: string;
-  /** Where the code would be sent. The part of the request that cannot be faked. */
-  readonly redirectHost: string;
-  /**
-   * The same destination as a CSP source, so the browser will follow the
-   * redirect this form's approval ends in rather than blocking it.
-   */
-  readonly formAction?: string;
-  /** Hidden fields carrying the authorization request through the POST. */
-  readonly fields: Readonly<Record<string, string>>;
-  readonly action: string;
-  /** A previous attempt presented the wrong token. */
-  readonly retry: boolean;
-  /** The target this endpoint runs as, so the hint below names the right store. */
-  readonly target: string;
+/**
+ * Something went wrong, said to the person it went wrong for.
+ *
+ * This replaces the consent form (ADR-062), and the two are worth contrasting.
+ * The form asked a browser on loopback for the endpoint token — the one
+ * credential that opened everything — which made it the most valuable thing a
+ * hostile local page could reach. Identity now comes from lanes.sh, so the only
+ * page this endpoint renders is one that *tells* rather than asks.
+ *
+ * Rendered as a page rather than returned as text because of who reads it. The
+ * important message here is "you signed in, and no profile on this endpoint
+ * lists you" — which arrives at a browser, at the end of a sign-in, addressed
+ * to somebody who needs to know what to ask their operator for.
+ */
+export function noticePage(message: string, status: number): Response {
+  // Deliberately whole-text-escaped and then split on blank lines: these
+  // messages carry a subject and sometimes a command, and neither is markup.
+  const body =
+    `<h1>Not authorised</h1>` +
+    message
+      .split('\n\n')
+      .map((paragraph) => `<p class="detail">${escapeHtml(paragraph)}</p>`)
+      .join('\n');
+
+  return shell(body, 'Not authorised', status, ' err');
 }
 
 /**
- * The one screen a remote client's authorization stops at.
+ * One document, both pages.
  *
- * Same card as the page above, because it is the same product and the reader
- * arrived here from a connector rather than from a terminal. What it asks for is
- * the endpoint token — the string `lanes link outputs` prints — because that is
- * already the proof of being the owner and inventing a second one would mean
- * inventing a password to go with it.
- *
- * The hint names the target rather than leaving it out. Credentials are
- * per-target, and the reader runs that command in a shell resolving a target of
- * its own — `local` by default, which is the one store a deployed endpoint's
- * token is never in. Omitting it sends them to fetch the wrong secret, and
- * `outputs` mints a fresh one when that store is empty rather than saying so.
- *
- * `autocomplete="off"` and `type="password"` are not theatre: this form is
- * submitted in whatever browser the phone opened, and a token remembered by a
- * shared browser is a token in the hands of whoever borrows the phone.
+ * No script hook any more, and no `form-action` parameter. Both existed for the
+ * consent form: it ran an inline listener to disable its own button, and it had
+ * to name in its policy the client origin its approval redirected to. Identity
+ * moved to lanes.sh (ADR-062) and the form went with it, so the policy narrows
+ * back to what it was before — which is the rare direction for a CSP to move
+ * and worth saying out loud.
  */
-export function approvalPage(page: ApprovalPage): Response {
-  const hidden = Object.entries(page.fields)
-    .map(([name, value]) => `<input type="hidden" name="${escapeHtml(name)}" value="${escapeHtml(value)}">`)
-    .join('\n');
-
-  // The name is self-reported and the host is not, so the host is what the
-  // reader is asked to recognise. Registration is open by design, which means
-  // anything can call itself anything — but an impostor still has to nominate
-  // somewhere for the code to go, and that is on the screen.
-  const body = `
-${page.retry ? '<p class="label err-text">That token was not accepted.</p>\n' : ''}<h1>Authorise ${escapeHtml(page.client)}?</h1>
-<p class="detail">It will be sent back to <strong>${escapeHtml(page.redirectHost)}</strong>, and will be able to reach every profile this endpoint serves, within the policy each one declares.</p>
-<form method="post" action="${escapeHtml(page.action)}">
-${hidden}
-<input class="field" type="password" name="token" placeholder="Endpoint token" autocomplete="off" autofocus required>
-<button class="go" type="submit">Approve</button>
-</form>
-<p class="small"><code>lanes link outputs --show --workspace ${escapeHtml(page.target)}</code></p>`;
-
-  return shell(body, 'Authorise', page.retry ? 401 : 200, '', {
-    script: SUBMIT_SPINNER,
-    ...(page.formAction ? { formAction: [page.formAction] } : {}),
-  });
-}
-
-/**
- * What runs while the approval is in flight.
- *
- * Approving is a round trip to an authorization server, and until it returns the
- * page looks exactly as it did before the click — so the honest reading is that
- * nothing happened, and the second click is the one that produces a duplicated
- * request. The button disables itself, which is the part that matters; the
- * spinner is what says why.
- *
- * The cost is real and worth naming: this is the one page that asks for the
- * endpoint token, and an inline listener means its policy admits inline script.
- * It is the minimum that does the job — one listener, no interpolation, nothing
- * read from the page — and the alternative, a static file, is an asset pipeline
- * this repository does not have.
- */
-const SUBMIT_SPINNER = `
-document.querySelector('form').addEventListener('submit', function (event) {
-  var button = event.currentTarget.querySelector('.go');
-  button.classList.add('busy');
-  button.disabled = true;
-});
-`.trim();
-
-function shell(
-  inner: string,
-  title: string,
-  status: number,
-  cardClass = '',
-  policy: { readonly script?: string; readonly formAction?: readonly string[] } = {},
-): Response {
-  const script = policy.script ?? '';
+function shell(inner: string, title: string, status: number, cardClass = ''): Response {
   return new Response(
     `<!doctype html>
 <html lang="en">
@@ -184,48 +128,25 @@ ${inner}
 </div>
 ${FOOTER}
 </div>
-${script ? `<script>\n${script}\n</script>` : ''}
 </body>
 </html>`,
     {
       status,
-      headers: {
-        ...PAGE_HEADERS,
-        'content-security-policy': pageCsp({
-          ...(script ? { script: true } : {}),
-          ...(policy.formAction ? { formAction: policy.formAction } : {}),
-        }),
-      },
+      headers: { ...PAGE_HEADERS, 'content-security-policy': pageCsp({}) },
     },
   );
 }
 
+/**
+ * What is left of the form styles.
+ *
+ * `.small` alone: the consent form's field, button and spinner went with the
+ * form (ADR-062). Kept as its own constant rather than folded into `STYLE`
+ * because the completion page still uses it for the line under the card.
+ */
 const FORM_STYLE = `
-.field { width: 100%; margin: 20px 0 12px; padding: 11px 13px; font: inherit; font-size: 15px;
-         color: inherit; background: var(--background); border: 1px solid var(--border);
-         border-radius: 6px; }
-.field:focus { outline: none; border-color: var(--accent-gold); }
-.go { width: 100%; padding: 11px 13px; font: inherit; font-size: 15px; font-weight: 500;
-      color: var(--foreground); background: transparent; border: 1px solid var(--border);
-      border-radius: 6px; cursor: pointer; }
-.go:hover { background: var(--muted); }
 .small { margin-top: 16px; font-size: 12px; color: var(--muted-foreground); opacity: 0.8; }
 .small code { font-size: 12px; }
-.err-text { color: var(--destructive); }
-
-/* The button, mid-flight. The label goes transparent rather than away, so the
-   button keeps the width it had and the card does not reflow under the cursor. */
-.go.busy { color: transparent; position: relative; pointer-events: none; }
-.go.busy::after { content: ''; position: absolute; inset: 0; margin: auto;
-                  width: 15px; height: 15px; border-radius: 50%;
-                  border: 2px solid var(--border); border-top-color: var(--foreground);
-                  animation: spin 0.6s linear infinite; }
-@keyframes spin { to { transform: rotate(360deg); } }
-/* Monochrome deliberately: gold says a thing turned out well, and a request in
-   flight has not turned out yet. */
-@media (prefers-reduced-motion: reduce) {
-  .go.busy::after { animation-duration: 2.4s; }
-}
 `.trim();
 
 export function completionPage(page: CallbackPage): Response {

--- a/src/cli/callback-page.ts
+++ b/src/cli/callback-page.ts
@@ -124,7 +124,7 @@ ${hidden}
 <input class="field" type="password" name="token" placeholder="Endpoint token" autocomplete="off" autofocus required>
 <button class="go" type="submit">Approve</button>
 </form>
-<p class="small"><code>lanes link outputs --show --target ${escapeHtml(page.target)}</code></p>`;
+<p class="small"><code>lanes link outputs --show --workspace ${escapeHtml(page.target)}</code></p>`;
 
   return shell(body, 'Authorise', page.retry ? 401 : 200, '', {
     script: SUBMIT_SPINNER,

--- a/src/cli/commands/auth-dispatch.ts
+++ b/src/cli/commands/auth-dispatch.ts
@@ -1,0 +1,48 @@
+import { parseArgv } from '../argv.ts';
+import { authLogin, authLogout, authStatus, authWorkspaces } from './auth.ts';
+
+/**
+ * `lanes auth <command>` — the grammar, and nothing else.
+ *
+ * Its own file for the reason `main.ts` is one: a dispatcher that also does the
+ * work is a file that grows a case at a time until nobody can see the grammar.
+ * Four commands, one line each.
+ */
+
+const USAGE = `lanes auth — who this machine is signed in as
+
+  lanes auth login        sign in, in a browser
+  lanes auth logout       forget this machine's session
+  lanes auth status       who you are, and how long the token lasts
+  lanes auth workspaces   the Lanes workspaces you are a member of
+
+  --json                  the same answer, as a document
+  --api-url <url>         a self-hosted API, instead of the default
+`;
+
+export async function runAuth(argv: readonly string[]): Promise<void> {
+  const { command, flags } = parseArgv(argv);
+  const [first] = command;
+
+  const options = {
+    json: flags['json'] === true,
+    ...(typeof flags['api-url'] === 'string' ? { apiUrl: flags['api-url'] } : {}),
+  };
+
+  switch (first) {
+    case 'login':
+      return authLogin(options);
+    case 'logout':
+      return authLogout(options);
+    case 'status':
+    case undefined:
+      return authStatus(options);
+    case 'workspaces':
+      return authWorkspaces(options);
+    case 'help':
+      console.log(USAGE);
+      return;
+    default:
+      throw new Error(`Unknown: lanes auth ${first}\n\n${USAGE}`);
+  }
+}

--- a/src/cli/commands/auth.ts
+++ b/src/cli/commands/auth.ts
@@ -1,0 +1,218 @@
+import { clearSession, isFresh, readSession } from '#auth/lanes/session.ts';
+import { DEFAULT_API_URL, currentIdToken, login } from '#auth/lanes/login.ts';
+import { print, ok, style, warn } from '../output.ts';
+
+/**
+ * `lanes auth` — who this machine is signed in as.
+ *
+ * A separate area from `lanes link auth`, which is a per-connection credential
+ * diagnostic and answers a different question entirely. Neither is renamed and
+ * neither gains an alias: one spelling per command, and the help text on each
+ * says which is which.
+ *
+ * Sign-in is required to consume a profile, local endpoints included (ADR-060).
+ * That is a real dependency on lanes.sh for a self-hostable tool, and the shape
+ * of it is worth stating plainly: **the network is needed to sign in and to
+ * refresh, not per request.** A machine offline for a day keeps serving, and
+ * `status` below is the command that says how long that has left to run — a
+ * session that lapses silently would present as an endpoint that worked
+ * yesterday and does not today, which is the worst failure to debug from the
+ * outside.
+ */
+
+export interface AuthFlags {
+  readonly json?: boolean | undefined;
+  readonly apiUrl?: string | undefined;
+}
+
+export async function authLogin(flags: AuthFlags = {}): Promise<void> {
+  const opened: string[] = [];
+
+  const session = await login({
+    apiUrl: flags.apiUrl,
+    onUrl: (url) => opened.push(url),
+    open: async (url) => {
+      // Printed as well as opened. A machine with no browser — a container, an
+      // SSH session — gets a URL it can paste somewhere that has one, which is
+      // the whole difference between "this does not work here" and "this takes
+      // one more step here".
+      print(style.dim('  Opening your browser to sign in. If nothing opens, use this:'));
+      print(`  ${url}`);
+      print('');
+      await openInBrowser(url);
+    },
+  });
+
+  if (flags.json === true) {
+    print(JSON.stringify({ subject: session.subject, email: session.email }, null, 2));
+    return;
+  }
+
+  print(ok(`signed in as ${style.bold(session.email ?? session.subject)}`));
+  print(style.dim(`      subject  ${session.subject}`));
+  print('');
+  print(
+    style.dim(
+      '      A profile reaches you only where its members list that subject:\n' +
+        '        lanes link profile members add <subject> --profile <name>',
+    ),
+  );
+  void opened;
+}
+
+export async function authLogout(flags: AuthFlags = {}): Promise<void> {
+  const session = await readSession();
+  await clearSession();
+
+  if (flags.json === true) {
+    print(JSON.stringify({ signedOut: session !== null }, null, 2));
+    return;
+  }
+
+  print(
+    session === null
+      ? style.dim('Not signed in; nothing to do.')
+      : ok(`signed out ${style.bold(session.email ?? session.subject)}`),
+  );
+
+  // Said out loud, because it is the surprising half. Signing out removes the
+  // identity this machine presents; it does not touch a profile's members list,
+  // and it does not revoke a token an agent already holds.
+  print(
+    style.dim(
+      '      Profiles still list you, and a client holding a token still holds it.\n' +
+        '      To take a token back: lanes link token rotate --workspace <name>',
+    ),
+  );
+}
+
+export async function authStatus(flags: AuthFlags = {}): Promise<void> {
+  const session = await readSession();
+
+  if (session === null) {
+    if (flags.json === true) {
+      print(JSON.stringify({ signedIn: false }, null, 2));
+      return;
+    }
+    print(warn('not signed in'));
+    print(style.dim('      Run: lanes auth login'));
+    process.exitCode = 1;
+    return;
+  }
+
+  const fresh = isFresh(session);
+
+  if (flags.json === true) {
+    print(
+      JSON.stringify(
+        {
+          signedIn: true,
+          subject: session.subject,
+          email: session.email,
+          expiresAt: session.expiresAt,
+          fresh,
+          apiUrl: session.apiUrl,
+        },
+        null,
+        2,
+      ),
+    );
+    return;
+  }
+
+  print(ok(`signed in as ${style.bold(session.email ?? session.subject)}`));
+  print(`      subject  ${style.dim(session.subject)}`);
+  print(`      api      ${style.dim(session.apiUrl)}`);
+  print(
+    `      token    ${
+      fresh
+        ? style.dim(`valid until ${session.expiresAt}`)
+        : style.dim('expired — the next command refreshes it')
+    }`,
+  );
+
+  if (session.apiUrl !== DEFAULT_API_URL) {
+    print(style.dim(`      This session was issued by ${session.apiUrl}, not the default.`));
+  }
+}
+
+/**
+ * Every workspace this identity can reach, and what it may do there.
+ *
+ * `GET /v1/me` is the source, and it is the server that decides — the client
+ * sends no uid, and the answer is derived from the token. That is what makes
+ * this listing something an operator can trust rather than a local guess.
+ */
+export async function authWorkspaces(flags: AuthFlags = {}): Promise<void> {
+  const session = await readSession();
+  if (session === null) {
+    print(warn('not signed in'));
+    print(style.dim('      Run: lanes auth login'));
+    process.exitCode = 1;
+    return;
+  }
+
+  const token = await currentIdToken();
+  if (token === null) {
+    print(warn('the session could not be refreshed'));
+    print(style.dim('      Run: lanes auth login'));
+    process.exitCode = 1;
+    return;
+  }
+
+  const response = await fetch(`${session.apiUrl}/v1/me`, {
+    headers: { authorization: `Bearer ${token}` },
+  });
+
+  if (!response.ok) {
+    print(warn(`${session.apiUrl} answered ${response.status}`));
+    process.exitCode = 1;
+    return;
+  }
+
+  const body = (await response.json()) as {
+    memberships?: { workspace_id: string; workspace_name: string; role: string }[];
+  };
+  const memberships = body.memberships ?? [];
+
+  if (flags.json === true) {
+    print(JSON.stringify({ memberships }, null, 2));
+    return;
+  }
+
+  print(style.dim(`signed in as ${session.email ?? session.subject}`));
+  print('');
+
+  if (memberships.length === 0) {
+    print(style.dim('You are a member of no Lanes workspace yet.'));
+  } else {
+    for (const one of memberships) {
+      print(`  ${style.bold(one.workspace_name)}  ${style.dim(one.role)}`);
+      print(`  ${style.dim(one.workspace_id)}`);
+    }
+  }
+
+  print('');
+  print(
+    style.dim(
+      'A remote lanes link workspace binds to one of these with `lanes_workspace:`\n' +
+        'in lanes-link.yaml, which is whose members a profile may delegate to.',
+    ),
+  );
+}
+
+/** Opens a URL, and says nothing if it cannot. The URL is printed either way. */
+async function openInBrowser(url: string): Promise<void> {
+  const command =
+    process.platform === 'darwin'
+      ? ['open', url]
+      : process.platform === 'win32'
+        ? ['cmd', '/c', 'start', '', url]
+        : ['xdg-open', url];
+
+  try {
+    await Bun.spawn(command, { stdout: 'ignore', stderr: 'ignore' }).exited;
+  } catch {
+    // Nothing to report: the URL is on screen above, which is the fallback.
+  }
+}

--- a/src/cli/commands/auth.ts
+++ b/src/cli/commands/auth.ts
@@ -1,5 +1,6 @@
 import { clearSession, isFresh, readSession } from '#auth/lanes/session.ts';
 import { DEFAULT_API_URL, currentIdToken, login } from '#auth/lanes/login.ts';
+import { completionPage } from '../callback-page.ts';
 import { print, ok, style, warn } from '../output.ts';
 
 /**
@@ -30,6 +31,16 @@ export async function authLogin(flags: AuthFlags = {}): Promise<void> {
 
   const session = await login({
     apiUrl: flags.apiUrl,
+    // The same card a provider connect flow ends on. For a few seconds this
+    // page is the whole product, and it used to be an unstyled sentence on a
+    // white rectangle — in a browser set to dark, on a sign-in that had just
+    // worked. `brand.ts` carries the palette for both modes.
+    page: (outcome) =>
+      completionPage(
+        outcome.ok
+          ? { label: 'Lanes', heading: 'Signed in', detail: outcome.detail, ok: true }
+          : { label: 'Lanes', heading: 'That did not work', detail: outcome.detail, ok: false },
+      ),
     onUrl: (url) => opened.push(url),
     open: async (url) => {
       // Printed as well as opened. A machine with no browser — a container, an

--- a/src/cli/commands/connect/accounts.ts
+++ b/src/cli/commands/connect/accounts.ts
@@ -32,12 +32,12 @@ export function credentialApp(manifest: ProviderManifest): string | undefined {
  */
 export function accountSiblings(
   manifest: ProviderManifest,
-  config: Config,
+  connections: readonly ConnectionConfig[],
   registry: { manifest(id: string): ProviderManifest | undefined },
 ): ConnectionConfig[] {
   const app = credentialApp(manifest);
 
-  return config.connections.filter((connection) => {
+  return connections.filter((connection) => {
     if (connection.provider === manifest.id) return true;
     if (!app) return false;
     const sibling = registry.manifest(connection.provider);
@@ -55,7 +55,7 @@ export function accountSiblings(
  */
 export function siblingAccountId(
   manifest: ProviderManifest,
-  config: Config,
+  connections: readonly ConnectionConfig[],
   registry: { manifest(id: string): ProviderManifest | undefined },
 ): string | undefined {
   if (!credentialApp(manifest)) return undefined;
@@ -63,7 +63,7 @@ export function siblingAccountId(
   // Asked of the registry, not inferred from the id: `app` is a manifest field,
   // and a provider is free to declare `app: icloud` under any name it likes.
   const ids = new Set(
-    accountSiblings(manifest, config, registry)
+    accountSiblings(manifest, connections, registry)
       .filter((connection) => connection.provider !== manifest.id)
       .map((connection) => connection.id),
   );

--- a/src/cli/commands/connect/authorise.ts
+++ b/src/cli/commands/connect/authorise.ts
@@ -1,3 +1,4 @@
+import { registering } from './registration.ts';
 import { auth, discoverOAuthProtectedResourceMetadata } from '@modelcontextprotocol/client';
 import { CredentialOAuthProvider } from '#connectivity/auth/index.ts';
 import type { SecretStore } from '#secrets';
@@ -146,10 +147,9 @@ export async function authorise(input: {
 
     const scope = manifest.auth.scopes.length > 0 ? manifest.auth.scopes.join(' ') : undefined;
 
-    const first = await auth(provider as never, {
-      serverUrl,
-      ...(scope ? { scope } : {}),
-    });
+    const first = await registering(manifest, serverUrl, () =>
+      auth(provider as never, { serverUrl, ...(scope ? { scope } : {}) }),
+    );
 
     if (first === 'AUTHORIZED') {
       progress(ok('already authorised'));

--- a/src/cli/commands/connect/bind-credential.ts
+++ b/src/cli/commands/connect/bind-credential.ts
@@ -1,3 +1,4 @@
+import { grantedConnections } from '../../runtime.ts';
 import { bindConnectionCredentials, type BindOutcome } from '#deployments/bind.ts';
 import type { Runtime } from '../../runtime.ts';
 
@@ -35,7 +36,7 @@ export function bindNewCredential(
   connectionId: string,
   account: string,
 ): Promise<BindOutcome> {
-  const declared = runtime.config.connections.find(
+  const declared = grantedConnections(runtime).find(
     (candidate) => candidate.provider === providerId && candidate.id === connectionId,
   );
 

--- a/src/cli/commands/connect/client.test.ts
+++ b/src/cli/commands/connect/client.test.ts
@@ -1,10 +1,11 @@
+import { newProfileTemplate } from '../../config-templates.ts';
 import { afterAll, describe, expect, test } from 'bun:test';
 import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { defineProvider } from '#connectivity';
 import type { SecretRef, SecretStore } from '#secrets';
-import { ConfigDocument, newProfileTemplate } from '../../config-edit.ts';
+import { ConfigDocument } from '../../config-edit.ts';
 import { nonInteractivePrompter } from '../../prompt.ts';
 import { brokeredScopes, hostedClientRefusal, resolveOAuthClient } from './client.ts';
 

--- a/src/cli/commands/connect/custom/ask.test.ts
+++ b/src/cli/commands/connect/custom/ask.test.ts
@@ -115,7 +115,7 @@ describe('a run with nobody to ask', () => {
   });
 
   test('and hands back a command that carries the selection', async () => {
-    // Asserted because a suggested command missing --profile or --target is
+    // Asserted because a suggested command missing --profile or --workspace is
     // refused the moment it is pasted, which reads as the tool being broken.
     const result = await gather({ connector: 'mcp', auth: 'none' }, silent);
 

--- a/src/cli/commands/connect/custom/index.test.ts
+++ b/src/cli/commands/connect/custom/index.test.ts
@@ -15,12 +15,12 @@ import { connectCustom, type ConnectCustomOptions } from './index.ts';
  * happens before it — the whole design of this command is that anything that can
  * be refused is refused before a file exists, so that a failure never leaves a
  * malformed manifest behind. One bad file in `providers.d/` makes
- * `loadProfileProviders` throw for the entire directory, which breaks `connect`,
+ * `loadWorkspaceProviders` throw for the entire directory, which breaks `connect`,
  * `doctor`, `plan`, `status`, `start` and `deploy` for that profile — and
  * `check`, whose whole job is catching that, does not read the directory at all.
  */
 
-const PROFILE = `contract: 2
+const PROFILE = `contract: 3
 
 instance:
   profile: personal
@@ -80,7 +80,7 @@ const declaring = (extra: Partial<ConnectCustomOptions> = {}): ConnectCustomOpti
 });
 
 const manifestAt = (root: string, id: string) =>
-  readFile(join(root, layout.providers('personal'), `${id}.yaml`), 'utf8');
+  readFile(join(root, layout.providers(), `${id}.yaml`), 'utf8');
 
 describe('declaring and connecting in one command', () => {
   test('writes the manifest and then hands off', async () => {

--- a/src/cli/commands/connect/custom/index.ts
+++ b/src/cli/commands/connect/custom/index.ts
@@ -92,7 +92,7 @@ export async function connectCustom(
   if (options.json !== true) announce(resolution);
 
   const path = manifestPath(workspaceRoot, profile, providerId);
-  const rerun = `${PROGRAM} connect custom ${providerId} --profile ${profile} --target ${target}`;
+  const rerun = `${PROGRAM} connect custom ${providerId} --profile ${profile} --workspace ${target}`;
 
   const prompter =
     options.prompter ??

--- a/src/cli/commands/connect/custom/write.test.ts
+++ b/src/cli/commands/connect/custom/write.test.ts
@@ -3,7 +3,7 @@ import { mkdtemp, readFile, rm, stat, writeFile, mkdir } from 'node:fs/promises'
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { layout } from '#profile';
-import { loadProfileProviders, parseManifest } from '#providers/custom/index.ts';
+import { loadWorkspaceProviders, parseManifest } from '#providers/custom/index.ts';
 import { deriveDeclaration, deriveManifest } from './derive.ts';
 import type { CustomAnswers } from './spec.ts';
 import {
@@ -18,7 +18,7 @@ import {
 /**
  * That the file this command writes is one the loader reads.
  *
- * Asserted against `loadProfileProviders` rather than against this file's own
+ * Asserted against `loadWorkspaceProviders` rather than against this file's own
  * idea of the path, because "wrote a manifest" and "declared a provider" are
  * only the same claim if the two agree about where manifests live — and the one
  * message that used to tell an operator that named the wrong directory.
@@ -56,7 +56,7 @@ describe('the manifest lands where the loader looks', () => {
 
     await writeManifest(path, renderManifest(deriveDeclaration(answers())));
 
-    const loaded = await loadProfileProviders(root, PROFILE);
+    const loaded = await loadWorkspaceProviders(root);
     expect(loaded.map((entry) => entry.manifest.id)).toEqual(['thing']);
     expect(loaded[0]?.manifest.auth).toMatchObject({ kind: 'bearer' });
   });
@@ -69,7 +69,7 @@ describe('the manifest lands where the loader looks', () => {
 
     await writeManifest(path, 'id: thing\n');
 
-    expect((await stat(join(root, layout.providers(PROFILE)))).isDirectory()).toBe(true);
+    expect((await stat(join(root, layout.providers()))).isDirectory()).toBe(true);
   });
 
   test('readable only by its owner, like every other file here', async () => {
@@ -87,10 +87,10 @@ describe('the manifest lands where the loader looks', () => {
     // loader tries to parse, which would break every command for this profile.
     const root = await workspace();
     const path = manifestPath(root, PROFILE, 'thing');
-    await mkdir(join(root, layout.providers(PROFILE)), { recursive: true });
+    await mkdir(join(root, layout.providers()), { recursive: true });
     await writeFile(`${path}.tmp`, 'id: broken');
 
-    await expect(loadProfileProviders(root, PROFILE)).resolves.toEqual([]);
+    await expect(loadWorkspaceProviders(root)).resolves.toEqual([]);
   });
 });
 
@@ -179,7 +179,7 @@ describe('an OpenAPI document named as a path', () => {
 
   test('one beside the manifest is found', async () => {
     const root = await workspace();
-    const directory = join(root, layout.providers(PROFILE));
+    const directory = join(root, layout.providers());
     await mkdir(directory, { recursive: true });
     await writeFile(join(directory, 'thing.json'), '{}');
 

--- a/src/cli/commands/connect/custom/write.ts
+++ b/src/cli/commands/connect/custom/write.ts
@@ -17,7 +17,7 @@ import { parseManifest } from '#providers/custom/index.ts';
 
 /** Where this profile keeps its own declarations. */
 export function manifestPath(workspaceRoot: string, profile: string, id: string): string {
-  return join(workspaceRoot, layout.providers(profile), `${id}.yaml`);
+  return join(workspaceRoot, layout.providers(), `${id}.yaml`);
 }
 
 /**
@@ -142,7 +142,7 @@ export async function checkOpenapiReachable(
 
   const beside = isAbsolute(value)
     ? value
-    : resolve(join(workspaceRoot, layout.providers(profile)), value);
+    : resolve(join(workspaceRoot, layout.providers()), value);
 
   if (await exists(beside)) return;
 

--- a/src/cli/commands/connect/declare.test.ts
+++ b/src/cli/commands/connect/declare.test.ts
@@ -13,7 +13,7 @@ import { declareConnection } from './declare.ts';
  * once, after which `connect` no longer recognised the account it had renamed.
  */
 
-const EMPTY = `contract: 2
+const EMPTY = `contract: 3
 instance:
   profile: personal
   host: 127.0.0.1

--- a/src/cli/commands/connect/grant.ts
+++ b/src/cli/commands/connect/grant.ts
@@ -1,27 +1,42 @@
+import type { Config } from '#profile';
 import type { ConfigDocument } from '../../config-edit.ts';
 import { matchesRule } from './accounts.ts';
 
 /**
  * What connecting grants.
  *
- * One rule per provider, not one per capability. The pinned-per-tool form this
- * replaced was 85 lines for four providers and unreadable, and what it bought —
- * a vendor cannot widen your policy by shipping a new tool — is preserved
- * instead by `doctor`, which reports capabilities that appeared after you
- * connected.
+ * One row naming the connection, carrying the wildcard for its provider — not
+ * one rule per capability. The pinned-per-tool form this replaced was 85 lines
+ * for four providers and unreadable, and what it bought — a vendor cannot widen
+ * your policy by shipping a new tool — is preserved instead by `doctor`, which
+ * reports capabilities that appeared after you connected.
  *
- * Idempotent, and by matching rather than by equality: a profile already holding
- * a broader rule that covers this one is not widened, and a second connect to
- * the same provider adds nothing.
+ * A row rather than a rule, since contract 3. The connection and the permission
+ * used to be two writes into two blocks, which is what made "a row with no rule"
+ * and "a rule with no row" both expressible and both silent: the first served
+ * nothing, the second was refused at load. A grant is one thing now (ADR-058),
+ * so neither state exists to be repaired.
+ *
+ * Idempotent, and by matching rather than by equality: a profile whose row for
+ * this connection already holds a broader rule is not widened, and a second
+ * connect to the same account adds nothing.
  */
-export function grantProvider(
+export function grantConnection(
   document: ConfigDocument,
-  allow: readonly { readonly capability: string }[],
-  providerId: string,
+  config: Config,
+  connection: string,
 ): string[] {
-  const rule = `${providerId}.*`;
-  if (allow.some((existing) => matchesRule(existing.capability, rule))) return [];
+  const rule = `${connection.split('.')[0] ?? ''}.*`;
+  const index = config.grants.findIndex((grant) => grant.connection === connection);
 
-  document.addTo(['policy', 'allow'], rule, { inline: true });
+  if (index === -1) {
+    document.addTo(['grants'], { connection, allow: [rule], deny: [] });
+    return [rule];
+  }
+
+  const existing = config.grants[index]!;
+  if (existing.allow.some((held) => matchesRule(held.capability, rule))) return [];
+
+  document.addTo(['grants', index, 'allow'], rule, { inline: true });
   return [rule];
 }

--- a/src/cli/commands/connect/index.ts
+++ b/src/cli/commands/connect/index.ts
@@ -204,7 +204,14 @@ export async function runConnect(
       manifest,
       provisionalId,
       credentials: runtime.credentials,
-      document,
+      // The connections file, not the profile. `oauth_apps` moved there in
+      // contract 3 — `configSchema` does not declare it any more and only
+      // `connectionsFileSchema` does — so `--own-client` was writing the switch
+      // into a key nothing reads. With no `--profile` the profile document is
+      // not even saved, so it was reported and discarded; with one, it landed in
+      // a block the schema drops, and dispatch fell back to the broker client
+      // while `deploy` bound none of the operator's own refs.
+      document: connectionsDocument,
       changes,
       providerId,
       connections: grantedConnections(runtime),

--- a/src/cli/commands/connect/index.ts
+++ b/src/cli/commands/connect/index.ts
@@ -7,7 +7,12 @@ import { nonInteractivePrompter, terminalPrompter, type Prompter } from '../../p
 import type { ConnectOptions } from './options.ts';
 
 export type { ConnectOptions } from './options.ts';
-import { grantedConnections, openRuntime, type GlobalFlags } from '../../runtime.ts';
+import {
+  grantedConnections,
+  openRuntime,
+  primaryProfile,
+  type GlobalFlags,
+} from '../../runtime.ts';
 import { moveCredential, siblingAccountId } from './accounts.ts';
 import { grantConnection } from './grant.ts';
 import { acquireCredential } from './acquire.ts';
@@ -59,7 +64,13 @@ export async function runConnect(
 
   // The runtime is opened first because its registry includes workspace
   // manifests — a custom provider must be as connectable as a built-in.
-  const runtime = await openRuntime(options);
+  // A connection belongs to the workspace, so connecting does not need a
+  // profile (ADR-057). One is still resolved, because the registry that reads
+  // `providers.d/` is opened through a runtime and a runtime carries one — but
+  // it is not the subject, and nothing is written to it unless `--profile` was
+  // actually given.
+  const granting = options.profile !== undefined;
+  const runtime = await openRuntime({ ...options, profile: await primaryProfile(options) });
 
   // Declared out here so the `finally` can close whatever it built.
   let address: ResolvedAddress | undefined;
@@ -70,7 +81,7 @@ export async function runConnect(
     // `gs://` workspace is a second network read of the same YAML. Still long
     // before the browser opens, which is the part that matters. Inside the
     // `try` so the `finally` closes the runtime if the rendering throws.
-    if (!announced) announceConnectTarget(runtime, options.json);
+    if (!announced) announceConnectTarget(runtime, options.json, granting);
 
     const registry = runtime.registry;
     const entry = registry.get(providerId);
@@ -268,7 +279,14 @@ export async function runConnect(
     // 5. Grant it — one row naming the connection, carrying its provider's
     //    wildcard (ADR-058). The row *is* the grant, so neither half can be
     //    written without the other.
-    const granted = grantConnection(document, runtime.config, `${providerId}.${connectionId}`);
+    //    Only when a profile was named. Connecting authorises an account into
+    //    the workspace; deciding what may be done with it belongs to a profile,
+    //    and those are two acts — so `connect` without `--profile` leaves the
+    //    account granted to nobody and says how to grant it. Writing a grant
+    //    into a profile the operator did not name would be choosing for them.
+    const granted = granting
+      ? grantConnection(document, runtime.config, `${providerId}.${connectionId}`)
+      : [];
 
     // 6. Repair the owner layer if this profile predates it.
     //
@@ -285,7 +303,7 @@ export async function runConnect(
     //    sentence in it is something a caller counting edits has to recognise
     //    and skip, and `granted` is the field that answers "what did this widen"
     //    — an audit reading it would have missed `setup.*` entirely.
-    const repair = ensureOwnerLayer(connectionsDocument, document);
+    const repair = ensureOwnerLayer(connectionsDocument, document, { grants: granting });
     changes.push(...repair.changes);
     granted.push(...repair.granted);
 
@@ -312,7 +330,10 @@ export async function runConnect(
       };
     }
 
-    await document.save();
+    // Untouched when no profile was named, and `save()` on an unchanged document
+    // still rewrites the file — which would restamp a profile nobody asked to
+    // edit.
+    if (granting) await document.save();
 
     // Where the endpoint that has to serve this reads its config, and then a
     // nudge to re-read it. Neither is a deploy (ADR-029).

--- a/src/cli/commands/connect/index.ts
+++ b/src/cli/commands/connect/index.ts
@@ -1,5 +1,6 @@
 import { CONNECTIONS_FILE } from '#profile';
 import { credentialRefForConnection, WRITE_BUNDLE } from '#connectivity';
+import { recordConfigChange } from '../../audit-change.ts';
 import { ConfigDocument } from '../../config-edit.ts';
 import { ensureOwnerLayer, repaired } from '../../config-repair.ts';
 import { emit, print } from '../../output.ts';
@@ -355,6 +356,21 @@ export async function runConnect(
     // still rewrites the file — which would restamp a profile nobody asked to
     // edit.
     if (granting) await document.save();
+
+    // A connection belongs to the workspace, so the row is scoped to the
+    // workspace even when a profile was granted it in the same breath — the
+    // grant is its own event, written by `grant`.
+    await recordConfigChange(
+      runtime.config,
+      runtime.resolution.workspaceRoot,
+      runtime.target,
+      {
+        capability: 'config.connection.create',
+        scope: runtime.target,
+        connection: connectionKey,
+        arguments: { account, ...(label ? { label } : {}) },
+      },
+    );
 
     // Where the endpoint that has to serve this reads its config, and then a
     // nudge to re-read it. Neither is a deploy (ADR-029).

--- a/src/cli/commands/connect/index.ts
+++ b/src/cli/commands/connect/index.ts
@@ -1,11 +1,15 @@
+import { CONNECTIONS_FILE } from '#profile';
 import { credentialRefForConnection, WRITE_BUNDLE } from '#connectivity';
 import { ConfigDocument } from '../../config-edit.ts';
 import { ensureOwnerLayer, repaired } from '../../config-repair.ts';
 import { emit, print } from '../../output.ts';
 import { nonInteractivePrompter, terminalPrompter, type Prompter } from '../../prompt.ts';
-import { openRuntime, type GlobalFlags } from '../../runtime.ts';
+import type { ConnectOptions } from './options.ts';
+
+export type { ConnectOptions } from './options.ts';
+import { grantedConnections, openRuntime, type GlobalFlags } from '../../runtime.ts';
 import { moveCredential, siblingAccountId } from './accounts.ts';
-import { grantProvider } from './grant.ts';
+import { grantConnection } from './grant.ts';
 import { acquireCredential } from './acquire.ts';
 import { declareConnection } from './declare.ts';
 import { resolveConnectionAddress, type ResolvedAddress } from './variables.ts';
@@ -26,79 +30,6 @@ import { runStrategySetup } from './strategy.ts';
 import { announceConnectTarget } from './target-note.ts';
 import { unknownProvider } from './unknown.ts';
 
-/**
- * `lanes link connect <provider>` — the one command that adds an account.
- *
- * The same command regardless of connectivity. A local provider declares a
- * connection and stops; an MCP provider authorises, asks the upstream server
- * what it exposes, and grants it. Core learns nothing about any vendor: the
- * manifest says how to reach them and what to ask the operator for.
- *
- * The five numbered steps below are the whole command, and each one that grew
- * past a paragraph moved out: `authorise.ts` gets the token, `setup.ts` asks the
- * operator for what the vendor's console produced, `settle.ts` works out whose
- * account it was, and `accounts.ts` knows which connections are siblings.
- */
-
-export interface ConnectOptions extends GlobalFlags {
-  readonly id?: string | undefined;
-  readonly displayName?: string | undefined;
-  /** `--set key=value`, repeatable: where this connection's service is. */
-  readonly set?: readonly string[] | string | undefined;
-  /**
-   * `--label`: what to call this connection, instead of being asked.
-   *
-   * Distinct from `--display-name`, which answers *whose account this is* for a
-   * provider that cannot report it. This one never touches the identity, so it
-   * is safe to pass anything a person would say out loud.
-   */
-  readonly label?: string | undefined;
-  /** Ask for the stored credential again — a key rotated, or a password revoked. */
-  readonly replace?: boolean | undefined;
-  /**
-   * Answer nothing from a terminal: resolve every declared value from the
-   * credential store, and refuse with instructions where one is missing.
-   */
-  readonly nonInteractive?: boolean | undefined;
-  /** The operator has already agreed to scopes broader than the provider needs. */
-  readonly acceptBroadScopes?: boolean | undefined;
-  /**
-   * Register an OAuth client of your own rather than using a hosted one.
-   *
-   * Sticky by consequence rather than by flag: it writes the `oauth_apps` entry,
-   * and a profile that declares one is never moved off it. So this is typed once
-   * and then forgotten, which is the right shape for a decision about a client
-   * that is shared by every connection of that vendor.
-   */
-  /**
-   * `--own-client`, the older spelling of one of the routes `--auth` now names.
-   *
-   * Kept because it is in scripts and in a year of documentation, and because
-   * it still says something true. It resolves to `--auth own_client`.
-   */
-  readonly ownClient?: boolean | undefined;
-  /**
-   * `--auth <method>`: which way in, for a provider that offers more than one.
-   *
-   * Unset means ask, where there is somebody to ask and something to ask
-   * about. It is not sticky the way `--own-client` is: `--own-client` writes an
-   * `oauth_apps` entry that every connection of the vendor then reads, whereas
-   * this decides one connection's credential and is recorded by that credential
-   * existing. Two accounts on the same profile may honestly differ.
-   */
-  readonly auth?: string | undefined;
-  /** Injected for tests. The broker is the only thing `connect` fetches. */
-  readonly fetch?: typeof globalThis.fetch | undefined;
-  readonly json?: boolean | undefined;
-}
-
-
-/**
- * The connection id used before the provider has said whose account this is.
- *
- * It is a placeholder rather than a name, and `setup.ts` reads it as one: a
- * credential filed under it belongs to a `connect` that did not finish.
- */
 const PROVISIONAL_ID = 'pending';
 
 export async function connect(target: string, options: ConnectOptions): Promise<void> {
@@ -171,7 +102,17 @@ export async function runConnect(
     }
 
     const manifest = entry.manifest;
-    const document = await ConfigDocument.open(runtime.resolution.workspaceRoot, runtime.resolution.profile);
+    // Two documents, because a connection and a grant live in two files
+    // (ADR-057). Both opened here, so a failure to open either happens before
+    // anything is written to the other.
+    const document = await ConfigDocument.open(
+      runtime.resolution.workspaceRoot,
+      runtime.resolution.profile,
+    );
+    const connectionsDocument = await ConfigDocument.openKey(
+      runtime.resolution.workspaceRoot,
+      CONNECTIONS_FILE,
+    );
     const changes: string[] = [];
 
     // 1. Authorise, if this provider needs it.
@@ -183,7 +124,7 @@ export async function runConnect(
     //    Unless a sibling already knows: when several providers of one vendor
     //    share a per-account credential, the second one should adopt the first's
     //    id rather than invent `pending` and ask for a password already held.
-    const adopted = siblingAccountId(manifest, runtime.config, registry);
+    const adopted = siblingAccountId(manifest, runtime.workspaceConnections, registry);
     const named = options.id ?? namedId;
     const provisionalId = named ?? adopted ?? PROVISIONAL_ID;
 
@@ -255,7 +196,7 @@ export async function runConnect(
       document,
       changes,
       providerId,
-      connections: runtime.config.connections,
+      connections: grantedConnections(runtime),
       target,
       profile,
       prompter,
@@ -313,8 +254,8 @@ export async function runConnect(
     // 4. Declare the connection, or update the one this account already has.
     changes.push(
       ...declareConnection({
-        document,
-        connections: runtime.config.connections,
+        document: connectionsDocument,
+        connections: runtime.workspaceConnections,
         providerId,
         connectionId,
         account,
@@ -324,8 +265,10 @@ export async function runConnect(
       }),
     );
 
-    // 5. Grant it — one rule per provider; `grant.ts` says why not per capability.
-    const granted = grantProvider(document, runtime.config.policy.allow, providerId);
+    // 5. Grant it — one row naming the connection, carrying its provider's
+    //    wildcard (ADR-058). The row *is* the grant, so neither half can be
+    //    written without the other.
+    const granted = grantConnection(document, runtime.config, `${providerId}.${connectionId}`);
 
     // 6. Repair the owner layer if this profile predates it.
     //
@@ -342,7 +285,7 @@ export async function runConnect(
     //    sentence in it is something a caller counting edits has to recognise
     //    and skip, and `granted` is the field that answers "what did this widen"
     //    — an audit reading it would have missed `setup.*` entirely.
-    const repair = ensureOwnerLayer(document);
+    const repair = ensureOwnerLayer(connectionsDocument, document);
     changes.push(...repair.changes);
     granted.push(...repair.granted);
 

--- a/src/cli/commands/connect/index.ts
+++ b/src/cli/commands/connect/index.ts
@@ -330,6 +330,20 @@ export async function runConnect(
       };
     }
 
+    // The connections file first, always, and the profile second.
+    //
+    // First because a grant naming a connection the workspace does not hold is
+    // refused at load by `assertGrantsResolve` — so if only one of these two
+    // writes lands, it has to be this one. The other order leaves a workspace
+    // that will not open.
+    //
+    // Always because this is where the connection is *declared*, and until this
+    // release it was never written at all: `declareConnection` edited a document
+    // in memory and nothing saved it, so a connect stored the credential, wrote
+    // the grant, and left no row. The account was authorised, invisible, and
+    // unusable.
+    await connectionsDocument.save();
+
     // Untouched when no profile was named, and `save()` on an unchanged document
     // still rewrites the file — which would restamp a profile nobody asked to
     // edit.

--- a/src/cli/commands/connect/options.ts
+++ b/src/cli/commands/connect/options.ts
@@ -1,0 +1,83 @@
+import type { GlobalFlags } from '../../runtime.ts';
+
+/**
+ * What `lanes link connect` accepts, and what it hands back.
+ *
+ * Split out of `index.ts` so that file stays inside the size budget. The seam is
+ * the one the command already has: this is the shape of the request, and that is
+ * the six steps that carry it out.
+ */
+
+/**
+ * `lanes link connect <provider>` — the one command that adds an account.
+ *
+ * The same command regardless of connectivity. A local provider declares a
+ * connection and stops; an MCP provider authorises, asks the upstream server
+ * what it exposes, and grants it. Core learns nothing about any vendor: the
+ * manifest says how to reach them and what to ask the operator for.
+ *
+ * The five numbered steps below are the whole command, and each one that grew
+ * past a paragraph moved out: `authorise.ts` gets the token, `setup.ts` asks the
+ * operator for what the vendor's console produced, `settle.ts` works out whose
+ * account it was, and `accounts.ts` knows which connections are siblings.
+ */
+
+export interface ConnectOptions extends GlobalFlags {
+  readonly id?: string | undefined;
+  readonly displayName?: string | undefined;
+  /** `--set key=value`, repeatable: where this connection's service is. */
+  readonly set?: readonly string[] | string | undefined;
+  /**
+   * `--label`: what to call this connection, instead of being asked.
+   *
+   * Distinct from `--display-name`, which answers *whose account this is* for a
+   * provider that cannot report it. This one never touches the identity, so it
+   * is safe to pass anything a person would say out loud.
+   */
+  readonly label?: string | undefined;
+  /** Ask for the stored credential again — a key rotated, or a password revoked. */
+  readonly replace?: boolean | undefined;
+  /**
+   * Answer nothing from a terminal: resolve every declared value from the
+   * credential store, and refuse with instructions where one is missing.
+   */
+  readonly nonInteractive?: boolean | undefined;
+  /** The operator has already agreed to scopes broader than the provider needs. */
+  readonly acceptBroadScopes?: boolean | undefined;
+  /**
+   * Register an OAuth client of your own rather than using a hosted one.
+   *
+   * Sticky by consequence rather than by flag: it writes the `oauth_apps` entry,
+   * and a profile that declares one is never moved off it. So this is typed once
+   * and then forgotten, which is the right shape for a decision about a client
+   * that is shared by every connection of that vendor.
+   */
+  /**
+   * `--own-client`, the older spelling of one of the routes `--auth` now names.
+   *
+   * Kept because it is in scripts and in a year of documentation, and because
+   * it still says something true. It resolves to `--auth own_client`.
+   */
+  readonly ownClient?: boolean | undefined;
+  /**
+   * `--auth <method>`: which way in, for a provider that offers more than one.
+   *
+   * Unset means ask, where there is somebody to ask and something to ask
+   * about. It is not sticky the way `--own-client` is: `--own-client` writes an
+   * `oauth_apps` entry that every connection of the vendor then reads, whereas
+   * this decides one connection's credential and is recorded by that credential
+   * existing. Two accounts on the same profile may honestly differ.
+   */
+  readonly auth?: string | undefined;
+  /** Injected for tests. The broker is the only thing `connect` fetches. */
+  readonly fetch?: typeof globalThis.fetch | undefined;
+  readonly json?: boolean | undefined;
+}
+
+
+/**
+ * The connection id used before the provider has said whose account this is.
+ *
+ * It is a placeholder rather than a name, and `setup.ts` reads it as one: a
+ * credential filed under it belongs to a `connect` that did not finish.
+ */

--- a/src/cli/commands/connect/persistence.test.ts
+++ b/src/cli/commands/connect/persistence.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, test } from 'bun:test';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+/**
+ * That `connect` writes down what it just authorised.
+ *
+ * Read off the source, which is the same technique `selection.test.ts` uses on
+ * `main.ts` and for the same reason: this is wiring, no unit test reaches it,
+ * and the thing that went wrong is a call that was never made rather than a
+ * value that was wrong.
+ *
+ * **What happened.** `declareConnection` edited a `ConfigDocument` held in
+ * memory and nothing ever saved it. A connect stored the credential, wrote the
+ * grant into the profile, printed `connections.yaml += gmail.x` among its
+ * changes, and left the file untouched — so the account was authorised,
+ * absent from every listing, and unusable. Every test passed, because each one
+ * asserted on the returned `changes` or on a document object rather than on
+ * what reached the disk.
+ *
+ * A real end-to-end test would be better and is not available: every provider
+ * that ships needs a browser or a pasted secret to get as far as declaring
+ * anything.
+ */
+
+const SOURCE = readFileSync(join(import.meta.dir, 'index.ts'), 'utf8');
+
+describe('connect persists what it declares', () => {
+  test('saves the connections document', () => {
+    expect(SOURCE).toContain('connectionsDocument.save()');
+  });
+
+  test('saves it unconditionally, not only when a profile was named', () => {
+    // `connect --workspace local` authorises into the workspace and grants
+    // nothing. That is the path where the row is the *only* thing written, so
+    // gating this save the way the profile's is gated would restore the bug for
+    // exactly the command that most needs it.
+    const at = SOURCE.indexOf('connectionsDocument.save()');
+    const line = SOURCE.slice(SOURCE.lastIndexOf('\n', at) + 1, at).trim();
+
+    expect(line).toBe('await');
+  });
+
+  test('saves the connections file before the profile', () => {
+    // A grant naming a connection the workspace does not hold is refused at
+    // load by `assertGrantsResolve`. If only one of the two writes lands it has
+    // to be the connection, or the workspace will not open.
+    expect(SOURCE.indexOf('connectionsDocument.save()')).toBeLessThan(
+      SOURCE.indexOf('document.save()', SOURCE.indexOf('connectionsDocument.save()') + 1),
+    );
+  });
+});

--- a/src/cli/commands/connect/registration.ts
+++ b/src/cli/commands/connect/registration.ts
@@ -1,0 +1,50 @@
+import type { ProviderManifest } from '#connectivity';
+
+/**
+ * Turn a refused registration into something an operator can act on.
+ *
+ * A provider declaring `registration: 'dynamic'` is promising that its
+ * authorization server will register a client on demand — that is the whole
+ * reason those providers need no setup. When the server refuses, the SDK throws
+ * the status and nothing else, and "Dynamic Client Registration rejected (HTTP
+ * 403): Forbidden" tells the reader neither what was being attempted nor that
+ * there is nothing wrong with their machine.
+ *
+ * It is a real state rather than a bug: a server may advertise a registration
+ * endpoint and gate it behind a plan, an allowlist, or a signed-in session.
+ * Figma's does, which is how this was found. What the operator needs to know is
+ * that the refusal came from the provider, that we sent nothing wrong, and
+ * where the answer lives — which is the provider's own documentation, because
+ * whatever unlocks it is theirs to state.
+ */
+export async function registering<T>(
+  manifest: ProviderManifest,
+  serverUrl: string,
+  run: () => Promise<T>,
+): Promise<T> {
+  if (manifest.auth.kind !== 'oauth' || manifest.auth.registration !== 'dynamic') return run();
+
+  try {
+    return await run();
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    if (!/registration/i.test(message)) throw error;
+
+    const host = new URL(serverUrl).host;
+    throw new Error(
+      `${manifest.name} refused to register this machine as a client.\n` +
+        `  ${message}\n` +
+        '\n' +
+        `  Nothing was written, and nothing about your setup is wrong: ${host}\n` +
+        '  advertises registration and then declined it. That is usually a plan, an\n' +
+        '  allowlist, or an account that has to be signed in first.\n' +
+        `  What unlocks it is theirs to say: ${docsFor(manifest) ?? host}`,
+    );
+  }
+}
+
+/** Where the provider tells you what it wants, when the manifest names it. */
+function docsFor(manifest: ProviderManifest): string | undefined {
+  const setup = (manifest as { setup?: { docs_url?: unknown } }).setup;
+  return typeof setup?.docs_url === 'string' ? setup.docs_url : undefined;
+}

--- a/src/cli/commands/connect/requirements.test.ts
+++ b/src/cli/commands/connect/requirements.test.ts
@@ -143,7 +143,7 @@ describe('preflight', () => {
     // five minutes. An agent's shell times out first, taking the listener with
     // it, and the operator gets no token and no explanation.
     expect(blocked?.reason).toBe('needs_browser');
-    expect(blocked?.then).toBe('lanes link connect cloudy --profile personal --target local');
+    expect(blocked?.then).toBe('lanes link connect cloudy --profile personal --workspace local');
     expect(blocked?.needs).toEqual([]);
   });
 

--- a/src/cli/commands/connect/requirements.ts
+++ b/src/cli/commands/connect/requirements.ts
@@ -102,7 +102,7 @@ export async function preflight(input: {
 }): Promise<Blocked | null> {
   const { manifest, connectionId, profile, target, spec } = input;
   const method = input.method ?? 'oauth';
-  const rerun = `lanes link connect ${spec} --profile ${profile} --target ${target}`;
+  const rerun = `lanes link connect ${spec} --profile ${profile} --workspace ${target}`;
   const assertion = manifest.auth.kind === 'oauth' ? manifest.auth.assertion : undefined;
 
   if (method === 'assertion' && assertion) {

--- a/src/cli/commands/connect/settle.test.ts
+++ b/src/cli/commands/connect/settle.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from 'bun:test';
 import { defineProvider } from '#connectivity';
-import type { Config } from '#profile';
+import type { ConnectionConfig, Config } from '#profile';
 import type { AnyConnector, ProviderManifest } from '#connectivity';
 import type { SecretRef, SecretStore } from '#secrets';
 import { PromptCancelled, type Prompter } from '../../prompt.ts';
@@ -88,9 +88,15 @@ const silent: Prompter = {
   confirm: async () => false,
 };
 
-function runtime(connections: Config['connections'] = [], identity: string | null = 'ada@example.com') {
+function runtime(
+  connections: readonly ConnectionConfig[] = [],
+  identity: string | null = 'ada@example.com',
+) {
   return {
-    config: { connections } as Config,
+    config: { grants: [] } as unknown as Config,
+    // The accounts are the workspace's now (ADR-057), and sibling matching reads
+    // them from there rather than from the profile being connected into.
+    workspaceConnections: connections,
     credentials: memoryStore(),
     registry: { manifest: () => undefined },
     connectorFor: () =>
@@ -136,7 +142,7 @@ describe('the label a connection is given at connect time', () => {
   test('offers the label already on the row when this connect is a reconnect', async () => {
     const declared = [
       { id: 'ada', provider: 'acme_mail', account: 'ada@example.com', label: 'Work mail' },
-    ] as Config['connections'];
+    ] as ConnectionConfig[];
     const asking = prompter('');
 
     const settled = await settle({ prompter: asking, runtime: runtime(declared) });

--- a/src/cli/commands/connect/settle.ts
+++ b/src/cli/commands/connect/settle.ts
@@ -1,7 +1,7 @@
 import { createMcpConnector } from '#connectivity/transports';
 import { bearerTokenAsStored } from '#connectivity/auth/index.ts';
 import type { SecretStore } from '#secrets';
-import type { Config } from '#profile';
+import type { ConnectionConfig, Config } from '#profile';
 import type { AnyConnector, ProviderManifest } from '#connectivity';
 import { idFromAccount, resolveAccount } from '../../identity.ts';
 import { style } from '../../output.ts';
@@ -38,6 +38,8 @@ export async function settleIdentity(input: {
   label?: string | undefined;
   runtime: {
     config: Config;
+    /** Every account the workspace holds, for sibling matching (ADR-057). */
+    workspaceConnections: readonly ConnectionConfig[];
     credentials: SecretStore;
     registry: { manifest(id: string): ProviderManifest | undefined };
     connectorFor(providerId: string, connectionId: string): AnyConnector | undefined;
@@ -51,7 +53,7 @@ export async function settleIdentity(input: {
   // Siblings across the whole vendor account, not just this provider — so
   // connecting iCloud Calendar after iCloud Mail lands on the same id, and
   // therefore the same credential, rather than a second `will2`.
-  const siblings = accountSiblings(manifest, runtime.config, runtime.registry);
+  const siblings = accountSiblings(manifest, runtime.workspaceConnections, runtime.registry);
 
   let account = input.account ?? null;
 

--- a/src/cli/commands/connect/target-note.ts
+++ b/src/cli/commands/connect/target-note.ts
@@ -1,5 +1,5 @@
 import type { Resolution } from '#profile';
-import { announce } from '../../output.ts';
+import { announce, announceWorkspace } from '../../output.ts';
 
 /**
  * The line `connect` prints before it acts.
@@ -23,6 +23,7 @@ import { announce } from '../../output.ts';
 export function announceConnectTarget(
   runtime: { readonly resolution: Resolution },
   json?: boolean | undefined,
+  granting = true,
 ): void {
   // `emit`'s early return only protects lines printed *at* the emit, and this
   // one has to precede the browser — so it carries its own guard, the one
@@ -30,5 +31,9 @@ export function announceConnectTarget(
   // beside `emit`: a line of prose in front of a JSON document corrupts it.
   if (json === true) return;
 
-  announce(runtime.resolution);
+  // Without `--profile` this connects into the workspace and edits no profile,
+  // so naming the one a runtime happened to resolve would report a subject the
+  // command does not have.
+  if (granting) announce(runtime.resolution);
+  else announceWorkspace(runtime.resolution);
 }

--- a/src/cli/commands/connect/unknown.ts
+++ b/src/cli/commands/connect/unknown.ts
@@ -28,7 +28,7 @@ export function unknownProvider(input: {
   const yours = available.filter((c) => c.origin === 'workspace').map((c) => c.manifest.id);
 
   const selection = `--profile ${input.profile} --target ${input.target}`;
-  const directory = `${input.workspaceRoot}/${layout.providers(input.profile)}`;
+  const directory = `${input.workspaceRoot}/${layout.providers()}`;
 
   return new Error(
     `Unknown provider "${input.providerId}".\n` +

--- a/src/cli/commands/connect/variables.ts
+++ b/src/cli/commands/connect/variables.ts
@@ -161,7 +161,8 @@ export async function resolveConnectionAddress(input: {
   readonly runtime: {
     readonly registry: ProviderRegistry;
     readonly credentials: SecretStore;
-    readonly config: { readonly connections: readonly ConnectionRow[] };
+    /** Every account the workspace holds, for the address a sibling already gave (ADR-057). */
+    readonly workspaceConnections: readonly ConnectionRow[];
     connectorFor(providerId: string, connectionId: string): AnyConnector | undefined;
   };
 }): Promise<ResolvedAddress> {
@@ -178,7 +179,7 @@ export async function resolveConnectionAddress(input: {
     // the id is not settled yet, and a second Nextcloud on a *different* host is
     // rarer than reconnecting the one there is. It is offered, not imposed —
     // pressing Enter accepts it and typing replaces it.
-    existing: previousAddress(runtime.config.connections, input.providerId, manifest),
+    existing: previousAddress(runtime.workspaceConnections, input.providerId, manifest),
     interactive: input.interactive,
     supplied: parseSet(input.set),
   });

--- a/src/cli/commands/connection-list.ts
+++ b/src/cli/commands/connection-list.ts
@@ -1,0 +1,116 @@
+import { RESERVED_PROVIDER_IDS } from '#connectivity';
+import {
+  connectionRefOf,
+  listProfiles,
+  loadProfileConfig,
+  readConnections,
+  resolveTargetWorkspace,
+  resolveWorkspaceRoot,
+} from '#profile';
+import { emit, heading, print, style, table } from '../output.ts';
+import type { GlobalFlags } from '../runtime.ts';
+
+/**
+ * `lanes link connection list` — every account this workspace holds, and which
+ * profiles reach each.
+ *
+ * The listing that had nowhere to live under contract 2, because there was no
+ * such thing as "the workspace's connections": each profile had its own list
+ * and `status` printed one profile's. A connection belongs to the workspace now
+ * (ADR-057), so the question "what have I authorised" has one answer.
+ *
+ * **The profiles column is the useful half.** An account granted to nobody is
+ * connected and unreachable, which looks identical to a working one from
+ * anywhere else — and an account granted to more profiles than the operator
+ * remembers is how a disconnect surprises somebody. Both are visible here and
+ * nowhere else.
+ *
+ * Workspace-scoped, so it takes no `--profile`. Passing one would narrow the
+ * column rather than the rows, which is a different command.
+ */
+
+export interface ConnectionSummary {
+  readonly key: string;
+  readonly provider: string;
+  readonly account: string;
+  readonly label: string | null;
+  /** Whether this is part of the owner layer rather than somebody's account. */
+  readonly builtIn: boolean;
+  /** Every profile in the workspace whose grants name it. */
+  readonly grantedTo: readonly string[];
+}
+
+export async function connectionList(flags: GlobalFlags & { json?: boolean }): Promise<void> {
+  const local = resolveWorkspaceRoot();
+  const root = await resolveTargetWorkspace(local, flags.target ?? 'local');
+
+  const held = (await readConnections(root)).connections;
+
+  // Read once, ahead of the loop. The alternative is a file read per connection
+  // per profile, which on a workspace with fifteen accounts and three profiles
+  // is forty-five reads of five files.
+  const grants = new Map<string, string[]>();
+  for (const name of await listProfiles(root)) {
+    try {
+      const { config } = await loadProfileConfig(root, name);
+      for (const grant of config.grants) {
+        grants.set(grant.connection, [...(grants.get(grant.connection) ?? []), name]);
+      }
+    } catch {
+      // A profile that will not load is `check`'s to report. Dropping it here
+      // makes this listing answer for the ones that do rather than failing
+      // wholesale on one broken file.
+    }
+  }
+
+  const summaries: ConnectionSummary[] = held.map((connection) => {
+    const key = connectionRefOf(connection);
+    return {
+      key,
+      provider: connection.provider,
+      account: connection.account,
+      label: connection.label ?? null,
+      builtIn: RESERVED_PROVIDER_IDS.includes(connection.provider),
+      grantedTo: grants.get(key) ?? [],
+    };
+  });
+
+  return emit(flags.json, { workspace: flags.target ?? 'local', connections: summaries }, () => {
+    print(style.dim(`workspace ${style.bold(flags.target ?? 'local')}  ${root}`));
+
+    const accounts = summaries.filter((one) => !one.builtIn);
+    const builtIns = summaries.filter((one) => one.builtIn);
+
+    if (accounts.length === 0) {
+      print('');
+      print(style.dim('No accounts connected yet. Connect one with: lanes link connect <provider>'));
+    } else {
+      heading(`Accounts (${accounts.length})`);
+      table(accounts.map(row));
+    }
+
+    if (builtIns.length > 0) {
+      heading(`Your own material (${builtIns.length})`);
+      table(builtIns.map(row));
+    }
+
+    print('');
+    print(
+      style.dim(
+        'A connection reaches a profile only where that profile grants it:\n' +
+          '  lanes link grant <provider>.<id> --profile <name>',
+      ),
+    );
+  });
+}
+
+function row(one: ConnectionSummary): string[] {
+  // "granted to nobody" is said rather than left blank, because a blank column
+  // reads as "not loaded yet" and this is a fact about the config.
+  const reach =
+    one.grantedTo.length === 0
+      ? style.dim('no profile grants it')
+      : one.grantedTo.join(', ');
+
+  return [`  ${style.bold(one.key)}`, one.label ?? one.account, reach];
+}

--- a/src/cli/commands/connection.test.ts
+++ b/src/cli/commands/connection.test.ts
@@ -4,11 +4,18 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { RESERVED_PROVIDER_IDS } from '#connectivity';
 import type { ProviderManifest } from '#connectivity';
-import { parseConfig, type Config } from '#profile';
+import {
+  CONNECTIONS_FILE,
+  parseConfig,
+  readConnections,
+  type Config,
+  type ConnectionConfig,
+} from '#profile';
 import { PROVIDER_MANIFESTS } from '#providers/index.ts';
 import { planAll } from '#providers/setup/plan.ts';
 import { createProfile } from './profile.ts';
-import { connectionsSharingCredential, removeConnection, renameConnection } from './connection.ts';
+import { connectionsSharingCredential, removeConnection } from './connection.ts';
+import { renameConnection } from './relabel.ts';
 
 /**
  * `lanes link disconnect` and `lanes link relabel`.
@@ -31,17 +38,20 @@ import { connectionsSharingCredential, removeConnection, renameConnection } from
 
 const WHERE = { profile: 'personal', target: 'local' } as const;
 
-// Only the accounts. The owner layer is not declared here: a fresh profile
-// arrives with `memory.main` and its siblings already granted (ADR-050), and
-// declaring one of them a second time is a duplicate the parser refuses — which
-// would fail every test in this file for a reason none of them is about.
+// Only the accounts. The owner layer is not declared here: a fresh workspace
+// arrives with `memory.main` and its siblings already in `connections.yaml`
+// (ADR-050, ADR-059), and declaring one of them a second time is a duplicate the
+// parser refuses — which would fail every test in this file for a reason none of
+// them is about.
 const CONNECTIONS = `
-  - id: main
-    provider: gmail
-    account: first@example.com
-  - id: side
-    provider: gmail
-    account: second@example.com
+  - { id: main, provider: gmail, account: first@example.com }
+  - { id: side, provider: gmail, account: second@example.com }
+`;
+
+/** The grants a profile needs to reach the two accounts above. */
+const GRANTS = `
+  - { connection: gmail.main, allow: [gmail.*], deny: [] }
+  - { connection: gmail.side, allow: [gmail.*], deny: [] }
 `;
 
 const roots: string[] = [];
@@ -54,10 +64,15 @@ async function workspace(): Promise<string> {
   await createProfile('personal', { targets: ['local'] });
 
   // Declared by hand rather than through `connect`, which would want a browser
-  // and a real Google account.
+  // and a real Google account. Two files now: the account belongs to the
+  // workspace and the permission to use it to the profile (ADR-057).
+  const connections = join(root, CONNECTIONS_FILE);
+  const held = await Bun.file(connections).text();
+  await Bun.write(connections, held.replace('connections:', `connections:${CONNECTIONS}`));
+
   const path = join(root, 'profiles', 'personal.yaml');
   const text = await Bun.file(path).text();
-  await Bun.write(path, text.replace('connections:', `connections:${CONNECTIONS}`));
+  await Bun.write(path, text.replace('grants:', `grants:${GRANTS}`));
   return root;
 }
 
@@ -72,8 +87,14 @@ async function onDisk(root: string): Promise<Config> {
   return parseConfig(text).config;
 }
 
+/** What the workspace holds, which is where a connection lives now. */
+async function held(root: string): Promise<string[]> {
+  return (await readConnections(root)).connections.map((one) => `${one.provider}.${one.id}`);
+}
+
+/** What the profile grants, which is a different question. */
 function keys(config: Config): string[] {
-  return config.connections.map((one) => `${one.provider}.${one.id}`);
+  return config.grants.map((grant) => grant.connection);
 }
 
 describe('disconnect', () => {
@@ -85,9 +106,11 @@ describe('disconnect', () => {
     expect(outcome).not.toBeNull();
     expect(outcome!.disconnected.key).toBe('gmail.side');
     expect(outcome!.disconnected.account).toBe('second@example.com');
+    expect(await held(root)).not.toContain('gmail.side');
+    expect(await held(root)).toContain('gmail.main');
+    expect(await held(root)).toContain('memory.main');
+    // And the grant that named it goes with it.
     expect(keys(await onDisk(root))).not.toContain('gmail.side');
-    expect(keys(await onDisk(root))).toContain('gmail.main');
-    expect(keys(await onDisk(root))).toContain('memory.main');
   });
 
   test('keeps the operator’s comments', async () => {
@@ -96,7 +119,7 @@ describe('disconnect', () => {
 
     const text = await Bun.file(join(root, 'profiles', 'personal.yaml')).text();
     // The template's own commentary, which a reformatting writer would drop.
-    expect(text).toContain('# One entry per authorised account');
+    expect(text).toContain('# One row per connection this profile may reach');
   });
 
   test('reports the credential it deleted', async () => {
@@ -118,7 +141,7 @@ describe('disconnect', () => {
 
     expect(outcome!.disconnected.credential).toBeNull();
     // The declaration still goes; only the secret stays.
-    expect(keys(await onDisk(await roots[roots.length - 1]!))).not.toContain('gmail.side');
+    expect(await held(roots[roots.length - 1]!)).not.toContain('gmail.side');
   });
 
   test('refuses a bare provider, and says which connections it has', async () => {
@@ -132,41 +155,62 @@ describe('disconnect', () => {
     );
   });
 
-  test('refuses a key the profile does not declare', async () => {
+  test('refuses a key the workspace does not hold', async () => {
     await workspace();
     await expect(removeConnection('gmail.nope', { ...WHERE, yes: true })).rejects.toThrow(
-      /does not declare "gmail\.nope"/,
+      /holds no connection "gmail\.nope"/,
     );
   });
 
-  test('refuses the owner layer, and says to edit the file', async () => {
+  test('refuses the last instance of a built-in, and says to deny it instead', async () => {
+    // Not a blanket refusal any more. An owner-layer surface is a connection
+    // like any other (ADR-059), so a second instance can be disconnected; the
+    // *last* one cannot, because `ensureOwnerLayer` puts it back on the next
+    // command and a success line the next command undoes is worse than a
+    // refusal.
     const root = await workspace();
 
     await expect(removeConnection('memory.main', { ...WHERE, yes: true })).rejects.toThrow(
-      /part of what this profile is[\s\S]*by hand/,
+      /only memory connection[\s\S]*policy deny/,
     );
     // And refuses before writing anything.
-    expect(keys(await onDisk(root))).toContain('memory.main');
+    expect(await held(root)).toContain('memory.main');
+  });
+
+  test('a second instance of a built-in disconnects normally', async () => {
+    const root = await workspace();
+    const connections = join(root, CONNECTIONS_FILE);
+    const text = await Bun.file(connections).text();
+    await Bun.write(
+      connections,
+      text.replace('connections:', 'connections:\n  - { id: work, provider: memory, account: Memory }'),
+    );
+
+    const outcome = await removeConnection('memory.work', { ...WHERE, yes: true });
+
+    expect(outcome!.disconnected.key).toBe('memory.work');
+    expect(await held(root)).not.toContain('memory.work');
+    expect(await held(root)).toContain('memory.main');
   });
 
   // Every reserved id, so one added to `RESERVED_PROVIDER_IDS` is covered here
   // the moment it exists rather than the next time somebody remembers.
-  test.each([...RESERVED_PROVIDER_IDS])('refuses %s', async (provider) => {
+  test.each([...RESERVED_PROVIDER_IDS])('refuses the last %s', async (provider) => {
     const root = await workspace();
-    const path = join(root, 'profiles', 'personal.yaml');
-    const text = await Bun.file(path).text();
-    // The template already declares every reserved id but `identity`; declaring
-    // one twice is a config the parser refuses, which would fail this for the
-    // wrong reason.
+    const connections = join(root, CONNECTIONS_FILE);
+    const text = await Bun.file(connections).text();
+    // The template already holds every reserved id but `identity`; declaring one
+    // twice is a config the parser refuses, which would fail this for the wrong
+    // reason.
     if (!text.includes(`provider: ${provider}`)) {
       await Bun.write(
-        path,
-        text.replace('connections:', `connections:\n  - id: main\n    provider: ${provider}\n    account: X\n`),
+        connections,
+        text.replace('connections:', `connections:\n  - { id: main, provider: ${provider}, account: X }`),
       );
     }
 
     await expect(removeConnection(`${provider}.main`, { ...WHERE, yes: true })).rejects.toThrow(
-      /part of what this profile is/,
+      /is the only .* connection in this workspace/,
     );
   });
 
@@ -175,7 +219,7 @@ describe('disconnect', () => {
     // script hits.
     const root = await workspace();
     await expect(removeConnection('gmail.side', WHERE)).rejects.toThrow(/Pass --yes/);
-    expect(keys(await onDisk(root))).toContain('gmail.side');
+    expect(await held(root)).toContain('gmail.side');
   });
 });
 
@@ -188,23 +232,22 @@ describe('a credential two connections resolve to', () => {
     capabilities: [],
   } as unknown as ProviderManifest;
 
-  const config = {
-    connections: [
-      { id: 'one', provider: 'shared', account: 'a' },
-      { id: 'two', provider: 'shared', account: 'b' },
-    ],
-  } as unknown as Config;
+  // Rows, not a profile. The accounts belong to the workspace now (ADR-057),
+  // and this check is about which of them resolve to one credential reference.
+  const rows: ConnectionConfig[] = [
+    { id: 'one', provider: 'shared', account: 'a' },
+    { id: 'two', provider: 'shared', account: 'b' },
+  ];
 
   test('is named, not deleted', () => {
     // The whole reason the check exists: a manifest-level `credential_ref` is one
     // reference for every connection of that provider.
-    const found = connectionsSharingCredential(config, 'shared/key', 0, () => shared);
+    const found = connectionsSharingCredential(rows, 'shared/key', 0, () => shared);
     expect(found).toEqual(['shared.two']);
   });
 
   test('is deleted once nothing else resolves to it', () => {
-    const only = { connections: [config.connections[0]] } as unknown as Config;
-    expect(connectionsSharingCredential(only, 'shared/key', 0, () => only && shared)).toEqual([]);
+    expect(connectionsSharingCredential([rows[0]!], 'shared/key', 0, () => shared)).toEqual([]);
   });
 
   test('does not confuse two OAuth connections, whose refs differ', () => {
@@ -215,12 +258,10 @@ describe('a credential two connections resolve to', () => {
       auth: { kind: 'oauth' },
       capabilities: [],
     } as unknown as ProviderManifest;
-    const two = {
-      connections: [
-        { id: 'main', provider: 'gmail', account: 'a' },
-        { id: 'side', provider: 'gmail', account: 'b' },
-      ],
-    } as unknown as Config;
+    const two: ConnectionConfig[] = [
+      { id: 'main', provider: 'gmail', account: 'a' },
+      { id: 'side', provider: 'gmail', account: 'b' },
+    ];
 
     expect(connectionsSharingCredential(two, 'gmail/main', 0, () => oauth)).toEqual([]);
   });
@@ -234,8 +275,8 @@ describe('relabel', () => {
 
     expect(relabelled.from).toBe('first@example.com');
     expect(relabelled.to).toBe('Work Mail');
-    const config = await onDisk(root);
-    expect(config.connections.find((c) => c.provider === 'gmail' && c.id === 'main')?.label)
+    const rows = (await readConnections(root)).connections;
+    expect(rows.find((one) => one.provider === 'gmail' && one.id === 'main')?.label)
       .toBe('Work Mail');
   });
 
@@ -255,8 +296,8 @@ describe('relabel', () => {
 
     await renameConnection('gmail.main', 'Work Mail', WHERE);
 
-    const config = await onDisk(root);
-    expect(config.connections.find((c) => c.provider === 'gmail' && c.id === 'main')?.account)
+    const rows = (await readConnections(root)).connections;
+    expect(rows.find((one) => one.provider === 'gmail' && one.id === 'main')?.account)
       .toBe('first@example.com');
   });
 
@@ -264,10 +305,11 @@ describe('relabel', () => {
     const root = await workspace();
     await renameConnection('gmail.main', 'Work Mail', WHERE);
 
-    const config = await onDisk(root);
-    expect(keys(config)).toContain('gmail.side');
-    expect(config.connections.find((c) => c.id === 'side')?.account).toBe('second@example.com');
-    expect(config.connections.find((c) => c.id === 'side')?.label).toBeUndefined();
+    expect(keys(await onDisk(root))).toContain('gmail.side');
+
+    const rows = (await readConnections(root)).connections;
+    expect(rows.find((one) => one.id === 'side')?.account).toBe('second@example.com');
+    expect(rows.find((one) => one.id === 'side')?.label).toBeUndefined();
   });
 
   test('reports the label it replaced, not the account, once there is one', async () => {
@@ -286,13 +328,13 @@ describe('relabel', () => {
     const root = await workspace();
     await renameConnection('memory.main', 'My notes', WHERE);
 
-    const config = await onDisk(root);
-    expect(config.connections.find((c) => c.provider === 'memory')?.label).toBe('My notes');
+    const rows = (await readConnections(root)).connections;
+    expect(rows.find((one) => one.provider === 'memory')?.label).toBe('My notes');
   });
 
-  test('refuses a key the profile does not declare', async () => {
+  test('refuses a key the workspace does not hold', async () => {
     await workspace();
-    await expect(renameConnection('gmail.nope', 'X', WHERE)).rejects.toThrow(/does not declare/);
+    await expect(renameConnection('gmail.nope', 'X', WHERE)).rejects.toThrow(/holds no connection/);
   });
 });
 
@@ -321,56 +363,62 @@ describe('the plan reports which providers are reserved', () => {
 });
 
 /**
- * The rule goes with the last connection that justified it.
+ * The grant goes with the connection, because it *is* the connection.
  *
- * Not a tidiness feature. `assertReferentialIntegrity` refuses an allow rule
+ * The bug this replaced: `assertReferentialIntegrity` refused an allow rule
  * naming a provider with no connection, and `removeConnection` saves through
  * `validateConfig` — so disconnecting the last account of a provider failed, on
  * a policy line the operator had not touched, and removed nothing. Every
  * single-account provider was undisconnectable, which is most of them.
+ *
+ * That state is now unrepresentable. A grant names its connection (ADR-058), so
+ * "the rule that outlived its account" is not a thing a file can say, and the
+ * hunting `dropProviderRules` did — find every rule whose capability begins
+ * `gmail.`, decide whether each is now dangling — collapsed into removing one
+ * row.
  */
 describe('disconnecting the last connection of a provider', () => {
-  /** The policy line itself — the template's comments quote `allow: [` too. */
-  const POLICY = 'allow: [memory.*';
-
-  /** The fixture's profile, plus the `gmail.*` rule `connect` would have written. */
-  async function granted(): Promise<string> {
-    const root = await workspace();
-    const path = join(root, 'profiles', 'personal.yaml');
-    const text = await Bun.file(path).text();
-    await Bun.write(path, text.replace(POLICY, 'allow: [gmail.*, gmail.send_message, memory.*'));
-    return root;
-  }
-
   test('works at all, which is the whole of the bug', async () => {
-    // It did not. `save` validates, and the loader refuses an allow rule naming
-    // a provider with no connection — so removing the last Gmail failed on a
-    // policy line the operator had not touched, and removed nothing.
-    const root = await granted();
-
-    await removeConnection('gmail.main', { ...WHERE, yes: true });
-    await removeConnection('gmail.side', { ...WHERE, yes: true });
-
-    const config = await onDisk(root);
-    expect(keys(config).filter((key) => key.startsWith('gmail.'))).toEqual([]);
-    expect(config.policy.allow.map((rule) => rule.capability)).not.toContain('gmail.*');
-  });
-
-  test('leaves the rule while a sibling still needs it', async () => {
-    const root = await granted();
-    await removeConnection('gmail.side', { ...WHERE, yes: true });
-
-    expect((await onDisk(root)).policy.allow.map((rule) => rule.capability)).toContain('gmail.*');
-  });
-
-  test('never touches a blanket allow, which names no provider', async () => {
     const root = await workspace();
-    const path = join(root, 'profiles', 'personal.yaml');
-    await Bun.write(path, (await Bun.file(path).text()).replace(POLICY, "allow: ['*', memory.*"));
 
     await removeConnection('gmail.main', { ...WHERE, yes: true });
     await removeConnection('gmail.side', { ...WHERE, yes: true });
 
-    expect((await onDisk(root)).policy.allow.map((rule) => rule.capability)).toContain('*');
+    expect((await held(root)).filter((key) => key.startsWith('gmail.'))).toEqual([]);
+    expect(keys(await onDisk(root)).filter((key) => key.startsWith('gmail.'))).toEqual([]);
+  });
+
+  test('leaves the sibling grant while the sibling is still there', async () => {
+    const root = await workspace();
+    await removeConnection('gmail.side', { ...WHERE, yes: true });
+
+    expect(keys(await onDisk(root))).toContain('gmail.main');
+    expect(keys(await onDisk(root))).not.toContain('gmail.side');
+  });
+
+  test('reports which profiles lost a grant', async () => {
+    // A connection belongs to the workspace, so disconnecting one reaches every
+    // profile that named it — including profiles the operator was not thinking
+    // about. Naming them is the whole point of computing this before asking.
+    const root = await workspace();
+    const outcome = await removeConnection('gmail.side', { ...WHERE, yes: true });
+
+    expect(outcome!.disconnected.ungranted).toEqual(['personal']);
+    expect(await held(root)).not.toContain('gmail.side');
+  });
+
+  test('a connection nothing grants still disconnects, and says nobody lost it', async () => {
+    const root = await workspace();
+    const connections = join(root, CONNECTIONS_FILE);
+    const text = await Bun.file(connections).text();
+    await Bun.write(
+      connections,
+      text.replace('connections:', 'connections:\n  - { id: spare, provider: gmail, account: third@example.com }'),
+    );
+
+    const outcome = await removeConnection('gmail.spare', { ...WHERE, yes: true });
+
+    expect(outcome!.disconnected.ungranted).toEqual([]);
+    expect(await held(root)).not.toContain('gmail.spare');
   });
 });

--- a/src/cli/commands/connection.ts
+++ b/src/cli/commands/connection.ts
@@ -255,7 +255,17 @@ export async function removeConnection(
         remaining: connectionsFile.connections.length - 1,
         ungranted: affected,
         published: nextAfterEdit(
-          await publishProfileEdit({ resolution, config: runtime.config, target }),
+          await publishProfileEdit({
+            resolution,
+            config: runtime.config,
+            target,
+            // Every profile that lost a grant, not just the one this ran under.
+            // Publishing one left the bucket with a `connections.yaml` missing
+            // the connection and a sibling still granting it — which
+            // `assertGrantsResolve` refuses at load, so `openReconciled` skipped
+            // that profile and it silently stopped being served.
+            touched: [...new Set([resolution.profile, ...affected])],
+          }),
         ),
       },
     };

--- a/src/cli/commands/connection.ts
+++ b/src/cli/commands/connection.ts
@@ -10,6 +10,7 @@ import {
 } from '#profile';
 import { ConfigDocument } from '../config-edit.ts';
 import { announce, announceWorkspace, emit, ok, print, style, warn } from '../output.ts';
+import { recordConfigChange } from './../audit-change.ts';
 import { openWorkspaceRuntime, type GlobalFlags } from '../runtime.ts';
 import { nextAfterEdit, publishProfileEdit } from '../publish.ts';
 import { confirm, isInteractive } from '../prompt.ts';
@@ -242,6 +243,21 @@ export async function removeConnection(
       await runtime.credentials.delete(ref);
       removed = ref;
     }
+
+    // `profiles` is the half of this that is easy to lose. A disconnect takes
+    // the account away from every profile that named it, and a row saying only
+    // "gmail.work removed" would leave a reader to work out which agents
+    // stopped being able to reach it.
+    await recordConfigChange(runtime.config, root, target, {
+      capability: 'config.connection.remove',
+      scope: target,
+      connection: key,
+      arguments: {
+        account: located.connection.account,
+        profiles: affected,
+        credentialRemoved: removed !== null,
+      },
+    });
 
     return {
       resolution,

--- a/src/cli/commands/connection.ts
+++ b/src/cli/commands/connection.ts
@@ -1,6 +1,13 @@
 import { RESERVED_PROVIDER_IDS } from '#connectivity';
 import { credentialRefFor } from '#registry';
-import type { ConnectionConfig, Config, Resolution } from '#profile';
+import {
+  CONNECTIONS_FILE,
+  listProfiles,
+  loadProfileConfig,
+  readConnections,
+  type ConnectionConfig,
+  type Resolution,
+} from '#profile';
 import { ConfigDocument } from '../config-edit.ts';
 import { announce, emit, ok, print, style, warn } from '../output.ts';
 import { openRuntime, type GlobalFlags } from '../runtime.ts';
@@ -44,18 +51,20 @@ export interface Disconnected {
   readonly credential: string | null;
   /** Set when the credential was left because something else still needs it. */
   readonly credentialSharedWith: readonly string[];
+  /**
+   * The profiles that lost a grant on this connection.
+   *
+   * Reported rather than counted, because a connection belongs to the workspace
+   * (ADR-057) and the profiles that lose one are not the profile the command was
+   * run against. Empty means it was granted by nobody, which is a legitimate
+   * state for an account connected and not yet used.
+   */
+  readonly ungranted: readonly string[];
+  /** Connections left in the workspace, not in the profile. */
   readonly remaining: number;
   readonly published: string;
 }
 
-export interface Relabelled {
-  readonly profile: string;
-  readonly target: string;
-  readonly key: string;
-  readonly from: string;
-  readonly to: string;
-  readonly published: string;
-}
 
 export interface DisconnectFlags extends GlobalFlags {
   readonly yes?: boolean | undefined;
@@ -63,9 +72,6 @@ export interface DisconnectFlags extends GlobalFlags {
   readonly json?: boolean | undefined;
 }
 
-export interface RelabelFlags extends GlobalFlags {
-  readonly json?: boolean | undefined;
-}
 
 /**
  * Find the one connection a key names.
@@ -75,45 +81,64 @@ export interface RelabelFlags extends GlobalFlags {
  * is nothing to choose here, and a bare `gmail` with two accounts declared would
  * be a command guessing which one to throw away.
  */
-function locate(config: Config, key: string, profile: string): Located {
+export function locate(
+  connections: readonly ConnectionConfig[],
+  key: string,
+  workspace: string,
+): Located {
   if (!key.includes('.')) {
-    const matches = config.connections.filter((one) => one.provider === key);
+    const matches = connections.filter((one) => one.provider === key);
     throw new Error(
       `"${key}" names a provider, not a connection.\n` +
         (matches.length > 0
-          ? `  This profile declares ${matches.map((one) => `${one.provider}.${one.id}`).join(', ')}.\n`
+          ? `  This workspace holds ${matches.map((one) => `${one.provider}.${one.id}`).join(', ')}.\n`
           : '') +
-        `  Run: lanes link status --profile ${profile}`,
+        `  Run: lanes link connection list --workspace ${workspace}`,
     );
   }
 
-  const index = config.connections.findIndex((one) => `${one.provider}.${one.id}` === key);
+  const index = connections.findIndex((one) => `${one.provider}.${one.id}` === key);
   if (index === -1) {
     throw new Error(
-      `Profile "${profile}" does not declare "${key}".\n` +
-        `  Run: lanes link status --profile ${profile}`,
+      `Workspace "${workspace}" holds no connection "${key}".\n` +
+        `  Run: lanes link connection list --workspace ${workspace}`,
     );
   }
 
-  return { index, connection: config.connections[index] as ConnectionConfig };
+  return { index, connection: connections[index] as ConnectionConfig };
 }
 
 /**
- * Refuse for a reserved provider, and say what to do instead.
+ * Refuse to remove the last instance of a built-in surface, and say why.
  *
- * `memory`, `skills`, `vault`, `setup` and `identity` are not accounts — they are
- * what the profile is *for*, they hold no credential, and each is granted by a
- * policy line this command does not touch. Removing the connection alone would
- * leave the policy granting `memory.*` against nothing: a config that is wrong
- * rather than merely untidy, which is the same reason `knowledge use` takes its
- * own block back. Hand-editing is the honest path and the file says so.
+ * A reserved provider is a connection like any other now (ADR-059), so
+ * `disconnect memory.acme` is a real thing to do and it works: the instance goes,
+ * every profile's grant on it goes, and the bytes stay where `rm -r` can find
+ * them.
+ *
+ * The *last* one is different, and refusing is honesty rather than caution. The
+ * owner layer arrives granted and is repaired back into place on the next
+ * `start`, `connect` or `deploy` (ADR-050), so removing the only `memory`
+ * connection succeeds, prints a success line, and is undone by the next command
+ * the operator runs. A command that reports a change the system immediately
+ * reverses is worse than one that refuses.
+ *
+ * `deny` is the way off, and it always was — the same line ADR-050 documents.
  */
-function refuseReserved(key: string, provider: string, path: string): void {
+function refuseLastReserved(
+  key: string,
+  provider: string,
+  connections: readonly ConnectionConfig[],
+): void {
   if (!RESERVED_PROVIDER_IDS.includes(provider)) return;
+  if (connections.filter((one) => one.provider === provider).length > 1) return;
+
   throw new Error(
-    `"${key}" is part of what this profile is, not an account it holds.\n` +
-      `  ${provider} keeps no credential, and its policy grant is a separate line this command does not touch.\n` +
-      `  To remove it, delete both from ${path} by hand.`,
+    `"${key}" is the only ${provider} connection in this workspace.\n` +
+      `  The owner layer is repaired back on the next start, connect or deploy, so removing it\n` +
+      `  would report a change that the next command undoes.\n` +
+      `  To take the surface away from a profile, deny it:\n` +
+      `    lanes link policy deny "${provider}.*" --connection ${key} --profile <name>`,
   );
 }
 
@@ -128,65 +153,45 @@ function refuseReserved(key: string, provider: string, path: string): void {
  * `unauthorized` for a `connect` nobody ran.
  */
 export function connectionsSharingCredential(
-  config: Config,
+  connections: readonly ConnectionConfig[],
   ref: string,
   exceptIndex: number,
   manifestFor: (provider: string) => Parameters<typeof credentialRefFor>[1],
 ): string[] {
-  return config.connections
+  return connections
     .filter((one, i) => i !== exceptIndex && credentialRefFor(one, manifestFor(one.provider)) === ref)
     .map((one) => `${one.provider}.${one.id}`);
 }
 
 /**
- * Take back the allow rules that named the provider, once nothing declares it.
+ * Take the grant row back from a profile that named this connection.
  *
- * Not a tidy-up. `assertReferentialIntegrity` refuses an allow rule naming a
- * provider with no connection, and `save` validates — so disconnecting the last
- * connection of a provider *failed*, with a config error about a policy line the
- * operator had not touched, and nothing removed. Every single-account provider
- * was undisconnectable, which is most of them: the bug reproduced on `slack.*`
- * and would have on `bunq.*`, while a profile with two Gmail accounts could
- * disconnect one perfectly well.
+ * Exact, where this used to be a search. A rule named a *capability*, so
+ * disconnecting the last Gmail meant hunting every rule whose capability began
+ * `gmail.` and deciding whether it was now dangling — and getting that wrong
+ * either left a config the loader refuses or silently dropped a rule about an
+ * account that was still there. A grant names the connection (ADR-058), so
+ * removing it is finding one row.
  *
- * Symmetry is the argument for removing rather than warning. `connect` writes
- * the row *and* the rule, and the pair is what `config-repair.ts` calls both
- * halves or neither — a rule with nothing behind it grants nothing and is what
- * that file exists to stop being written.
+ * Symmetry is still the argument. `connect` writes the connection and the
+ * profiles that asked for it get a grant; a connection that goes takes its
+ * grants with it, because a grant naming nothing is what
+ * `assertGrantsResolve` refuses at load.
  *
- * `allow: ['*']` is untouched: it names no provider, so nothing about it becomes
- * false. Narrower rules go with the wide one — `gmail.send_message` is as
- * dangling as `gmail.*` once the last Gmail is gone, and the loader refuses it
- * for the same reason.
- *
- * `deny` is left alone, deliberately. The loader permits a deny naming a
- * provider with no connection, because denying something you have not connected
- * yet is a reasonable thing to write ahead of time — and removing it here would
- * silently re-permit whatever it covered if the account came back.
+ * Returns whether anything was removed, so the caller can report which profiles
+ * it touched rather than claiming all of them.
  */
-function dropProviderRules(document: ConfigDocument, config: Config, index: number): void {
-  const going = config.connections[index];
-  if (!going) return;
-
-  const stillDeclared = config.connections.some(
-    (one, i) => i !== index && one.provider === going.provider,
-  );
-  if (stillDeclared) return;
-
-  const rules = document.getIn(['policy', 'allow']) as { items?: unknown[] } | null;
+function dropGrantRow(document: ConfigDocument, key: string): boolean {
+  const rows = document.getIn(['grants']) as { items?: unknown[] } | null;
   const doomed: number[] = [];
 
-  (rules?.items ?? []).forEach((_rule, at) => {
-    const bare = document.getIn(['policy', 'allow', at]);
-    const capability =
-      typeof bare === 'string' ? bare : document.getIn(['policy', 'allow', at, 'capability']);
-    if (typeof capability !== 'string') return;
-
-    if (capability.split('.')[0] === going.provider) doomed.push(at);
+  (rows?.items ?? []).forEach((_row, at) => {
+    if (document.getIn(['grants', at, 'connection']) === key) doomed.push(at);
   });
 
   // Descending, so each removal cannot move the index of one still to come.
-  for (const at of doomed.reverse()) document.removeFrom(['policy', 'allow'], at);
+  for (const at of doomed.reverse()) document.removeFrom(['grants'], at);
+  return doomed.length > 0;
 }
 
 export async function removeConnection(
@@ -196,29 +201,41 @@ export async function removeConnection(
   const runtime = await openRuntime(flags);
 
   try {
-    const { resolution, config, target } = runtime;
-    const located = locate(config, key, resolution.profile);
-    const document = await ConfigDocument.open(resolution.workspaceRoot, resolution.profile);
+    const { resolution, target } = runtime;
+    const root = resolution.workspaceRoot;
 
-    refuseReserved(key, located.connection.provider, document.path);
+    const connectionsFile = await readConnections(root);
+    const located = locate(connectionsFile.connections, key, target);
 
-    if (!(await confirmed(key, flags))) return null;
+    refuseLastReserved(key, located.connection.provider, connectionsFile.connections);
+
+    // Which profiles lose a grant, computed before anything is asked, because it
+    // is the fact that decides whether this is a small change or a large one. A
+    // connection belongs to the workspace now (ADR-057), so disconnecting it
+    // reaches every profile that named it — including ones the operator is not
+    // thinking about, which is exactly why the confirmation lists them.
+    const affected = await profilesGranting(root, key);
+
+    if (!(await confirmed(key, affected, flags))) return null;
 
     const manifestFor = (provider: string) => runtime.registry.get(provider)?.manifest;
     const ref = credentialRefFor(located.connection, manifestFor(located.connection.provider));
-    const shared = ref ? connectionsSharingCredential(config, ref, located.index, manifestFor) : [];
+    const shared = ref
+      ? connectionsSharingCredential(connectionsFile.connections, ref, located.index, manifestFor)
+      : [];
 
-    // The config edit first. If deleting the credential fails, a connection left
-    // declared with no credential reports `unauthorized`, which is recoverable by
-    // running `connect`. The reverse — credential gone, declaration kept, edit
-    // failed — is the same state, so ordering costs nothing either way; doing the
-    // edit first means the file is right even if the store is unreachable.
-    // Both edits before the one `save`, so the file is never written in the
-    // state where the row is gone and the rule that named it is not — which is
-    // the state the loader refuses.
-    dropProviderRules(document, config, located.index);
-    document.removeFrom(['connections'], located.index);
-    await document.save();
+    // Grants first, then the connection. That order is the one the loader can
+    // survive halfway through: a profile granting a connection that is gone is
+    // refused at load, while a connection nothing grants is merely unused. So if
+    // the process dies between the two writes, the workspace still opens.
+    for (const profile of affected) {
+      const document = await ConfigDocument.openKey(root, `profiles/${profile}.yaml`);
+      if (dropGrantRow(document, key)) await document.save();
+    }
+
+    const connectionsDocument = await ConfigDocument.openKey(root, CONNECTIONS_FILE);
+    connectionsDocument.removeFrom(['connections'], located.index);
+    await connectionsDocument.save();
 
     let removed: string | null = null;
     if (ref && shared.length === 0 && flags.keepCredential !== true) {
@@ -235,8 +252,11 @@ export async function removeConnection(
         account: located.connection.account,
         credential: removed,
         credentialSharedWith: shared,
-        remaining: config.connections.length - 1,
-        published: nextAfterEdit(await publishProfileEdit({ resolution, config, target })),
+        remaining: connectionsFile.connections.length - 1,
+        ungranted: affected,
+        published: nextAfterEdit(
+          await publishProfileEdit({ resolution, config: runtime.config, target }),
+        ),
       },
     };
   } finally {
@@ -244,10 +264,34 @@ export async function removeConnection(
   }
 }
 
+/**
+ * Every profile in the workspace whose grants name this connection.
+ *
+ * Read from the files rather than from the open runtime, which knows about one
+ * profile. Reading them all is the point: the operator named a connection, and
+ * the set of profiles that lose something is not visible from the one they
+ * happen to have selected.
+ */
+async function profilesGranting(root: string, key: string): Promise<string[]> {
+  const names = await listProfiles(root);
+  const granting: string[] = [];
+
+  for (const name of names) {
+    const { config } = await loadProfileConfig(root, name);
+    if (config.grants.some((grant) => grant.connection === key)) granting.push(name);
+  }
+
+  return granting;
+}
+
 /** A plain y/N. Not `profile remove`'s type-the-name, which guards the
  *  destruction of whole stores; this takes back one authorisation that `connect`
  *  can grant again. */
-async function confirmed(key: string, flags: DisconnectFlags): Promise<boolean> {
+async function confirmed(
+  key: string,
+  affected: readonly string[],
+  flags: DisconnectFlags,
+): Promise<boolean> {
   if (flags.yes === true) return true;
   if (!isInteractive()) {
     throw new Error(
@@ -255,8 +299,18 @@ async function confirmed(key: string, flags: DisconnectFlags): Promise<boolean> 
         `  Pass --yes to proceed.`,
     );
   }
+
+  // The profiles are named in the question rather than printed above it. A
+  // connection is the workspace's now, so "disconnect gmail.personal" can take
+  // the account away from a profile the operator is not looking at, and the one
+  // place that is certain to be read is the line they have to answer.
+  const reach =
+    affected.length === 0
+      ? 'no profile grants it'
+      : `${affected.length} profile(s) lose it: ${affected.join(', ')}`;
+
   // Defaults to no: this deletes a credential, and a stray return should not.
-  return confirm(`Disconnect ${key} and delete its credential?`, false);
+  return confirm(`Disconnect ${key} and delete its credential? (${reach})`, false);
 }
 
 export async function disconnect(key: string | undefined, flags: DisconnectFlags): Promise<void> {
@@ -285,78 +339,15 @@ export async function disconnect(key: string | undefined, flags: DisconnectFlags
       );
     }
 
-    print(style.dim(`      ${result.remaining} connection(s) left in this profile.`));
+    if (result.ungranted.length > 0) {
+      print(`      ungranted   ${result.ungranted.join(', ')}`);
+    }
+    print(style.dim(`      ${result.remaining} connection(s) left in this workspace.`));
     // The state record survives on purpose, and the next reconcile is what marks
     // it disabled. Saying so stops "it is still in `status`" reading as a failure.
     print(
       style.dim(
         '      The state record stays until the next reconcile, which marks it disabled rather than deleting it.',
-      ),
-    );
-    if (result.published) print(style.dim(`      ${result.published}`));
-  })
-}
-
-/**
- * Rename a connection, writing `label` and never `account`.
- *
- * It wrote `account` until it was noticed that `account` is not a display name:
- * `settleIdentity` matches on it to tell a repair from a new account,
- * `idFromAccount` derives the id from it, and `gmail.send_message` writes it
- * into a `From` header. Renaming through it therefore un-recognised the account
- * it renamed — the next `connect` added a second row beside it.
- */
-export async function renameConnection(
-  key: string,
-  label: string,
-  flags: RelabelFlags,
-): Promise<{ resolution: Resolution; relabelled: Relabelled }> {
-  const runtime = await openRuntime(flags);
-
-  try {
-    const { resolution, config, target } = runtime;
-    const located = locate(config, key, resolution.profile);
-    const document = await ConfigDocument.open(resolution.workspaceRoot, resolution.profile);
-
-    document.setIn(['connections', located.index, 'label'], label);
-    await document.save();
-
-    return {
-      resolution,
-      relabelled: {
-        profile: resolution.profile,
-        target,
-        key,
-        // What it was called a moment ago, which is the account only until the
-        // first rename.
-        from: located.connection.label ?? located.connection.account,
-        to: label,
-        published: nextAfterEdit(await publishProfileEdit({ resolution, config, target })),
-      },
-    };
-  } finally {
-    await runtime.close();
-  }
-}
-
-export async function relabel(
-  key: string | undefined,
-  label: string | undefined,
-  flags: RelabelFlags,
-): Promise<void> {
-  if (!key) throw new Error('Which connection? Run: lanes link status');
-  if (!label) throw new Error(`What should ${key} be called? Run: lanes link relabel ${key} "New name"`);
-
-  const { resolution, relabelled: result } = await renameConnection(key, label, flags);
-
-  return emit(flags.json, result, () => {
-    announce(resolution);
-    print(ok(`${style.bold(result.key)} is now ${style.bold(result.to)}`));
-    if (result.from) print(`      was     ${style.dim(result.from)}`);
-    // The label is a display name in two places, and only one of them changed.
-    print(
-      style.dim(
-        '      The state store keeps the old name until the next reconcile, which updates it.',
       ),
     );
     if (result.published) print(style.dim(`      ${result.published}`));

--- a/src/cli/commands/connection.ts
+++ b/src/cli/commands/connection.ts
@@ -9,8 +9,8 @@ import {
   type Resolution,
 } from '#profile';
 import { ConfigDocument } from '../config-edit.ts';
-import { announce, emit, ok, print, style, warn } from '../output.ts';
-import { openRuntime, type GlobalFlags } from '../runtime.ts';
+import { announce, announceWorkspace, emit, ok, print, style, warn } from '../output.ts';
+import { openWorkspaceRuntime, type GlobalFlags } from '../runtime.ts';
 import { nextAfterEdit, publishProfileEdit } from '../publish.ts';
 import { confirm, isInteractive } from '../prompt.ts';
 
@@ -198,7 +198,7 @@ export async function removeConnection(
   key: string,
   flags: DisconnectFlags,
 ): Promise<{ resolution: Resolution; disconnected: Disconnected } | null> {
-  const runtime = await openRuntime(flags);
+  const runtime = await openWorkspaceRuntime(flags);
 
   try {
     const { resolution, target } = runtime;
@@ -324,7 +324,7 @@ export async function disconnect(key: string | undefined, flags: DisconnectFlags
   const { resolution, disconnected: result } = outcome;
 
   return emit(flags.json, result, () => {
-    announce(resolution);
+    announceWorkspace(resolution);
     print(ok(`disconnected ${style.bold(result.key)}${result.account ? ` (${result.account})` : ''}`));
 
     if (result.credential) {

--- a/src/cli/commands/grant.ts
+++ b/src/cli/commands/grant.ts
@@ -1,0 +1,140 @@
+import { ConfigError, connectionRefOf, readConnections, type Resolution } from '#profile';
+import { ConfigDocument } from '../config-edit.ts';
+import { announce, emit, ok, print, style } from '../output.ts';
+import { nextAfterEdit, publishProfileEdit } from '../publish.ts';
+import { resolveProfile, type GlobalFlags } from '../runtime.ts';
+
+/**
+ * `lanes link grant` and `lanes link revoke` — which of the workspace's accounts
+ * a profile may reach.
+ *
+ * The command that did not need to exist under contract 2, because connecting an
+ * account and granting it were the same act: `connect` wrote a row into the
+ * profile and a rule beside it, and a second profile wanting the same mailbox
+ * connected it again. A connection belongs to the workspace now (ADR-057), so
+ * authorising an account and deciding who may use it are two commands — and
+ * this is the second one.
+ *
+ * A grant row carries the provider wildcard, which is what `connect` writes for
+ * the profile that made the connection. Narrowing it afterwards is
+ * `lanes link policy deny <capability> --connection <ref>`; the two are separate
+ * because widening and narrowing are different decisions and reading them in one
+ * command's flags would hide which had happened.
+ */
+
+export interface Granted {
+  readonly profile: string;
+  readonly target: string;
+  readonly connection: string;
+  readonly account: string;
+  readonly allowed: readonly string[];
+  readonly published: string;
+}
+
+export async function grantConnectionTo(
+  key: string | undefined,
+  flags: GlobalFlags & { json?: boolean },
+): Promise<void> {
+  if (!key) {
+    throw new ConfigError(
+      'Which connection? Run: lanes link connection list\n' +
+        '  e.g. lanes link grant gmail.personal --profile assistant',
+    );
+  }
+
+  const { resolution, config, target } = await resolveProfile(flags);
+  const root = resolution.workspaceRoot;
+
+  const held = (await readConnections(root)).connections;
+  const connection = held.find((one) => connectionRefOf(one) === key);
+
+  // Refused rather than written on trust. A grant naming a connection the
+  // workspace does not hold is refused at load by `assertGrantsResolve`, so
+  // writing one would leave a profile that no longer opens — and the operator
+  // would have been told "ok" by the command that broke it.
+  if (connection === undefined) {
+    throw new ConfigError(
+      `This workspace holds no connection "${key}".\n` +
+        (held.length > 0
+          ? `  It holds: ${held.map(connectionRefOf).join(', ')}\n`
+          : '  It holds none yet. Connect one with: lanes link connect <provider>\n') +
+        `  Run "lanes link connection list --workspace ${target}" to see them.`,
+    );
+  }
+
+  if (config.grants.some((grant) => grant.connection === key)) {
+    print(style.dim(`${resolution.profile} already grants ${key}.`));
+    return;
+  }
+
+  const rule = `${connection.provider}.*`;
+  const document = await ConfigDocument.open(root, resolution.profile);
+  document.addTo(['grants'], { connection: key, allow: [rule], deny: [] }, { inline: true });
+  await document.save();
+
+  const granted: Granted = {
+    profile: resolution.profile,
+    target,
+    connection: key,
+    account: connection.account,
+    allowed: [rule],
+    published: nextAfterEdit(await publishProfileEdit({ resolution, config, target })),
+  };
+
+  return emit(flags.json, granted, () => {
+    announce(resolution);
+    print(ok(`granted ${style.bold(key)} to ${style.bold(granted.profile)}`));
+    print(`      account     ${style.dim(granted.account)}`);
+    print(`      allowed     ${granted.allowed.join(', ')}`);
+    print(
+      style.dim(
+        `      Narrow it with: lanes link policy deny <capability> --connection ${key} ` +
+          `--profile ${granted.profile}`,
+      ),
+    );
+    if (granted.published) print(style.dim(`      ${granted.published}`));
+  });
+}
+
+/**
+ * Take a grant back, leaving the account where it is.
+ *
+ * Not `disconnect`, and the difference is the whole reason both exist: this
+ * removes one profile's permission and touches nothing else, while `disconnect`
+ * removes the account from the workspace and every profile that named it.
+ * Conflating them is how somebody loses a mailbox meaning to narrow an agent.
+ */
+export async function revokeConnectionFrom(
+  key: string | undefined,
+  flags: GlobalFlags & { json?: boolean },
+): Promise<void> {
+  if (!key) {
+    throw new ConfigError(
+      'Which connection? Run: lanes link policy list\n' +
+        '  e.g. lanes link revoke gmail.personal --profile assistant',
+    );
+  }
+
+  const { resolution, config, target } = await resolveProfile(flags);
+  const at = config.grants.findIndex((grant) => grant.connection === key);
+
+  if (at === -1) {
+    print(style.dim(`${resolution.profile} does not grant ${key}.`));
+    return;
+  }
+
+  const document = await ConfigDocument.open(resolution.workspaceRoot, resolution.profile);
+  document.removeFrom(['grants'], at);
+  await document.save();
+
+  return emit(flags.json, { profile: resolution.profile, target, connection: key }, () => {
+    announce(resolution);
+    print(ok(`revoked ${style.bold(key)} from ${style.bold(resolution.profile)}`));
+    print(
+      style.dim(
+        '      The account is untouched, and every other profile granting it still reaches it.\n' +
+          `      To remove the account itself: lanes link disconnect ${key}`,
+      ),
+    );
+  });
+}

--- a/src/cli/commands/identity.test.ts
+++ b/src/cli/commands/identity.test.ts
@@ -2,7 +2,8 @@ import { afterAll, describe, expect, test } from 'bun:test';
 import { mkdtemp, rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { parseConfig } from '#profile';
+import {
+  readConnections, parseConfig } from '#profile';
 import { createProfile } from './profile.ts';
 import { addIdentity, identityList, readIdentity, removeIdentity } from './identity.ts';
 
@@ -81,12 +82,27 @@ describe('declaring an identity makes it readable', () => {
 
     const { added } = await addIdentity('name', 'Ada', { ...WHERE, note: 'for papers' });
 
-    expect(added.provisioned).toEqual(['connections += identity.main', 'policy.allow += identity.*']);
+    expect(added.provisioned).toEqual([
+      'connections.yaml += identity.main',
+      'grants += identity.main',
+      'grants[].allow += identity.*',
+    ]);
 
     const config = await onDisk(root);
     expect(config.identity).toEqual([{ kind: 'name', value: 'Ada', note: 'for papers' }]);
-    expect(config.connections.some((row) => row.provider === 'identity')).toBe(true);
-    expect(config.policy.allow.some((rule) => rule.capability === 'identity.*')).toBe(true);
+    // The row is in the workspace and the grant is in the profile (ADR-057), and
+    // `identity add` writes both or neither — a grant naming a connection that
+    // does not exist is refused at load.
+    expect((await readConnections(root)).connections.some((row) => row.provider === 'identity')).toBe(
+      true,
+    );
+    expect(
+      config.grants.some(
+        (grant) =>
+          grant.connection === 'identity.main' &&
+          grant.allow.some((rule) => rule.capability === 'identity.*'),
+      ),
+    ).toBe(true);
   });
 
   test('a second entry provisions nothing, because there is nothing left to do', async () => {
@@ -169,8 +185,10 @@ describe('removing an entry', () => {
 
     const config = await onDisk(root);
     expect(config.identity).toEqual([]);
-    expect(config.connections.some((row) => row.provider === 'identity')).toBe(true);
-    expect(config.policy.allow.some((rule) => rule.capability === 'identity.*')).toBe(true);
+    expect((await readConnections(root)).connections.some((row) => row.provider === 'identity')).toBe(
+      true,
+    );
+    expect(config.grants.some((grant) => grant.allow.some((rule) => rule.capability === 'identity.*'))).toBe(true);
   });
 });
 

--- a/src/cli/commands/identity.ts
+++ b/src/cli/commands/identity.ts
@@ -1,4 +1,4 @@
-import type { IdentityEntry, ProfileSelection, Resolution } from '#profile';
+import { CONNECTIONS_FILE, type IdentityEntry, type ProfileSelection, type Resolution } from '#profile';
 import { ConfigDocument } from '../config-edit.ts';
 import { ensureIdentityConnection, repairLines, repaired } from '../config-repair.ts';
 import { announce, announceProfile, emit, ok, print, style, table, warn } from '../output.ts';
@@ -51,14 +51,20 @@ function covers(rules: ReadonlyArray<{ capability: string }>): boolean {
  * misleading thing this command could print.
  */
 function readable(config: {
-  connections: ReadonlyArray<{ provider: string }>;
-  policy: { allow: ReadonlyArray<{ capability: string }>; deny: ReadonlyArray<{ capability: string }> };
+  grants: ReadonlyArray<{
+    connection: string;
+    allow: ReadonlyArray<{ capability: string }>;
+    deny: ReadonlyArray<{ capability: string }>;
+  }>;
 }): boolean {
-  return (
-    config.connections.some((connection) => connection.provider === 'identity') &&
-    covers(config.policy.allow) &&
-    !covers(config.policy.deny)
-  );
+  // One row now rather than a connection and a rule that had to agree
+  // (ADR-058). The old shape could say "declared but not granted" and
+  // "granted but not declared", and both served nothing while reading like
+  // configuration that worked; neither is expressible here.
+  const grant = config.grants.find((row) => row.connection.startsWith('identity.'));
+  if (grant === undefined) return false;
+
+  return covers(grant.allow) && !covers(grant.deny);
 }
 
 /**
@@ -96,7 +102,13 @@ export async function addIdentity(
   const entry: IdentityEntry = { kind, value, ...(options.note ? { note: options.note } : {}) };
   document.addTo(['identity'], entry, { inline: true });
 
-  const repair = ensureIdentityConnection(document);
+  // The identity *connection* is the workspace's, like every other (ADR-057),
+  // so provisioning the surface on first use touches two files. Both saves, or
+  // neither: a grant naming a connection that does not exist is refused at load,
+  // so writing the profile alone would leave one that no longer opens.
+  const connections = await ConfigDocument.openKey(resolution.workspaceRoot, CONNECTIONS_FILE);
+  const repair = ensureIdentityConnection(connections, document);
+  await connections.save();
   await document.save();
 
   return {

--- a/src/cli/commands/knowledge.ts
+++ b/src/cli/commands/knowledge.ts
@@ -7,4 +7,5 @@
  * the grammar that puts them in order.
  */
 
-export { knowledgeShow, knowledgeUse, type KnowledgeFlags } from './knowledge/index.ts';
+export { knowledgeUse, type KnowledgeFlags } from './knowledge/index.ts';
+export { knowledgeShow } from './knowledge/show.ts';

--- a/src/cli/commands/knowledge/index.ts
+++ b/src/cli/commands/knowledge/index.ts
@@ -100,7 +100,7 @@ async function useGithub(flags: KnowledgeFlags): Promise<void> {
   const runtime = await openRuntime(flags, { fetch: flags.fetch });
   try {
     announce(runtime.resolution);
-    const selection = ` --profile ${runtime.resolution.profile} --target ${runtime.target}`;
+    const selection = ` --profile ${runtime.resolution.profile} --workspace ${runtime.target}`;
 
     if (runtime.knowledge) {
       print(style.dim(`  This profile already reads ${runtime.knowledge.describe}.`));
@@ -134,7 +134,16 @@ async function useGithub(flags: KnowledgeFlags): Promise<void> {
       ['  token', viewer, style.dim('can write')],
     ]);
 
-    const movable = await localContents(runtime.storage, runtime.skills ?? null, knowledge);
+    // Which instances this profile grants, so `memory/` and `entities/` reach
+    // only its own and not every profile's (ADR-059).
+    const instances = grantedInstances(runtime.config);
+
+    const movable = await localContents(
+      runtime.storage,
+      runtime.skills ?? null,
+      knowledge,
+      instances,
+    );
     const moving = await decideMigration(movable.length > 0, flags);
 
     if (moving) {
@@ -153,7 +162,7 @@ async function useGithub(flags: KnowledgeFlags): Promise<void> {
       if (flags.keep) {
         print(style.dim('  --keep: the local copies are still there, and are no longer read.'));
       } else {
-        await removeLocal(runtime.storage, runtime.skills ?? null, movable);
+        await removeLocal(runtime.storage, runtime.skills ?? null, movable, instances);
         print(ok('removed the local copies'));
       }
     } else if (movable.length > 0) {
@@ -208,7 +217,13 @@ async function useLocal(flags: KnowledgeFlags): Promise<void> {
       flags.migrate ??
       (await agreedTo(flags, `Copy everything in ${knowledge.repo} back onto this target's storage?`))
     ) {
-      const moved = await moveOut(repository, knowledge, local.storage, local.skills);
+      const moved = await moveOut(
+        repository,
+        knowledge,
+        local.storage,
+        local.skills,
+        grantedInstances(runtime.config),
+      );
       print(
         ok(
           `wrote back ${moved.memory} memory entr${moved.memory === 1 ? 'y' : 'ies'}, ` +
@@ -319,4 +334,22 @@ async function agreedTo(flags: KnowledgeFlags, question: string): Promise<boolea
   const yes = await confirm(question, true);
   if (!yes) print(style.dim('  cancelled'));
   return yes;
+}
+
+/**
+ * The memory and entities instances one profile grants.
+ *
+ * `main` where a profile grants none, which is what a profile that predates the
+ * owner layer looks like and is also where a fresh one puts them. The point is
+ * that this is never the *surface* — `memory/` alone matches every profile's
+ * notes now that the blob root is the workspace's.
+ */
+function grantedInstances(config: Parameters<typeof soleGrantFor>[0]): {
+  memory: string;
+  entities: string;
+} {
+  return {
+    memory: soleGrantFor(config, 'memory') ?? 'main',
+    entities: soleGrantFor(config, 'entities') ?? 'main',
+  };
 }

--- a/src/cli/commands/knowledge/index.ts
+++ b/src/cli/commands/knowledge/index.ts
@@ -1,4 +1,5 @@
 import {
+  soleGrantFor,
   ConfigError,
   KNOWLEDGE_LAYOUT,
   knowledgeTargetSchema,
@@ -23,7 +24,6 @@ import {
   removeLocal,
   summarise,
 } from './migrate.ts';
-
 /**
  * `lanes link knowledge` — where this profile's memory and skills are kept.
  *
@@ -63,78 +63,6 @@ export interface KnowledgeFlags extends GlobalFlags {
   readonly json?: boolean | undefined;
   /** Injected for tests. The repository is the only thing this command reaches. */
   readonly fetch?: FetchLike | undefined;
-}
-
-export async function knowledgeShow(flags: KnowledgeFlags): Promise<void> {
-  const runtime = await openRuntime(flags, { fetch: flags.fetch });
-  try {
-    if (!flags.json) announce(runtime.resolution);
-
-    const profile = runtime.config.instance.profile;
-    const selection = ` --profile ${runtime.resolution.profile} --target ${runtime.target}`;
-    const skills = (await runtime.skills.list()).length;
-    const memory = (await runtime.storage.list(`${KNOWLEDGE_LAYOUT.memory}/`)).length;
-    const entities = (await runtime.storage.list(`${KNOWLEDGE_LAYOUT.entities}/`)).length;
-    const where = runtime.knowledge?.describe;
-
-    if (flags.json) {
-      print(
-        JSON.stringify(
-          { target: runtime.target, where: where ?? 'local', memory, skills, entities },
-          null,
-          2,
-        ),
-      );
-      return;
-    }
-
-    heading('Knowledge');
-    table([
-      // The memory *directory*, not the blob root it sits in. `layout.blobs`
-      // is `data/<profile>`, which is where every provider's namespace lives —
-      // printing it here would name a directory that is mostly not memory.
-      [
-        '  memory',
-        where ? `${where}/${KNOWLEDGE_LAYOUT.memory}` : `${layout.blobs(profile)}/${KNOWLEDGE_LAYOUT.memory}`,
-        style.dim(`${memory} file${memory === 1 ? '' : 's'}`),
-      ],
-      [
-        '  skills',
-        where ? `${where}/${KNOWLEDGE_LAYOUT.skills}` : layout.skills(profile),
-        style.dim(`${skills} file${skills === 1 ? '' : 's'}`),
-      ],
-      // The count includes the derived `_index.json`, deliberately: it is a
-      // file in that directory and it is committed with the rest, so a number
-      // that quietly excluded it would not match what a person sees there.
-      [
-        '  entities',
-        where
-          ? `${where}/${KNOWLEDGE_LAYOUT.entities}`
-          : `${layout.blobs(profile)}/${KNOWLEDGE_LAYOUT.entities}`,
-        style.dim(`${entities} file${entities === 1 ? '' : 's'}`),
-      ],
-    ]);
-
-    print('');
-    print(
-      style.dim(
-        `  The vault, the credential store, runtime state and the audit log stay in target "${runtime.target}".`,
-      ),
-    );
-    // Complete commands, not shapes. Every one of these is pasted, and with
-    // nothing left to fall back on (ADR-037) a line missing either flag is a
-    // line that refuses — `emitted.test.ts` states the rule for the templates
-    // reachable without a runtime, and this is the same rule where there is one.
-    print(
-      style.dim(
-        where
-          ? `  Bring them back with: lanes link knowledge use local --migrate${selection}`
-          : `  Keep them in a repository with: lanes link knowledge use github --repo <owner/name>${selection}`,
-      ),
-    );
-  } finally {
-    await runtime.close();
-  }
 }
 
 export async function knowledgeUse(where: string | undefined, flags: KnowledgeFlags): Promise<void> {
@@ -206,7 +134,7 @@ async function useGithub(flags: KnowledgeFlags): Promise<void> {
       ['  token', viewer, style.dim('can write')],
     ]);
 
-    const movable = await localContents(runtime.storage, runtime.skills, knowledge);
+    const movable = await localContents(runtime.storage, runtime.skills ?? null, knowledge);
     const moving = await decideMigration(movable.length > 0, flags);
 
     if (moving) {
@@ -225,7 +153,7 @@ async function useGithub(flags: KnowledgeFlags): Promise<void> {
       if (flags.keep) {
         print(style.dim('  --keep: the local copies are still there, and are no longer read.'));
       } else {
-        await removeLocal(runtime.storage, runtime.skills, movable);
+        await removeLocal(runtime.storage, runtime.skills ?? null, movable);
         print(ok('removed the local copies'));
       }
     } else if (movable.length > 0) {
@@ -314,7 +242,7 @@ async function useLocal(flags: KnowledgeFlags): Promise<void> {
  */
 async function openLocalStores(
   runtime: Runtime,
-): Promise<{ storage: BlobStore; skills: BlobStore }> {
+): Promise<{ storage: BlobStore; skills: BlobStore | null }> {
   const { openStorage } = await import('#deployments/target.ts');
   const declared = runtime.declared;
 
@@ -327,7 +255,13 @@ async function openLocalStores(
     },
     runtime.credentials,
   );
-  return { storage: factory(), skills: factory(layout.skills(runtime.config.instance.profile)) };
+  // The *granted* connection, not the profile name. `layout.skills` changed
+  // meaning without changing arity at ADR-059, so the compiler was silent.
+  const skillsConnection = soleGrantFor(runtime.config, 'skills');
+  return {
+    storage: factory(),
+    skills: skillsConnection === undefined ? null : factory(layout.skills(skillsConnection)),
+  };
 }
 
 /**

--- a/src/cli/commands/knowledge/knowledge.test.ts
+++ b/src/cli/commands/knowledge/knowledge.test.ts
@@ -1,4 +1,5 @@
-import { workspaceYaml } from '#profile/testing.ts';
+import { CONNECTIONS_FILE } from '#profile';
+import { connectionsYaml, workspaceYaml } from '#profile/testing.ts';
 import { afterAll, beforeEach, describe, expect, test } from 'bun:test';
 import { mkdtemp, mkdir, readFile, rm, writeFile } from 'node:fs/promises';
 import { existsSync } from 'node:fs';
@@ -10,7 +11,8 @@ import { openSecretStoreFor, resolveProfile } from '../../runtime.ts';
 import { doctor } from '../operate.ts';
 import { targetShow } from '../target.ts';
 import { removeProfile } from '../profile/remove.ts';
-import { knowledgeShow, knowledgeUse } from './index.ts';
+import { knowledgeUse } from './index.ts';
+import { knowledgeShow } from './show.ts';
 import { probe } from './setup.ts';
 
 /**
@@ -28,18 +30,16 @@ import { probe } from './setup.ts';
 const roots: string[] = [];
 const previousHome = process.env['LANES_LINK_HOME'];
 
-const PROFILE = `contract: 2
+const PROFILE = `contract: 3
 
 instance:
   profile: personal
 
-connections:
-  - id: main
-    provider: memory
-    account: Personal
-
-policy:
-  allow: ['*']
+grants:
+  - { connection: memory.main, allow: [memory.*], deny: [] }
+  - { connection: skills.main, allow: [skills.*], deny: [] }
+  - { connection: entities.main, allow: [entities.*], deny: [] }
+members: []
 `;
 
 /**
@@ -60,15 +60,16 @@ async function workspace(seed = true): Promise<string> {
   await mkdir(join(root, 'profiles'), { recursive: true });
   await writeFile(join(root, 'lanes-link.yaml'), workspaceYaml(['local'], {defaultProfile: 'personal'}));
   await writeFile(join(root, 'profiles', 'personal.yaml'), PROFILE);
+  await writeFile(join(root, CONNECTIONS_FILE), connectionsYaml());
 
   if (seed) {
-    await mkdir(join(root, 'data/personal/memory/main'), { recursive: true });
-    await writeFile(join(root, 'data/personal/memory/main/a-note.md'), ENTRY);
-    await mkdir(join(root, 'data/personal/skills.d/triage'), { recursive: true });
-    await writeFile(join(root, 'data/personal/skills.d/triage/SKILL.md'), SKILL);
-    await mkdir(join(root, 'data/personal/entities/main'), { recursive: true });
-    await writeFile(join(root, 'data/personal/entities/main/jan-bakker.md'), ENTITY);
-    await writeFile(join(root, 'data/personal/entities/main/_index.json'), '{"v":1}');
+    await mkdir(join(root, 'data/memory/main'), { recursive: true });
+    await writeFile(join(root, 'data/memory/main/a-note.md'), ENTRY);
+    await mkdir(join(root, 'data/skills.d/main/triage'), { recursive: true });
+    await writeFile(join(root, 'data/skills.d/main/triage/SKILL.md'), SKILL);
+    await mkdir(join(root, 'data/entities/main'), { recursive: true });
+    await writeFile(join(root, 'data/entities/main/jan-bakker.md'), ENTITY);
+    await writeFile(join(root, 'data/entities/main/_index.json'), '{"v":1}');
   }
 
   process.env['LANES_LINK_HOME'] = root;
@@ -124,9 +125,9 @@ describe('switching to a repository', () => {
     // One commit for all of them, not one each.
     expect(github.calls.filter((call) => call.includes('/git/commits')).length).toBe(1);
 
-    expect(existsSync(join(root, 'data/personal/memory/main/a-note.md'))).toBe(false);
-    expect(existsSync(join(root, 'data/personal/skills.d/triage/SKILL.md'))).toBe(false);
-    expect(existsSync(join(root, 'data/personal/entities/main/jan-bakker.md'))).toBe(false);
+    expect(existsSync(join(root, 'data/memory/main/a-note.md'))).toBe(false);
+    expect(existsSync(join(root, 'data/skills.d/main/triage/SKILL.md'))).toBe(false);
+    expect(existsSync(join(root, 'data/entities/main/jan-bakker.md'))).toBe(false);
   });
 
   test('writes one block, on the profile', async () => {
@@ -149,8 +150,8 @@ describe('switching to a repository', () => {
     await use({ migrate: true, keep: true });
 
     expect(Object.keys(github.files())).toHaveLength(4);
-    expect(existsSync(join(root, 'data/personal/memory/main/a-note.md'))).toBe(true);
-    expect(existsSync(join(root, 'data/personal/entities/main/jan-bakker.md'))).toBe(true);
+    expect(existsSync(join(root, 'data/memory/main/a-note.md'))).toBe(true);
+    expect(existsSync(join(root, 'data/entities/main/jan-bakker.md'))).toBe(true);
   });
 
   test('--no-migrate switches and leaves what is stored where it is', async () => {
@@ -159,7 +160,7 @@ describe('switching to a repository', () => {
     await use({ migrate: false });
 
     expect(github.files()).toEqual({});
-    expect(existsSync(join(root, 'data/personal/memory/main/a-note.md'))).toBe(true);
+    expect(existsSync(join(root, 'data/memory/main/a-note.md'))).toBe(true);
     expect(await readProfile(root)).toContain('repo: my-org/my-notes');
   });
 
@@ -219,7 +220,7 @@ describe('refusals leave the profile exactly as it was', () => {
     await expect(use({ migrate: true })).rejects.toThrow(/is public/);
 
     expect(await readProfile(root)).not.toContain('knowledge:');
-    expect(existsSync(join(root, 'data/personal/memory/main/a-note.md'))).toBe(true);
+    expect(existsSync(join(root, 'data/memory/main/a-note.md'))).toBe(true);
     expect(github.files()).toEqual({});
   });
 
@@ -260,7 +261,7 @@ describe('refusals leave the profile exactly as it was', () => {
 
     await expect(use({ migrate: true })).rejects.toThrow(/did not read back correctly/);
 
-    expect(existsSync(join(root, 'data/personal/memory/main/a-note.md'))).toBe(true);
+    expect(existsSync(join(root, 'data/memory/main/a-note.md'))).toBe(true);
     expect(await readProfile(root)).not.toContain('knowledge:');
   });
 
@@ -279,9 +280,9 @@ describe('coming back', () => {
 
     await knowledgeUse('local', { ...SELECT, fetch: github.fetch, migrate: true, yes: true });
 
-    expect(await readFile(join(root, 'data/personal/memory/main/a-note.md'), 'utf8')).toBe(ENTRY);
-    expect(await readFile(join(root, 'data/personal/skills.d/triage/SKILL.md'), 'utf8')).toBe(SKILL);
-    expect(await readFile(join(root, 'data/personal/entities/main/jan-bakker.md'), 'utf8')).toBe(
+    expect(await readFile(join(root, 'data/memory/main/a-note.md'), 'utf8')).toBe(ENTRY);
+    expect(await readFile(join(root, 'data/skills.d/main/triage/SKILL.md'), 'utf8')).toBe(SKILL);
+    expect(await readFile(join(root, 'data/entities/main/jan-bakker.md'), 'utf8')).toBe(
       ENTITY,
     );
     expect(await readProfile(root)).not.toContain('knowledge:');
@@ -372,7 +373,7 @@ describe('knowledge show', () => {
 
     const output = await captureStdout(() => knowledgeShow({ ...SELECT }));
 
-    expect(output).toContain('data/personal/skills.d');
+    expect(output).toContain('data/skills.d');
     expect(output).toContain('lanes link knowledge use github');
   });
 

--- a/src/cli/commands/knowledge/migrate.ts
+++ b/src/cli/commands/knowledge/migrate.ts
@@ -45,13 +45,29 @@ export interface Movable {
  */
 type LocalArea = { readonly store: BlobStore; readonly prefix: string };
 
-function localAreas(storage: BlobStore, skills: BlobStore): Record<KnowledgeArea, LocalArea> {
+function localAreas(
+  storage: BlobStore,
+  skills: BlobStore | null,
+): Record<KnowledgeArea, LocalArea> {
   return {
     memory: { store: storage, prefix: `${KNOWLEDGE_LAYOUT.memory}/` },
-    skills: { store: skills, prefix: '' },
+    // Null becomes an empty area rather than a refusal: a profile granting no
+    // skills connection has none to move, and `knowledge use` should still move
+    // its memory and entities rather than failing on the one area that is empty
+    // by construction (ADR-059).
+    skills: { store: skills ?? EMPTY_AREA, prefix: '' },
     entities: { store: storage, prefix: `${KNOWLEDGE_LAYOUT.entities}/` },
   };
 }
+
+/** Nothing to list, nothing to delete. See `localAreas`. */
+const EMPTY_AREA: BlobStore = {
+  get: async () => null,
+  put: async () => {},
+  has: async () => false,
+  delete: async () => {},
+  list: async () => [],
+};
 
 const AREAS = ['memory', 'skills', 'entities'] as const;
 
@@ -66,7 +82,8 @@ const AREAS = ['memory', 'skills', 'entities'] as const;
  */
 export async function localContents(
   storage: BlobStore,
-  skills: BlobStore,
+  /** Null when the profile grants no skills connection (ADR-059). */
+  skills: BlobStore | null,
   knowledge: KnowledgeConfig,
 ): Promise<Movable[]> {
   const areas = localAreas(storage, skills);
@@ -128,7 +145,8 @@ export async function moveIn(
 /** Remove what has been verified elsewhere. Never called before `moveIn`. */
 export async function removeLocal(
   storage: BlobStore,
-  skills: BlobStore,
+  /** Null when the profile grants no skills connection (ADR-059). */
+  skills: BlobStore | null,
   movable: readonly Movable[],
 ): Promise<void> {
   const areas = localAreas(storage, skills);
@@ -152,7 +170,8 @@ export async function moveOut(
   repository: GithubRepository,
   knowledge: KnowledgeConfig,
   storage: BlobStore,
-  skills: BlobStore,
+  /** Null when the profile grants no skills connection (ADR-059). */
+  skills: BlobStore | null,
 ): Promise<Record<KnowledgeArea, number>> {
   const { entries } = await repository.entries();
   const areas = localAreas(storage, skills);

--- a/src/cli/commands/knowledge/migrate.ts
+++ b/src/cli/commands/knowledge/migrate.ts
@@ -43,20 +43,59 @@ export interface Movable {
  * it once means `localContents`, `removeLocal` and `moveOut` each became a loop
  * over this rather than a branch on a literal.
  */
-type LocalArea = { readonly store: BlobStore; readonly prefix: string };
+/**
+ * One area's local home: where to look, and what of that key is the repository's.
+ *
+ * Two prefixes rather than one, and the difference is the whole fix. `scope` is
+ * what is listed — `memory/<instance>/`, so a profile sees only the instance it
+ * grants. `prefix` is what is stripped to get the repository path, which stays
+ * `memory/<instance>/<file>` because that is the layout ADR-041 documents and
+ * what makes two profiles' notes distinguishable in one repository.
+ *
+ * Collapsing them listed every profile's memory and then wrote it flat.
+ */
+type LocalArea = {
+  readonly store: BlobStore;
+  readonly scope: string;
+  readonly prefix: string;
+};
+
+/** The connection ids this profile's memory and entities live under. */
+export interface Instances {
+  readonly memory: string;
+  readonly entities: string;
+}
 
 function localAreas(
   storage: BlobStore,
   skills: BlobStore | null,
+  /** Which instance of each surface this profile grants (ADR-059). */
+  instances: Instances,
 ): Record<KnowledgeArea, LocalArea> {
   return {
-    memory: { store: storage, prefix: `${KNOWLEDGE_LAYOUT.memory}/` },
+    // Scoped to the instance this profile grants, not to the surface.
+    //
+    // `layout.blobs()` is the whole workspace since contract 3, so a prefix of
+    // `memory/` matched every profile's memory — and `knowledge use github
+    // --migrate --profile personal` therefore committed `work`'s notes to
+    // personal's repository and then deleted them locally, leaving `work`
+    // reading an empty store with no knowledge block of its own. `skills` was
+    // already connection-scoped, which is why it alone was correct.
+    memory: {
+      store: storage,
+      scope: `${KNOWLEDGE_LAYOUT.memory}/${instances.memory}/`,
+      prefix: `${KNOWLEDGE_LAYOUT.memory}/`,
+    },
     // Null becomes an empty area rather than a refusal: a profile granting no
     // skills connection has none to move, and `knowledge use` should still move
     // its memory and entities rather than failing on the one area that is empty
     // by construction (ADR-059).
-    skills: { store: skills ?? EMPTY_AREA, prefix: '' },
-    entities: { store: storage, prefix: `${KNOWLEDGE_LAYOUT.entities}/` },
+    skills: { store: skills ?? EMPTY_AREA, scope: '', prefix: '' },
+    entities: {
+      store: storage,
+      scope: `${KNOWLEDGE_LAYOUT.entities}/${instances.entities}/`,
+      prefix: `${KNOWLEDGE_LAYOUT.entities}/`,
+    },
   };
 }
 
@@ -85,14 +124,15 @@ export async function localContents(
   /** Null when the profile grants no skills connection (ADR-059). */
   skills: BlobStore | null,
   knowledge: KnowledgeConfig,
+  instances: Instances,
 ): Promise<Movable[]> {
-  const areas = localAreas(storage, skills);
+  const areas = localAreas(storage, skills, instances);
   const found: Movable[] = [];
 
   for (const area of AREAS) {
-    const { store, prefix } = areas[area];
+    const { store, scope, prefix } = areas[area];
 
-    for (const entry of await store.list(prefix)) {
+    for (const entry of await store.list(scope)) {
       const data = await store.get(entry.key);
       if (data === null) continue; // Listed then deleted; not worth failing over.
 
@@ -148,8 +188,9 @@ export async function removeLocal(
   /** Null when the profile grants no skills connection (ADR-059). */
   skills: BlobStore | null,
   movable: readonly Movable[],
+  instances: Instances,
 ): Promise<void> {
-  const areas = localAreas(storage, skills);
+  const areas = localAreas(storage, skills, instances);
 
   for (const item of movable) {
     const { store, prefix } = areas[item.area];
@@ -172,9 +213,10 @@ export async function moveOut(
   storage: BlobStore,
   /** Null when the profile grants no skills connection (ADR-059). */
   skills: BlobStore | null,
+  instances: Instances,
 ): Promise<Record<KnowledgeArea, number>> {
   const { entries } = await repository.entries();
-  const areas = localAreas(storage, skills);
+  const areas = localAreas(storage, skills, instances);
   const counts: Record<KnowledgeArea, number> = { memory: 0, skills: 0, entities: 0 };
 
   for (const entry of entries.values()) {

--- a/src/cli/commands/knowledge/show.ts
+++ b/src/cli/commands/knowledge/show.ts
@@ -41,7 +41,7 @@ export async function knowledgeShow(flags: KnowledgeFlags): Promise<void> {
     heading('Knowledge');
     table([
       // The memory *directory*, not the blob root it sits in. `layout.blobs`
-      // is `data/<profile>`, which is where every provider's namespace lives —
+      // is `data/`, which is where every provider's namespace lives —
       // printing it here would name a directory that is mostly not memory.
       [
         '  memory',

--- a/src/cli/commands/knowledge/show.ts
+++ b/src/cli/commands/knowledge/show.ts
@@ -72,7 +72,7 @@ export async function knowledgeShow(flags: KnowledgeFlags): Promise<void> {
     print('');
     print(
       style.dim(
-        `  The vault, the credential store, runtime state and the audit log stay in target "${runtime.target}".`,
+        `  The vault, the credential store, runtime state and the audit log stay in workspace "${runtime.target}".`,
       ),
     );
     // Complete commands, not shapes. Every one of these is pasted, and with

--- a/src/cli/commands/knowledge/show.ts
+++ b/src/cli/commands/knowledge/show.ts
@@ -1,0 +1,92 @@
+import { KNOWLEDGE_LAYOUT, layout, soleGrantFor } from '#profile';
+import { announce, emit, heading, print, style, table } from '../../output.ts';
+import { openRuntime } from '../../runtime.ts';
+import type { KnowledgeFlags } from './index.ts';
+
+/**
+ * `lanes link knowledge show` — where memory, skills and entities actually are.
+ *
+ * Split from `knowledge use` so `index.ts` stays inside the size budget, on the
+ * seam the two commands already have: this one opens stores and counts, and
+ * never writes. That difference is why `show` can answer for a repository `use`
+ * would refuse to touch.
+ */
+
+export async function knowledgeShow(flags: KnowledgeFlags): Promise<void> {
+  const runtime = await openRuntime(flags, { fetch: flags.fetch });
+  try {
+    if (!flags.json) announce(runtime.resolution);
+
+    const profile = runtime.config.instance.profile;
+    const selection = ` --profile ${runtime.resolution.profile} --target ${runtime.target}`;
+    const skills = runtime.skills ? (await runtime.skills.list()).length : 0;
+    const memory = (await runtime.storage.list(`${KNOWLEDGE_LAYOUT.memory}/`)).length;
+    const entities = (await runtime.storage.list(`${KNOWLEDGE_LAYOUT.entities}/`)).length;
+    const where = runtime.knowledge?.describe;
+    // Null when no skills connection is granted (ADR-059). The row still prints,
+    // saying so: a missing row reads as "there are none", not "not granted".
+    const skillsConnection = soleGrantFor(runtime.config, 'skills');
+
+    if (flags.json) {
+      print(
+        JSON.stringify(
+          { target: runtime.target, where: where ?? 'local', memory, skills, entities },
+          null,
+          2,
+        ),
+      );
+      return;
+    }
+
+    heading('Knowledge');
+    table([
+      // The memory *directory*, not the blob root it sits in. `layout.blobs`
+      // is `data/<profile>`, which is where every provider's namespace lives —
+      // printing it here would name a directory that is mostly not memory.
+      [
+        '  memory',
+        where ? `${where}/${KNOWLEDGE_LAYOUT.memory}` : `${layout.blobs()}/${KNOWLEDGE_LAYOUT.memory}`,
+        style.dim(`${memory} file${memory === 1 ? '' : 's'}`),
+      ],
+      [
+        '  skills',
+        where
+          ? `${where}/${KNOWLEDGE_LAYOUT.skills}`
+          : skillsConnection
+            ? layout.skills(skillsConnection)
+            : style.dim('not granted'),
+        style.dim(`${skills} file${skills === 1 ? '' : 's'}`),
+      ],
+      // The count includes the derived `_index.json`, deliberately: it is a
+      // file in that directory and it is committed with the rest, so a number
+      // that quietly excluded it would not match what a person sees there.
+      [
+        '  entities',
+        where
+          ? `${where}/${KNOWLEDGE_LAYOUT.entities}`
+          : `${layout.blobs()}/${KNOWLEDGE_LAYOUT.entities}`,
+        style.dim(`${entities} file${entities === 1 ? '' : 's'}`),
+      ],
+    ]);
+
+    print('');
+    print(
+      style.dim(
+        `  The vault, the credential store, runtime state and the audit log stay in target "${runtime.target}".`,
+      ),
+    );
+    // Complete commands, not shapes. Every one of these is pasted, and with
+    // nothing left to fall back on (ADR-037) a line missing either flag is a
+    // line that refuses — `emitted.test.ts` states the rule for the templates
+    // reachable without a runtime, and this is the same rule where there is one.
+    print(
+      style.dim(
+        where
+          ? `  Bring them back with: lanes link knowledge use local --migrate${selection}`
+          : `  Keep them in a repository with: lanes link knowledge use github --repo <owner/name>${selection}`,
+      ),
+    );
+  } finally {
+    await runtime.close();
+  }
+}

--- a/src/cli/commands/mcp.ts
+++ b/src/cli/commands/mcp.ts
@@ -20,3 +20,4 @@ export { harnessCommands } from './mcp/harnesses.ts';
 export { mcpList } from './mcp/list.ts';
 export { mcpAdd, type McpAddOptions } from './mcp/register.ts';
 export { mcpStdio } from './mcp/stdio.ts';
+export { installInstructions, type InstallInstructionsFlags } from './mcp/onboarding.ts';

--- a/src/cli/commands/mcp/harnesses.ts
+++ b/src/cli/commands/mcp/harnesses.ts
@@ -17,12 +17,31 @@ import { join } from 'node:path';
  * command, write the file where it does not. A skill is content in a documented
  * location, not a config format we would be guessing at, and the directory
  * written is named after this project.
+ *
+ * **No registration carries a token any more** (ADR-062). Every endpoint runs
+ * the authorization flow, discovery is served ahead of the auth gate on
+ * loopback as well as deployed, and a client pointed at a bare URL finds
+ * `/.well-known/oauth-protected-resource`, signs its owner in at lanes.sh, and
+ * comes back with a token of its own. What that removes is worth stating: the
+ * registration no longer contains a credential, so a config file synced to a
+ * dotfiles repository is no longer a leak, and a rotation does not invalidate
+ * every harness at once.
+ *
+ * The exception is `tokenEnv`, which survives for the one caller that has no
+ * browser — see `token show`, which is now documented as a CI command.
  */
 
 export interface AddInput {
   readonly name: string;
   readonly url: string;
-  readonly token: string;
+  /**
+   * The endpoint's static token, for a harness that cannot run a browser.
+   *
+   * Nothing passes this in the ordinary path. It is here because
+   * `--headless` exists for CI, where there is no browser to complete an
+   * authorization in and a pasted credential is the only thing that works.
+   */
+  readonly token?: string | undefined;
   readonly tokenEnv: string;
   readonly scope: string;
   /**
@@ -44,11 +63,12 @@ export interface Harness {
   /** Whether `--scope` means anything here. Codex config is global. */
   readonly scoped: boolean;
   /**
-   * Whether the token is handed to the harness at all.
+   * Whether a credential reaches the harness's config at all.
    *
-   * Codex stores the *name* of an environment variable and reads it when it
-   * launches, so the secret never reaches its config file and a rotation is
-   * picked up without re-registering. Claude Code stores the header value.
+   * Both are `false` in the ordinary path now — the client authorises itself.
+   * This still distinguishes what a `--headless` registration would write:
+   * Claude Code would hold the header value, and Codex stores only the *name*
+   * of an environment variable it reads at launch.
    */
   readonly storesToken: boolean;
   /**
@@ -99,8 +119,10 @@ export const HARNESSES: readonly Harness[] = [
       'http',
       name,
       url,
-      '--header',
-      `Authorization: Bearer ${token}`,
+      // Only when there is no browser to sign in with. Registering the bare URL
+      // is the ordinary path: Claude Code discovers the protected-resource
+      // document and runs the authorization itself.
+      ...(token ? ['--header', `Authorization: Bearer ${token}`] : []),
       '--scope',
       scope,
     ],

--- a/src/cli/commands/mcp/harnesses.ts
+++ b/src/cli/commands/mcp/harnesses.ts
@@ -142,7 +142,7 @@ export const HARNESSES: readonly Harness[] = [
       // anywhere else: an unresolvable substitution yields the empty string, the
       // header becomes "Bearer ", and the only symptom is a 401 that reads as a
       // bad token rather than a command that refused.
-      `    export ${tokenEnv}="$(lanes link token show --raw --profile ${profile} --target ${target})"`,
+      `    export ${tokenEnv}="$(lanes link token show --raw --profile ${profile} --workspace ${target})"`,
       '',
       'Add that to your shell profile. This is the better half of the bargain: the token never',
       'reaches ~/.codex/config.toml, and a "lanes link token rotate" is picked up on next launch',

--- a/src/cli/commands/mcp/onboarding.ts
+++ b/src/cli/commands/mcp/onboarding.ts
@@ -1,0 +1,86 @@
+import { print } from '../../output.ts';
+
+/**
+ * `lanes link mcp install-instructions` — the block a client should be told once.
+ *
+ * A registration points a client at this endpoint. It does not tell the *model*
+ * anything, and the model is what decides whether to look here at all. The
+ * common failure is not a client that cannot reach the endpoint; it is one that
+ * can and answers from nothing anyway, because reaching for a tool is a habit
+ * and no habit is installed by adding a server to a config file.
+ *
+ * So this prints a short block for a person to paste into whatever their client
+ * treats as durable instruction — a project file, a custom instruction, a
+ * memory. It says where things are and what to read first, and nothing else:
+ * the full account lives at `lanes://instructions` and is served by the
+ * endpoint, so it can be corrected without anybody pasting anything again.
+ *
+ * **Printed rather than written.** Every client keeps this somewhere different
+ * and several keep it somewhere a person curates by hand. Writing into one of
+ * those is the class of thing ADR-016 puts on the other side of the line from
+ * `mcp add`: delegate where the harness owns a command, write the file only
+ * where it does not, and where neither is true, hand over the text.
+ */
+
+/** What each client calls the place this belongs, so the hint is actionable. */
+const WHERE: Record<string, string> = {
+  claude: 'CLAUDE.md in your project, or ~/.claude/CLAUDE.md for every project',
+  chatgpt: "Settings → Personalization → Custom instructions, under 'anything else'",
+  codex: 'AGENTS.md in your project, or ~/.codex/AGENTS.md',
+  cursor: '.cursor/rules/ in your project',
+};
+
+export interface InstallInstructionsFlags {
+  readonly client?: string | undefined;
+}
+
+export function installInstructions(flags: InstallInstructionsFlags = {}): void {
+  const client = flags.client?.toLowerCase();
+
+  if (client !== undefined && !(client in WHERE)) {
+    throw new Error(
+      `Unknown client "${client}". Known: ${Object.keys(WHERE).join(', ')}.\n` +
+        '  Omit --client for the block on its own.',
+    );
+  }
+
+  if (client !== undefined) {
+    // To stderr, so the block on stdout stays pasteable. Somebody piping this
+    // into a file wants the text and not the advice about where to put it.
+    process.stderr.write(`Paste this into ${WHERE[client]}:\n\n`);
+  }
+
+  print(BLOCK);
+}
+
+/**
+ * The block itself.
+ *
+ * Deliberately short and deliberately not a copy of the endpoint's own
+ * instructions. It exists to establish one habit — look here before answering
+ * from nothing — and to name the document that carries the rest. A longer block
+ * pasted into a project file is one that goes stale in a place nobody will
+ * think to update.
+ *
+ * No vendor names and no account details, for the same reason nothing under
+ * `server/` may carry one: what the owner connected is theirs.
+ */
+const BLOCK = `## Lanes Link
+
+Lanes Link is the route to my accounts, my memory, my notes, my saved procedures
+and my contacts. It is an MCP endpoint, and it is already connected.
+
+- Before saying you do not know something about me or my work, search memory.
+- Before using anyone's address or handle, look them up in entities. It returns
+  every match and never picks one; if there is more than one, ask me.
+- A thing for me to do is a task, not a memory. Tasks have a status.
+- If I have a saved procedure for something, tell me it exists and let me run it
+  rather than improvising your own version.
+- Before telling me something cannot be reached or that an account is missing,
+  ask the setup surface. It reports what exists and gives the exact command for
+  what does not. Run nothing yourself: every change here is mine to make.
+- Read \`lanes://instructions\` before your first call for the full account of
+  how routing, profiles and refusals work.
+
+Every tool takes a profile. A profile is how I keep things apart, so when it is
+ambiguous which one I mean, ask rather than picking the first.`;

--- a/src/cli/commands/mcp/register.ts
+++ b/src/cli/commands/mcp/register.ts
@@ -74,7 +74,7 @@ export async function mcpAdd(target: string | undefined, options: McpAddOptions)
     const { token } = await ensureProfileToken(runtime.credentials, runtime.config.auth.token_ref);
 
     // The target's own address, not the local one. This built
-    // `http://<host>:<port>/mcp` unconditionally, so `mcp add --target cloud`
+    // `http://<host>:<port>/mcp` unconditionally, so `mcp add --workspace cloud`
     // registered loopback with the agent: a registration that reports success,
     // names the right server, and points at a port with nothing behind it.
     const url = await endpointUrl(runtime.config, runtime.declared);

--- a/src/cli/commands/mcp/register.ts
+++ b/src/cli/commands/mcp/register.ts
@@ -32,6 +32,17 @@ export interface McpAddOptions extends GlobalFlags {
   readonly force?: boolean | undefined;
   /** Register only; leave the skill and the agent alone. */
   readonly noSkill?: boolean | undefined;
+  /**
+   * Write the endpoint token into the registration, for a machine with no browser.
+   *
+   * The ordinary path registers a bare URL and the client authorises itself
+   * against lanes.sh (ADR-062), which is both safer and less to get wrong. This
+   * is the CI escape hatch, and it is a flag rather than a fallback because the
+   * difference has to be a decision somebody made: a registration that quietly
+   * embedded a credential when a browser was unavailable is one nobody would
+   * notice had done so.
+   */
+  readonly headless?: boolean | undefined;
 }
 
 export async function mcpAdd(target: string | undefined, options: McpAddOptions): Promise<void> {
@@ -71,6 +82,9 @@ export async function mcpAdd(target: string | undefined, options: McpAddOptions)
   const runtime = await openRuntime(options);
 
   try {
+    // Minted either way. The endpoint needs one to serve at all, and `outputs`
+    // prints it; what `--headless` decides is whether it is written into
+    // somebody's agent config.
     const { token } = await ensureProfileToken(runtime.credentials, runtime.config.auth.token_ref);
 
     // The target's own address, not the local one. This built
@@ -81,7 +95,7 @@ export async function mcpAdd(target: string | undefined, options: McpAddOptions)
     const input: AddInput = {
       name,
       url,
-      token,
+      ...(options.headless === true ? { token } : {}),
       tokenEnv,
       scope,
       profile: runtime.resolution.profile,

--- a/src/cli/commands/members.ts
+++ b/src/cli/commands/members.ts
@@ -1,7 +1,8 @@
 import { readSession } from '#auth/lanes/session.ts';
 import { ConfigError, readRegistry, resolveWorkspaceRoot } from '#profile';
 import { ConfigDocument } from '../config-edit.ts';
-import { announce, emit, ok, print, style, table } from '../output.ts';
+import { describeMember, workspaceMembers } from '#auth/lanes/members.ts';
+import { announce, emit, heading, ok, print, style, table } from '../output.ts';
 import { nextAfterEdit, publishProfileEdit } from '../publish.ts';
 import { resolveProfile, type GlobalFlags } from '../runtime.ts';
 
@@ -12,11 +13,15 @@ import { resolveProfile, type GlobalFlags } from '../runtime.ts';
  * and for the sharpest version of that argument: an agent able to edit this
  * could add itself.
  *
- * **A subject is validated against the Lanes workspace where there is one.** A
- * remote workspace binds to a Lanes workspace with `lanes_workspace:`, and a
- * member of that is somebody the server already vouches for. For `local` there
- * is no such list, so the only subject accepted is the signed-in one — a local
- * workspace delegating to a stranger is a typo, not a use case.
+ * **This is a selection from the Lanes workspace, not a list beside it.**
+ * Membership is managed on the dashboard — invited, accepted, given a role,
+ * removed — and a workspace bound with `lanes_workspace:` is asked who it holds.
+ * Somebody added there shows up here the moment they accept, and granting them a
+ * profile is a local edit naming a subject the server already vouches for.
+ *
+ * For `local` there is no such list, so the only subject accepted is the
+ * signed-in one — a local workspace delegating to a stranger is a typo, not a
+ * use case.
  */
 
 export interface MemberRow {
@@ -27,7 +32,7 @@ export interface MemberRow {
 }
 
 export async function membersList(flags: GlobalFlags & { json?: boolean }): Promise<void> {
-  const { resolution, config } = await resolveProfile(flags);
+  const { resolution, config, target } = await resolveProfile(flags);
   const session = await readSession();
 
   const rows: MemberRow[] = config.members.map((member) => ({
@@ -36,25 +41,63 @@ export async function membersList(flags: GlobalFlags & { json?: boolean }): Prom
     you: member.subject === session?.subject,
   }));
 
-  return emit(flags.json, { profile: resolution.profile, members: rows }, () => {
-    announce(resolution);
+  // The workspace's own people, so this listing answers both halves of the
+  // question: who may use this profile, and who *could* be given it. Without
+  // the second, adding somebody means going to the dashboard to copy a subject
+  // out of it.
+  const held = await workspaceMembers(await boundWorkspace(target));
+  const granted = new Set(rows.map((row) => row.subject));
+  const available = held.members.filter(
+    (member) => member.subject === null || !granted.has(member.subject),
+  );
 
-    if (rows.length === 0) {
-      // Empty is nobody, and saying so matters: the natural reading of a blank
-      // list is "no restriction", which is the opposite of what it means.
-      print(style.dim('No members. Nobody may consume this profile.'));
-      print(style.dim('  Add yourself with: lanes link profile members add --me'));
-      return;
-    }
+  return emit(
+    flags.json,
+    { profile: resolution.profile, members: rows, available: available },
+    () => {
+      announce(resolution);
 
-    table(
-      rows.map((row) => [
-        `  ${style.bold(row.subject)}`,
-        row.role,
-        row.you ? style.dim('you') : '',
-      ]),
-    );
-  });
+      if (rows.length === 0) {
+        // Empty is nobody, and saying so matters: the natural reading of a blank
+        // list is "no restriction", which is the opposite of what it means.
+        print(style.dim('No members. Nobody may consume this profile.'));
+        print(style.dim('  Add yourself with: lanes link profile members add --me'));
+      } else {
+        heading(`May consume ${resolution.profile} (${rows.length})`);
+        table(
+          rows.map((row) => [
+            `  ${style.bold(row.subject)}`,
+            row.role,
+            row.you ? style.dim('you') : '',
+          ]),
+        );
+      }
+
+      if (available.length > 0) {
+        heading(`In the workspace, not granted (${available.length})`);
+        table(
+          available.map((member) => [
+            `  ${style.bold(describeMember(member))}`,
+            member.role,
+            member.status === 'pending'
+              ? style.dim('invitation not accepted')
+              : style.dim(member.subject ?? ''),
+          ]),
+        );
+      }
+
+      if (held.unavailable !== null && held.unavailable !== 'this workspace is not bound to a Lanes workspace') {
+        print('');
+        print(style.dim(`Could not list the workspace's members: ${held.unavailable}`));
+      }
+    },
+  );
+}
+
+/** The Lanes workspace this one is bound to, if any. */
+async function boundWorkspace(target: string): Promise<string | undefined> {
+  const registry = await readRegistry(resolveWorkspaceRoot());
+  return registry[target]?.lanes_workspace;
 }
 
 export interface MembersFlags extends GlobalFlags {
@@ -147,19 +190,20 @@ export async function membersRemove(
  * The check exists because the alternative is a profile listing a subject
  * nobody can produce a token for — which reads exactly like a working
  * delegation until the person tries to use it.
+ *
+ * Bound to a Lanes workspace, the answer is the workspace's own member list:
+ * somebody added on the dashboard is delegatable here, and nobody else is.
+ * Unbound, there is no list to ask, so the only verifiable subject is the one at
+ * the keyboard.
  */
 async function assertDelegatable(
   subject: string,
   target: string,
   signedIn: string | undefined,
 ): Promise<void> {
-  const registry = await readRegistry(resolveWorkspaceRoot());
-  const bound = registry[target]?.lanes_workspace;
+  const bound = await boundWorkspace(target);
 
   if (bound === undefined) {
-    // No Lanes workspace behind this one, so there is no membership list to
-    // check against and the only subject that can be verified is the one at the
-    // keyboard.
     if (subject === signedIn) return;
 
     throw new ConfigError(
@@ -171,8 +215,38 @@ async function assertDelegatable(
     );
   }
 
-  // Bound: the server holds the list, and it is the authority. Not checked here
-  // over the network, deliberately — `profile members add` would then fail
-  // offline on a workspace that is otherwise entirely local to edit, and the
-  // endpoint verifies the subject at token time regardless.
+  const held = await workspaceMembers(bound);
+
+  // Unreachable rather than empty. Refusing on a network failure would make a
+  // local edit depend on our uptime, and the endpoint verifies the subject when
+  // it mints a token regardless — so this warns and proceeds.
+  if (held.unavailable !== null) {
+    print(
+      style.dim(
+        `  Could not check the workspace's members (${held.unavailable}), so this was not verified.`,
+      ),
+    );
+    return;
+  }
+
+  const match = held.members.find((member) => member.subject === subject);
+  if (match !== undefined) return;
+
+  // A pending invitation is the interesting refusal: the person exists, the
+  // operator can see them on the dashboard, and there is still no subject to
+  // write down. Saying "not a member" would send them to add somebody who is
+  // already there.
+  const pending = held.members.filter((member) => member.status === 'pending');
+
+  throw new ConfigError(
+    `${subject} is not a member of the Lanes workspace behind "${target}".\n` +
+      (held.members.length > 0
+        ? `  It holds: ${held.members.map(describeMember).join(', ')}\n`
+        : '  It holds nobody yet.\n') +
+      (pending.length > 0
+        ? `  ${pending.map(describeMember).join(', ')} ${pending.length === 1 ? 'has' : 'have'} not ` +
+          'accepted the invitation yet, so there is no subject for them to be granted.\n'
+        : '') +
+      '  Invite them on the dashboard first: https://lanes.sh/dashboard/settings/members',
+  );
 }

--- a/src/cli/commands/members.ts
+++ b/src/cli/commands/members.ts
@@ -1,8 +1,9 @@
 import { readSession } from '#auth/lanes/session.ts';
+import { recordConfigChange } from '../audit-change.ts';
 import { ConfigError, readRegistry, resolveWorkspaceRoot } from '#profile';
 import { ConfigDocument } from '../config-edit.ts';
 import { describeMember, workspaceMembers } from '#auth/lanes/members.ts';
-import { announce, emit, heading, ok, print, style, table } from '../output.ts';
+import { announce, emit, heading, ok, print, style, table, warn } from '../output.ts';
 import { nextAfterEdit, publishProfileEdit } from '../publish.ts';
 import { resolveProfile, type GlobalFlags } from '../runtime.ts';
 
@@ -138,6 +139,18 @@ export async function membersAdd(
   document.addTo(['members'], { subject: wanted, role }, { inline: true });
   await document.save();
 
+  await recordConfigChange(
+    config,
+    resolution.workspaceRoot,
+    target,
+    {
+      capability: 'config.member.add',
+      scope: resolution.profile,
+      arguments: { subject: wanted, role },
+    },
+    (note) => print(warn(note)),
+  );
+
   const published = nextAfterEdit(await publishProfileEdit({ resolution, config, target }));
 
   return emit(flags.json, { profile: resolution.profile, subject: wanted, role }, () => {
@@ -164,6 +177,14 @@ export async function membersRemove(
   const document = await ConfigDocument.open(resolution.workspaceRoot, resolution.profile);
   document.removeFrom(['members'], at);
   await document.save();
+
+  await recordConfigChange(
+    config,
+    resolution.workspaceRoot,
+    target,
+    { capability: 'config.member.remove', scope: resolution.profile, arguments: { subject } },
+    (note) => print(warn(note)),
+  );
 
   const published = nextAfterEdit(await publishProfileEdit({ resolution, config, target }));
 

--- a/src/cli/commands/members.ts
+++ b/src/cli/commands/members.ts
@@ -1,0 +1,178 @@
+import { readSession } from '#auth/lanes/session.ts';
+import { ConfigError, readRegistry, resolveWorkspaceRoot } from '#profile';
+import { ConfigDocument } from '../config-edit.ts';
+import { announce, emit, ok, print, style, table } from '../output.ts';
+import { nextAfterEdit, publishProfileEdit } from '../publish.ts';
+import { resolveProfile, type GlobalFlags } from '../runtime.ts';
+
+/**
+ * `lanes link profile members` — who may consume a profile (ADR-060).
+ *
+ * CLI-only, like everything that authorises future agent behaviour (ADR-007),
+ * and for the sharpest version of that argument: an agent able to edit this
+ * could add itself.
+ *
+ * **A subject is validated against the Lanes workspace where there is one.** A
+ * remote workspace binds to a Lanes workspace with `lanes_workspace:`, and a
+ * member of that is somebody the server already vouches for. For `local` there
+ * is no such list, so the only subject accepted is the signed-in one — a local
+ * workspace delegating to a stranger is a typo, not a use case.
+ */
+
+export interface MemberRow {
+  readonly subject: string;
+  readonly role: 'owner' | 'member';
+  /** Whether this is the identity running the command. */
+  readonly you: boolean;
+}
+
+export async function membersList(flags: GlobalFlags & { json?: boolean }): Promise<void> {
+  const { resolution, config } = await resolveProfile(flags);
+  const session = await readSession();
+
+  const rows: MemberRow[] = config.members.map((member) => ({
+    subject: member.subject,
+    role: member.role,
+    you: member.subject === session?.subject,
+  }));
+
+  return emit(flags.json, { profile: resolution.profile, members: rows }, () => {
+    announce(resolution);
+
+    if (rows.length === 0) {
+      // Empty is nobody, and saying so matters: the natural reading of a blank
+      // list is "no restriction", which is the opposite of what it means.
+      print(style.dim('No members. Nobody may consume this profile.'));
+      print(style.dim('  Add yourself with: lanes link profile members add --me'));
+      return;
+    }
+
+    table(
+      rows.map((row) => [
+        `  ${style.bold(row.subject)}`,
+        row.role,
+        row.you ? style.dim('you') : '',
+      ]),
+    );
+  });
+}
+
+export interface MembersFlags extends GlobalFlags {
+  readonly json?: boolean | undefined;
+  /** Add the signed-in subject, rather than one typed out. */
+  readonly me?: boolean | undefined;
+  readonly role?: string | undefined;
+}
+
+export async function membersAdd(
+  subject: string | undefined,
+  flags: MembersFlags,
+): Promise<void> {
+  const { resolution, config, target } = await resolveProfile(flags);
+  const session = await readSession();
+
+  const wanted = flags.me === true ? session?.subject : subject;
+
+  if (wanted === undefined) {
+    throw new ConfigError(
+      flags.me === true
+        ? 'Not signed in, so there is no "me" to add. Run: lanes auth login'
+        : 'Which subject? Run: lanes link profile members add <subject> --profile <name>\n' +
+          '  Or add yourself: lanes link profile members add --me --profile <name>',
+    );
+  }
+
+  const role = flags.role === 'owner' ? 'owner' : 'member';
+
+  if (config.members.some((member) => member.subject === wanted)) {
+    print(style.dim(`${resolution.profile} already lists ${wanted}.`));
+    return;
+  }
+
+  await assertDelegatable(wanted, target, session?.subject);
+
+  const document = await ConfigDocument.open(resolution.workspaceRoot, resolution.profile);
+  document.addTo(['members'], { subject: wanted, role }, { inline: true });
+  await document.save();
+
+  const published = nextAfterEdit(await publishProfileEdit({ resolution, config, target }));
+
+  return emit(flags.json, { profile: resolution.profile, subject: wanted, role }, () => {
+    announce(resolution);
+    print(ok(`${wanted} may now consume ${style.bold(resolution.profile)} as ${role}`));
+    print(style.dim('      They reach exactly what this profile grants, and nothing else.'));
+    if (published) print(style.dim(`      ${published}`));
+  });
+}
+
+export async function membersRemove(
+  subject: string | undefined,
+  flags: MembersFlags,
+): Promise<void> {
+  const { resolution, config, target } = await resolveProfile(flags);
+  if (!subject) throw new ConfigError('Which subject? Run: lanes link profile members list');
+
+  const at = config.members.findIndex((member) => member.subject === subject);
+  if (at === -1) {
+    print(style.dim(`${resolution.profile} does not list ${subject}.`));
+    return;
+  }
+
+  const document = await ConfigDocument.open(resolution.workspaceRoot, resolution.profile);
+  document.removeFrom(['members'], at);
+  await document.save();
+
+  const published = nextAfterEdit(await publishProfileEdit({ resolution, config, target }));
+
+  return emit(flags.json, { profile: resolution.profile, subject }, () => {
+    announce(resolution);
+    print(ok(`${subject} may no longer consume ${style.bold(resolution.profile)}`));
+
+    // The half that is not obvious, and is the difference between this and a
+    // session manager. A token already issued keeps working until it expires:
+    // membership is read when one is minted, not on every call (ADR-060).
+    print(
+      style.dim(
+        '      A token they already hold keeps working until it expires.\n' +
+          `      To close that window now: lanes link token rotate --workspace ${target}`,
+      ),
+    );
+    if (published) print(style.dim(`      ${published}`));
+  });
+}
+
+/**
+ * Whether this workspace may delegate to that subject.
+ *
+ * The check exists because the alternative is a profile listing a subject
+ * nobody can produce a token for — which reads exactly like a working
+ * delegation until the person tries to use it.
+ */
+async function assertDelegatable(
+  subject: string,
+  target: string,
+  signedIn: string | undefined,
+): Promise<void> {
+  const registry = await readRegistry(resolveWorkspaceRoot());
+  const bound = registry[target]?.lanes_workspace;
+
+  if (bound === undefined) {
+    // No Lanes workspace behind this one, so there is no membership list to
+    // check against and the only subject that can be verified is the one at the
+    // keyboard.
+    if (subject === signedIn) return;
+
+    throw new ConfigError(
+      `Workspace "${target}" is not bound to a Lanes workspace, so it can only delegate to you.\n` +
+        '  Add yourself with: lanes link profile members add --me\n' +
+        '  To delegate to somebody else, bind the workspace:\n' +
+        `    lanes_workspace: <id>   # in lanes-link.yaml, under workspaces.${target}\n` +
+        '  Run "lanes auth workspaces" for the ids you belong to.',
+    );
+  }
+
+  // Bound: the server holds the list, and it is the authority. Not checked here
+  // over the network, deliberately — `profile members add` would then fail
+  // offline on a workspace that is otherwise entirely local to edit, and the
+  // endpoint verifies the subject at token time regardless.
+}

--- a/src/cli/commands/members.ts
+++ b/src/cli/commands/members.ts
@@ -1,6 +1,11 @@
 import { readSession } from '#auth/lanes/session.ts';
 import { recordConfigChange } from '../audit-change.ts';
-import { ConfigError, readRegistry, resolveWorkspaceRoot } from '#profile';
+import {
+  ConfigError,
+  readRegistry,
+  resolveTargetWorkspace,
+  resolveWorkspaceRoot,
+} from '#profile';
 import { ConfigDocument } from '../config-edit.ts';
 import { describeMember, workspaceMembers } from '#auth/lanes/members.ts';
 import { announce, emit, heading, ok, print, style, table, warn } from '../output.ts';
@@ -97,7 +102,17 @@ export async function membersList(flags: GlobalFlags & { json?: boolean }): Prom
 
 /** The Lanes workspace this one is bound to, if any. */
 async function boundWorkspace(target: string): Promise<string | undefined> {
-  const registry = await readRegistry(resolveWorkspaceRoot());
+  // **The workspace that declares the target, which is not this machine once it
+  // is deployed.** `lanes_workspace` is a declaration field, and
+  // `recordDeployment` writes the declaration into the bucket while leaving
+  // this machine a pointer carrying only `at`, `primary` and the deploy stamps.
+  // So reading it here found nothing the moment a target was deployed: binding
+  // a workspace stopped taking effect, `members add` refused everyone but the
+  // person at the keyboard, and the remedy it printed — add `lanes_workspace:`
+  // under `workspaces.<target>` — named the pointer entry, which the next
+  // deploy overwrites. A declaration resolves back to this root unchanged.
+  const local = resolveWorkspaceRoot();
+  const registry = await readRegistry(await resolveTargetWorkspace(local, target).catch(() => local));
   return registry[target]?.lanes_workspace;
 }
 

--- a/src/cli/commands/operate.test.ts
+++ b/src/cli/commands/operate.test.ts
@@ -54,7 +54,7 @@ describe('the token command outputs prints', () => {
     const invocation = await tokenInvocation('a-token-no-endpoint-will-match', 'work', 'cloud');
 
     expect(invocation.command).toContain('--profile work');
-    expect(invocation.command).toContain('--target cloud');
+    expect(invocation.command).toContain('--workspace cloud');
     expect(invocation.command).toContain('token show --raw');
   });
 });

--- a/src/cli/commands/operate.ts
+++ b/src/cli/commands/operate.ts
@@ -11,6 +11,7 @@
  *   outputs.ts   what an agent harness needs, and proving the short form works
  *   desktop.ts   opening the Lanes app, on the page that drives this CLI
  *   serve.ts     start
+ *   pair.ts      pair — the dashboard's read surface (ADR-063)
  *   audit.ts     audit tail and verify, and the Markdown rendering of tail
  *   token.ts     token show, token rotate
  *   policy.ts    policy list/allow/deny, config show
@@ -25,6 +26,7 @@ export { status } from './operate/status.ts';
 export { outputs, type OutputsFlags } from './operate/outputs.ts';
 export { tools, type ToolsFlags } from './operate/tools.ts';
 export { start } from './operate/serve.ts';
+export { pair, PAIR_CERT_REF, PAIR_KEY_REF, PAIR_TOKEN_REF, type PairFlags } from './operate/pair.ts';
 export { desktop, settingsUrl, type DesktopFlags } from './operate/desktop.ts';
 export { auditTail, auditVerify, markdownCell } from './operate/audit.ts';
 export { attachFile } from './operate/attach.ts';

--- a/src/cli/commands/operate/attach.ts
+++ b/src/cli/commands/operate/attach.ts
@@ -2,7 +2,7 @@ import { readFile } from 'node:fs/promises';
 import { basename } from 'node:path';
 import { ownerPrincipal } from '#auth';
 import { announce, print, style } from '../../output.ts';
-import { openRuntime, type GlobalFlags } from '../../runtime.ts';
+import { grantedConnections, openRuntime, type GlobalFlags } from '../../runtime.ts';
 
 /**
  * `lanes link attach <file> --connection <provider>.<account>`
@@ -44,11 +44,11 @@ export async function attachFile(
 
     // Checked against config rather than trusted, so a typo names the mistake
     // instead of staging into a namespace nothing will ever read.
-    const known = runtime.config.connections.some(
+    const known = grantedConnections(runtime).some(
       (connection) => connection.provider === providerId && connection.id === connectionId,
     );
     if (!known) {
-      const have = runtime.config.connections.map((c) => `${c.provider}.${c.id}`);
+      const have = grantedConnections(runtime).map((c) => `${c.provider}.${c.id}`);
       throw new Error(
         `No connection "${flags.connection}" in this profile. Configured: ${have.join(', ') || 'none'}.`,
       );

--- a/src/cli/commands/operate/audit.ts
+++ b/src/cli/commands/operate/audit.ts
@@ -1,5 +1,5 @@
-import { announce, print, style, table } from '../../output.ts';
-import { openRuntime, type GlobalFlags } from '../../runtime.ts';
+import { announceWorkspace, print, style, table } from '../../output.ts';
+import { openWorkspaceRuntime, type GlobalFlags } from '../../runtime.ts';
 
 /** `lanes link audit tail` — the log the dispatcher writes, rendered for a terminal. */
 
@@ -15,11 +15,11 @@ export async function auditTail(
   }
   const markdown = flags.format === 'md';
 
-  const runtime = await openRuntime(flags);
+  const runtime = await openWorkspaceRuntime(flags);
   try {
     // The banner is chrome around a table; in Markdown it is a stray line in
     // the middle of a document someone is pasting somewhere.
-    if (!markdown) announce(runtime.resolution);
+    if (!markdown) announceWorkspace(runtime.resolution);
 
     const events = await runtime.audit.tail({
       limit: flags.limit ?? 25,
@@ -35,7 +35,11 @@ export async function auditTail(
       // The log lives in the database; this is a rendering of it, not a second
       // copy of it. See ADR-013 — storage format and display format are not the
       // same decision.
-      print(`# Audit — ${runtime.resolution.profile}\n`);
+      // The workspace, not the profile. Contract 3 gave the workspace one
+      // chain covering every profile in it, and a heading naming whichever
+      // profile happened to open the store described a log that does not
+      // exist. Each row carries its own profile.
+      print(`# Audit — ${runtime.resolution.target}\n`);
       print('| Time | Result | Capability | Connection | Duration | Arguments |');
       print('|---|---|---|---|---|---|');
       for (const event of events) {
@@ -81,9 +85,9 @@ export async function auditTail(
  * can see how much was looked at.
  */
 export async function auditVerify(flags: GlobalFlags): Promise<void> {
-  const runtime = await openRuntime(flags);
+  const runtime = await openWorkspaceRuntime(flags);
   try {
-    announce(runtime.resolution);
+    announceWorkspace(runtime.resolution);
     const report = await runtime.audit.verify();
 
     const scope = `${report.events} event${report.events === 1 ? '' : 's'} across ${report.runs} run${report.runs === 1 ? '' : 's'}`;

--- a/src/cli/commands/operate/auth.test.ts
+++ b/src/cli/commands/operate/auth.test.ts
@@ -61,7 +61,7 @@ describe('classifyOAuth', () => {
  * reported as broken by a probe that simply asked the resolver about everything.
  */
 describe('probeConnections, before the resolver', () => {
-  const forSelection = (command: string) => `${command} --profile p --target t`;
+  const forSelection = (command: string) => `${command} --profile p --workspace <name>`;
 
   const store = (seed: Record<string, string> = {}): SecretStore => {
     const map = new Map(Object.entries(seed));
@@ -130,7 +130,7 @@ describe('probeConnections, before the resolver', () => {
     );
 
     expect(result!.verdict).toBe('missing');
-    expect(result!.fix).toBe('lanes link connect icloud_mail.main --profile p --target t');
+    expect(result!.fix).toBe('lanes link connect icloud_mail.main --profile p --workspace <name>');
   });
 
   test('the owner layer needs no credential and costs no store read', async () => {

--- a/src/cli/commands/operate/auth.ts
+++ b/src/cli/commands/operate/auth.ts
@@ -2,8 +2,14 @@ import type { ConnectionConfig } from '#profile';
 import { credentialResolver, ReauthRequired } from '#connectivity/auth/index.ts';
 import type { ResolvedCredential } from '#connectivity/auth/credential.ts';
 import { credentialRefFor } from '#registry';
-import { announce, emit, fail, ok, print, warn } from '../../output.ts';
-import { grantedConnections, openRuntime, type GlobalFlags, type Runtime } from '../../runtime.ts';
+import { announceWorkspace, emit, fail, ok, print, warn } from '../../output.ts';
+import { readConnections } from '#profile';
+import {
+  grantedConnections,
+  openWorkspaceRuntime,
+  type GlobalFlags,
+  type Runtime,
+} from '../../runtime.ts';
 
 /**
  * Whether each connection could still authenticate, asked rather than guessed.
@@ -246,20 +252,30 @@ export async function probeConnections(
 }
 
 export async function auth(flags: AuthFlags): Promise<void> {
-  const runtime = await openRuntime(flags);
+  const runtime = await openWorkspaceRuntime(flags);
 
   try {
     const { profile, target } = runtime.resolution;
-    const forSelection = (command: string) => `${command} --profile ${profile} --workspace ${target}`;
+    const forSelection = (command: string) => `${command} --workspace ${target}`;
+
+    // Every connection the workspace holds, not the ones one profile grants.
+    // Whether an account can still authenticate is a fact about the account
+    // (ADR-057), and scoping it to a profile's grants meant an account that had
+    // just been connected could not be checked until somebody granted it —
+    // which is exactly the moment you want to check.
+    //
+    // `--profile` narrows to what that profile can reach, because "can the
+    // things this profile uses still sign in" is also a real question.
+    const all = flags.profile === undefined
+      ? (await readConnections(runtime.resolution.workspaceRoot)).connections
+      : grantedConnections(runtime);
 
     const wanted = flags.connection;
-    const connections = wanted
-      ? grantedConnections(runtime).filter((c) => `${c.provider}.${c.id}` === wanted)
-      : grantedConnections(runtime);
+    const connections = wanted ? all.filter((c) => `${c.provider}.${c.id}` === wanted) : all;
 
     if (wanted && connections.length === 0) {
       throw new Error(
-        `No connection "${wanted}" in profile ${profile}. Run: ${forSelection('lanes link status')}`,
+        `No connection "${wanted}" in workspace ${target}. Run: ${forSelection('lanes link connection list')}`,
       );
     }
 
@@ -271,7 +287,7 @@ export async function auth(flags: AuthFlags): Promise<void> {
     // why it cannot read `doctor`. A connection needing a person is the answer
     // this command was asked for, not a failure to produce one.
     return emit(flags.json, { profile, target, ok: needsSomeone.length === 0, connections: results }, () => {
-      announce(runtime.resolution);
+      announceWorkspace(runtime.resolution);
 
       for (const result of results) {
         const line = `${result.key} — ${describe(result.verdict)}`;

--- a/src/cli/commands/operate/auth.ts
+++ b/src/cli/commands/operate/auth.ts
@@ -1,8 +1,9 @@
+import type { ConnectionConfig } from '#profile';
 import { credentialResolver, ReauthRequired } from '#connectivity/auth/index.ts';
 import type { ResolvedCredential } from '#connectivity/auth/credential.ts';
 import { credentialRefFor } from '#registry';
 import { announce, emit, fail, ok, print, warn } from '../../output.ts';
-import { openRuntime, type GlobalFlags, type Runtime } from '../../runtime.ts';
+import { grantedConnections, openRuntime, type GlobalFlags, type Runtime } from '../../runtime.ts';
 
 /**
  * Whether each connection could still authenticate, asked rather than guessed.
@@ -146,13 +147,13 @@ export interface AuthFlags extends GlobalFlags {
  */
 export async function probeConnections(
   runtime: Runtime,
-  connections: readonly Runtime['config']['connections'][number][],
+  connections: readonly ConnectionConfig[],
   forSelection: (command: string) => string,
 ): Promise<ConnectionAuth[]> {
   const resolve = credentialResolver(runtime.registry, runtime.credentials);
 
   const probe = async (
-    connection: Runtime['config']['connections'][number],
+    connection: ConnectionConfig,
   ): Promise<ConnectionAuth> => {
     const key = `${connection.provider}.${connection.id}`;
     const manifest = runtime.manifestFor(connection.provider);
@@ -249,12 +250,12 @@ export async function auth(flags: AuthFlags): Promise<void> {
 
   try {
     const { profile, target } = runtime.resolution;
-    const forSelection = (command: string) => `${command} --profile ${profile} --target ${target}`;
+    const forSelection = (command: string) => `${command} --profile ${profile} --workspace ${target}`;
 
     const wanted = flags.connection;
     const connections = wanted
-      ? runtime.config.connections.filter((c) => `${c.provider}.${c.id}` === wanted)
-      : runtime.config.connections;
+      ? grantedConnections(runtime).filter((c) => `${c.provider}.${c.id}` === wanted)
+      : grantedConnections(runtime);
 
     if (wanted && connections.length === 0) {
       throw new Error(

--- a/src/cli/commands/operate/findings.ts
+++ b/src/cli/commands/operate/findings.ts
@@ -1,3 +1,4 @@
+import { grantedConnections } from '../../runtime.ts';
 import { ownerPrincipal } from '#auth';
 import type { DiscoveredCapability } from '#connectivity';
 import { allowedConnections } from '#policy';
@@ -49,7 +50,7 @@ export async function reportCapabilityDrift(
   const principal = ownerPrincipal(runtime.config.instance.profile).id;
 
   for (const entry of runtime.registry.list()) {
-    const connection = runtime.config.connections.find((c) => c.provider === entry.manifest.id);
+    const connection = grantedConnections(runtime).find((c) => c.provider === entry.manifest.id);
     if (!connection) continue;
 
     const connector = runtime.connectorFor(entry.manifest.id, connection.id);

--- a/src/cli/commands/operate/inspect.ts
+++ b/src/cli/commands/operate/inspect.ts
@@ -115,7 +115,7 @@ export async function doctor(flags: DoctorFlags): Promise<void> {
 
   try {
     const forSelection = (command: string) =>
-      `${command} --profile ${runtime.resolution.profile} --target ${runtime.resolution.target}`;
+      `${command} --profile ${runtime.resolution.profile} --workspace ${runtime.resolution.target}`;
 
     checks.push('config is valid');
     checks.push('state store is reachable');

--- a/src/cli/commands/operate/inspect.ts
+++ b/src/cli/commands/operate/inspect.ts
@@ -1,4 +1,5 @@
 import { formatPlan, planIsNoop, planReconcile } from '#registry';
+import type { ConnectionConfig, SelectedConnection } from '#profile';
 import { DEFAULT_SURFACES } from '../../config-repair.ts';
 import { announce, announceProfile, emit, fail, ok, print, warn } from '../../output.ts';
 import { staleNudge } from '../../release.ts';
@@ -16,6 +17,18 @@ import { migratedContract, migratedRenamedProviders } from './migrate.ts';
  */
 
 /** Static validation only. No external calls, no database, no credentials. */
+/**
+ * The accounts this profile actually reaches, as reconcile wants them.
+ *
+ * A profile grants a subset of the workspace's connections (ADR-057), and
+ * reconcile is about the ones it reaches: an account granted to nobody has no
+ * state to keep in step, and marking it `disabled` here would fight with the
+ * profile next door that does grant it.
+ */
+function grantedConnections(runtime: { connections: readonly SelectedConnection[] }): ConnectionConfig[] {
+  return runtime.connections.map(({ connection }) => connection);
+}
+
 export async function check(flags: GlobalFlags): Promise<void> {
   const { selection, config } = await resolveProfileOnly(flags);
   announceProfile(selection);
@@ -25,8 +38,10 @@ export async function check(flags: GlobalFlags): Promise<void> {
   // validates a file, and the file is the same whichever target reads it.
   print(ok(`${selection.profilePath} is valid`));
   print(
-    `      ${config.connections.length} connection(s), ` +
-      `${config.policy.allow.length} allow rule(s), ${config.policy.deny.length} deny rule(s)`,
+    `      ${config.grants.length} grant(s), ` +
+      `${config.grants.reduce((n, g) => n + g.allow.length, 0)} allow rule(s), ` +
+      `${config.grants.reduce((n, g) => n + g.deny.length, 0)} deny rule(s), ` +
+      `${config.members.length} member(s)`,
   );
 }
 
@@ -35,7 +50,7 @@ export async function plan(flags: GlobalFlags): Promise<void> {
   const runtime = await openRuntime(flags);
   try {
     announce(runtime.resolution);
-    const result = await planReconcile(runtime.config, runtime.state, runtime.credentials, runtime.manifestFor);
+    const result = await planReconcile(grantedConnections(runtime), runtime.state, runtime.credentials, runtime.manifestFor);
     print(formatPlan(result));
   } finally {
     await runtime.close();
@@ -134,7 +149,7 @@ export async function doctor(flags: DoctorFlags): Promise<void> {
     // `probeConnections` answers it by attempting the renewal, which is the only
     // thing that actually knows. Same classifier as `lanes link auth`, so the two
     // cannot drift apart again.
-    const probed = await probeConnections(runtime, runtime.config.connections, forSelection);
+    const probed = await probeConnections(runtime, grantedConnections(runtime), forSelection);
 
     for (const result of probed) {
       switch (result.verdict) {
@@ -209,7 +224,7 @@ export async function doctor(flags: DoctorFlags): Promise<void> {
       }
     }
 
-    for (const name of new Set(runtime.config.connections.map((c) => c.provider))) {
+    for (const name of new Set(grantedConnections(runtime).map((one) => one.provider))) {
       if (!runtime.registry.has(name)) {
         problems.push({
           kind: 'unknown_provider',
@@ -236,22 +251,25 @@ export async function doctor(flags: DoctorFlags): Promise<void> {
     // covering it is not reported. That is the same rule the repair follows, and
     // reading it here from `policy.deny` rather than asking the repair keeps
     // `doctor` a read.
-    const denied = (rule: string): boolean =>
-      runtime.config.policy.deny.some(
-        (entry) => entry.capability === '*' || entry.capability === rule,
-      );
+    // A grant row *is* the connection and the rule together now (ADR-058), so
+    // "has a row but no rule" is a state that stopped existing — which removes
+    // the half-repaired case this check was originally written for. What is left
+    // is one question per surface: does this profile grant one, and is the grant
+    // more than a deny.
+    const grantFor = (provider: string) =>
+      runtime.config.grants.find((grant) => grant.connection.startsWith(`${provider}.`));
 
     const missing = DEFAULT_SURFACES.filter((provider) => {
-      const rule = `${provider}.*`;
-      if (denied(rule)) return false;
+      const grant = grantFor(provider);
+      if (grant === undefined) return true;
 
-      const hasRow = runtime.config.connections.some(
-        (connection) => connection.provider === provider,
-      );
-      const granted = runtime.config.policy.allow.some(
+      const rule = `${provider}.*`;
+      const denied = grant.deny.some(
         (entry) => entry.capability === '*' || entry.capability === rule,
       );
-      return !hasRow || !granted;
+      if (denied) return false;
+
+      return !grant.allow.some((entry) => entry.capability === '*' || entry.capability === rule);
     });
 
     if (missing.length > 0) {
@@ -287,7 +305,7 @@ export async function doctor(flags: DoctorFlags): Promise<void> {
       warnings.push({ kind: 'capability_drift', message }),
     );
 
-    const drift = await planReconcile(runtime.config, runtime.state, runtime.credentials, runtime.manifestFor);
+    const drift = await planReconcile(grantedConnections(runtime), runtime.state, runtime.credentials, runtime.manifestFor);
     if (!planIsNoop(drift)) {
       warnings.push({
         kind: 'reconcile_drift',
@@ -309,7 +327,7 @@ export async function doctor(flags: DoctorFlags): Promise<void> {
     const rotation = await unboundRotatableRefs({
       deploy: runtime.declared.deploy,
       target: runtime.target,
-      connections: runtime.config.connections,
+      connections: grantedConnections(runtime),
       manifestFor: runtime.manifestFor,
     });
     if (rotation.unbound.length > 0) {

--- a/src/cli/commands/operate/migrate.ts
+++ b/src/cli/commands/operate/migrate.ts
@@ -1,9 +1,10 @@
 import {
   CONNECTIONS_FILE,
-  listProfiles, ConfigError, resolveSelection, resolveTargetWorkspace, resolveWorkspaceRoot } from '#profile';
+  listProfiles, ConfigError, resolveSelection, resolveTargetWorkspace, resolveWorkspaceRoot,
+  SUPPORTED_CONTRACT } from '#profile';
 import { ConfigDocument } from '../../config-edit.ts';
 import { migrateRenamedProviders, pendingRenames, shapeOf } from '../../config-migrate.ts';
-import { migrateWorkspace, needsMigration } from '../../workspace-migrate.ts';
+import { migrateToCurrentContract } from '../../workspace-migrate.ts';
 import { emit, fail, ok, print, style, warn } from '../../output.ts';
 import { openSecretStoreFor, type GlobalFlags } from '../../runtime.ts';
 
@@ -152,9 +153,14 @@ export async function migratedContract(flags: RenameFlags, refusal: unknown): Pr
   const where = await resolveTargetWorkspace(root, target).catch(() => null);
   if (where === null) return false;
 
-  if (!(await needsMigration(where))) return false;
+  // Running the migration is how "is there anything to do" is answered, rather
+  // than a predicate beside it. The predicate was `needsMigration`, which asks
+  // only about contract 1 — so a contract-2 bucket, the exact thing this
+  // function exists to rescue, returned false here and fell through to the
+  // refusal it was supposed to fix. With `--fix` absent this writes nothing.
+  const migration = await migrateToCurrentContract(where, { apply: flags.fix === true });
+  if (migration.alreadyCurrent) return false;
 
-  const migration = await migrateWorkspace(where, { apply: flags.fix === true });
   const applied = flags.fix === true;
   const remote = where !== root;
 
@@ -177,8 +183,8 @@ export async function migratedContract(flags: RenameFlags, refusal: unknown): Pr
       print();
       print(
         applied
-          ? ok('migrated to contract 2 — a target is declared by the workspace, not by each profile')
-          : warn('this workspace is contract 1, and nothing here reads that any more'),
+          ? ok(`migrated to contract ${SUPPORTED_CONTRACT} — a workspace declares its own adapters, and holds the connections a profile grants`)
+          : warn(`this workspace is behind contract ${SUPPORTED_CONTRACT}, and nothing here reads that any more`),
       );
       for (const change of migration.changes) print(`  ${change}`);
 

--- a/src/cli/commands/operate/migrate.ts
+++ b/src/cli/commands/operate/migrate.ts
@@ -1,4 +1,6 @@
-import { ConfigError, resolveSelection, resolveTargetWorkspace, resolveWorkspaceRoot } from '#profile';
+import {
+  CONNECTIONS_FILE,
+  listProfiles, ConfigError, resolveSelection, resolveTargetWorkspace, resolveWorkspaceRoot } from '#profile';
 import { ConfigDocument } from '../../config-edit.ts';
 import { migrateRenamedProviders, pendingRenames, shapeOf } from '../../config-migrate.ts';
 import { migrateWorkspace, needsMigration } from '../../workspace-migrate.ts';
@@ -52,16 +54,25 @@ export async function migratedRenamedProviders(
   const root = await resolveTargetWorkspace(localRoot, target).catch(() => localRoot);
 
   const selection = await resolveSelection({ profileFlag: flags.profile, root });
-  const document = await ConfigDocument.open(root, selection.profile);
+
+  // The rename is a property of the *connection*, so it is found in the
+  // workspace's file (ADR-057) — and applied across every profile, because any
+  // of them may grant the row being renamed.
+  const document = await ConfigDocument.openKey(root, CONNECTIONS_FILE);
   if (pendingRenames(document).length === 0) return false;
+
+  const profiles: ConfigDocument[] = [];
+  for (const name of await listProfiles(root)) {
+    profiles.push(await ConfigDocument.open(root, name));
+  }
 
   // Shape-only, because the check this document fails runs after the schema.
   // Throws when it is malformed beyond a rename, which is a better sentence
   // than the referential one it would otherwise be reported under.
-  const config = shapeOf(document);
+  const config = shapeOf(await ConfigDocument.open(root, selection.profile));
   const credentials = await openSecretStoreFor(config, root, target);
 
-  const migration = await migrateRenamedProviders(document, credentials, {
+  const migration = await migrateRenamedProviders(document, profiles, credentials, {
     apply: flags.fix === true,
   });
 
@@ -177,15 +188,15 @@ export async function migratedContract(flags: RenameFlags, refusal: unknown): Pr
           style.dim(
             applied
               ? '  The endpoint serving this bucket is running an older image and cannot read\n' +
-                `  what was just written. Roll a new one: lanes link deploy --target ${target}`
-              : `  lanes link deploy --target ${target} migrates it and ships the image that\n` +
+                `  what was just written. Roll a new one: lanes link deploy --workspace ${target}`
+              : `  lanes link deploy --workspace ${target} migrates it and ships the image that\n` +
                 '  understands it, in one step. Prefer that to --fix here.',
           ),
         );
         return;
       }
 
-      if (!applied) print(style.dim(`  Fix it with: lanes link doctor --fix --target ${target}`));
+      if (!applied) print(style.dim(`  Fix it with: lanes link doctor --fix --workspace ${target}`));
     },
   );
 

--- a/src/cli/commands/operate/outputs.ts
+++ b/src/cli/commands/operate/outputs.ts
@@ -158,7 +158,7 @@ export async function tokenInvocation(
   // only into one where the same default happens to resolve.
   const selection = ` --profile ${profile} --workspace ${target}`;
   const short = `lanes link token show --raw${selection}`;
-  const argv = ['link', 'token', 'show', '--raw', '--profile', profile, '--target', target];
+  const argv = ['link', 'token', 'show', '--raw', '--profile', profile, '--workspace', target];
 
   const resolved = Bun.which('lanes');
   if (resolved) {

--- a/src/cli/commands/operate/outputs.ts
+++ b/src/cli/commands/operate/outputs.ts
@@ -151,12 +151,12 @@ export async function tokenInvocation(
   target: string,
 ): Promise<{ command: string; onPath: boolean }> {
   // Both, always, and from the *resolved* selection rather than the flags. A
-  // token is per-target, so `outputs --target cloud` printing a bare
+  // token is per-target, so `outputs --workspace cloud` printing a bare
   // `token show --raw` hands over the local one beside a deployed URL — a
   // credential that looks like an answer and fails as a wrong password. Naming
   // the profile as well makes the line pasteable into any shell rather than
   // only into one where the same default happens to resolve.
-  const selection = ` --profile ${profile} --target ${target}`;
+  const selection = ` --profile ${profile} --workspace ${target}`;
   const short = `lanes link token show --raw${selection}`;
   const argv = ['link', 'token', 'show', '--raw', '--profile', profile, '--target', target];
 

--- a/src/cli/commands/operate/pair-certificate.ts
+++ b/src/cli/commands/operate/pair-certificate.ts
@@ -1,0 +1,141 @@
+import { mkdtemp, readFile, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { ConfigError, PAIR_CERT_REF, PAIR_KEY_REF } from '#profile';
+import type { SecretStore } from '#secrets';
+import { print, style, warn } from '../../output.ts';
+import { confirm, isInteractive } from '../../prompt.ts';
+import type { PairDeps, PairFlags } from './pair.ts';
+
+/**
+ * Making a loopback address one this machine's browsers will trust.
+ *
+ * Split from `./pair.ts` because it is the half of pairing that only loopback
+ * has. A deployed endpoint terminates TLS with a certificate a browser already
+ * trusts, so none of this runs for one — and keeping it beside the command made
+ * a file most of which did not apply to half its callers.
+ *
+ * It is also the largest side effect any command in this CLI has: a persistent
+ * change to the machine's trust store, made by a CLI. That is why everything
+ * here asks first, and why a run with nobody at the terminal is refused rather
+ * than assumed.
+ */
+
+/** The names the certificate has to cover. All three are this machine. */
+const HOSTS = ['127.0.0.1', 'localhost', '::1'];
+
+/**
+ * A certificate a browser on this machine will accept.
+ *
+ * mkcert and nothing else, deliberately. It is the one tool that installs into
+ * the system trust store *and* Firefox's separate NSS store, across macOS,
+ * Linux and Windows — and a self-signed certificate this command generated
+ * itself would fail in the browser with an error the page cannot read, which is
+ * the worst of both: the work is done and the feature does not work.
+ */
+export async function ensureCertificate(
+  credentials: SecretStore,
+  flags: PairFlags,
+  deps: PairDeps,
+): Promise<'reused' | 'installed'> {
+  const held =
+    (await credentials.get(PAIR_CERT_REF)) !== null &&
+    (await credentials.get(PAIR_KEY_REF)) !== null;
+
+  if (held && flags.rotate !== true) return 'reused';
+
+  const which = deps.which ?? ((binary: string) => Bun.which(binary));
+  const run = deps.run ?? runCommand;
+
+  let mkcert = which('mkcert');
+  if (!mkcert) mkcert = await installMkcert(flags, deps, which, run);
+
+  // Installs the local CA if it is not already there, and says nothing if it
+  // is. This is the step that touches the trust store, and it has already been
+  // consented to by the time it runs.
+  const installed = await run([mkcert, '-install']);
+  if (installed !== null) {
+    throw new ConfigError(`mkcert -install failed.\n${installed || '  It said nothing.'}`);
+  }
+
+  const scratch = await mkdtemp(join(tmpdir(), 'lanes-pair-'));
+  try {
+    const certPath = join(scratch, 'cert.pem');
+    const keyPath = join(scratch, 'key.pem');
+
+    const failed = await run([mkcert, '-cert-file', certPath, '-key-file', keyPath, ...HOSTS]);
+    if (failed !== null) {
+      throw new ConfigError(`mkcert failed to issue a certificate.\n${failed || '  It said nothing.'}`);
+    }
+
+    // Into the credential store rather than left on disk. The private key is a
+    // secret by any reading, and the store is the one place in a workspace that
+    // is encrypted at rest.
+    await credentials.set(PAIR_CERT_REF, await readFile(certPath, 'utf8'));
+    await credentials.set(PAIR_KEY_REF, await readFile(keyPath, 'utf8'));
+  } finally {
+    await rm(scratch, { recursive: true, force: true });
+  }
+
+  return 'installed';
+}
+
+async function installMkcert(
+  flags: PairFlags,
+  deps: PairDeps,
+  which: (binary: string) => string | null,
+  run: (command: readonly string[]) => Promise<string | null>,
+): Promise<string> {
+  const line = 'brew install mkcert';
+  const brew = which('brew');
+
+  if (!brew) {
+    // The one path where this command cannot finish the job, so it hands over
+    // the whole of it rather than half.
+    throw new ConfigError(
+      'Pairing needs mkcert, which issues a certificate this machine\'s browsers trust.\n' +
+        `  With Homebrew: ${line}\n` +
+        '  Otherwise: https://github.com/FiloSottile/mkcert#installation\n' +
+        '  Then run "lanes link pair" again.',
+    );
+  }
+
+  print(warn('pairing needs mkcert, and it is not installed'));
+  print(
+    style.dim(
+      '  It issues a certificate for 127.0.0.1 that this machine trusts, which is what\n' +
+        '  lets a page on lanes.sh read your endpoint at all. Safari will not fetch\n' +
+        '  http://127.0.0.1 from an https page, and offers no way to allow it.\n' +
+        '\n' +
+        '  This installs a local certificate authority into your system trust store.\n' +
+        `  ${line}`,
+    ),
+  );
+
+  if (flags.yes !== true) {
+    if (!(deps.interactive ?? isInteractive())) {
+      throw new ConfigError(
+        'Nothing here can answer a prompt, and installing a certificate authority because\n' +
+          '  nobody was there to say no is the wrong way to resolve that.\n' +
+          `  Run "${line}" yourself, or pass --yes.`,
+      );
+    }
+    if (!(await (deps.confirm ?? ((question: string) => confirm(question)))('Install it now?'))) {
+      throw new ConfigError(`Not paired. When you want it: ${line}`);
+    }
+  }
+
+  const failed = await run([brew, 'install', 'mkcert']);
+  if (failed !== null) throw new ConfigError(`${line} failed.\n${failed || '  It said nothing.'}`);
+
+  const found = which('mkcert');
+  if (!found) throw new ConfigError(`${line} reported success but mkcert is still not on PATH.`);
+  return found;
+}
+
+/** Runs it. Null on success; whatever it said on failure. */
+async function runCommand(command: readonly string[]): Promise<string | null> {
+  const spawned = Bun.spawn([...command], { stdout: 'pipe', stderr: 'pipe' });
+  const [code, stderr] = await Promise.all([spawned.exited, new Response(spawned.stderr).text()]);
+  return code === 0 ? null : stderr.trim();
+}

--- a/src/cli/commands/operate/pair.test.ts
+++ b/src/cli/commands/operate/pair.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from 'bun:test';
 import { isValidSecretRef } from '#secrets';
-import { PAIR_CERT_REF, PAIR_KEY_REF, PAIR_TOKEN_REF } from './pair.ts';
+import { pairingLink, PAIR_CERT_REF, PAIR_KEY_REF, PAIR_TOKEN_REF } from './pair.ts';
 
 /**
  * The three references `lanes link pair` writes.
@@ -34,5 +34,50 @@ describe('the pairing credential references', () => {
     for (const ref of [PAIR_TOKEN_REF, PAIR_CERT_REF, PAIR_KEY_REF]) {
       expect(ref.startsWith('workspace/')).toBe(true);
     }
+  });
+});
+
+/**
+ * The link the browser opens, which nothing used to assert on.
+ *
+ * A loopback link carried no address for as long as loopback looked derivable.
+ * It is not: the read listener sits one port above `instance.port`, so an
+ * endpoint on any port but the default printed a link the dashboard then read at
+ * 7338, reported unreachable, and gave no way to correct — a silent failure in a
+ * command that had reported success.
+ *
+ * These read the fragment rather than the whole string, because the origin comes
+ * from `LANES_WEB_URL` and is a local dashboard as often as it is lanes.sh.
+ */
+
+function fragment(url: string): URLSearchParams {
+  return new URLSearchParams(new URL(url).hash.replace(/^#/, ''));
+}
+
+describe('the pairing link', () => {
+  test('carries the address, so a non-default port survives the trip', () => {
+    const parsed = fragment(pairingLink('llp_token', 'https://127.0.0.1:7401'));
+    expect(parsed.get('at')).toBe('https://127.0.0.1:7401');
+  });
+
+  test('carries a deployed address the same way', () => {
+    const parsed = fragment(pairingLink('llp_token', 'https://link.example.test'));
+    expect(parsed.get('at')).toBe('https://link.example.test');
+  });
+
+  test('puts both in the fragment, never in the query', () => {
+    // The fragment is never sent to a server, which is the whole reason a
+    // credential for a surface Lanes cannot see may travel in a URL at all. An
+    // address in the query would put a workspace's public address in an access
+    // log for the same trip.
+    const url = new URL(pairingLink('llp_token', 'https://127.0.0.1:7338'));
+    expect(url.search).toBe('');
+    expect(url.pathname).toBe('/dashboard/link');
+    expect(fragment(url.href).get('pair')).toBe('llp_token');
+  });
+
+  test('encodes the address, so its own separators do not end the parameter', () => {
+    const raw = new URL(pairingLink('llp_token', 'https://127.0.0.1:7401')).hash;
+    expect(raw).toContain('at=https%3A%2F%2F127.0.0.1%3A7401');
   });
 });

--- a/src/cli/commands/operate/pair.test.ts
+++ b/src/cli/commands/operate/pair.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, test } from 'bun:test';
+import { isValidSecretRef } from '#secrets';
+import { PAIR_CERT_REF, PAIR_KEY_REF, PAIR_TOKEN_REF } from './pair.ts';
+
+/**
+ * The three references `lanes link pair` writes.
+ *
+ * A constant that is never validated until somebody runs the command is a
+ * constant that is wrong until somebody runs the command. These were
+ * `workspace/pair.cert` and friends, which `isValidSecretRef` refuses — a
+ * secret reference is `[a-z0-9_-]` between slashes, because these names become
+ * Secret Manager entries on a deployed workspace and Google allows no dots
+ * either. The command failed on its first real invocation, having passed every
+ * test in the suite.
+ */
+
+describe('the pairing credential references', () => {
+  test.each([
+    ['token', PAIR_TOKEN_REF],
+    ['certificate', PAIR_CERT_REF],
+    ['key', PAIR_KEY_REF],
+  ])('the %s reference is one a store will accept', (_name, ref) => {
+    expect(isValidSecretRef(ref)).toBe(true);
+  });
+
+  test('all three are distinct, so none overwrites another', () => {
+    expect(new Set([PAIR_TOKEN_REF, PAIR_CERT_REF, PAIR_KEY_REF]).size).toBe(3);
+  });
+
+  test('they share a namespace that says what owns them', () => {
+    // `workspace/` rather than `profile/`: pairing is a property of the machine
+    // and its workspace, not of any one profile, and the read surface it opens
+    // lists every profile there.
+    for (const ref of [PAIR_TOKEN_REF, PAIR_CERT_REF, PAIR_KEY_REF]) {
+      expect(ref.startsWith('workspace/')).toBe(true);
+    }
+  });
+});

--- a/src/cli/commands/operate/pair.ts
+++ b/src/cli/commands/operate/pair.ts
@@ -1,0 +1,233 @@
+import { randomBytes } from 'node:crypto';
+import { mkdtemp, readFile, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { ConfigError } from '#profile';
+import { ok, print, style, warn } from '../../output.ts';
+import { confirm, isInteractive } from '../../prompt.ts';
+import { openRuntime, type GlobalFlags } from '../../runtime.ts';
+
+/**
+ * `lanes link pair` — let the Lanes dashboard read this machine (ADR-063).
+ *
+ * Three things, and each is the operator's to decline. It installs a locally
+ * trusted certificate, mints a credential that reads the whole workspace, and
+ * hands the browser a link carrying it. None of that happens without being
+ * asked for, and none of it is implied by `start`.
+ *
+ * **The certificate is the largest side effect any command in this CLI has.**
+ * It is a persistent change to the machine's trust store, made by a CLI, and
+ * ADR-053's precedent applies unchanged: offer it, name what it is, and stop if
+ * declined. A run with nobody at the terminal is refused rather than assumed.
+ *
+ * **The token travels in a fragment.** `#pair=` is never sent to a server, so a
+ * credential for a surface whose entire point is that Lanes cannot see it does
+ * not end up in a Lanes access log, a proxy, or a referrer header.
+ */
+
+export const PAIR_TOKEN_REF = 'workspace/pair.token';
+export const PAIR_CERT_REF = 'workspace/pair.cert';
+export const PAIR_KEY_REF = 'workspace/pair.key';
+
+/** Where the dashboard lives, overridable so `lanes dev` can pair against it. */
+const DASHBOARD_URL = process.env['LANES_WEB_URL'] ?? 'https://lanes.sh';
+
+/** The names the certificate has to cover. All three are this machine. */
+const HOSTS = ['127.0.0.1', 'localhost', '::1'];
+
+export interface PairFlags extends GlobalFlags {
+  /** Print the link for an existing pairing and change nothing. */
+  readonly print?: boolean | undefined;
+  /** Mint a fresh token, invalidating whatever a browser already holds. */
+  readonly rotate?: boolean | undefined;
+  /** Do not ask before installing mkcert. */
+  readonly yes?: boolean | undefined;
+}
+
+export interface PairDeps {
+  readonly which?: (binary: string) => string | null;
+  readonly run?: (command: readonly string[]) => Promise<string | null>;
+  readonly confirm?: (question: string) => Promise<boolean>;
+  readonly interactive?: boolean;
+}
+
+export async function pair(flags: PairFlags, deps: PairDeps = {}): Promise<void> {
+  const runtime = await openRuntime(flags);
+
+  try {
+    const host = runtime.config.instance.host;
+    if (!isLoopback(host)) {
+      // A deployed endpoint is already reachable by URL and needs none of this.
+      // Pairing one would mean installing a certificate for an address this
+      // machine does not answer on.
+      throw new ConfigError(
+        `This workspace's endpoint is bound to ${host}, not loopback, so there is nothing here to pair.\n` +
+          '  Pairing exists so a browser can read an endpoint on *this* machine.',
+      );
+    }
+
+    const readPort = runtime.config.instance.port + 1;
+
+    if (flags.print === true) {
+      const existing = await runtime.credentials.get(PAIR_TOKEN_REF);
+      if (existing === null) {
+        throw new ConfigError('Not paired yet. Run: lanes link pair');
+      }
+      print(link(existing));
+      return;
+    }
+
+    const certificate = await ensureCertificate(runtime, flags, deps);
+
+    const rotating = flags.rotate === true;
+    const existing = rotating ? null : await runtime.credentials.get(PAIR_TOKEN_REF);
+    const token = existing ?? `llp_${randomBytes(32).toString('base64url')}`;
+    if (existing === null) await runtime.credentials.set(PAIR_TOKEN_REF, token);
+
+    print(ok(certificate === 'reused' ? 'certificate already installed' : 'certificate installed'));
+    if (rotating) {
+      print(style.dim('      The previous pairing link no longer works. Re-open the new one.'));
+    }
+    print('');
+    print(ok(`the dashboard may now read ${style.bold(`https://127.0.0.1:${readPort}`)}`));
+    print('');
+    print(link(token));
+    print('');
+    print(
+      style.dim(
+        '      Open that in a browser on this machine. The token is in the URL fragment,\n' +
+          '      so it never reaches a Lanes server.\n' +
+          '      It reads every connection, profile and audit entry in this workspace, and\n' +
+          '      can change nothing. Take it back with: lanes link pair --rotate\n' +
+          '\n' +
+          '      The endpoint has to be running: lanes link start',
+      ),
+    );
+  } finally {
+    await runtime.close();
+  }
+}
+
+function link(token: string): string {
+  return `${DASHBOARD_URL}/dashboard/link#pair=${token}`;
+}
+
+function isLoopback(host: string): boolean {
+  return host === '127.0.0.1' || host === 'localhost' || host === '::1';
+}
+
+/**
+ * A certificate a browser on this machine will accept.
+ *
+ * mkcert and nothing else, deliberately. It is the one tool that installs into
+ * the system trust store *and* Firefox's separate NSS store, across macOS,
+ * Linux and Windows — and a self-signed certificate this command generated
+ * itself would fail in the browser with an error the page cannot read, which is
+ * the worst of both: the work is done and the feature does not work.
+ */
+async function ensureCertificate(
+  runtime: Awaited<ReturnType<typeof openRuntime>>,
+  flags: PairFlags,
+  deps: PairDeps,
+): Promise<'reused' | 'installed'> {
+  const held =
+    (await runtime.credentials.get(PAIR_CERT_REF)) !== null &&
+    (await runtime.credentials.get(PAIR_KEY_REF)) !== null;
+
+  if (held && flags.rotate !== true) return 'reused';
+
+  const which = deps.which ?? ((binary: string) => Bun.which(binary));
+  const run = deps.run ?? runCommand;
+
+  let mkcert = which('mkcert');
+  if (!mkcert) mkcert = await installMkcert(flags, deps, which, run);
+
+  // Installs the local CA if it is not already there, and says nothing if it
+  // is. This is the step that touches the trust store, and it has already been
+  // consented to by the time it runs.
+  const installed = await run([mkcert, '-install']);
+  if (installed !== null) {
+    throw new ConfigError(`mkcert -install failed.\n${installed || '  It said nothing.'}`);
+  }
+
+  const scratch = await mkdtemp(join(tmpdir(), 'lanes-pair-'));
+  try {
+    const certPath = join(scratch, 'cert.pem');
+    const keyPath = join(scratch, 'key.pem');
+
+    const failed = await run([mkcert, '-cert-file', certPath, '-key-file', keyPath, ...HOSTS]);
+    if (failed !== null) {
+      throw new ConfigError(`mkcert failed to issue a certificate.\n${failed || '  It said nothing.'}`);
+    }
+
+    // Into the credential store rather than left on disk. The private key is a
+    // secret by any reading, and the store is the one place in a workspace that
+    // is encrypted at rest.
+    await runtime.credentials.set(PAIR_CERT_REF, await readFile(certPath, 'utf8'));
+    await runtime.credentials.set(PAIR_KEY_REF, await readFile(keyPath, 'utf8'));
+  } finally {
+    await rm(scratch, { recursive: true, force: true });
+  }
+
+  return 'installed';
+}
+
+async function installMkcert(
+  flags: PairFlags,
+  deps: PairDeps,
+  which: (binary: string) => string | null,
+  run: (command: readonly string[]) => Promise<string | null>,
+): Promise<string> {
+  const line = 'brew install mkcert';
+  const brew = which('brew');
+
+  if (!brew) {
+    // The one path where this command cannot finish the job, so it hands over
+    // the whole of it rather than half.
+    throw new ConfigError(
+      'Pairing needs mkcert, which issues a certificate this machine\'s browsers trust.\n' +
+        `  With Homebrew: ${line}\n` +
+        '  Otherwise: https://github.com/FiloSottile/mkcert#installation\n' +
+        '  Then run "lanes link pair" again.',
+    );
+  }
+
+  print(warn('pairing needs mkcert, and it is not installed'));
+  print(
+    style.dim(
+      '  It issues a certificate for 127.0.0.1 that this machine trusts, which is what\n' +
+        '  lets a page on lanes.sh read your endpoint at all. Safari will not fetch\n' +
+        '  http://127.0.0.1 from an https page, and offers no way to allow it.\n' +
+        '\n' +
+        '  This installs a local certificate authority into your system trust store.\n' +
+        `  ${line}`,
+    ),
+  );
+
+  if (flags.yes !== true) {
+    if (!(deps.interactive ?? isInteractive())) {
+      throw new ConfigError(
+        'Nothing here can answer a prompt, and installing a certificate authority because\n' +
+          '  nobody was there to say no is the wrong way to resolve that.\n' +
+          `  Run "${line}" yourself, or pass --yes.`,
+      );
+    }
+    if (!(await (deps.confirm ?? ((question: string) => confirm(question)))('Install it now?'))) {
+      throw new ConfigError(`Not paired. When you want it: ${line}`);
+    }
+  }
+
+  const failed = await run([brew, 'install', 'mkcert']);
+  if (failed !== null) throw new ConfigError(`${line} failed.\n${failed || '  It said nothing.'}`);
+
+  const found = which('mkcert');
+  if (!found) throw new ConfigError(`${line} reported success but mkcert is still not on PATH.`);
+  return found;
+}
+
+/** Runs it. Null on success; whatever it said on failure. */
+async function runCommand(command: readonly string[]): Promise<string | null> {
+  const spawned = Bun.spawn([...command], { stdout: 'pipe', stderr: 'pipe' });
+  const [code, stderr] = await Promise.all([spawned.exited, new Response(spawned.stderr).text()]);
+  return code === 0 ? null : stderr.trim();
+}

--- a/src/cli/commands/operate/pair.ts
+++ b/src/cli/commands/operate/pair.ts
@@ -25,9 +25,18 @@ import { openRuntime, type GlobalFlags } from '../../runtime.ts';
  * not end up in a Lanes access log, a proxy, or a referrer header.
  */
 
-export const PAIR_TOKEN_REF = 'workspace/pair.token';
-export const PAIR_CERT_REF = 'workspace/pair.cert';
-export const PAIR_KEY_REF = 'workspace/pair.key';
+/**
+ * Where the three pieces live in the credential store.
+ *
+ * Underscores, not dots. A secret reference is `[a-z0-9_-]` separated by `/`
+ * (see `isValidSecretRef`), and that is not arbitrary: these names become
+ * Secret Manager entries on a deployed workspace, and Google allows no dots
+ * there either. `workspace/pair.cert` was refused at the moment somebody first
+ * ran the command.
+ */
+export const PAIR_TOKEN_REF = 'workspace/pair_token';
+export const PAIR_CERT_REF = 'workspace/pair_cert';
+export const PAIR_KEY_REF = 'workspace/pair_key';
 
 /** Where the dashboard lives, overridable so `lanes dev` can pair against it. */
 const DASHBOARD_URL = process.env['LANES_WEB_URL'] ?? 'https://lanes.sh';

--- a/src/cli/commands/operate/pair.ts
+++ b/src/cli/commands/operate/pair.ts
@@ -9,6 +9,7 @@ import {
   type LoadedProfile,
   resolveWorkspaceRoot,
 } from '#profile';
+import { recordConfigChange } from '../../audit-change.ts';
 import { ok, print, style, warn } from '../../output.ts';
 import { confirm, isInteractive } from '../../prompt.ts';
 import type { SecretStore } from '#secrets';
@@ -143,6 +144,18 @@ export async function pair(flags: PairFlags, deps: PairDeps = {}): Promise<void>
   const existing = rotating ? null : await credentials.get(PAIR_TOKEN_REF);
   const token = existing ?? `llp_${randomBytes(32).toString('base64url')}`;
   if (existing === null) await credentials.set(PAIR_TOKEN_REF, token);
+
+  // The token itself never goes in, obviously. What is worth recording is that
+  // a credential reading the whole workspace now exists, and when — and for a
+  // rotation, that whatever a browser was holding stopped working at that
+  // moment.
+  if (existing === null) {
+    await recordConfigChange(chosen.config, root, target, {
+      capability: rotating ? 'config.pair.rotate' : 'config.pair.mint',
+      scope: target,
+      arguments: { readPort, certificate },
+    });
+  }
 
   print(ok(certificate === 'reused' ? 'certificate already installed' : 'certificate installed'));
   if (rotating) {

--- a/src/cli/commands/operate/pair.ts
+++ b/src/cli/commands/operate/pair.ts
@@ -146,10 +146,17 @@ export async function pair(flags: PairFlags, deps: PairDeps = {}): Promise<void>
 
   const readPort = chosen.config.instance.port + 1;
 
+  // `127.0.0.1` rather than `instance.host`, even though `localhost` and `::1`
+  // are equally loopback and equally covered by the certificate. It is one
+  // address for one machine, and the browser has to agree with `open.ts` about
+  // which spelling it is: two pairings of the same endpoint under two names
+  // would be two entries in the switcher, both working, neither wrong.
+  const address = `https://127.0.0.1:${readPort}`;
+
   if (flags.print === true) {
     const existing = await credentials.get(PAIR_TOKEN_REF);
     if (existing === null) throw new ConfigError('Not paired yet. Run: lanes link pair');
-    print(link(existing));
+    print(pairingLink(existing, address));
     return;
   }
 
@@ -177,9 +184,9 @@ export async function pair(flags: PairFlags, deps: PairDeps = {}): Promise<void>
     print(style.dim('      The previous pairing link no longer works. Re-open the new one.'));
   }
   print('');
-  print(ok(`the dashboard may now read ${style.bold(`https://127.0.0.1:${readPort}`)}`));
+  print(ok(`the dashboard may now read ${style.bold(address)}`));
   print('');
-  print(link(token));
+  print(pairingLink(token, address));
   print('');
   print(
     style.dim(
@@ -238,7 +245,7 @@ async function pairDeployed(input: {
     if (existing === null || existing === '') {
       throw new ConfigError(`Not paired yet. Run: lanes link pair --workspace ${target}`);
     }
-    print(link(existing, endpoint));
+    print(pairingLink(existing, endpoint));
     return;
   }
 
@@ -268,7 +275,7 @@ async function pairDeployed(input: {
   print('');
   print(ok(`the dashboard may now read ${style.bold(endpoint)}`));
   print('');
-  print(link(token, endpoint));
+  print(pairingLink(token, endpoint));
   print('');
   print(
     style.dim(
@@ -294,14 +301,22 @@ async function pairDeployed(input: {
  * thing telling the page which of several paired endpoints this link is for,
  * and a query parameter would put a workspace's public address in that log.
  *
- * A link with no `at=` is a local one. Every link minted before deployed
- * pairing existed is that shape, and the page reads it as loopback.
+ * **A loopback link carries its address too**, and the parameter is required so
+ * that it cannot quietly stop. It used to be omitted here on the reasoning that
+ * loopback is derivable — and it is not: the read listener sits one port above
+ * whatever `instance.port` says, so an endpoint on any port but the default
+ * printed a link the dashboard then read at `7338`, reported unreachable, and
+ * gave no way to correct. The page still treats a link with no `at=` as
+ * loopback on the default port, because every link minted before this is that
+ * shape.
+ *
+ * Exported for `pair.test.ts` and for nothing else. The whole of the defect
+ * above was a shape nothing asserted on, in a command whose output no test
+ * reads, so the fix is not worth much without something that fails when the
+ * address goes missing again.
  */
-function link(token: string, endpoint?: string): string {
-  const fragment = endpoint
-    ? `pair=${token}&at=${encodeURIComponent(endpoint)}`
-    : `pair=${token}`;
-  return `${DASHBOARD_URL}/dashboard/link#${fragment}`;
+export function pairingLink(token: string, endpoint: string): string {
+  return `${DASHBOARD_URL}/dashboard/link#pair=${token}&at=${encodeURIComponent(endpoint)}`;
 }
 
 function isLoopback(host: string): boolean {

--- a/src/cli/commands/operate/pair.ts
+++ b/src/cli/commands/operate/pair.ts
@@ -2,10 +2,17 @@ import { randomBytes } from 'node:crypto';
 import { mkdtemp, readFile, rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { ConfigError } from '#profile';
+import {
+  ConfigError,
+  loadWorkspaceProfiles,
+  openTarget,
+  type LoadedProfile,
+  resolveWorkspaceRoot,
+} from '#profile';
 import { ok, print, style, warn } from '../../output.ts';
 import { confirm, isInteractive } from '../../prompt.ts';
-import { openRuntime, type GlobalFlags } from '../../runtime.ts';
+import type { SecretStore } from '#secrets';
+import { openSecretStoreFor, type GlobalFlags } from '../../runtime.ts';
 
 /**
  * `lanes link pair` — let the Lanes dashboard read this machine (ADR-063).
@@ -23,6 +30,13 @@ import { openRuntime, type GlobalFlags } from '../../runtime.ts';
  * **The token travels in a fragment.** `#pair=` is never sent to a server, so a
  * credential for a surface whose entire point is that Lanes cannot see it does
  * not end up in a Lanes access log, a proxy, or a referrer header.
+ *
+ * **It names a workspace, not a profile**, because that is what it pairs. The
+ * surface it opens lists every connection and every profile the workspace holds,
+ * and the credential it mints reads all of them — so asking which profile was
+ * asking a question with no answer, and implying a per-profile pairing that does
+ * not exist. `--profile` is still accepted, and picks the port when profiles
+ * disagree about one.
  */
 
 /**
@@ -61,60 +75,94 @@ export interface PairDeps {
 }
 
 export async function pair(flags: PairFlags, deps: PairDeps = {}): Promise<void> {
-  const runtime = await openRuntime(flags);
+  const target = flags.target!;
+  const root = resolveWorkspaceRoot();
+  const resolved = await openTarget(root, target);
+  const { loaded: profiles } = await loadWorkspaceProfiles(resolved.workspaceRoot);
 
-  try {
-    const host = runtime.config.instance.host;
-    if (!isLoopback(host)) {
-      // A deployed endpoint is already reachable by URL and needs none of this.
-      // Pairing one would mean installing a certificate for an address this
-      // machine does not answer on.
-      throw new ConfigError(
-        `This workspace's endpoint is bound to ${host}, not loopback, so there is nothing here to pair.\n` +
-          '  Pairing exists so a browser can read an endpoint on *this* machine.',
-      );
-    }
-
-    const readPort = runtime.config.instance.port + 1;
-
-    if (flags.print === true) {
-      const existing = await runtime.credentials.get(PAIR_TOKEN_REF);
-      if (existing === null) {
-        throw new ConfigError('Not paired yet. Run: lanes link pair');
-      }
-      print(link(existing));
-      return;
-    }
-
-    const certificate = await ensureCertificate(runtime, flags, deps);
-
-    const rotating = flags.rotate === true;
-    const existing = rotating ? null : await runtime.credentials.get(PAIR_TOKEN_REF);
-    const token = existing ?? `llp_${randomBytes(32).toString('base64url')}`;
-    if (existing === null) await runtime.credentials.set(PAIR_TOKEN_REF, token);
-
-    print(ok(certificate === 'reused' ? 'certificate already installed' : 'certificate installed'));
-    if (rotating) {
-      print(style.dim('      The previous pairing link no longer works. Re-open the new one.'));
-    }
-    print('');
-    print(ok(`the dashboard may now read ${style.bold(`https://127.0.0.1:${readPort}`)}`));
-    print('');
-    print(link(token));
-    print('');
-    print(
-      style.dim(
-        '      Open that in a browser on this machine. The token is in the URL fragment,\n' +
-          '      so it never reaches a Lanes server.\n' +
-          '      It reads every connection, profile and audit entry in this workspace, and\n' +
-          '      can change nothing. Take it back with: lanes link pair --rotate\n' +
-          '\n' +
-          '      The endpoint has to be running: lanes link start',
-      ),
+  if (profiles.length === 0) {
+    throw new ConfigError(
+      `Workspace "${target}" holds no profiles, so there is no endpoint to pair.\n` +
+        `  Create one with: lanes link profile add <name> --workspace ${target}`,
     );
-  } finally {
-    await runtime.close();
   }
+
+  // One endpoint serves every profile in a workspace, so they normally agree on
+  // a port and the choice is not a choice. Where they do not, the ambiguity is
+  // real and `--profile` is how it is settled — refused rather than guessed,
+  // because pairing the wrong port produces a dashboard that says "not
+  // connected" with everything working.
+  const named = flags.profile
+    ? profiles.find((one: LoadedProfile) => one.profile === flags.profile)
+    : undefined;
+
+  if (flags.profile && !named) {
+    throw new ConfigError(
+      `Workspace "${target}" has no profile "${flags.profile}".\n` +
+        `  It holds: ${profiles.map((one: LoadedProfile) => one.profile).join(', ')}`,
+    );
+  }
+
+  const ports = new Set(profiles.map((one: LoadedProfile) => one.config.instance.port));
+  if (!named && ports.size > 1) {
+    throw new ConfigError(
+      `The profiles in "${target}" do not agree on a port, so it is not clear which endpoint to pair.\n` +
+        profiles
+          .map((one: LoadedProfile) => `    ${one.profile}  ${one.config.instance.port}`)
+          .join('\n') +
+        '\n  Name one: lanes link pair --profile <name>',
+    );
+  }
+
+  const chosen = named ?? profiles[0]!;
+  const host = chosen.config.instance.host;
+
+  if (!isLoopback(host)) {
+    // A deployed endpoint is already reachable by URL and needs none of this.
+    // Pairing one would mean installing a certificate for an address this
+    // machine does not answer on.
+    throw new ConfigError(
+      `"${target}" is bound to ${host}, not loopback, so there is nothing here to pair.\n` +
+        '  Pairing exists so a browser can read an endpoint on *this* machine.',
+    );
+  }
+
+  const readPort = chosen.config.instance.port + 1;
+  const credentials = await openSecretStoreFor(chosen.config, root, target);
+
+  if (flags.print === true) {
+    const existing = await credentials.get(PAIR_TOKEN_REF);
+    if (existing === null) throw new ConfigError('Not paired yet. Run: lanes link pair');
+    print(link(existing));
+    return;
+  }
+
+  const certificate = await ensureCertificate(credentials, flags, deps);
+
+  const rotating = flags.rotate === true;
+  const existing = rotating ? null : await credentials.get(PAIR_TOKEN_REF);
+  const token = existing ?? `llp_${randomBytes(32).toString('base64url')}`;
+  if (existing === null) await credentials.set(PAIR_TOKEN_REF, token);
+
+  print(ok(certificate === 'reused' ? 'certificate already installed' : 'certificate installed'));
+  if (rotating) {
+    print(style.dim('      The previous pairing link no longer works. Re-open the new one.'));
+  }
+  print('');
+  print(ok(`the dashboard may now read ${style.bold(`https://127.0.0.1:${readPort}`)}`));
+  print('');
+  print(link(token));
+  print('');
+  print(
+    style.dim(
+      '      Open that in a browser on this machine. The token is in the URL fragment,\n' +
+        '      so it never reaches a Lanes server.\n' +
+        '      It reads every connection, profile and audit entry in this workspace, and\n' +
+        '      can change nothing. Take it back with: lanes link pair --rotate\n' +
+        '\n' +
+        `      The endpoint has to be running: lanes link start --workspace ${target}`,
+    ),
+  );
 }
 
 function link(token: string): string {
@@ -135,13 +183,13 @@ function isLoopback(host: string): boolean {
  * the worst of both: the work is done and the feature does not work.
  */
 async function ensureCertificate(
-  runtime: Awaited<ReturnType<typeof openRuntime>>,
+  credentials: SecretStore,
   flags: PairFlags,
   deps: PairDeps,
 ): Promise<'reused' | 'installed'> {
   const held =
-    (await runtime.credentials.get(PAIR_CERT_REF)) !== null &&
-    (await runtime.credentials.get(PAIR_KEY_REF)) !== null;
+    (await credentials.get(PAIR_CERT_REF)) !== null &&
+    (await credentials.get(PAIR_KEY_REF)) !== null;
 
   if (held && flags.rotate !== true) return 'reused';
 
@@ -172,8 +220,8 @@ async function ensureCertificate(
     // Into the credential store rather than left on disk. The private key is a
     // secret by any reading, and the store is the one place in a workspace that
     // is encrypted at rest.
-    await runtime.credentials.set(PAIR_CERT_REF, await readFile(certPath, 'utf8'));
-    await runtime.credentials.set(PAIR_KEY_REF, await readFile(keyPath, 'utf8'));
+    await credentials.set(PAIR_CERT_REF, await readFile(certPath, 'utf8'));
+    await credentials.set(PAIR_KEY_REF, await readFile(keyPath, 'utf8'));
   } finally {
     await rm(scratch, { recursive: true, force: true });
   }

--- a/src/cli/commands/operate/pair.ts
+++ b/src/cli/commands/operate/pair.ts
@@ -1,17 +1,19 @@
 import { randomBytes } from 'node:crypto';
-import { mkdtemp, readFile, rm } from 'node:fs/promises';
-import { tmpdir } from 'node:os';
-import { join } from 'node:path';
 import {
   ConfigError,
+  PAIR_CERT_REF,
+  PAIR_KEY_REF,
+  PAIR_TOKEN_REF,
   loadWorkspaceProfiles,
   openTarget,
   type LoadedProfile,
   resolveWorkspaceRoot,
 } from '#profile';
+import type { ResolvedTarget } from '#profile';
+import { deployedUrl } from '../../endpoint-url.ts';
+import { ensureCertificate } from './pair-certificate.ts';
 import { recordConfigChange } from '../../audit-change.ts';
-import { ok, print, style, warn } from '../../output.ts';
-import { confirm, isInteractive } from '../../prompt.ts';
+import { ok, print, style } from '../../output.ts';
 import type { SecretStore } from '#secrets';
 import { openSecretStoreFor, type GlobalFlags } from '../../runtime.ts';
 
@@ -32,6 +34,12 @@ import { openSecretStoreFor, type GlobalFlags } from '../../runtime.ts';
  * credential for a surface whose entire point is that Lanes cannot see it does
  * not end up in a Lanes access log, a proxy, or a referrer header.
  *
+ * **A deployed workspace pairs too, and skips all of that** (ADR-064). The
+ * certificate was the whole of the old refusal — installing one for an address
+ * this machine does not answer on is meaningless — and it is the one piece a
+ * deployed endpoint does not need, because the platform terminates TLS with a
+ * certificate a browser already trusts. What remains is a token and an address.
+ *
  * **It names a workspace, not a profile**, because that is what it pairs. The
  * surface it opens lists every connection and every profile the workspace holds,
  * and the credential it mints reads all of them — so asking which profile was
@@ -43,21 +51,17 @@ import { openSecretStoreFor, type GlobalFlags } from '../../runtime.ts';
 /**
  * Where the three pieces live in the credential store.
  *
- * Underscores, not dots. A secret reference is `[a-z0-9_-]` separated by `/`
- * (see `isValidSecretRef`), and that is not arbitrary: these names become
- * Secret Manager entries on a deployed workspace, and Google allows no dots
- * there either. `workspace/pair.cert` was refused at the moment somebody first
- * ran the command.
+ * Declared in `#profile` rather than here, because three components read these
+ * names now and only one of them is the CLI — the server opens the read surface
+ * with them and a deploy binds the token so the revision may read it. Importing
+ * a *command* module for a string constant pulled the CLI's output and prompt
+ * handling into the container's runtime graph. Re-exported because a year of
+ * callers spell them from here.
  */
-export const PAIR_TOKEN_REF = 'workspace/pair_token';
-export const PAIR_CERT_REF = 'workspace/pair_cert';
-export const PAIR_KEY_REF = 'workspace/pair_key';
+export { PAIR_CERT_REF, PAIR_KEY_REF, PAIR_TOKEN_REF };
 
 /** Where the dashboard lives, overridable so `lanes dev` can pair against it. */
 const DASHBOARD_URL = process.env['LANES_WEB_URL'] ?? 'https://lanes.sh';
-
-/** The names the certificate has to cover. All three are this machine. */
-const HOSTS = ['127.0.0.1', 'localhost', '::1'];
 
 export interface PairFlags extends GlobalFlags {
   /** Print the link for an existing pairing and change nothing. */
@@ -117,19 +121,30 @@ export async function pair(flags: PairFlags, deps: PairDeps = {}): Promise<void>
 
   const chosen = named ?? profiles[0]!;
   const host = chosen.config.instance.host;
+  const credentials = await openSecretStoreFor(chosen.config, root, target);
+
+  // A workspace that declares a deployment is paired over the address the
+  // platform gave it, not over loopback — which is what `declared.deploy`
+  // answers and what `instance.host` does not: a deployed revision takes its
+  // host from the container's environment, so a profile bound to `127.0.0.1`
+  // in config is still serving `0.0.0.0` on Cloud Run.
+  if (resolved.declared.deploy) {
+    await pairDeployed({ flags, target, chosen, root, credentials, deploy: resolved.declared.deploy });
+    return;
+  }
 
   if (!isLoopback(host)) {
-    // A deployed endpoint is already reachable by URL and needs none of this.
-    // Pairing one would mean installing a certificate for an address this
-    // machine does not answer on.
+    // Not deployed, and not on this machine either. There is no certificate
+    // this command could install for an address this machine does not answer
+    // on, and no platform URL to hand the browser instead.
     throw new ConfigError(
-      `"${target}" is bound to ${host}, not loopback, so there is nothing here to pair.\n` +
-        '  Pairing exists so a browser can read an endpoint on *this* machine.',
+      `"${target}" is bound to ${host}, which is neither loopback nor a deployment.\n` +
+        '  Pairing reaches an endpoint on *this* machine, or one `lanes link deploy` put\n' +
+        '  somewhere with an address of its own.',
     );
   }
 
   const readPort = chosen.config.instance.port + 1;
-  const credentials = await openSecretStoreFor(chosen.config, root, target);
 
   if (flags.print === true) {
     const existing = await credentials.get(PAIR_TOKEN_REF);
@@ -178,126 +193,117 @@ export async function pair(flags: PairFlags, deps: PairDeps = {}): Promise<void>
   );
 }
 
-function link(token: string): string {
-  return `${DASHBOARD_URL}/dashboard/link#pair=${token}`;
+/**
+ * Pairing a workspace that lives somewhere with an address of its own (ADR-064).
+ *
+ * The half of `pair` that is *not* shared with loopback is the certificate, and
+ * that was always the whole of the old refusal: installing one for an address
+ * this machine does not answer on is meaningless, and it is still meaningless.
+ * What was never the thing being refused is the credential and the address —
+ * the endpoint terminates TLS with a certificate a browser already trusts, so
+ * the two pieces that remain are a token and a URL.
+ *
+ * So there is no `mkcert` here, nothing is installed, and nothing is asked. The
+ * command writes one secret and prints a link.
+ */
+async function pairDeployed(input: {
+  flags: PairFlags;
+  target: string;
+  chosen: LoadedProfile;
+  root: string;
+  credentials: SecretStore;
+  deploy: NonNullable<ResolvedTarget['declared']['deploy']>;
+}): Promise<void> {
+  const { flags, target, chosen, root, credentials } = input;
+
+  // `deployedUrl` asks the platform where the service ended up and degrades to
+  // null for every reason that is not this command's business — no driver, not
+  // deployed yet, no credentials for the project. A link with no address in it
+  // reads nothing, so this refuses rather than printing half of one.
+  const mcpUrl = await deployedUrl(input.deploy);
+  if (mcpUrl === null) {
+    throw new ConfigError(
+      `Could not find the address of "${target}".\n` +
+        '  The service may not be deployed yet, or the platform CLI may not be signed in.\n' +
+        `  Check it with: lanes link outputs --workspace ${target}`,
+    );
+  }
+
+  // The read surface answers on the endpoint's own origin, beside `/mcp` rather
+  // than on a port of its own — Cloud Run routes exactly one.
+  const endpoint = mcpUrl.replace(/\/mcp$/, '');
+
+  if (flags.print === true) {
+    const existing = await credentials.get(PAIR_TOKEN_REF);
+    if (existing === null || existing === '') {
+      throw new ConfigError(`Not paired yet. Run: lanes link pair --workspace ${target}`);
+    }
+    print(link(existing, endpoint));
+    return;
+  }
+
+  const rotating = flags.rotate === true;
+  const held = rotating ? null : await credentials.get(PAIR_TOKEN_REF);
+
+  // An empty string, not just a missing ref: `lanes link deploy` creates this
+  // secret with no version so the revision's IAM binding has something to
+  // attach to, and a secret that exists with no version reads back as null
+  // here and as `unpaired` there. Either shape means nobody has paired yet.
+  const existing = held === '' ? null : held;
+  const token = existing ?? `llp_${randomBytes(32).toString('base64url')}`;
+  if (existing === null) await credentials.set(PAIR_TOKEN_REF, token);
+
+  if (existing === null) {
+    await recordConfigChange(chosen.config, root, target, {
+      capability: rotating ? 'config.pair.rotate' : 'config.pair.mint',
+      scope: target,
+      arguments: { endpoint },
+    });
+  }
+
+  print(ok('no certificate needed — this endpoint already has one a browser trusts'));
+  if (rotating) {
+    print(style.dim('      The previous pairing link no longer works. Re-open the new one.'));
+  }
+  print('');
+  print(ok(`the dashboard may now read ${style.bold(endpoint)}`));
+  print('');
+  print(link(token, endpoint));
+  print('');
+  print(
+    style.dim(
+      '      Open that in any browser, on any machine. The token is in the URL fragment,\n' +
+        '      so it never reaches a Lanes server.\n' +
+        '      It reads every connection, profile and audit entry in this workspace, and\n' +
+        '      can change nothing. Take it back with:\n' +
+        `        lanes link pair --workspace ${target} --rotate\n` +
+        '\n' +
+        '      A rotation takes up to five seconds to be refused, because the endpoint\n' +
+        '      caches what it read rather than calling Secret Manager per request.',
+    ),
+  );
+}
+
+/**
+ * The link the browser opens.
+ *
+ * The token rides in the fragment, which is never sent to a server — so a
+ * credential for a surface whose entire point is that Lanes cannot see this
+ * data does not land in a Lanes access log, a proxy, or a referrer header. The
+ * address rides beside it for the same reason and one more: it is the only
+ * thing telling the page which of several paired endpoints this link is for,
+ * and a query parameter would put a workspace's public address in that log.
+ *
+ * A link with no `at=` is a local one. Every link minted before deployed
+ * pairing existed is that shape, and the page reads it as loopback.
+ */
+function link(token: string, endpoint?: string): string {
+  const fragment = endpoint
+    ? `pair=${token}&at=${encodeURIComponent(endpoint)}`
+    : `pair=${token}`;
+  return `${DASHBOARD_URL}/dashboard/link#${fragment}`;
 }
 
 function isLoopback(host: string): boolean {
   return host === '127.0.0.1' || host === 'localhost' || host === '::1';
-}
-
-/**
- * A certificate a browser on this machine will accept.
- *
- * mkcert and nothing else, deliberately. It is the one tool that installs into
- * the system trust store *and* Firefox's separate NSS store, across macOS,
- * Linux and Windows — and a self-signed certificate this command generated
- * itself would fail in the browser with an error the page cannot read, which is
- * the worst of both: the work is done and the feature does not work.
- */
-async function ensureCertificate(
-  credentials: SecretStore,
-  flags: PairFlags,
-  deps: PairDeps,
-): Promise<'reused' | 'installed'> {
-  const held =
-    (await credentials.get(PAIR_CERT_REF)) !== null &&
-    (await credentials.get(PAIR_KEY_REF)) !== null;
-
-  if (held && flags.rotate !== true) return 'reused';
-
-  const which = deps.which ?? ((binary: string) => Bun.which(binary));
-  const run = deps.run ?? runCommand;
-
-  let mkcert = which('mkcert');
-  if (!mkcert) mkcert = await installMkcert(flags, deps, which, run);
-
-  // Installs the local CA if it is not already there, and says nothing if it
-  // is. This is the step that touches the trust store, and it has already been
-  // consented to by the time it runs.
-  const installed = await run([mkcert, '-install']);
-  if (installed !== null) {
-    throw new ConfigError(`mkcert -install failed.\n${installed || '  It said nothing.'}`);
-  }
-
-  const scratch = await mkdtemp(join(tmpdir(), 'lanes-pair-'));
-  try {
-    const certPath = join(scratch, 'cert.pem');
-    const keyPath = join(scratch, 'key.pem');
-
-    const failed = await run([mkcert, '-cert-file', certPath, '-key-file', keyPath, ...HOSTS]);
-    if (failed !== null) {
-      throw new ConfigError(`mkcert failed to issue a certificate.\n${failed || '  It said nothing.'}`);
-    }
-
-    // Into the credential store rather than left on disk. The private key is a
-    // secret by any reading, and the store is the one place in a workspace that
-    // is encrypted at rest.
-    await credentials.set(PAIR_CERT_REF, await readFile(certPath, 'utf8'));
-    await credentials.set(PAIR_KEY_REF, await readFile(keyPath, 'utf8'));
-  } finally {
-    await rm(scratch, { recursive: true, force: true });
-  }
-
-  return 'installed';
-}
-
-async function installMkcert(
-  flags: PairFlags,
-  deps: PairDeps,
-  which: (binary: string) => string | null,
-  run: (command: readonly string[]) => Promise<string | null>,
-): Promise<string> {
-  const line = 'brew install mkcert';
-  const brew = which('brew');
-
-  if (!brew) {
-    // The one path where this command cannot finish the job, so it hands over
-    // the whole of it rather than half.
-    throw new ConfigError(
-      'Pairing needs mkcert, which issues a certificate this machine\'s browsers trust.\n' +
-        `  With Homebrew: ${line}\n` +
-        '  Otherwise: https://github.com/FiloSottile/mkcert#installation\n' +
-        '  Then run "lanes link pair" again.',
-    );
-  }
-
-  print(warn('pairing needs mkcert, and it is not installed'));
-  print(
-    style.dim(
-      '  It issues a certificate for 127.0.0.1 that this machine trusts, which is what\n' +
-        '  lets a page on lanes.sh read your endpoint at all. Safari will not fetch\n' +
-        '  http://127.0.0.1 from an https page, and offers no way to allow it.\n' +
-        '\n' +
-        '  This installs a local certificate authority into your system trust store.\n' +
-        `  ${line}`,
-    ),
-  );
-
-  if (flags.yes !== true) {
-    if (!(deps.interactive ?? isInteractive())) {
-      throw new ConfigError(
-        'Nothing here can answer a prompt, and installing a certificate authority because\n' +
-          '  nobody was there to say no is the wrong way to resolve that.\n' +
-          `  Run "${line}" yourself, or pass --yes.`,
-      );
-    }
-    if (!(await (deps.confirm ?? ((question: string) => confirm(question)))('Install it now?'))) {
-      throw new ConfigError(`Not paired. When you want it: ${line}`);
-    }
-  }
-
-  const failed = await run([brew, 'install', 'mkcert']);
-  if (failed !== null) throw new ConfigError(`${line} failed.\n${failed || '  It said nothing.'}`);
-
-  const found = which('mkcert');
-  if (!found) throw new ConfigError(`${line} reported success but mkcert is still not on PATH.`);
-  return found;
-}
-
-/** Runs it. Null on success; whatever it said on failure. */
-async function runCommand(command: readonly string[]): Promise<string | null> {
-  const spawned = Bun.spawn([...command], { stdout: 'pipe', stderr: 'pipe' });
-  const [code, stderr] = await Promise.all([spawned.exited, new Response(spawned.stderr).text()]);
-  return code === 0 ? null : stderr.trim();
 }

--- a/src/cli/commands/operate/policy.ts
+++ b/src/cli/commands/operate/policy.ts
@@ -15,56 +15,93 @@ export async function policyList(flags: GlobalFlags): Promise<void> {
   const { selection, config } = await resolveProfileOnly(flags);
   announceProfile(selection);
 
-  if (config.policy.allow.length === 0 && config.policy.deny.length === 0) {
-    print(style.dim('No rules. Default deny is in effect: nothing is reachable.'));
+  if (config.grants.length === 0) {
+    print(style.dim('No grants. Default deny is in effect: nothing is reachable.'));
     return;
   }
 
   const expiry = (rule: { capability: string; expires_at?: string | undefined }) =>
     rule.expires_at ? style.dim(`until ${rule.expires_at}`) : '';
 
-  if (config.policy.allow.length > 0) {
-    heading('Allow');
-    table(config.policy.allow.map((rule) => [`  ${style.green('+')}`, rule.capability, expiry(rule)]));
-  }
+  // Grouped by connection rather than by effect, which reverses how this used to
+  // read. A rule governs one account now (ADR-058), so "what may be done with
+  // the work mailbox" is the question the listing should answer in one place —
+  // and the old shape, two lists of capabilities with the account nowhere in
+  // them, could not answer it at all.
+  for (const grant of config.grants) {
+    heading(grant.connection);
 
-  if (config.policy.deny.length > 0) {
-    heading('Deny');
-    print(style.dim('  A deny beats any allow, whatever the order in the file.'));
-    table(config.policy.deny.map((rule) => [`  ${style.red('-')}`, rule.capability, expiry(rule)]));
+    if (grant.allow.length === 0 && grant.deny.length === 0) {
+      print(style.dim('  Granted nothing. The connection is reachable and no capability is.'));
+      continue;
+    }
+
+    table([
+      ...grant.allow.map((rule) => [`  ${style.green('+')}`, rule.capability, expiry(rule)]),
+      ...grant.deny.map((rule) => [`  ${style.red('-')}`, rule.capability, expiry(rule)]),
+    ]);
   }
 
   print('');
+  print(style.dim('A deny beats any allow on the same connection, whatever the order in the file.'));
   print(
-    style.dim('Rules cover every account of a provider. For different grants, use a second profile.'),
+    style.dim('A connection with no row above is not reachable at all, and is never advertised.'),
   );
+}
+
+export interface PolicyFlags extends GlobalFlags {
+  readonly connection?: string | undefined;
 }
 
 export async function policyRule(
   effect: 'allow' | 'deny',
   capability: string,
-  flags: GlobalFlags,
+  flags: PolicyFlags,
 ): Promise<void> {
   const { resolution, config, target } = await resolveProfile(flags);
-  const document = await ConfigDocument.open(resolution.workspaceRoot, resolution.profile);
 
-  if (config.policy[effect].some((rule) => rule.capability === capability)) {
-    print(style.dim(`${effect} ${capability} is already declared.`));
+  // Required, and refused rather than guessed. A rule has to land in a row, and
+  // with two mailboxes granted there is no answer to "which one" that is not a
+  // guess about which account the operator meant to widen.
+  const key = flags.connection;
+  if (key === undefined) {
+    throw new Error(
+      `--connection is required. A rule governs one connection (ADR-058).\n` +
+        (config.grants.length > 0
+          ? `  This profile grants: ${config.grants.map((grant) => grant.connection).join(', ')}`
+          : `  This profile grants nothing yet. Run: lanes link status --profile ${resolution.profile}`),
+    );
+  }
+
+  const index = config.grants.findIndex((grant) => grant.connection === key);
+  if (index === -1) {
+    throw new Error(
+      `Profile "${resolution.profile}" does not grant "${key}".\n` +
+        `  Grant it first, then narrow it:\n` +
+        `    lanes link grant ${key} --profile ${resolution.profile}`,
+    );
+  }
+
+  const grant = config.grants[index]!;
+  if (grant[effect].some((rule) => rule.capability === capability)) {
+    print(style.dim(`${effect} ${capability} on ${key} is already declared.`));
     return;
   }
 
+  const document = await ConfigDocument.open(resolution.workspaceRoot, resolution.profile);
+
   // A bare string, because that is what the file should read like. The object
   // form exists for `expires_at` and is not worth writing by default.
-  document.addTo(['policy', effect], capability, { inline: true });
-  // Validation runs before the write, so a rule naming a provider with no
-  // connection fails here rather than silently granting nothing at runtime.
+  document.addTo(['grants', index, effect], capability, { inline: true });
+  // Validation runs before the write, so a rule naming a provider other than the
+  // row's own fails here rather than matching nothing at runtime.
   await document.save();
 
   announce(resolution);
-  print(ok(`${effect} ${style.bold(capability)}`));
+  print(ok(`${effect} ${style.bold(capability)} on ${style.bold(key)}`));
 
-  if (effect === 'deny' && config.policy.allow.some((rule) => rule.capability === '*')) {
-    print(style.dim('  This narrows the catch-all allow; a deny always wins.'));
+  if (effect === 'deny' && grant.allow.some((rule) => rule.capability === '*')) {
+    print(style.dim("  This narrows that row's catch-all allow; a deny always wins."));
   }
 
   // A deny the endpoint has not heard about is still granting what it names, so

--- a/src/cli/commands/operate/policy.ts
+++ b/src/cli/commands/operate/policy.ts
@@ -1,6 +1,7 @@
 import { loadConfigFile } from '#profile';
+import { recordConfigChange } from '../../audit-change.ts';
 import { ConfigDocument } from '../../config-edit.ts';
-import { announce, announceProfile, heading, ok, print, style, table } from '../../output.ts';
+import { announce, announceProfile, heading, ok, print, style, table, warn } from '../../output.ts';
 import { resolveProfile, resolveProfileOnly, type GlobalFlags } from '../../runtime.ts';
 import { nextAfterEdit, publishProfileEdit } from '../../publish.ts';
 
@@ -96,6 +97,19 @@ export async function policyRule(
   // Validation runs before the write, so a rule naming a provider other than the
   // row's own fails here rather than matching nothing at runtime.
   await document.save();
+
+  await recordConfigChange(
+    config,
+    resolution.workspaceRoot,
+    target,
+    {
+      capability: effect === 'allow' ? 'config.policy.allow' : 'config.policy.deny',
+      scope: resolution.profile,
+      connection: key,
+      arguments: { capability },
+    },
+    (note) => print(warn(note)),
+  );
 
   announce(resolution);
   print(ok(`${effect} ${style.bold(capability)} on ${style.bold(key)}`));

--- a/src/cli/commands/operate/serve.ts
+++ b/src/cli/commands/operate/serve.ts
@@ -56,7 +56,7 @@ export async function start(
         print(ok(`reconciled ${ofMany ? profile : ''}`.trim()));
       },
       tokenMinted({ target }) {
-        print(warn(`minted a token — run: lanes link outputs --show --target ${target}`));
+        print(warn(`minted a token — run: lanes link outputs --show --workspace ${target}`));
       },
     },
   });

--- a/src/cli/commands/operate/serve.ts
+++ b/src/cli/commands/operate/serve.ts
@@ -1,3 +1,5 @@
+import { readSession } from '#auth/lanes/session.ts';
+import { ConfigError } from '#profile';
 import { startEndpoint } from '#server/endpoint.ts';
 import { streamLogger } from '#server/logging.ts';
 import { repairOwnerLayer } from '../../config-repair.ts';
@@ -16,6 +18,8 @@ export async function start(
 ): Promise<void> {
   const { resolution } = await resolveProfile(flags);
   announce(resolution);
+
+  await requireSignIn();
 
   // Before the bootstrap, and only here.
   //
@@ -80,4 +84,35 @@ export async function start(
   process.on('SIGTERM', () => void shutdown());
 
   await new Promise(() => {});
+}
+
+/**
+ * Refuse to serve without a Lanes session.
+ *
+ * A local endpoint requires this as much as a deployed one does, which is the
+ * uncomfortable half of ADR-060 and worth stating plainly: **a self-hostable
+ * tool now needs an account to start.** The alternative was worse. A profile
+ * declares who may consume it, and there is no way to check that against
+ * anybody if the endpoint has no idea who is asking — so "local is exempt"
+ * means local profiles cannot express delegation at all, and the model would be
+ * two models.
+ *
+ * What is *not* required is the network per request. A machine offline for a
+ * day keeps serving; the session is needed to sign in and to refresh, and
+ * `lanes auth status` says how long that has left to run.
+ *
+ * The CI token is the exception and stays one (ADR-009): a headless runner has
+ * no browser, presents `llk_…`, and reaches the whole workspace.
+ */
+async function requireSignIn(): Promise<void> {
+  if ((await readSession()) !== null) return;
+
+  throw new ConfigError(
+    'Not signed in, so there is nobody for this endpoint to serve.\n' +
+      '  Run: lanes auth login\n' +
+      '\n' +
+      '  A profile reaches you only where its members list your subject, which is why\n' +
+      '  this is required for a local endpoint too. See:\n' +
+      '    lanes link profile members add --me --profile <name>',
+  );
 }

--- a/src/cli/commands/operate/serve.ts
+++ b/src/cli/commands/operate/serve.ts
@@ -5,7 +5,7 @@ import { streamLogger } from '#server/logging.ts';
 import { repairOwnerLayer } from '../../config-repair.ts';
 import { announce, ok, print, style, warn } from '../../output.ts';
 import { staleNudge } from '../../release.ts';
-import { resolveProfile, type GlobalFlags } from '../../runtime.ts';
+import { primaryProfile, resolveProfile, type GlobalFlags } from '../../runtime.ts';
 
 /** `lanes link start` — reconcile, then serve every profile on one endpoint. */
 
@@ -16,7 +16,20 @@ export async function start(
     only?: boolean | undefined;
   },
 ): Promise<void> {
-  const { resolution } = await resolveProfile(flags);
+  // One endpoint serves every profile in the workspace, so the workspace is the
+  // subject and a profile is not required. What `--profile` picks is the
+  // *primary*: whose token opens the endpoint and whose port it binds (ADR-009).
+  // `--only` is the flag that narrows what is served, and it has nothing to
+  // narrow unless a profile was named.
+  if (flags.only === true && flags.profile === undefined) {
+    throw new ConfigError(
+      '--only serves one profile, so it needs to be told which.\n' +
+        '  Add --profile <name>, or drop --only to serve every profile in the workspace.',
+    );
+  }
+
+  const resolved = { ...flags, profile: await primaryProfile(flags) };
+  const { resolution } = await resolveProfile(resolved);
   announce(resolution);
 
   await requireSignIn();
@@ -45,7 +58,7 @@ export async function start(
   // entrypoint. What stays here is what a terminal wants: the plan, printed as
   // it is applied, and the endpoint at the end.
   const endpoint = await startEndpoint({
-    flags,
+    flags: resolved,
     port: flags.port,
     only: flags.only,
     mintToken: true,

--- a/src/cli/commands/operate/status.ts
+++ b/src/cli/commands/operate/status.ts
@@ -1,3 +1,4 @@
+import { wasDefaulted } from '../../selection-require.ts';
 import {
   isPointer,
   listProfiles,
@@ -11,7 +12,7 @@ import {
 import { oneProfile, visibleCapabilities } from '#server/mcp';
 import { toPolicyDocument } from '#registry';
 import { announce, emit, heading, print, style, table } from '../../output.ts';
-import { openRuntime, ownerPrincipal, type GlobalFlags } from '../../runtime.ts';
+import { grantedConnections, openRuntime, ownerPrincipal, type GlobalFlags } from '../../runtime.ts';
 import { deploymentIdentity } from '../../endpoint-url.ts';
 
 /** `lanes link status` — connections, what is reachable through them, and where. */
@@ -29,7 +30,7 @@ export interface StatusFlags extends GlobalFlags {
  *
  * Which is why a deployed target prints its *identity* rather than its address.
  * This used to print `http://<host>:<port>/mcp` unconditionally, so
- * `status --target cloud` named a loopback port with nothing behind it — the
+ * `status --workspace cloud` named a loopback port with nothing behind it — the
  * bug `endpoint-url.ts` records having already fixed in `mcp add`. Reaching for
  * `endpointUrl` here would fix the lie by surrendering the property above: it
  * shells out to `gcloud`, costs seconds, needs the CLI installed and
@@ -48,7 +49,7 @@ export async function status(flags: StatusFlags): Promise<void> {
     const records = await runtime.state.connections.list();
     const byKey = new Map(records.map((record) => [`${record.provider}.${record.id}`, record]));
 
-    const connections = runtime.config.connections.map((connection) => {
+    const connections = grantedConnections(runtime).map((connection) => {
       const key = `${connection.provider}.${connection.id}`;
       return {
         key,
@@ -197,12 +198,12 @@ async function workspaceStatus(flags: StatusFlags): Promise<void> {
     unreachable = error instanceof Error ? error.message : String(error);
   }
 
-  const root = resolved?.workspaceRoot ?? (isPointer(entry) ? entry.workspace : localRoot);
+  const root = resolved?.workspaceRoot ?? (isPointer(entry) ? entry.at : localRoot);
   const workspace = resolved ? await loadWorkspaceProfiles(root) : undefined;
 
   const profiles = (workspace?.loaded ?? []).map((loaded) => ({
     name: loaded.profile,
-    connections: loaded.config.connections.length,
+    grants: loaded.config.grants.length,
   }));
 
   const deployment = deploymentIdentity(resolved?.declared.deploy);
@@ -220,7 +221,14 @@ async function workspaceStatus(flags: StatusFlags): Promise<void> {
       unreadable: workspace?.unreadable ?? [],
     },
     () => {
-      print(style.dim(`workspace ${style.bold(root)}  target ${style.bold(target)}`));
+      // The same shape `announce` prints, including whether the workspace was
+      // typed or defaulted — a command that reported it differently would make
+      // ADR-061's echo a thing an operator has to learn twice.
+      print(
+        style.dim(
+          `workspace ${style.bold(target)}${wasDefaulted(target) ? ' (default)' : ''}  ${root}`,
+        ),
+      );
 
       if (unreachable !== undefined) {
         heading('Unreachable');
@@ -234,12 +242,12 @@ async function workspaceStatus(flags: StatusFlags): Promise<void> {
       heading('Profiles');
       if (profiles.length === 0) {
         print(style.dim('  None yet.'));
-        print(style.dim(`  Create one with: lanes link profile add <name> --target ${target}`));
+        print(style.dim(`  Create one with: lanes link profile add <name> --workspace ${target}`));
       } else {
         table(
           profiles.map((profile) => [
             `  ${style.bold(profile.name)}`,
-            style.dim(`${profile.connections} connection(s)`),
+            style.dim(`${profile.grants} grant(s)`),
           ]),
         );
       }
@@ -257,7 +265,7 @@ async function workspaceStatus(flags: StatusFlags): Promise<void> {
       print(
         style.dim(
           "  the address is the platform's to assign — run: " +
-            `lanes link outputs --target ${target} --profile ${profiles[0]?.name ?? '<name>'}`,
+            `lanes link outputs --workspace ${target} --profile ${profiles[0]?.name ?? '<name>'}`,
         ),
       );
     },

--- a/src/cli/commands/operate/status.ts
+++ b/src/cli/commands/operate/status.ts
@@ -143,7 +143,7 @@ export async function status(flags: StatusFlags): Promise<void> {
           print(
             style.dim(
               '  the address is the platform\'s to assign — run: ' +
-                `lanes link outputs --target ${runtime.target}`,
+                `lanes link outputs --workspace ${runtime.target}`,
             ),
           );
         }

--- a/src/cli/commands/operate/tools.test.ts
+++ b/src/cli/commands/operate/tools.test.ts
@@ -83,7 +83,7 @@ describe('grouping names by provider', () => {
 
   test('a name matching nothing known is marked unattributed, not guessed', () => {
     // Reachable in normal use: the registry is the invoking profile's, and the
-    // endpoint may serve several — or, under `--target cloud`, run an image
+    // endpoint may serve several — or, under `--workspace cloud`, run an image
     // this checkout does not have. Filing `drive_files_list` under a confident
     // `drive` heading would be a guess wearing a count.
     const grouped = groupByProvider(['drive_files_list'], ids);

--- a/src/cli/commands/operate/tools.ts
+++ b/src/cli/commands/operate/tools.ts
@@ -50,7 +50,7 @@ export async function tools(flags: ToolsFlags): Promise<void> {
       {
         url,
         target: runtime.target,
-        // Both, because `--target cloud` reaching loopback is indistinguishable
+        // Both, because `--workspace cloud` reaching loopback is indistinguishable
         // from success without them.
         deployed: deployed !== null,
         answering: mine,
@@ -297,7 +297,7 @@ export function parse(text: string): Record<string, unknown> {
  * `capabilityIdForToolName` answers it exactly against a set of known ids, and
  * falls back to that first-underscore split when it recognises none — which is
  * reachable here, because the registry is the *invoking profile's* while the
- * endpoint may serve several, and under `--target cloud` may run an image this
+ * endpoint may serve several, and under `--workspace cloud` may run an image this
  * checkout does not have. So the fallback is detected rather than trusted: a
  * name that resolves to nothing known is grouped as unattributed, because a
  * guessed heading with a confident count is worse than an honest "these did not

--- a/src/cli/commands/owner.test.ts
+++ b/src/cli/commands/owner.test.ts
@@ -3,7 +3,8 @@ import { afterAll, describe, expect, test } from 'bun:test';
 import { mkdtemp, mkdir, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { parseConfig } from '#profile';
+import {
+  CONNECTIONS_FILE, parseConfig } from '#profile';
 import { assetStorage, entityStorage, memoryStorage, taskStorage } from '#providers/owner.ts';
 import { openRuntime, ownerPrincipal } from '../runtime.ts';
 import { memoryStore, ownerConnection } from './owner.ts';
@@ -28,15 +29,27 @@ import { openCatalogue } from '#providers/entities/catalogue.ts';
 const roots: string[] = [];
 const previousHome = process.env['LANES_LINK_HOME'];
 
-const PROFILE = `contract: 2
+const PROFILE = `contract: 3
 
 instance:
   profile: personal
 
-# Labelled the way the CLI writes them: the provider's own name. A tasks row
-# under any other label is refused, because that is the only signal a config
-# carries that it used to be Google Tasks (ADR-051). The ids stay "owner",
-# since what these tests are about is that --connection resolves.
+# The ids stay "owner", since what these tests are about is that --connection
+# resolves — and a grant names the connection, so the id is visible here too.
+grants:
+  - { connection: memory.owner, allow: ['memory.*'], deny: [] }
+  - { connection: tasks.owner, allow: ['tasks.*'], deny: [] }
+  - { connection: assets.owner, allow: ['assets.*'], deny: [] }
+  - { connection: skills.owner, allow: ['skills.*'], deny: [] }
+  - { connection: vault.owner, allow: ['vault.*'], deny: [] }
+  - { connection: entities.owner, allow: ['entities.*'], deny: [] }
+members: []
+`;
+
+// Labelled the way the CLI writes them: the provider's own name. A tasks row
+// under any other label is refused, because that is the only signal a config
+// carries that it used to be Google Tasks (ADR-051).
+const CONNECTIONS = `contract: 3
 connections:
   - { id: owner, provider: memory, account: Memory }
   - { id: owner, provider: tasks,  account: Tasks }
@@ -44,9 +57,7 @@ connections:
   - { id: owner, provider: skills, account: Skills }
   - { id: owner, provider: vault,  account: Vault }
   - { id: owner, provider: entities, account: Entities }
-
-policy:
-  allow: ['*']
+oauth_apps: {}
 `;
 
 async function workspace(): Promise<string> {
@@ -56,6 +67,7 @@ async function workspace(): Promise<string> {
   await mkdir(join(root, 'profiles'), { recursive: true });
   await writeFile(join(root, 'lanes-link.yaml'), workspaceYaml(['local'], {defaultProfile: 'personal'}));
   await writeFile(join(root, 'profiles', 'personal.yaml'), PROFILE);
+  await writeFile(join(root, CONNECTIONS_FILE), CONNECTIONS);
 
   process.env['LANES_LINK_HOME'] = root;
   return root;
@@ -355,7 +367,7 @@ describe('which connection a command acts on', () => {
   });
 
   test('none at all says how to make one', () => {
-    const bare = parseConfig(PROFILE.replace(/connections:[\s\S]*?\npolicy:/, 'policy:')).config;
+    const bare = parseConfig(PROFILE.replace(/grants:[\s\S]*?\nmembers:/, 'grants: []\nmembers:')).config;
 
     expect(() => ownerConnection(bare, 'memory', {})).toThrow(/lanes link connect memory/);
   });
@@ -363,8 +375,9 @@ describe('which connection a command acts on', () => {
   test('two is ambiguous, and refuses rather than picking', () => {
     const two = parseConfig(
       PROFILE.replace(
-        '  - { id: owner, provider: memory, account: Memory }',
-        '  - { id: owner, provider: memory, account: Memory }\n  - { id: work, provider: memory, account: Memory }',
+        "  - { connection: memory.owner, allow: ['memory.*'], deny: [] }",
+        "  - { connection: memory.owner, allow: ['memory.*'], deny: [] }\n" +
+          "  - { connection: memory.work, allow: ['memory.*'], deny: [] }",
       ),
     ).config;
 

--- a/src/cli/commands/owner/shared.ts
+++ b/src/cli/commands/owner/shared.ts
@@ -73,7 +73,15 @@ export async function withRuntime(
  * the candidates rather than picking.
  */
 export function ownerConnection(config: Config, provider: string, flags: OwnerFlags): string {
-  const candidates = config.connections.filter((connection) => connection.provider === provider);
+  // Derived from the grants, not from the workspace's connections. The question
+  // is which store *this profile* may reach, and a workspace holding
+  // `memory.acme` that this profile does not grant is not a candidate — offering
+  // it would let the CLI write somewhere the endpoint would refuse to read
+  // (ADR-057, ADR-058).
+  const prefix = `${provider}.`;
+  const candidates = config.grants
+    .filter((grant) => grant.connection.startsWith(prefix))
+    .map((grant) => ({ id: grant.connection.slice(prefix.length) }));
 
   if (flags.connection) {
     const match = candidates.find((connection) => connection.id === flags.connection);
@@ -90,7 +98,10 @@ export function ownerConnection(config: Config, provider: string, flags: OwnerFl
 
   if (candidates.length === 0) {
     throw new ConfigError(
-      `This profile has no ${provider} connection. Add one with: lanes link connect ${provider}`,
+      `This profile grants no ${provider} connection.\n` +
+        `  Connect one to the workspace, then grant it:\n` +
+        `    lanes link connect ${provider}\n` +
+        `    lanes link grant ${provider}.<id> --profile ${config.instance.profile}`,
     );
   }
   if (candidates.length > 1) {

--- a/src/cli/commands/owner/skills.ts
+++ b/src/cli/commands/owner/skills.ts
@@ -1,4 +1,5 @@
-import { ConfigError } from '#profile';
+import { ConfigError, type Config } from '#profile';
+import type { BlobStore } from '#stores/blobs';
 import {
   loadProfileSkills,
   readSkill,
@@ -10,9 +11,28 @@ import { agreed, readStdin, required, withRuntime, type OwnerFlags } from './sha
 
 /** `lanes link skills` — the reusable procedures agents can invoke. */
 
+/**
+ * The store, or a refusal naming why there is none.
+ *
+ * A profile grants at most one `skills` connection and may grant none
+ * (ADR-059), so `store(runtime)` is genuinely absent rather than empty. The two
+ * are worth telling apart: "you have no skills" invites writing one, and
+ * "this profile is not granted skills" is a config fact the operator has to fix
+ * before writing one would do anything.
+ */
+function store(runtime: { skills: BlobStore | undefined; config: Config }): BlobStore {
+  if (runtime.skills) return runtime.skills;
+  throw new ConfigError(
+    `Profile "${runtime.config.instance.profile}" grants no skills connection.\n` +
+      `  Grant one, then try again:\n` +
+      `    lanes link grant skills.main --profile ${runtime.config.instance.profile}`,
+  );
+}
+
+
 export async function skillsList(flags: OwnerFlags): Promise<void> {
   await withRuntime(flags, async (runtime) => {
-    const skills = await loadProfileSkills(runtime.skills);
+    const skills = await loadProfileSkills(store(runtime));
 
     heading(`Skills (${skills.length})`);
     if (skills.length === 0) {
@@ -43,10 +63,10 @@ export async function skillsShow(name: string | undefined, flags: OwnerFlags): P
   const skillName = required(name, 'lanes link skills show <name>');
 
   await withRuntime(flags, async (runtime) => {
-    const skill = await readSkill(runtime.skills, skillName);
+    const skill = await readSkill(store(runtime), skillName);
     if (!skill) throw new ConfigError(`No skill "${skillName}" in this workspace.`);
 
-    const bytes = await runtime.skills.get(skill.path);
+    const bytes = await store(runtime).get(skill.path);
     print('');
     print(bytes ? new TextDecoder().decode(bytes) : skill.body);
   });
@@ -63,8 +83,8 @@ export async function skillsAdd(name: string | undefined, flags: OwnerFlags): Pr
       );
 
   await withRuntime(flags, async (runtime) => {
-    const existing = await readSkill(runtime.skills, skillName);
-    const skill = await writeSkill(runtime.skills, skillName, text);
+    const existing = await readSkill(store(runtime), skillName);
+    const skill = await writeSkill(store(runtime), skillName, text);
 
     print(ok(`${existing ? 'replaced' : 'added'} skill ${style.bold(skill.name)}`));
     print(
@@ -79,14 +99,14 @@ export async function skillsRemove(name: string | undefined, flags: OwnerFlags):
   const skillName = required(name, 'lanes link skills remove <name>');
 
   await withRuntime(flags, async (runtime) => {
-    const skill = await readSkill(runtime.skills, skillName);
+    const skill = await readSkill(store(runtime), skillName);
     if (!skill) throw new ConfigError(`No skill "${skillName}" in this workspace.`);
 
     print(`  ${style.bold(skill.name)}  ${skill.description}`);
     print(style.dim(`  ${skill.path}`));
     if (!(await agreed(flags, 'Remove this skill?'))) return;
 
-    await removeSkill(runtime.skills, skillName);
+    await removeSkill(store(runtime), skillName);
     print(ok(`removed skill ${style.bold(skillName)}`));
   });
 }

--- a/src/cli/commands/profile.test.ts
+++ b/src/cli/commands/profile.test.ts
@@ -119,7 +119,7 @@ describe('createProfile', () => {
     const text = await readFile(created.path, 'utf8');
 
     expect(created.targets).toEqual(['local']);
-    expect(text).toContain('contract: 2');
+    expect(text).toContain('contract: 3');
     expect(text).not.toContain('targets:');
     expect(text).not.toContain('credentials:');
   });
@@ -144,7 +144,7 @@ describe('createProfile', () => {
   });
 
   test('creates the workspace file first, so an empty directory can be seeded', async () => {
-    // `profile add <name> --target local` on nothing at all is how a workspace
+    // `profile add <name> --workspace local` on nothing at all is how a workspace
     // comes into existence, and the target it names is declared *by* the file it
     // is about to write. Resolving before writing would be resolving a target
     // nothing has declared yet.

--- a/src/cli/commands/profile.ts
+++ b/src/cli/commands/profile.ts
@@ -17,6 +17,7 @@ import {
 } from '#profile';
 
 import { emit, ok, print, style, table } from '../output.ts';
+import { readSession } from '#auth/lanes/session.ts';
 
 /**
  * Profile management.
@@ -109,10 +110,23 @@ export async function createProfile(
   // sibling's, or asked. It declares no target now (ADR-052): it is written into
   // the workspace of the target it was named with, and that workspace already
   // says where its bytes go.
+  // The signed-in subject, so the profile reaches somebody the moment it
+  // exists. Without it every new profile shipped `members: []` while the
+  // template writes `authorization: mode: self` — an endpoint that advertises
+  // OAuth and lists nobody, where the owner signs in at lanes.sh and is told no
+  // profile lists them. A local stdio or CI caller still worked, which is why a
+  // smoke test passed: those carry `profiles: undefined` and `mayReach` admits
+  // everything.
+  //
+  // Null when nobody is signed in, which is a real state — `lanes auth login`
+  // has not been run yet — and the template then says how to fix it rather than
+  // inventing a subject.
+  const session = await readSession();
+
   await writeWorkspaceFile(
     workspaceFiles(root),
     `profiles/${name}.yaml`,
-    newProfileTemplate(name, port),
+    newProfileTemplate(name, port, session?.subject),
   );
 
   return { name, path, port, targets: options.targets, copiedFrom: {} };

--- a/src/cli/commands/profile.ts
+++ b/src/cli/commands/profile.ts
@@ -16,6 +16,8 @@ import {
   resolveWorkspaceRoot,
 } from '#profile';
 
+import { recordConfigChange } from '../audit-change.ts';
+import { resolveProfile } from '../runtime.ts';
 import { emit, ok, print, style, table } from '../output.ts';
 import { readSession } from '#auth/lanes/session.ts';
 
@@ -175,6 +177,16 @@ export async function profileAdd(
   }
 
   const created = await createProfile(name, options);
+
+  // Re-read rather than assembled from `created`, because the file on disk is
+  // what a workspace with a remote credential store needs to open one.
+  const primary = created.targets[0]!;
+  const { resolution, config } = await resolveProfile({ profile: created.name, target: primary });
+  await recordConfigChange(config, resolution.workspaceRoot, primary, {
+    capability: 'config.profile.add',
+    scope: created.name,
+    arguments: { port: created.port, workspace: primary },
+  });
 
   return emit(options.json, created, () => {
     print(ok(`created profile ${style.bold(created.name)}`));

--- a/src/cli/commands/profile.ts
+++ b/src/cli/commands/profile.ts
@@ -1,7 +1,9 @@
+import { newConnectionsTemplate, newProfileTemplate, newWorkspaceTemplate } from '../config-templates.ts';
 import { mkdir, writeFile } from 'node:fs/promises';
 import { existsSync } from 'node:fs';
 import { join } from 'node:path';
 import {
+  CONNECTIONS_FILE,
   ConfigError,
   WORKSPACE_FILE,
   listProfiles,
@@ -13,7 +15,7 @@ import {
   resolveTargetWorkspace,
   resolveWorkspaceRoot,
 } from '#profile';
-import { newProfileTemplate, newWorkspaceTemplate } from '../config-edit.ts';
+
 import { emit, ok, print, style, table } from '../output.ts';
 
 /**
@@ -58,7 +60,7 @@ export interface ProfileListing {
  *
  * It now decides *where the file goes* rather than what is written in it: a
  * profile lives in one target's workspace and declares nothing about it
- * (ADR-052), so `--target cloud` writes into the bucket and the endpoint there
+ * (ADR-052), so `--workspace cloud` writes into the bucket and the endpoint there
  * serves it on its next reconcile.
  */
 export async function createProfile(
@@ -69,7 +71,7 @@ export async function createProfile(
   const target = options.targets[0]!;
 
   // The workspace file before the target is resolved, not after. `profile add
-  // <name> --target local` on an empty directory is how a workspace comes into
+  // <name> --workspace local` on an empty directory is how a workspace comes into
   // existence, and the target it names is declared *by* that file — so writing
   // it second means resolving a target nothing has declared yet.
   if (!isRemoteWorkspace(local) && !existsSync(join(local, WORKSPACE_FILE))) {
@@ -79,6 +81,14 @@ export async function createProfile(
 
   const root = await resolveTargetWorkspace(local, target);
   const path = profilePath(root, name);
+
+  // The connections file comes into existence with the workspace, carrying the
+  // owner layer. It is written before the profile because the profile's grants
+  // name rows in it, and `assertGrantsResolve` refuses a grant with nothing
+  // behind it — so a profile written first would not load until this existed.
+  if (!(await workspaceFiles(root).has(CONNECTIONS_FILE))) {
+    await writeWorkspaceFile(workspaceFiles(root), CONNECTIONS_FILE, newConnectionsTemplate());
+  }
 
   if (await workspaceFiles(root).has(`profiles/${name}.yaml`)) {
     throw new Error(`Profile "${name}" already exists at ${path}`);
@@ -142,8 +152,8 @@ export async function profileAdd(
   if (options.targets.length === 0) {
     throw new ConfigError(
       'Say which targets this profile declares:\n' +
-        `  lanes link profile add ${name} --target local\n` +
-        `  lanes link profile add ${name} --target local --target cloud\n` +
+        `  lanes link profile add ${name} --workspace local\n` +
+        `  lanes link profile add ${name} --workspace local --workspace cloud\n` +
         '\n' +
         '  A target is where a profile runs — a credential store and a blob store.\n' +
         '  There is no default to inherit before the profile exists.',
@@ -180,7 +190,7 @@ export async function profileList(
   return emit(options.json, listing, () => {
     if (listing.profiles.length === 0) {
       print(style.dim(`No profiles in ${listing.root}.`));
-      print(style.dim('Create one with: lanes link profile add personal --target local'));
+      print(style.dim('Create one with: lanes link profile add personal --workspace local'));
       return;
     }
 
@@ -210,7 +220,7 @@ export function profileDefault(name: string | undefined): never {
   throw new ConfigError(
     'lanes link profile default was removed.\n' +
       '  Nothing reads default_profile any more — pass --profile on every command:\n' +
-      `    lanes link status --profile ${name ?? '<name>'} --target <target>\n` +
+      `    lanes link status --profile ${name ?? '<name>'} --workspace <name>\n` +
       '  If the key is still in lanes-link.yaml it is inert, and safe to delete.',
   );
 }

--- a/src/cli/commands/profile.ts
+++ b/src/cli/commands/profile.ts
@@ -166,7 +166,7 @@ export async function profileAdd(
     print(ok(`created profile ${style.bold(created.name)}`));
     print(`      config   ${created.path}`);
     print(`      port     ${created.port}`);
-    print(`      targets  ${created.targets.join(', ')}`);
+    print(`      workspace  ${created.targets.join(', ')}`);
 
     for (const [target, from] of Object.entries(created.copiedFrom)) {
       print(`      ${style.dim(`${target} adapters copied from profile "${from}"`)}`);
@@ -175,7 +175,7 @@ export async function profileAdd(
     print();
     print(
       style.dim(
-        `Next: lanes link connect example --profile ${created.name} --target ${created.targets[0]}`,
+        `Next: lanes link connect example --profile ${created.name} --workspace ${created.targets[0]}`,
       ),
     );
   });

--- a/src/cli/commands/profile/removal.test.ts
+++ b/src/cli/commands/profile/removal.test.ts
@@ -84,10 +84,17 @@ describe('declaredRefs', () => {
     expect(declaredRefs(config(), target())).not.toContain('vault/document');
   });
 
-  test('a secret adapter with no ref falls back to the documented default', () => {
+  test('a secret adapter with no ref names the vault connection, not a constant', () => {
+    // This asserted `vault/document`, the contract-2 constant, and so pinned the
+    // defect rather than the behaviour: `openVault` seals under
+    // `vault/<connection>` (ADR-059), so removal queued a ref nothing had
+    // written and left the real sealed document behind. Under-deletion, because
+    // the survivor set was wrong the same way — but what survived is credential
+    // material belonging to a profile the operator asked to be gone.
     const sealed = target({ vault: { adapter: 'secret' } } as never);
 
-    expect(declaredRefs(config(), sealed)).toContain('vault/document');
+    expect(declaredRefs(config(), sealed)).toContain('vault/main');
+    expect(declaredRefs(config(), sealed)).not.toContain('vault/document');
   });
 
   test('a connection whose provider no longer resolves contributes nothing', () => {

--- a/src/cli/commands/profile/removal.test.ts
+++ b/src/cli/commands/profile/removal.test.ts
@@ -122,6 +122,34 @@ describe('declaredRefs', () => {
 
     expect(refs).toEqual(['profile/token', 'vault/document']);
   });
+
+  test('a ref a surviving profile also declares is left alone', () => {
+    // The credential store is one file per workspace since contract 3, and
+    // every profile takes the template default `token_ref: profile/token`. So
+    // removing one profile deleted the endpoint token the others are served by,
+    // and the deployed revision then refused every request with "No profile
+    // token in this target's credential store". The vault ref is read off the
+    // target and is identical for every profile there, which made the sibling's
+    // sealed items unrecoverable in the same command.
+    const sealed = target({ vault: { adapter: 'secret', ref: 'vault/document' } } as never);
+
+    expect(declaredRefs(config(), sealed, [config()])).toEqual([]);
+  });
+
+  test('with nobody staying, it is still the profile\'s to lose', () => {
+    // The last profile in a workspace: there is no survivor to share with, so
+    // the token and the vault go with it.
+    const sealed = target({ vault: { adapter: 'secret', ref: 'vault/document' } } as never);
+
+    expect(declaredRefs(config(), sealed, [])).toEqual(['profile/token', 'vault/document']);
+  });
+
+  test('a survivor with a different token ref does not protect this one', () => {
+    // Sharing is the reason to keep a ref, not the mere existence of a sibling.
+    const other = config({ auth: { mode: 'bearer', token_ref: 'other/token' } } as never);
+
+    expect(declaredRefs(config(), target(), [other])).toContain('profile/token');
+  });
 });
 
 // --- removalPlan -----------------------------------------------------------

--- a/src/cli/commands/profile/removal.test.ts
+++ b/src/cli/commands/profile/removal.test.ts
@@ -31,25 +31,47 @@ const target = (over: Partial<TargetConfig> = {}): TargetConfig =>
 
 const config = (over: Partial<Config> = {}): Config =>
   ({
-    contract: 2,
+    contract: 3,
     instance: { profile: 'personal' },
     auth: { mode: 'bearer', token_ref: 'profile/token' },
-    oauth_apps: {
-      google: { client_id_ref: 'google/client_id', client_secret_ref: 'google/client_secret' },
-    },
-    connections: [{ id: 'someone', provider: 'gmail', account: 'someone@example.com' }],
-    policy: { allow: [] },
+    grants: [{ connection: 'gmail.someone', allow: [], deny: [] }],
+    members: [],
     ...over,
   }) as unknown as Config;
 
 describe('declaredRefs', () => {
-  test('covers the profile token, the connection, and the oauth client', () => {
-    const refs = declaredRefs(config(), registry, target());
+  test("covers the profile's own token, and nothing an account owns", () => {
+    const refs = declaredRefs(config(), target());
 
     expect(refs).toContain('profile/token');
-    expect(refs).toContain('gmail/someone');
-    expect(refs).toContain('google/client_id');
-    expect(refs).toContain('google/client_secret');
+
+    // **Not the connection, and not the OAuth client.** Both belong to the
+    // workspace now (ADR-057), and every one of them may be granted by a profile
+    // that is staying — so removing a profile removes no account and no
+    // credential. `lanes link disconnect` is the command that does that, and it
+    // is the one that knows how to check whether anybody else still needs it.
+    expect(refs).not.toContain('gmail/someone');
+    expect(refs).not.toContain('google/client_id');
+  });
+
+  test('an oidc audience ref travels with the profile, because it is the profile\'s', () => {
+    const refs = declaredRefs(
+      config({
+        auth: {
+          mode: 'bearer',
+          token_ref: 'profile/token',
+          authorization: {
+            mode: 'oidc',
+            issuer: 'https://issuer.example',
+            client_id_ref: 'oidc/audience',
+            allowed_subjects: ['someone'],
+          },
+        },
+      } as never),
+      target(),
+    );
+
+    expect(refs).toContain('oidc/audience');
   });
 
   test('the vault ref comes from the target, because that is where it is declared', () => {
@@ -58,14 +80,14 @@ describe('declaredRefs', () => {
     // would attach one target's vault to another's removal.
     const sealed = target({ vault: { adapter: 'secret', ref: 'vault/document' } } as never);
 
-    expect(declaredRefs(config(), registry, sealed)).toContain('vault/document');
-    expect(declaredRefs(config(), registry, target())).not.toContain('vault/document');
+    expect(declaredRefs(config(), sealed)).toContain('vault/document');
+    expect(declaredRefs(config(), target())).not.toContain('vault/document');
   });
 
   test('a secret adapter with no ref falls back to the documented default', () => {
     const sealed = target({ vault: { adapter: 'secret' } } as never);
 
-    expect(declaredRefs(config(), registry, sealed)).toContain('vault/document');
+    expect(declaredRefs(config(), sealed)).toContain('vault/document');
   });
 
   test('a connection whose provider no longer resolves contributes nothing', () => {
@@ -75,37 +97,30 @@ describe('declaredRefs', () => {
       connections: [{ id: 'x', provider: 'no_such_provider', account: 'x' }],
     } as never);
 
-    const refs = declaredRefs(gone, registry, target());
+    const refs = declaredRefs(gone, target());
 
     expect(refs).not.toContain('no_such_provider/x');
     expect(refs).toContain('profile/token');
   });
 
-  test('an explicit credential_ref still counts when the manifest is gone', () => {
-    // `credentialRefFor` is the single authority: the manifest answers first,
-    // and the connection's own field is the answer when it gives none.
-    const explicit = config({
-      connections: [
-        { id: 'x', provider: 'no_such_provider', account: 'x', credential_ref: 'mything/api_key' },
+  test('the vault key is still the profile\'s to lose, and the connections are not', () => {
+    // The asymmetry is the whole of ADR-057 at this seam. A vault document is
+    // sealed per target and named by the target, so it goes with the removal;
+    // a connection's credential belongs to an account that outlives the
+    // profile, so it does not — whatever else the profile happened to say.
+    const withConnections = config({
+      grants: [
+        { connection: 'gmail.a', allow: [], deny: [] },
+        { connection: 'drive.b', allow: [], deny: [] },
       ],
     } as never);
 
-    expect(declaredRefs(explicit, registry, target())).toContain('mything/api_key');
-  });
+    const refs = declaredRefs(
+      withConnections,
+      target({ vault: { adapter: 'secret', ref: 'vault/document' } } as never),
+    );
 
-  test('returns each ref once, even when two connections share a client', () => {
-    const two = config({
-      connections: [
-        { id: 'a', provider: 'gmail', account: 'a@example.com' },
-        { id: 'b', provider: 'drive', account: 'b@example.com' },
-      ],
-    } as never);
-
-    const refs = declaredRefs(two, registry, target());
-
-    expect(refs.filter((ref) => ref === 'google/client_id')).toHaveLength(1);
-    expect(refs).toContain('gmail/a');
-    expect(refs).toContain('drive/b');
+    expect(refs).toEqual(['profile/token', 'vault/document']);
   });
 });
 
@@ -156,19 +171,26 @@ describe('removalPlan', () => {
     expect(ids(plan, 'config').filter((id) => !id.startsWith('profiles/'))).toHaveLength(1);
   });
 
-  test('deletes secrets before blobs, because the file store is itself a blob', async () => {
-    // `layout.credentials(p)` is `data/<p>/credentials.enc`, inside the blob
-    // root `data/<p>`. Delete blobs first and the store the secret deletions
-    // read through is gone.
+
+  test('plans no blob deletion at all, because a profile owns no bytes', async () => {
+    // The property that replaced six tests about a sweep. Under contract 2 the
+    // blob root *was* the profile's directory and `rm -r data/work` was the
+    // whole answer to "what could this profile reach". The root is the
+    // workspace's now (ADR-057, ADR-059), and the stores under it belong to
+    // connections other profiles may grant — so listing it here would queue
+    // every byte in the workspace for deletion because one profile is going.
     const plan = await removalPlan(config(), '/ws', 'personal', registry, {
       target: 'local',
       declared: target(),
       openSecrets: async () => fakeSecrets(['profile/token']),
-      openBlobs: async () => fakeBlobs(['credentials.enc']),
+      openBlobs: async () => fakeBlobs(['memory/main/note.md', 'skills.d/main/triage.md']),
     });
 
-    const kinds = plan.items.filter((i) => i.target === 'local').map((i) => i.kind);
-    expect(kinds.indexOf('secret')).toBeLessThan(kinds.indexOf('blob'));
+    expect(plan.items.filter((item) => item.kind === 'blob')).toEqual([]);
+    expect(plan.items.filter((item) => item.kind === 'file')).toEqual([]);
+    // The profile's own token still goes, and the profile file still goes.
+    expect(ids(plan, 'secret')).toContain('profile/token');
+    expect(plan.items.some((item) => item.kind === 'config')).toBe(true);
   });
 
   test('the local config is the last item, because it is the record of where things are', async () => {
@@ -222,93 +244,10 @@ describe('removalPlan', () => {
     expect(plan.warnings.join(' ')).toMatch(/keep answering|still answer/i);
   });
 
-  test('a credential store that cannot be opened warns, and the blobs still plan', async () => {
-    // There is no sibling target left to carry on with, so what this pins is the
-    // other half: one unreachable store does not abandon the rest of the plan.
-    const plan = await removalPlan(config(), '/ws', 'personal', registry, {
-      target: 'cloud',
-      declared: target(),
-      openSecrets: async () => {
-        throw new Error('no credentials for this project');
-      },
-      openBlobs: async () => fakeBlobs(['a']),
-    });
 
-    expect(plan.warnings.join(' ')).toMatch(/cloud/);
-    expect(plan.items.some((item) => item.kind === 'blob')).toBe(true);
-  });
 
-  test('skills and manifests go with the profile that owns them — ADR-030', async () => {
-    // They used to be workspace-wide, and this test used to assert the
-    // opposite: that removal never touched them, because every profile saw
-    // them. Now they are inside the profile's own blob root, so the sweep has
-    // them for the same reason it has state and the log.
-    const plan = await removalPlan(config(), '/ws', 'personal', registry, {
-      target: 'local',
-      declared: target(),
-      openSecrets: async () => fakeSecrets([]),
-      openBlobs: async () =>
-        fakeBlobs([
-          'state.kv/a',
-          'audit.log/b',
-          'skills.d/review-diff/SKILL.md',
-          'providers.d/acme.yaml',
-        ]),
-    });
 
-    const blobs = plan.items.filter((item) => item.kind === 'blob').map((item) => item.id);
-    expect(blobs).toContain('skills.d/review-diff/SKILL.md');
-    expect(blobs).toContain('providers.d/acme.yaml');
-  });
 
-  test('a declared storage path does not leave the authored areas behind', async () => {
-    // `layout.skills` and `layout.providers` are explicit areas, like state and
-    // the log — so a profile that points `storage.path` elsewhere moves its
-    // provider blobs and nothing else. The sweep walks the declared root, so
-    // without these two items the skills and manifests would survive a removal
-    // that reported success.
-    const plan = await removalPlan(config(), '/ws', 'personal', registry, {
-      target: 'local',
-      declared: target({ storage: { adapter: 'filesystem', path: './elsewhere' } }),
-      openSecrets: async () => fakeSecrets([]),
-      openBlobs: async () => fakeBlobs([]),
-    });
-
-    const files = plan.items.filter((item) => item.kind === 'file').map((item) => item.id);
-    expect(files).toContain('./elsewhere');
-    expect(files).toContain('data/personal/skills.d');
-    expect(files).toContain('data/personal/providers.d');
-  });
-
-  test('the ordinary layout names them once, not twice', async () => {
-    // Inside the blob root, the sweep already has them. A second `file` item
-    // for the same bytes would read as two things to delete in the preview the
-    // operator confirms.
-    const plan = await removalPlan(config(), '/ws', 'personal', registry, {
-      target: 'local',
-      declared: target(),
-      openSecrets: async () => fakeSecrets([]),
-      openBlobs: async () => fakeBlobs(['skills.d/review-diff/SKILL.md']),
-    });
-
-    const files = plan.items.filter((item) => item.kind === 'file').map((item) => item.id);
-    expect(files).toEqual(['data/personal']);
-  });
-
-  test('"./data/personal" is the same directory as "data/personal"', async () => {
-    // What `newProfileTemplate` actually writes, against what `layout` returns.
-    // Compared as strings these differ, and every default profile would have
-    // its skills and manifests named twice in the preview.
-    const plan = await removalPlan(config(), '/ws', 'personal', registry, {
-      target: 'local',
-      declared: target({ storage: { adapter: 'filesystem', path: './data/personal' } }),
-      openSecrets: async () => fakeSecrets([]),
-      openBlobs: async () => fakeBlobs([]),
-    });
-
-    const files = plan.items.filter((item) => item.kind === 'file').map((item) => item.id);
-    expect(files).toEqual(['./data/personal']);
-  });
 });
 
 // --- renderPlan ------------------------------------------------------------

--- a/src/cli/commands/profile/removal.ts
+++ b/src/cli/commands/profile/removal.ts
@@ -1,4 +1,4 @@
-import { layout, profilePath, workspacePath, type Config, type TargetConfig } from '#profile';
+import { layout, profilePath, vaultRef, workspacePath, type Config, type TargetConfig } from '#profile';
 import type { SecretStore } from '#secrets';
 import type { BlobStore } from '#stores/blobs';
 import { credentialRefFor, ownClientRefsFor, type ProviderRegistry } from '#registry';
@@ -53,8 +53,18 @@ export function declaredRefs(
   // `targetSchema`, so two targets may seal the same items in different places;
   // taking it from the profile would attach one target's vault to another
   // target's removal.
+  //
+  // **Through `vaultRef`, because the name carries the connection.** This said
+  // `vault/document`, the contract-2 constant, while `openVault` seals under
+  // `vault/<connection>` (ADR-059) — so removing a profile queued a ref nothing
+  // had ever written and left the real document behind. Under-deletion rather
+  // than over, since the survivor set was wrong the same way and they cancelled,
+  // but what stayed behind is sealed credential material belonging to a profile
+  // the operator asked to be gone. Per connection also makes the survivor check
+  // mean something: two profiles granting different vaults no longer look like
+  // one document to it.
   if (declared.vault?.adapter === 'secret') {
-    refs.add(declared.vault.ref ?? 'vault/document');
+    refs.add(vaultRef(declared, config));
   }
 
   // **No connection credentials.** They belong to the workspace now (ADR-057),
@@ -77,7 +87,7 @@ export function declaredRefs(
   const kept = new Set(
     survivors.flatMap((other) => [
       other.auth.token_ref,
-      ...(declared.vault?.adapter === 'secret' ? [declared.vault.ref ?? 'vault/document'] : []),
+      ...(declared.vault?.adapter === 'secret' ? [vaultRef(declared, other)] : []),
       ...(other.auth.authorization?.mode === 'oidc'
         ? [other.auth.authorization.client_id_ref]
         : []),
@@ -174,11 +184,12 @@ export async function removalPlan(
       );
     }
 
-    // Secrets first, and this ordering is load-bearing rather than tidy:
-    // `layout.credentials(p)` is `data/<p>/credentials.enc`, *inside* the blob
-    // root `data/<p>`. For the file adapter the credential store is itself a
-    // blob, so blobs-first would delete the store the secret deletions read
-    // through and turn every one of them into a failure.
+    // Secrets, and there is nothing left to order them against. This used to
+    // run before a blob sweep because `layout.credentials(p)` was
+    // `data/<p>/credentials.enc`, *inside* the blob root `data/<p>`, so
+    // blobs-first deleted the store the secret deletions read through. Both the
+    // sweep and the per-profile root are gone (ADR-057, ADR-059) — see the note
+    // below — and the credential store is the workspace's now.
     try {
       const secrets = await options.openSecrets(name);
       const present = await secrets.list();

--- a/src/cli/commands/profile/removal.ts
+++ b/src/cli/commands/profile/removal.ts
@@ -30,36 +30,29 @@ import { print, style, warn } from '../../output.ts';
  * reports those rather than guessing, which is the honest position: a guess
  * here is indistinguishable from another profile's credential.
  */
-export function declaredRefs(
-  config: Config,
-  registry: ProviderRegistry,
-  declared: TargetConfig,
-): string[] {
+export function declaredRefs(config: Config, declared: TargetConfig): string[] {
   const refs = new Set<string>([config.auth.token_ref]);
 
   // Read off the *target*, not the profile. `vaultTargetSchema` sits inside
-  // `targetSchema`, so two targets may seal the same profile's items in
-  // different places; taking it from the profile would attach one target's
-  // vault to another target's removal.
+  // `targetSchema`, so two targets may seal the same items in different places;
+  // taking it from the profile would attach one target's vault to another
+  // target's removal.
   if (declared.vault?.adapter === 'secret') {
     refs.add(declared.vault.ref ?? 'vault/document');
   }
 
-  for (const connection of config.connections) {
-    const manifest = registry.manifest(connection.provider);
-
-    // `credentialRefFor` rather than `credentialRefForConnection`: it is the
-    // single authority on where a connection's credential lives, and it exists
-    // because two callers once derived the answer differently and disagreed.
-    // Asking the lower-level one here would open that gap again from a third
-    // side — and it would miss a `local` provider, whose only ref is the one
-    // the connection declares itself.
-    const ref = credentialRefFor(connection, manifest);
-    if (ref) refs.add(ref);
-
-    if (manifest) {
-      for (const own of ownClientRefsFor(manifest, config.oauth_apps)) refs.add(own);
-    }
+  // **No connection credentials.** They belong to the workspace now (ADR-057),
+  // and every one of them may be granted by a profile that is staying. Removing
+  // a profile therefore removes no account and no credential — `lanes link
+  // disconnect` is the command that does that, and it is the one that knows how
+  // to check whether anybody else still needs the credential first.
+  //
+  // This is the sharpest edge in the whole decoupling, so `renderPlan` says it
+  // out loud rather than leaving an operator to infer it from a short list:
+  // "remove the work profile" used to mean "revoke what work could reach", and
+  // it does not any more.
+  if (config.auth.authorization?.mode === 'oidc') {
+    refs.add(config.auth.authorization.client_id_ref);
   }
 
   return [...refs];
@@ -152,7 +145,7 @@ export async function removalPlan(
     try {
       const secrets = await options.openSecrets(name);
       const present = await secrets.list();
-      const mine = new Set(declaredRefs(config, registry, declared));
+      const mine = new Set(declaredRefs(config, declared));
 
       for (const ref of present) if (mine.has(ref)) items.push({ target: name, kind: 'secret', id: ref });
 
@@ -164,54 +157,16 @@ export async function removalPlan(
       );
     }
 
-    try {
-      const blobs = await options.openBlobs(name);
-      for (const blob of await blobs.list()) items.push({ target: name, kind: 'blob', id: blob.key });
-    } catch (cause) {
-      warnings.push(
-        `Target "${name}": its storage could not be opened (${reason(cause)}), so nothing in it will be removed.`,
-      );
-    }
-
-    // The blob store's root is the profile's own directory, and an adapter must
-    // never delete the root it was configured with — so emptying it leaves the
-    // directory. `layout.ts` frames that directory as the unit ("rm -r
-    // data/work is exactly remove the work profile's data"), and one left
-    // behind is silently reused by a later `profile add` of the same name.
-    if (declared.storage.adapter === 'filesystem') {
-      const blobRoot = declared.storage.path ?? layout.blobs(profile);
-      items.push({
-        target: name,
-        kind: 'file',
-        id: blobRoot,
-        note: 'the profile directory, once emptied',
-      });
-
-      // Skills and manifests sit at fixed areas under `data/<profile>/`, the
-      // same way state and the log do — an explicit area, so a profile that
-      // declares its own `storage.path` moves its provider blobs and leaves
-      // these where `layout` says they are. The sweep above walks the blob root
-      // and would then walk straight past them, so they are named. Ordinary
-      // case: both are already inside `blobRoot` and the sweep has them, which
-      // is why this only fires when the two have been pointed apart.
-      //
-      // Resolved before comparing, because they are not compared as paths
-      // otherwise: `newProfileTemplate` writes `./data/<profile>` and
-      // `layout.blobs` returns `data/<profile>`, which is one directory spelled
-      // two ways — the same leading `./` that `profile/layout.ts` has a
-      // paragraph about. Comparing the strings names every default profile's
-      // skills twice in the preview an operator confirms.
-      if (workspacePath(root, blobRoot) !== workspacePath(root, layout.blobs(profile))) {
-        for (const area of [layout.skills(profile), layout.providers(profile)]) {
-          items.push({
-            target: name,
-            kind: 'file',
-            id: area,
-            note: 'outside the declared storage path, so not swept with it',
-          });
-        }
-      }
-    }
+    // **No blob sweep, and no profile directory.** Both existed because a
+    // profile owned `data/<profile>/`, and `rm -r` on it was exactly "what could
+    // this profile reach". It owns nothing now (ADR-057, ADR-059): the blob root
+    // is the workspace's, and the stores under it belong to connections other
+    // profiles may grant. Listing it here would queue every byte in the
+    // workspace for deletion because one profile is going.
+    //
+    // What replaces it is `lanes link disconnect`, which takes one connection,
+    // its grants, and its credential — after checking whether anything else
+    // still needs them. That check is the whole reason this cannot happen here.
 
     // A deployed revision reads its config from the bucket rather than the
     // image (ADR-023), so that copy is the profile too — and it is outside the

--- a/src/cli/commands/profile/removal.ts
+++ b/src/cli/commands/profile/removal.ts
@@ -30,7 +30,23 @@ import { print, style, warn } from '../../output.ts';
  * reports those rather than guessing, which is the honest position: a guess
  * here is indistinguishable from another profile's credential.
  */
-export function declaredRefs(config: Config, declared: TargetConfig): string[] {
+export function declaredRefs(
+  config: Config,
+  declared: TargetConfig,
+  /**
+   * What the profiles that are staying declare.
+   *
+   * Nothing in here is deleted, however plainly the profile being removed also
+   * declares it. The credential store is one file per *workspace* since
+   * contract 3, and every profile takes the template default
+   * `token_ref: profile/token` — so removing one profile deleted the endpoint
+   * token the others are served by, and the deployed revision then refused every
+   * request with "No profile token in this target's credential store". The vault
+   * ref is read off the target and is identical for every profile there, which
+   * made the sibling's sealed items unrecoverable in the same command.
+   */
+  survivors: readonly Config[] = [],
+): string[] {
   const refs = new Set<string>([config.auth.token_ref]);
 
   // Read off the *target*, not the profile. `vaultTargetSchema` sits inside
@@ -55,7 +71,20 @@ export function declaredRefs(config: Config, declared: TargetConfig): string[] {
     refs.add(config.auth.authorization.client_id_ref);
   }
 
-  return [...refs];
+  // Shared with a profile that is staying, so not ours to delete. Computed the
+  // same way for the survivors as for this one, because "what does a profile
+  // declare" has to have one answer.
+  const kept = new Set(
+    survivors.flatMap((other) => [
+      other.auth.token_ref,
+      ...(declared.vault?.adapter === 'secret' ? [declared.vault.ref ?? 'vault/document'] : []),
+      ...(other.auth.authorization?.mode === 'oidc'
+        ? [other.auth.authorization.client_id_ref]
+        : []),
+    ]),
+  );
+
+  return [...refs].filter((ref) => !kept.has(ref));
 }
 
 export interface RemovalItem {
@@ -89,6 +118,14 @@ export interface PlanOptions {
   readonly openSecrets: (target: string) => Promise<SecretStore>;
   readonly openBlobs: (target: string, area?: string) => Promise<BlobStore>;
   readonly readDefaultProfile?: (() => Promise<string | undefined>) | undefined;
+  /**
+   * The profiles that are staying.
+   *
+   * So a credential both this one and a survivor declares is left alone — see
+   * `declaredRefs`. Defaulted to empty, which is the single-profile workspace
+   * and the shape every existing caller had.
+   */
+  readonly survivors?: readonly Config[] | undefined;
 }
 
 const reason = (cause: unknown): string => (cause instanceof Error ? cause.message : String(cause));
@@ -145,7 +182,7 @@ export async function removalPlan(
     try {
       const secrets = await options.openSecrets(name);
       const present = await secrets.list();
-      const mine = new Set(declaredRefs(config, declared));
+      const mine = new Set(declaredRefs(config, declared, options.survivors ?? []));
 
       for (const ref of present) if (mine.has(ref)) items.push({ target: name, kind: 'secret', id: ref });
 

--- a/src/cli/commands/profile/remove.ts
+++ b/src/cli/commands/profile/remove.ts
@@ -21,6 +21,7 @@ import {
   resolveProfileOnly,
   type GlobalFlags,
 } from '../../runtime.ts';
+import { loadWorkspaceProfiles } from '#profile';
 import { removalPlan, renderPlan, type RemovalItem, type RemovalPlan } from './removal.ts';
 
 /**
@@ -265,6 +266,11 @@ export async function removeProfile(name: string, flags: RemoveFlags): Promise<v
     openSecrets: (target) => openSecretStoreFor(config, root, target),
     openBlobs: (target, area) => openBlobStoreFor(config, root, target, area),
     readDefaultProfile: async () => (await readWorkspace(root))?.default_profile,
+    // What the workspace keeps. The credential store is one file for all of
+    // them now, so anything a survivor declares is not this removal's to delete.
+    survivors: (await loadWorkspaceProfiles(root)).loaded
+      .filter((one) => one.profile !== name)
+      .map((one) => one.config),
   });
 
   renderPlan(plan);

--- a/src/cli/commands/profile/remove.ts
+++ b/src/cli/commands/profile/remove.ts
@@ -255,7 +255,7 @@ export async function removeProfile(name: string, flags: RemoveFlags): Promise<v
   announceProfile(selection);
 
   const root = selection.workspaceRoot;
-  const registry = await buildRegistryWithWorkspace(root, name);
+  const registry = await buildRegistryWithWorkspace(root);
   const files = workspaceFiles(root);
   const { declared } = await openTarget(root, target);
 

--- a/src/cli/commands/profile/remove.ts
+++ b/src/cli/commands/profile/remove.ts
@@ -13,6 +13,7 @@ import {
 import { parseDocument } from 'yaml';
 import { rm } from 'node:fs/promises';
 import { terminalPrompter, type Prompter } from '../../prompt.ts';
+import { recordConfigChange } from '../../audit-change.ts';
 import { announceProfile, emit, fail, ok, print, style } from '../../output.ts';
 import {
   buildRegistryWithWorkspace,
@@ -290,6 +291,14 @@ export async function removeProfile(name: string, flags: RemoveFlags): Promise<v
     removeDirectory: async (path) => await rm(workspacePath(root, path), { recursive: true, force: true }),
     clearDefaultProfile: async () => await clearDefault(root),
     retry: retryCommand,
+  });
+
+  // Before the render, and against the config loaded above — the profile's file
+  // is gone by now, so a helper that re-read it would find nothing.
+  await recordConfigChange(config, root, target, {
+    capability: 'config.profile.remove',
+    scope: name,
+    arguments: { connections: config.grants.map((grant) => grant.connection) },
   });
 
   return emit(flags.json, outcome, () => renderOutcome(outcome));

--- a/src/cli/commands/relabel.ts
+++ b/src/cli/commands/relabel.ts
@@ -1,0 +1,104 @@
+import { CONNECTIONS_FILE, readConnections, type Resolution } from '#profile';
+import { ConfigDocument } from '../config-edit.ts';
+import { announce, emit, ok, print, style } from '../output.ts';
+import { openRuntime, type GlobalFlags } from '../runtime.ts';
+import { nextAfterEdit, publishProfileEdit } from '../publish.ts';
+import { locate } from './connection.ts';
+
+/**
+ * `lanes link relabel` — the operator's own word for an account.
+ *
+ * Split from `disconnect` so `connection.ts` stays inside the size budget, and
+ * on a real seam rather than a line count: `disconnect` reaches two files, every
+ * profile that granted the row, and the credential store, while this writes one
+ * field in one document.
+ *
+ * The label is a separate field from `account` for the reason the bug below
+ * gives, and the two must not be merged back.
+ */
+
+export interface Relabelled {
+  readonly profile: string;
+  readonly target: string;
+  readonly key: string;
+  readonly from: string;
+  readonly to: string;
+  readonly published: string;
+}
+
+export interface RelabelFlags extends GlobalFlags {
+  readonly json?: boolean | undefined;
+}
+
+/**
+ * Rename a connection, writing `label` and never `account`.
+ *
+ * It wrote `account` until it was noticed that `account` is not a display name:
+ * `settleIdentity` matches on it to tell a repair from a new account,
+ * `idFromAccount` derives the id from it, and `gmail.send_message` writes it
+ * into a `From` header. Renaming through it therefore un-recognised the account
+ * it renamed — the next `connect` added a second row beside it.
+ */
+export async function renameConnection(
+  key: string,
+  label: string,
+  flags: RelabelFlags,
+): Promise<{ resolution: Resolution; relabelled: Relabelled }> {
+  const runtime = await openRuntime(flags);
+
+  try {
+    const { resolution, config, target } = runtime;
+    const root = resolution.workspaceRoot;
+
+    // The workspace's file, not the profile's. A label is the operator's own
+    // word for an account (ADR-057 moved the row that carries it), so renaming
+    // it once renames it everywhere — which is what someone renaming "the work
+    // mailbox" means, and what two copies could never keep true.
+    const connectionsFile = await readConnections(root);
+    const located = locate(connectionsFile.connections, key, target);
+
+    const document = await ConfigDocument.openKey(root, CONNECTIONS_FILE);
+    document.setIn(['connections', located.index, 'label'], label);
+    await document.save();
+
+    return {
+      resolution,
+      relabelled: {
+        profile: resolution.profile,
+        target,
+        key,
+        // What it was called a moment ago, which is the account only until the
+        // first rename.
+        from: located.connection.label ?? located.connection.account,
+        to: label,
+        published: nextAfterEdit(await publishProfileEdit({ resolution, config, target })),
+      },
+    };
+  } finally {
+    await runtime.close();
+  }
+}
+
+export async function relabel(
+  key: string | undefined,
+  label: string | undefined,
+  flags: RelabelFlags,
+): Promise<void> {
+  if (!key) throw new Error('Which connection? Run: lanes link status');
+  if (!label) throw new Error(`What should ${key} be called? Run: lanes link relabel ${key} "New name"`);
+
+  const { resolution, relabelled: result } = await renameConnection(key, label, flags);
+
+  return emit(flags.json, result, () => {
+    announce(resolution);
+    print(ok(`${style.bold(result.key)} is now ${style.bold(result.to)}`));
+    if (result.from) print(`      was     ${style.dim(result.from)}`);
+    // The label is a display name in two places, and only one of them changed.
+    print(
+      style.dim(
+        '      The state store keeps the old name until the next reconcile, which updates it.',
+      ),
+    );
+    if (result.published) print(style.dim(`      ${result.published}`));
+  })
+}

--- a/src/cli/commands/relabel.ts
+++ b/src/cli/commands/relabel.ts
@@ -1,7 +1,7 @@
 import { CONNECTIONS_FILE, readConnections, type Resolution } from '#profile';
 import { ConfigDocument } from '../config-edit.ts';
-import { announce, emit, ok, print, style } from '../output.ts';
-import { openRuntime, type GlobalFlags } from '../runtime.ts';
+import { announce, announceWorkspace, emit, ok, print, style } from '../output.ts';
+import { openWorkspaceRuntime, type GlobalFlags } from '../runtime.ts';
 import { nextAfterEdit, publishProfileEdit } from '../publish.ts';
 import { locate } from './connection.ts';
 
@@ -44,7 +44,7 @@ export async function renameConnection(
   label: string,
   flags: RelabelFlags,
 ): Promise<{ resolution: Resolution; relabelled: Relabelled }> {
-  const runtime = await openRuntime(flags);
+  const runtime = await openWorkspaceRuntime(flags);
 
   try {
     const { resolution, config, target } = runtime;
@@ -90,7 +90,7 @@ export async function relabel(
   const { resolution, relabelled: result } = await renameConnection(key, label, flags);
 
   return emit(flags.json, result, () => {
-    announce(resolution);
+    announceWorkspace(resolution);
     print(ok(`${style.bold(result.key)} is now ${style.bold(result.to)}`));
     if (result.from) print(`      was     ${style.dim(result.from)}`);
     // The label is a display name in two places, and only one of them changed.

--- a/src/cli/commands/relabel.ts
+++ b/src/cli/commands/relabel.ts
@@ -1,6 +1,7 @@
 import { CONNECTIONS_FILE, readConnections, type Resolution } from '#profile';
 import { ConfigDocument } from '../config-edit.ts';
 import { announce, announceWorkspace, emit, ok, print, style } from '../output.ts';
+import { recordConfigChange } from '../audit-change.ts';
 import { openWorkspaceRuntime, type GlobalFlags } from '../runtime.ts';
 import { nextAfterEdit, publishProfileEdit } from '../publish.ts';
 import { locate } from './connection.ts';
@@ -60,6 +61,13 @@ export async function renameConnection(
     const document = await ConfigDocument.openKey(root, CONNECTIONS_FILE);
     document.setIn(['connections', located.index, 'label'], label);
     await document.save();
+
+    await recordConfigChange(config, root, target, {
+      capability: 'config.connection.relabel',
+      scope: target,
+      connection: key,
+      arguments: { from: located.connection.label ?? located.connection.account, to: label },
+    });
 
     return {
       resolution,

--- a/src/cli/commands/secrets.ts
+++ b/src/cli/commands/secrets.ts
@@ -1,7 +1,13 @@
 import { ConfigError } from '#profile';
 import { assertValidSecretRef } from '#secrets';
-import { announce, announceProfile, heading, ok, print, style } from '../output.ts';
-import { openSecretStoreFor, resolveProfile, resolveProfileOnly, type GlobalFlags } from '../runtime.ts';
+import { announceWorkspace, announceProfile, heading, ok, print, style } from '../output.ts';
+import {
+  openSecretStoreFor,
+  primaryProfile,
+  resolveProfile,
+  resolveProfileOnly,
+  type GlobalFlags,
+} from '../runtime.ts';
 
 /**
  * `lanes link secrets` — moving credential values between a profile's targets.
@@ -43,7 +49,7 @@ export async function secretsPush(flags: SecretsFlags): Promise<void> {
 
   const refs = await source.list();
   if (refs.length === 0) {
-    print(style.dim(`No credentials in target "${flags.from}".`));
+    print(style.dim(`No credentials in workspace "${flags.from}".`));
     return;
   }
 
@@ -119,8 +125,16 @@ export async function secretsSet(ref: string | undefined, flags: GlobalFlags): P
     );
   }
 
-  const { resolution, config, target } = await resolveProfile(flags);
-  announce(resolution);
+  // The credential store belongs to the workspace since contract 3, so every
+  // profile opened the same one and naming one chose nothing. A profile is
+  // still resolved, because `openSecretStoreFor` reads the adapter set through
+  // one — so the banner names the workspace rather than reporting whichever
+  // profile happened to supply it.
+  const { resolution, config, target } = await resolveProfile({
+    ...flags,
+    profile: await primaryProfile(flags),
+  });
+  announceWorkspace(resolution);
 
   const value = (await Bun.stdin.text()).replace(/\n$/, '');
   if (!value) {
@@ -133,20 +147,28 @@ export async function secretsSet(ref: string | undefined, flags: GlobalFlags): P
   const replacing = await credentials.has(ref);
   await credentials.set(ref, value);
 
-  print(ok(`${replacing ? 'replaced' : 'stored'} ${style.bold(ref)} in target ${target}`));
+  print(ok(`${replacing ? 'replaced' : 'stored'} ${style.bold(ref)} in workspace ${target}`));
   if (replacing) {
     print(style.dim('  Anything still using the old value will start failing.'));
   }
 }
 
 export async function secretsList(flags: GlobalFlags): Promise<void> {
-  const { resolution, config, target } = await resolveProfile(flags);
-  announce(resolution);
+  // The credential store belongs to the workspace since contract 3, so every
+  // profile opened the same one and naming one chose nothing. A profile is
+  // still resolved, because `openSecretStoreFor` reads the adapter set through
+  // one — so the banner names the workspace rather than reporting whichever
+  // profile happened to supply it.
+  const { resolution, config, target } = await resolveProfile({
+    ...flags,
+    profile: await primaryProfile(flags),
+  });
+  announceWorkspace(resolution);
 
   const credentials = await openSecretStoreFor(config, resolution.workspaceRoot, target);
   const refs = await credentials.list();
 
-  heading(`Credential references in target ${target} (${refs.length})`);
+  heading(`Credential references in workspace ${target} (${refs.length})`);
   if (refs.length === 0) {
     print(style.dim('  none'));
   } else {

--- a/src/cli/commands/secrets.ts
+++ b/src/cli/commands/secrets.ts
@@ -7,8 +7,8 @@ import { openSecretStoreFor, resolveProfile, resolveProfileOnly, type GlobalFlag
  * `lanes link secrets` — moving credential values between a profile's targets.
  *
  * Credentials follow the target, because each target has its own credential
- * store: `lanes link connect gmail.side --target cloud` writes the refresh token into
- * Secret Manager, and the same command with `--target local` writes it into
+ * store: `lanes link connect gmail.side --workspace cloud` writes the refresh token into
+ * Secret Manager, and the same command with `--workspace local` writes it into
  * the encrypted file. That is the right default and it leaves one gap, which
  * this command fills — a setup built locally first, and now wanted in the
  * cloud, without re-running every OAuth flow.
@@ -104,7 +104,7 @@ export async function secretsSet(ref: string | undefined, flags: GlobalFlags): P
   if (!ref) {
     throw new ConfigError(
       'Usage: lanes link secrets set <ref>   (the value is read from stdin)\n' +
-        '  e.g. printf %s "$DATABASE_URL" | lanes link secrets set cloud/database_url --target cloud',
+        '  e.g. printf %s "$DATABASE_URL" | lanes link secrets set cloud/database_url --workspace cloud',
     );
   }
   assertValidSecretRef(ref);

--- a/src/cli/commands/set-workspace.ts
+++ b/src/cli/commands/set-workspace.ts
@@ -1,0 +1,96 @@
+import {
+  ConfigError,
+  WORKSPACE_FILE,
+  readRegistry,
+  readWorkspace,
+  resolveWorkspaceRoot,
+} from '#profile';
+import { ConfigDocument } from '../config-edit.ts';
+import { ok, print, style } from '../output.ts';
+
+/**
+ * `lanes set-workspace <name>` — which workspace a command means when it does
+ * not say.
+ *
+ * ADR-037 deleted the command this replaces, and its reasoning is the thing to
+ * read before changing anything here:
+ *
+ * > Persisted context state is the standard way operators run destructive
+ * > commands against the wrong target, and the version of it that bites is the
+ * > dotfile nothing prints.
+ *
+ * Both halves of that sentence are answered rather than argued with (ADR-061).
+ * The default is **printed on every command that uses it**, so it is not the
+ * dotfile nothing prints; and it is **refused by every command that publishes or
+ * destroys**, so it is not what runs a destructive command against the wrong
+ * thing. Take either half away and the objection stands again.
+ *
+ * Top level rather than under `lanes link`, because it selects the workspace
+ * *the CLI* acts in and a second area added to `lanes` will want the same
+ * answer.
+ */
+
+export interface SetWorkspaceResult {
+  readonly workspace: string;
+  readonly previous: string | null;
+  readonly path: string;
+}
+
+export async function setWorkspace(
+  name: string | undefined,
+  options: { json?: boolean } = {},
+): Promise<void> {
+  const root = resolveWorkspaceRoot();
+
+  if (name === undefined) {
+    const current = (await readWorkspace(root))?.default_workspace;
+    throw new ConfigError(
+      `Usage: lanes set-workspace <name>\n` +
+        (current ? `  The default is currently "${current}".\n` : '  No default is set.\n') +
+        `  Run "lanes link workspace list" to see what there is.`,
+    );
+  }
+
+  // Checked against the registry, not accepted on trust. A default naming a
+  // workspace that does not exist would turn every later command's refusal into
+  // one about the wrong thing — and the operator would have been told "ok" by
+  // the command that caused it.
+  const registry = await readRegistry(root);
+  if (!(name in registry)) {
+    const names = Object.keys(registry).sort();
+    throw new ConfigError(
+      `${root} declares no workspace "${name}".\n` +
+        (names.length > 0
+          ? `  It has: ${names.join(', ')}\n`
+          : '  It has none yet. Create one with: lanes link profile add <name> --workspace local\n') +
+        `  Run "lanes link workspace list" to see them.`,
+    );
+  }
+
+  const document = await ConfigDocument.openKey(root, WORKSPACE_FILE);
+  const previous = document.getIn(['default_workspace']);
+  document.setIn(['default_workspace'], name);
+  await document.save();
+
+  const result: SetWorkspaceResult = {
+    workspace: name,
+    previous: typeof previous === 'string' ? previous : null,
+    path: `${root}/${WORKSPACE_FILE}`,
+  };
+
+  if (options.json === true) {
+    print(JSON.stringify(result, null, 2));
+    return;
+  }
+
+  print(ok(`default workspace: ${style.bold(name)}`));
+  print(style.dim(`      ${result.path}`));
+  print('');
+  print(
+    style.dim(
+      '      Every command that uses it prints it. Commands that publish or destroy —\n' +
+        '      deploy, sync, secrets push, profile remove, disconnect, token rotate —\n' +
+        '      still want --workspace typed out.',
+    ),
+  );
+}

--- a/src/cli/commands/setup.ts
+++ b/src/cli/commands/setup.ts
@@ -25,11 +25,11 @@ export async function setupPlan(provider: string | undefined, flags: SetupFlags)
     const context = {
       profile: runtime.resolution.profile,
       target: runtime.resolution.target,
-      connections: runtime.config.connections.map((c) => `${c.provider}.${c.id}`),
+      connections: runtime.connections.map(({ ref }) => ref),
       // Declaring an `oauth_apps` entry is how a profile says "use my own
       // client". Without this the plan would tell someone who has already
       // registered one that they need nothing.
-      ownClients: Object.keys(runtime.config.oauth_apps),
+      ownClients: runtime.ownClients,
     };
 
     const manifests = runtime.registry.list().map((entry) => entry.manifest);

--- a/src/cli/commands/sync.ts
+++ b/src/cli/commands/sync.ts
@@ -64,7 +64,7 @@ async function locateRemote(
   }
 
   const entry = (await readRegistry(root))[target];
-  if (entry?.workspace) return { workspace: entry.workspace, how: 'already recorded' };
+  if (entry?.at) return { workspace: entry.at, how: 'already recorded' };
 
   if (flags.discover !== true) {
     throw new ConfigError(
@@ -72,7 +72,7 @@ async function locateRemote(
         '  No pointer to it in lanes-link.yaml, and nothing else records one.\n\n' +
         '  If you know the bucket:  lanes link sync targets --target ' +
         `${target} --from gs://<bucket>\n` +
-        `  If you do not:           lanes link sync targets --target ${target} --discover`,
+        `  If you do not:           lanes link sync targets --workspace ${target} --discover`,
     );
   }
 
@@ -99,7 +99,7 @@ async function locateRemote(
   if (candidates.length > 1 || !isInteractive()) {
     throw new ConfigError(
       `Found ${candidates.length} deployment(s). Name the one you mean:\n` +
-        `  lanes link sync targets --target ${target} --from ${first.workspace}`,
+        `  lanes link sync targets --workspace ${target} --from ${first.workspace}`,
     );
   }
 
@@ -132,7 +132,7 @@ export async function syncTargets(flags: SyncFlags): Promise<void> {
   const remoteRegistry = await readRegistry(workspace);
   const declaresIt = remoteRegistry[target] !== undefined;
   const existing = (await readRegistry(root))[target];
-  const already = existing?.workspace === workspace;
+  const already = existing?.at === workspace;
 
   const payload = { workspace: root, remote: workspace, target, how, declaresIt, applied: false };
 
@@ -163,7 +163,7 @@ export async function syncTargets(flags: SyncFlags): Promise<void> {
     }
 
     heading('Would write');
-    print(`  targets.${target}.workspace: ${workspace}`);
+    print(`  workspaces.${target}.at: ${workspace}`);
     print(style.dim('  The bucket keeps everything else; this records where it is.'));
   };
 
@@ -184,11 +184,11 @@ export async function syncTargets(flags: SyncFlags): Promise<void> {
   // deploy block, whose token opens it — is declared where it lives, and reading
   // it from there is what makes this safe to run on a workspace that has lost
   // its own copy of anything.
-  await recordTarget(root, target, { workspace });
+  await recordTarget(root, target, { at: workspace });
 
   print('');
   print(ok(`"${target}" now points at ${workspace}`));
-  print(style.dim(`  lanes link status --target ${target}   reads it from there`));
+  print(style.dim(`  lanes link status --workspace ${target}   reads it from there`));
 
   return emit(flags.json, { ...payload, applied: true }, () => {});
 }

--- a/src/cli/commands/sync.ts
+++ b/src/cli/commands/sync.ts
@@ -70,7 +70,7 @@ async function locateRemote(
     throw new ConfigError(
       `Nothing here says where "${target}" lives.\n` +
         '  No pointer to it in lanes-link.yaml, and nothing else records one.\n\n' +
-        '  If you know the bucket:  lanes link sync targets --target ' +
+        '  If you know the bucket:  lanes link sync workspaces --workspace ' +
         `${target} --from gs://<bucket>\n` +
         `  If you do not:           lanes link sync targets --workspace ${target} --discover`,
     );

--- a/src/cli/commands/target.test.ts
+++ b/src/cli/commands/target.test.ts
@@ -18,7 +18,7 @@ const roots: string[] = [];
 const previousHome = process.env['LANES_LINK_HOME'];
 const previousTarget = process.env['LANES_LINK_TARGET'];
 
-const PROFILE = `contract: 2
+const PROFILE = `contract: 3
 
 instance:
   profile: personal
@@ -34,10 +34,10 @@ instance:
  * once per profile (ADR-052). `cloud` deploys and `staging` does not, which is
  * the distinction the listing below is about.
  */
-const TARGETS = `contract: 2
+const TARGETS = `contract: 3
 default_profile: personal
 
-targets:
+workspaces:
   local:
     credentials: { adapter: file }
     storage: { adapter: filesystem }
@@ -161,7 +161,7 @@ describe('what a profile declares', () => {
     for (const target of listing.targets) expect('url' in target).toBe(false);
   });
 
-  test('nothing is selected until --target names one', async () => {
+  test('nothing is selected until --workspace names one', async () => {
     // This is the command you run to find out what to pass, so it is the one
     // command that does not require the answer as input. Requiring it would be
     // circular.
@@ -171,7 +171,7 @@ describe('what a profile declares', () => {
     expect(listing.targets.every((target) => !target.isSelected)).toBe(true);
   });
 
-  test('--target marks the one it names', async () => {
+  test('--workspace marks the one it names', async () => {
     const { env } = await workspace();
 
     const listing = await readTargets({ profile: 'personal', target: 'cloud' }, { env });
@@ -205,11 +205,11 @@ describe('a pointer, which is what a deployed target looks like from here', () =
     const { root, env } = await workspace();
     await writeFile(
       join(root, 'lanes-link.yaml'),
-      `contract: 2
+      `contract: 3
 
-targets:
+workspaces:
   cloud:
-    workspace: gs://your-bucket
+    at: gs://your-bucket
     primary: personal
     last_deploy: "2026-08-28T09:00:00.000Z"
     last_deploy_version: "0.6.6"
@@ -229,8 +229,8 @@ targets:
  *
  * `openTarget` merges the local pointer over the remote declaration — so a
  * redeploy from a second machine does not lose the first one's record of who
- * opens the endpoint — and the merged entry therefore carries `workspace:`
- * beside the adapters. `isPointer` answers yes to anything with a `workspace:`.
+ * opens the endpoint — and the merged entry therefore carries `at:`
+ * beside the adapters. `isPointer` answers yes to anything with an `at:`.
  * The result was that `target show cloud` reported no adapters, no deployment,
  * and "this target runs wherever the CLI does" about a target with a live Cloud
  * Run service in front of it, and the deploy record it is now asked to print
@@ -255,7 +255,7 @@ describe('showing a target this workspace only points at', () => {
     workspaceRoot: 'gs://your-bucket',
     declared,
     entry: {
-      workspace: 'gs://your-bucket',
+      at: 'gs://your-bucket',
       ...declared,
       primary: 'personal',
       last_deploy: '2026-08-28T09:00:00.000Z',
@@ -267,7 +267,7 @@ describe('showing a target this workspace only points at', () => {
   test('the adapters and the deployment come through, rather than reading as a pointer', () => {
     const entry = resolvedEntry(resolved);
 
-    expect(entry.workspace).toBeUndefined();
+    expect(entry.at).toBeUndefined();
     expect(entry.storage?.bucket).toBe('your-bucket');
     expect(entry.deploy?.service).toBe('my-service');
   });
@@ -278,7 +278,7 @@ describe('showing a target this workspace only points at', () => {
   });
 });
 
-describe('when --target names a target that does not exist', () => {
+describe('when --workspace names a target that does not exist', () => {
   test('the listing survives and says so', async () => {
     // The state in which every other command is refusing, and this is the
     // command someone runs to find out why — so it must not fail the same way.
@@ -331,6 +331,6 @@ describe('target use, after it was removed', () => {
     // months, so it says what happened instead.
     expect(() => targetUse('cloud')).toThrow('was removed');
     expect(() => targetUse('cloud')).toThrow('instance.default_target');
-    expect(() => targetUse('cloud')).toThrow('--target cloud');
+    expect(() => targetUse('cloud')).toThrow('--workspace cloud');
   });
 });

--- a/src/cli/commands/target.ts
+++ b/src/cli/commands/target.ts
@@ -261,7 +261,7 @@ export async function targetList(flags: TargetFlags): Promise<void> {
     // as input would be circular, and it has to keep working in the state every
     // other command fails in — which is what `selectedDeclared` reports.
     if (listing.selected === null) {
-      print(style.dim('  Every other command names one of these with --target.'));
+      print(style.dim('  Every other command names one of these with --workspace.'));
       return;
     }
 

--- a/src/cli/commands/target.ts
+++ b/src/cli/commands/target.ts
@@ -158,7 +158,7 @@ function summarise(name: string, entry: WorkspaceTarget, isSelected: boolean): T
     return {
       name,
       isSelected,
-      pointsAt: entry.workspace,
+      pointsAt: entry.at,
       credentials: null,
       storage: null,
       vault: null,
@@ -200,7 +200,7 @@ function summarise(name: string, entry: WorkspaceTarget, isSelected: boolean): T
  * line above, from the same object.
  */
 export function resolvedEntry(resolved: ResolvedTarget): WorkspaceTarget {
-  const { workspace: _followed, ...record } = resolved.entry;
+  const { at: _followed, ...record } = resolved.entry;
   return { ...resolved.declared, ...record };
 }
 
@@ -299,10 +299,12 @@ function deploymentCell(target: TargetSummary): string {
  */
 export function targetUse(name: string | undefined): never {
   throw new ConfigError(
-    'lanes link target use was removed.\n' +
-      '  Nothing reads instance.default_target any more — pass --target on every\n' +
-      '  command instead:\n' +
-      `    lanes link status --profile <name> --target ${name ?? '<target>'}\n` +
+    'lanes link workspace use was removed, and came back under a new name.\n' +
+      '  `instance.default_target` is still inert — nothing reads it. What does\n' +
+      '  read a default is `default_workspace` in lanes-link.yaml (ADR-061):\n' +
+      `    lanes set-workspace ${name ?? '<name>'}\n` +
+      '  Or name it per command:\n' +
+      `    lanes link status --profile <name> --workspace ${name ?? '<name>'}\n` +
       '  If the key is still in your profile it is inert, and safe to delete.',
   );
 }

--- a/src/cli/commands/update.ts
+++ b/src/cli/commands/update.ts
@@ -2,8 +2,8 @@ import { homedir } from 'node:os';
 import { join, sep } from 'node:path';
 import { installRoot, resolveWorkspaceRoot } from '#profile';
 import { repairOwnerLayer } from '../config-repair.ts';
-import { migrateWorkspace, needsMigration } from '../workspace-migrate.ts';
-import { migrateToContract3, needsContract3 } from '../contract3.ts';
+import { migrateToCurrentContract, type ContractMigration } from '../workspace-migrate.ts';
+import type { Contract3Migration } from '../contract3.ts';
 import { emit, fail, ok, print, printErr, progress, style, warn } from '../output.ts';
 import { PACKAGE, release, type ReleaseState } from '../release.ts';
 import { version } from '../version.ts';
@@ -315,20 +315,7 @@ async function runInstall(argv: readonly string[], json: boolean): Promise<boole
  * fifteen accounts were merged into one store should see that happen rather than
  * discover it from a directory listing.
  */
-async function migrateContract3(root: string, say: (line: string) => void): Promise<void> {
-  if (!(await needsContract3(root))) return;
-
-  // The same subject `profile add` writes, for the same reason: a migrated
-  // profile that lists nobody is an endpoint that advertises OAuth and refuses
-  // its own owner. Absent when nobody has signed in yet, which the migration
-  // reports rather than guessing at.
-  const session = await readSession();
-  const migration = await migrateToContract3(root, {
-    apply: true,
-    ...(session ? { subject: session.subject } : {}),
-  });
-  if (migration.alreadyCurrent) return;
-
+function sayContract3(migration: Contract3Migration, say: (line: string) => void): void {
   say(
     `migrated ${migration.profiles.length} profile(s) to contract 3 — connections belong to the ` +
       'workspace now, and a profile grants them one by one',
@@ -345,24 +332,31 @@ async function migrateContract3(root: string, say: (line: string) => void): Prom
 
 async function migrateLocal(root: string, say: (line: string) => void): Promise<void> {
   try {
-    // Contract 1 first, then contract 2, in that order. A workspace that
-    // predates both walks through them rather than jumping, so each step's
-    // reasoning applies to the shape it was written for — and a contract-1
-    // workspace reaches contract 3 in one run rather than needing two.
-    await migrateLegacyTargets(root, say);
-    await migrateContract3(root, say);
+    // One call, both steps, in order — a workspace that predates both walks
+    // through them rather than jumping, so each step's reasoning applies to the
+    // shape it was written for. `update` used to spell that walk itself, which
+    // is how `deploy` and `doctor --fix` came to spell only half of it.
+    //
+    // The subject is passed rather than left to be defaulted because this is
+    // the one caller that already had it in hand.
+    const session = await readSession();
+    const migration = await migrateToCurrentContract(root, {
+      apply: true,
+      ...(session ? { subject: session.subject } : {}),
+    });
+
+    if (migration.legacy) sayLegacyTargets(migration.legacy, say);
+    if (migration.contract3) sayContract3(migration.contract3, say);
   } catch (error) {
     say(`could not migrate this workspace: ${error instanceof Error ? error.message : String(error)}`);
   }
 }
 
 /** Contract 1 to contract 2: targets move from the profile to the workspace. */
-async function migrateLegacyTargets(root: string, say: (line: string) => void): Promise<void> {
-  if (!(await needsMigration(root))) return;
-
-  const migration = await migrateWorkspace(root);
-  if (migration.alreadyCurrent) return;
-
+function sayLegacyTargets(
+  migration: NonNullable<ContractMigration['legacy']>,
+  say: (line: string) => void,
+): void {
   say(
     `migrated ${migration.profiles.length} profile(s) to contract 2 — a target is declared by ` +
       'the workspace now, not by each profile',

--- a/src/cli/commands/update.ts
+++ b/src/cli/commands/update.ts
@@ -7,6 +7,7 @@ import { migrateToContract3, needsContract3 } from '../contract3.ts';
 import { emit, fail, ok, print, printErr, progress, style, warn } from '../output.ts';
 import { PACKAGE, release, type ReleaseState } from '../release.ts';
 import { version } from '../version.ts';
+import { readSession } from '#auth/lanes/session.ts';
 
 /**
  * `lanes link update` — install the newer release, or say why it will not.
@@ -317,7 +318,15 @@ async function runInstall(argv: readonly string[], json: boolean): Promise<boole
 async function migrateContract3(root: string, say: (line: string) => void): Promise<void> {
   if (!(await needsContract3(root))) return;
 
-  const migration = await migrateToContract3(root);
+  // The same subject `profile add` writes, for the same reason: a migrated
+  // profile that lists nobody is an endpoint that advertises OAuth and refuses
+  // its own owner. Absent when nobody has signed in yet, which the migration
+  // reports rather than guessing at.
+  const session = await readSession();
+  const migration = await migrateToContract3(root, {
+    apply: true,
+    ...(session ? { subject: session.subject } : {}),
+  });
   if (migration.alreadyCurrent) return;
 
   say(

--- a/src/cli/commands/update.ts
+++ b/src/cli/commands/update.ts
@@ -3,6 +3,7 @@ import { join, sep } from 'node:path';
 import { installRoot, resolveWorkspaceRoot } from '#profile';
 import { repairOwnerLayer } from '../config-repair.ts';
 import { migrateWorkspace, needsMigration } from '../workspace-migrate.ts';
+import { migrateToContract3, needsContract3 } from '../contract3.ts';
 import { emit, fail, ok, print, printErr, progress, style, warn } from '../output.ts';
 import { PACKAGE, release, type ReleaseState } from '../release.ts';
 import { version } from '../version.ts';
@@ -306,27 +307,64 @@ async function runInstall(argv: readonly string[], json: boolean): Promise<boole
  * about, in a sentence naming the fix, rather than a reason for the upgrade to
  * fail. `check` and `doctor` both refuse loudly on the next run.
  */
+/**
+ * Contract 2 to contract 3, reported the same way its predecessor is.
+ *
+ * Loud about what moved, because this one moves credentials. An operator whose
+ * fifteen accounts were merged into one store should see that happen rather than
+ * discover it from a directory listing.
+ */
+async function migrateContract3(root: string, say: (line: string) => void): Promise<void> {
+  if (!(await needsContract3(root))) return;
+
+  const migration = await migrateToContract3(root);
+  if (migration.alreadyCurrent) return;
+
+  say(
+    `migrated ${migration.profiles.length} profile(s) to contract 3 — connections belong to the ` +
+      'workspace now, and a profile grants them one by one',
+  );
+  for (const change of migration.changes) say(`  ${change}`);
+
+  if (migration.renames.length > 0) {
+    say('  Two profiles named different accounts with the same id, so one was renamed.');
+    say('  Check the grants in each profile before running an agent against them.');
+  }
+
+  say(`  The old per-profile credential stores are left in place; remove them once this works.`);
+}
+
 async function migrateLocal(root: string, say: (line: string) => void): Promise<void> {
   try {
-    if (!(await needsMigration(root))) return;
-
-    const migration = await migrateWorkspace(root);
-    if (migration.alreadyCurrent) return;
-
-    say(
-      `migrated ${migration.profiles.length} profile(s) to contract 2 — a target is declared by ` +
-        'the workspace now, not by each profile',
-    );
-    for (const change of migration.changes) say(`  ${change}`);
-
-    const pointers = migration.targets.filter((one) => one.kind === 'pointer');
-    for (const pointer of pointers) {
-      say(
-        `  "${pointer.name}" points at ${pointer.where} — run ` +
-          `lanes link deploy --target ${pointer.name} to migrate what is there`,
-      );
-    }
+    // Contract 1 first, then contract 2, in that order. A workspace that
+    // predates both walks through them rather than jumping, so each step's
+    // reasoning applies to the shape it was written for — and a contract-1
+    // workspace reaches contract 3 in one run rather than needing two.
+    await migrateLegacyTargets(root, say);
+    await migrateContract3(root, say);
   } catch (error) {
     say(`could not migrate this workspace: ${error instanceof Error ? error.message : String(error)}`);
   }
 }
+
+/** Contract 1 to contract 2: targets move from the profile to the workspace. */
+async function migrateLegacyTargets(root: string, say: (line: string) => void): Promise<void> {
+  if (!(await needsMigration(root))) return;
+
+  const migration = await migrateWorkspace(root);
+  if (migration.alreadyCurrent) return;
+
+  say(
+    `migrated ${migration.profiles.length} profile(s) to contract 2 — a target is declared by ` +
+      'the workspace now, not by each profile',
+  );
+  for (const change of migration.changes) say(`  ${change}`);
+
+  for (const pointer of migration.targets.filter((one) => one.kind === 'pointer')) {
+    say(
+      `  "${pointer.name}" points at ${pointer.where} — run ` +
+        `lanes link deploy --workspace ${pointer.name} to migrate what is there`,
+    );
+  }
+}
+

--- a/src/cli/config-edit.test.ts
+++ b/src/cli/config-edit.test.ts
@@ -1,9 +1,11 @@
+import { newConnectionsTemplate, newProfileTemplate } from './config-templates.ts';
 import { afterAll, describe, expect, test } from 'bun:test';
 import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
 import { readdir } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { ConfigDocument, newProfileTemplate } from './config-edit.ts';
+import { ConfigDocument } from './config-edit.ts';
+import { CONNECTIONS_FILE } from '#profile';
 import {
   DEFAULT_SURFACES,
   ensureOwnerLayer,
@@ -39,6 +41,43 @@ async function profileFile(contents?: string): Promise<{ root: string; path: str
   return { root, path };
 }
 
+/**
+ * The two documents a repair now touches.
+ *
+ * The owner layer is a connection in the workspace and a grant in the profile
+ * (ADR-057, ADR-059), so `ensureReservedConnection` writes into both or
+ * neither. Handing tests a pair keeps that pairing in one place rather than in
+ * thirty setups that could drift apart.
+ */
+interface Pair {
+  readonly root: string;
+  readonly path: string;
+  readonly connections: ConfigDocument;
+  readonly profile: ConfigDocument;
+}
+
+/** Re-open both documents of a workspace that has already been written. */
+async function pair2(root: string): Promise<Pair> {
+  return {
+    root,
+    path: join(root, 'profiles', 'personal.yaml'),
+    connections: await ConfigDocument.openKey(root, CONNECTIONS_FILE),
+    profile: await ConfigDocument.open(root, 'personal'),
+  };
+}
+
+async function pair(contents?: string, connections?: string): Promise<Pair> {
+  const { root, path } = await profileFile(contents);
+  await writeFile(join(root, CONNECTIONS_FILE), connections ?? newConnectionsTemplate());
+
+  return {
+    root,
+    path,
+    connections: await ConfigDocument.openKey(root, CONNECTIONS_FILE),
+    profile: await ConfigDocument.open(root, 'personal'),
+  };
+}
+
 afterAll(async () => {
   await Promise.all(roots.map((root) => rm(root, { recursive: true, force: true })));
 });
@@ -49,7 +88,7 @@ describe('comments and ordering survive an edit', () => {
     const before = await readFile(path, 'utf8');
 
     const document = await ConfigDocument.open(root, 'personal');
-    document.setIn(['oauth_apps', 'google'], { client_id_ref: 'google/id', client_secret_ref: 'google/secret' });
+    document.setIn(['limits', 'requests_per_minute'], 240);
     await document.save();
 
     const after = await readFile(path, 'utf8');
@@ -57,7 +96,7 @@ describe('comments and ordering survive an edit', () => {
     for (const comment of [
       '# Lanes Link profile: personal',
       '# This file says nothing about where it runs, and that is the point.',
-      '# Only what is listed here is reachable, and an empty policy grants nothing.',
+      '# One row per connection this profile may reach, and what it may do with each.',
     ]) {
       expect(before).toContain(comment);
       expect(after).toContain(comment);
@@ -67,10 +106,10 @@ describe('comments and ordering survive an edit', () => {
   test('an operator comment added by hand survives too', async () => {
     const { root, path } = await profileFile();
     const original = await readFile(path, 'utf8');
-    await writeFile(path, original.replace('connections:', '# my note here\nconnections:'));
+    await writeFile(path, original.replace('grants:', '# my note here\ngrants:'));
 
     const document = await ConfigDocument.open(root, 'personal');
-    document.setIn(['oauth_apps', 'google'], { client_id_ref: 'google/id', client_secret_ref: 'google/secret' });
+    document.setIn(['limits', 'requests_per_minute'], 240);
     await document.save();
 
     expect(await readFile(path, 'utf8')).toContain('# my note here');
@@ -84,8 +123,8 @@ describe('comments and ordering survive an edit', () => {
     const before = keysOf(await readFile(path, 'utf8'));
 
     const document = await ConfigDocument.open(root, 'personal');
-    document.setIn(['oauth_apps', 'google'], { client_id_ref: 'google/id', client_secret_ref: 'google/secret' });
-    document.addTo(['connections'], { id: 'a', provider: 'example', account: 'a@example.com' });
+    document.setIn(['limits', 'requests_per_minute'], 240);
+    document.addTo(['grants'], { connection: 'example.a', allow: ['example.*'], deny: [] });
     await document.save();
 
     expect(keysOf(await readFile(path, 'utf8'))).toEqual(before);
@@ -98,24 +137,22 @@ describe('comments and ordering survive an edit', () => {
     // and its allow rule. Reading the starting state from the template would
     // leave this asserting nothing the day that changed, which is the day it
     // most needs to hold.
-    const { root, path } = await profileFile(`contract: 2
+    const { root, path } = await profileFile(`contract: 3
 
 instance:
   profile: personal
 
 oauth_apps: {}
-connections: []
-policy:
-  allow: []
-  deny: []
+grants: []
+members: []
 `);
 
     const document = await ConfigDocument.open(root, 'personal');
-    document.setIn(['oauth_apps', 'google'], { client_id_ref: 'google/id', client_secret_ref: 'google/secret' });
-    document.addTo(['connections'], { id: 'a', provider: 'example', account: 'a@example.com' });
-    document.addTo(['connections'], { id: 'b', provider: 'example', account: 'b@example.com' });
+    document.setIn(['limits', 'requests_per_minute'], 240);
+    document.addTo(['grants'], { connection: 'example.a', allow: ['example.*'], deny: [] });
+    document.addTo(['grants'], { connection: 'example.b', allow: ['example.*'], deny: [] });
     document.addTo(
-      ['policy', 'allow'],
+      ['grants', 0, 'allow'],
       'example.*',
       { inline: true },
     );
@@ -123,9 +160,9 @@ policy:
 
     const text = await readFile(path, 'utf8');
 
-    // Connections carry enough fields to want a block; a policy rule is far
+    // A grant carries enough fields to want a block; a rule inside it is far
     // easier to scan one per line, which is how init.md writes them too.
-    expect(text).toContain('connections:\n  - id: a');
+    expect(text).toContain('grants:\n  - connection: example.a');
     expect(text).toMatch(/allow:\n\s+- example\.\*/);
     expect(text.split('\n').every((line) => line.length < 120)).toBe(true);
   });
@@ -155,9 +192,9 @@ describe('validation runs before the write', () => {
     const before = await readFile(path, 'utf8');
 
     const document = await ConfigDocument.open(root, 'personal');
-    document.addTo(['policy', 'allow'], 'gmail.search');
+    document.addTo(['grants', 0, 'allow'], 'gmail.search');
 
-    await expect(document.save()).rejects.toThrow(/has no connection/);
+    await expect(document.save()).rejects.toThrow(/names provider "gmail"/);
     // The file is untouched: a config left invalid by a failed command is
     // worse than a command that refuses to run.
     expect(await readFile(path, 'utf8')).toBe(before);
@@ -168,10 +205,7 @@ describe('validation runs before the write', () => {
     const before = await readFile(path, 'utf8');
 
     const document = await ConfigDocument.open(root, 'personal');
-    document.setIn(['oauth_apps', 'google'], {
-      client_id_ref: 'google/client_id',
-      client_secret: 'ya29.a0AfH6SMBnotreal',
-    });
+    document.setIn(['auth', 'token_ref'], 'ya29.a0AfH6SMBnotreal');
 
     await expect(document.save()).rejects.toThrow(/credential/i);
     expect(await readFile(path, 'utf8')).toBe(before);
@@ -182,11 +216,11 @@ describe('validation runs before the write', () => {
     const directory = join(path, '..');
 
     const good = await ConfigDocument.open(root, 'personal');
-    good.addTo(['connections'], { id: 'a', provider: 'example', account: 'a@example.com' });
+    good.addTo(['grants'], { connection: 'example.a', allow: ['example.*'], deny: [] });
     await good.save();
 
     const bad = await ConfigDocument.open(root, 'personal');
-    bad.addTo(['policy', 'allow'], 'gmail.search');
+    bad.addTo(['grants', 0, 'allow'], 'gmail.search');
     await bad.save().catch(() => {});
 
     expect((await readdir(directory)).filter((name) => name.includes('.tmp'))).toEqual([]);
@@ -198,7 +232,7 @@ describe('idempotence', () => {
     const { root, path } = await profileFile();
 
     const first = await ConfigDocument.open(root, 'personal');
-    first.addTo(['connections'], { id: 'a', provider: 'example', account: 'a@example.com' });
+    first.addTo(['grants'], { connection: 'example.a', allow: ['example.*'], deny: [] });
     await first.save();
     const afterFirst = await readFile(path, 'utf8');
 
@@ -206,9 +240,9 @@ describe('idempotence', () => {
     // The same edit `connect` would make on a re-run. It must not append a
     // second copy, or reconnecting a live account would grow the file forever
     // — which is exactly the bug that produced `main2` and `main3`.
-    const existing = (second.getIn(['connections']) as { items?: unknown[] })?.items ?? [];
+    const existing = (second.getIn(['grants']) as { items?: unknown[] })?.items ?? [];
     if (existing.length === 0) {
-      second.addTo(['connections'], { id: 'a', provider: 'example', account: 'a@example.com' });
+      second.addTo(['grants'], { connection: 'example.a', allow: ['example.*'], deny: [] });
     }
     await second.save();
 
@@ -228,462 +262,249 @@ describe('repairing a profile that predates the setup surface', () => {
   /**
    * One surface at a time, which is what these tests are about.
    *
-   * `ensureOwnerLayer` runs this over six of them and accumulates; the rules
+   * `ensureOwnerLayer` runs this over seven of them and accumulates; the rules
    * that are subtle — a deny that survives, an expiry that counts, a blanket
    * allow that already covers — are per surface, so they are checked here and
    * the layer's own behaviour is checked in the block below.
+   *
+   * It touches two documents now. The connection belongs to the workspace and
+   * the grant to the profile (ADR-057), and a repair that wrote one without the
+   * other would leave a workspace that does not load.
    */
-  const ensureSetup = (document: ConfigDocument): SurfaceRepair =>
-    ensureReservedConnection(document, 'setup');
+  const ensureSetup = (p: Pair): SurfaceRepair =>
+    ensureReservedConnection(p.connections, p.profile, 'setup');
 
   /** A profile as it was written before the surface, and as this operator's is. */
-  const OLD = `contract: 2
+  const OLD = `contract: 3
 instance:
   profile: personal
   port: 7337
-connections:
-  - id: ada_lovelace
-    provider: gmail
-    account: ada.lovelace@example.com
-policy:
-  allow:
-    - gmail.*
-  deny: []
+grants:
+  - { connection: gmail.ada_lovelace, allow: [gmail.*], deny: [] }
+members: []
 `;
 
+  /** The workspace it lives in, with no owner-layer row in it. */
+  const OLD_CONNECTIONS = `contract: 3
+connections:
+  - { id: ada_lovelace, provider: gmail, account: ada.lovelace@example.com }
+oauth_apps: {}
+`;
+
+  const rowsOf = (p: Pair) =>
+    (p.connections.toJSON() as { connections: { id: string; provider: string; account: string }[] })
+      .connections;
+
+  const grantsOf = (p: Pair) =>
+    (p.profile.toJSON() as {
+      grants: { connection: string; allow: unknown[]; deny: unknown[] }[];
+    }).grants;
+
   test('adds both halves, because either alone is inert', async () => {
-    const { root } = await profileFile(OLD);
+    const p = await pair(OLD, OLD_CONNECTIONS);
+    const added = repairLines(ensureSetup(p));
 
-    const document = await ConfigDocument.open(root, 'personal');
-    const added = repairLines(ensureSetup(document));
-    await document.save();
+    expect(added).toEqual([
+      'connections.yaml += setup.main',
+      'grants += setup.main',
+      'grants[].allow += setup.*',
+    ]);
 
-    expect(added).toEqual(['connections += setup.main', 'policy.allow += setup.*']);
-
-    const config = document.toJSON() as {
-      connections: { id: string; provider: string; account: string }[];
-      policy: { allow: string[] };
-    };
-    expect(config.connections).toContainEqual({ id: 'main', provider: 'setup', account: 'Setup' });
-    expect(config.policy.allow).toContain('setup.*');
+    expect(rowsOf(p)).toContainEqual({ id: 'main', provider: 'setup', account: 'Setup' });
+    expect(grantsOf(p)).toContainEqual({ connection: 'setup.main', allow: ['setup.*'], deny: [] });
   });
 
-  test('the existing connection and grant are left alone', async () => {
-    const { root } = await profileFile(OLD);
+  test("the operator's own connection and grant are left alone", async () => {
+    const p = await pair(OLD, OLD_CONNECTIONS);
+    ensureSetup(p);
 
-    const document = await ConfigDocument.open(root, 'personal');
-    ensureSetup(document);
-
-    const config = document.toJSON() as {
-      connections: { id: string; provider: string; account: string }[];
-      policy: { allow: string[] };
-    };
-    expect(config.connections).toContainEqual({
+    expect(rowsOf(p)).toContainEqual({
       id: 'ada_lovelace',
       provider: 'gmail',
       account: 'ada.lovelace@example.com',
     });
-    expect(config.policy.allow).toContain('gmail.*');
+    expect(grantsOf(p)).toContainEqual({
+      connection: 'gmail.ada_lovelace',
+      allow: ['gmail.*'],
+      deny: [],
+    });
   });
 
   test('a second run changes nothing', async () => {
-    const { root, path } = await profileFile(OLD);
+    const p = await pair(OLD, OLD_CONNECTIONS);
+    ensureSetup(p);
+    await p.profile.save();
+    await p.connections.save();
 
-    const first = await ConfigDocument.open(root, 'personal');
-    ensureSetup(first);
-    await first.save();
-    const afterFirst = await readFile(path, 'utf8');
-
-    const second = await ConfigDocument.open(root, 'personal');
-    expect(repairLines(ensureSetup(second))).toEqual([]);
-    await second.save();
-
-    expect(await readFile(path, 'utf8')).toBe(afterFirst);
+    const again = await pair2(p.root);
+    expect(repairLines(ensureSetup(again))).toEqual([]);
   });
 
-  test('a fresh profile from the template needs no repair at all', async () => {
-    const { root } = await profileFile();
-
-    const document = await ConfigDocument.open(root, 'personal');
-
-    // The template already writes both. If this ever fails, the template and
-    // its repair have drifted and one of them is writing a second spelling.
-    expect(repairLines(ensureSetup(document))).toEqual([]);
-  });
-
-  test('the row alone is repaired when only the grant is there', async () => {
-    const { root } = await profileFile(OLD.replace('    - gmail.*', '    - gmail.*\n    - setup.*'));
-
-    const document = await ConfigDocument.open(root, 'personal');
-
-    expect(repairLines(ensureSetup(document))).toEqual(['connections += setup.main']);
-  });
-
-  test('the grant alone is repaired when only the row is there', async () => {
-    const { root } = await profileFile(
-      OLD.replace(
-        '    account: ada.lovelace@example.com',
-        '    account: ada.lovelace@example.com\n  - { id: main, provider: setup, account: Setup }',
-      ),
+  test('the row alone is repaired when the grant is already there', async () => {
+    const p = await pair(
+      OLD.replace('members: []', '  - { connection: setup.main, allow: [setup.*], deny: [] }\nmembers: []'),
+      OLD_CONNECTIONS,
     );
 
-    const document = await ConfigDocument.open(root, 'personal');
-
-    expect(repairLines(ensureSetup(document))).toEqual(['policy.allow += setup.*']);
+    expect(repairLines(ensureSetup(p))).toEqual(['connections.yaml += setup.main']);
   });
 
-  test('a blanket allow already covers it, so no rule is added', async () => {
-    const { root } = await profileFile(OLD.replace('    - gmail.*', "    - '*'"));
-
-    const document = await ConfigDocument.open(root, 'personal');
-
-    expect(repairLines(ensureSetup(document))).toEqual(['connections += setup.main']);
-  });
-
-  test('a rule written with an expiry is recognised, not duplicated', async () => {
-    // `policyRuleSchema` takes a bare pattern or `{ capability, expires_at }`.
-    // Reading only the string form would re-add a rule the operator has.
-    const { root } = await profileFile(
-      OLD.replace('    - gmail.*', '    - gmail.*\n    - { capability: setup.*, expires_at: "2030-01-01T00:00:00Z" }'),
+  test('the grant alone is repaired when the row is already there', async () => {
+    const p = await pair(
+      OLD,
+      OLD_CONNECTIONS.replace('oauth_apps: {}', '  - { id: main, provider: setup, account: Setup }\noauth_apps: {}'),
     );
 
-    const document = await ConfigDocument.open(root, 'personal');
-
-    expect(repairLines(ensureSetup(document))).toEqual(['connections += setup.main']);
+    expect(repairLines(ensureSetup(p))).toEqual(['grants += setup.main', 'grants[].allow += setup.*']);
   });
 
-  /**
-   * A lapsed rule is in force for nothing (`evaluate` holds one to
-   * `expiresAt > now`), and reading the capability alone got both directions
-   * wrong in the way that is hardest to see from the output.
-   */
+  test('an operator who renamed the row keeps their id', async () => {
+    // Any instance will do, and the first is taken rather than `main`
+    // specifically — bolting a second `setup.main` on beside a renamed one
+    // would be the repair inventing a surface the operator already has.
+    const p = await pair(
+      OLD,
+      OLD_CONNECTIONS.replace('oauth_apps: {}', '  - { id: mine, provider: setup, account: Setup }\noauth_apps: {}'),
+    );
+
+    expect(repairLines(ensureSetup(p))).toEqual(['grants += setup.mine', 'grants[].allow += setup.*']);
+  });
+
   describe('a rule that has expired is not a rule', () => {
-    const LAPSED = '2020-01-01T00:00:00Z';
-
-    test('a lapsed allow does not count as the grant', async () => {
-      const { root } = await profileFile(
-        OLD.replace('    - gmail.*', `    - gmail.*\n    - { capability: setup.*, expires_at: "${LAPSED}" }`),
-      );
-
-      const document = await ConfigDocument.open(root, 'personal');
-
-      // Reading it as live wrote the row, skipped the rule, and reported "an
-      // agent can now see what is connected here" — the inert half-state this
-      // whole function exists to make impossible.
-      expect(repairLines(ensureSetup(document))).toEqual([
-        'connections += setup.main',
-        'policy.allow += setup.*',
-      ]);
-    });
-
-    test('a lapsed deny does not block the repair', async () => {
-      const { root } = await profileFile(
+    test('a rule written with an expiry is recognised, not duplicated', async () => {
+      // `policyRuleSchema` takes a bare pattern or `{ capability, expires_at }`.
+      // Reading only the string form would re-add a rule the operator has.
+      const p = await pair(
         OLD.replace(
-          '  deny: []',
-          `  deny:\n    - { capability: setup.*, expires_at: "${LAPSED}" }`,
+          'members: []',
+          '  - { connection: setup.main, allow: [{ capability: setup.*, expires_at: "2030-01-01T00:00:00Z" }], deny: [] }\nmembers: []',
         ),
+        OLD_CONNECTIONS,
       );
 
-      const document = await ConfigDocument.open(root, 'personal');
-
-      // Reading it as live meant a deny that stopped denying years ago blocked
-      // the repair for good — and printed nothing, because returning nothing to
-      // add is exactly how "already had it" looks.
-      expect(repairLines(ensureSetup(document))).toEqual([
-        'connections += setup.main',
-        'policy.allow += setup.*',
-      ]);
-    });
-
-    test('a deny that has not expired still stops it', async () => {
-      const { root } = await profileFile(
-        OLD.replace(
-          '  deny: []',
-          '  deny:\n    - { capability: setup.*, expires_at: "2999-01-01T00:00:00Z" }',
-        ),
-      );
-
-      const document = await ConfigDocument.open(root, 'personal');
-
-      expect(repairLines(ensureSetup(document))).toEqual([]);
+      expect(repairLines(ensureSetup(p))).toEqual(['connections.yaml += setup.main']);
     });
   });
 
-  test("the operator's comments survive the repair", async () => {
-    const { root, path } = await profileFile(`# my own note about this profile\n${OLD}`);
-
-    const document = await ConfigDocument.open(root, 'personal');
-    ensureSetup(document);
-    await document.save();
-
-    expect(await readFile(path, 'utf8')).toContain('# my own note about this profile');
-  });
-
-  test('the repaired file is still valid config', async () => {
-    const { root } = await profileFile(OLD);
-
-    const document = await ConfigDocument.open(root, 'personal');
-    ensureSetup(document);
-
-    // `save` validates the rendered text before writing, so this throwing is
-    // the assertion — a repair that produced an invalid file would leave the
-    // profile unopenable.
-    await document.save();
-  });
-
-  /**
-   * Nothing here has been through a schema. `deploy` repairs sibling profiles
-   * it never validated, so this reads whatever was typed — and a key written
-   * with no value under it is a null scalar, not an absent one.
-   */
   describe('a hand-edited file that no schema has seen', () => {
-    test('a bare `connections:` key is written into, not crashed on', async () => {
-      const { root } = await profileFile(
-        OLD.replace(
-          'connections:\n  - id: ada_lovelace\n    provider: gmail\n    account: ada.lovelace@example.com',
-          'connections:',
-        ),
-      );
+    test('a missing grants block is created rather than crashed on', async () => {
+      const p = await pair(`contract: 3\ninstance:\n  profile: personal\n`, OLD_CONNECTIONS);
 
-      const document = await ConfigDocument.open(root, 'personal');
-
-      // Deleting the last entry by hand leaves exactly this. It used to reach
-      // `null.add(...)` — a TypeError with a stack trace, mid-deploy, after the
-      // provision steps had already created cloud resources.
-      expect(repairLines(ensureSetup(document))).toEqual([
-        'connections += setup.main',
-        'policy.allow += setup.*',
-      ]);
-
-      const config = document.toJSON() as {
-        connections: { id: string; provider: string; account: string }[];
-      };
-      expect(config.connections).toContainEqual({ id: 'main', provider: 'setup', account: 'Setup' });
-    });
-
-    test('a bare `allow:` key is written into too', async () => {
-      const { root } = await profileFile(OLD.replace('    - gmail.*', ''));
-
-      const document = await ConfigDocument.open(root, 'personal');
-
-      expect(repairLines(ensureSetup(document))).toEqual([
-        'connections += setup.main',
-        'policy.allow += setup.*',
+      expect(repairLines(ensureSetup(p))).toEqual([
+        'connections.yaml += setup.main',
+        'grants += setup.main',
+        'grants[].allow += setup.*',
       ]);
     });
 
-    test('a connections mapping is left alone rather than throwing', async () => {
+    test('a grants mapping is left alone rather than throwing', async () => {
       // Not a shape any schema accepts, so the row cannot be appended to it —
       // but `validateConfig` is what should say so, on the whole file, rather
       // than this dying on `.some`.
-      const { root } = await profileFile(
-        OLD.replace(
-          'connections:\n  - id: ada_lovelace\n    provider: gmail\n    account: ada.lovelace@example.com',
-          'connections:\n  a: { provider: gmail }',
-        ),
+      const p = await pair(
+        `contract: 3\ninstance:\n  profile: personal\ngrants:\n  a: { connection: gmail.x }\n`,
+        OLD_CONNECTIONS,
       );
 
-      const document = await ConfigDocument.open(root, 'personal');
-
-      expect(() => ensureSetup(document)).not.toThrow();
+      expect(() => ensureSetup(p)).not.toThrow();
     });
   });
 
-  /**
-   * Deleting the two lines no longer removes the surface — the next `connect`
-   * or `deploy` puts them back. A deny is what makes it stay off, so it is the
-   * one thing the repair must not undo.
-   */
   describe('an operator who turned it off', () => {
     test('a deny covering the surface stops the repair entirely', async () => {
-      const { root } = await profileFile(OLD.replace('  deny: []', '  deny:\n    - setup.*'));
+      // Deleting the row no longer removes the surface, because the next
+      // command puts it back. A deny is the way it stays off, so it is the one
+      // thing the repair must not undo (ADR-050).
+      const p = await pair(
+        OLD.replace('members: []', '  - { connection: setup.main, allow: [], deny: [setup.*] }\nmembers: []'),
+        OLD_CONNECTIONS,
+      );
 
-      const document = await ConfigDocument.open(root, 'personal');
-
-      // Not "added the rule but it is denied": a deny beats an allow, so the
-      // caller would have printed that an agent can now see what is connected
-      // here, about a surface that is still refused.
-      expect(repairLines(ensureSetup(document))).toEqual([]);
-    });
-
-    test('a blanket deny stops it too', async () => {
-      const { root } = await profileFile(OLD.replace('  deny: []', "  deny:\n    - '*'"));
-
-      const document = await ConfigDocument.open(root, 'personal');
-
-      expect(repairLines(ensureSetup(document))).toEqual([]);
+      expect(repairLines(ensureSetup(p))).toEqual([]);
     });
 
     test('denying one capability is a narrowing, and the repair still runs', async () => {
       // `setup.provider` withheld is the operator keeping the overview and
       // dropping the command detail — not switching the surface off. Refusing
       // to repair would leave them with neither.
-      const { root } = await profileFile(OLD.replace('  deny: []', '  deny:\n    - setup.provider'));
+      const p = await pair(
+        OLD.replace('members: []', '  - { connection: setup.main, allow: [], deny: [setup.provider] }\nmembers: []'),
+        OLD_CONNECTIONS,
+      );
 
-      const document = await ConfigDocument.open(root, 'personal');
-
-      expect(repairLines(ensureSetup(document))).toEqual([
-        'connections += setup.main',
-        'policy.allow += setup.*',
+      expect(repairLines(ensureSetup(p))).toEqual([
+        'connections.yaml += setup.main',
+        'grants[].allow += setup.*',
       ]);
     });
   });
 });
 
 /**
- * The owner layer as a whole — ADR-050.
+ * The owner layer as a whole — ADR-050, as amended by ADR-059.
  *
  * The per-surface rules are held above. What this block is for is the part that
- * only exists once there are six of them: that a profile written before they
- * were default gets all six on the next command, that each is still decided on
+ * only exists once there are seven of them: that a profile written before they
+ * were default gets all seven on the next command, that each is still decided on
  * its own, and that the template needs no repair — because a template and its
  * repair writing two spellings of one row is the failure `config-repair.ts` is
  * shaped to prevent.
  */
 describe('repairing a profile that predates the owner layer', () => {
-  const OLD = `contract: 2
+  const OLD = `contract: 3
 instance:
   profile: personal
-connections:
-  - id: ada_lovelace
-    provider: gmail
-    account: ada.lovelace@example.com
-policy:
-  allow:
-    - gmail.*
-  deny: []
+  port: 7337
+grants:
+  - { connection: gmail.ada_lovelace, allow: [gmail.*], deny: [] }
+members: []
 `;
 
-  test('all seven arrive, both halves each, in the order the template writes', async () => {
-    const { root } = await profileFile(OLD);
+  const OLD_CONNECTIONS = `contract: 3
+connections:
+  - { id: ada_lovelace, provider: gmail, account: ada.lovelace@example.com }
+oauth_apps: {}
+`;
 
-    const document = await ConfigDocument.open(root, 'personal');
-    const added = repairLines(ensureOwnerLayer(document));
-    await document.save();
+  test('every default surface arrives, and identity does not', async () => {
+    const p = await pair(OLD, OLD_CONNECTIONS);
+    const repair = ensureOwnerLayer(p.connections, p.profile);
 
-    expect(added).toEqual([
-      'connections += memory.main',
-      'connections += tasks.main',
-      'connections += assets.main',
-      'connections += skills.main',
-      'connections += vault.main',
-      'connections += setup.main',
-      'connections += entities.main',
-      'policy.allow += memory.*',
-      'policy.allow += tasks.*',
-      'policy.allow += assets.*',
-      'policy.allow += skills.*',
-      'policy.allow += vault.*',
-      'policy.allow += setup.*',
-      'policy.allow += entities.*',
-    ]);
-  });
-
-  test('identity is not among them, because a profile declaring none has nothing to report', async () => {
-    const { root } = await profileFile(OLD);
-
-    const document = await ConfigDocument.open(root, 'personal');
-    ensureOwnerLayer(document);
-
-    const config = document.toJSON() as {
-      connections: { provider: string }[];
-      policy: { allow: string[] };
-    };
-    expect(config.connections.map((row) => row.provider)).not.toContain('identity');
-    expect(config.policy.allow).not.toContain('identity.*');
-  });
-
-  test('the account already there is untouched', async () => {
-    const { root } = await profileFile(OLD);
-
-    const document = await ConfigDocument.open(root, 'personal');
-    ensureOwnerLayer(document);
-
-    const config = document.toJSON() as {
-      connections: { id: string; provider: string; account: string }[];
-      policy: { allow: string[] };
-    };
-    expect(config.connections).toContainEqual({
-      id: 'ada_lovelace',
-      provider: 'gmail',
-      account: 'ada.lovelace@example.com',
-    });
-    expect(config.policy.allow).toContain('gmail.*');
-  });
-
-  test('the prose after a repair names every surface it wrote', async () => {
-    // The summary line was typed out, and still named six after a seventh had
-    // been added: a deploy printed `connections += entities.main` and then said
-    // the layer was six things. Read out of the report rather than out of
-    // `repairLines`, because it was the *prose* that drifted and the lines were
-    // right all along.
-    const { root } = await profileFile(OLD);
-
-    const lines: string[] = [];
-    await repairOwnerLayer(root, ['personal'], { report: (line) => lines.push(line) });
-
-    const summary = lines.find((line) => line.includes('your own material'));
-    expect(summary).toBeDefined();
-    for (const surface of DEFAULT_SURFACES) {
-      expect(summary).toContain(surface);
+    for (const provider of DEFAULT_SURFACES) {
+      expect(repair.granted).toContain(`${provider}.*`);
     }
+
+    // ADR-042: a profile declaring no identity has nothing for the surface to
+    // report, so it arrives with the first `identity add` rather than here.
+    expect(repair.granted).not.toContain('identity.*');
   });
 
-  test('a fresh profile from the template needs no repair at all', async () => {
-    const { root } = await profileFile();
+  test('a surface the operator denied is left off', async () => {
+    const p = await pair(
+      OLD.replace('members: []', '  - { connection: skills.main, allow: [], deny: [skills.*] }\nmembers: []'),
+      OLD_CONNECTIONS,
+    );
+    const repair = ensureOwnerLayer(p.connections, p.profile);
 
-    const document = await ConfigDocument.open(root, 'personal');
+    expect(repair.granted).not.toContain('skills.*');
+    expect(repair.granted).toContain('memory.*');
+  });
 
-    // If this fails, the template and its repair have drifted and one of them is
-    // writing a second spelling of a row the other already wrote.
-    expect(repairLines(ensureOwnerLayer(document))).toEqual([]);
+  test('a fresh profile and workspace need no repair at all', async () => {
+    // The check that keeps the template and the repair in one spelling. Two
+    // spellings of one row is how they drift apart, and this is what notices.
+    const p = await pair(newProfileTemplate('personal', 7337), newConnectionsTemplate());
+
+    expect(repairLines(ensureOwnerLayer(p.connections, p.profile))).toEqual([]);
   });
 
   test('a second run changes nothing', async () => {
-    const { root, path } = await profileFile(OLD);
+    const p = await pair(OLD, OLD_CONNECTIONS);
+    ensureOwnerLayer(p.connections, p.profile);
+    await p.profile.save();
+    await p.connections.save();
 
-    const first = await ConfigDocument.open(root, 'personal');
-    ensureOwnerLayer(first);
-    await first.save();
-    const afterFirst = await readFile(path, 'utf8');
-
-    const second = await ConfigDocument.open(root, 'personal');
-    expect(repairLines(ensureOwnerLayer(second))).toEqual([]);
-    await second.save();
-
-    expect(await readFile(path, 'utf8')).toBe(afterFirst);
-  });
-
-  test('one surface denied stays denied while the rest are repaired', async () => {
-    // The operator who does not want an agent writing skills. Repairing that one
-    // would undo a decision; refusing to repair the others would punish them for
-    // having made it.
-    const { root } = await profileFile(OLD.replace('  deny: []', '  deny:\n    - skills.*'));
-
-    const document = await ConfigDocument.open(root, 'personal');
-    const added = repairLines(ensureOwnerLayer(document));
-
-    expect(added).not.toContain('connections += skills.main');
-    expect(added).not.toContain('policy.allow += skills.*');
-    expect(added).toContain('connections += memory.main');
-    expect(added).toContain('policy.allow += tasks.*');
-  });
-
-  test('a blanket deny leaves the whole layer off', async () => {
-    const { root } = await profileFile(OLD.replace('  deny: []', "  deny:\n    - '*'"));
-
-    const document = await ConfigDocument.open(root, 'personal');
-
-    expect(repairLines(ensureOwnerLayer(document))).toEqual([]);
-  });
-
-  test('a blanket allow needs no rules, only rows', async () => {
-    const { root } = await profileFile(OLD.replace('    - gmail.*', "    - '*'"));
-
-    const document = await ConfigDocument.open(root, 'personal');
-    const added = repairLines(ensureOwnerLayer(document));
-
-    expect(added.filter((line) => line.startsWith('policy.allow'))).toEqual([]);
-    expect(added).toHaveLength(7);
+    const again = await pair2(p.root);
+    expect(repairLines(ensureOwnerLayer(again.connections, again.profile))).toEqual([]);
   });
 });

--- a/src/cli/config-edit.ts
+++ b/src/cli/config-edit.ts
@@ -1,7 +1,14 @@
 import { rename, writeFile } from 'node:fs/promises';
 import { Document, parseDocument, type Node } from 'yaml';
 import {
+  CONNECTIONS_FILE,
   ConfigError,
+  WORKSPACE_FILE,
+  workspaceSchema,
+  assertConnectionsUnique,
+  connectionsFileSchema,
+  findSecrets,
+  formatSecretFindings,
   isRemoteWorkspace,
   readWorkspaceFile,
   validateConfig,
@@ -23,6 +30,53 @@ import {
  * A config file left invalid by a failed command is worse than a command that
  * refuses to run.
  */
+
+/**
+ * Validate a document against the schema for the file it is.
+ *
+ * The key is the discriminator because it is the only thing that is always
+ * right: a caller could be asked to say which shape it holds, and a caller that
+ * said the wrong one would get the wrong check silently.
+ */
+function validateDocument(
+  raw: unknown,
+  path: string,
+  key: string | undefined,
+  options: { shapeOnly?: boolean },
+): void {
+  if (key === WORKSPACE_FILE) {
+    const parsed = workspaceSchema.safeParse(raw);
+    if (!parsed.success) {
+      throw new ConfigError(
+        `${path}:\n${parsed.error.issues.map((issue) => `  ${issue.path.join('.')}: ${issue.message}`).join('\n')}`,
+      );
+    }
+    return;
+  }
+
+  if (key === CONNECTIONS_FILE) {
+    const secrets = findSecrets(raw);
+    if (secrets.length > 0) {
+      throw new ConfigError(
+        `${path}: ${formatSecretFindings(secrets)}`,
+        secrets.map((finding) => finding.path),
+      );
+    }
+
+    const parsed = connectionsFileSchema.safeParse(raw);
+    if (!parsed.success) {
+      throw new ConfigError(
+        `${path}:\n${parsed.error.issues.map((issue) => `  ${issue.path.join('.')}: ${issue.message}`).join('\n')}`,
+      );
+    }
+
+    assertConnectionsUnique(parsed.data.connections);
+    return;
+  }
+
+  if (options.shapeOnly === true) validateConfigShape(raw, path);
+  else validateConfig(raw, path);
+}
 
 export class ConfigDocument {
   readonly #document: Document;
@@ -47,7 +101,20 @@ export class ConfigDocument {
    * `gs://` URL produces something that addresses nothing.
    */
   static async open(workspaceRoot: string, profile: string): Promise<ConfigDocument> {
-    const key = `profiles/${profile}.yaml`;
+    return ConfigDocument.openKey(workspaceRoot, `profiles/${profile}.yaml`);
+  }
+
+  /**
+   * Open any document the workspace holds, by key.
+   *
+   * `open` above is this with the profile path spelled out, and stays because
+   * it is what almost every caller wants. This exists for `connections.yaml`,
+   * which is a workspace document rather than a profile's (ADR-057) and needs
+   * the same comment-preserving edit path — a connection row carries the
+   * account label an operator wrote, and rewriting the file through the schema
+   * would drop every comment beside it.
+   */
+  static async openKey(workspaceRoot: string, key: string): Promise<ConfigDocument> {
     const shown = isRemoteWorkspace(workspaceRoot)
       ? `${workspaceRoot}/${key}`
       : `${workspaceRoot}/${key}`;
@@ -200,8 +267,13 @@ export class ConfigDocument {
 
     // Throws on any validation failure, including a credential value that has
     // crept in — so a CLI edit can never introduce one.
-    if (options.shapeOnly === true) validateConfigShape(this.#document.toJSON(), this.#path);
-    else validateConfig(this.#document.toJSON(), this.#path);
+    //
+    // Which schema, decided by the key rather than by the caller. This class
+    // edits two shapes now: a profile, and the workspace's `connections.yaml`
+    // (ADR-057). Validating one against the other's schema is not a stricter
+    // check, it is the wrong one — a connections file has no `instance:` block,
+    // so it would be refused for a field it is not supposed to have.
+    validateDocument(this.#document.toJSON(), this.#path, this.#location?.key, options);
 
     if (!this.#location) {
       throw new ConfigError(`${this.#path}: opened from text, so there is nowhere to save it`);
@@ -234,140 +306,3 @@ export class ConfigDocument {
  * Written with comments, because this is the file an operator will read first
  * and most of what it needs to say is *why*, not *what*.
  */
-export function newProfileTemplate(profile: string, port: number): string {
-  return `# Lanes Link profile: ${profile}
-#
-# This file is the source of truth for what exists. It never contains a
-# credential value — only "_ref" pointers into the credential store, which
-# lives beside it and is encrypted at rest.
-#
-# Edit it by hand or through the CLI; both are supported, and CLI edits
-# preserve your comments and ordering.
-contract: 2
-
-instance:
-  profile: ${profile}
-  port: ${port}
-  host: 127.0.0.1
-
-# This file says nothing about where it runs, and that is the point.
-#
-# A profile lives in exactly one target, and the target is the workspace holding
-# this file — which declares its own adapters, once, in lanes-link.yaml beside
-# the profiles/ directory (ADR-052). Moving this profile somewhere else is
-# copying the file there; there is no block in it to edit.
-#
-# Every command still names both, because neither is inferred (ADR-037):
-#
-#     lanes link status --profile ${profile} --target <name>
-#
-# The bearer token for the endpoint this profile serves.
-#
-# "lanes link start" serves every profile in the workspace from one URL, and this
-# token is what opens it — so it admits every profile that "lanes link outputs"
-# lists, not only this one. Each call names the profile it means. Run a separate
-# workspace if you need a token that cannot reach them all.
-auth:
-  mode: bearer
-  token_ref: profile/token
-
-limits:
-  requests_per_minute: 120      # per profile
-  upstream_calls_per_minute: 60 # per connection, protects vendor quota
-
-# App registrations, shared by every connection of that vendor.
-oauth_apps: {}
-
-# One entry per authorised account. "account" is the identity the provider
-# reports — an address, a workspace — so this list says whose data is reachable
-# without having to look anything up.
-#
-# The seven below hold no account, and that is why they are here already: they
-# reach your own material rather than anybody's API, so there was never anything
-# for a connect step to authorise (ADR-050). What each one is:
-#
-#   memory   what you want remembered between sessions
-#   tasks    what you have to do, each with a status
-#   assets   files you want kept, by name
-#   skills   procedures you have written, handed to an agent as instructions
-#   vault    passwords and API keys, released one at a time
-#   setup    what is connected here, and what connecting more would take
-#   entities the people, companies and projects you deal with, and how to
-#            reach each of them — so an agent looks an address up rather
-#            than recalling one
-#
-# Nothing is stored in any of them until you or an agent puts something there,
-# and none of them can read an account. To switch one off, deny it below —
-# deleting the entry no longer works, because the next connect or deploy puts it
-# back.
-connections:
-  - { id: main, provider: memory, account: Memory }
-  - { id: main, provider: tasks, account: Tasks }
-  - { id: main, provider: assets, account: Assets }
-  - { id: main, provider: skills, account: Skills }
-  - { id: main, provider: vault, account: Vault }
-  - { id: main, provider: setup, account: Setup }
-  - { id: main, provider: entities, account: Entities }
-
-# Only what is listed here is reachable, and an empty policy grants nothing.
-#
-# Rules name capabilities, never accounts: "gmail.*" covers every Gmail
-# connection in this profile. To grant two accounts differently, run a second
-# profile — profiles share no database and no credential store. They do now
-# share an endpoint and its token, so that separation is enforced per call
-# rather than per URL.
-#
-#   allow: ['*']                  everything, which is what connect writes
-#   allow: [notion.*, gmail.*]    two providers
-#   deny:  [gmail.send_message]   a deny always beats an allow
-#
-# The rules below grant each of the seven its whole namespace, writes included —
-# the same thing "connect memory" wrote when it was a command you had to run.
-# Narrowing is one line, and these are the three worth knowing:
-#
-#   deny: [memory.write, memory.forget]   memory becomes read-only
-#   deny: [skills.manage.*]               skills can be invoked but not authored
-#   deny: [vault.put, vault.remove]       nothing new can be stored
-#   deny: [entities.write, entities.link, entities.forget]
-#                                         entities becomes read-only
-#
-# Those lists are exhaustive on purpose: a namespace is read-only only when
-# every capability that changes something is named, so "deny: [memory.write]"
-# alone leaves "memory.forget" granted.
-#
-# A vault read is not granted by "vault.*" alone: each stored item is its own
-# "vault.get.<id>" capability and only appears after a restart, so a write can
-# never hand itself a read (ADR-012).
-policy:
-  allow: [memory.*, tasks.*, assets.*, skills.*, vault.*, setup.*, entities.*]
-  deny: []
-`;
-}
-
-export function newWorkspaceTemplate(): string {
-  return `# Lanes Link workspace
-#
-# A workspace holds one or more profiles, and one endpoint serves all of them:
-# every call names the profile it means, with --profile. Profiles never share a
-# database or a credential store, so what one holds is invisible to another.
-#
-# This workspace IS a target. "targets:" below says where its bytes go, once,
-# for every profile in it — a profile says nothing about where it runs, so
-# there is one copy of it and nothing to keep in step (ADR-052).
-#
-# A target somewhere else is a pointer, and "deploy" writes one:
-#
-#   targets:
-#     cloud:
-#       workspace: gs://your-bucket
-#
-# The workspace at that address declares its own adapters, and is the only
-# thing that does. Reading it is a network call, which is why "--target cloud"
-# needs that bucket reachable.
-contract: 2
-targets:
-  local:
-    credentials: { adapter: file }
-    storage: { adapter: filesystem }
-`;
-}

--- a/src/cli/config-migrate.test.ts
+++ b/src/cli/config-migrate.test.ts
@@ -2,7 +2,7 @@ import { afterAll, describe, expect, test } from 'bun:test';
 import { mkdtemp, rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { parseConfig, type Config } from '#profile';
+import { CONNECTIONS_FILE, parseConfig, readConnections, type Config } from '#profile';
 import type { SecretStore } from '#secrets';
 import { doctor } from './commands/operate.ts';
 import { createProfile } from './commands/profile.ts';
@@ -44,29 +44,60 @@ async function brokenWorkspace(options: { keepBuiltIn?: boolean } = {}): Promise
   process.env['LANES_LINK_HOME'] = root;
   await createProfile('personal', { targets: ['local'] });
 
-  const path = join(root, 'profiles', 'personal.yaml');
-  const text = await Bun.file(path).text();
+  // The row is the workspace's now, and the grant that names it is the
+  // profile's (ADR-057) — so a pre-rename workspace is broken in two files.
+  const connectionsPath = join(root, CONNECTIONS_FILE);
+  const held = await Bun.file(connectionsPath).text();
   const builtIn = '  - { id: main, provider: tasks, account: Tasks }';
 
   await Bun.write(
+    connectionsPath,
+    held.replace(builtIn, options.keepBuiltIn === true ? `${builtIn}\n${GOOGLE_TASKS}` : GOOGLE_TASKS),
+  );
+
+  const path = join(root, 'profiles', 'personal.yaml');
+  const text = await Bun.file(path).text();
+  const grant = '  - { connection: tasks.main, allow: [tasks.*], deny: [] }';
+
+  await Bun.write(
     path,
-    text.replace(builtIn, options.keepBuiltIn === true ? `${builtIn}\n${GOOGLE_TASKS}` : GOOGLE_TASKS),
+    text.replace(
+      grant,
+      options.keepBuiltIn === true
+        ? `${grant}\n  - { connection: tasks.personal, allow: [tasks.*], deny: [] }`
+        : '  - { connection: tasks.personal, allow: [tasks.*], deny: [] }',
+    ),
   );
 
   return root;
 }
 
-async function open(root: string): Promise<{ document: ConfigDocument; credentials: SecretStore }> {
-  const document = await ConfigDocument.open(root, 'personal');
-  return { document, credentials: await openSecretStoreFor(shapeOf(document), root, 'local') };
+async function open(root: string): Promise<{
+  document: ConfigDocument;
+  profiles: ConfigDocument[];
+  credentials: SecretStore;
+}> {
+  const document = await ConfigDocument.openKey(root, CONNECTIONS_FILE);
+  const profiles = [await ConfigDocument.open(root, 'personal')];
+  return {
+    document,
+    profiles,
+    credentials: await openSecretStoreFor(shapeOf(profiles[0]!), root, 'local'),
+  };
 }
 
 async function onDisk(root: string): Promise<Config> {
   return parseConfig(await Bun.file(join(root, 'profiles', 'personal.yaml')).text()).config;
 }
 
+/** What the workspace holds. */
+async function held(root: string): Promise<string[]> {
+  return (await readConnections(root)).connections.map((one) => `${one.provider}.${one.id}`);
+}
+
+/** What the profile grants, which is the other half of a rename. */
 function keys(config: Config): string[] {
-  return config.connections.map((one) => `${one.provider}.${one.id}`);
+  return config.grants.map((grant) => grant.connection);
 }
 
 afterAll(async () => {
@@ -76,9 +107,12 @@ afterAll(async () => {
 });
 
 describe('a profile still naming a renamed provider', () => {
-  test('is refused by the loader, which is the state this repairs', async () => {
+  test('is refused when the workspace is read, which is the state this repairs', async () => {
+    // The refusal moved with the row it inspects. Its evidence is the account —
+    // "is this really Google Tasks?" — and an account lives in connections.yaml
+    // now (ADR-057), so the profile loader has nothing to judge it by.
     const root = await brokenWorkspace();
-    await expect(onDisk(root)).rejects.toThrow(/set provider to google_tasks/);
+    await expect(readConnections(root)).rejects.toThrow(/set account to Tasks/);
   });
 
   test('is found in raw YAML, which is all there is to read', async () => {
@@ -94,34 +128,42 @@ describe('a profile still naming a renamed provider', () => {
 describe('with a stored credential to prove what the row was', () => {
   async function ready(options: { keepBuiltIn?: boolean } = {}) {
     const root = await brokenWorkspace(options);
-    const { document, credentials } = await open(root);
+    const { document, profiles, credentials } = await open(root);
     await credentials.set('tasks/personal', '{"refresh_token":"not-a-real-token"}');
-    return { root, document, credentials };
+    return { root, document, profiles, credentials };
   }
 
   test('reports what it would do, and writes nothing', async () => {
-    const { root, document, credentials } = await ready();
+    const { root, document, profiles, credentials } = await ready();
 
-    const migration = await migrateRenamedProviders(document, credentials, { apply: false });
+    const migration = await migrateRenamedProviders(document, profiles, credentials, { apply: false });
 
     expect(migration.changes).toContain('credential: tasks/personal → google_tasks/personal');
     expect(migration.blocked).toEqual([]);
-    await expect(onDisk(root)).rejects.toThrow(/set provider to google_tasks/);
+    // The profile itself loads: its grant names `tasks.personal`, and whether
+    // that is Google's or the built-in is a question only the account answers.
+    await expect(readConnections(root)).rejects.toThrow(/set provider to google_tasks/);
     expect(await credentials.has('tasks/personal')).toBe(true);
     expect(await credentials.has('google_tasks/personal')).toBe(false);
   });
 
   test('moves the row, the rule and the credential together', async () => {
-    const { root, document, credentials } = await ready();
+    const { root, document, profiles, credentials } = await ready();
 
-    const migration = await migrateRenamedProviders(document, credentials, { apply: true });
+    const migration = await migrateRenamedProviders(document, profiles, credentials, { apply: true });
     expect(migration.blocked).toEqual([]);
 
     const config = await onDisk(root);
+    expect(await held(root)).toContain('google_tasks.personal');
     expect(keys(config)).toContain('google_tasks.personal');
+    expect(await held(root)).not.toContain('tasks.personal');
     expect(keys(config)).not.toContain('tasks.personal');
-    expect(config.policy.allow.map((rule) => rule.capability)).toContain('google_tasks.*');
-    expect(config.policy.allow.map((rule) => rule.capability)).not.toContain('tasks.*');
+    expect(config.grants.flatMap((grant) => grant.allow.map((rule) => rule.capability))).toContain(
+      'google_tasks.*',
+    );
+    expect(config.grants.flatMap((grant) => grant.allow.map((rule) => rule.capability))).not.toContain(
+      'tasks.*',
+    );
 
     // All three, because any one alone is inert: the row without the rule is
     // granted nothing, and either without the credential is unauthorized.
@@ -131,22 +173,28 @@ describe('with a stored credential to prove what the row was', () => {
   });
 
   test('leaves the comments an operator reads the file for', async () => {
-    const { root, document, credentials } = await ready();
-    await migrateRenamedProviders(document, credentials, { apply: true });
+    const { root, document, profiles, credentials } = await ready();
+    await migrateRenamedProviders(document, profiles, credentials, { apply: true });
 
     const text = await Bun.file(join(root, 'profiles', 'personal.yaml')).text();
     expect(text).toContain('# Lanes Link profile: personal');
-    expect(text).toContain('# Only what is listed here is reachable');
+    expect(text).toContain('# One row per connection this profile may reach');
   });
 
   test('is a no-op the second time, because there is nothing left to move', async () => {
     const { root, credentials } = await ready();
-    await migrateRenamedProviders(await ConfigDocument.open(root, 'personal'), credentials, {
-      apply: true,
+    const reopen = async () => ({
+      connections: await ConfigDocument.openKey(root, CONNECTIONS_FILE),
+      profiles: [await ConfigDocument.open(root, 'personal')],
     });
 
+    const first = await reopen();
+    await migrateRenamedProviders(first.connections, first.profiles, credentials, { apply: true });
+
+    const second = await reopen();
     const again = await migrateRenamedProviders(
-      await ConfigDocument.open(root, 'personal'),
+      second.connections,
+      second.profiles,
       credentials,
       { apply: true },
     );
@@ -154,19 +202,30 @@ describe('with a stored credential to prove what the row was', () => {
     expect(again.changes).toEqual([]);
   });
 
-  test('keeps a rule that two providers would then share', async () => {
-    // A profile declaring the built-in *and* a pre-rename row has one `tasks.*`
-    // serving both, so moving it would silently revoke the one that kept its
-    // name. The row still moves; the rule is reported instead.
-    const { root, document, credentials } = await ready({ keepBuiltIn: true });
+  test('a workspace holding both rows migrates one and leaves the other', async () => {
+    // This used to be the hard case, and ADR-058 dissolved it. A rule lived in
+    // one flat block and named a provider, so a profile holding the built-in
+    // *and* a pre-rename row had one `tasks.*` serving both — moving it would
+    // silently revoke whichever kept its name, so the migration reported rather
+    // than guessed. A rule lives inside the row that names one connection now,
+    // so each of the two grants carries its own and neither can speak for the
+    // other. There is nothing left to decide, and nothing to block.
+    const { root, document, profiles, credentials } = await ready({ keepBuiltIn: true });
 
-    const migration = await migrateRenamedProviders(document, credentials, { apply: true });
+    const migration = await migrateRenamedProviders(document, profiles, credentials, { apply: true });
 
-    expect(migration.blocked.join('\n')).toMatch(/still declares a "tasks" connection/);
+    expect(migration.blocked).toEqual([]);
+
+    expect(await held(root)).toContain('google_tasks.personal');
+    expect(await held(root)).toContain('tasks.main');
 
     const config = await onDisk(root);
-    expect(keys(config)).toContain('google_tasks.personal');
-    expect(config.policy.allow.map((rule) => rule.capability)).toContain('tasks.*');
+    const google = config.grants.find((grant) => grant.connection === 'google_tasks.personal');
+    const builtIn = config.grants.find((grant) => grant.connection === 'tasks.main');
+
+    expect(google?.allow.map((rule) => rule.capability)).toEqual(['google_tasks.*']);
+    // Untouched, and still valid: its rule names its own provider.
+    expect(builtIn?.allow.map((rule) => rule.capability)).toEqual(['tasks.*']);
   });
 });
 
@@ -176,16 +235,20 @@ describe('a deny rule follows the rename too', () => {
     const path = join(root, 'profiles', 'personal.yaml');
     await Bun.write(
       path,
-      (await Bun.file(path).text()).replace('deny: []', 'deny: [tasks.tasks.tasks.delete]'),
+      (await Bun.file(path).text()).replace(
+        '  - { connection: tasks.personal, allow: [tasks.*], deny: [] }',
+        '  - { connection: tasks.personal, allow: [tasks.*], deny: [tasks.tasks.tasks.delete] }',
+      ),
     );
 
-    const { document, credentials } = await open(root);
+    const { document, profiles, credentials } = await open(root);
     await credentials.set('tasks/personal', 'token');
-    await migrateRenamedProviders(document, credentials, { apply: true });
+    await migrateRenamedProviders(document, profiles, credentials, { apply: true });
 
-    expect((await onDisk(root)).policy.deny.map((rule) => rule.capability)).toEqual([
-      'google_tasks.tasks.tasks.delete',
-    ]);
+    const grant = (await onDisk(root)).grants.find(
+      (row) => row.connection === 'google_tasks.personal',
+    );
+    expect(grant?.deny.map((rule) => rule.capability)).toEqual(['google_tasks.tasks.tasks.delete']);
   });
 });
 
@@ -217,12 +280,14 @@ describe('with nothing to prove what the row was', () => {
     // opposite one. Picking here would be the silent rebind the refusal exists
     // to prevent, arrived at from the other direction.
     const root = await brokenWorkspace();
-    const { document, credentials } = await open(root);
+    const { document, profiles, credentials } = await open(root);
 
-    const migration = await migrateRenamedProviders(document, credentials, { apply: true });
+    const migration = await migrateRenamedProviders(document, profiles, credentials, { apply: true });
 
     expect(migration.changes).toEqual([]);
     expect(migration.blocked.join('\n')).toMatch(/no stored credential/);
-    await expect(onDisk(root)).rejects.toThrow(/set provider to google_tasks/);
+    // The profile itself loads: its grant names `tasks.personal`, and whether
+    // that is Google's or the built-in is a question only the account answers.
+    await expect(readConnections(root)).rejects.toThrow(/set provider to google_tasks/);
   });
 });

--- a/src/cli/config-migrate.ts
+++ b/src/cli/config-migrate.ts
@@ -91,10 +91,12 @@ export function pendingRenames(document: ConfigDocument): PendingRename[] {
  * connection that lost its authorisation for no reason anyone can see.
  */
 export async function migrateRenamedProviders(
-  document: ConfigDocument,
+  connections: ConfigDocument,
+  profiles: readonly ConfigDocument[],
   credentials: SecretStore,
   options: { apply: boolean },
 ): Promise<RenameMigration> {
+  const document = connections;
   const rows = pendingRenames(document);
   if (rows.length === 0) return { rows, changes: [], blocked: [] };
 
@@ -116,15 +118,14 @@ export async function migrateRenamedProviders(
     }
   }
 
-  // The policy rules second, because whether one can move depends on what is
-  // left declaring the old id once the rows above have.
-  for (const [from, to] of new Map(accepted.map((row) => [row.from, row.to]))) {
-    const policy = renamePolicyRules(document, { from, to }, {
-      stillDeclared: keepsDeclaring(document, from, accepted),
-      apply: options.apply,
-    });
-    changes.push(...policy.changes);
-    blocked.push(...policy.blocked);
+  // The grant rules second, because whether one can move depends on what is
+  // left declaring the old id once the rows above have — and because they live
+  // in the profiles now rather than beside the connection (ADR-057), so this is
+  // one pass per profile over a rename computed once.
+  for (const row of accepted) {
+    for (const profile of profiles) {
+      changes.push(...renameGrantRules(profile, row, { apply: options.apply }).changes);
+    }
   }
 
   if (!options.apply || accepted.length === 0) return { rows, changes, blocked };
@@ -137,8 +138,11 @@ export async function migrateRenamedProviders(
   }
 
   // Throws unless the result is a config that loads, which is the assertion
-  // worth having here — the whole premise was that it did not.
+  // worth having here — the whole premise was that it did not. Both files, in
+  // the order that survives a crash between them: a grant naming a connection
+  // that has not been renamed yet is refused at load, so the profiles go last.
   await document.save();
+  if (options.apply) for (const profile of profiles) await profile.save();
 
   for (const row of accepted) await credentials.delete(`${row.from}/${row.id}`);
 
@@ -146,7 +150,7 @@ export async function migrateRenamedProviders(
 }
 
 /**
- * Rewrite the policy rules that named the old id, where that is unambiguous.
+ * Rewrite the grant rules that named the old id, where that is unambiguous.
  *
  * A rule names a provider and never an account, so `tasks.*` written for Google
  * Tasks has to follow the rename or the migrated connection is granted nothing
@@ -154,66 +158,80 @@ export async function migrateRenamedProviders(
  * consulted, so the repair would land a row that serves exactly as little as
  * the broken one did.
  *
- * But a profile declaring *both* — a Google Tasks row and the built-in — has one
- * rule serving two providers, and moving it would silently revoke the one that
- * kept its name. That profile keeps its rule and is told to add the second,
- * which is a sentence rather than a guess at which was meant.
+ * The ambiguity this used to guard against is gone, and it is worth saying why.
+ * A rule lived in one flat block and named a provider, so a profile holding a
+ * Google Tasks row *and* the built-in had one `tasks.*` serving both — moving it
+ * would silently revoke whichever kept its name, so the migration reported
+ * rather than guessed. A rule lives inside the row that names one connection
+ * now (ADR-058), so `tasks.*` on a `google_tasks` row is not ambiguous: it is
+ * invalid, and `assertReferentialIntegrity` refuses it. There is nothing left to
+ * decide.
  *
- * Both lists. A `deny` written to switch Google Tasks off means it as firmly as
- * an allow means it on, and leaving it behind would re-enable something the
- * operator turned off.
+ * Both lists, on every row. A `deny` written to switch Google Tasks off means it
+ * as firmly as an allow means it on, and leaving it behind would re-enable
+ * something the operator turned off.
+ *
+ * The row's `connection` moves too, and that is new: a grant names the account
+ * rather than the provider now (ADR-058), so `tasks.main` becomes
+ * `google_tasks.main` or the grant resolves to nothing.
  */
-function renamePolicyRules(
+function renameGrantRules(
   document: ConfigDocument,
-  provider: { from: string; to: string },
-  options: { stillDeclared: boolean; apply: boolean },
-): { changes: string[]; blocked: string[] } {
+  moved: { from: string; to: string; id: string; key: string },
+  options: { apply: boolean },
+): { changes: string[] } {
   const changes: string[] = [];
-  const blocked: string[] = [];
 
-  for (const field of ['allow', 'deny'] as const) {
-    const rules = document.getIn(['policy', field]) as { items?: unknown[] } | null;
+  const provider = { from: moved.from, to: moved.to };
+  const grants = document.getIn(['grants']) as { items?: unknown[] } | null;
 
-    (rules?.items ?? []).forEach((_item, index) => {
-      // Either spelling: a bare pattern, or `{ capability, expires_at }`. The
-      // path to it differs; the decision does not.
-      const bare = document.getIn(['policy', field, index]);
-      const path =
-        typeof bare === 'string'
-          ? (['policy', field, index] as const)
-          : (['policy', field, index, 'capability'] as const);
+  (grants?.items ?? []).forEach((_row, at) => {
+    const connection = document.getIn(['grants', at, 'connection']);
+    if (typeof connection !== 'string') return;
 
-      const capability = typeof bare === 'string' ? bare : document.getIn(path);
-      if (typeof capability !== 'string') return;
+    // The *exact* connection that moved, not every grant naming the old
+    // provider. A workspace holding a Google Tasks row beside the built-in has
+    // two `tasks.` grants and only one of them is being renamed — moving both
+    // would point the built-in's grant at a connection that does not exist.
+    if (connection !== moved.key) return;
 
-      const [named, ...rest] = capability.split('.');
-      if (named !== provider.from) return;
+    // The `connection` field always follows, and this is the one place the
+    // ambiguity does not reach. It names the exact row being renamed, so there
+    // is nothing to guess — and leaving it behind would point the grant at a
+    // connection that no longer exists, which `assertGrantsResolve` refuses at
+    // load. The rename would have made the workspace unopenable.
+    const renamedConnection = `${provider.to}.${moved.id}`;
+    if (options.apply) document.setIn(['grants', at, 'connection'], renamedConnection);
+    changes.push(`grants[${at}].connection: ${connection} → ${renamedConnection}`);
 
-      const moved = [provider.to, ...rest].join('.');
+    for (const field of ['allow', 'deny'] as const) {
+      const rules = document.getIn(['grants', at, field]) as { items?: unknown[] } | null;
 
-      if (options.stillDeclared) {
-        blocked.push(
-          `policy.${field} keeps "${capability}" — this profile still declares a ` +
-            `"${provider.from}" connection, so add "${moved}" rather than moving it`,
-        );
-        return;
-      }
+      (rules?.items ?? []).forEach((_item, index) => {
+        // Either spelling: a bare pattern, or `{ capability, expires_at }`. The
+        // path to it differs; the decision does not.
+        const bare = document.getIn(['grants', at, field, index]);
+        const path =
+          typeof bare === 'string'
+            ? (['grants', at, field, index] as const)
+            : (['grants', at, field, index, 'capability'] as const);
 
-      if (options.apply) document.setIn(path, moved);
-      changes.push(`policy.${field}: ${capability} → ${moved}`);
-    });
-  }
+        const capability = typeof bare === 'string' ? bare : document.getIn(path);
+        if (typeof capability !== 'string') return;
 
-  return { changes, blocked };
+        const [head, ...rest] = capability.split('.');
+        if (head !== provider.from) return;
+
+        const renamed = [provider.to, ...rest].join('.');
+        if (options.apply) document.setIn(path, renamed);
+        changes.push(`grants[${at}].${field}: ${capability} → ${renamed}`);
+      });
+    }
+  });
+
+  return { changes };
 }
 
-/**
- * Whether a row naming the old provider survives the migration.
- *
- * Computed against the accepted set rather than by re-reading the document,
- * because the same answer has to hold on a report-only run, where nothing has
- * been rewritten yet.
- */
 function keepsDeclaring(
   document: ConfigDocument,
   provider: string,

--- a/src/cli/config-repair.ts
+++ b/src/cli/config-repair.ts
@@ -104,7 +104,12 @@ export function ensureReservedConnection(
   connections: ConfigDocument,
   profile: ConfigDocument,
   provider: ReservedSurface,
+  options: { grants?: boolean } = {},
 ): SurfaceRepair {
+  // Whether the profile half is written at all. `connect` without `--profile`
+  // repairs the workspace's connection rows and touches no profile, because it
+  // was not told which one to touch (ADR-057).
+  const grants = options.grants ?? true;
   // Raw YAML, so nothing here has been through a schema: this runs over sibling
   // profiles that were never validated, and every field is whatever was typed.
   const workspace = connections.toJSON() as { connections?: unknown } | null;
@@ -114,7 +119,7 @@ export function ensureReservedConnection(
   const covers = (pattern: string): boolean => pattern === '*' || pattern === rule;
 
   const rows = Array.isArray(workspace?.connections) ? workspace.connections : [];
-  const grants = Array.isArray(config?.grants) ? config.grants : [];
+  const held_grants = Array.isArray(config?.grants) ? config.grants : [];
 
   // The row this profile would use. Any instance of the provider will do, and
   // the *first* one is taken rather than `main` specifically: an operator who
@@ -125,7 +130,7 @@ export function ensureReservedConnection(
   const id = typeof existing?.id === 'string' ? existing.id : 'main';
   const key = `${provider}.${id}`;
 
-  const held = grants.find(
+  const held = held_grants.find(
     (row) => (row as { connection?: unknown } | null)?.connection === key,
   ) as { allow?: unknown; deny?: unknown } | undefined;
 
@@ -155,6 +160,8 @@ export function ensureReservedConnection(
     changes.push(`connections.yaml += ${key}`);
   }
 
+  if (!grants) return { changes, granted };
+
   if (held === undefined) {
     profile.addTo(['grants'], { connection: key, allow: [rule], deny: [] }, { inline: true });
     changes.push(`grants += ${key}`);
@@ -163,7 +170,7 @@ export function ensureReservedConnection(
     // A row that exists and grants nothing is a surface that is present and
     // silent. Widening it back is the repair; the deny check above is what stops
     // this undoing a deliberate narrowing.
-    const at = grants.indexOf(held as never);
+    const at = held_grants.indexOf(held as never);
     profile.addTo(['grants', at, 'allow'], rule, { inline: true });
     granted.push(rule);
   }
@@ -252,12 +259,13 @@ function patternsIn(rules: unknown, now = Date.now()): string[] {
 export function ensureOwnerLayer(
   connections: ConfigDocument,
   profile: ConfigDocument,
+  options: { grants?: boolean } = {},
 ): SurfaceRepair {
   const changes: string[] = [];
   const granted: string[] = [];
 
   for (const provider of DEFAULT_SURFACES) {
-    const repair = ensureReservedConnection(connections, profile, provider);
+    const repair = ensureReservedConnection(connections, profile, provider, options);
     changes.push(...repair.changes);
     granted.push(...repair.granted);
   }

--- a/src/cli/config-repair.ts
+++ b/src/cli/config-repair.ts
@@ -1,4 +1,5 @@
-import { listProfiles } from '#profile';
+import { newConnectionsTemplate } from './config-templates.ts';
+import { CONNECTIONS_FILE, listProfiles, workspaceFiles, writeWorkspaceFile } from '#profile';
 import { ConfigDocument } from './config-edit.ts';
 import { ok, print, style, warn } from './output.ts';
 
@@ -100,59 +101,88 @@ export interface SurfaceRepair {
  * (ADR-023) so it could not write this even if the code let it.
  */
 export function ensureReservedConnection(
-  document: ConfigDocument,
+  connections: ConfigDocument,
+  profile: ConfigDocument,
   provider: ReservedSurface,
 ): SurfaceRepair {
   // Raw YAML, so nothing here has been through a schema: this runs over sibling
   // profiles that were never validated, and every field is whatever was typed.
-  const config = document.toJSON() as {
-    connections?: unknown;
-    policy?: { allow?: unknown; deny?: unknown };
-  } | null;
+  const workspace = connections.toJSON() as { connections?: unknown } | null;
+  const config = profile.toJSON() as { grants?: unknown } | null;
 
   const rule = `${provider}.*`;
   const covers = (pattern: string): boolean => pattern === '*' || pattern === rule;
 
+  const rows = Array.isArray(workspace?.connections) ? workspace.connections : [];
+  const grants = Array.isArray(config?.grants) ? config.grants : [];
+
+  // The row this profile would use. Any instance of the provider will do, and
+  // the *first* one is taken rather than `main` specifically: an operator who
+  // renamed theirs should not get a second one bolted on beside it.
+  const existing = rows.find(
+    (row) => (row as { provider?: unknown } | null)?.provider === provider,
+  ) as { id?: unknown } | undefined;
+  const id = typeof existing?.id === 'string' ? existing.id : 'main';
+  const key = `${provider}.${id}`;
+
+  const held = grants.find(
+    (row) => (row as { connection?: unknown } | null)?.connection === key,
+  ) as { allow?: unknown; deny?: unknown } | undefined;
+
   // Denied on purpose, and a deny beats an allow — so writing the rule would
   // widen nothing while announcing that an agent can now read the surface,
-  // which would be false. For `setup`, deleting the two lines no longer removes
-  // it either, because the next `connect` or `deploy` puts them back; a deny is
-  // the way it stays off, so it is the one thing this must not undo. The same
-  // holds for `identity`, where the next `identity add` is what would put them
-  // back.
+  // which would be false. Deleting the row no longer removes the surface
+  // either, because the next `connect` or `deploy` puts it back; a deny is the
+  // way it stays off, so it is the one thing this must not undo.
   //
   // Only a rule covering the whole surface counts. `deny: [setup.provider]` is
   // an operator narrowing it, not switching it off, and that narrowing survives
   // the repair untouched — which is the point of denying one capability.
-  if (patternsIn(config?.policy?.deny).some(covers)) return { changes: [], granted: [] };
+  if (patternsIn(held?.deny).some(covers)) return { changes: [], granted: [] };
 
   const changes: string[] = [];
   const granted: string[] = [];
 
-  const connections = Array.isArray(config?.connections) ? config.connections : [];
-  const declared = (row: unknown): boolean =>
-    (row as { provider?: unknown } | null)?.provider === provider;
-
-  if (!connections.some(declared)) {
-    // Inline, and `main` for the id, so a repaired profile is spelled exactly
-    // like `newProfileTemplate` writes a fresh one. Two spellings of one row is
-    // how a template and its repair drift apart.
-    document.addTo(
+  if (existing === undefined) {
+    // Inline, and `main` for the id, so a repaired workspace is spelled exactly
+    // like `newConnectionsTemplate` writes a fresh one. Two spellings of one row
+    // is how a template and its repair drift apart.
+    connections.addTo(
       ['connections'],
       { id: 'main', provider, account: RESERVED_SURFACES[provider] },
       { inline: true },
     );
-    changes.push(`connections += ${provider}.main`);
+    changes.push(`connections.yaml += ${key}`);
   }
 
-  // `*` already covers it. Re-stating the rule under a blanket allow would be
-  // noise in the file and a diff the operator did not ask for.
-  if (!patternsIn(config?.policy?.allow).some(covers)) {
-    document.addTo(['policy', 'allow'], rule, { inline: true });
+  if (held === undefined) {
+    profile.addTo(['grants'], { connection: key, allow: [rule], deny: [] }, { inline: true });
+    changes.push(`grants += ${key}`);
+    granted.push(rule);
+  } else if (!patternsIn(held.allow).some(covers)) {
+    // A row that exists and grants nothing is a surface that is present and
+    // silent. Widening it back is the repair; the deny check above is what stops
+    // this undoing a deliberate narrowing.
+    const at = grants.indexOf(held as never);
+    profile.addTo(['grants', at, 'allow'], rule, { inline: true });
     granted.push(rule);
   }
 
   return { changes, granted };
+}
+
+/** The workspace's connections document, written from the template if missing. */
+async function openOrCreateConnections(workspaceRoot: string): Promise<ConfigDocument> {
+  try {
+    return await ConfigDocument.openKey(workspaceRoot, CONNECTIONS_FILE);
+  } catch {
+    await writeWorkspaceFile(
+      workspaceFiles(workspaceRoot),
+      CONNECTIONS_FILE,
+      newConnectionsTemplate(),
+    );
+    return ConfigDocument.openKey(workspaceRoot, CONNECTIONS_FILE);
+  }
 }
 
 /** Whether a repair did anything, without a caller adding up two lists. */
@@ -169,7 +199,7 @@ export function repaired(repair: SurfaceRepair): boolean {
 
 /** The repair as display lines, in the order the two halves are applied. */
 export function repairLines(repair: SurfaceRepair): string[] {
-  return [...repair.changes, ...repair.granted.map((rule) => `policy.allow += ${rule}`)];
+  return [...repair.changes, ...repair.granted.map((rule) => `grants[].allow += ${rule}`)];
 }
 
 /**
@@ -219,12 +249,15 @@ function patternsIn(rules: unknown, now = Date.now()): string[] {
  * Each surface is still decided independently, so a profile that denied exactly
  * one of them keeps that decision while the rest are repaired.
  */
-export function ensureOwnerLayer(document: ConfigDocument): SurfaceRepair {
+export function ensureOwnerLayer(
+  connections: ConfigDocument,
+  profile: ConfigDocument,
+): SurfaceRepair {
   const changes: string[] = [];
   const granted: string[] = [];
 
   for (const provider of DEFAULT_SURFACES) {
-    const repair = ensureReservedConnection(document, provider);
+    const repair = ensureReservedConnection(connections, profile, provider);
     changes.push(...repair.changes);
     granted.push(...repair.granted);
   }
@@ -241,8 +274,11 @@ export function ensureOwnerLayer(document: ConfigDocument): SurfaceRepair {
  * paragraph of the instructions budget to say so. `identity add` is the only
  * caller, so the grant arrives exactly when there is something behind it.
  */
-export function ensureIdentityConnection(document: ConfigDocument): SurfaceRepair {
-  return ensureReservedConnection(document, 'identity');
+export function ensureIdentityConnection(
+  connections: ConfigDocument,
+  profile: ConfigDocument,
+): SurfaceRepair {
+  return ensureReservedConnection(connections, profile, 'identity');
 }
 
 /**
@@ -288,14 +324,25 @@ export async function repairOwnerLayer(
   const say = options.report ?? print;
   const wanted = profiles === undefined ? undefined : new Set(profiles);
 
+  // One connections document for the whole sweep. The owner layer is the
+  // workspace's now (ADR-059), so repairing three profiles must not add three
+  // `memory.main` rows — opening it once and saving it once is what makes the
+  // second profile see what the first one created.
+  // Created if absent rather than refused. A contract-3 workspace always has
+  // one, but a hand-made or half-migrated one may not — and this is the repair,
+  // so the file it needs is a thing to write rather than a reason to stop.
+  const connections = await openOrCreateConnections(workspaceRoot);
+  let connectionsChanged = false;
+
   for (const name of await listProfiles(workspaceRoot)) {
     if (wanted !== undefined && !wanted.has(name)) continue;
 
     try {
       const document = await ConfigDocument.open(workspaceRoot, name);
-      const repair = ensureOwnerLayer(document);
+      const repair = ensureOwnerLayer(connections, document);
       if (!repaired(repair)) continue;
 
+      connectionsChanged = true;
       await document.save();
 
       say(ok(`gave ${style.bold(name)} its own owner layer`));
@@ -313,4 +360,6 @@ export async function repairOwnerLayer(
       );
     }
   }
+
+  if (connectionsChanged) await connections.save();
 }

--- a/src/cli/config-templates.ts
+++ b/src/cli/config-templates.ts
@@ -1,0 +1,198 @@
+import { SUPPORTED_CONTRACT } from '#profile';
+
+/**
+ * The files a fresh workspace and a fresh profile are written from.
+ *
+ * Split out of `config-edit.ts` because they are prose rather than machinery:
+ * that file knows how to edit YAML without disturbing what an operator wrote,
+ * and these are the comments an operator reads. Keeping both in one file put it
+ * over the size budget, and the seam was already there.
+ *
+ * **The template and the repair must write a row in one spelling.** Two
+ * spellings of one row is how they drift apart, and `config-edit.test.ts`
+ * asserts that a fresh profile and workspace need no repair, which is the check
+ * that catches it (ADR-050).
+ */
+
+export function newProfileTemplate(profile: string, port: number, subject?: string): string {
+  return `# Lanes Link profile: ${profile}
+#
+# A profile is a *selection*: which of the workspace's accounts this agent may
+# reach, what it may do with each, and who may use it. The accounts themselves
+# live in connections.yaml beside this file, because authorising an account and
+# deciding what may be done with it are two different acts (ADR-057).
+#
+# This file never contains a credential value — only "_ref" pointers into the
+# credential store, which is the workspace's and is encrypted at rest.
+#
+# Edit it by hand or through the CLI; both are supported, and CLI edits preserve
+# your comments and ordering.
+contract: 3
+
+instance:
+  profile: ${profile}
+  port: ${port}
+  host: 127.0.0.1
+
+# What this profile is for, in your own words. Members see it, and so does
+# setup_overview — "reads my mail, keeps the calendar, never sends" is what
+# somebody needs to know before accepting it.
+# description: 
+
+# This file says nothing about where it runs, and that is the point.
+#
+# A profile lives in exactly one workspace, and that workspace declares its own
+# adapters, once, in lanes-link.yaml beside the profiles/ directory (ADR-052).
+# Moving this profile somewhere else is copying the file there.
+#
+#     lanes link status --profile ${profile} --workspace <name>
+#
+# The bearer token below is for CI. People sign in instead: a client that asks
+# for authorization is sent to the Lanes login, and comes back as somebody
+# (ADR-062). "lanes link token show" is for a runner with no browser.
+auth:
+  mode: bearer
+  token_ref: profile/token
+  authorization:
+    mode: self
+
+limits:
+  requests_per_minute: 120      # per profile
+  upstream_calls_per_minute: 60 # per connection, protects vendor quota
+
+# One row per connection this profile may reach, and what it may do with each.
+#
+# A row is the grant. There is no separate list of accounts and list of rules
+# that have to agree — naming a connection here is what makes it reachable, and
+# the allow list is what makes any of its capabilities callable. An account the
+# workspace holds and this file does not name is simply absent: not denied, not
+# advertised, not there.
+#
+# Rules name capabilities of that row's own provider. "gmail.*" covers
+# everything Gmail offers *for that one account*, which is what lets a second
+# row over a second mailbox allow something different (ADR-058).
+#
+# The seven below hold no account, and that is why they are here already: they
+# reach your own material rather than anybody's API, so there was never anything
+# for a connect step to authorise (ADR-050). What each one is:
+#
+#   memory   what you want remembered between sessions
+#   tasks    what you have to do, each with a status
+#   assets   files you want kept, by name
+#   skills   procedures you have written, handed to an agent as instructions
+#   vault    passwords and API keys, released one at a time
+#   setup    what is connected here, and what connecting more would take
+#   entities the people, companies and projects you deal with, and how to
+#            reach each of them — so an agent looks an address up rather
+#            than recalling one
+#
+# To switch one off, add it to that row's deny — deleting the row no longer
+# works, because the next connect or deploy puts it back. The three narrowings
+# worth knowing:
+#
+#   deny: [memory.write]        remember nothing new
+#   deny: [skills.manage.*]     invoke procedures, do not write them
+#   deny: [vault.put, vault.remove]
+grants:
+  - { connection: memory.main, allow: [memory.*], deny: [] }
+  - { connection: tasks.main, allow: [tasks.*], deny: [] }
+  - { connection: assets.main, allow: [assets.*], deny: [] }
+  - { connection: skills.main, allow: [skills.*], deny: [] }
+  - { connection: vault.main, allow: [vault.*], deny: [] }
+  - { connection: setup.main, allow: [setup.*], deny: [] }
+  - { connection: entities.main, allow: [entities.*], deny: [] }
+
+# Who may consume this profile (ADR-060).
+#
+# Empty is nobody, not everybody — default deny on the identity axis. A caller
+# proves who they are by signing in to Lanes, and reaches this profile only if
+# their subject is listed here.
+#
+# "owner" may edit this list. Both roles reach exactly what the grants above
+# allow: a role that changed what an agent could call would be a second policy
+# system beside grants, answering a question the first one already answers.
+members:${
+    subject
+      ? `
+  - { subject: ${subject}, role: owner }`
+      : ' []'
+  }
+`;
+}
+
+export function newWorkspaceTemplate(): string {
+  return `# Lanes Link workspace
+#
+# A workspace holds the accounts you have authorised (connections.yaml) and the
+# profiles that select among them (profiles/). One endpoint serves all of them:
+# every call names the profile it means, with --profile.
+#
+# "workspaces:" below says where this one's bytes go, once, for every profile in
+# it — a profile says nothing about where it runs, so there is one copy of it and
+# nothing to keep in step (ADR-052).
+#
+# A workspace somewhere else is a pointer, and "deploy" writes one:
+#
+#   workspaces:
+#     cloud:
+#       at: gs://your-bucket
+#       lanes_workspace: <id>     # whose members may be delegated to
+#
+# The workspace at that address declares its own adapters, and is the only thing
+# that does. Reading it is a network call, which is why "--workspace cloud" needs
+# that bucket reachable.
+#
+# default_workspace is used when --workspace is absent, and every command that
+# uses it prints which one it got. Commands that publish or destroy — deploy,
+# sync, secrets push, profile remove, disconnect, token rotate — refuse it and
+# make you type the name (ADR-061).
+contract: 3
+default_workspace: local
+workspaces:
+  local:
+    credentials: { adapter: file }
+    storage: { adapter: filesystem }
+`;
+}
+
+/**
+ * `connections.yaml` for a workspace that has just been created.
+ *
+ * The owner layer arrives here rather than in the profile, because these are
+ * connections now (ADR-059) and a second profile should select the same stores
+ * rather than get its own empty ones. `ensureOwnerLayer` keeps this in one
+ * spelling with the repair, which `config-edit.test.ts` asserts by checking that
+ * a fresh workspace needs no repair.
+ */
+export function newConnectionsTemplate(): string {
+  return `# Lanes Link connections
+#
+# Every account authorised in this workspace, in one place. A profile names the
+# ones it may reach in its own "grants:" block — connecting an account and
+# deciding what may be done with it are two acts, and only the second belongs to
+# a profile (ADR-057).
+#
+# "account" is the identity the provider reports — an address, a workspace — so
+# this list says whose data is reachable without having to look anything up.
+# "label" is your own word for the same row, and only ever displayed.
+#
+# The seven below hold no account: they reach your own material rather than
+# anybody's API, so there was never anything for a connect step to authorise
+# (ADR-050). Make a second one — "lanes link connect memory --id work" — when you
+# want two profiles to share nothing.
+contract: 3
+
+connections:
+  - { id: main, provider: memory, account: Memory }
+  - { id: main, provider: tasks, account: Tasks }
+  - { id: main, provider: assets, account: Assets }
+  - { id: main, provider: skills, account: Skills }
+  - { id: main, provider: vault, account: Vault }
+  - { id: main, provider: setup, account: Setup }
+  - { id: main, provider: entities, account: Entities }
+
+# App registrations, shared by every connection of that vendor.
+oauth_apps: {}
+`;
+}
+

--- a/src/cli/contract3-data.ts
+++ b/src/cli/contract3-data.ts
@@ -101,20 +101,27 @@ export async function mergeCredentials(root: string, profiles: readonly string[]
 /**
  * Where every object under `data/<profile>/` is going.
  *
- * Computed from the hoisted rows rather than from what is on disk, so a blob
- * belonging to a connection that was renamed follows the rename. Anything that
- * matches no rule is left exactly where it is: this moves what it understands
- * and never deletes what it does not.
+ * Driven by `perProfile`, the per-profile map the hoist already built from old
+ * key to new — because the rename that matters is *this profile's*. The first
+ * version of this keyed a lookup by the hoisted (new) key and queried it with
+ * the old one, which made the resolution an unconditional no-op: provider and
+ * connection ids contain no dot, so anything the map returned already had the id
+ * being looked up. Two profiles holding `gmail.main` for different mailboxes
+ * both sent their blobs to `data/gmail/main/`, and the second one's landed in
+ * the first one's namespace.
+ *
+ * Anything that matches no rule is left exactly where it is: this moves what it
+ * understands and never deletes what it does not.
  */
 export async function planMoves(
   files: BlobStore,
   profiles: readonly string[],
-  rows: readonly { id: string; provider: string }[],
+  perProfile: ReadonlyMap<string, ReadonlyMap<string, string>>,
 ): Promise<Move[]> {
   const moves: Move[] = [];
-  const byOldKey = new Map(rows.map((row) => [keyOf(row), row]));
 
   for (const profile of profiles) {
+    const mapping = perProfile.get(profile) ?? new Map<string, string>();
     const prefix = `${DATA_DIR}/${profile}/`;
 
     for (const blob of await files.list(prefix)) {
@@ -128,16 +135,25 @@ export async function planMoves(
       // every record, so they are concatenated by moving the objects across.
       if (head === 'credentials.enc' || head === 'credentials.enc.key') continue;
 
+      // The instance this profile's single-instance surfaces became. Both are
+      // one store per profile in contract 2 and one per *connection* in
+      // contract 3, so two profiles' vaults are two documents — sending both to
+      // `vault('main')` orphaned the second and silently gave it the first's,
+      // which is the worst of the collisions because the wrong answer is a
+      // credential (ADR-059).
       if (head === 'vault.enc') {
-        moves.push({ from: blob.key, to: layout.vault('main') });
+        moves.push({ from: blob.key, to: layout.vault(instanceOf(mapping, 'vault')) });
         continue;
       }
       if (head === 'vault.enc.key') {
-        moves.push({ from: blob.key, to: `${layout.vault('main')}.key` });
+        moves.push({ from: blob.key, to: `${layout.vault(instanceOf(mapping, 'vault'))}.key` });
         continue;
       }
       if (head === 'skills.d') {
-        moves.push({ from: blob.key, to: `${layout.skills('main')}/${tail.join('/')}` });
+        moves.push({
+          from: blob.key,
+          to: `${layout.skills(instanceOf(mapping, 'skills'))}/${tail.join('/')}`,
+        });
         continue;
       }
       if (head === 'providers.d') {
@@ -154,8 +170,9 @@ export async function planMoves(
       const connection = tail[0];
       if (connection === undefined) continue;
 
-      const renamed = byOldKey.get(`${head}.${connection}`);
-      const id = renamed ? renamed.id : connection;
+      // This profile's old key, through this profile's mapping.
+      const settled = mapping.get(`${head}.${connection}`);
+      const id = settled === undefined ? connection : (settled.split('.')[1] ?? connection);
       moves.push({ from: blob.key, to: `${DATA_DIR}/${head}/${id}/${tail.slice(1).join('/')}` });
     }
   }
@@ -167,18 +184,37 @@ export async function planMoves(
  * Copy, verify, then delete. In that order, per object.
  *
  * A move that deleted first would lose an object on any failure, and these are
- * the owner's notes, tasks and entities. Copying into a key that already holds
- * something is skipped rather than overwritten: two profiles that both had
- * `memory.main` are two sets of notes, and the second one keeps its own home
- * under a suffixed connection rather than being interleaved with the first.
+ * the owner's notes, tasks and entities.
+ *
+ * A destination that already holds something is a bug rather than a case to
+ * handle, now that the hoist gives every profile's owner layer its own instance:
+ * two sets of notes can no longer be aimed at one key. It used to be skipped
+ * silently, which is how work's vault came to be orphaned while `moved` reported
+ * it as moved. It refuses instead, before deleting anything.
  */
+/** Which instance of a single-instance surface this profile's store became. */
+function instanceOf(mapping: ReadonlyMap<string, string>, provider: string): string {
+  for (const [from, to] of mapping) {
+    if (from.startsWith(`${provider}.`)) return to.split('.')[1] ?? 'main';
+  }
+  return 'main';
+}
+
 export async function applyMoves(files: BlobStore, moves: readonly Move[]): Promise<void> {
   for (const move of moves) {
     if (move.from === move.to) continue;
 
     const data = await files.get(move.from);
     if (data === null) continue;
-    if (await files.has(move.to)) continue;
+
+    if (await files.has(move.to)) {
+      throw new ConfigError(
+        `Two objects want to be at ${move.to}, and this migration cannot merge them.\n` +
+          `  ${move.from} is the second. Nothing has been deleted.\n` +
+          '  This should be unreachable: the hoist gives every profile its own instance of ' +
+          'each owner-layer surface. Please report it with the layout of your data directory.',
+      );
+    }
 
     await files.put(move.to, data);
     if ((await files.get(move.to)) === null) {

--- a/src/cli/contract3-data.ts
+++ b/src/cli/contract3-data.ts
@@ -1,4 +1,4 @@
-import { ConfigError, DATA_DIR, layout } from '#profile';
+import { ConfigError, DATA_DIR, isRemoteWorkspace, layout } from '#profile';
 import { createFileSecretStore } from '#secrets';
 import type { BlobStore } from '#stores/blobs';
 
@@ -30,8 +30,19 @@ function keyOf(connection: { provider: string; id: string }): string {
  * different values is the one thing this cannot resolve, and it is reported
  * rather than merged: both are real credentials, and picking either would point
  * a connection at the wrong account's token.
+ *
+ * **A workspace in a bucket has nothing to merge, and this says so rather than
+ * finding out.** `workspacePath` refuses a filesystem adapter against a remote
+ * root, so the only credential store such a workspace can declare is
+ * `gcp-secret-manager` — whose refs were never scoped by profile, and are
+ * therefore already what contract 3 wants. Without the guard the path below is
+ * built by string interpolation into `gs://bucket/data/<profile>/credentials.enc`
+ * and handed to `Bun.file`, where the failure is swallowed by the `catch` and
+ * reads exactly like a workspace with no credentials in it.
  */
 export async function planCredentials(root: string, profiles: readonly string[]): Promise<string[]> {
+  if (isRemoteWorkspace(root)) return [];
+
   const refs = new Set<string>();
 
   for (const profile of profiles) {
@@ -57,8 +68,14 @@ export async function planCredentials(root: string, profiles: readonly string[])
  * The old stores are left in place regardless. They are a few kilobytes, they
  * are the only copy of anything if this went wrong, and `doctor` names them so
  * an operator can remove them once the endpoint has served a request.
+ *
+ * Skipped entirely for a workspace in a bucket, for the reason `planCredentials`
+ * gives: its credentials are in Secret Manager under refs that were never
+ * per-profile, so there is no second store to fold in.
  */
 export async function mergeCredentials(root: string, profiles: readonly string[]): Promise<void> {
+  if (isRemoteWorkspace(root)) return;
+
   const destination = createFileSecretStore({ path: `${root}/${layout.credentials()}` });
 
   for (const profile of profiles) {
@@ -177,7 +194,35 @@ export async function planMoves(
     }
   }
 
+  assertOneObjectPerDestination(moves);
   return moves;
+}
+
+/**
+ * Two objects aimed at one key, caught while this is still a plan.
+ *
+ * `applyMoves` checks the destination per object as well, but that check cannot
+ * see a collision between two objects *in this run* once the moves are applied
+ * concurrently — both would look at an absent destination and both would write.
+ * Hoisting it here also puts it where this file says it belongs: everything that
+ * can fail happens before the first byte moves, so a refusal leaves the
+ * workspace exactly as it was.
+ */
+function assertOneObjectPerDestination(moves: readonly Move[]): void {
+  const seen = new Map<string, string>();
+
+  for (const move of moves) {
+    const first = seen.get(move.to);
+    if (first !== undefined) {
+      throw new ConfigError(
+        `Two objects want to be at ${move.to}, and this migration cannot merge them.\n` +
+          `  ${first} and ${move.from}. Nothing has been written.\n` +
+          '  This should be unreachable: the hoist gives every profile its own instance of ' +
+          'each owner-layer surface. Please report it with the layout of your data directory.',
+      );
+    }
+    seen.set(move.to, move.from);
+  }
 }
 
 /**
@@ -186,11 +231,20 @@ export async function planMoves(
  * A move that deleted first would lose an object on any failure, and these are
  * the owner's notes, tasks and entities.
  *
- * A destination that already holds something is a bug rather than a case to
- * handle, now that the hoist gives every profile's owner layer its own instance:
- * two sets of notes can no longer be aimed at one key. It used to be skipped
- * silently, which is how work's vault came to be orphaned while `moved` reported
- * it as moved. It refuses instead, before deleting anything.
+ * A destination that already holds *different* bytes is a bug rather than a case
+ * to handle, now that the hoist gives every profile's owner layer its own
+ * instance: two sets of notes can no longer be aimed at one key. It used to be
+ * skipped silently, which is how work's vault came to be orphaned while `moved`
+ * reported it as moved. `assertOneObjectPerDestination` refuses that while this
+ * is still a plan, and the check here catches what a plan cannot see.
+ *
+ * **The same bytes at the destination is the interrupted move, and it finishes
+ * it.** Copy-then-delete has a window between the two, and this migration now
+ * runs against buckets — where the window is a network round trip rather than a
+ * syscall, and an interruption is something that happens rather than something
+ * to reason about. Refusing there would have meant a workspace that could not be
+ * migrated by running the migration again, which is the one recovery this file
+ * promises.
  */
 /** Which instance of a single-instance surface this profile's store became. */
 function instanceOf(mapping: ReadonlyMap<string, string>, provider: string): string {
@@ -200,31 +254,75 @@ function instanceOf(mapping: ReadonlyMap<string, string>, provider: string): str
   return 'main';
 }
 
+/**
+ * How many objects are in flight at once.
+ *
+ * Serial was fine while this only ever ran against a local disk. A deployed
+ * workspace's audit log is one object per event, so the first real bucket this
+ * migrated held 1,906 of them — three round trips each, in series, is minutes of
+ * a deploy spent with nothing on screen. The same 16 the read paths in
+ * `#providers/memory` and `#providers/tasks` settled on, and for the same
+ * reason: enough to hide the latency, not enough to look like an incident to the
+ * other end.
+ *
+ * Safe to widen only while each move stays independent, which is what
+ * `assertOneObjectPerDestination` guarantees.
+ */
+const MOVE_CONCURRENCY = 16;
+
 export async function applyMoves(files: BlobStore, moves: readonly Move[]): Promise<void> {
-  for (const move of moves) {
-    if (move.from === move.to) continue;
+  const pending = moves.filter((move) => move.from !== move.to);
 
-    const data = await files.get(move.from);
-    if (data === null) continue;
-
-    if (await files.has(move.to)) {
-      throw new ConfigError(
-        `Two objects want to be at ${move.to}, and this migration cannot merge them.\n` +
-          `  ${move.from} is the second. Nothing has been deleted.\n` +
-          '  This should be unreachable: the hoist gives every profile its own instance of ' +
-          'each owner-layer surface. Please report it with the layout of your data directory.',
-      );
-    }
-
-    await files.put(move.to, data);
-    if ((await files.get(move.to)) === null) {
-      throw new ConfigError(
-        `${move.to} did not read back after being written. Nothing has been deleted; ` +
-          `fix the store and run this again.`,
-      );
-    }
-
-    await files.delete(move.from);
+  for (let start = 0; start < pending.length; start += MOVE_CONCURRENCY) {
+    await Promise.all(
+      pending.slice(start, start + MOVE_CONCURRENCY).map((move) => applyMove(files, move)),
+    );
   }
+}
+
+/** One object, moved or finished. Never deletes before the copy reads back. */
+async function applyMove(files: BlobStore, move: Move): Promise<void> {
+  const data = await files.get(move.from);
+  if (data === null) return;
+
+  if (await files.has(move.to)) {
+    const held = await files.get(move.to);
+
+    // Raced away between the two calls, so there is nothing there after all and
+    // the ordinary path below is still the right one.
+    if (held !== null) {
+      if (!sameBytes(held, data)) {
+        throw new ConfigError(
+          `Two objects want to be at ${move.to}, and this migration cannot merge them.\n` +
+            `  ${move.from} is the second, and what is already there is not a copy of it.\n` +
+            '  Nothing has been deleted. This should be unreachable: the hoist gives every ' +
+            'profile its own instance of each owner-layer surface. Please report it with the ' +
+            'layout of your data directory.',
+        );
+      }
+
+      // Already copied, by a run that did not get to the delete.
+      await files.delete(move.from);
+      return;
+    }
+  }
+
+  await files.put(move.to, data);
+  if ((await files.get(move.to)) === null) {
+    throw new ConfigError(
+      `${move.to} did not read back after being written. Nothing has been deleted; ` +
+        `fix the store and run this again.`,
+    );
+  }
+
+  await files.delete(move.from);
+}
+
+function sameBytes(left: Uint8Array, right: Uint8Array): boolean {
+  if (left.length !== right.length) return false;
+  for (let index = 0; index < left.length; index += 1) {
+    if (left[index] !== right[index]) return false;
+  }
+  return true;
 }
 

--- a/src/cli/contract3-data.ts
+++ b/src/cli/contract3-data.ts
@@ -1,0 +1,194 @@
+import { ConfigError, DATA_DIR, layout } from '#profile';
+import { createFileSecretStore } from '#secrets';
+import type { BlobStore } from '#stores/blobs';
+
+/**
+ * The half of the contract-3 migration that moves bytes rather than YAML.
+ *
+ * Split from `contract3.ts` on the seam the migration already has: that file
+ * decides *what* the new shape is, and this one carries the credentials and
+ * objects into it. Both halves are ordered so a crash between any two steps
+ * leaves a workspace that still opens, and the rule that makes that true lives
+ * here — nothing is deleted until what replaced it has been read back.
+ */
+
+export interface Move {
+  readonly from: string;
+  readonly to: string;
+}
+
+/** `gmail.main` — how a connection is addressed in every file after this. */
+function keyOf(connection: { provider: string; id: string }): string {
+  return `${connection.provider}.${connection.id}`;
+}
+
+/**
+ * Which credential refs the merged store will hold.
+ *
+ * Read-only, and it runs before anything is written so the report an operator
+ * confirms is the real one. A ref present in two profiles' stores with two
+ * different values is the one thing this cannot resolve, and it is reported
+ * rather than merged: both are real credentials, and picking either would point
+ * a connection at the wrong account's token.
+ */
+export async function planCredentials(root: string, profiles: readonly string[]): Promise<string[]> {
+  const refs = new Set<string>();
+
+  for (const profile of profiles) {
+    const store = createFileSecretStore({ path: `${root}/${DATA_DIR}/${profile}/credentials.enc` });
+    try {
+      for (const ref of await store.list()) refs.add(ref);
+    } catch {
+      // A store that will not open is reported by `doctor`, not here. This is a
+      // preview and must not fail on a workspace that is already broken.
+    }
+  }
+
+  return [...refs].sort();
+}
+
+/**
+ * Copy every profile's credentials into the workspace store.
+ *
+ * Written and read back before the old stores are touched, which is the whole
+ * of the safety argument: a half-finished merge that has not deleted anything is
+ * recoverable by running it again, and one that deleted first is not.
+ *
+ * The old stores are left in place regardless. They are a few kilobytes, they
+ * are the only copy of anything if this went wrong, and `doctor` names them so
+ * an operator can remove them once the endpoint has served a request.
+ */
+export async function mergeCredentials(root: string, profiles: readonly string[]): Promise<void> {
+  const destination = createFileSecretStore({ path: `${root}/${layout.credentials()}` });
+
+  for (const profile of profiles) {
+    const source = createFileSecretStore({ path: `${root}/${DATA_DIR}/${profile}/credentials.enc` });
+
+    let refs: string[];
+    try {
+      refs = await source.list();
+    } catch {
+      continue;
+    }
+
+    for (const ref of refs) {
+      const value = await source.get(ref);
+      if (value === null) continue;
+
+      const held = await destination.get(ref);
+      if (held !== null) {
+        if (held === value) continue;
+        throw new ConfigError(
+          `Two profiles hold different values for the credential "${ref}", and this migration ` +
+            `cannot choose between them.\n` +
+            `  Both are real credentials for different accounts, and picking either would point a ` +
+            `connection at the wrong one.\n` +
+            `  Rename one connection before migrating, so its credential ref differs.`,
+        );
+      }
+
+      await destination.set(ref, value);
+      if ((await destination.get(ref)) !== value) {
+        throw new ConfigError(
+          `The credential "${ref}" did not read back after being written to ` +
+            `${layout.credentials()}. Nothing has been deleted; fix the store and run this again.`,
+        );
+      }
+    }
+  }
+}
+
+/**
+ * Where every object under `data/<profile>/` is going.
+ *
+ * Computed from the hoisted rows rather than from what is on disk, so a blob
+ * belonging to a connection that was renamed follows the rename. Anything that
+ * matches no rule is left exactly where it is: this moves what it understands
+ * and never deletes what it does not.
+ */
+export async function planMoves(
+  files: BlobStore,
+  profiles: readonly string[],
+  rows: readonly { id: string; provider: string }[],
+): Promise<Move[]> {
+  const moves: Move[] = [];
+  const byOldKey = new Map(rows.map((row) => [keyOf(row), row]));
+
+  for (const profile of profiles) {
+    const prefix = `${DATA_DIR}/${profile}/`;
+
+    for (const blob of await files.list(prefix)) {
+      const rest = blob.key.slice(prefix.length);
+      const [head, ...tail] = rest.split('/');
+      if (head === undefined) continue;
+
+      // The credential store is merged rather than moved, and the old copy is
+      // deliberately left behind. `state.kv` and `audit.log` are per profile and
+      // become the workspace's, but their contents already carry the profile in
+      // every record, so they are concatenated by moving the objects across.
+      if (head === 'credentials.enc' || head === 'credentials.enc.key') continue;
+
+      if (head === 'vault.enc') {
+        moves.push({ from: blob.key, to: layout.vault('main') });
+        continue;
+      }
+      if (head === 'vault.enc.key') {
+        moves.push({ from: blob.key, to: `${layout.vault('main')}.key` });
+        continue;
+      }
+      if (head === 'skills.d') {
+        moves.push({ from: blob.key, to: `${layout.skills('main')}/${tail.join('/')}` });
+        continue;
+      }
+      if (head === 'providers.d') {
+        moves.push({ from: blob.key, to: `${layout.providers()}/${tail.join('/')}` });
+        continue;
+      }
+      if (head === 'state.kv' || head === 'audit.log') {
+        moves.push({ from: blob.key, to: `${DATA_DIR}/${head}/${tail.join('/')}` });
+        continue;
+      }
+
+      // Otherwise it is `<provider>/<connection>/...`, the namespace every
+      // provider's blobs are scoped into.
+      const connection = tail[0];
+      if (connection === undefined) continue;
+
+      const renamed = byOldKey.get(`${head}.${connection}`);
+      const id = renamed ? renamed.id : connection;
+      moves.push({ from: blob.key, to: `${DATA_DIR}/${head}/${id}/${tail.slice(1).join('/')}` });
+    }
+  }
+
+  return moves;
+}
+
+/**
+ * Copy, verify, then delete. In that order, per object.
+ *
+ * A move that deleted first would lose an object on any failure, and these are
+ * the owner's notes, tasks and entities. Copying into a key that already holds
+ * something is skipped rather than overwritten: two profiles that both had
+ * `memory.main` are two sets of notes, and the second one keeps its own home
+ * under a suffixed connection rather than being interleaved with the first.
+ */
+export async function applyMoves(files: BlobStore, moves: readonly Move[]): Promise<void> {
+  for (const move of moves) {
+    if (move.from === move.to) continue;
+
+    const data = await files.get(move.from);
+    if (data === null) continue;
+    if (await files.has(move.to)) continue;
+
+    await files.put(move.to, data);
+    if ((await files.get(move.to)) === null) {
+      throw new ConfigError(
+        `${move.to} did not read back after being written. Nothing has been deleted; ` +
+          `fix the store and run this again.`,
+      );
+    }
+
+    await files.delete(move.from);
+  }
+}
+

--- a/src/cli/contract3-shape.ts
+++ b/src/cli/contract3-shape.ts
@@ -1,0 +1,186 @@
+import { RESERVED_PROVIDER_IDS } from '#connectivity';
+import type { ContractRename, LegacyConnection, LegacyProfile } from './contract3.ts';
+import { keyOf } from './contract3.ts';
+
+/**
+ * Turning contract 2's shape into contract 3's, without touching a file.
+ *
+ * Split from the flow because these are the decisions and that is the ordering:
+ * which connections exist after hoisting, what each profile's grants become, and
+ * what a rule with an expiry means. Every defect review found in this migration
+ * was in one of those three, and none of them needed a filesystem to reproduce.
+ */
+
+/**
+ * Hoist every profile's connections into one list.
+ *
+ * **Keyed on provider and account, not on the id.** The common case is two
+ * profiles that both connected the same mailbox: same provider, same account,
+ * usually the same id, and they merge into one row because they *are* one
+ * account. The interesting case is two profiles each holding a row spelled
+ * `gmail.main` naming different mailboxes, which is legal under contract 2
+ * because a connection lived inside one profile and nothing ever compared them.
+ *
+ * That collision is resolved by renaming, never by picking. Both accounts are
+ * real, both have a credential, and choosing either would take somebody's
+ * mailbox away silently. The second becomes `gmail.main_2`, and the rename is
+ * reported so the operator sees it before anything else reads the file.
+ */
+export function hoistConnections(profiles: ReadonlyMap<string, LegacyProfile>): {
+  rows: LegacyConnection[];
+  renames: ContractRename[];
+  perProfile: Map<string, Map<string, string>>;
+} {
+  const rows: LegacyConnection[] = [];
+  const renames: ContractRename[] = [];
+  const byAccount = new Map<string, LegacyConnection>();
+  const taken = new Set<string>();
+  const perProfile = new Map<string, Map<string, string>>();
+
+  for (const [profile, config] of profiles) {
+    const mapping = new Map<string, string>();
+    perProfile.set(profile, mapping);
+
+    for (const connection of config.connections ?? []) {
+      // Two profiles' owner layers are never the same thing, whatever their
+      // rows say. Every contract-2 profile carried an identical owner layer
+      // written from a fixed table — `{memory: 'Memory', vault: 'Vault', ...}`
+      // — so an identity of provider-plus-account made all of them collide and
+      // merge. That is the one outcome ADR-059 forbids: interleaving two sets of
+      // notes is not reversible and not reviewable, and for the vault the wrong
+      // answer is a credential. Keying on the profile forces a rename instead.
+      const owner = RESERVED_PROVIDER_IDS.includes(connection.provider);
+      const identity = owner
+        ? `${connection.provider} @${profile}`
+        : `${connection.provider} ${connection.account}`;
+      const existing = byAccount.get(identity);
+
+      if (existing) {
+        // The same account, already hoisted. This profile's old key maps to
+        // whatever the first one settled on, which may itself be a rename.
+        mapping.set(keyOf(connection), keyOf(existing));
+        continue;
+      }
+
+      let id = connection.id;
+      if (taken.has(`${connection.provider}.${id}`)) {
+        // The profile's own name for an owner-layer surface, which is what
+        // ADR-059 specifies and reads far better than `memory.main_2` when the
+        // thing being separated is "work's notes". A numeric suffix is the
+        // fallback for a real account, and for the case where the profile name
+        // is itself taken.
+        const preferred = owner ? sanitise(profile) : `${id}_2`;
+        let candidate = preferred;
+        let suffix = 2;
+        while (taken.has(`${connection.provider}.${candidate}`)) {
+          suffix += 1;
+          candidate = `${preferred}_${suffix}`;
+        }
+        renames.push({
+          from: `${connection.provider}.${id}`,
+          to: `${connection.provider}.${candidate}`,
+          reason: owner
+            ? `"${profile}" has its own ${connection.provider}, which is not "${id}"'s`
+            : `"${profile}" named a different account (${connection.account}) with that id`,
+        });
+        id = candidate;
+      }
+
+      const row: LegacyConnection = { ...connection, id };
+      rows.push(row);
+      byAccount.set(identity, row);
+      taken.add(keyOf(row));
+      mapping.set(keyOf(connection), keyOf(row));
+    }
+  }
+
+  return { rows, renames, perProfile };
+}
+
+/** A profile name as a connection id: the same alphabet `connectionRef` allows. */
+function sanitise(profile: string): string {
+  const cleaned = profile.toLowerCase().replace(/[^a-z0-9_]/g, '_').replace(/^_+/, '');
+  return cleaned.length > 0 ? cleaned : 'two';
+}
+
+/**
+ * A rule, in whichever of the two shapes contract 2 accepted, with its expiry.
+ *
+ * Reading the capability alone got both directions wrong, and it is the same
+ * mistake `config-repair.ts` documents. `isRuleActive` is what made a lapsed
+ * rule inert, so dropping `expires_at` turned an allow that died months ago into
+ * a live permanent grant — and an expired *deny* into a permanent one, which is
+ * not the safe direction either, because a deny outranks every allow.
+ *
+ * A rule that has already lapsed is dropped rather than carried: it granted and
+ * denied nothing on the day of the migration, and writing it forward would give
+ * it a meaning it did not have.
+ */
+type Rule = string | { capability: string; expires_at: string };
+
+function patternsOf(rules: unknown, now = Date.now()): Rule[] {
+  if (!Array.isArray(rules)) return [];
+
+  return rules.flatMap((rule): Rule[] => {
+    if (typeof rule === 'string') return [rule];
+
+    const object = rule as { capability?: unknown; expires_at?: unknown } | null;
+    const capability = object?.capability;
+    if (typeof capability !== 'string') return [];
+
+    const expiry = object?.expires_at;
+    if (typeof expiry !== 'string') return [capability];
+
+    const at = Date.parse(expiry);
+    if (Number.isNaN(at)) return [capability];
+    return at > now ? [{ capability, expires_at: expiry }] : [];
+  });
+}
+
+/** The capability a rule names, whichever shape it is in. */
+function capabilityOf(rule: Rule): string {
+  return typeof rule === 'string' ? rule : rule.capability;
+}
+
+/**
+ * The grant rows one contract-2 profile becomes.
+ *
+ * Every connection gets the rules that named its provider, which is precisely
+ * what the flat block meant: rules covered every account of a provider in the
+ * profile. So this loses nothing, and gains the ability to diverge afterwards.
+ *
+ * A rule naming a provider the profile has no connection for is dropped rather
+ * than carried. Under contract 2 an `allow` like that was refused at load, and a
+ * `deny` was permitted as a note to self; there is nowhere to put either now,
+ * because a row without a connection is not expressible.
+ */
+export function grantsFor(
+  config: LegacyProfile,
+  mapping: ReadonlyMap<string, string>,
+): { connection: string; allow: Rule[]; deny: Rule[] }[] {
+  const allow = patternsOf(config.policy?.allow);
+  const deny = patternsOf(config.policy?.deny);
+
+  const covers = (rule: Rule, provider: string): boolean => {
+    const pattern = capabilityOf(rule);
+    return pattern === '*' || pattern.startsWith(`${provider}.`);
+  };
+
+  return (config.connections ?? []).map((connection) => {
+    const provider = connection.provider;
+    // A bare `*` becomes the provider wildcard rather than being copied
+    // through. It would still mean the same thing inside a row, which is
+    // already scoped to one connection, but writing it out is what makes the
+    // file say so. An expiry rides along untouched.
+    const widen = (rule: Rule): Rule => {
+      if (typeof rule === 'string') return rule === '*' ? `${provider}.*` : rule;
+      return rule.capability === '*' ? { ...rule, capability: `${provider}.*` } : rule;
+    };
+
+    return {
+      connection: mapping.get(keyOf(connection)) ?? keyOf(connection),
+      allow: allow.filter((rule) => covers(rule, provider)).map(widen),
+      deny: deny.filter((rule) => covers(rule, provider)).map(widen),
+    };
+  });
+}

--- a/src/cli/contract3.test.ts
+++ b/src/cli/contract3.test.ts
@@ -4,6 +4,9 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { parse } from 'yaml';
 import { migrateToContract3 } from './contract3.ts';
+import { migrateToCurrentContract } from './workspace-migrate.ts';
+import { applyMoves, planCredentials, planMoves } from './contract3-data.ts';
+import { createMemoryBlobStore } from '#stores/blobs/testing.ts';
 
 /**
  * Contract 2 to contract 3, against a real workspace on disk.
@@ -267,5 +270,136 @@ describe('running it again', () => {
 
     expect(second.alreadyCurrent).toBe(true);
     expect(await refs(root)).toEqual(before);
+  });
+});
+
+describe('reaching the current contract, the way deploy does', () => {
+  /**
+   * The gap this covers was not a refusal, which is why it survived.
+   *
+   * `deploy` and `doctor --fix` ran the contract 1→2 step and stopped, so a
+   * contract-2 bucket went through untouched: the config was replaced with
+   * contract-3 YAML and the bytes stayed under `data/<profile>/`. The revision
+   * came up healthy reading an empty `data/`, and an empty audit chain verifies
+   * as intact. Nothing anywhere said a word.
+   */
+  test('a contract-2 workspace arrives at contract 3', async () => {
+    const root = await workspace({ personal: legacy({ profile: 'personal' }) });
+
+    const migration = await migrateToCurrentContract(root, {
+      apply: true,
+      subject: 'lanes:somebody',
+    });
+
+    expect(migration.alreadyCurrent).toBe(false);
+    expect(migration.contract3).not.toBeNull();
+    expect(migration.profiles).toEqual(['personal']);
+
+    expect((await readYaml(root, 'profiles/personal.yaml'))['contract']).toBe(3);
+
+    const registry = await readYaml(root, 'lanes-link.yaml');
+    expect(registry['contract']).toBe(3);
+    expect(registry['workspaces']).toBeDefined();
+    expect(registry['targets']).toBeUndefined();
+  });
+
+  test('a second run finds nothing to do', async () => {
+    const root = await workspace({ personal: legacy({ profile: 'personal' }) });
+    const options = { apply: true, subject: 'lanes:somebody' };
+
+    await migrateToCurrentContract(root, options);
+    const again = await migrateToCurrentContract(root, options);
+
+    expect(again.alreadyCurrent).toBe(true);
+    expect(again.changes).toEqual([]);
+  });
+});
+
+describe('moving the bytes', () => {
+  const bytes = (text: string) => new TextEncoder().encode(text);
+
+  test('an interrupted move is finished rather than refused', async () => {
+    // Copy-then-delete has a window between the two, and this now runs against
+    // buckets where that window is a network round trip. Refusing here would
+    // mean a workspace that cannot be migrated by running the migration again,
+    // which is the one recovery this migration promises.
+    const files = createMemoryBlobStore();
+    await files.put('data/personal/memory/main/a.md', bytes('note'));
+    await files.put('data/memory/main/a.md', bytes('note'));
+
+    await applyMoves(files, [
+      { from: 'data/personal/memory/main/a.md', to: 'data/memory/main/a.md' },
+    ]);
+
+    expect(await files.has('data/personal/memory/main/a.md')).toBe(false);
+    expect(await files.get('data/memory/main/a.md')).toEqual(bytes('note'));
+  });
+
+  test('different bytes at the destination refuse, and delete nothing', async () => {
+    const files = createMemoryBlobStore();
+    await files.put('data/personal/memory/main/a.md', bytes('mine'));
+    await files.put('data/memory/main/a.md', bytes('somebody else\u2019s'));
+
+    await expect(
+      applyMoves(files, [{ from: 'data/personal/memory/main/a.md', to: 'data/memory/main/a.md' }]),
+    ).rejects.toThrow(/cannot merge them/);
+
+    expect(await files.has('data/personal/memory/main/a.md')).toBe(true);
+  });
+
+  test('two objects aimed at one key refuse while this is still a plan', async () => {
+    // The per-object check cannot see this one once the moves run concurrently:
+    // both would look at an absent destination and both would write.
+    const files = createMemoryBlobStore();
+    await files.put('data/personal/memory/main/a.md', bytes('one'));
+    await files.put('data/work/memory/main/a.md', bytes('two'));
+
+    const collide = new Map([
+      ['personal', new Map([['memory.main', 'memory.main']])],
+      ['work', new Map([['memory.main', 'memory.main']])],
+    ]);
+
+    await expect(planMoves(files, ['personal', 'work'], collide)).rejects.toThrow(
+      /cannot merge them/,
+    );
+    expect(await files.has('data/personal/memory/main/a.md')).toBe(true);
+    expect(await files.has('data/work/memory/main/a.md')).toBe(true);
+  });
+});
+
+describe('a workspace in a bucket', () => {
+  test('has no per-profile credential stores to merge', async () => {
+    // `workspacePath` refuses a filesystem credential adapter against a remote
+    // root, so the only store such a workspace can declare is Secret Manager —
+    // whose refs were never scoped by profile. Without the guard this built
+    // `gs://.../data/personal/credentials.enc`, handed it to `Bun.file`, and let
+    // the catch report an empty list, which is the same answer for the wrong
+    // reason and would have hidden a real store that would not open.
+    expect(await planCredentials('gs://your-bucket', ['personal'])).toEqual([]);
+  });
+});
+
+describe('the contract stamp is the record that this finished', () => {
+  test('a move that fails leaves the profile at contract 2, so a re-run retries', async () => {
+    // `needsContract3` reads nothing but the stamp, so writing it before the
+    // bytes had moved turned any interruption into silent data loss: the re-run
+    // saw contract 3 and did nothing, and every object stayed under
+    // `data/<profile>/` where the contract-3 reader does not look.
+    //
+    // The failure is induced with an occupied destination, which is the one
+    // thing `applyMoves` refuses part-way through.
+    const root = await workspace({ personal: legacy({ profile: 'personal' }) });
+
+    await mkdir(join(root, 'data', 'personal', 'memory', 'main'), { recursive: true });
+    await writeFile(join(root, 'data', 'personal', 'memory', 'main', 'a.md'), 'mine');
+    await mkdir(join(root, 'data', 'memory', 'main'), { recursive: true });
+    await writeFile(join(root, 'data', 'memory', 'main', 'a.md'), 'not a copy of it');
+
+    await expect(migrateToContract3(root)).rejects.toThrow(/cannot merge them/);
+
+    expect((await readYaml(root, 'profiles/personal.yaml'))['contract']).toBe(2);
+    expect(await readFile(join(root, 'data', 'personal', 'memory', 'main', 'a.md'), 'utf8')).toBe(
+      'mine',
+    );
   });
 });

--- a/src/cli/contract3.test.ts
+++ b/src/cli/contract3.test.ts
@@ -1,0 +1,271 @@
+import { afterAll, describe, expect, test } from 'bun:test';
+import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { parse } from 'yaml';
+import { migrateToContract3 } from './contract3.ts';
+
+/**
+ * Contract 2 to contract 3, against a real workspace on disk.
+ *
+ * This file did not exist, and the migration it covers carries every existing
+ * operator's credentials, vault, memory and tasks through a breaking change.
+ * Four separate defects were found in it by review, three of which lost, leaked
+ * or misrouted data *while reporting success* — so the tests below are written
+ * against the outcomes rather than the internals: what is in the files
+ * afterwards, and what is in the blob store.
+ *
+ * The fixtures are the shapes that actually collide. Two profiles that hold the
+ * same account, two that hold different accounts under one id, and two that hold
+ * the owner layer — which every contract-2 profile did, written from a fixed
+ * table, and which is therefore the collision every real migration hits.
+ */
+
+const homes: string[] = [];
+
+async function workspace(profiles: Record<string, string>): Promise<string> {
+  const root = await mkdtemp(join(tmpdir(), 'lanes-c3-'));
+  homes.push(root);
+
+  await writeFile(
+    join(root, 'lanes-link.yaml'),
+    'contract: 2\ntargets:\n  local:\n    credentials: { adapter: file }\n    storage: { adapter: filesystem }\n',
+  );
+  await mkdir(join(root, 'profiles'), { recursive: true });
+  for (const [name, body] of Object.entries(profiles)) {
+    await writeFile(join(root, 'profiles', `${name}.yaml`), body);
+  }
+  return root;
+}
+
+/** A contract-2 profile: the owner layer every one of them carried, plus extras. */
+function legacy(options: {
+  profile: string;
+  connections?: string;
+  allow?: string;
+  deny?: string;
+}): string {
+  return [
+    'contract: 2',
+    `instance: { profile: ${options.profile}, port: 7337 }`,
+    'connections:',
+    '  - { id: main, provider: memory, account: Memory }',
+    '  - { id: main, provider: vault, account: Vault }',
+    options.connections ?? '',
+    'policy:',
+    `  allow: [${options.allow ?? "'*'"}]`,
+    `  deny: [${options.deny ?? ''}]`,
+    '',
+  ]
+    .filter((line) => line !== '')
+    .join('\n');
+}
+
+async function readYaml(root: string, path: string): Promise<Record<string, unknown>> {
+  return parse(await readFile(join(root, path), 'utf8')) as Record<string, unknown>;
+}
+
+/** Every connection ref the workspace ended up with. */
+async function refs(root: string): Promise<string[]> {
+  const file = await readYaml(root, 'connections.yaml');
+  const rows = (file['connections'] ?? []) as { provider: string; id: string }[];
+  return rows.map((row) => `${row.provider}.${row.id}`).sort();
+}
+
+afterAll(async () => {
+  await Promise.all(homes.map((one) => rm(one, { recursive: true, force: true })));
+});
+
+describe('the owner layer', () => {
+  test('is never merged between profiles', async () => {
+    // The defect this test exists for. Every contract-2 profile carried an
+    // identical owner layer from a fixed table, so keying the hoist on
+    // provider-plus-account made all of them collide and merge — which is the
+    // one outcome ADR-059 forbids, because interleaving two sets of notes is not
+    // reversible and for the vault the wrong answer is a credential.
+    const root = await workspace({
+      personal: legacy({ profile: 'personal' }),
+      work: legacy({ profile: 'work' }),
+    });
+
+    await migrateToContract3(root);
+
+    expect(await refs(root)).toEqual(['memory.main', 'memory.work', 'vault.main', 'vault.work']);
+  });
+
+  test('takes the profile name, not a number', async () => {
+    // ADR-059 specifies `memory.<profile>`, and it reads far better than
+    // `memory.main_2` when the thing being separated is "work's notes".
+    const root = await workspace({
+      personal: legacy({ profile: 'personal' }),
+      work: legacy({ profile: 'work' }),
+    });
+
+    const result = await migrateToContract3(root);
+
+    expect(result.renames.map((one) => one.to)).toContain('memory.work');
+  });
+
+  test('each profile grants its own instance and no other', async () => {
+    const root = await workspace({
+      personal: legacy({ profile: 'personal' }),
+      work: legacy({ profile: 'work' }),
+    });
+
+    await migrateToContract3(root);
+
+    const work = await readYaml(root, 'profiles/work.yaml');
+    const granted = ((work['grants'] ?? []) as { connection: string }[]).map(
+      (one) => one.connection,
+    );
+
+    expect(granted).toContain('memory.work');
+    expect(granted).not.toContain('memory.main');
+  });
+});
+
+describe('two profiles holding one provider', () => {
+  test('the same account is one connection', async () => {
+    // The merge that *is* correct: one mailbox authorised twice is one mailbox.
+    const root = await workspace({
+      personal: legacy({
+        profile: 'personal',
+        connections: '  - { id: main, provider: gmail, account: ada@example.com }',
+      }),
+      work: legacy({
+        profile: 'work',
+        connections: '  - { id: main, provider: gmail, account: ada@example.com }',
+      }),
+    });
+
+    await migrateToContract3(root);
+
+    expect(await refs(root)).toContain('gmail.main');
+    expect((await refs(root)).filter((ref) => ref.startsWith('gmail.'))).toHaveLength(1);
+  });
+
+  test('different accounts under one id are two connections', async () => {
+    const root = await workspace({
+      personal: legacy({
+        profile: 'personal',
+        connections: '  - { id: main, provider: gmail, account: ada@example.com }',
+      }),
+      work: legacy({
+        profile: 'work',
+        connections: '  - { id: main, provider: gmail, account: rin@example.com }',
+      }),
+    });
+
+    await migrateToContract3(root);
+    const gmail = (await refs(root)).filter((ref) => ref.startsWith('gmail.'));
+
+    expect(gmail).toHaveLength(2);
+  });
+});
+
+describe('a rule that had an expiry', () => {
+  test('one that has lapsed is dropped rather than made permanent', async () => {
+    // `isRuleActive` is what made a lapsed rule inert. Reading the capability
+    // and discarding `expires_at` turned an allow that died months ago into a
+    // live permanent grant.
+    const root = await workspace({
+      personal: legacy({
+        profile: 'personal',
+        connections: '  - { id: main, provider: gmail, account: ada@example.com }',
+        allow: "{ capability: 'gmail.*', expires_at: '2020-01-01T00:00:00Z' }",
+      }),
+    });
+
+    await migrateToContract3(root);
+    const config = await readYaml(root, 'profiles/personal.yaml');
+    const gmail = ((config['grants'] ?? []) as { connection: string; allow: unknown[] }[]).find(
+      (one) => one.connection === 'gmail.main',
+    );
+
+    expect(gmail?.allow).toEqual([]);
+  });
+
+  test('one still in force keeps its expiry', async () => {
+    const root = await workspace({
+      personal: legacy({
+        profile: 'personal',
+        connections: '  - { id: main, provider: gmail, account: ada@example.com }',
+        allow: "{ capability: 'gmail.*', expires_at: '2099-01-01T00:00:00Z' }",
+      }),
+    });
+
+    await migrateToContract3(root);
+    const config = await readYaml(root, 'profiles/personal.yaml');
+    const gmail = ((config['grants'] ?? []) as { connection: string; allow: unknown[] }[]).find(
+      (one) => one.connection === 'gmail.main',
+    );
+
+    expect(gmail?.allow).toEqual([
+      { capability: 'gmail.*', expires_at: '2099-01-01T00:00:00Z' },
+    ]);
+  });
+
+  test('an expired deny is dropped too, which is not the safe-looking direction', async () => {
+    // Carrying it forward would make it permanent, and a deny outranks every
+    // allow unconditionally.
+    const root = await workspace({
+      personal: legacy({
+        profile: 'personal',
+        connections: '  - { id: main, provider: gmail, account: ada@example.com }',
+        deny: "{ capability: 'gmail.users.drafts.send', expires_at: '2020-01-01T00:00:00Z' }",
+      }),
+    });
+
+    await migrateToContract3(root);
+    const config = await readYaml(root, 'profiles/personal.yaml');
+    const gmail = ((config['grants'] ?? []) as { connection: string; deny: unknown[] }[]).find(
+      (one) => one.connection === 'gmail.main',
+    );
+
+    expect(gmail?.deny).toEqual([]);
+  });
+});
+
+describe('the registry', () => {
+  test('is stamped, renamed, and given a default', async () => {
+    const root = await workspace({ personal: legacy({ profile: 'personal' }) });
+
+    await migrateToContract3(root);
+    const registry = await readYaml(root, 'lanes-link.yaml');
+
+    expect(registry['contract']).toBe(3);
+    expect(registry['workspaces']).toBeDefined();
+    expect(registry['targets']).toBeUndefined();
+    expect(registry['default_workspace']).toBe('local');
+  });
+
+  test('is written first, so an interrupted run leaves a workspace that opens', async () => {
+    // The registry is the one step that is not idempotent — it reads `targets:`
+    // and finds none the second time. Running it last meant an interruption
+    // anywhere before it left profiles at contract 3 and the registry at
+    // contract 2, which re-entry read as nothing to do and every command read as
+    // "declares no workspace".
+    const source = await readFile(join(import.meta.dir, 'contract3.ts'), 'utf8');
+    const apply = source.slice(source.indexOf('if (!options.apply) return result;'));
+
+    expect(apply.indexOf('rewriteRegistry')).toBeLessThan(apply.indexOf('writeConnections'));
+  });
+});
+
+describe('running it again', () => {
+  test('is a no-op rather than a second migration', async () => {
+    const root = await workspace({
+      personal: legacy({
+        profile: 'personal',
+        connections: '  - { id: main, provider: gmail, account: ada@example.com }',
+      }),
+    });
+
+    await migrateToContract3(root);
+    const before = await refs(root);
+    const second = await migrateToContract3(root);
+
+    expect(second.alreadyCurrent).toBe(true);
+    expect(await refs(root)).toEqual(before);
+  });
+});

--- a/src/cli/contract3.ts
+++ b/src/cli/contract3.ts
@@ -12,7 +12,9 @@ import {
   workspaceFiles,
   writeWorkspaceFile,
 } from '#profile';
+import { RESERVED_PROVIDER_IDS } from '#connectivity';
 import { ConfigDocument } from './config-edit.ts';
+import { grantsFor, hoistConnections } from './contract3-shape.ts';
 
 /**
  * Contract 2 to contract 3: connections move out of the profile.
@@ -57,7 +59,7 @@ export interface Contract3Migration {
   readonly alreadyCurrent: boolean;
 }
 
-interface LegacyConnection {
+export interface LegacyConnection {
   readonly id: string;
   readonly provider: string;
   readonly account: string;
@@ -66,7 +68,7 @@ interface LegacyConnection {
   readonly config?: Record<string, unknown>;
 }
 
-interface LegacyProfile {
+export interface LegacyProfile {
   readonly contract?: number;
   readonly connections?: LegacyConnection[];
   readonly policy?: { allow?: unknown[]; deny?: unknown[] };
@@ -95,121 +97,8 @@ async function readProfile(root: string, profile: string): Promise<LegacyProfile
 }
 
 /** `gmail.main` — how a connection is addressed in every file after this. */
-function keyOf(connection: { provider: string; id: string }): string {
+export function keyOf(connection: { provider: string; id: string }): string {
   return `${connection.provider}.${connection.id}`;
-}
-
-/**
- * Hoist every profile's connections into one list.
- *
- * **Keyed on provider and account, not on the id.** The common case is two
- * profiles that both connected the same mailbox: same provider, same account,
- * usually the same id, and they merge into one row because they *are* one
- * account. The interesting case is two profiles each holding a row spelled
- * `gmail.main` naming different mailboxes, which is legal under contract 2
- * because a connection lived inside one profile and nothing ever compared them.
- *
- * That collision is resolved by renaming, never by picking. Both accounts are
- * real, both have a credential, and choosing either would take somebody's
- * mailbox away silently. The second becomes `gmail.main_2`, and the rename is
- * reported so the operator sees it before anything else reads the file.
- */
-function hoistConnections(profiles: ReadonlyMap<string, LegacyProfile>): {
-  rows: LegacyConnection[];
-  renames: ContractRename[];
-  perProfile: Map<string, Map<string, string>>;
-} {
-  const rows: LegacyConnection[] = [];
-  const renames: ContractRename[] = [];
-  const byAccount = new Map<string, LegacyConnection>();
-  const taken = new Set<string>();
-  const perProfile = new Map<string, Map<string, string>>();
-
-  for (const [profile, config] of profiles) {
-    const mapping = new Map<string, string>();
-    perProfile.set(profile, mapping);
-
-    for (const connection of config.connections ?? []) {
-      const identity = `${connection.provider} ${connection.account}`;
-      const existing = byAccount.get(identity);
-
-      if (existing) {
-        // The same account, already hoisted. This profile's old key maps to
-        // whatever the first one settled on, which may itself be a rename.
-        mapping.set(keyOf(connection), keyOf(existing));
-        continue;
-      }
-
-      let id = connection.id;
-      if (taken.has(`${connection.provider}.${id}`)) {
-        let suffix = 2;
-        while (taken.has(`${connection.provider}.${id}_${suffix}`)) suffix += 1;
-        const renamed = `${id}_${suffix}`;
-        renames.push({
-          from: `${connection.provider}.${id}`,
-          to: `${connection.provider}.${renamed}`,
-          reason: `"${profile}" named a different account (${connection.account}) with that id`,
-        });
-        id = renamed;
-      }
-
-      const row: LegacyConnection = { ...connection, id };
-      rows.push(row);
-      byAccount.set(identity, row);
-      taken.add(keyOf(row));
-      mapping.set(keyOf(connection), keyOf(row));
-    }
-  }
-
-  return { rows, renames, perProfile };
-}
-
-/** A capability pattern, whichever of the two shapes the rule was written in. */
-function patternsOf(rules: unknown): string[] {
-  if (!Array.isArray(rules)) return [];
-  return rules.flatMap((rule) => {
-    if (typeof rule === 'string') return [rule];
-    const capability = (rule as { capability?: unknown } | null)?.capability;
-    return typeof capability === 'string' ? [capability] : [];
-  });
-}
-
-/**
- * The grant rows one contract-2 profile becomes.
- *
- * Every connection gets the rules that named its provider, which is precisely
- * what the flat block meant: rules covered every account of a provider in the
- * profile. So this loses nothing, and gains the ability to diverge afterwards.
- *
- * A rule naming a provider the profile has no connection for is dropped rather
- * than carried. Under contract 2 an `allow` like that was refused at load, and a
- * `deny` was permitted as a note to self; there is nowhere to put either now,
- * because a row without a connection is not expressible.
- */
-function grantsFor(
-  config: LegacyProfile,
-  mapping: ReadonlyMap<string, string>,
-): { connection: string; allow: string[]; deny: string[] }[] {
-  const allow = patternsOf(config.policy?.allow);
-  const deny = patternsOf(config.policy?.deny);
-
-  const covers = (pattern: string, provider: string): boolean =>
-    pattern === '*' || pattern.startsWith(`${provider}.`);
-
-  return (config.connections ?? []).map((connection) => {
-    const provider = connection.provider;
-    // A bare `*` becomes the provider wildcard rather than being copied
-    // through. It would still mean the same thing inside a row, which is
-    // already scoped to one connection, but writing it out is what makes the
-    // file say so.
-    const widen = (pattern: string): string => (pattern === '*' ? `${provider}.*` : pattern);
-
-    return {
-      connection: mapping.get(keyOf(connection)) ?? keyOf(connection),
-      allow: allow.filter((pattern) => covers(pattern, provider)).map(widen),
-      deny: deny.filter((pattern) => covers(pattern, provider)).map(widen),
-    };
-  });
 }
 
 export async function migrateToContract3(
@@ -241,7 +130,7 @@ export async function migrateToContract3(
   // Everything that can be computed is computed before the first write, so a
   // refusal leaves the workspace exactly as it was.
   const credentials = await planCredentials(workspaceRoot, [...legacy.keys()]);
-  const moves = await planMoves(files, [...legacy.keys()], rows);
+  const moves = await planMoves(files, [...legacy.keys()], perProfile);
 
   const changes: string[] = [
     `${CONNECTIONS_FILE}: ${rows.length} connection(s) hoisted`,
@@ -266,11 +155,24 @@ export async function migrateToContract3(
 
   if (!options.apply) return result;
 
+  // The registry first, and this ordering is the whole of the re-entrancy.
+  //
+  // Every later step is idempotent — writing `connections.yaml` again produces
+  // the same file, merging a credential that is already there is a no-op,
+  // rewriting a contract-3 profile is skipped, and a move whose source is gone
+  // is skipped. `rewriteRegistry` is the one step that is not, because it reads
+  // `targets:` and would find none the second time.
+  //
+  // Running it last meant an interruption anywhere before it left profiles at
+  // contract 3 and `lanes-link.yaml` still at contract 2 — a state where
+  // re-entry found nothing to migrate, and `workspaceSchema` parsed a file whose
+  // `workspaces:` defaulted to empty, so every command refused with "declares no
+  // workspace" and there was no way back.
+  await rewriteRegistry(workspaceRoot);
   await writeConnections(workspaceRoot, rows, legacy);
   await mergeCredentials(workspaceRoot, [...legacy.keys()]);
   await rewriteProfiles(workspaceRoot, legacy, perProfile, options.subject);
   await applyMoves(files, moves);
-  await rewriteRegistry(workspaceRoot);
 
   return result;
 }
@@ -333,17 +235,25 @@ async function rewriteRegistry(root: string): Promise<void> {
   } | null;
 
   const targets = registry?.targets;
-  if (targets === undefined) return;
 
-  const workspaces: Record<string, unknown> = {};
-  for (const [name, entry] of Object.entries(targets)) {
-    const { workspace, ...rest } = entry;
-    workspaces[name] = workspace === undefined ? rest : { at: workspace, ...rest };
+  // Already renamed, which is what a contract-1 workspace looks like here: the
+  // 1-to-2 migration wrote `workspaces:` on its way through. Returning early
+  // skipped the contract stamp and the default below, so that path finished a
+  // migration and left neither.
+  if (targets !== undefined) {
+    const workspaces: Record<string, unknown> = {};
+    for (const [name, entry] of Object.entries(targets)) {
+      const { workspace, ...rest } = entry;
+      workspaces[name] = workspace === undefined ? rest : { at: workspace, ...rest };
+    }
+
+    document.setIn(['workspaces'], workspaces);
+    document.removeIn(['targets']);
   }
 
   document.setIn(['contract'], 3);
-  document.setIn(['workspaces'], workspaces);
-  document.removeIn(['targets']);
+  const workspaces = (document.toJSON() as { workspaces?: Record<string, unknown> } | null)
+    ?.workspaces ?? {};
 
   // The first workspace in the registry, which for every workspace this
   // migration will ever see is `local`. Written rather than left absent so the

--- a/src/cli/contract3.ts
+++ b/src/cli/contract3.ts
@@ -171,8 +171,23 @@ export async function migrateToContract3(
   await rewriteRegistry(workspaceRoot);
   await writeConnections(workspaceRoot, rows, legacy);
   await mergeCredentials(workspaceRoot, [...legacy.keys()]);
-  await rewriteProfiles(workspaceRoot, legacy, perProfile, options.subject);
+
+  // **The bytes move before the profile says they have.**
+  //
+  // `rewriteProfiles` is what stamps `contract: 3`, and that stamp is the only
+  // thing `needsContract3` reads — so it is not a step among steps, it is the
+  // record that the migration finished. Running it before `applyMoves` meant an
+  // interruption between the two left profiles claiming contract 3 with every
+  // byte still under `data/<profile>/`, and a re-run that looked at the stamp
+  // and found nothing to do. The workspace opened, which is what this file
+  // ordered its steps to guarantee, and the owner's memory, tasks, skills and
+  // audit log were not in it.
+  //
+  // A network round trip per object made that window real rather than
+  // theoretical: this migrates buckets now, and the first one it was pointed at
+  // held 1,906 objects.
   await applyMoves(files, moves);
+  await rewriteProfiles(workspaceRoot, legacy, perProfile, options.subject);
 
   return result;
 }

--- a/src/cli/contract3.ts
+++ b/src/cli/contract3.ts
@@ -1,0 +1,357 @@
+import { newConnectionsTemplate } from './config-templates.ts';
+import { applyMoves, mergeCredentials, planCredentials, planMoves, type Move } from './contract3-data.ts';
+import { parseDocument } from 'yaml';
+import {
+  CONNECTIONS_FILE,
+  ConfigError,
+  DATA_DIR,
+  WORKSPACE_FILE,
+  layout,
+  listProfiles,
+  readWorkspaceFile,
+  workspaceFiles,
+  writeWorkspaceFile,
+} from '#profile';
+import { ConfigDocument } from './config-edit.ts';
+
+/**
+ * Contract 2 to contract 3: connections move out of the profile.
+ *
+ * The hardest migration this project has done, and the one it could least
+ * afford to skip. `layout.ts` and ADR-030 both set the precedent that there is
+ * no migration, because machinery to move an old layout is more code than the
+ * thing it moves and has to keep working forever. That precedent was set for
+ * *empty directories*. Here the thing being moved is every credential the
+ * operator holds, and "re-authorise fifteen accounts in a browser" is not a
+ * release note anyone should write.
+ *
+ * Four moves, in an order chosen so a crash between any two leaves a workspace
+ * that still opens:
+ *
+ *   1. Connections are hoisted into `connections.yaml`.
+ *   2. Credentials are merged into one store, and read back before the old ones
+ *      are touched.
+ *   3. Profiles are rewritten, `grants:` being the old connections crossed with
+ *      the old flat policy, which is exactly what contract 2 meant.
+ *   4. Bytes move to their connection-keyed homes.
+ *
+ * The registry rename rides along at the end, because it is the one step that
+ * cannot half-apply: it is a single document.
+ */
+
+/** What a divergent id was renamed to, and why. */
+export interface ContractRename {
+  readonly from: string;
+  readonly to: string;
+  readonly reason: string;
+}
+
+export interface Contract3Migration {
+  readonly workspaceRoot: string;
+  readonly profiles: readonly string[];
+  readonly connections: readonly string[];
+  readonly renames: readonly ContractRename[];
+  readonly credentials: readonly string[];
+  readonly moved: readonly string[];
+  readonly changes: readonly string[];
+  readonly alreadyCurrent: boolean;
+}
+
+interface LegacyConnection {
+  readonly id: string;
+  readonly provider: string;
+  readonly account: string;
+  readonly label?: string;
+  readonly credential_ref?: string;
+  readonly config?: Record<string, unknown>;
+}
+
+interface LegacyProfile {
+  readonly contract?: number;
+  readonly connections?: LegacyConnection[];
+  readonly policy?: { allow?: unknown[]; deny?: unknown[] };
+  readonly oauth_apps?: Record<string, unknown>;
+}
+
+/** Whether this workspace still holds anything at contract 2. */
+export async function needsContract3(workspaceRoot: string): Promise<boolean> {
+  for (const profile of await listProfiles(workspaceRoot)) {
+    const raw = await readProfile(workspaceRoot, profile);
+    if (raw !== null && (raw.contract ?? 0) === 2) return true;
+  }
+  return false;
+}
+
+async function readProfile(root: string, profile: string): Promise<LegacyProfile | null> {
+  const text = await readWorkspaceFile(workspaceFiles(root), `profiles/${profile}.yaml`);
+  if (text === null) return null;
+  try {
+    return parseDocument(text).toJSON() as LegacyProfile;
+  } catch {
+    // A file that will not parse is not this function's problem to report;
+    // `check` gives it a better sentence than "needs migrating" would.
+    return null;
+  }
+}
+
+/** `gmail.main` — how a connection is addressed in every file after this. */
+function keyOf(connection: { provider: string; id: string }): string {
+  return `${connection.provider}.${connection.id}`;
+}
+
+/**
+ * Hoist every profile's connections into one list.
+ *
+ * **Keyed on provider and account, not on the id.** The common case is two
+ * profiles that both connected the same mailbox: same provider, same account,
+ * usually the same id, and they merge into one row because they *are* one
+ * account. The interesting case is two profiles each holding a row spelled
+ * `gmail.main` naming different mailboxes, which is legal under contract 2
+ * because a connection lived inside one profile and nothing ever compared them.
+ *
+ * That collision is resolved by renaming, never by picking. Both accounts are
+ * real, both have a credential, and choosing either would take somebody's
+ * mailbox away silently. The second becomes `gmail.main_2`, and the rename is
+ * reported so the operator sees it before anything else reads the file.
+ */
+function hoistConnections(profiles: ReadonlyMap<string, LegacyProfile>): {
+  rows: LegacyConnection[];
+  renames: ContractRename[];
+  perProfile: Map<string, Map<string, string>>;
+} {
+  const rows: LegacyConnection[] = [];
+  const renames: ContractRename[] = [];
+  const byAccount = new Map<string, LegacyConnection>();
+  const taken = new Set<string>();
+  const perProfile = new Map<string, Map<string, string>>();
+
+  for (const [profile, config] of profiles) {
+    const mapping = new Map<string, string>();
+    perProfile.set(profile, mapping);
+
+    for (const connection of config.connections ?? []) {
+      const identity = `${connection.provider} ${connection.account}`;
+      const existing = byAccount.get(identity);
+
+      if (existing) {
+        // The same account, already hoisted. This profile's old key maps to
+        // whatever the first one settled on, which may itself be a rename.
+        mapping.set(keyOf(connection), keyOf(existing));
+        continue;
+      }
+
+      let id = connection.id;
+      if (taken.has(`${connection.provider}.${id}`)) {
+        let suffix = 2;
+        while (taken.has(`${connection.provider}.${id}_${suffix}`)) suffix += 1;
+        const renamed = `${id}_${suffix}`;
+        renames.push({
+          from: `${connection.provider}.${id}`,
+          to: `${connection.provider}.${renamed}`,
+          reason: `"${profile}" named a different account (${connection.account}) with that id`,
+        });
+        id = renamed;
+      }
+
+      const row: LegacyConnection = { ...connection, id };
+      rows.push(row);
+      byAccount.set(identity, row);
+      taken.add(keyOf(row));
+      mapping.set(keyOf(connection), keyOf(row));
+    }
+  }
+
+  return { rows, renames, perProfile };
+}
+
+/** A capability pattern, whichever of the two shapes the rule was written in. */
+function patternsOf(rules: unknown): string[] {
+  if (!Array.isArray(rules)) return [];
+  return rules.flatMap((rule) => {
+    if (typeof rule === 'string') return [rule];
+    const capability = (rule as { capability?: unknown } | null)?.capability;
+    return typeof capability === 'string' ? [capability] : [];
+  });
+}
+
+/**
+ * The grant rows one contract-2 profile becomes.
+ *
+ * Every connection gets the rules that named its provider, which is precisely
+ * what the flat block meant: rules covered every account of a provider in the
+ * profile. So this loses nothing, and gains the ability to diverge afterwards.
+ *
+ * A rule naming a provider the profile has no connection for is dropped rather
+ * than carried. Under contract 2 an `allow` like that was refused at load, and a
+ * `deny` was permitted as a note to self; there is nowhere to put either now,
+ * because a row without a connection is not expressible.
+ */
+function grantsFor(
+  config: LegacyProfile,
+  mapping: ReadonlyMap<string, string>,
+): { connection: string; allow: string[]; deny: string[] }[] {
+  const allow = patternsOf(config.policy?.allow);
+  const deny = patternsOf(config.policy?.deny);
+
+  const covers = (pattern: string, provider: string): boolean =>
+    pattern === '*' || pattern.startsWith(`${provider}.`);
+
+  return (config.connections ?? []).map((connection) => {
+    const provider = connection.provider;
+    // A bare `*` becomes the provider wildcard rather than being copied
+    // through. It would still mean the same thing inside a row, which is
+    // already scoped to one connection, but writing it out is what makes the
+    // file say so.
+    const widen = (pattern: string): string => (pattern === '*' ? `${provider}.*` : pattern);
+
+    return {
+      connection: mapping.get(keyOf(connection)) ?? keyOf(connection),
+      allow: allow.filter((pattern) => covers(pattern, provider)).map(widen),
+      deny: deny.filter((pattern) => covers(pattern, provider)).map(widen),
+    };
+  });
+}
+
+export async function migrateToContract3(
+  workspaceRoot: string,
+  options: { apply: boolean; subject?: string } = { apply: true },
+): Promise<Contract3Migration> {
+  const legacy = new Map<string, LegacyProfile>();
+
+  for (const profile of await listProfiles(workspaceRoot)) {
+    const raw = await readProfile(workspaceRoot, profile);
+    if (raw !== null && (raw.contract ?? 0) === 2) legacy.set(profile, raw);
+  }
+
+  const nothing: Contract3Migration = {
+    workspaceRoot,
+    profiles: [],
+    connections: [],
+    renames: [],
+    credentials: [],
+    moved: [],
+    changes: [],
+    alreadyCurrent: true,
+  };
+  if (legacy.size === 0) return nothing;
+
+  const { rows, renames, perProfile } = hoistConnections(legacy);
+  const files = workspaceFiles(workspaceRoot);
+
+  // Everything that can be computed is computed before the first write, so a
+  // refusal leaves the workspace exactly as it was.
+  const credentials = await planCredentials(workspaceRoot, [...legacy.keys()]);
+  const moves = await planMoves(files, [...legacy.keys()], rows);
+
+  const changes: string[] = [
+    `${CONNECTIONS_FILE}: ${rows.length} connection(s) hoisted`,
+    ...renames.map((rename) => `renamed ${rename.from} to ${rename.to} (${rename.reason})`),
+    ...[...legacy.keys()].map((profile) => `profiles/${profile}.yaml: contract 3, grants`),
+  ];
+  if (credentials.length > 0) {
+    changes.push(`${layout.credentials()}: ${credentials.length} credential(s) merged`);
+  }
+  if (moves.length > 0) changes.push(`${moves.length} object(s) moved to their connection`);
+
+  const result: Contract3Migration = {
+    workspaceRoot,
+    profiles: [...legacy.keys()],
+    connections: rows.map(keyOf),
+    renames,
+    credentials,
+    moved: moves.map((move) => move.to),
+    changes,
+    alreadyCurrent: false,
+  };
+
+  if (!options.apply) return result;
+
+  await writeConnections(workspaceRoot, rows, legacy);
+  await mergeCredentials(workspaceRoot, [...legacy.keys()]);
+  await rewriteProfiles(workspaceRoot, legacy, perProfile, options.subject);
+  await applyMoves(files, moves);
+  await rewriteRegistry(workspaceRoot);
+
+  return result;
+}
+
+/** The hoisted rows, plus every profile's `oauth_apps` merged into one block. */
+async function writeConnections(
+  root: string,
+  rows: readonly LegacyConnection[],
+  legacy: ReadonlyMap<string, LegacyProfile>,
+): Promise<void> {
+  const apps: Record<string, unknown> = {};
+  for (const config of legacy.values()) Object.assign(apps, config.oauth_apps ?? {});
+
+  const document = ConfigDocument.fromText(newConnectionsTemplate(), CONNECTIONS_FILE);
+  document.setIn(['connections'], rows);
+  document.setIn(['oauth_apps'], apps);
+
+  await writeWorkspaceFile(workspaceFiles(root), CONNECTIONS_FILE, document.toString());
+}
+
+/** Contract 3, `grants:` and `members:`, with everything else left as written. */
+async function rewriteProfiles(
+  root: string,
+  legacy: ReadonlyMap<string, LegacyProfile>,
+  perProfile: ReadonlyMap<string, Map<string, string>>,
+  subject: string | undefined,
+): Promise<void> {
+  for (const [profile, config] of legacy) {
+    const document = await ConfigDocument.open(root, profile);
+
+    document.setIn(['contract'], 3);
+    document.setIn(['grants'], grantsFor(config, perProfile.get(profile) ?? new Map()));
+    // Empty unless the migration was run by somebody signed in. Nobody is a
+    // legitimate state and it is default deny on the identity axis, but a
+    // workspace whose profiles nobody can consume is a poor thing to hand back,
+    // so `update` passes the signed-in subject through.
+    document.setIn(['members'], subject ? [{ subject, role: 'owner' }] : []);
+
+    // The authorization block arrives here rather than in the template, because
+    // an existing profile has one only if it was deployed. Every endpoint runs
+    // the flow now, loopback included (ADR-062).
+    if (document.getIn(['auth', 'authorization']) === undefined) {
+      document.setIn(['auth', 'authorization'], { mode: 'self' });
+    }
+
+    document.removeIn(['connections']);
+    document.removeIn(['policy']);
+    document.removeIn(['oauth_apps']);
+
+    await document.save();
+  }
+}
+
+/** `targets:` becomes `workspaces:`, and a pointer's `workspace:` becomes `at:`. */
+async function rewriteRegistry(root: string): Promise<void> {
+  const document = await ConfigDocument.openKey(root, WORKSPACE_FILE);
+  const registry = document.toJSON() as {
+    contract?: number;
+    targets?: Record<string, { workspace?: string }>;
+  } | null;
+
+  const targets = registry?.targets;
+  if (targets === undefined) return;
+
+  const workspaces: Record<string, unknown> = {};
+  for (const [name, entry] of Object.entries(targets)) {
+    const { workspace, ...rest } = entry;
+    workspaces[name] = workspace === undefined ? rest : { at: workspace, ...rest };
+  }
+
+  document.setIn(['contract'], 3);
+  document.setIn(['workspaces'], workspaces);
+  document.removeIn(['targets']);
+
+  // The first workspace in the registry, which for every workspace this
+  // migration will ever see is `local`. Written rather than left absent so the
+  // sticky default is on from the first command after upgrading (ADR-061).
+  if (document.getIn(['default_workspace']) === undefined) {
+    const first = Object.keys(workspaces)[0];
+    if (first !== undefined) document.setIn(['default_workspace'], first);
+  }
+
+  await document.save();
+}

--- a/src/cli/emitted.test.ts
+++ b/src/cli/emitted.test.ts
@@ -30,7 +30,7 @@ describe('what setup tells someone to run', () => {
       const plan = planFor(manifest, { ...WHERE, connections: [] });
 
       expect(plan.command).toContain('--profile work');
-      expect(plan.command).toContain('--target cloud');
+      expect(plan.command).toContain('--workspace cloud');
     }
   });
 
@@ -42,13 +42,13 @@ describe('what setup tells someone to run', () => {
     if (brokered) {
       const plan = planFor(brokered, { ...WHERE, connections: [] });
       expect(plan.ownClientCommand).toContain('--profile work');
-      expect(plan.ownClientCommand).toContain('--target cloud');
+      expect(plan.ownClientCommand).toContain('--workspace cloud');
     }
   });
 
   test('and the secrets set line for a value it needs first', () => {
     // The one that would be worst to get wrong: it writes a credential, so a
-    // missing --target puts it in a store the endpoint asking for it does not
+    // missing --workspace puts it in a store the endpoint asking for it does not
     // read, and reports success.
     const withPrompts = PROVIDER_MANIFESTS.filter(
       (manifest) => (manifest.setup?.prompts ?? []).length > 0,
@@ -59,7 +59,7 @@ describe('what setup tells someone to run', () => {
     for (const manifest of withPrompts) {
       for (const requirement of setupRequirements(manifest, 'main', WHERE).requirements) {
         expect(requirement.command).toContain('--profile work');
-        expect(requirement.command).toContain('--target cloud');
+        expect(requirement.command).toContain('--workspace cloud');
       }
     }
   });
@@ -70,6 +70,6 @@ describe('what outputs tells someone to run', () => {
     const invocation = await tokenInvocation('a-token-no-endpoint-will-match', 'work', 'cloud');
 
     expect(invocation.command).toContain('--profile work');
-    expect(invocation.command).toContain('--target cloud');
+    expect(invocation.command).toContain('--workspace cloud');
   });
 });

--- a/src/cli/endpoint-url.test.ts
+++ b/src/cli/endpoint-url.test.ts
@@ -6,7 +6,7 @@ import { deploymentIdentity, endpointUrl } from './endpoint-url.ts';
  * Which address a command hands to an agent.
  *
  * The failure this guards is silent in the worst way: `mcp add` built the local
- * URL unconditionally, so `--target cloud` registered
+ * URL unconditionally, so `--workspace cloud` registered
  * `http://127.0.0.1:7337/mcp` with the harness. The command reported success,
  * named the right server, and pointed at a port with nothing behind it — and
  * the first symptom was a failed tool call, later, somewhere else.

--- a/src/cli/endpoint-url.ts
+++ b/src/cli/endpoint-url.ts
@@ -9,7 +9,7 @@ import type { Config, DeployConfig, TargetConfig } from '#profile';
  *
  * Shared because getting it wrong is silent in the worst way. `outputs` asked
  * the driver; `mcp add` built the local URL unconditionally, so
- * `lanes link mcp add --target cloud` registered `http://127.0.0.1:7337/mcp`
+ * `lanes link mcp add --workspace cloud` registered `http://127.0.0.1:7337/mcp`
  * with the agent — a registration that looks successful, names the right
  * server, and points at a port with nothing behind it. One of the two had the
  * answer and the other could not see it, which is what a copied line does

--- a/src/cli/instructions.test.ts
+++ b/src/cli/instructions.test.ts
@@ -262,17 +262,24 @@ describe('the skill covers the lifecycle, not only the calls', () => {
     // between: no deploy, no status, no way to add a profile. An agent asked to
     // deploy read the file, found nothing, and improvised from the CLI's help.
     // Listing them here means the operator half cannot quietly fall out again.
+    //
+    // The 0.8.0 entries are here for the same reason and are the ones most
+    // likely to be missed: a connection is granted to a profile rather than
+    // living in one, and a profile reaches nobody until its members say so.
     const asset = ASSETS.find((candidate) => candidate.kind === 'skill')!;
     const named = new Set(commandsNamedIn(await readAsset(asset)));
 
     const wanted = [
       'deploy',
       'status',
-      'sync targets',
+      'sync workspaces',
       'profile add',
       'profile remove',
       'profile list',
-      'target list',
+      'workspace list',
+      'connection list',
+      'grant add',
+      'profile members',
       'doctor',
       'mcp add',
       'mcp list',

--- a/src/cli/lanes.test.ts
+++ b/src/cli/lanes.test.ts
@@ -96,7 +96,7 @@ describe('the fallback token invocation', () => {
     await writeFile(join(root, 'lanes-link.yaml'), workspaceYaml(['local'], {defaultProfile: 'scratch'}));
     await writeFile(
       join(root, 'profiles', 'scratch.yaml'),
-      `contract: 2
+      `contract: 3
 
 instance:
   profile: scratch

--- a/src/cli/lanes.ts
+++ b/src/cli/lanes.ts
@@ -21,13 +21,23 @@ const AREAS: Record<string, string> = {
   link: 'a self-hostable MCP gateway for all your connections, memory, tasks, files, and secrets',
 };
 
+/** Commands that belong to the binary rather than to any one area. */
+const TOP_LEVEL: Record<string, string> = {
+  auth: 'sign in to Lanes, so a profile can say who may use it',
+  'set-workspace': 'which workspace a command means when it does not say',
+};
+
 function areasUsage(): string {
   const rows = Object.entries(AREAS)
     .map(([name, blurb]) => `  ${style.bold(`lanes ${name}`)}  ${blurb}`)
     .join('\n');
 
+  const top = Object.entries(TOP_LEVEL)
+    .map(([name, blurb]) => `  ${style.bold(`lanes ${name}`)}  ${blurb}`)
+    .join('\n');
+
   return (
-    `${style.bold('lanes')} — your own tools, wherever you work\n\n${rows}\n\n` +
+    `${style.bold('lanes')} — your own tools, wherever you work\n\n${rows}\n\n${top}\n\n` +
     `Run ${style.bold('lanes <area> help')} for what an area can do, ` +
     `or ${style.bold('lanes --version')} for which release this is.\n`
   );
@@ -49,6 +59,20 @@ async function main(argv: readonly string[]): Promise<void> {
   if (area === '--version' || area === '-v') {
     print(version());
     return;
+  }
+
+  // A top-level command rather than an area, because it selects the workspace
+  // *the CLI* acts in — every area's commands read the same answer (ADR-061).
+  if (area === 'auth') {
+    const { runAuth } = await import('./commands/auth-dispatch.ts');
+    return await runAuth(rest);
+  }
+
+  if (area === 'set-workspace') {
+    const { setWorkspace } = await import('./commands/set-workspace.ts');
+    const { parseArgv } = await import('./argv.ts');
+    const { command, flags } = parseArgv(rest);
+    return await setWorkspace(command[0], { json: flags['json'] === true });
   }
 
   if (area === 'link') {

--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -15,6 +15,7 @@ import {
   desktop,
   doctor,
   outputs,
+  pair,
   plan,
   policyList,
   policyRule,
@@ -288,6 +289,14 @@ export async function run(argv: readonly string[]): Promise<void> {
         default:
           throw new Error(`Unknown: ${PROGRAM} token ${second}`);
       }
+
+    case 'pair':
+      return pair({
+        ...global,
+        print: flags['print'] === true,
+        rotate: flags['rotate'] === true,
+        yes: flags['yes'] === true,
+      });
 
     case 'audit':
       if (second === 'verify') return auditVerify(global);

--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -1,6 +1,10 @@
 import { connect } from './commands/connect/index.ts';
 import { connectCustom } from './commands/connect/custom/index.ts';
-import { disconnect, relabel } from './commands/connection.ts';
+import { disconnect } from './commands/connection.ts';
+import { grantConnectionTo, revokeConnectionFrom } from './commands/grant.ts';
+import { connectionList } from './commands/connection-list.ts';
+import { membersAdd, membersList, membersRemove } from './commands/members.ts';
+import { relabel } from './commands/relabel.ts';
 import {
   attachFile,
   auditTail,
@@ -32,7 +36,17 @@ import { secretsList, secretsPush, secretsSet } from './commands/secrets.ts';
 import { knowledgeShow, knowledgeUse } from './commands/knowledge.ts';
 import { dispatchOwner } from './dispatch-owner.ts';
 import { update } from './commands/update.ts';
-import { all, customFlags, globalFlags, knowledgeFlags, ownerFlags, parseArgv, text } from './argv.ts';
+import {
+  all,
+  customFlags,
+  globalFlags,
+  knowledgeFlags,
+  ownerFlags,
+  parseArgv,
+  text,
+} from './argv.ts';
+import type { GlobalFlags } from './runtime.ts';
+import type { OwnerFlags } from './commands/owner/shared.ts';
 import { assertKnownFlags } from './selection.ts';
 import { requireSelection } from './selection-require.ts';
 import { PROGRAM, USAGE } from './usage.ts';
@@ -57,8 +71,12 @@ export async function run(argv: readonly string[]): Promise<void> {
   const { command, flags } = parseArgv(argv);
   const [first, second, ...rest] = command;
 
-  const global = globalFlags(flags);
-  const owner = ownerFlags(flags, argv);
+  // Both are read *after* `requireSelection`, which is what resolves
+  // `default_workspace` onto `flags` (ADR-061). Capturing them before it would
+  // hand every command an undefined workspace on the path the default exists to
+  // serve — the flag would be resolved and nothing would be looking.
+  let global: GlobalFlags;
+  let owner: OwnerFlags;
 
   const show = flags['show'] === true;
   const raw = flags['raw'] === true;
@@ -76,6 +94,9 @@ export async function run(argv: readonly string[]): Promise<void> {
   // leaves room for.
   assertKnownFlags(first, second, flags);
   await requireSelection(first, second, flags);
+
+  global = globalFlags(flags);
+  owner = ownerFlags(flags, argv);
 
   switch (first) {
     case 'connect':
@@ -117,6 +138,20 @@ export async function run(argv: readonly string[]): Promise<void> {
           });
       }
 
+    // The command connecting no longer implies. A connection belongs to the
+    // workspace (ADR-057), so which profiles may reach it is a separate say.
+    case 'connection':
+      if (second !== 'list' && second !== undefined) {
+        throw new Error(`Unknown: ${PROGRAM} connection ${second}`);
+      }
+      return connectionList({ ...global, json });
+
+    case 'grant':
+      return grantConnectionTo(second, { ...global, json });
+
+    case 'revoke':
+      return revokeConnectionFrom(second, { ...global, json });
+
     case 'setup':
       if (second !== 'plan' && second !== undefined) {
         throw new Error(`Unknown: ${PROGRAM} setup ${second}`);
@@ -127,27 +162,46 @@ export async function run(argv: readonly string[]): Promise<void> {
       switch (second) {
         case 'add':
           if (!rest[0]) {
-            throw new Error(`Usage: ${PROGRAM} profile add <name> --target <name>`);
+            throw new Error(`Usage: ${PROGRAM} profile add <name> --workspace <name>`);
           }
           return profileAdd(rest[0], {
             // One target, not a list. A profile declared every target it could
             // run on under contract 1, which is why this read the repeated flag
             // out of argv; it lives in exactly one now (ADR-052), so a second
             // --target would be naming a second place to put the same file.
-            targets: [text(flags, 'target')!],
+            targets: [text(flags, 'workspace')!],
             nonInteractive: flags['non-interactive'] === true,
             json,
           });
         case 'list':
         case undefined:
-          return profileList(text(flags, 'target')!, { json });
+          return profileList(text(flags, 'workspace')!, { json });
         case 'default':
           if (!rest[0]) throw new Error(`Usage: ${PROGRAM} profile default <name>`);
           return profileDefault(rest[0]);
+        case 'members': {
+          const [action, subject] = rest;
+          switch (action) {
+            case 'add':
+              return membersAdd(subject, {
+                ...global,
+                json,
+                me: flags['me'] === true,
+                role: text(flags, 'role'),
+              });
+            case 'remove':
+              return membersRemove(subject, { ...global, json });
+            case 'list':
+            case undefined:
+              return membersList({ ...global, json });
+            default:
+              throw new Error(`Unknown: ${PROGRAM} profile members ${action}`);
+          }
+        }
         case 'remove':
           if (!rest[0]) {
             throw new Error(
-              `Usage: ${PROGRAM} profile remove <name> [--target t] [--dry-run] [--yes]`,
+              `Usage: ${PROGRAM} profile remove <name> [--workspace <name>] [--dry-run] [--yes]`,
             );
           }
           return profileRemove(rest[0], {
@@ -160,18 +214,22 @@ export async function run(argv: readonly string[]): Promise<void> {
           throw new Error(`Unknown: ${PROGRAM} profile ${second}`);
       }
 
+    // `target` was the old word for the same thing (ADR-061). Kept as its own
+    // case rather than aliased, so `selection.test.ts` sees both spellings and
+    // neither can default quietly.
     case 'target':
+    case 'workspace':
       switch (second) {
         case 'list':
         case undefined:
           return targetList({ ...global, json, urls: flags['urls'] === true });
         case 'use':
-          if (!rest[0]) throw new Error(`Usage: ${PROGRAM} target use <name>`);
+          if (!rest[0]) throw new Error(`Usage: ${PROGRAM} workspace use <name>`);
           return targetUse(rest[0]);
         case 'show':
           return targetShow(rest[0], { ...global, json });
         default:
-          throw new Error(`Unknown: ${PROGRAM} target ${second}`);
+          throw new Error(`Unknown: ${PROGRAM} workspace ${second}`);
       }
 
     case 'identity': {
@@ -206,11 +264,15 @@ export async function run(argv: readonly string[]): Promise<void> {
           const [capability] = rest;
           if (!capability) {
             throw new Error(
-              `Usage: ${PROGRAM} policy ${second} <capability>\n` +
-                `  e.g. ${PROGRAM} policy ${second} gmail.send_message, or gmail.* for the whole provider`,
+              `Usage: ${PROGRAM} policy ${second} <capability> --connection <provider>.<id>\n` +
+                `  e.g. ${PROGRAM} policy ${second} gmail.send_message --connection gmail.personal,\n` +
+                `       or gmail.* for everything that connection's provider offers`,
             );
           }
-          return policyRule(second, capability, global);
+          return policyRule(second, capability, {
+            ...global,
+            ...(typeof flags.connection === 'string' ? { connection: flags.connection } : {}),
+          });
         }
         default:
           throw new Error(`Unknown: ${PROGRAM} policy ${second}`);
@@ -398,6 +460,7 @@ export async function run(argv: readonly string[]): Promise<void> {
       switch (second) {
         case undefined:
         case 'targets':
+        case 'workspaces':
           return syncTargets({
             ...global,
             dryRun: flags['dry-run'] === true,

--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -31,7 +31,7 @@ import { syncTargets } from './commands/sync.ts';
 import { targetList, targetShow, targetUse } from './commands/target.ts';
 import { identityAdd, identityList, identityRemove } from './commands/identity.ts';
 import { setupPlan } from './commands/setup.ts';
-import { mcpAdd, mcpList, mcpStdio, skillDocument } from './commands/mcp.ts';
+import { installInstructions, mcpAdd, mcpList, mcpStdio, skillDocument } from './commands/mcp.ts';
 import { deploy } from '#deployments/deploy.ts';
 import { secretsList, secretsPush, secretsSet } from './commands/secrets.ts';
 import { knowledgeShow, knowledgeUse } from './commands/knowledge.ts';
@@ -413,6 +413,8 @@ export async function run(argv: readonly string[]): Promise<void> {
             noSkill: flags['no-skill'] === true,
             headless: flags['headless'] === true,
           });
+        case 'install-instructions':
+          return installInstructions({ ...(text(flags, 'client') ? { client: text(flags, 'client') } : {}) });
         case 'stdio':
           return mcpStdio({ ...global, ...(flags['only'] === true ? { only: true } : {}) });
         case 'list':

--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -402,6 +402,7 @@ export async function run(argv: readonly string[]): Promise<void> {
             dryRun: flags['dry-run'] === true,
             force: flags['force'] === true,
             noSkill: flags['no-skill'] === true,
+            headless: flags['headless'] === true,
           });
         case 'stdio':
           return mcpStdio({ ...global, ...(flags['only'] === true ? { only: true } : {}) });

--- a/src/cli/migrate-plan.ts
+++ b/src/cli/migrate-plan.ts
@@ -1,4 +1,5 @@
-import { ConfigError, layout, isRemoteWorkspace, type LegacyTarget, type WorkspaceTarget } from '#profile';
+import {
+  DATA_DIR, ConfigError, layout, isRemoteWorkspace, type LegacyTarget, type WorkspaceTarget } from '#profile';
 import { deployedWorkspace } from '#deployments/upload.ts';
 
 /**
@@ -88,7 +89,7 @@ export function toEntry(
   // produces `gs://b` pointing at `gs://b`. That is a loop, and `openTarget`
   // refuses it — which made `deploy` unable to run against the bucket it had
   // just migrated, on the one command the refusal names as the fix.
-  if (remote && remote !== workspaceRoot) return { workspace: remote };
+  if (remote && remote !== workspaceRoot) return { at: remote };
 
   // **A filesystem target is dropped from a remote workspace.**
   //
@@ -105,8 +106,13 @@ export function toEntry(
   const storagePath = declared.storage.path;
   const credentialsPath = declared.credentials.path;
 
-  const defaultStorage = `./${layout.blobs(profile)}`;
-  const defaultCredentials = `./${layout.credentials(profile)}`;
+  // The **contract-1** defaults, spelled out rather than taken from `layout`.
+  // This function reads a contract-1 profile, where every path was per profile,
+  // and `layout` describes where things live *now* — workspace-level since
+  // ADR-057. Asking it would compare a contract-1 path against a contract-3
+  // default and refuse every profile that had written the ordinary one.
+  const defaultStorage = `./${DATA_DIR}/${profile}`;
+  const defaultCredentials = `./${DATA_DIR}/${profile}/credentials.enc`;
 
   refuseCustomPath(name, profile, workspaceRoot, 'storage.path', storagePath, defaultStorage);
   refuseCustomPath(
@@ -149,12 +155,12 @@ function refuseCustomPath(
       `  A target is declared once for the whole workspace now (ADR-052), so it cannot hold a\n` +
       `  different path per profile. The default it would get is ${expected}.\n\n` +
       `  Move the data there and delete the line, or keep this profile in a workspace of its\n` +
-      `  own: LANES_LINK_HOME=${workspaceRoot}/<somewhere> lanes link profile add ${profile} --target ${target}`,
+      `  own: LANES_LINK_HOME=${workspaceRoot}/<somewhere> lanes link profile add ${profile} --workspace ${target}`,
   );
 }
 
 export function summarise(entry: WorkspaceTarget): string {
-  if (entry.workspace !== undefined) return `points at ${entry.workspace}`;
+  if (entry.at !== undefined) return `points at ${entry.at}`;
   const parts = [entry.credentials?.adapter, entry.storage?.adapter].filter(Boolean);
   return `${parts.join(' + ')}${entry.deploy ? `, deploys ${entry.deploy.service}` : ''}`;
 }

--- a/src/cli/output.ts
+++ b/src/cli/output.ts
@@ -1,3 +1,4 @@
+import { wasDefaulted } from './selection-require.ts';
 import type { Resolution } from '#profile';
 
 /**
@@ -126,11 +127,23 @@ export function announceProfile(selection: {
   print(style.dim(`profile ${style.bold(selection.profile)}  ${selection.workspaceRoot}`));
 }
 
+/**
+ * The line every command prints before its output.
+ *
+ * It names the workspace, and whether that workspace was *typed* or came from
+ * `default_workspace`. The provenance is not decoration: ADR-037 removed sticky
+ * selection because "the dotfile nothing prints" is how an operator runs a
+ * command against the wrong thing, and ADR-061 gives the default back only on
+ * the condition that it announces itself. Dropping the `(default)` marker for
+ * tidiness would reverse that decision.
+ */
 export function announce(resolution: Resolution): void {
+  const provenance = wasDefaulted(resolution.target) ? ' (default)' : '';
+
   print(
     style.dim(
       `profile ${style.bold(resolution.profile)}  ` +
-        `target ${style.bold(resolution.target)}  ` +
+        `workspace ${style.bold(resolution.target)}${provenance}  ` +
         `${resolution.workspaceRoot}`,
     ),
   );

--- a/src/cli/output.ts
+++ b/src/cli/output.ts
@@ -150,6 +150,26 @@ export function announce(resolution: Resolution): void {
 }
 
 /**
+ * The same line, for a command whose subject is the workspace.
+ *
+ * It names no profile, and that is the point rather than a saving. A
+ * workspace-level command still opens a runtime, and a runtime carries a
+ * profile — so `announce` would print whichever one happened to be picked, and
+ * a reader would take it for the thing being acted on. The audit log is one
+ * chain for the whole workspace; saying `profile personal` above it describes a
+ * log that does not exist.
+ */
+export function announceWorkspace(resolution: Resolution): void {
+  const provenance = wasDefaulted(resolution.target) ? ' (default)' : '';
+
+  print(
+    style.dim(
+      `workspace ${style.bold(resolution.target)}${provenance}  ${resolution.workspaceRoot}`,
+    ),
+  );
+}
+
+/**
  * Print a machine-readable result, or fall through to the human rendering.
  *
  * The early return is the whole point. `announce` is the first thing every

--- a/src/cli/publish.ts
+++ b/src/cli/publish.ts
@@ -53,7 +53,8 @@ export async function publishAndNotify(input: {
   readonly config: Config;
   readonly workspaceRoot: string;
   readonly target: string;
-  readonly profile: string;
+  /** Every profile the edit touched. See `publishWorkspace`. */
+  readonly profile: string | readonly string[];
   readonly credentials: SecretStore;
 }): Promise<PublishOutcome> {
   let published: string | null = null;
@@ -98,6 +99,8 @@ export async function publishProfileEdit(input: {
   readonly resolution: { readonly workspaceRoot: string; readonly profile: string };
   readonly config: Config;
   readonly target: string;
+  /** Every profile the edit touched, where it reached more than the one named. */
+  readonly touched?: readonly string[] | undefined;
 }): Promise<PublishOutcome> {
   const credentials = await openSecretStoreFor(
     input.config,
@@ -109,7 +112,7 @@ export async function publishProfileEdit(input: {
     config: input.config,
     workspaceRoot: input.resolution.workspaceRoot,
     target: input.target,
-    profile: input.resolution.profile,
+    profile: input.touched ?? input.resolution.profile,
     credentials,
   });
 }

--- a/src/cli/runtime.test.ts
+++ b/src/cli/runtime.test.ts
@@ -1,9 +1,9 @@
-import { workspaceYaml } from '#profile/testing.ts';
+import { connectionsYaml, workspaceYaml } from '#profile/testing.ts';
 import { afterAll, describe, expect, test } from 'bun:test';
 import { mkdtemp, mkdir, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { layout } from '#profile';
+import { CONNECTIONS_FILE, layout } from '#profile';
 import { createFileSecretStore } from '#secrets';
 import { openSecretStoreFor, openRuntime, resolveProfile } from './runtime.ts';
 
@@ -19,13 +19,16 @@ import { openSecretStoreFor, openRuntime, resolveProfile } from './runtime.ts';
 const roots: string[] = [];
 const previousHome = process.env['LANES_LINK_HOME'];
 
-const PROFILE = `contract: 2
+const PROFILE = `contract: 3
 
 instance:
   profile: personal
 
-policy:
-  allow: ['*']
+grants:
+  - { connection: memory.main, allow: ['memory.*'], deny: [] }
+  - { connection: skills.main, allow: ['skills.*'], deny: [] }
+  - { connection: vault.main, allow: ['vault.*'], deny: [] }
+members: []
 `;
 
 /**
@@ -36,10 +39,10 @@ policy:
  * by the workspace that is them — which is exactly the shape this file is here
  * to exercise.
  */
-const TARGETS = `contract: 2
+const TARGETS = `contract: 3
 default_profile: personal
 
-targets:
+workspaces:
   local:
     credentials: { adapter: file,       path: ./data/personal.credentials.enc }
     storage:     { adapter: filesystem, path: ./data/files }
@@ -73,6 +76,7 @@ async function workspace(): Promise<string> {
   await mkdir(join(root, 'profiles'), { recursive: true });
   await writeFile(join(root, 'lanes-link.yaml'), TARGETS);
   await writeFile(join(root, 'profiles', 'personal.yaml'), PROFILE);
+  await writeFile(join(root, CONNECTIONS_FILE), connectionsYaml());
 
   process.env['LANES_LINK_HOME'] = root;
   return root;
@@ -102,13 +106,15 @@ describe('the local target', () => {
 });
 
 describe('the owner layer follows the target — ADR-014', () => {
-  test("skills load from the profile's own directory — ADR-030", async () => {
+  test("skills load from the granted connection's directory — ADR-059", async () => {
     const root = await workspace();
     // Not `<root>/skills/`, which is where they lived while every profile
-    // shared them. A skill left there now loads for nobody, deliberately.
-    await mkdir(join(root, layout.skills('personal')), { recursive: true });
+    // shared them, and not `data/<profile>/skills.d/` either — they follow the
+    // skills *connection* a profile grants now (ADR-059). A skill left at
+    // either old path loads for nobody, deliberately.
+    await mkdir(join(root, layout.skills('main')), { recursive: true });
     await writeFile(
-      join(root, layout.skills('personal'), 'review-diff.md'),
+      join(root, layout.skills('main'), 'review-diff.md'),
       '---\ndescription: Review a diff\n---\nReview it.\n',
     );
     await mkdir(join(root, 'skills'), { recursive: true });
@@ -124,7 +130,7 @@ describe('the owner layer follows the target — ADR-014', () => {
       );
       // The same store the provider reads, exposed so `lanes link skills` cannot drift
       // into a second spelling of the same layout.
-      expect((await runtime.skills.list()).map((blob) => blob.key)).toEqual(['review-diff.md']);
+      expect((await runtime.skills?.list())?.map((blob) => blob.key)).toEqual(['review-diff.md']);
       expect(runtime.registry.capabilities().map((entry) => entry.id)).not.toContain(
         'skills.stale',
       );
@@ -139,11 +145,12 @@ describe('the owner layer follows the target — ADR-014', () => {
 
     try {
       await runtime.vault.put('owner', { id: 'token', value: 'secret' });
-      // Inside the profile's own directory, beside its state and its
-      // credential store — one profile, one folder.
-      expect(await Bun.file(join(root, 'data', 'personal', 'vault.enc')).exists()).toBe(true);
+      // Under the vault connection this profile grants (ADR-059), not under the
+      // profile — a profile owns no bytes now, and two profiles granting the
+      // same vault reach the same sealed document.
+      expect(await Bun.file(join(root, 'data', 'vault.d', 'main.enc')).exists()).toBe(true);
       // Its own key, never the credential store's.
-      expect(await Bun.file(join(root, 'data', 'personal', 'vault.enc.key')).exists()).toBe(true);
+      expect(await Bun.file(join(root, 'data', 'vault.d', 'main.enc.key')).exists()).toBe(true);
     } finally {
       await runtime.close();
     }

--- a/src/cli/runtime.test.ts
+++ b/src/cli/runtime.test.ts
@@ -166,7 +166,14 @@ describe('the owner layer follows the target — ADR-014', () => {
     try {
       await runtime.vault.put('owner', { id: 'token', value: 'secret' });
 
-      expect(await Bun.file(join(root, 'data', 'files', 'vault.enc')).exists()).toBe(true);
+      // `vault.d/<connection>.enc`, not a single `vault.enc`: one sealed
+      // document per vault connection (ADR-059), and the blob adapter honours
+      // that as the file adapter does. It used to write one document for every
+      // vault connection in the workspace, which is the collision whose wrong
+      // answer is a credential.
+      expect(
+        await Bun.file(join(root, 'data', 'files', 'vault.d', 'main.enc')).exists(),
+      ).toBe(true);
       expect(await Bun.file(join(root, 'data', 'personal.vault.enc')).exists()).toBe(false);
     } finally {
       delete process.env['LANES_LINK_VAULT_KEY'];

--- a/src/cli/runtime.ts
+++ b/src/cli/runtime.ts
@@ -33,4 +33,4 @@ export {
 } from './runtime/registry.ts';
 
 export { grantedConnections, openRuntime, type OpenOptions, type Runtime } from './runtime/open.ts';
-export { openWorkspaceRuntime } from './runtime/workspace.ts';
+export { openWorkspaceRuntime, primaryProfile } from './runtime/workspace.ts';

--- a/src/cli/runtime.ts
+++ b/src/cli/runtime.ts
@@ -32,4 +32,4 @@ export {
   type OwnerLayerOptions,
 } from './runtime/registry.ts';
 
-export { openRuntime, type OpenOptions, type Runtime } from './runtime/open.ts';
+export { grantedConnections, openRuntime, type OpenOptions, type Runtime } from './runtime/open.ts';

--- a/src/cli/runtime.ts
+++ b/src/cli/runtime.ts
@@ -33,3 +33,4 @@ export {
 } from './runtime/registry.ts';
 
 export { grantedConnections, openRuntime, type OpenOptions, type Runtime } from './runtime/open.ts';
+export { openWorkspaceRuntime } from './runtime/workspace.ts';

--- a/src/cli/runtime/discovery.test.ts
+++ b/src/cli/runtime/discovery.test.ts
@@ -26,7 +26,7 @@ import { capabilityDiff, discoveryProbe, isEmptyDiff } from './discovery.ts';
 const roots: string[] = [];
 const previousHome = process.env['LANES_LINK_HOME'];
 
-const PROFILE = `contract: 2
+const PROFILE = `contract: 3
 
 instance:
   profile: personal

--- a/src/cli/runtime/open.ts
+++ b/src/cli/runtime/open.ts
@@ -6,11 +6,17 @@ import type { BlobStore } from '#stores/blobs';
 import type { AnyConnector, ProviderManifest } from '#connectivity';
 import { RateLimiter, allowedConnections } from '#policy';
 import {
+  assertGrantsResolve,
   layout,
   listProfiles,
+  readConnections,
+  selectConnections,
+  soleGrantFor,
   workspacePath,
   type Config,
+  type ConnectionConfig,
   type Resolution,
+  type SelectedConnection,
   type TargetConfig,
 } from '#profile';
 import { ProviderRegistry, toPolicyDocument } from '#registry';
@@ -33,6 +39,10 @@ import { resolveProfile, type GlobalFlags } from './select.ts';
 import { buildRegistryWithWorkspace, readSkillsForStart, reloadSkills } from './registry.ts';
 import { discoveryProbe } from './discovery.ts';
 import { openVault } from './vault.ts';
+import { EMPTY_SKILL_STORE, skillStore } from './stores.ts';
+import type { Runtime } from './types.ts';
+
+export type { Runtime } from './types.ts';
 
 /**
  * Assembling a profile's runtime from its declared target.
@@ -43,63 +53,20 @@ import { openVault } from './vault.ts';
  * nothing at the application layer.
  */
 
-export interface Runtime {
-  readonly resolution: Resolution;
-  readonly config: Config;
-  readonly target: string;
-  /**
-   * The target's adapter set, from the workspace that declares it.
-   *
-   * Here because the config no longer carries it. Every caller that used to
-   * reach `config.targets[target]` — for a `deploy` block, a storage adapter, a
-   * knowledge repository — reads this instead, and reads it without following
-   * the pointer a second time (ADR-052).
-   */
-  readonly declared: TargetConfig;
-  readonly state: RuntimeState;
-  /** The durable log, for reading. Copies, if any, are write-only and not here. */
-  readonly audit: AuditReader;
-  readonly credentials: SecretStore;
-  readonly storage: BlobStore;
-  /** Where skills are kept — `data/<profile>/skills.d/` locally. */
-  readonly skills: BlobStore;
-  /**
-   * Present only when this target keeps memory and skills in a repository.
-   *
-   * Nothing on the dispatch path reads it: `storage` and `skills` above are
-   * already pointed at the right bytes, which is the whole design. It is here
-   * so `target show` and `doctor` can say where those bytes are without
-   * re-reading the config, and so the migration can reach the repository it is
-   * committing to.
-   */
-  readonly knowledge?: KnowledgeStores | undefined;
-  /** The vault's own store, so `lanes link vault` reaches the same bytes MCP does. */
-  readonly vault: VaultStore;
-  readonly registry: ProviderRegistry;
-  /**
-   * Re-read the skills into the registry when they have changed on the store.
-   *
-   * Cheap and idempotent — one `list()`, and a rebuild only when the listing
-   * differs from the last one. The caller decides how often to ask.
-   */
-  refreshSkills(): Promise<void>;
-  readonly dispatcher: Dispatcher;
-  readonly authenticator: BearerAuthenticator;
-  /** Same factory the dispatcher uses, exposed for commands that probe upstream. */
-  connectorFor(providerId: string, connectionId: string): AnyConnector | undefined;
-  /**
-   * Same authorizer the dispatcher uses, for the same reason `connectorFor` is here.
-   *
-   * A command that probes upstream needs the credential on the request, and it
-   * must not learn how to put it there — that is one switch on the resolved
-   * shape (`connectivity/auth/authorize.ts`) and a second copy would be a
-   * second answer. `settleIdentity` is the caller: it asks a provider whose
-   * account was just authorised, over whatever method that provider declares.
-   */
-  authorizeRequest(providerId: string, connectionId: string, request: Request): Promise<Request>;
-  /** A provider's manifest, so an omitted `credential_ref` can be derived from it. */
-  manifestFor(providerId: string): ProviderManifest | undefined;
-  close(): Promise<void>;
+/**
+ * The accounts a profile reaches, as most callers want them.
+ *
+ * `runtime.connections` pairs each with the grant governing it, which is what
+ * policy and the setup surface need. Everything else — probing credentials,
+ * listing accounts, reconciling state — wants the rows alone, and unwrapping
+ * them at twenty call sites is twenty chances to reach for
+ * `workspaceConnections` by mistake and answer for accounts this profile was
+ * never granted.
+ */
+export function grantedConnections(
+  runtime: Pick<Runtime, 'connections'>,
+): ConnectionConfig[] {
+  return runtime.connections.map(({ connection }) => connection);
 }
 
 /**
@@ -121,10 +88,6 @@ export interface Runtime {
  * declares its own `storage.path` moves its provider blobs, not the reserved
  * roots beside them.
  */
-function skillStore(storage: StorageFactory, profile: string): BlobStore {
-  return storage(layout.skills(profile));
-}
-
 /**
  * What a caller may hand the runtime that is not a flag somebody typed.
  *
@@ -152,6 +115,15 @@ export async function openRuntime(
   const root = resolved.workspaceRoot;
   const adapters: TargetInput = { declared, config, root, target };
 
+  // The workspace's accounts, and the check that this profile's grants name
+  // real ones (ADR-057). Read here rather than inside `resolveProfile` because
+  // it is a property of the workspace rather than of the selection, and because
+  // a command that only wants to know which profiles exist should not have to
+  // parse every connection to find out.
+  const connectionsFile = await readConnections(root);
+  assertGrantsResolve(config, connectionsFile.connections);
+  const selected = selectConnections(config, connectionsFile.connections);
+
   // Credentials first: an S3 key pair is itself a credential reference, so the
   // credential store has to exist before the blob store that names it. State
   // and the log then ride that blob store rather than opening backends of
@@ -174,7 +146,7 @@ export async function openRuntime(
   // own roots on the target's own storage and are untouched.
   const knowledge = await openKnowledge(adapters, credentials, options.fetch);
   const storage = knowledge ? routeBlobStore(storageFor(), knowledgeRoutes(knowledge)) : storageFor();
-  const state = openState(storageFor, config.instance.profile);
+  const state = openState(storageFor);
 
   // The durable log, plus any copies the target declares. `sink` is what
   // dispatch writes to; `audit` is what `tail` and `verify` read, and those are
@@ -187,7 +159,18 @@ export async function openRuntime(
     (message) => logger.warn(message),
   );
 
-  const skills = knowledge?.skills ?? skillStore(storageFor, config.instance.profile);
+  // Rooted at the skills connection this profile grants, not at the profile
+  // (ADR-059). At most one can be granted, which is what makes this a lookup
+  // rather than a choice — `load.ts` refuses a second one, for the reason a
+  // prompt has no argument to route on.
+  //
+  // `EMPTY_SKILLS` when none is granted: a profile that denies `skills.*` has
+  // no store to open, and handing it the workspace root instead would serve
+  // every other profile's procedures.
+  const skillsConnection = soleGrantFor(config, 'skills');
+  const skills =
+    knowledge?.skills ??
+    (skillsConnection === undefined ? undefined : skillStore(storageFor, skillsConnection));
 
   // The vault's own store, beside the credential store and never it: a separate
   // document, a separate key, and a separate environment variable
@@ -208,6 +191,7 @@ export async function openRuntime(
   let registry: ProviderRegistry;
   let fingerprint = '';
   const refreshSkills = async (): Promise<void> => {
+    if (skills === undefined) return;
     fingerprint = await reloadSkills(registry, skills, fingerprint, refreshSkills);
   };
 
@@ -226,23 +210,18 @@ export async function openRuntime(
   // registered into. Per call rather than a snapshot, so a policy the runtime
   // was opened with is re-evaluated rather than remembered.
   const reachable = (): ReadonlyArray<{ key: string; provider: string; account: string }> =>
-    config.connections
-      .filter((connection) =>
+    selected
+      .filter(({ ref, connection }) =>
         registry
           .capabilities()
           .some(
             ({ id }) =>
               id.startsWith(`${connection.provider}.`) &&
-              allowedConnections(
-                id,
-                [`${connection.provider}.${connection.id}`],
-                principal,
-                policy,
-              ).length > 0,
+              allowedConnections(id, [ref], principal, policy).length > 0,
           ),
       )
-      .map((connection) => ({
-        key: `${connection.provider}.${connection.id}`,
+      .map(({ ref, connection }) => ({
+        key: ref,
         provider: connection.provider,
         account: connection.account,
         ...(connection.label ? { label: connection.label } : {}),
@@ -253,14 +232,14 @@ export async function openRuntime(
   // tolerated when the store is a repository: a local directory that will not
   // read is a real fault worth failing on, exactly as it always was.
   const loaded = await readSkillsForStart(
-    skills,
+    skills ?? EMPTY_SKILL_STORE,
     knowledge !== undefined,
     (message) => logger.warn(message),
-    ` --profile ${config.instance.profile} --target ${target}`,
+    ` --profile ${config.instance.profile} --workspace ${target}`,
   );
 
-  registry = await buildRegistryWithWorkspace(root, config.instance.profile, {
-    skillStore: skills,
+  registry = await buildRegistryWithWorkspace(root, {
+    ...(skills ? { skillStore: skills } : {}),
     skills: loaded.skills,
     onSkillsChanged: refreshSkills,
     vault: { store: vaultStore, items: await vaultStore.ids() },
@@ -269,7 +248,7 @@ export async function openRuntime(
       target,
       profiles: await listProfiles(root),
       catalogue: PROVIDER_MANIFESTS,
-      ownClients: Object.keys(config.oauth_apps),
+      ownClients: Object.keys(connectionsFile.oauth_apps),
       reachable,
     },
     // Straight off the config: unlike `reachable`, nothing has to be filtered
@@ -329,14 +308,16 @@ export async function openRuntime(
     credentials,
     // From the connection row, which is where a per-connection setting has
     // always lived. One lookup behind both, so they cannot disagree.
-    connectionConfig: (provider, id) => row(config, provider, id)?.config,
-    isDeclared: (provider, id) => row(config, provider, id) !== undefined,
+    connectionConfig: (provider, id) => row(connectionsFile.connections, provider, id)?.config,
+    isDeclared: (provider, id) => row(connectionsFile.connections, provider, id) !== undefined,
   });
   const authorizeRequest = requestAuthorizer(registry, credentials);
   let closed = false;
 
   const dispatcher = new Dispatcher({
     config,
+    connections: connectionsFile.connections,
+    oauthApps: Object.keys(connectionsFile.oauth_apps),
     registry,
     connectorFor,
     authorizeRequest,
@@ -354,6 +335,9 @@ export async function openRuntime(
     config,
     target,
     declared,
+    connections: selected,
+    workspaceConnections: connectionsFile.connections,
+    ownClients: Object.keys(connectionsFile.oauth_apps),
     state,
     audit,
     credentials,
@@ -390,5 +374,5 @@ export async function openRuntime(
   };
 }
 
-const row = (config: Config, provider: string, id: string) =>
-  config.connections.find((connection) => connection.provider === provider && connection.id === id);
+const row = (connections: readonly ConnectionConfig[], provider: string, id: string) =>
+  connections.find((connection) => connection.provider === provider && connection.id === id);

--- a/src/cli/runtime/open.ts
+++ b/src/cli/runtime/open.ts
@@ -70,25 +70,6 @@ export function grantedConnections(
 }
 
 /**
- * Where this profile's skills live, in either target.
- *
- * Locally `data/<profile>/skills.d/`; deployed, the same key under the bucket
- * prefix. Going through the store rather than a filesystem path is what gives a
- * deployment skills at all — a path is baked into a container image at build
- * time and an object key is not, so before ADR-014 a deployed instance could
- * only ever serve the skills that existed when its image was built.
- *
- * **Per profile**, which reverses ADR-012 §1. Policy gating `skills.<name>`
- * was the whole isolation story while the bytes were shared, and it is a weak
- * one: it decides who may *run* a procedure, not who may read that it exists or
- * what it says. A skill written for work names work's accounts and work's
- * people. ADR-030.
- *
- * An explicit area, matching `openState` and `openAudit` — a profile that
- * declares its own `storage.path` moves its provider blobs, not the reserved
- * roots beside them.
- */
-/**
  * What a caller may hand the runtime that is not a flag somebody typed.
  *
  * One field, and it exists for the same reason `connect`'s does: the only thing

--- a/src/cli/runtime/registry.ts
+++ b/src/cli/runtime/registry.ts
@@ -3,7 +3,7 @@ import type { ProviderDefinition } from '#connectivity';
 import { ConfigError } from '#profile';
 import { ProviderRegistry } from '#registry';
 import { RESERVED_BY_GRAMMAR } from '../commands/connect/custom/spec.ts';
-import { loadProfileProviders } from '#providers/custom/index.ts';
+import { loadWorkspaceProviders } from '#providers/custom/index.ts';
 import { loadProfileSkills, type LoadedSkill } from '#providers/skills/store.ts';
 import { exampleProvider } from '#providers/example/provider.ts';
 import {
@@ -138,21 +138,20 @@ export function buildRegistry(owner: OwnerLayerOptions = {}): ProviderRegistry {
  * overriding it — an operator shadowing `gmail` by accident would be very hard
  * to diagnose from the outside.
  *
- * The profile is a parameter rather than read from a config here because two of
- * the three callers do not have one: `deploy` walks every profile in turn, and
- * `profile remove` is holding the name of the one being deleted. Passing it
- * makes "which profile's manifests" a question the caller has already answered.
+ * No profile parameter any more. Manifests moved to the workspace with the
+ * connections they describe (ADR-057), so "which profile's manifests" stopped
+ * being a question — and with it the whole reason `deploy` had to rebuild a
+ * registry per profile to collect credential refs.
  */
 export async function buildRegistryWithWorkspace(
   root: string,
-  profile: string,
   owner: OwnerLayerOptions = {},
 ): Promise<ProviderRegistry> {
   const skills =
     owner.skills ?? (owner.skillStore ? await loadProfileSkills(owner.skillStore) : []);
   const registry = buildRegistry({ ...owner, skills });
 
-  for (const { manifest, path } of await loadProfileProviders(root, profile)) {
+  for (const { manifest, path } of await loadWorkspaceProviders(root)) {
     if (registry.has(manifest.id)) {
       throw new ConfigError(
         `${path}: provider "${manifest.id}" is already built in. Rename it, or remove the file to use the built-in.`,

--- a/src/cli/runtime/scoping.test.ts
+++ b/src/cli/runtime/scoping.test.ts
@@ -3,32 +3,53 @@ import { afterAll, describe, expect, test } from 'bun:test';
 import { mkdtemp, mkdir, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { layout } from '#profile';
+import { CONNECTIONS_FILE, layout } from '#profile';
 import { openRuntime, type Runtime } from '../runtime.ts';
 
 /**
- * That a profile's owner layer is the profile's — ADR-030.
+ * That skills follow the instance a profile grants — ADR-059.
  *
- * Skills and provider manifests used to live at the workspace root, shared by
- * every profile, with policy gating `skills.<name>` as the whole isolation
- * story. Policy decides who may *run* a procedure; it never hid that the
- * procedure existed, or what it said, or which host a manifest names.
+ * Skills lived at the workspace root once, shared by every profile, with policy
+ * gating `skills.<name>` as the whole isolation story; ADR-030 moved them into
+ * the profile because policy decides who may *run* a procedure and never hid
+ * that the procedure existed. ADR-059 keeps that isolation and changes what
+ * expresses it: a skills connection, granted by name, so two profiles share
+ * nothing by granting different instances and share everything by granting one.
+ *
+ * The privacy argument is unchanged. What changed is that the owner chooses,
+ * where the file path used to choose for them.
  *
  * These tests open two real runtimes over one real workspace, because that is
  * the only arrangement where the bug was reachable: one profile is never wrong
  * about whose skills it is holding.
+ *
+ * Manifests are the exception and moved the other way (ADR-057): a manifest
+ * defines a connection, and connections are the workspace's, so one profile's
+ * manifest *is* the other's now.
  */
 
 const roots: string[] = [];
 const previousHome = process.env['LANES_LINK_HOME'];
 
-const profileConfig = (name: string): string => `contract: 2
+const profileConfig = (name: string, skills = name): string => `contract: 3
 
 instance:
   profile: ${name}
 
-policy:
-  allow: ['*']
+grants:
+  - { connection: skills.${skills}, allow: ['skills.*'], deny: [] }
+  - { connection: setup.main, allow: ['setup.*'], deny: [] }
+members: []
+`;
+
+/** The workspace's rows: one skills instance per profile, plus the owner layer. */
+const CONNECTIONS = `contract: 3
+connections:
+  - { id: personal, provider: skills, account: Skills }
+  - { id: work, provider: skills, account: Skills }
+  - { id: shared, provider: skills, account: Skills }
+  - { id: main, provider: setup, account: Setup }
+oauth_apps: {}
 `;
 
 const skill = (description: string, body: string): string =>
@@ -37,14 +58,18 @@ const skill = (description: string, body: string): string =>
 const manifest = (id: string, host: string): string =>
   `id: ${id}\nname: ${id}\nconnector: { kind: http, base_url: https://${host}, openapi: https://${host}/openapi.json }\nauth: { kind: header, header: X-API-Key, credential_ref: ${id}/api_key }\n`;
 
-async function workspace(files: Record<string, string>): Promise<string> {
+async function workspace(
+  files: Record<string, string>,
+  granting?: Record<string, string>,
+): Promise<string> {
   const root = await mkdtemp(join(tmpdir(), 'lanes-link-scoping-'));
   roots.push(root);
 
   await mkdir(join(root, 'profiles'), { recursive: true });
   await writeFile(join(root, 'lanes-link.yaml'), workspaceYaml(['local'], {defaultProfile: 'personal'}));
+  await writeFile(join(root, CONNECTIONS_FILE), CONNECTIONS);
   for (const name of ['personal', 'work']) {
-    await writeFile(join(root, 'profiles', `${name}.yaml`), profileConfig(name));
+    await writeFile(join(root, 'profiles', `${name}.yaml`), profileConfig(name, granting?.[name]));
   }
 
   for (const [key, contents] of Object.entries(files)) {
@@ -80,8 +105,8 @@ afterAll(async () => {
   await Promise.all(roots.map((root) => rm(root, { recursive: true, force: true })));
 });
 
-describe('skills belong to one profile', () => {
-  test("a profile's skills are invisible to its sibling", async () => {
+describe('skills follow the instance a profile grants', () => {
+  test("a profile's skills are invisible to a sibling granting a different instance", async () => {
     await workspace({
       [`${layout.skills('personal')}/holiday-plan/SKILL.md`]: skill('Plan a holiday', 'Plan it.'),
       [`${layout.skills('work')}/incident-review/SKILL.md`]: skill('Review an incident', 'Review it.'),
@@ -110,7 +135,7 @@ describe('skills belong to one profile', () => {
 
     try {
       const body = async (runtime: typeof personal): Promise<string> =>
-        new TextDecoder().decode((await runtime.skills.get('triage.md'))!);
+        new TextDecoder().decode((await runtime.skills!.get('triage.md'))!);
 
       expect(await body(personal)).toContain('Sort the personal inbox.');
       expect(await body(work)).toContain('Page the on-call engineer.');
@@ -135,10 +160,18 @@ describe('skills belong to one profile', () => {
   });
 });
 
-describe('provider manifests belong to one profile', () => {
-  test('a manifest one profile declares is not registered in the other', async () => {
+describe('provider manifests belong to the workspace', () => {
+  test('a manifest is registered in every profile, because it defines a connection', async () => {
+    // The reversal ADR-057 makes, and the one place this file moves the other
+    // way. ADR-030 put manifests in the profile on the reasoning that a manifest
+    // "names a host, an OpenAPI document, and the credential refs that reach
+    // them" — a description of somebody's infrastructure. That is still true,
+    // and it is now a description of a *connection*, which the workspace owns.
+    //
+    // What keeps the boundary is the grant: a profile that does not grant
+    // `ledger.<id>` reaches nothing through it, however registered it is.
     await workspace({
-      [`${layout.providers('work')}/ledger.yaml`]: manifest('ledger', 'ledger.example.com'),
+      [`${layout.providers()}/ledger.yaml`]: manifest('ledger', 'ledger.example.com'),
     });
 
     // `has`, not `capabilities()`: an http provider's capability list comes
@@ -146,7 +179,7 @@ describe('provider manifests belong to one profile', () => {
     // manifest was registered at all is the question this change decides.
     await bothProfiles(async ({ personal, work }) => {
       expect(work.registry.has('ledger')).toBe(true);
-      expect(personal.registry.has('ledger')).toBe(false);
+      expect(personal.registry.has('ledger')).toBe(true);
     });
   });
 

--- a/src/cli/runtime/select.test.ts
+++ b/src/cli/runtime/select.test.ts
@@ -17,7 +17,7 @@ import { openBlobStoreFor } from './select.ts';
 
 const config = (): Config =>
   ({
-    contract: 2,
+    contract: 3,
     instance: { profile: 'personal' },
     connections: [],
     policy: { allow: [] },
@@ -36,7 +36,7 @@ async function workspace(storage?: string): Promise<string> {
   const root = await mkdtemp(join(tmpdir(), 'lanes-link-select-'));
   await writeFile(
     join(root, 'lanes-link.yaml'),
-    'contract: 2\ntargets:\n  local:\n' +
+    'contract: 3\nworkspaces:\n  local:\n' +
       '    credentials: { adapter: file }\n' +
       `    storage: { adapter: filesystem${storage ? `, path: ${storage}` : ''} }\n`,
   );

--- a/src/cli/runtime/stores.ts
+++ b/src/cli/runtime/stores.ts
@@ -30,6 +30,23 @@ export const EMPTY_SKILL_STORE: BlobStore = {
   list: async () => [],
 };
 
+/**
+ * Where a connection's skills live, in either workspace.
+ *
+ * `data/skills.d/<connection>/`, and deployed the same key under the bucket
+ * prefix. Going through the store rather than a filesystem path is what gives a
+ * deployment skills at all — a path is baked into a container image at build
+ * time and an object key is not, so before ADR-014 a deployed instance could
+ * only ever serve the skills that existed when its image was built.
+ *
+ * **Per connection**, which is the third answer this question has had. Policy
+ * gating `skills.<name>` was the whole isolation story while the bytes were
+ * shared (ADR-012 §1), and it is a weak one: it decides who may *run* a
+ * procedure, not who may read that it exists or what it says. ADR-030 made the
+ * bytes per profile; ADR-059 made them per connection, so two profiles granting
+ * one skills connection share a set and two granting different ones share
+ * nothing.
+ */
 export function skillStore(storage: StorageFactory, connection: string): BlobStore {
   return storage(layout.skills(connection));
 }

--- a/src/cli/runtime/stores.ts
+++ b/src/cli/runtime/stores.ts
@@ -1,0 +1,36 @@
+import { layout } from '#profile';
+import type { BlobStore } from '#stores/blobs';
+import type { StorageFactory } from '#deployments/target.ts';
+
+/**
+ * Where the owner layer's bytes are, for a runtime being assembled.
+ *
+ * Split from `open.ts` so that file stays inside the size budget, on the seam
+ * it already had: `open.ts` decides what a runtime *is* and this decides where
+ * one store lives. Both roots are explicit areas rather than derived from
+ * `storage.path`, matching `openState` and `openAudit` — a workspace that moves
+ * its provider blobs does not move the reserved roots beside them.
+ */
+
+/**
+ * A store with nothing in it, for a profile that grants no skills connection.
+ *
+ * Written out rather than imported from `#stores/blobs/testing.ts`: that module
+ * exists for tests, and production code reaching into it is how a test double
+ * ends up on a real path. Five methods, none of which can fail, is cheaper than
+ * the import would be to justify.
+ */
+export const EMPTY_SKILL_STORE: BlobStore = {
+  get: async () => null,
+  put: async () => {
+    throw new Error('this profile grants no skills connection');
+  },
+  has: async () => false,
+  delete: async () => {},
+  list: async () => [],
+};
+
+export function skillStore(storage: StorageFactory, connection: string): BlobStore {
+  return storage(layout.skills(connection));
+}
+

--- a/src/cli/runtime/types.ts
+++ b/src/cli/runtime/types.ts
@@ -1,0 +1,106 @@
+import type { BearerAuthenticator } from '#auth';
+import type { SecretStore } from '#secrets';
+import type { AuditReader } from '#audit';
+import type { RuntimeState } from '#stores/state';
+import type { BlobStore } from '#stores/blobs';
+import type { AnyConnector, ProviderManifest } from '#connectivity';
+import type {
+  Config,
+  ConnectionConfig,
+  Resolution,
+  SelectedConnection,
+  TargetConfig,
+} from '#profile';
+import type { ProviderRegistry } from '#registry';
+import type { Dispatcher } from '#dispatch';
+import type { VaultStore } from '#providers/owner.ts';
+import type { KnowledgeStores } from '#deployments/knowledge.ts';
+
+/**
+ * What a command is handed once a profile has been opened.
+ *
+ * Its own file so `open.ts` stays inside the size budget, and because this is
+ * the thing every command in the CLI is written against — a reader looking for
+ * "what do I get" should not have to read the assembly to find it.
+ */
+
+export interface Runtime {
+  readonly resolution: Resolution;
+  readonly config: Config;
+  readonly target: string;
+  /**
+   * The target's adapter set, from the workspace that declares it.
+   *
+   * Here because the config no longer carries it. Every caller that used to
+   * reach `config.targets[target]` — for a `deploy` block, a storage adapter, a
+   * knowledge repository — reads this instead, and reads it without following
+   * the pointer a second time (ADR-052).
+   */
+  readonly declared: TargetConfig;
+  /**
+   * The accounts this profile selects, joined to the grants that govern them.
+   *
+   * The join is done once, here, because everything that asks — status, doctor,
+   * reconcile, setup — wants the same answer and three implementations of it is
+   * three chances to disagree (`profile/connections.ts`).
+   */
+  readonly connections: readonly SelectedConnection[];
+  /** Every account the workspace holds, granted or not. `connection list` reads this. */
+  readonly workspaceConnections: readonly ConnectionConfig[];
+  /** Vendors this workspace registered a client of its own for (`oauth_apps`). */
+  readonly ownClients: readonly string[];
+  readonly state: RuntimeState;
+  /** The durable log, for reading. Copies, if any, are write-only and not here. */
+  readonly audit: AuditReader;
+  readonly credentials: SecretStore;
+  readonly storage: BlobStore;
+  /**
+   * Where this profile's skills are kept — `data/skills.d/<connection>/` locally.
+   *
+   * `undefined` when the profile grants no `skills` connection. That is a real
+   * state rather than an empty one, and it is worth the optionality: the owner
+   * layer arrives granted (ADR-050), so a profile without it was denied it on
+   * purpose, and handing back an empty store would report "no skills" for a
+   * profile that is not allowed to have any — the same answer for two different
+   * facts.
+   */
+  readonly skills: BlobStore | undefined;
+  /**
+   * Present only when this target keeps memory and skills in a repository.
+   *
+   * Nothing on the dispatch path reads it: `storage` and `skills` above are
+   * already pointed at the right bytes, which is the whole design. It is here
+   * so `target show` and `doctor` can say where those bytes are without
+   * re-reading the config, and so the migration can reach the repository it is
+   * committing to.
+   */
+  readonly knowledge?: KnowledgeStores | undefined;
+  /** The vault's own store, so `lanes link vault` reaches the same bytes MCP does. */
+  readonly vault: VaultStore;
+  readonly registry: ProviderRegistry;
+  /**
+   * Re-read the skills into the registry when they have changed on the store.
+   *
+   * Cheap and idempotent — one `list()`, and a rebuild only when the listing
+   * differs from the last one. The caller decides how often to ask.
+   */
+  refreshSkills(): Promise<void>;
+  readonly dispatcher: Dispatcher;
+  readonly authenticator: BearerAuthenticator;
+  /** Same factory the dispatcher uses, exposed for commands that probe upstream. */
+  connectorFor(providerId: string, connectionId: string): AnyConnector | undefined;
+  /**
+   * Same authorizer the dispatcher uses, for the same reason `connectorFor` is here.
+   *
+   * A command that probes upstream needs the credential on the request, and it
+   * must not learn how to put it there — that is one switch on the resolved
+   * shape (`connectivity/auth/authorize.ts`) and a second copy would be a
+   * second answer. `settleIdentity` is the caller: it asks a provider whose
+   * account was just authorised, over whatever method that provider declares.
+   */
+  authorizeRequest(providerId: string, connectionId: string, request: Request): Promise<Request>;
+  /** A provider's manifest, so an omitted `credential_ref` can be derived from it. */
+  manifestFor(providerId: string): ProviderManifest | undefined;
+  close(): Promise<void>;
+}
+

--- a/src/cli/runtime/vault.ts
+++ b/src/cli/runtime/vault.ts
@@ -1,5 +1,5 @@
 import {
-  soleGrantFor, layout, workspacePath } from '#profile';
+  soleGrantFor, layout, vaultRef, workspacePath } from '#profile';
 import type { SecretStore } from '#secrets';
 import {
   createBlobVaultStore,
@@ -64,7 +64,7 @@ export function openVault(
       // answer is a credential.
       return createSecretVaultStore({
         store: credentials,
-        ref: vault.ref ?? `vault/${connection}`,
+        ref: vaultRef(declared, config),
       });
 
     case 'blob':

--- a/src/cli/runtime/vault.ts
+++ b/src/cli/runtime/vault.ts
@@ -1,4 +1,5 @@
-import { layout, workspacePath } from '#profile';
+import {
+  soleGrantFor, layout, workspacePath } from '#profile';
 import type { SecretStore } from '#secrets';
 import {
   createBlobVaultStore,
@@ -36,10 +37,15 @@ export function openVault(
   const { declared, config, root } = input;
   const vault = declared.vault ?? { adapter: 'file' as const };
 
+  // The vault connection this profile grants (ADR-059). `main` when it grants
+  // none, which keeps a profile that denied the vault opening against the same
+  // document every other profile uses rather than inventing a second one.
+  const connection = soleGrantFor(config, 'vault') ?? 'main';
+
   switch (vault.adapter) {
     case 'file':
       return createFileVaultStore({
-        path: workspacePath(root, vault.path ?? layout.vault(config.instance.profile)),
+        path: workspacePath(root, vault.path ?? layout.vault(connection)),
       });
 
     case 'secret':

--- a/src/cli/runtime/vault.ts
+++ b/src/cli/runtime/vault.ts
@@ -53,15 +53,24 @@ export function openVault(
       // so the credential store holds ciphertext it cannot read. Separate
       // document, separate key, separate environment variable — the backend
       // was never what kept the two stores apart. ADR-022.
+      //
+      // Named per connection, like the file adapter. A `ref` written by hand
+      // still wins, because a deployment that already seals under one name has
+      // to keep opening it — but the default carries the instance, so two
+      // profiles granting different vaults share nothing. Without this only
+      // `file` honoured ADR-059 and every deployed workspace, which uses this
+      // adapter or `blob`, had one document behind every vault connection:
+      // ADR-059 calls that the worst of the three collisions, because the wrong
+      // answer is a credential.
       return createSecretVaultStore({
         store: credentials,
-        ...(vault.ref !== undefined ? { ref: vault.ref } : {}),
+        ref: vault.ref ?? `vault/${connection}`,
       });
 
     case 'blob':
       return createBlobVaultStore({
         store: storage(),
-        ...(vault.path !== undefined ? { key: vault.path } : {}),
+        key: vault.path ?? layout.vaultKey(connection),
       });
   }
 }

--- a/src/cli/runtime/workspace.ts
+++ b/src/cli/runtime/workspace.ts
@@ -33,3 +33,28 @@ export async function openWorkspaceRuntime(flags: GlobalFlags): Promise<Runtime>
 
   return openRuntime({ ...flags, profile: names[0]! });
 }
+
+/**
+ * Which profile a workspace-level command should act *as*.
+ *
+ * Distinct from `openWorkspaceRuntime` because the caller needs the name rather
+ * than a runtime — `start` puts it back into flags and hands them on. Same rule:
+ * `--profile` wins, and otherwise the first is taken without being reported as
+ * a choice, because for the things this is used for it is not one.
+ */
+export async function primaryProfile(flags: GlobalFlags): Promise<string> {
+  if (flags.profile !== undefined) return flags.profile;
+
+  const root = resolveWorkspaceRoot();
+  const resolved = await openTarget(root, flags.target!);
+  const names = await listProfiles(resolved.workspaceRoot);
+
+  if (names.length === 0) {
+    throw new ConfigError(
+      `Workspace "${flags.target}" holds no profiles, so there is nothing to serve.\n` +
+        `  Create one with: lanes link profile add <name> --workspace ${flags.target}`,
+    );
+  }
+
+  return names[0]!;
+}

--- a/src/cli/runtime/workspace.ts
+++ b/src/cli/runtime/workspace.ts
@@ -1,0 +1,35 @@
+import { ConfigError, listProfiles, openTarget, resolveWorkspaceRoot } from '#profile';
+import { openRuntime, type Runtime } from './open.ts';
+import type { GlobalFlags } from './select.ts';
+
+/**
+ * A runtime for a workspace, when the command does not act on one profile.
+ *
+ * Contract 3 moved the credential store, the audit log, the state store and the
+ * blob root up to the workspace, so a command that opens any of them opens the
+ * same thing whichever profile it was handed. `openRuntime` still wants one,
+ * because a `Runtime` carries a resolved profile — so this picks one rather
+ * than making the caller ask a question with no answer.
+ *
+ * `--profile` still narrows where narrowing means something: the audit log is
+ * one chain and the flag filters it, rather than selecting which log to read.
+ * What it must never do is *decide* anything, which is why the profile chosen
+ * here when none is given is simply the first and is never reported as though
+ * it were the subject.
+ */
+export async function openWorkspaceRuntime(flags: GlobalFlags): Promise<Runtime> {
+  if (flags.profile !== undefined) return openRuntime(flags);
+
+  const root = resolveWorkspaceRoot();
+  const resolved = await openTarget(root, flags.target!);
+  const names = await listProfiles(resolved.workspaceRoot);
+
+  if (names.length === 0) {
+    throw new ConfigError(
+      `Workspace "${flags.target}" holds no profiles, so there is nothing to open.\n` +
+        `  Create one with: lanes link profile add <name> --workspace ${flags.target}`,
+    );
+  }
+
+  return openRuntime({ ...flags, profile: names[0]! });
+}

--- a/src/cli/selection-require.ts
+++ b/src/cli/selection-require.ts
@@ -1,5 +1,6 @@
 import {
   listProfiles,
+  readWorkspace,
   noProfileNamed,
   noTargetNamed,
   readRegistry,
@@ -7,7 +8,7 @@ import {
   resolveWorkspaceRoot,
 } from '#profile';
 import type { Flags } from './argv.ts';
-import { dispatchWillRefuse, requirementFor } from './selection.ts';
+import { EXPLICIT_WORKSPACE, dispatchWillRefuse, requirementFor, selectionKey } from './selection.ts';
 import { refuseIfUnmigrated } from './workspace-migrate.ts';
 
 /**
@@ -46,26 +47,40 @@ export async function requireSelection(
 
   const root = resolveWorkspaceRoot(env ? { env } : {});
 
-  // **Target before profile, for both levels.** It used to ask for the profile
-  // and read that profile's own target list — the ordering ADR-052 inverted,
-  // since the profile lives inside the target and there is nowhere to look for
-  // one until the target is known. `refuseIfUnmigrated` is on the refusal path
-  // only, so it costs nothing when the flag is present.
-  if (typeof flags['target'] !== 'string') {
-    await refuseIfUnmigrated(root);
-    throw noTargetNamed(await readRegistry(root), root, env);
+  // **Workspace before profile, for both levels.** It used to ask for the
+  // profile and read that profile's own target list — the ordering ADR-052
+  // inverted, since a profile lives inside a workspace and there is nowhere to
+  // look for one until the workspace is known. `refuseIfUnmigrated` is on the
+  // refusal path only, so it costs nothing when the flag is present.
+  if (typeof flags['workspace'] !== 'string') {
+    const fallback = EXPLICIT_WORKSPACE.has(selectionKey(first, second))
+      ? undefined
+      : (await readWorkspace(root))?.default_workspace;
+
+    if (fallback === undefined) {
+      await refuseIfUnmigrated(root);
+      throw noTargetNamed(await readRegistry(root), root, env, {
+        refusedDefault: EXPLICIT_WORKSPACE.has(selectionKey(first, second)),
+      });
+    }
+
+    // Written back onto the flags so every command downstream reads one key and
+    // cannot tell a default from a typed flag — the difference belongs in the
+    // line printed above the output, not in thirty call sites (ADR-061).
+    flags['workspace'] = fallback;
+    defaulted.add(fallback);
   }
 
-  // A named target the registry cannot know, because it does not exist yet.
-  if (!(flags['target'] in (await readRegistry(root)))) await refuseIfUnmigrated(root);
+  // A named workspace the registry cannot know, because it does not exist yet.
+  if (!(flags['workspace'] in (await readRegistry(root)))) await refuseIfUnmigrated(root);
 
-  if (needs === 'target') return;
+  if (needs === 'workspace') return;
 
   if (typeof flags['profile'] !== 'string') {
     // Listed from the target's own workspace, so the names offered are ones that
     // command could act on. An unreachable pointer degrades to the empty list
     // rather than failing — "which profile" is still the question being asked.
-    const where = await resolveTargetWorkspace(root, flags['target']).catch(() => root);
+    const where = await resolveTargetWorkspace(root, flags['workspace'] as string).catch(() => root);
     throw noProfileNamed(where, await listProfiles(where).catch(() => []), env);
   }
 }
@@ -77,3 +92,19 @@ export async function requireSelection(
  * that listing it per command would be noise. `--quiet` is read by `announce`
  * rather than by any one command.
  */
+
+/**
+ * Workspaces resolved from `default_workspace` rather than from a flag.
+ *
+ * A set rather than a boolean because `announce` is called from thirty places
+ * and none of them threads a resolution result through — and because the thing
+ * being remembered is small, true for one run, and read exactly once per line
+ * of output. If the echo is ever dropped for tidiness, ADR-061 has been
+ * reversed: the printed line is the whole of what makes a sticky default
+ * different from the dotfile nothing prints.
+ */
+const defaulted = new Set<string>();
+
+export function wasDefaulted(workspace: string): boolean {
+  return defaulted.has(workspace);
+}

--- a/src/cli/selection.test.ts
+++ b/src/cli/selection.test.ts
@@ -11,7 +11,7 @@ import { CONNECT_CUSTOM_FLAGS, RESERVED_BY_GRAMMAR } from './commands/connect/cu
  * saying.
  *
  * The bug this file exists for is not a wrong answer, it is a missing one:
- * `main.ts` built an options literal for `profile add` and dropped `--target`
+ * `main.ts` built an options literal for `profile add` and dropped `--workspace`
  * into it, and nothing refused because nothing held a list of what the command
  * accepts. A table only helps if it cannot fall behind the grammar, so the first
  * test reads `main.ts` rather than trusting anyone to keep two files in step.
@@ -68,7 +68,7 @@ describe('every dispatched command declares what it needs', () => {
   test('an unrecognised command still gets the strict default', () => {
     // Not an oversight, and the safe direction: a command nobody classified
     // asks for both rather than silently opening whatever it likes.
-    expect(requirementFor('something-new', undefined)).toBe('profile+target');
+    expect(requirementFor('something-new', undefined)).toBe('profile+workspace');
   });
 });
 
@@ -89,31 +89,31 @@ describe('requiring a selection', () => {
     // exist" cannot be answered — or refused usefully — until the target is
     // known.
     await expect(
-      requireSelection('connect', undefined, { target: 'local' }, nowhere),
+      requireSelection('connect', undefined, { workspace: 'local' }, nowhere),
     ).rejects.toThrow('--profile is required');
   });
 
   test('asks for the target before the profile, because the target says where to look', async () => {
     await expect(requireSelection('connect', undefined, {}, nowhere)).rejects.toThrow(
-      '--target is required',
+      '--workspace is required',
     );
   });
 
   test('asks a target-scoped command for a target, and not for a profile', async () => {
     await expect(requireSelection('status', undefined, {}, nowhere)).rejects.toThrow(
-      '--target is required',
+      '--workspace is required',
     );
     await expect(
-      requireSelection('status', undefined, { target: 'cloud' }, nowhere),
+      requireSelection('status', undefined, { workspace: 'cloud' }, nowhere),
     ).resolves.toBeUndefined();
   });
 
   test('and still accepts --profile there, as a filter', async () => {
     await expect(
-      requireSelection('status', undefined, { target: 'cloud', profile: 'work' }, nowhere),
+      requireSelection('status', undefined, { workspace: 'cloud', profile: 'work' }, nowhere),
     ).resolves.toBeUndefined();
     expect(() =>
-      assertKnownFlags('status', undefined, { target: 'cloud', profile: 'work' }),
+      assertKnownFlags('status', undefined, { workspace: 'cloud', profile: 'work' }),
     ).not.toThrow();
   });
 
@@ -126,10 +126,10 @@ describe('requiring a selection', () => {
     for (const command of ['check', 'config show', 'policy list'] as const) {
       const [first, second] = command.split(' ');
       await expect(requireSelection(first!, second, { profile: 'work' }, nowhere)).rejects.toThrow(
-        '--target is required',
+        '--workspace is required',
       );
       await expect(
-        requireSelection(first!, second, { profile: 'work', target: 'local' }, nowhere),
+        requireSelection(first!, second, { profile: 'work', workspace: 'local' }, nowhere),
       ).resolves.toBeUndefined();
     }
   });
@@ -144,20 +144,20 @@ describe('requiring a selection', () => {
 
   test('accepts a command that names both', async () => {
     await expect(
-      requireSelection('status', undefined, { profile: 'work', target: 'cloud' }, nowhere),
+      requireSelection('status', undefined, { profile: 'work', workspace: 'cloud' }, nowhere),
     ).resolves.toBeUndefined();
   });
 
   test('asks profile add for a target, because that is where the file goes', async () => {
     // It named neither while every profile was written into the same directory.
-    // `--target` now decides *which workspace* it is created in (ADR-052), so it
+    // `--workspace` now decides *which workspace* it is created in (ADR-052), so it
     // is the one thing the command cannot proceed without. The profile name is
     // still positional.
     await expect(requireSelection('profile', 'add', {}, nowhere)).rejects.toThrow(
-      '--target is required',
+      '--workspace is required',
     );
     await expect(
-      requireSelection('profile', 'add', { target: 'local' }, nowhere),
+      requireSelection('profile', 'add', { workspace: 'local' }, nowhere),
     ).resolves.toBeUndefined();
   });
 
@@ -183,8 +183,8 @@ describe('refusing a flag the command does not read', () => {
     expect(() => assertKnownFlags('status', undefined, { porfile: 'work' })).toThrow(
       'Did you mean --profile?',
     );
-    expect(() => assertKnownFlags('status', undefined, { taget: 'cloud' })).toThrow(
-      'Did you mean --target?',
+    expect(() => assertKnownFlags('status', undefined, { workspce: 'cloud' })).toThrow(
+      'Did you mean --workspace?',
     );
   });
 
@@ -197,11 +197,11 @@ describe('refusing a flag the command does not read', () => {
     );
   });
 
-  test('refuses --target on a command with nothing to select', () => {
-    // The reported bug, as a test: `profile add work --target cloud` printed ok
+  test('refuses --workspace on a command with nothing to select', () => {
+    // The reported bug, as a test: `profile add work --workspace cloud` printed ok
     // and dropped the flag. It now declares a target rather than selecting one,
     // so it is accepted here — but a profile flag is not.
-    expect(() => assertKnownFlags('profile', 'add', { target: 'cloud' })).not.toThrow();
+    expect(() => assertKnownFlags('profile', 'add', { workspace: 'cloud' })).not.toThrow();
     expect(() => assertKnownFlags('profile', 'add', { profile: 'work' })).toThrow('Unknown flag');
   });
 
@@ -228,13 +228,13 @@ describe('refusing a flag the command does not read', () => {
  *
  * The table said `profile` for five commands and their handlers called
  * `resolveProfile`, which requires a target — while `assertKnownFlags` refused
- * `--target` because the table said they did not take one. Every one of them was
+ * `--workspace` because the table said they did not take one. Every one of them was
  * unrunnable in both spellings at once:
  *
  *     $ lanes link check --profile personal
- *     error  --target is required.
- *     $ lanes link check --profile personal --target local
- *     error  Unknown flag "--target" for "lanes link check".
+ *     error  --workspace is required.
+ *     $ lanes link check --profile personal --workspace local
+ *     error  Unknown flag "--workspace" for "lanes link check".
  *
  * A requirement and an allowlist that disagree cannot be caught by testing
  * either one, which is why this asserts the pair — and asserts it over the whole
@@ -257,8 +257,8 @@ describe('every command is runnable in the spelling it demands', () => {
       if (requires === 'none') continue;
 
       const flags: Record<string, string> = {};
-      if (requires === 'profile+target') flags['profile'] = 'work';
-      if (requires === 'target' || requires === 'profile+target') flags['target'] = 'local';
+      if (requires === 'profile+workspace') flags['profile'] = 'work';
+      if (requires === 'workspace' || requires === 'profile+workspace') flags['workspace'] = 'local';
 
       expect(() => assertKnownFlags(first, second, flags), `${key} accepts what it requires`).not.toThrow();
     }
@@ -270,8 +270,8 @@ describe('every command is runnable in the spelling it demands', () => {
       if (twoWord.has(key) && second === undefined) continue;
 
       const flags: Record<string, string> = {};
-      if (requires === 'profile+target') flags['profile'] = 'work';
-      if (requires === 'target' || requires === 'profile+target') flags['target'] = 'local';
+      if (requires === 'profile+workspace') flags['profile'] = 'work';
+      if (requires === 'workspace' || requires === 'profile+workspace') flags['workspace'] = 'local';
 
       await expect(
         requireSelection(first, second, flags, nowhere),
@@ -286,7 +286,7 @@ describe('every command is runnable in the spelling it demands', () => {
     // point of naming them here is that moving four of the five would leave the
     // fifth quietly unrunnable.
     for (const key of ['check', 'config show', 'policy list', 'secrets push', 'identity list']) {
-      expect(SELECTION[key], key).toBe('profile+target');
+      expect(SELECTION[key], key).toBe('profile+workspace');
     }
   });
 
@@ -294,17 +294,17 @@ describe('every command is runnable in the spelling it demands', () => {
     // Both take the name as an argument, so a `--profile` flag could only name a
     // second one and disagree with it.
     await expect(
-      requireSelection('profile', 'remove', { target: 'local' }, nowhere),
+      requireSelection('profile', 'remove', { workspace: 'local' }, nowhere),
     ).resolves.toBeUndefined();
     expect(() => assertKnownFlags('profile', 'remove', { profile: 'work' })).toThrow('Unknown flag');
   });
 
-  test('profile remove takes the --target that says which workspace holds it', () => {
+  test('profile remove takes the --workspace that says which workspace holds it', () => {
     // It used to mean "decommission this one target's stores and keep the
     // profile". It now says where the profile *is* (ADR-052), and is required
     // rather than optional.
     expect(() =>
-      assertKnownFlags('profile', 'remove', { target: 'cloud', 'dry-run': true }),
+      assertKnownFlags('profile', 'remove', { workspace: 'cloud', 'dry-run': true }),
     ).not.toThrow();
   });
 
@@ -349,13 +349,13 @@ describe('every command is runnable in the spelling it demands', () => {
     // The target first, because it is what says which workspace holds the
     // profile (ADR-052) — so a command naming neither is refused for the target.
     await expect(requireSelection('connect', 'custom', {}, nowhere)).rejects.toThrow(
-      '--target is required',
+      '--workspace is required',
     );
     await expect(
-      requireSelection('connect', 'custom', { target: 'local' }, nowhere),
+      requireSelection('connect', 'custom', { workspace: 'local' }, nowhere),
     ).rejects.toThrow('--profile is required');
     await expect(
-      requireSelection('connect', 'custom', { profile: 'work', target: 'local' }, nowhere),
+      requireSelection('connect', 'custom', { profile: 'work', workspace: 'local' }, nowhere),
     ).resolves.toBeUndefined();
   });
 

--- a/src/cli/selection.test.ts
+++ b/src/cli/selection.test.ts
@@ -80,23 +80,38 @@ const nowhere = { LANES_LINK_HOME: '/nonexistent-workspace-for-a-test' };
 describe('requiring a selection', () => {
 
   test('refuses a command that names no profile, once it has a target', async () => {
-    // `connect` acts on one account, so the profile is the subject and there is
-    // nothing to fall back to. `status` used to stand here and no longer can:
-    // its subject is the target (ADR-043).
+    // `policy allow` edits one profile's grants, so the profile is the subject
+    // and there is nothing to fall back to. `connect` used to stand here and no
+    // longer can: a connection belongs to the workspace, and connecting one is
+    // not an edit to any profile (ADR-057).
     //
     // The target has to be given first, and that is the ordering ADR-052
     // inverted: a profile lives in one target's workspace, so "which profiles
     // exist" cannot be answered — or refused usefully — until the target is
     // known.
     await expect(
-      requireSelection('connect', undefined, { workspace: 'local' }, nowhere),
+      requireSelection('policy', 'allow', { workspace: 'local' }, nowhere),
     ).rejects.toThrow('--profile is required');
   });
 
   test('asks for the target before the profile, because the target says where to look', async () => {
+    await expect(requireSelection('policy', 'allow', {}, nowhere)).rejects.toThrow(
+      '--workspace is required',
+    );
+  });
+
+  test('connect asks for a workspace and not for a profile', async () => {
+    // The account is authorised into the workspace; granting it to a profile is
+    // the second act and the only one that is a profile's (ADR-057). Requiring
+    // `--profile` made "connect this account" mean "connect it and decide what
+    // may be done with it", which are different decisions taken at different
+    // times.
     await expect(requireSelection('connect', undefined, {}, nowhere)).rejects.toThrow(
       '--workspace is required',
     );
+    await expect(
+      requireSelection('connect', undefined, { workspace: 'local' }, nowhere),
+    ).resolves.toBeUndefined();
   });
 
   test('asks a target-scoped command for a target, and not for a profile', async () => {
@@ -345,15 +360,16 @@ describe('every command is runnable in the spelling it demands', () => {
     );
   });
 
-  test('and it needs both a profile and a target, like connect', async () => {
-    // The target first, because it is what says which workspace holds the
-    // profile (ADR-052) — so a command naming neither is refused for the target.
+  test('and it needs a workspace, like every other connect', async () => {
+    // `connect custom` declares a provider and authorises it, both of which are
+    // the workspace's (ADR-057). It takes `--profile` optionally, for the same
+    // reason `connect` does: to grant what it just connected.
     await expect(requireSelection('connect', 'custom', {}, nowhere)).rejects.toThrow(
       '--workspace is required',
     );
     await expect(
       requireSelection('connect', 'custom', { workspace: 'local' }, nowhere),
-    ).rejects.toThrow('--profile is required');
+    ).resolves.toBeUndefined();
     await expect(
       requireSelection('connect', 'custom', { profile: 'work', workspace: 'local' }, nowhere),
     ).resolves.toBeUndefined();

--- a/src/cli/selection.ts
+++ b/src/cli/selection.ts
@@ -1,7 +1,9 @@
 import { ConfigError } from '#profile';
 import type { Flags } from './argv.ts';
-import { CONNECT_CUSTOM_FLAGS } from './commands/connect/custom/spec.ts';
+import { ACCEPTS } from './accepts.ts';
 import { nearest } from './nearest.ts';
+
+export { ACCEPTS } from './accepts.ts';
 
 /**
  * Which commands must name a profile and a target, and which flags each accepts.
@@ -10,7 +12,7 @@ import { nearest } from './nearest.ts';
  * one makes the other legible.
  *
  * **A flag that is silently ignored is the defect.** `lanes link profile add
- * work --target cloud` printed `ok` and dropped the flag: `main.ts` built a
+ * work --workspace cloud` printed `ok` and dropped the flag: `main.ts` built a
  * literal for that command and never spread the global flags into it. Nothing
  * refused, because nothing had a list of what the command accepts. That is what
  * `assertKnownFlags` is — and it matters more than the requirement, because
@@ -39,7 +41,7 @@ import { nearest } from './nearest.ts';
  * there is no file to read. The level is gone rather than left empty, so nobody
  * adds a sixth command to a level that cannot resolve.
  */
-export type Requires = 'none' | 'target' | 'profile+target';
+export type Requires = 'none' | 'workspace' | 'profile+workspace';
 
 /**
  * The rule, per command path.
@@ -54,7 +56,7 @@ export type Requires = 'none' | 'target' | 'profile+target';
  * `check`, `config show` and `policy list` take no `--target`. All three are
  * target-independent — a YAML file, the whole of it, and a policy block that is
  * declared once and applies everywhere. Demanding a target would be the
- * ceremony that teaches people to type `--target local` without reading it,
+ * ceremony that teaches people to type `--workspace local` without reading it,
  * which is how a required flag stops being a guard.
  *
  * `target list` takes no required `--target` either, and that is not an
@@ -85,55 +87,67 @@ export const SELECTION: Record<string, Requires> = {
   // `lanes link profile` is `profile list`, and needs the same as it.
   mcp: 'none',
   'profile default': 'none',
+  'workspace use': 'none',
   'target use': 'none',
   'vault key': 'none',
   // Listing the registry is what you run to find out what `--target` accepts, so
   // requiring the answer as input would be circular (ADR-052).
+  workspace: 'none',
+  // The old word, kept for one minor (ADR-061).
   target: 'none',
+  'workspace list': 'none',
   'target list': 'none',
 
   // A profile lives in one target's workspace, so listing or creating one names
   // which workspace. `target show` follows the pointer, which `list` does not.
-  profile: 'target',
-  'profile list': 'target',
-  'profile add': 'target',
-  'profile remove': 'target',
-  'target show': 'target',
+  profile: 'workspace',
+  'profile list': 'workspace',
+  'profile add': 'workspace',
+  'profile remove': 'workspace',
+  // Editing who may consume one profile, so it names the profile.
+  'profile members': 'profile+workspace',
+  'target show': 'workspace',
 
   // These read one profile's file and open nothing. The target is what says
   // which workspace holds it — required to *locate* the profile, not to open it.
-  check: 'profile+target',
-  config: 'profile+target',
-  'config show': 'profile+target',
-  policy: 'profile+target',
-  'policy list': 'profile+target',
-  identity: 'profile+target',
-  'identity list': 'profile+target',
-  'secrets push': 'profile+target',
+  check: 'profile+workspace',
+  config: 'profile+workspace',
+  'config show': 'profile+workspace',
+  policy: 'profile+workspace',
+  'policy list': 'profile+workspace',
+  identity: 'profile+workspace',
+  'identity list': 'profile+workspace',
+  'secrets push': 'profile+workspace',
 
-  connect: 'profile+target',
+  connect: 'profile+workspace',
+  // Workspace-scoped: it answers "what has this workspace authorised", and a
+  // profile would narrow the column rather than the rows.
+  connection: 'workspace',
+  'connection list': 'workspace',
+  grant: 'profile+workspace',
+  revoke: 'profile+workspace',
   // Both edit the profile config, and `disconnect` also opens the target's
   // credential store to delete from it. Same requirement as `connect` for the
   // same reasons.
-  disconnect: 'profile+target',
-  relabel: 'profile+target',
+  disconnect: 'profile+workspace',
+  relabel: 'profile+workspace',
   // Its own row rather than an inheritance from `connect`. Both need the same
   // two things, but the row is what makes `selectionKey` return the two-word
   // key — and that is what keeps thirty declaration flags off
   // `connect <provider>`, where a mistyped one would otherwise be accepted and
   // ignored, which is the defect this whole file exists for.
-  'connect custom': 'profile+target',
-  setup: 'profile+target',
-  token: 'profile+target',
-  audit: 'profile+target',
-  secrets: 'profile+target',
-  plan: 'profile+target',
-  doctor: 'profile+target',
-  auth: 'profile+target',
+  'connect custom': 'profile+workspace',
+  setup: 'profile+workspace',
+  token: 'profile+workspace',
+  audit: 'profile+workspace',
+  secrets: 'profile+workspace',
+  plan: 'profile+workspace',
+  doctor: 'profile+workspace',
+  auth: 'profile+workspace',
   // Target-scoped: see the note above. `--profile` narrows each to one profile.
-  status: 'target',
-  outputs: 'profile+target',
-  tools: 'profile+target',
+  status: 'workspace',
+  outputs: 'profile+workspace',
+  tools: 'profile+workspace',
   // It resolves nothing and opens nothing — it hands macOS a URL (ADR-053).
   // `target list` is the precedent for a `'none'` command that still takes a
   // flag of its own. Both spellings need a row: `selection.test.ts` reads
@@ -141,38 +155,39 @@ export const SELECTION: Record<string, Requires> = {
   // the `profile+target` default.
   dashboard: 'none',
   desktop: 'none',
-  attach: 'profile+target',
-  start: 'profile+target',
-  deploy: 'target',
+  attach: 'profile+workspace',
+  start: 'profile+workspace',
+  deploy: 'workspace',
   // Both spellings: `sync` alone is `sync targets`, which is the only thing
   // there is to sync, and naming it leaves room for the next one.
-  sync: 'target',
-  'sync targets': 'target',
-  'policy allow': 'profile+target',
-  'policy deny': 'profile+target',
+  sync: 'workspace',
+  'sync targets': 'workspace',
+  'sync workspaces': 'workspace',
+  'policy allow': 'profile+workspace',
+  'policy deny': 'profile+workspace',
   // Both, unlike `identity list`, and for the same reason the policy edits are:
   // each publishes the edit, which opens the target's credential store and
   // reaches that target's endpoint.
-  'identity add': 'profile+target',
-  'identity remove': 'profile+target',
-  'token show': 'profile+target',
-  'token rotate': 'profile+target',
-  'audit tail': 'profile+target',
-  'audit verify': 'profile+target',
-  'secrets set': 'profile+target',
-  'secrets list': 'profile+target',
-  'mcp add': 'profile+target',
-  'mcp stdio': 'profile+target',
-  memory: 'profile+target',
-  tasks: 'profile+target',
-  assets: 'profile+target',
-  skills: 'profile+target',
-  vault: 'profile+target',
-  entities: 'profile+target',
+  'identity add': 'profile+workspace',
+  'identity remove': 'profile+workspace',
+  'token show': 'profile+workspace',
+  'token rotate': 'profile+workspace',
+  'audit tail': 'profile+workspace',
+  'audit verify': 'profile+workspace',
+  'secrets set': 'profile+workspace',
+  'secrets list': 'profile+workspace',
+  'mcp add': 'profile+workspace',
+  'mcp stdio': 'profile+workspace',
+  memory: 'profile+workspace',
+  tasks: 'profile+workspace',
+  assets: 'profile+workspace',
+  skills: 'profile+workspace',
+  vault: 'profile+workspace',
+  entities: 'profile+workspace',
   // Both halves open the target's adapters — `show` counts what is in the
   // stores, and `use` migrates between them — and both edit the profile's
   // config. Neither can be answered without being told which.
-  knowledge: 'profile+target',
+  knowledge: 'profile+workspace',
 };
 
 /**
@@ -186,7 +201,9 @@ export const SELECTION: Record<string, Requires> = {
  * asserts this stays true.
  */
 const SUBCOMMANDS: Record<string, readonly string[]> = {
-  profile: ['add', 'list', 'default', 'remove'],
+  profile: ['add', 'list', 'default', 'remove', 'members'],
+  connection: ['list'],
+  workspace: ['list', 'use', 'show'],
   target: ['list', 'use', 'show'],
   policy: ['list', 'allow', 'deny'],
   identity: ['add', 'list', 'remove'],
@@ -205,7 +222,7 @@ const SUBCOMMANDS: Record<string, readonly string[]> = {
   mcp: ['skill', 'add', 'stdio', 'list'],
   secrets: ['push', 'set', 'list'],
   knowledge: ['show', 'use'],
-  sync: ['targets'],
+  sync: ['targets', 'workspaces'],
 };
 
 /**
@@ -235,99 +252,41 @@ export function selectionKey(first: string, second: string | undefined): string 
 
 /** Whether this command needs a profile, a target, both, or neither. */
 export function requirementFor(first: string, second: string | undefined): Requires {
-  return SELECTION[selectionKey(first, second)] ?? 'profile+target';
+  return SELECTION[selectionKey(first, second)] ?? 'profile+workspace';
 }
 
-const UNIVERSAL = ['help', 'json', 'quiet'];
-
 /**
- * What each command accepts beyond the universal set and its own selection.
+ * The commands that refuse `default_workspace` and make you type the name.
  *
- * Only commands with flags of their own appear. Anything absent accepts the
- * universal set plus whatever `SELECTION` says it must be told.
+ * ADR-037 removed every implicit selection, on reasoning worth keeping: a
+ * persisted context is the standard way an operator runs a destructive command
+ * against the wrong thing. ADR-061 gives the default back for the forty
+ * commands a day that only read, and keeps the refusal exactly where that
+ * argument bites — anything that publishes or destroys.
+ *
+ * `connect` is deliberately absent. It creates rather than destroys, it is the
+ * command someone runs while learning the tool, and it prints the workspace it
+ * wrote to. Requiring a flag there is the ceremony ADR-043 identified as the way
+ * a required flag stops being a guard.
  */
-const ACCEPTS: Record<string, readonly string[]> = {
-  // Imported rather than written out. Thirty-odd entries here would take this
-  // file past the size budget for a data literal, and the command's own
-  // `spec.ts` already derives most of them from the per-kind field tables — so
-  // a flag added there cannot be forgotten here.
-  'connect custom': CONNECT_CUSTOM_FLAGS,
-  // `own-client` is the older spelling of one of the routes `auth` names, kept
-  // because it is in scripts and a year of documentation (ADR-038).
-  connect: [
-    'id',
-    'display-name',
-    // Repeatable: `--set host=cloud.example.com`. The only way to give a
-    // provider its address without a terminal to ask at.
-    'set',
-    'label',
-    'replace',
-    'non-interactive',
-    'accept-broad-scopes',
-    'own-client',
-    'auth',
-  ],
-  setup: ['id'],
-  'profile add': ['target', 'non-interactive'],
-  // `--target` decommissions one target's stores and leaves the profile file in
-  // place (`removal.ts`). It is documented in `usage.ts` and read by
-  // `removalPlan`, and was refused here — the flag existed everywhere except in
-  // the list that decides whether it may be typed.
-  'profile remove': ['dry-run', 'yes', 'target'],
-  disconnect: ['yes', 'keep-credential'],
-  // The one repair `doctor` can apply rather than only name. Narrow on purpose:
-  // it undoes a provider rename this project shipped, and every other finding
-  // there is something only the operator can decide.
-  doctor: ['fix'],
-  // A filter, not a second subject: it narrows the answer to one connection so
-  // a caller can re-ask about the row it just repaired. Same shape as `attach`.
-  auth: ['connection'],
-  relabel: [],
-  'target list': ['urls', 'target'],
-  'target show': ['target'],
-  'token show': ['show', 'raw'],
-  'token rotate': ['show', 'raw', 'yes'],
-  'audit tail': ['limit', 'denied-only', 'format'],
-  'audit verify': ['limit', 'format'],
-  attach: ['connection'],
-  outputs: ['show'],
-  start: ['port', 'only'],
-  'mcp stdio': ['only'],
-  'mcp add': ['name', 'scope', 'token-env', 'dry-run', 'force', 'no-skill'],
-  'mcp skill': ['print', 'force'],
-  'mcp list': ['name', 'scope'],
-  // `--yes` because it installs the app when nothing answers the scheme, and
-  // that is the one prompt in this CLI that puts an application on the machine.
-  dashboard: ['print', 'yes'],
-  desktop: ['print', 'yes'],
-  skill: ['print', 'force'],
-  deploy: ['dry-run', 'iam', 'access', 'service-account', 'tag', 'yes', 'non-interactive'],
-  'secrets push': ['from', 'to', 'overwrite', 'dry-run'],
-  sync: ['dry-run', 'from', 'discover', 'prefer'],
-  'sync targets': ['dry-run', 'from', 'discover', 'prefer'],
-  update: ['check'],
-  'identity add': ['note'],
-  memory: ['connection', 'title', 'description', 'file', 'tag'],
-  // `--yes` on both, because both have a delete that asks first.
-  tasks: ['connection', 'title', 'status', 'due', 'tag', 'yes'],
-  assets: ['connection', 'name', 'content-type', 'yes'],
-  skills: ['connection', 'title', 'description', 'file'],
-  vault: ['connection'],
-  // `alias`, `attr` and `related` are repeatable — see `ownerFlags`. `name`
-  // overrides the id derived from the positional name, which is how you get
-  // `acme-bv` rather than `acme-b-v`.
-  entities: ['connection', 'type', 'name', 'alias', 'attr', 'related', 'tag', 'yes'],
-  // `no-migrate` is listed beside `migrate` because they are three states
-  // rather than two: neither one asks, and a run with no terminal has to be
-  // able to say which it meant (ADR-041).
-  knowledge: ['repo', 'branch', 'path', 'migrate', 'no-migrate', 'keep', 'allow-public', 'replace', 'yes'],
-};
+export const EXPLICIT_WORKSPACE = new Set([
+  'deploy',
+  'sync',
+  'sync targets',
+  'sync workspaces',
+  'secrets push',
+  'profile remove',
+  'disconnect',
+  'token rotate',
+]);
+
+const UNIVERSAL = ['help', 'json', 'quiet'];
 
 /**
  * Refuse a flag this command does not read, and guess what was meant.
  *
  * This is the fix for the reported bug rather than a nicety. `profile add
- * --target cloud` was accepted and dropped, and nothing could refuse it because
+ * --workspace cloud` was accepted and dropped, and nothing could refuse it because
  * `parseArgv` returns every `--anything` it sees and no command ever inspected
  * the leftovers. A typo was swallowed the same way on every command in the CLI.
  */
@@ -345,7 +304,7 @@ export function assertKnownFlags(first: string, second: string | undefined, flag
   if (dispatchWillRefuse(first, second)) return;
 
   const key = selectionKey(first, second);
-  const needs = SELECTION[key] ?? 'profile+target';
+  const needs = SELECTION[key] ?? 'profile+workspace';
 
   const allowed = new Set<string>([
     ...UNIVERSAL,
@@ -353,7 +312,7 @@ export function assertKnownFlags(first: string, second: string | undefined, flag
     // `target` accepts both: the target is what it acts on, and `--profile`
     // narrows it to one of the profiles behind it.
     ...(needs !== 'none' && !POSITIONAL_PROFILE.has(key) ? ['profile'] : []),
-    ...(needs === 'target' || needs === 'profile+target' ? ['target'] : []),
+    ...(needs === 'workspace' || needs === 'profile+workspace' ? ['workspace'] : []),
   ]);
 
   const named = [first, second].filter(Boolean).join(' ');

--- a/src/cli/selection.ts
+++ b/src/cli/selection.ts
@@ -170,6 +170,7 @@ export const SELECTION: Record<string, Requires> = {
   // reaches that target's endpoint.
   'identity add': 'profile+workspace',
   'identity remove': 'profile+workspace',
+  'mcp install-instructions': 'none',
   pair: 'profile+workspace',
   'token show': 'profile+workspace',
   'token rotate': 'profile+workspace',

--- a/src/cli/selection.ts
+++ b/src/cli/selection.ts
@@ -126,11 +126,13 @@ export const SELECTION: Record<string, Requires> = {
   'connection list': 'workspace',
   grant: 'profile+workspace',
   revoke: 'profile+workspace',
-  // Both edit the profile config, and `disconnect` also opens the target's
-  // credential store to delete from it. Same requirement as `connect` for the
-  // same reasons.
-  disconnect: 'profile+workspace',
-  relabel: 'profile+workspace',
+  // Both act on a connection, which belongs to the workspace (ADR-057).
+  // `disconnect` already reaches every profile that granted it and `label` is a
+  // field on the connection row, so neither had a profile to be told — naming
+  // one described a slice of a change that was never scoped to it. `--profile`
+  // still narrows what is listed back.
+  disconnect: 'workspace',
+  relabel: 'workspace',
   // Its own row rather than an inheritance from `connect`. Both need the same
   // two things, but the row is what makes `selectionKey` return the two-word
   // key — and that is what keeps thirty declaration flags off
@@ -142,10 +144,15 @@ export const SELECTION: Record<string, Requires> = {
   // One chain per workspace since contract 3, so the workspace is the subject
   // and `--profile` filters the rows rather than choosing which log to read.
   audit: 'workspace',
-  secrets: 'profile+workspace',
+  // One credential store per workspace since contract 3, so every profile
+  // opened the same one.
+  secrets: 'workspace',
   plan: 'profile+workspace',
   doctor: 'profile+workspace',
-  auth: 'profile+workspace',
+  // Whether an account can still sign in is a fact about the account. Scoped to
+  // a profile's grants it could not check one that had just been connected,
+  // which is when you most want to.
+  auth: 'workspace',
   // Target-scoped: see the note above. `--profile` narrows each to one profile.
   status: 'workspace',
   outputs: 'profile+workspace',
@@ -158,7 +165,10 @@ export const SELECTION: Record<string, Requires> = {
   dashboard: 'none',
   desktop: 'none',
   attach: 'profile+workspace',
-  start: 'profile+workspace',
+  // One endpoint serves every profile in the workspace (ADR-009), so naming one
+  // described a slice of what it does. `--profile` picks the primary, whose
+  // token opens it, and `--only` is what narrows what is served.
+  start: 'workspace',
   deploy: 'workspace',
   // Both spellings: `sync` alone is `sync targets`, which is the only thing
   // there is to sync, and naming it leaves room for the next one.
@@ -182,8 +192,8 @@ export const SELECTION: Record<string, Requires> = {
   'token rotate': 'profile+workspace',
   'audit tail': 'workspace',
   'audit verify': 'workspace',
-  'secrets set': 'profile+workspace',
-  'secrets list': 'profile+workspace',
+  'secrets set': 'workspace',
+  'secrets list': 'workspace',
   'mcp add': 'profile+workspace',
   'mcp stdio': 'profile+workspace',
   memory: 'profile+workspace',

--- a/src/cli/selection.ts
+++ b/src/cli/selection.ts
@@ -170,6 +170,7 @@ export const SELECTION: Record<string, Requires> = {
   // reaches that target's endpoint.
   'identity add': 'profile+workspace',
   'identity remove': 'profile+workspace',
+  pair: 'profile+workspace',
   'token show': 'profile+workspace',
   'token rotate': 'profile+workspace',
   'audit tail': 'profile+workspace',

--- a/src/cli/selection.ts
+++ b/src/cli/selection.ts
@@ -171,7 +171,11 @@ export const SELECTION: Record<string, Requires> = {
   'identity add': 'profile+workspace',
   'identity remove': 'profile+workspace',
   'mcp install-instructions': 'none',
-  pair: 'profile+workspace',
+  // What it pairs is the workspace: the surface it opens lists every connection
+  // and profile there, and the credential it mints reads all of them. Asking
+  // which profile was a question with no answer. `--profile` still narrows, and
+  // is how a port is chosen when profiles disagree about one.
+  pair: 'workspace',
   'token show': 'profile+workspace',
   'token rotate': 'profile+workspace',
   'audit tail': 'profile+workspace',

--- a/src/cli/selection.ts
+++ b/src/cli/selection.ts
@@ -119,7 +119,12 @@ export const SELECTION: Record<string, Requires> = {
   'identity list': 'profile+workspace',
   'secrets push': 'profile+workspace',
 
-  connect: 'profile+workspace',
+  // A connection belongs to the workspace (ADR-057), so connecting does not
+  // name a profile. `--profile` is what *also* grants it there, which is the
+  // second of the two acts and the one that is a profile's — without it the
+  // account is authorised and granted to nobody, and `connect` says how to
+  // grant it.
+  connect: 'workspace',
   // Workspace-scoped: it answers "what has this workspace authorised", and a
   // profile would narrow the column rather than the rows.
   connection: 'workspace',
@@ -138,7 +143,7 @@ export const SELECTION: Record<string, Requires> = {
   // key — and that is what keeps thirty declaration flags off
   // `connect <provider>`, where a mistyped one would otherwise be accepted and
   // ignored, which is the defect this whole file exists for.
-  'connect custom': 'profile+workspace',
+  'connect custom': 'workspace',
   setup: 'profile+workspace',
   token: 'profile+workspace',
   // One chain per workspace since contract 3, so the workspace is the subject

--- a/src/cli/selection.ts
+++ b/src/cli/selection.ts
@@ -139,7 +139,9 @@ export const SELECTION: Record<string, Requires> = {
   'connect custom': 'profile+workspace',
   setup: 'profile+workspace',
   token: 'profile+workspace',
-  audit: 'profile+workspace',
+  // One chain per workspace since contract 3, so the workspace is the subject
+  // and `--profile` filters the rows rather than choosing which log to read.
+  audit: 'workspace',
   secrets: 'profile+workspace',
   plan: 'profile+workspace',
   doctor: 'profile+workspace',
@@ -178,8 +180,8 @@ export const SELECTION: Record<string, Requires> = {
   pair: 'workspace',
   'token show': 'profile+workspace',
   'token rotate': 'profile+workspace',
-  'audit tail': 'profile+workspace',
-  'audit verify': 'profile+workspace',
+  'audit tail': 'workspace',
+  'audit verify': 'workspace',
   'secrets set': 'profile+workspace',
   'secrets list': 'profile+workspace',
   'mcp add': 'profile+workspace',

--- a/src/cli/usage.ts
+++ b/src/cli/usage.ts
@@ -21,7 +21,8 @@ export const USAGE = `${style.bold(PROGRAM)} — a self-hostable MCP gateway for
 ${style.bold('Everyday')}
   ${PROGRAM} setup plan [--json]        what each provider needs, and which are connected
   ${PROGRAM} setup plan <provider>      the console steps, the values, and the command
-  ${PROGRAM} connect <provider>         add an account (run once per account)
+  ${PROGRAM} connect <provider>         authorise an account into this workspace
+                                        (once per account, not once per profile)
   ${PROGRAM} connect <provider>.<id>    re-authorise one existing account
   ${PROGRAM} connect <...> --replace    ask for the stored password or key again
   ${PROGRAM} connect <...> --auth <method>  pick how, where there is a choice
@@ -35,6 +36,9 @@ ${style.bold('Everyday')}
                                  asked for; the manifest it writes is yours to edit
                                         answer nothing from a terminal: take every value
                                         from the credential store, or say what is missing
+  ${PROGRAM} connection list [--json]   every account in this workspace, and who grants it
+  ${PROGRAM} grant add <provider>.<id>   let a profile reach one, with nothing allowed yet
+  ${PROGRAM} grant remove <provider>.<id>
   ${PROGRAM} start [--only]             reconcile and serve every profile on one endpoint
   ${PROGRAM} outputs [--show] [--json]  the endpoint an agent needs
   ${PROGRAM} desktop [--print] [--yes]  open the Lanes app on its Lanes Link page,
@@ -45,6 +49,10 @@ ${style.bold('Everyday')}
   ${PROGRAM} mcp list                   where it is registered, and whether the skill is current
   ${PROGRAM} mcp stdio                  serve on stdin/stdout, for a client that spawns it
   ${PROGRAM} mcp skill [--print]        the bundled skill — its path, or the document itself
+  ${PROGRAM} mcp install-instructions [--client claude|chatgpt|codex|cursor]
+                                 a block to paste where a client keeps its own
+                                 standing instructions, so it knows to look here
+  ${PROGRAM} pair [--print] [--rotate]  let the Lanes dashboard read this machine
   ${PROGRAM} status [--json]            connections, reachable capabilities, endpoint
 
 ${style.bold('Profiles')}
@@ -55,14 +63,13 @@ ${style.bold('Profiles')}
   ${PROGRAM} profile remove <name> [--workspace <name>] [--dry-run] [--yes] [--json]
                                  the profile, its credentials, and its data
 
-${style.bold('Targets')}
-  ${PROGRAM} target list [--urls]      where this profile can run
-  ${PROGRAM} target show <name>        one target's adapters, and the address it answers on
-  ${PROGRAM} sync targets --workspace <name> [--from gs://bucket] [--discover]
+${style.bold('Workspaces')}
+  ${PROGRAM} workspace list [--urls]   every workspace this one knows
+  ${PROGRAM} workspace show <name>     one workspace's adapters, and its address
+  ${PROGRAM} sync workspaces --workspace <name> [--from gs://bucket] [--discover]
                                  [--prefer local|remote] [--dry-run]
                                  reconcile this workspace with the copy the
-                                 deployment reads; recovers a target a profile
-                                 has lost
+                                 deployment reads; recovers one a profile has lost
 
 ${style.bold('Who you are')}
   ${PROGRAM} identity add <kind> <value> [--note text] [--json]
@@ -72,10 +79,15 @@ ${style.bold('Who you are')}
 
 ${style.bold('Permissions')}
   ${PROGRAM} policy list
-  ${PROGRAM} policy allow <capability>  e.g. gmail.* or gmail.send_message
-  ${PROGRAM} policy deny  <capability>
-  ${PROGRAM} token show [--show|--raw]  --raw prints only the token, for $(…)
-  ${PROGRAM} token rotate [--show]
+  ${PROGRAM} policy allow <capability> --connection <provider>.<id>
+                                 e.g. gmail.* or gmail.send_message. A rule lands
+                                 in one grant, so two accounts can differ
+  ${PROGRAM} policy deny  <capability> --connection <provider>.<id>
+  ${PROGRAM} profile members list       who may consume this profile, and who could
+  ${PROGRAM} profile members add <subject>|--me [--role owner|member]
+  ${PROGRAM} profile members remove <subject>
+  ${PROGRAM} token show [--show|--raw]  CI only: --raw prints only the token, for $(…)
+  ${PROGRAM} token rotate [--show]      also ends every session a member holds
 
 ${style.bold('Your own context')}
   ${PROGRAM} memory list [--tag t]      what you have stored
@@ -158,9 +170,13 @@ ${style.bold('Attachments')}
 
 ${style.bold('Naming what a command acts on')}
   --profile <name>               required by every command that reads or writes a profile
-  --workspace <name>                required by every command that opens a target's stores.
-                                 There is no default and no environment variable: a
-                                 command that names neither refuses and lists what exists.
+  --workspace <name>             required by every command that opens a workspace's
+                                 stores. "lanes set-workspace <name>" writes a default;
+                                 every command that uses it prints the name it resolved,
+                                 and deploy, sync, secrets push, profile remove,
+                                 disconnect and token rotate refuse it and want the flag.
+  --target <name>                the old spelling of --workspace. Accepted for one
+                                 minor, and it warns.
 
 ${style.bold('Other flags')}
   --connection <id>              which memory/tasks/assets/skills/vault/entities

--- a/src/cli/usage.ts
+++ b/src/cli/usage.ts
@@ -48,17 +48,17 @@ ${style.bold('Everyday')}
   ${PROGRAM} status [--json]            connections, reachable capabilities, endpoint
 
 ${style.bold('Profiles')}
-  ${PROGRAM} profile add <name> --target <name> [--target <name>] [--json]
+  ${PROGRAM} profile add <name> --workspace <name> [--workspace <name>] [--json]
                                  a target per place it runs; local is derived, the
                                  rest are copied from a sibling profile
   ${PROGRAM} profile list [--json]
-  ${PROGRAM} profile remove <name> [--target t] [--dry-run] [--yes] [--json]
+  ${PROGRAM} profile remove <name> [--workspace <name>] [--dry-run] [--yes] [--json]
                                  the profile, its credentials, and its data
 
 ${style.bold('Targets')}
   ${PROGRAM} target list [--urls]      where this profile can run
   ${PROGRAM} target show <name>        one target's adapters, and the address it answers on
-  ${PROGRAM} sync targets --target t [--from gs://bucket] [--discover]
+  ${PROGRAM} sync targets --workspace <name> [--from gs://bucket] [--discover]
                                  [--prefer local|remote] [--dry-run]
                                  reconcile this workspace with the copy the
                                  deployment reads; recovers a target a profile
@@ -126,10 +126,10 @@ ${style.bold('Your own context')}
   ${PROGRAM} vault key generate         a fresh LANES_LINK_VAULT_KEY, printed once
 
 ${style.bold('Deploying')}
-  ${PROGRAM} deploy --target t [--dry-run]
+  ${PROGRAM} deploy --workspace <name> [--dry-run]
                                  set up, build, and roll one revision serving
                                  every profile that declares the target
-  ${PROGRAM} deploy --target t --profile a --profile b
+  ${PROGRAM} deploy --workspace <name> --profile a --profile b
                                  only these; the first owns the endpoint token
   ${PROGRAM} deploy --non-interactive   take the stored answers, never prompt
   ${PROGRAM} deploy --access iam|public who gets past the platform's own door
@@ -158,7 +158,7 @@ ${style.bold('Attachments')}
 
 ${style.bold('Naming what a command acts on')}
   --profile <name>               required by every command that reads or writes a profile
-  --target <name>                required by every command that opens a target's stores.
+  --workspace <name>                required by every command that opens a target's stores.
                                  There is no default and no environment variable: a
                                  command that names neither refuses and lists what exists.
 

--- a/src/cli/workspace-migrate.test.ts
+++ b/src/cli/workspace-migrate.test.ts
@@ -1,7 +1,7 @@
 import { afterAll, describe, expect, test } from 'bun:test';
-import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { mkdir, mkdtemp, readdir, readFile, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
-import { join } from 'node:path';
+import { join, relative } from 'node:path';
 import { legacyTargetSchema, readRegistry } from '#profile';
 import { migrateWorkspace, needsMigration } from './workspace-migrate.ts';
 import { toEntry } from './migrate-plan.ts';
@@ -161,5 +161,51 @@ describe('reporting without writing', () => {
     expect(again.alreadyCurrent).toBe(true);
     expect(again.changes).toEqual([]);
     expect(await needsMigration(root)).toBe(false);
+  });
+});
+
+describe('one spelling of "bring this workspace up to date"', () => {
+  /**
+   * The guard for the defect that made this whole seam worth naming.
+   *
+   * `migrateWorkspace` is the contract 1 → 2 step and nothing more. Three
+   * callers reached for it meaning "migrate this workspace": `update` followed
+   * it with the 2 → 3 step, and `deploy` and `doctor --fix` did not. Neither of
+   * those two refused anything — a contract-2 bucket passed straight through,
+   * its config was replaced with contract-3 YAML, and the revision came up
+   * reading an empty `data/` while every byte stayed under `data/<profile>/`.
+   * Somebody's memory, tasks, skills and audit log were simply not there, and
+   * the endpoint reported itself healthy.
+   *
+   * So the half-step is not for general use, and this is what says so. A fourth
+   * contract adds a step to `migrateToCurrentContract` and every caller gets it;
+   * a caller that reaches past it fails here instead of in a bucket.
+   */
+  test('nothing outside this module calls the half-step', async () => {
+    const src = join(import.meta.dir, '..');
+    const found: string[] = [];
+
+    const walk = async (directory: string): Promise<void> => {
+      for (const entry of await readdir(directory, { withFileTypes: true })) {
+        const full = join(directory, entry.name);
+        if (entry.isDirectory()) await walk(full);
+        else if (entry.name.endsWith('.ts')) found.push(full);
+      }
+    };
+    await walk(src);
+
+    const offenders: string[] = [];
+    for (const path of found) {
+      // A test wires whatever it needs to exercise the thing it covers, and the
+      // module that defines the step is where it is meant to be called from.
+      if (path.endsWith('.test.ts')) continue;
+      if (path.endsWith(join('cli', 'workspace-migrate.ts'))) continue;
+
+      if (/\bmigrateWorkspace\s*\(/.test(await readFile(path, 'utf8'))) {
+        offenders.push(relative(src, path));
+      }
+    }
+
+    expect(offenders).toEqual([]);
   });
 });

--- a/src/cli/workspace-migrate.test.ts
+++ b/src/cli/workspace-migrate.test.ts
@@ -54,7 +54,7 @@ describe('hoisting a profile’s targets into the workspace', () => {
     const registry = await readRegistry(root);
 
     expect(registry['local']?.storage?.adapter).toBe('filesystem');
-    expect(registry['cloud']?.workspace).toBe('gs://personal-lanes');
+    expect(registry['cloud']?.at).toBe('gs://personal-lanes');
     expect(registry['cloud']?.storage).toBeUndefined();
   });
 
@@ -66,6 +66,8 @@ describe('hoisting a profile’s targets into the workspace', () => {
     await migrateWorkspace(root);
     const written = await readFile(join(root, 'profiles', 'personal.yaml'), 'utf8');
 
+    // This migration produces contract 2, and `migrateToContract3` takes it the
+    // rest of the way — so the number here is literally 2, not the newest.
     expect(written).toContain('contract: 2');
     expect(written).not.toContain('targets:');
     expect(written).not.toContain('default_target');
@@ -115,10 +117,10 @@ describe('migrating the workspace a target already lives in', () => {
     // `openTarget` refuses as a loop — leaving `deploy` unable to run against the
     // bucket it had just migrated, on the one command the refusal names as the fix.
     const fromLaptop = toEntry('cloud', parse('gcs'), 'personal', '/Users/x/.lanes-link');
-    expect(fromLaptop?.workspace).toBe('gs://personal-lanes');
+    expect(fromLaptop?.at).toBe('gs://personal-lanes');
 
     const fromBucket = toEntry('cloud', parse('gcs'), 'personal', 'gs://personal-lanes');
-    expect(fromBucket?.workspace).toBeUndefined();
+    expect(fromBucket?.at).toBeUndefined();
     expect(fromBucket?.storage?.bucket).toBe('personal-lanes');
   });
 

--- a/src/cli/workspace-migrate.ts
+++ b/src/cli/workspace-migrate.ts
@@ -1,4 +1,5 @@
-import { needsContract3 } from './contract3.ts';
+import { migrateToContract3, needsContract3, type Contract3Migration } from './contract3.ts';
+import { readSession } from '#auth/lanes/session.ts';
 import { parseDocument } from 'yaml';
 import {
   ConfigError,
@@ -180,6 +181,82 @@ export async function migrateWorkspace(
     targets: describe(registry),
     changes,
     alreadyCurrent: false,
+  };
+}
+
+export interface ContractMigration {
+  readonly workspaceRoot: string;
+  /** The contract 1 → 2 half, when this workspace needed one. */
+  readonly legacy: WorkspaceMigration | null;
+  /** The contract 2 → 3 half, when this workspace needed one. */
+  readonly contract3: Contract3Migration | null;
+  /** Every profile either half rewrote, deduplicated. */
+  readonly profiles: readonly string[];
+  /** Targets written into the registry by the contract 1 → 2 half. */
+  readonly targets: readonly { name: string; kind: 'declared' | 'pointer'; where?: string }[];
+  /** Both halves' lines, in the order they happened. */
+  readonly changes: readonly string[];
+  /** Nothing to do: this workspace is already at `SUPPORTED_CONTRACT`. */
+  readonly alreadyCurrent: boolean;
+}
+
+/**
+ * Bring one workspace to `SUPPORTED_CONTRACT`, whatever it is on now.
+ *
+ * **This exists because "migrate a workspace" was spelled three times and only
+ * one of them arrived.** `update` ran the 1→2 step and then the 2→3 step;
+ * `deploy` and `doctor --fix` ran the first and stopped, which nothing said out
+ * loud — `migrateTargetWorkspace`'s own docstring claimed it brought a target
+ * "to the current contract" while calling only `migrateWorkspace`.
+ *
+ * What that cost is worth writing down, because it is not a refusal. A deploy
+ * uploaded contract-3 config over a contract-2 bucket and rolled a revision that
+ * read `data/state.kv` and `data/audit.log` — while the bytes sat where contract
+ * 2 put them, under `data/<profile>/`. The endpoint came up healthy and answered
+ * every call with an empty store: no memory, no tasks, no skills, and an audit
+ * log that verified as intact because an empty chain does. Nothing in the
+ * deploy, the health probe, or `doctor` had a way to notice.
+ *
+ * So there is one function now, and the contract number lives in one place. A
+ * fourth contract adds a step here and every caller gets it.
+ *
+ * **A dry run of a contract-1 workspace reports only the first half**, and that
+ * is honest rather than a gap: the 1→2 step wrote nothing, so the profiles are
+ * still contract 1 and the 2→3 step has nothing it recognises to describe. What
+ * it would do is knowable only after the step before it has run.
+ *
+ * **The signed-in subject is defaulted here rather than by each caller.** A
+ * migrated profile that lists nobody is an endpoint that advertises OAuth and
+ * then refuses its own owner, so it matters on every path — but `deployments`
+ * may not import `#auth` (see `MAY_IMPORT` in `src/architecture.test.ts`), and
+ * `deploy` is the caller that most needs it: once a target's profiles live in
+ * its bucket there is no upload behind it to put the members row back. A caller
+ * that knows better passes one; nobody signed in is a legitimate answer and
+ * stays default-deny on the identity axis.
+ */
+export async function migrateToCurrentContract(
+  workspaceRoot: string,
+  options: { apply: boolean; subject?: string } = { apply: true },
+): Promise<ContractMigration> {
+  const legacy = (await needsMigration(workspaceRoot))
+    ? await migrateWorkspace(workspaceRoot, { apply: options.apply })
+    : null;
+
+  const subject = options.subject ?? (await readSession().catch(() => null))?.subject;
+
+  const contract3 = await migrateToContract3(workspaceRoot, {
+    apply: options.apply,
+    ...(subject === undefined ? {} : { subject }),
+  });
+
+  return {
+    workspaceRoot,
+    legacy: legacy !== null && !legacy.alreadyCurrent ? legacy : null,
+    contract3: contract3.alreadyCurrent ? null : contract3,
+    profiles: [...new Set([...(legacy?.profiles ?? []), ...contract3.profiles])],
+    targets: legacy?.targets ?? [],
+    changes: [...(legacy?.changes ?? []), ...contract3.changes],
+    alreadyCurrent: (legacy === null || legacy.alreadyCurrent) && contract3.alreadyCurrent,
   };
 }
 

--- a/src/cli/workspace-migrate.ts
+++ b/src/cli/workspace-migrate.ts
@@ -1,3 +1,4 @@
+import { needsContract3 } from './contract3.ts';
 import { parseDocument } from 'yaml';
 import {
   ConfigError,
@@ -25,7 +26,7 @@ import { hoist, summarise } from './migrate-plan.ts';
  * of each profile — one in `~/.lanes-link`, one in the bucket the endpoint reads
  * — and gave them nothing to keep them honest. It failed the way it was always
  * going to: a local file was rewritten, lost its cloud target and eight
- * connections, and `status --target cloud` reported seven where the endpoint was
+ * connections, and `status --workspace cloud` reported seven where the endpoint was
  * serving fifteen. `sync targets` and ADR-044's deployment index were both
  * written in response to earlier rounds of the same thing.
  *
@@ -122,8 +123,8 @@ export async function migrateWorkspace(
   const changes: string[] = [];
   for (const [name, entry] of Object.entries(registry)) {
     changes.push(
-      entry.workspace !== undefined
-        ? `targets.${name}: pointer to ${entry.workspace}`
+      entry.at !== undefined
+        ? `workspaces.${name}: pointer to ${entry.at}`
         : `targets.${name}: declared in ${WORKSPACE_FILE}`,
     );
   }
@@ -147,17 +148,30 @@ export async function migrateWorkspace(
   // again.
   await writeRegistry(workspaceRoot, registry);
 
-  for (const { document } of legacy) {
+  for (const { document, profile } of legacy) {
     document.removeIn(['targets']);
-    document.setIn(['contract'], SUPPORTED_CONTRACT);
+    // Literally 2, not `SUPPORTED_CONTRACT`. This migration produces a
+    // contract-2 profile and nothing else; `migrateToContract3` takes it the
+    // rest of the way. Writing the current contract here would stamp a file
+    // that still has contract-2 shapes with the newest number, and the loader
+    // would then read it as a contract-3 document that is missing `grants:`.
+    document.setIn(['contract'], 2);
     // `instance.default_target` went with the block it selected from. It has
     // been inert since ADR-037 and there is now nothing for it to name.
     document.removeIn(['instance', 'default_target']);
-    // Shape-only: a profile may carry an unrelated problem the full loader
-    // refuses — a connection row still spelling a renamed provider is the one
-    // that happens — and blocking the structural fix on it would strand the file
-    // at a contract nothing reads. `doctor --fix` names and repairs that one.
-    await document.save({ shapeOnly: true });
+    // Written rather than saved, because `save` validates and what this
+    // produces is deliberately not valid *yet*: a contract-2 profile, which the
+    // runtime does not read. `migrateToContract3` is the step that makes it
+    // loadable, and it runs immediately after — so validating here would refuse
+    // the only shape this function is able to produce.
+    //
+    // Nothing is lost by not validating: the next step reads the file it just
+    // wrote, and `check` refuses anything either step leaves broken.
+    await writeWorkspaceFile(
+      workspaceFiles(workspaceRoot),
+      `profiles/${profile}.yaml`,
+      document.toString(),
+    );
   }
 
   return {
@@ -186,7 +200,7 @@ async function writeRegistry(
   const text = (await readWorkspaceFile(files, WORKSPACE_FILE)) ?? `contract: ${SUPPORTED_CONTRACT}\n`;
   const document = parseDocument(text);
   const current = (document.toJSON() ?? {}) as {
-    targets?: Record<string, WorkspaceTarget>;
+    workspaces?: Record<string, WorkspaceTarget>;
     deployments?: {
       target?: string;
       workspace?: string;
@@ -198,7 +212,7 @@ async function writeRegistry(
   // Anything already in the file wins over what was hoisted: a workspace part
   // way through this has entries that are already right, and re-deriving them
   // from a profile that still carries a stale block would undo a correction.
-  const merged: Record<string, WorkspaceTarget> = { ...registry, ...(current.targets ?? {}) };
+  const merged: Record<string, WorkspaceTarget> = { ...registry, ...(current.workspaces ?? {}) };
 
   // ADR-044's index, folded into the entries it described. `primary` and
   // `last_deploy` were kept beside the declaration precisely because the
@@ -214,11 +228,16 @@ async function writeRegistry(
     };
   }
 
+  // `workspaces:`, not `targets:` — the registry is read back by the current
+  // schema even while the profiles beside it are still contract 2, because it
+  // is one document that both migrations share (ADR-061). The profiles are the
+  // half that stays at 2 until `migrateToContract3` runs.
   document.setIn(['contract'], SUPPORTED_CONTRACT);
   document.setIn(
-    ['targets'],
+    ['workspaces'],
     Object.fromEntries(Object.entries(merged).sort(([a], [b]) => a.localeCompare(b))),
   );
+  document.deleteIn(['targets']);
   document.deleteIn(['deployments']);
   document.deleteIn(['default_target']);
 
@@ -229,8 +248,8 @@ function describe(
   registry: Record<string, WorkspaceTarget>,
 ): { name: string; kind: 'declared' | 'pointer'; where?: string }[] {
   return Object.entries(registry).map(([name, entry]) =>
-    entry.workspace !== undefined
-      ? { name, kind: 'pointer' as const, where: entry.workspace }
+    entry.at !== undefined
+      ? { name, kind: 'pointer' as const, where: entry.at }
       : { name, kind: 'declared' as const },
   );
 }
@@ -249,6 +268,19 @@ function describe(
  * part of what it already means (ADR-052).
  */
 export async function refuseIfUnmigrated(root: string): Promise<void> {
+  if (await needsContract3(root)) {
+    throw new ConfigError(
+      `${root} is a contract 2 workspace, and this version does not read one.\n\n` +
+        '  Under contract 2 each profile carried its own connections and one flat\n' +
+        '  policy. Connections belong to the workspace now, and a profile selects\n' +
+        '  among them with per-connection scopes (ADR-057, ADR-058).\n\n' +
+        '  Migrate it:  lanes link update\n' +
+        '  Preview it:  lanes link update --check\n\n' +
+        '  Nothing is deleted by the migration: credentials are merged and read back\n' +
+        '  before the old stores are left in place.',
+    );
+  }
+
   if (!(await needsMigration(root))) return;
 
   throw new ConfigError(
@@ -258,6 +290,6 @@ export async function refuseIfUnmigrated(root: string): Promise<void> {
       '  copies of every profile that could drift apart (ADR-052).\n\n' +
       '  Migrate it:  lanes link update\n' +
       '  A deployed target is migrated by the deploy that ships the image reading it:\n' +
-      '               lanes link deploy --target <name>',
+      '               lanes link deploy --workspace <name>',
   );
 }

--- a/src/connectivity/manifest/provider.ts
+++ b/src/connectivity/manifest/provider.ts
@@ -18,7 +18,9 @@ import { connectionVariableSchema, placeholdersInConnector } from './variables.t
  *
  *   - built-ins, written as typed TS modules under `#providers/` and validated
  *     at import
- *   - the profile's own manifests in `data/<profile>/providers.d/*.yaml`, validated on load
+ *   - the workspace's own manifests in `data/providers.d/*.yaml`, validated on load
+ *     — the workspace's, not a profile's, because a manifest defines a
+ *     connection and connections stopped belonging to profiles (ADR-057)
  *
  * That second one is the scalability claim. A service nobody has integrated is
  * a YAML file the operator writes, not a pull request they wait on.

--- a/src/connectivity/manifest/requirements.ts
+++ b/src/connectivity/manifest/requirements.ts
@@ -76,7 +76,7 @@ export interface SetupNeeds {
 function storeCommand(ref: string, placeholder: string, where: Selection): string {
   return (
     `printf %s "${placeholder}" | lanes link secrets set ${ref}` +
-    ` --profile ${where.profile} --target ${where.target}`
+    ` --profile ${where.profile} --workspace ${where.target}`
   );
 }
 

--- a/src/deployments/bind.test.ts
+++ b/src/deployments/bind.test.ts
@@ -159,7 +159,7 @@ describe('binding a connection made since the last deploy', () => {
     });
 
     expect(outcome.bound).toEqual([]);
-    expect(outcome.failed).toContain('lanes link deploy --target cloud');
+    expect(outcome.failed).toContain('lanes link deploy --workspace cloud');
     expect(outcome.failed).toContain('rotate');
   });
 

--- a/src/deployments/bind.ts
+++ b/src/deployments/bind.ts
@@ -121,7 +121,7 @@ export async function bindConnectionCredentials(input: {
           `could not bind ${connection.provider}.${connection.id}'s credential to ` +
           `${serviceAccount}, so the deployed endpoint will be able to read it and not ` +
           'rotate it — which fails about an hour after the first use. ' +
-          `Run \`lanes link deploy --target ${input.target}\` to bind it. ` +
+          `Run \`lanes link deploy --workspace ${input.target}\` to bind it. ` +
           `(${driver.tool}: ${result.stderr.trim().split('\n').slice(-1)[0] ?? 'failed'})`,
       };
     }

--- a/src/deployments/bootstrap.test.ts
+++ b/src/deployments/bootstrap.test.ts
@@ -93,7 +93,7 @@ describe('a target the workspace already answers', () => {
     roots.push(root);
     await writeFile(
       join(root, 'lanes-link.yaml'),
-      'contract: 2\ntargets:\n  cloud:\n' +
+      'contract: 3\nworkspaces:\n  cloud:\n' +
         '    credentials: { adapter: gcp-secret-manager, project: p }\n' +
         '    storage: { adapter: gcs, bucket: b }\n' +
         '    deploy:\n      platform: cloudrun\n      project: p\n' +

--- a/src/deployments/deploy.test.ts
+++ b/src/deployments/deploy.test.ts
@@ -1,10 +1,10 @@
-import { CONNECTIONS_FILE } from '#profile';
+import { CONNECTIONS_FILE, type TargetConfig } from '#profile';
 import { workspaceYaml } from '#profile/testing.ts';
 import { afterAll, describe, expect, test } from 'bun:test';
 import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { rotatableRefs } from './prepare.ts';
+import { readableRefs, rotatableRefs } from './prepare.ts';
 import {
   deployedWorkspace,
   isWorkspaceConfig,
@@ -334,10 +334,50 @@ members: []
     // Per connection, never per provider: two mailboxes hold two refresh
     // tokens, and binding one would leave the other failing exactly as before.
     // Sorted, which is what makes the list stable across runs.
-    expect(await rotatableRefs(root, undefined)).toEqual([
+    expect(await rotatableRefs(root, undefined, undefined)).toEqual([
       'gmail/ada_lovelace',
       'gmail/rin_shaw',
     ]);
+  });
+
+  const vaultTarget = (vault: TargetConfig['vault']): TargetConfig =>
+    ({
+      credentials: { adapter: 'gcp-secret-manager', project: 'my-project' },
+      storage: { adapter: 'gcs', bucket: 'your-bucket' },
+      vault,
+    }) as TargetConfig;
+
+  test('the vault document is named per connection, the way openVault opens it', async () => {
+    // The blocker this pins. `openVault` names the document `vault/<connection>`
+    // (ADR-059); `provisionSteps` named `vault/document`, the contract-2
+    // constant. So a deploy created and granted one secret and the revision
+    // asked Secret Manager for another, got `PERMISSION_DENIED`, exited 1, and
+    // never listened on its port — on every deployed workspace that did not
+    // hand-write `vault.ref`. A rehearsal that sets one tests the path nobody
+    // takes, which is exactly how this reached a live endpoint.
+    //
+    // Both sets, because the revision reads the document at startup and writes
+    // it back under policy (ADR-022): a ref in only one of them is the same 403.
+    // Granting no vault is the ordinary case and resolves to `main`, which is
+    // what keeps a profile that denied the vault opening the same document as
+    // everyone else rather than inventing a second one.
+    const root = await workspaceOf({
+      personal: '  - { id: ada_lovelace, provider: gmail, account: a@example.test }',
+    });
+    const declared = vaultTarget({ adapter: 'secret' });
+
+    expect(await rotatableRefs(root, undefined, declared)).toContain('vault/main');
+    expect(await readableRefs(root, undefined, declared)).toContain('vault/main');
+    expect(await rotatableRefs(root, undefined, declared)).not.toContain('vault/document');
+  });
+
+  test('a hand-written ref still wins, because a sealed document keeps its name', async () => {
+    const root = await workspaceOf({
+      personal: '  - { id: ada_lovelace, provider: gmail, account: a@example.test }',
+    });
+    const declared = vaultTarget({ adapter: 'secret', ref: 'vault/kept' });
+
+    expect(await rotatableRefs(root, undefined, declared)).toContain('vault/kept');
   });
 
   test('a provider that authenticates with nothing contributes nothing', async () => {
@@ -345,7 +385,7 @@ members: []
 
     // A grant on a secret nobody writes is a grant that says the boundary is
     // wider than it is.
-    expect(await rotatableRefs(root, undefined)).toEqual([]);
+    expect(await rotatableRefs(root, undefined, undefined)).toEqual([]);
   });
 
   test('every profile the upload sends, when none is named', async () => {
@@ -357,7 +397,7 @@ members: []
       work: '  - { id: theirs, provider: gmail, account: b@example.test }',
     });
 
-    expect(await rotatableRefs(root, undefined)).toEqual(['gmail/mine', 'gmail/theirs']);
+    expect(await rotatableRefs(root, undefined, undefined)).toEqual(['gmail/mine', 'gmail/theirs']);
   });
 
   test('naming a profile changes nothing, because the accounts are the workspace\'s', async () => {
@@ -371,7 +411,7 @@ members: []
     // now (ADR-057) and `connections.yaml` always goes up, so every account is
     // served whichever profiles were named — and a credential the revision
     // cannot read is a broken account, not a boundary being widened.
-    expect(await rotatableRefs(root, ['personal'])).toEqual(['gmail/mine', 'gmail/theirs']);
+    expect(await rotatableRefs(root, ['personal'], undefined)).toEqual(['gmail/mine', 'gmail/theirs']);
   });
 
   test('a profile that cannot be read is skipped, not fatal', async () => {
@@ -382,7 +422,7 @@ members: []
 
     // Matching the repair: a broken sibling nobody named should not cost the
     // operator a rollout, and provisioning happens before anything is uploaded.
-    expect(await rotatableRefs(root, undefined)).toEqual(['gmail/mine']);
+    expect(await rotatableRefs(root, undefined, undefined)).toEqual(['gmail/mine']);
   });
 });
 

--- a/src/deployments/deploy.test.ts
+++ b/src/deployments/deploy.test.ts
@@ -1,3 +1,4 @@
+import { CONNECTIONS_FILE } from '#profile';
 import { workspaceYaml } from '#profile/testing.ts';
 import { afterAll, describe, expect, test } from 'bun:test';
 import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
@@ -45,42 +46,47 @@ describe('what a deploy sends up', () => {
     // ADR-030 moved both into the profile. They still have to go up: a skill
     // that does not is the ADR-014 §2 regression, and a manifest that does not
     // is a provider the revision has never heard of.
-    expect(isWorkspaceConfig('data/personal/skills.d/review-diff/SKILL.md')).toBe(true);
-    expect(isWorkspaceConfig('data/personal/skills.d/review-diff.md')).toBe(true);
-    expect(isWorkspaceConfig('data/personal/providers.d/acme.yaml')).toBe(true);
+    expect(isWorkspaceConfig('data/skills.d/main/review-diff/SKILL.md')).toBe(true);
+    expect(isWorkspaceConfig('data/skills.d/main/review-diff.md')).toBe(true);
+    expect(isWorkspaceConfig('data/providers.d/acme.yaml')).toBe(true);
   });
 
-  test('the old workspace-wide paths do not go — nothing reads them now', () => {
+  test('the old paths do not go — nothing reads them now', () => {
     expect(isWorkspaceConfig('providers/acme.yaml')).toBe(false);
     expect(isWorkspaceConfig('skills/review-diff/SKILL.md')).toBe(false);
+    // The per-profile shape contract 3 replaced.
+    expect(isWorkspaceConfig('data/personal/skills.d/review-diff.md')).toBe(false);
+    expect(isWorkspaceConfig('data/personal/providers.d/acme.yaml')).toBe(false);
   });
 
   test('credentials never go, however they are spelled', () => {
     for (const key of [
-      'data/personal/credentials.enc',
-      'data/personal/credentials.enc.key',
-      'data/personal/vault.enc',
-      'data/personal/vault.enc.key',
-      'data/personal/state.kv/connections%2Ev1/gmail%2Emain.json',
-      'data/personal/audit.log/2026/08/12/x.json',
-      'data/personal/memory/main/note.md',
-      'data/personal/gmail/ada_lovelace/attachments/x.pdf',
+      'data/credentials.enc',
+      'data/credentials.enc.key',
+      'data/vault.d/main.enc',
+      'data/vault.d/main.enc.key',
+      'data/state.kv/connections%2Ev1/gmail%2Emain.json',
+      'data/audit.log/2026/08/12/x.json',
+      'data/memory/main/note.md',
+      'data/gmail/ada_lovelace/attachments/x.pdf',
     ]) {
       expect(isWorkspaceConfig(key)).toBe(false);
     }
   });
 
   test('reaching into data/ matches whole segments, never prefixes', () => {
-    // The allowlist now names two directories inside the tree it otherwise
-    // refuses wholesale. A prefix match would send anything merely starting
-    // with the same letters, and the thing on the other side of that boundary
-    // is the credential store.
+    // The allowlist names two directories inside the tree it otherwise refuses
+    // wholesale. A prefix match would send anything merely starting with the
+    // same letters, and the thing on the other side of that boundary is the
+    // credential store.
     for (const key of [
-      'data/personal/skills.detour/leak.md',
-      'data/personal/providers.disabled/acme.yaml',
-      'data/personal/skills.d',
-      'data/personal/providers.d',
-      'data/skills.d/review-diff.md',
+      'data/skills.detour/leak.md',
+      'data/providers.disabled/acme.yaml',
+      'data/skills.d',
+      'data/providers.d',
+      // The area itself, with a connection but no file — a directory is not a
+      // file to send.
+      'data/skills.d/main',
       'data//skills.d/review-diff.md',
     ]) {
       expect({ key, sent: isWorkspaceConfig(key) }).toEqual({ key, sent: false });
@@ -96,17 +102,30 @@ describe('what a deploy sends up', () => {
     }
   });
 
-  test('naming a profile sends only that one', () => {
+  test('naming a profile sends only that profile file', () => {
     // A workspace holding personal and work should not push both into a bucket
     // that only one of them is for.
     expect(isWorkspaceConfig('profiles/personal.yaml', ['personal'])).toBe(true);
     expect(isWorkspaceConfig('profiles/work.yaml', ['personal'])).toBe(false);
+  });
 
-    // Same question for the authored areas, which are now the larger half of
-    // what goes up.
-    expect(isWorkspaceConfig('data/personal/skills.d/a.md', ['personal'])).toBe(true);
-    expect(isWorkspaceConfig('data/work/skills.d/a.md', ['personal'])).toBe(false);
-    expect(isWorkspaceConfig('data/work/providers.d/acme.yaml', ['personal'])).toBe(false);
+  test('the authored areas are not filtered by profile, because they cannot be', () => {
+    // Skills and manifests are keyed by *connection* now (ADR-057, ADR-059), and
+    // any profile in the workspace may grant one — so "only this profile's
+    // skills" is not a set that can be computed, and withholding them would
+    // deploy an endpoint whose prompts are missing.
+    expect(isWorkspaceConfig('data/skills.d/main/a.md', ['personal'])).toBe(true);
+    expect(isWorkspaceConfig('data/providers.d/acme.yaml', ['personal'])).toBe(true);
+  });
+
+  test('the connections file always goes, and the registry never does', () => {
+    // The endpoint cannot resolve a single grant without connections.yaml, and
+    // there is nothing machine-specific in it. The registry is the opposite: it
+    // holds this machine's pointer, and copying it into the bucket left the
+    // bucket pointing at itself (ADR-052).
+    expect(isWorkspaceConfig('connections.yaml')).toBe(true);
+    expect(isWorkspaceConfig('connections.yaml', ['personal'])).toBe(true);
+    expect(isWorkspaceConfig('lanes-link.yaml')).toBe(false);
   });
 });
 
@@ -122,15 +141,20 @@ describe('what a deploy sends up', () => {
  */
 describe('what a deploy repairs before sending it', () => {
   /** An old profile: a real connection, its grant, and no setup surface. */
-  const OLD = (name: string) => `contract: 2
+  const OLD = (name: string) => `contract: 3
 instance:
   profile: ${name}
   port: 7337
+grants:
+  - { connection: example.a, allow: [example.*], deny: [] }
+members: []
+`;
+
+  /** The workspace it lives in, with the account and no owner-layer row. */
+  const OLD_CONNECTIONS = `contract: 3
 connections:
   - { id: a, provider: example, account: someone@example.test }
-policy:
-  allow: [example.*]
-  deny: []
+oauth_apps: {}
 `;
 
   async function workspace(...profiles: string[]): Promise<string> {
@@ -140,11 +164,15 @@ policy:
     for (const name of profiles) {
       await writeFile(join(root, 'profiles', `${name}.yaml`), OLD(name));
     }
+    await writeFile(join(root, CONNECTIONS_FILE), OLD_CONNECTIONS);
     return root;
   }
 
+  // The grant is what says the surface is reachable now: a row *is* the
+  // connection and the rule together (ADR-058), so there is no second half to
+  // check for.
   const has = async (root: string, name: string): Promise<boolean> =>
-    (await readFile(join(root, 'profiles', `${name}.yaml`), 'utf8')).includes('provider: setup');
+    (await readFile(join(root, 'profiles', `${name}.yaml`), 'utf8')).includes('connection: setup.');
 
   test('every profile it would upload, when none is named', async () => {
     const root = await workspace('personal', 'work');
@@ -260,23 +288,39 @@ policy:
  * manifest → the ref `CredentialOAuthProvider` rewrites while serving.
  */
 describe('which credentials a deploy asks provision to bind', () => {
-  const PROFILE = (name: string, connections: string) => `contract: 2
+  // The rows are the workspace's now, so a "profile" in these fixtures is the
+  // set of connections it grants and the file that grants them (ADR-057).
+  const PROFILE = (name: string, connections: string) => `contract: 3
 instance:
   profile: ${name}
-connections:
-${connections}
-policy:
-  allow: ['*']
-  deny: []
+grants:
+${connections
+  .split('\n')
+  .filter((line) => line.trim().length > 0)
+  .map((line) => {
+    const id = /id:\s*([a-z0-9_]+)/.exec(line)?.[1] ?? '';
+    const provider = /provider:\s*([a-z0-9_]+)/.exec(line)?.[1] ?? '';
+    return `  - { connection: ${provider}.${id}, allow: ['${provider}.*'], deny: [] }`;
+  })
+  .join('\n')}
+members: []
 `;
 
   async function workspaceOf(profiles: Record<string, string>): Promise<string> {
     const root = await mkdtemp(join(tmpdir(), 'lanes-link-rotatable-'));
     roots.push(root);
     await mkdir(join(root, 'profiles'), { recursive: true });
+
+    const rows: string[] = [];
     for (const [name, connections] of Object.entries(profiles)) {
       await writeFile(join(root, 'profiles', `${name}.yaml`), PROFILE(name, connections));
+      rows.push(connections);
     }
+
+    await writeFile(
+      join(root, CONNECTIONS_FILE),
+      `contract: 3\nconnections:\n${rows.join('\n')}\noauth_apps: {}\n`,
+    );
     return root;
   }
 
@@ -316,15 +360,18 @@ policy:
     expect(await rotatableRefs(root, undefined)).toEqual(['gmail/mine', 'gmail/theirs']);
   });
 
-  test('only the named one, matching what the upload sends', async () => {
+  test('naming a profile changes nothing, because the accounts are the workspace\'s', async () => {
     const root = await workspaceOf({
       personal: '  - { id: mine, provider: gmail, account: a@example.test }',
       work: '  - { id: theirs, provider: gmail, account: b@example.test }',
     });
 
-    // Not going up, so not served, so granting for it would widen the boundary
-    // over a profile this run was told to leave alone.
-    expect(await rotatableRefs(root, ['personal'])).toEqual(['gmail/mine']);
+    // This narrowed by profile until contract 3, on the reasoning that a
+    // profile not going up is not served. A connection belongs to the workspace
+    // now (ADR-057) and `connections.yaml` always goes up, so every account is
+    // served whichever profiles were named — and a credential the revision
+    // cannot read is a broken account, not a boundary being widened.
+    expect(await rotatableRefs(root, ['personal'])).toEqual(['gmail/mine', 'gmail/theirs']);
   });
 
   test('a profile that cannot be read is skipped, not fatal', async () => {
@@ -349,14 +396,13 @@ policy:
  */
 describe('publishing a config edit', () => {
   const targets = (extra: string): string => `
-contract: 2
+contract: 3
 instance:
   profile: personal
   port: 7337
 ${extra}
-connections: []
-policy:
-  allow: []
+grants: []
+members: []
 `;
 
   test('a filesystem target publishes nowhere', async () => {
@@ -425,22 +471,23 @@ describe('the allowlist against a real workspace listing', () => {
     roots.push(source, destination);
 
     const profile = (name: string): string =>
-      `contract: 2\ninstance:\n  profile: ${name}\nconnections: []\npolicy:\n  allow: []\n`;
+      `contract: 3\ninstance:\n  profile: ${name}\ngrants: []\nmembers: []\n`;
 
     const files: Record<string, string> = {
       'lanes-link.yaml': workspaceYaml(['local', 'cloud'], { defaultProfile: 'personal' }),
       'profiles/personal.yaml': profile('personal'),
       'profiles/work.yaml': profile('work'),
-      [`${layout.skills('personal')}/review-diff/SKILL.md`]: '---\ndescription: d\n---\nb\n',
-      [`${layout.providers('personal')}/acme.yaml`]: 'id: acme\n',
+      'connections.yaml': `contract: 3\nconnections: []\noauth_apps: {}\n`,
+      [`${layout.skills('main')}/review-diff/SKILL.md`]: '---\ndescription: d\n---\nb\n',
       [`${layout.skills('work')}/triage.md`]: '---\ndescription: d\n---\nb\n',
-      'data/personal/credentials.enc': 'ciphertext',
-      'data/personal/credentials.enc.key': 'the key that opens it',
-      'data/personal/vault.enc': 'ciphertext',
-      'data/personal/state.kv/connections%2Ev1/example%2Ea.json': '{}',
-      'data/personal/audit.log/2026/08/24/x.json': '{}',
-      'data/personal/memory/main/note.md': 'a note',
-      'data/personal/example/a/attachments/x.pdf': 'bytes',
+      [`${layout.providers()}/acme.yaml`]: 'id: acme\n',
+      'data/credentials.enc': 'ciphertext',
+      'data/credentials.enc.key': 'the key that opens it',
+      'data/vault.d/main.enc': 'ciphertext',
+      'data/state.kv/connections%2Ev1/example%2Ea.json': '{}',
+      'data/audit.log/2026/08/24/x.json': '{}',
+      'data/memory/main/note.md': 'a note',
+      'data/example/a/attachments/x.pdf': 'bytes',
     };
 
     for (const [key, contents] of Object.entries(files)) {
@@ -460,22 +507,30 @@ describe('the allowlist against a real workspace listing', () => {
     await uploadWorkspace(source, destination, undefined);
 
     expect(await landed(destination)).toEqual([
-      'data/personal/providers.d/acme.yaml',
-      'data/personal/skills.d/review-diff/SKILL.md',
-      'data/work/skills.d/triage.md',
+      'connections.yaml',
+      'data/providers.d/acme.yaml',
+      'data/skills.d/main/review-diff/SKILL.md',
+      'data/skills.d/work/triage.md',
       'profiles/personal.yaml',
       'profiles/work.yaml',
     ]);
   });
 
-  test('naming a profile sends that profile and nothing of its siblings', async () => {
+  test('naming a profile narrows the profile files and nothing else', async () => {
     const { source, destination } = await populated();
 
     await uploadWorkspace(source, destination, ['personal']);
 
+    // The authored areas are keyed by connection now, and any profile may grant
+    // one — so "this profile's skills" is not a set that can be computed, and
+    // withholding them would deploy an endpoint whose prompts are missing
+    // (ADR-057, ADR-059). The profile files are still narrowed, which is the
+    // part that was ever about a profile.
     expect(await landed(destination)).toEqual([
-      'data/personal/providers.d/acme.yaml',
-      'data/personal/skills.d/review-diff/SKILL.md',
+      'connections.yaml',
+      'data/providers.d/acme.yaml',
+      'data/skills.d/main/review-diff/SKILL.md',
+      'data/skills.d/work/triage.md',
       'profiles/personal.yaml',
     ]);
   });
@@ -486,7 +541,7 @@ describe('the allowlist against a real workspace listing', () => {
     // either, silently.
     const { source } = await populated();
 
-    expect(await landed(source)).toContain('data/personal/credentials.enc.key');
+    expect(await landed(source)).toContain('data/credentials.enc.key');
   });
 });
 

--- a/src/deployments/deploy.ts
+++ b/src/deployments/deploy.ts
@@ -15,7 +15,7 @@ import { printSteps, runSteps } from './steps.ts';
 import { driverFor } from './drivers.ts';
 import { prepareSecrets, readableRefs, rotatableRefs } from './prepare.ts';
 import { repairOwnerLayer } from '#cli/config-repair.ts';
-import { migrateWorkspace } from '#cli/workspace-migrate.ts';
+import { migrateToCurrentContract } from '#cli/workspace-migrate.ts';
 import { deployedWorkspace, uploadWorkspace } from './upload.ts';
 import { servingProfiles } from './serving.ts';
 import { healthLine, reachability, registerLine, reportUnauthorised } from './report.ts';
@@ -75,9 +75,14 @@ export async function deploy(flags: DeployFlags): Promise<void> {
   // declare anything: it reads this machine's pointer and stops. So the bucket is
   // located, migrated, and only then opened.
   //
-  // Idempotent, and silent on a workspace already at contract 2 — a listing and
-  // no writes. `--dry-run` reports what it would do and writes nothing, like
-  // every other step of this command.
+  // Idempotent, and silent on a workspace already current — a listing and no
+  // writes. `--dry-run` reports what it would do and writes nothing, like every
+  // other step of this command.
+  //
+  // It goes all the way to `SUPPORTED_CONTRACT`, which it did not use to: this
+  // ran the contract 1→2 step alone, so a contract-2 bucket passed straight
+  // through and the revision came up reading an empty `data/` while the bytes
+  // stayed under `data/<profile>/`. See `migrateToCurrentContract`.
   if (!(await migrateTargetWorkspace(requireTargetFlag(flags), flags.dryRun !== true))) return;
 
   // The one command allowed to name a target that does not exist yet: creating
@@ -274,6 +279,17 @@ export async function deploy(flags: DeployFlags): Promise<void> {
     // workspace that this target cannot open, and nothing left to check.
     await repairOwnerLayer(resolution.workspaceRoot, serving);
 
+    // **The bucket's own contract, before anything is written over it.**
+    //
+    // The pass at the top of the command resolves the target through this
+    // machine's pointer, which a *first* deploy does not have: the entry is
+    // still a declaration, `resolveTargetWorkspace` answers with the local root,
+    // and it returns early. So this is the only pass that ever sees an existing
+    // bucket at contract 2 — and running it after the upload is the same as not
+    // running it, because the upload writes contract-3 profiles and
+    // `needsContract3` reads the profiles.
+    await migrateToCurrentContract(workspace, { apply: true });
+
     // Before the rollout, so the revision that comes up finds a config to read.
     // Uploading after would leave a window where the service is serving and the
     // workspace it was told to read is not there yet.
@@ -290,15 +306,9 @@ export async function deploy(flags: DeployFlags): Promise<void> {
       await uploadWorkspace(resolution.workspaceRoot, workspace, serving);
     }
 
-    // **The bucket's own migration, here and nowhere else.**
-    //
-    // A second pass, and it is not redundant. The one at the top of the command
-    // migrated whatever the bucket already held; this catches what the upload
-    // just put there — profiles from a workspace that is itself at contract 2
-    // arrive migrated, but a first deploy of a *newly created* bucket writes
-    // them here for the first time. Idempotent, so the ordinary case is one
-    // listing and no writes.
-    await migrateWorkspace(workspace, { apply: true });
+    // Again for what the upload put there: a newly created bucket gets its
+    // profiles written here for the first time. Idempotent — one listing.
+    await migrateToCurrentContract(workspace, { apply: true });
 
     // Where this deployment lives, in both registries — see `record.ts`. The
     // declaration has to land before the revision boots, so it goes here rather
@@ -364,7 +374,7 @@ async function migrateTargetWorkspace(target: string, apply: boolean): Promise<b
   const workspace = await resolveTargetWorkspace(root, target).catch(() => null);
   if (workspace === null || workspace === root) return true;
 
-  const migrated = await migrateWorkspace(workspace, { apply });
+  const migrated = await migrateToCurrentContract(workspace, { apply });
   if (migrated.alreadyCurrent) return true;
 
   heading(apply ? 'Migrated' : 'Would migrate');

--- a/src/deployments/deploy.ts
+++ b/src/deployments/deploy.ts
@@ -154,7 +154,7 @@ export async function deploy(flags: DeployFlags): Promise<void> {
   // below are, and read from config and manifests before anything opens a
   // store — `--dry-run` must reach the printed step list without touching a
   // credential.
-  const rotatable = await rotatableRefs(resolution.workspaceRoot, serving);
+  const rotatable = await rotatableRefs(resolution.workspaceRoot, serving, declared);
   const readable = await readableRefs(resolution.workspaceRoot, serving, declared);
   const provision = await driver.provision({
     deploy: deployConfig,

--- a/src/deployments/deploy.ts
+++ b/src/deployments/deploy.ts
@@ -17,7 +17,7 @@ import { prepareSecrets, readableRefs, rotatableRefs } from './prepare.ts';
 import { repairOwnerLayer } from '#cli/config-repair.ts';
 import { migrateWorkspace } from '#cli/workspace-migrate.ts';
 import { deployedWorkspace, uploadWorkspace } from './upload.ts';
-import { collidingRefs, collisionRefusal, servingProfiles } from './serving.ts';
+import { servingProfiles } from './serving.ts';
 import { healthLine, reachability, registerLine, reportUnauthorised } from './report.ts';
 
 /**
@@ -112,14 +112,13 @@ export async function deploy(flags: DeployFlags): Promise<void> {
     print(style.dim(`         serving ${serving.join(', ')} — ${primary} owns the token`));
   }
 
-  // Before anything external, beside `check`, and for the same reason: two
-  // profiles writing one flat credential ref into one store is a failure with
-  // no later symptom worth having.
-  const colliding = await collidingRefs(resolution.workspaceRoot, serving);
-  if (colliding.length > 0) {
-    heading('Cannot share a credential store');
-    throw new ConfigError(collisionRefusal(colliding, target));
-  }
+  // The credential-collision preflight is gone. It existed because two profiles
+  // each held their own `gmail.main` and both derived the flat ref `gmail/main`
+  // into one store — the last deploy winning, with no later symptom worth
+  // having. A connection belongs to the workspace now and `<provider>.<id>` is
+  // unique by construction (ADR-057), so the state it guarded against cannot be
+  // written: `assertConnectionsUnique` refuses it at load, before a deploy runs
+  // at all.
 
   // `check` before anything external, per the gate order: a config that will be
   // rejected on boot should be rejected here, not after a five-minute build.
@@ -240,7 +239,7 @@ export async function deploy(flags: DeployFlags): Promise<void> {
     for (const problem of prepared.blocking) print(fail(problem));
     throw new ConfigError(
       'The deployed instance cannot start without these. Store them with ' +
-        `lanes link secrets set <ref> --profile ${resolution.profile} --target ${target}, or ` +
+        `lanes link secrets set <ref> --profile ${resolution.profile} --workspace ${target}, or ` +
         `copy a local setup with lanes link secrets push --profile ${resolution.profile} ` +
         `--from local --to ${target}.`,
     );
@@ -325,7 +324,7 @@ export async function deploy(flags: DeployFlags): Promise<void> {
   if (!url) {
     print(
       warn(
-        `deployed, but the platform reported no URL yet — run: lanes link outputs --profile ${resolution.profile} --target ${target}`,
+        `deployed, but the platform reported no URL yet — run: lanes link outputs --profile ${resolution.profile} --workspace ${target}`,
       ),
     );
     return;
@@ -383,6 +382,6 @@ async function migrateTargetWorkspace(target: string, apply: boolean): Promise<b
   print(style.dim('  Nothing was written, and nothing else was checked: the rest of this'));
   print(style.dim('  command opens the target, which is not readable until this has run.'));
   print('');
-  print(style.dim(`  Run it for real:  lanes link deploy --target ${target}`));
+  print(style.dim(`  Run it for real:  lanes link deploy --workspace ${target}`));
   return false;
 }

--- a/src/deployments/gcp/bucket.ts
+++ b/src/deployments/gcp/bucket.ts
@@ -77,9 +77,10 @@ export function bucketGrants(bucket: string, profiles: readonly string[]): Condi
    */
   const theBucket = `resource.name == "projects/_/buckets/${bucket}"`;
 
-  const manifestPrefixes = profiles.map((profile) =>
-    objectsUnder(`${layout.providers(profile)}/`),
-  );
+  // One prefix, not one per profile. Manifests are the workspace's since
+  // ADR-057 — a manifest defines a connection, and connections do not live in a
+  // profile — so the carve-out no longer varies with the profile set.
+  const manifestPrefixes = [objectsUnder(`${layout.providers()}/`)];
   // No profiles leaves the carve-out off rather than guessing at one: the
   // revision keeps write on its own data, as it did before this existed.
   const manifests = manifestPrefixes.length > 0 ? `(${manifestPrefixes.join(' || ')})` : null;

--- a/src/deployments/gcp/bucket.ts
+++ b/src/deployments/gcp/bucket.ts
@@ -1,5 +1,5 @@
 import { join } from 'node:path';
-import { installRoot, layout } from '#profile';
+import { CONNECTIONS_FILE, WORKSPACE_FILE, installRoot, layout } from '#profile';
 import type { DeployStep } from '../driver.ts';
 import {
   removalStep,
@@ -96,11 +96,21 @@ export function bucketGrants(bucket: string, profiles: readonly string[]): Condi
     {
       // `expression=true` was here, which is every object in the bucket — the
       // step title and ADR-023 both claim a narrowing this did not do. The
-      // config the revision reads is the workspace file, the profiles beside it,
-      // and each profile's own manifests, so name exactly those.
+      // config the revision reads is the workspace file, `connections.yaml`
+      // beside it, the profiles, and the manifests, so name exactly those.
+      //
+      // **Named by the constants, because the list went stale once already.**
+      // ADR-057 moved connections out of the profile into `connections.yaml` at
+      // the workspace root, and `upload.ts` puts it in the bucket because "the
+      // endpoint cannot resolve a single grant without it" — but this expression
+      // still enumerated the contract-2 set. Every fresh deploy built its image,
+      // rolled a revision, and died on `GCS refused to read "connections.yaml"
+      // (403)` before it could listen on its port. Nothing caught it: the
+      // condition is a string assembled here and asserted nowhere, so the suite
+      // saw a passing build and Cloud Run saw a container that never started.
       role: 'roles/storage.objectViewer',
       title: 'reads-its-config',
-      expression: `${theBucket} || ${objectsUnder('profiles/')} || ${objectIs('lanes-link.yaml')}${manifests ? ` || ${manifests}` : ''}`,
+      expression: `${theBucket} || ${objectsUnder('profiles/')} || ${objectIs(WORKSPACE_FILE)} || ${objectIs(CONNECTIONS_FILE)}${manifests ? ` || ${manifests}` : ''}`,
     },
   ];
 }

--- a/src/deployments/gcp/driver.test.ts
+++ b/src/deployments/gcp/driver.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, test } from 'bun:test';
-import { DEPLOY_DEFAULTS, type DeployConfig, type TargetConfig } from '#profile';
+import {
+  CONNECTIONS_FILE,
+  DEPLOY_DEFAULTS,
+  WORKSPACE_FILE,
+  type DeployConfig,
+  type TargetConfig,
+} from '#profile';
 import { cloudRunDriver, deployPlan, imageReference } from './driver.ts';
 import { provisionSteps } from './provision.ts';
 
@@ -327,7 +333,16 @@ describe('first-run provisioning', () => {
 
     expect(condition).not.toContain('expression=true');
     expect(condition).toContain('/objects/profiles/');
-    expect(condition).toContain('/objects/lanes-link.yaml');
+    expect(condition).toContain(`/objects/${WORKSPACE_FILE}`);
+    // **Every file the uploader writes to the workspace root belongs here**, and
+    // `connections.yaml` did not. ADR-057 moved connections out of the profile
+    // and `readConnections` runs at load, so a revision that cannot read it
+    // resolves no grant at all: it exited 1 with `GCS refused to read
+    // "connections.yaml" (403)` and never listened on its port. The build was
+    // green — the condition is a string assembled in `bucket.ts` and this is the
+    // only place that reads it back. Named by the constants for that reason: a
+    // rename must not be able to pass here and fail in Cloud Run.
+    expect(condition).toContain(`/objects/${CONNECTIONS_FILE}`);
     // It does reach into `data/` now, for the manifests ADR-030 moved in there
     // — but by the anchored pattern only. A blanket `startsWith(".../data/")`
     // here would hand the revision read on every credential-adjacent object in

--- a/src/deployments/gcp/driver.test.ts
+++ b/src/deployments/gcp/driver.test.ts
@@ -336,7 +336,7 @@ describe('first-run provisioning', () => {
     // conditions have no `matches`, and refused the whole expression. The
     // binding carries `tolerateFailure`, so the narrowing silently did not apply
     // and the bucket kept whatever condition was already on it.
-    expect(condition).toContain('/objects/data/personal/providers.d/');
+    expect(condition).toContain('/objects/data/providers.d/');
     expect(condition).not.toContain('matches(');
     expect(condition).not.toMatch(/startsWith\("[^"]*\/objects\/data\/"\)/);
   });
@@ -361,7 +361,7 @@ describe('first-run provisioning', () => {
     expect(write).not.toContain('profiles/');
     expect(write).not.toContain('lanes-link.yaml');
     expect(write).toContain('!(resource.name.startsWith(');
-    expect(write).toContain('/objects/data/personal/providers.d/');
+    expect(write).toContain('/objects/data/providers.d/');
     expect(write).not.toContain('matches(');
 
     expect(conditions.some((condition) => condition.includes('reads-its-config'))).toBe(true);

--- a/src/deployments/gcp/provision.ts
+++ b/src/deployments/gcp/provision.ts
@@ -1,4 +1,4 @@
-import { VAULT_DOCUMENT_REF, type SecretRef } from '#secrets';
+import type { SecretRef } from '#secrets';
 import type { DeployStep, ProvisionInput } from '../driver.ts';
 import { encodeRef } from '../adapters/gcp-secret-manager.ts';
 import { bucketSteps } from './bucket.ts';
@@ -312,12 +312,12 @@ export async function provisionSteps(
     // mind: nothing here was wrong, it was incomplete, and being incomplete
     // looked exactly like being finished. Reading mail 403'd an hour after every
     // deploy.
-    const rotatable = [
-      ...(input.declared.vault?.adapter === 'secret'
-        ? [input.declared.vault.ref ?? VAULT_DOCUMENT_REF]
-        : []),
-      ...(input.rotatable ?? []),
-    ];
+    // Both kinds arrive already derived: the vault document is named per vault
+    // connection (ADR-059) and only `prepare.ts` has the profile configs to work
+    // it out. Naming `vault/document` here — the contract-2 constant — created
+    // and granted one secret while `openVault` asked for another, and the
+    // revision died on `PERMISSION_DENIED` before it could listen. See `vaultRef`.
+    const rotatable = [...(input.rotatable ?? [])];
 
     // Read, named one secret at a time, for the same reason the write side is:
     // a resource-level grant needs no condition to be scoped.

--- a/src/deployments/grants.test.ts
+++ b/src/deployments/grants.test.ts
@@ -306,8 +306,21 @@ describe('what the revision is granted, against what it writes', () => {
 });
 
 describe('the vault, which is the one thing a revision writes back to its store', () => {
+  // Handed in, the way `deploy` hands it in. The vault document is named per
+  // vault connection (ADR-059), so only `prepare.ts` — which has the profile
+  // configs — can work it out. `provisionSteps` naming `vault/document` itself
+  // is the defect these tests used to pin: it created and granted one secret
+  // while `openVault` asked for another, and the revision died on
+  // `PERMISSION_DENIED` before it could listen on its port.
+  const VAULT = 'vault/main';
   const provision = (declared: TargetConfig) =>
-    provisionSteps({ deploy: cloudrun, declared, target: 'cloud', profiles: [PROFILE] });
+    provisionSteps({
+      deploy: cloudrun,
+      declared,
+      target: 'cloud',
+      profiles: [PROFILE],
+      rotatable: [VAULT],
+    });
 
   test('the document secret is created here, so the revision never needs secrets.create', async () => {
     // `secrets.create` is project-level: a revision holding it could mint
@@ -318,7 +331,7 @@ describe('the vault, which is the one thing a revision writes back to its store'
       (step) => step.argv[0] === 'secrets' && step.argv[1] === 'create',
     );
 
-    expect(create?.argv).toContain('vault__document');
+    expect(create?.argv).toContain('vault__main');
     expect(create?.tolerateFailure).toBe(true);
   });
 
@@ -328,13 +341,25 @@ describe('the vault, which is the one thing a revision writes back to its store'
       (step) => step.argv[0] === 'secrets' && step.argv[1] === 'add-iam-policy-binding',
     )!;
 
-    expect(binding.argv[2]).toBe('vault__document');
+    expect(binding.argv[2]).toBe('vault__main');
     expect(binding.argv).toContain('roles/secretmanager.secretVersionAdder');
   });
 
-  test('a target with no vault is granted nothing extra', async () => {
+  test('a target with no vault contributes no ref, so nothing extra is granted', async () => {
+    // The *decision* moved to `prepare.ts` with the profile configs; what stays
+    // provision's is that it grants exactly what it was handed and invents
+    // nothing. `rotatableRefs` is what turns "this target has no vault" into an
+    // empty list, and `readableRefs` is covered beside it.
     const { vault: _vault, ...withoutVault } = target;
-    const roles = (await provision(withoutVault as TargetConfig))
+    const roles = (
+      await provisionSteps({
+        deploy: cloudrun,
+        declared: withoutVault as TargetConfig,
+        target: 'cloud',
+        profiles: [PROFILE],
+        rotatable: [],
+      })
+    )
       .flatMap((step) => step.argv)
       .filter((argument) => argument.startsWith('roles/'));
 
@@ -466,7 +491,7 @@ describe('the credentials a revision rotates, against what it is bound to', () =
   });
 
   test('each rotatable secret is created here too, for the reason the vault one is', async () => {
-    const steps = await provisionWith(['gmail/ada_lovelace']);
+    const steps = await provisionWith(['gmail/ada_lovelace', 'vault/main']);
     const created = steps
       .filter((step) => step.argv[0] === 'secrets' && step.argv[1] === 'create')
       .map((step) => step.argv[2]!);
@@ -474,7 +499,7 @@ describe('the credentials a revision rotates, against what it is bound to', () =
     // A binding cannot attach to a secret that does not exist, and a connection
     // authorised after the last deploy has no secret up here yet.
     expect(created).toContain('gmail__ada_lovelace');
-    expect(created).toContain('vault__document');
+    expect(created).toContain('vault__main');
   });
 
   test('a manual client stays the operator\'s, and is never bound', async () => {

--- a/src/deployments/grants.test.ts
+++ b/src/deployments/grants.test.ts
@@ -68,8 +68,8 @@ const target: TargetConfig = {
  * one that was broken — a provider's own store, which asks for no area at all.
  */
 const AREAS: Record<string, [string | undefined, string]> = {
-  'connection state': [layout.state(PROFILE), 'connections.v1/gmail.ada_lovelace'],
-  'the audit log': [layout.audit(PROFILE), '2026/08/13/1755075600000-abc.json'],
+  'connection state': [layout.state(), 'connections.v1/gmail.ada_lovelace'],
+  'the audit log': [layout.audit(), '2026/08/13/1755075600000-abc.json'],
   'a memory entry': [undefined, 'memory/main/note.md'],
   'an attachment': [undefined, 'gmail/ada_lovelace/attachments/x.pdf'],
   'a skill': [layout.skills(PROFILE), 'review-diff/SKILL.md'],
@@ -114,7 +114,7 @@ beforeAll(async () => {
 
     // And one listing, which is the call that has no object in it at all.
     captured.length = 0;
-    await storage(layout.state(PROFILE)).list('connections.v1/');
+    await storage(layout.state()).list('connections.v1/');
     LISTED = captured[0]!;
   } finally {
     globalThis.fetch = real;
@@ -131,7 +131,7 @@ const READS = {
   'the workspace file': 'lanes-link.yaml',
   // Inside `data/` since ADR-030, so the write condition has to carve it back
   // out rather than simply not mentioning it.
-  'a provider manifest': `${layout.providers(PROFILE)}/acme.yaml`,
+  'a provider manifest': `${layout.providers()}/acme.yaml`,
 };
 
 /** The CEL of the one conditioned binding whose title carries `name`. */

--- a/src/deployments/prepare.ts
+++ b/src/deployments/prepare.ts
@@ -1,5 +1,6 @@
 import { credentialRefFor, ownClientRefsFor, rotatableCredentialRefsFor } from '#registry';
-import { listProfiles, loadProfileConfig, type Config, type TargetConfig } from '#profile';
+import {
+  readConnections, listProfiles, loadProfileConfig, type Config, type TargetConfig } from '#profile';
 import { VAULT_DOCUMENT_REF, VAULT_KEY_REF, generateVaultKey, type SecretStore } from '#secrets';
 import { ok, print, style, warn } from '#cli/output.ts';
 import { buildRegistryWithWorkspace, ensureProfileToken } from '#cli/runtime.ts';
@@ -80,16 +81,22 @@ export async function rotatableRefs(
       continue;
     }
 
-    // Inside the loop because manifests are the profile's own (ADR-030): a
-    // connection in `work` naming a provider only `work` declares resolves to
-    // nothing against `personal`'s registry, and a missed ref here is a 403 an
-    // hour after the revision reports healthy.
-    const registry = await buildRegistryWithWorkspace(root, name);
+    void config;
+  }
 
-    for (const connection of config.connections) {
-      const manifest = registry.manifest(connection.provider);
-      for (const ref of rotatableCredentialRefsFor(connection, manifest)) refs.add(ref);
-    }
+  // Once, outside the profile loop. Connections and the manifests that describe
+  // them belong to the workspace (ADR-057), so the per-profile registry ADR-030
+  // required is gone — and with it the failure it guarded against, where a
+  // connection in `work` resolved to nothing against `personal`'s registry and
+  // the missed ref became a 403 an hour after the revision reported healthy.
+  //
+  // Every connection, not just granted ones: a credential a revision cannot read
+  // is a broken account, and whether some profile currently grants it is a
+  // question that changes without redeploying.
+  const registry = await buildRegistryWithWorkspace(root);
+  for (const connection of (await readConnections(root)).connections) {
+    const manifest = registry.manifest(connection.provider);
+    for (const ref of rotatableCredentialRefsFor(connection, manifest)) refs.add(ref);
   }
 
   // Sorted, and a set: two Gmail connections share one dynamically registered
@@ -158,17 +165,18 @@ export async function readableRefs(
       refs.add(config.auth.authorization.client_id_ref);
     }
 
-    // Per profile, for the reason `rotatableRefs` gives: a manifest is this
-    // profile's, so the registry that resolves its connections must be too.
-    const registry = await buildRegistryWithWorkspace(root, name);
+  }
 
-    for (const connection of config.connections) {
-      const manifest = registry.manifest(connection.provider);
-      const ref = credentialRefFor(connection, manifest);
-      if (ref) refs.add(ref);
-      for (const rotatable of rotatableCredentialRefsFor(connection, manifest)) refs.add(rotatable);
-      for (const client of ownClientRefsFor(manifest, config.oauth_apps)) refs.add(client);
-    }
+  // Once, for the reason `rotatableRefs` gives.
+  const connectionsFile = await readConnections(root);
+  const registry = await buildRegistryWithWorkspace(root);
+
+  for (const connection of connectionsFile.connections) {
+    const manifest = registry.manifest(connection.provider);
+    const ref = credentialRefFor(connection, manifest);
+    if (ref) refs.add(ref);
+    for (const rotatable of rotatableCredentialRefsFor(connection, manifest)) refs.add(rotatable);
+    for (const client of ownClientRefsFor(manifest, connectionsFile.oauth_apps)) refs.add(client);
   }
 
   return [...refs].sort();
@@ -190,13 +198,13 @@ export async function prepareSecrets(input: PrepareInput): Promise<PrepareResult
   // The command is spelled out rather than described. This is the one manual
   // step a deploy genuinely cannot take for you, so it should cost a paste
   // rather than a trip to the docs to work out how the id is spelled.
-  const registry = await buildRegistryWithWorkspace(root, config.instance.profile);
-  for (const connection of config.connections) {
+  const registry = await buildRegistryWithWorkspace(root);
+  for (const connection of (await readConnections(root)).connections) {
     const ref = credentialRefFor(connection, registry.manifest(connection.provider));
     if (!ref || (await credentials.has(ref))) continue;
     warnings.push(
       `${connection.provider}.${connection.id} is not authorised yet — no credential at "${ref}"\n` +
-        `    lanes link connect ${connection.provider} --profile ${input.config.instance.profile} --target ${target} --id ${connection.id}`,
+        `    lanes link connect ${connection.provider} --profile ${input.config.instance.profile} --workspace ${target} --id ${connection.id}`,
     );
   }
 

--- a/src/deployments/prepare.ts
+++ b/src/deployments/prepare.ts
@@ -1,5 +1,6 @@
 import { credentialRefFor, ownClientRefsFor, rotatableCredentialRefsFor } from '#registry';
 import {
+  PAIR_TOKEN_REF,
   readConnections, listProfiles, loadProfileConfig, vaultRef, type Config, type TargetConfig } from '#profile';
 import { VAULT_DOCUMENT_REF, VAULT_KEY_REF, generateVaultKey, type SecretStore } from '#secrets';
 import { ok, print, style, warn } from '#cli/output.ts';
@@ -144,6 +145,35 @@ export async function readableRefs(
   declared: TargetConfig | undefined,
 ): Promise<string[]> {
   const refs = new Set<string>();
+
+  // Unconditionally, for every deploy, whether or not this workspace has ever
+  // been paired — and that is the point rather than a rounding up.
+  //
+  // Secret Manager answers a *missing binding* with 403, not 404, so that an
+  // identity cannot enumerate secrets by their error codes. The adapter returns
+  // null for the 404 and throws for the 403, so an unbound ref is a thrown
+  // error on the read path — and that is the failure `server/read/open.ts`
+  // records: a deployed revision asked for refs no binding covered and never
+  // went healthy.
+  //
+  // Bound, the deployed-but-never-paired case becomes the 404 instead — a
+  // secret that exists with no version — which reads back as null and renders
+  // as `401 {error:'unpaired'}`. The grant is what turns a crash into a
+  // refusal.
+  //
+  // Deciding it by asking *whether the workspace is paired* is the thing that
+  // cannot happen: that means opening a credential store inside `readableRefs`,
+  // which `--dry-run` reaches and must not do.
+  //
+  // Deliberately not in `rotatableRefs`. The revision never writes this one —
+  // minting is `lanes link pair`, from the operator's machine — and
+  // `secretVersionAdder` here would let a compromised revision issue itself a
+  // credential that reads the whole workspace.
+  //
+  // The cert and key refs are absent for a different reason: Cloud Run
+  // terminates TLS with a certificate a browser already trusts, so a deployed
+  // revision never calls `serveRead` and never reads either.
+  refs.add(PAIR_TOKEN_REF);
 
   // Only the key is the target's. The *document* is named per vault connection
   // (ADR-059), so it is added inside the profile loop below — naming it here

--- a/src/deployments/prepare.ts
+++ b/src/deployments/prepare.ts
@@ -1,6 +1,6 @@
 import { credentialRefFor, ownClientRefsFor, rotatableCredentialRefsFor } from '#registry';
 import {
-  readConnections, listProfiles, loadProfileConfig, type Config, type TargetConfig } from '#profile';
+  readConnections, listProfiles, loadProfileConfig, vaultRef, type Config, type TargetConfig } from '#profile';
 import { VAULT_DOCUMENT_REF, VAULT_KEY_REF, generateVaultKey, type SecretStore } from '#secrets';
 import { ok, print, style, warn } from '#cli/output.ts';
 import { buildRegistryWithWorkspace, ensureProfileToken } from '#cli/runtime.ts';
@@ -67,6 +67,7 @@ export interface PrepareResult {
 export async function rotatableRefs(
   root: string,
   profiles: readonly string[] | undefined,
+  declared: TargetConfig | undefined,
 ): Promise<string[]> {
   const refs = new Set<string>();
   const wanted = profiles === undefined ? undefined : new Set(profiles);
@@ -81,7 +82,12 @@ export async function rotatableRefs(
       continue;
     }
 
-    void config;
+    // `vault.put` is a capability an agent may hold under policy (ADR-022), so
+    // the revision rewrites this one — and it is per vault connection, which is
+    // what makes this a per-profile pass rather than a target-level constant.
+    // The loop had been reduced to `void config` when the derivation moved out;
+    // this is it moving back, next to the config it needs.
+    if (declared?.vault?.adapter === 'secret') refs.add(vaultRef(declared, config));
   }
 
   // Once, outside the profile loop. Connections and the manifests that describe
@@ -139,9 +145,12 @@ export async function readableRefs(
 ): Promise<string[]> {
   const refs = new Set<string>();
 
+  // Only the key is the target's. The *document* is named per vault connection
+  // (ADR-059), so it is added inside the profile loop below — naming it here
+  // meant `vault/document`, which is not what `openVault` opens, and the
+  // revision 403'd on a ref nothing had created. See `vaultRef`.
   if (declared?.vault?.adapter === 'secret') {
     refs.add(VAULT_KEY_REF);
-    refs.add(declared.vault.ref ?? VAULT_DOCUMENT_REF);
   } else if (declared?.vault?.adapter === 'blob') {
     // Ciphertext lives in the bucket, but the key that opens it is still here.
     refs.add(VAULT_KEY_REF);
@@ -160,6 +169,7 @@ export async function readableRefs(
     }
 
     refs.add(config.auth.token_ref);
+    if (declared?.vault?.adapter === 'secret') refs.add(vaultRef(declared, config));
     // The OIDC audience check reads this on every verify (`server/endpoint.ts`).
     if (config.auth.authorization?.mode === 'oidc') {
       refs.add(config.auth.authorization.client_id_ref);

--- a/src/deployments/record.test.ts
+++ b/src/deployments/record.test.ts
@@ -33,7 +33,7 @@ afterAll(async () => {
 async function workspace(): Promise<string> {
   const root = await mkdtemp(join(tmpdir(), 'lanes-link-record-'));
   roots.push(root);
-  await writeFile(join(root, 'lanes-link.yaml'), 'contract: 2\n');
+  await writeFile(join(root, 'lanes-link.yaml'), 'contract: 3\n');
   return root;
 }
 
@@ -67,8 +67,8 @@ describe('recording a deployment', () => {
     const here = (await readRegistry(machine))['cloud']!;
 
     expect(there.storage?.bucket).toBe('lanes-link-demo-data');
-    expect(there.workspace).toBeUndefined();
-    expect(here.workspace).toBe(target);
+    expect(there.at).toBeUndefined();
+    expect(here.at).toBe(target);
     expect(here.storage).toBeUndefined();
   });
 
@@ -111,8 +111,8 @@ describe('recording a deployment', () => {
     // A pointer beside adapters is what the schema refuses, and this is the one
     // write that touches both entries twice.
     expect(there.storage?.bucket).toBe('lanes-link-demo-data');
-    expect(there.workspace).toBeUndefined();
-    expect(here.workspace).toBe(target);
+    expect(there.at).toBeUndefined();
+    expect(here.at).toBe(target);
     expect(here.last_deploy_version).toBe('0.6.6');
   });
 });

--- a/src/deployments/record.ts
+++ b/src/deployments/record.ts
@@ -56,7 +56,7 @@ export async function recordDeployment(record: DeploymentRecord): Promise<void> 
   // there pointed the bucket at itself, and the revision that came up refused to
   // open its own target.
   await recordTarget(resolveWorkspaceRoot(), record.target, {
-    workspace: record.workspace,
+    at: record.workspace,
     ...stamp,
   });
 }

--- a/src/deployments/report.ts
+++ b/src/deployments/report.ts
@@ -37,7 +37,7 @@ import { heading, ok, print, style, warn } from '#cli/output.ts';
 export function registerLine(profile: string, target: string): string {
   return style.dim(
     `  Connect your accounts first, then register with:\n` +
-      `    lanes link outputs --profile ${profile} --target ${target}\n` +
+      `    lanes link outputs --profile ${profile} --workspace ${target}\n` +
       '  A client keeps the tool list it fetched when it connected, so one registered\n' +
       '  before the accounts holds a surface without them until it is re-added.',
   );
@@ -66,7 +66,7 @@ export function reportUnauthorised(warnings: readonly string[], profile: string,
   print(
     style.dim(
       '  A browser consent per account is the one step this cannot take for you:\n' +
-        `    lanes link connect <provider> --profile ${profile} --target ${target}\n` +
+        `    lanes link connect <provider> --profile ${profile} --workspace ${target}\n` +
         '  Each is served as soon as it is authorised. There is no second deploy —\n' +
         '  deploying is how code gets here, and authorising an account changes none.',
     ),

--- a/src/deployments/serving.test.ts
+++ b/src/deployments/serving.test.ts
@@ -3,7 +3,7 @@ import { afterAll, describe, expect, test } from 'bun:test';
 import { mkdtemp, mkdir, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { collidingRefs, collisionRefusal, servingProfiles } from './serving.ts';
+import { servingProfiles } from './serving.ts';
 
 /**
  * Which profiles a deploy sends, and whether they can share one store.
@@ -151,56 +151,13 @@ describe('deciding which profiles a deploy sends', () => {
   });
 });
 
-describe('two profiles sharing one credential store', () => {
-  test('the same connection id in both is a collision', async () => {
-    // `gmail/main` is one secret in one project. The last deploy wins, and
-    // nothing downstream can catch it — by then the credential is valid.
-    const root = await workspace({
-      personal: profileYaml('personal', { gmail: 'main' }),
-      work: profileYaml('work', { gmail: 'main' }),
-    });
-
-    const found = await collidingRefs(root, ['personal', 'work']);
-    expect(found).toMatchObject([{ ref: 'gmail/main', profiles: ['personal', 'work'] }]);
-  });
-
-  test('different ids are not', async () => {
-    const root = await workspace({
-      personal: profileYaml('personal', { gmail: 'main' }),
-      work: profileYaml('work', { gmail: 'desk' }),
-    });
-
-    expect(await collidingRefs(root, ['personal', 'work'])).toEqual([]);
-  });
-
-  test('one profile alone can never collide with itself', async () => {
-    const root = await workspace({
-      personal: profileYaml('personal', { gmail: 'main' }),
-      work: profileYaml('work', { gmail: 'main' }),
-    });
-
-    expect(await collidingRefs(root, ['personal'])).toEqual([]);
-  });
-
-  test('the shared endpoint token is not a collision, because sharing it is the design', async () => {
-    // Every profile defaults to `profile/token`, and ADR-009 says one endpoint
-    // has one token. Reporting it would fire on every multi-profile deploy.
-    const root = await workspace({
-      personal: profileYaml('personal'),
-      work: profileYaml('work'),
-    });
-
-    expect(await collidingRefs(root, ['personal', 'work'])).toEqual([]);
-  });
-
-  test('the refusal names the reference and both profiles', async () => {
-    const message = collisionRefusal(
-      [{ ref: 'gmail/main', profiles: ['personal', 'work'] }],
-      'cloud',
-    );
-
-    expect(message).toContain('gmail/main   personal, work');
-    expect(message).toContain('the last deploy');
-    expect(message).toContain('separate projects');
-  });
-});
+/**
+ * The collision preflight is gone, and that is the point.
+ *
+ * Two profiles each holding their own `gmail.main` both derived the flat ref
+ * `gmail/main` into one credential store — the last deploy winning, with no
+ * later symptom worth having, so `deploy` refused before it started. A
+ * connection belongs to the workspace now and `<provider>.<id>` is unique by
+ * construction (ADR-057), so the state cannot be written: it is refused at load
+ * by `assertConnectionsUnique`, long before a deploy is involved.
+ */

--- a/src/deployments/serving.ts
+++ b/src/deployments/serving.ts
@@ -4,6 +4,7 @@ import {
   listProfiles,
   loadWorkspaceProfiles,
   readRegistry,
+  resolveTargetWorkspace,
   type WorkspaceProfiles,
 } from '#profile';
 import { rotatableCredentialRefsFor } from '#registry';
@@ -50,7 +51,16 @@ export async function servingProfiles(input: {
     return { profiles: [...named], primary: named[0]! };
   }
 
-  const living = await listProfiles(workspaceRoot);
+  // **Where the profiles actually are, which is not this machine.** After
+  // ADR-052 a deployed target's profiles live in its workspace, so listing the
+  // local root answered with whatever happened to be here: an empty workspace
+  // holding nothing but a pointer refused a redeploy of a live endpoint
+  // outright, and a local profile the bucket does not hold would have been sent
+  // to a revision that cannot open it. A declaration resolves back to the local
+  // root, which is the right answer there — a first deploy is exactly the case
+  // where the profiles are still on this machine and about to be uploaded.
+  const where = await resolveTargetWorkspace(workspaceRoot, target).catch(() => workspaceRoot);
+  const living = await listProfiles(where);
 
   if (living.length === 0) {
     throw new ConfigError(

--- a/src/deployments/serving.ts
+++ b/src/deployments/serving.ts
@@ -1,4 +1,5 @@
 import {
+  readConnections,
   ConfigError,
   listProfiles,
   loadWorkspaceProfiles,
@@ -56,9 +57,9 @@ export async function servingProfiles(input: {
       `No profile lives in "${target}", so there is no set to deploy.\n` +
         '  A first deploy creates the target, and has to be told which profile\n' +
         '  it belongs to:\n' +
-        `    lanes link deploy --target ${target} --profile <name>\n\n` +
+        `    lanes link deploy --workspace ${target} --profile <name>\n\n` +
         `  If "${target}" was deployed before and the pointer to it was lost:\n` +
-        `    lanes link sync targets --target ${target} --discover`,
+        `    lanes link sync targets --workspace ${target} --discover`,
     );
   }
 
@@ -89,7 +90,7 @@ async function choosePrimary(
       "of them owns the endpoint's token. One token opens the endpoint and\n" +
       'reaches every profile behind it, so this cannot be picked for you.\n\n' +
       `  Name it once and it is remembered:\n` +
-      `    lanes link deploy --target ${target} --profile ${declaring[0]!}` +
+      `    lanes link deploy --workspace ${target} --profile ${declaring[0]!}` +
       declaring
         .slice(1)
         .map((name) => ` --profile ${name}`)
@@ -97,73 +98,3 @@ async function choosePrimary(
   );
 }
 
-/**
- * A credential reference two profiles would both write, in one store.
- *
- * References are flat — `gmail/main`, not `personal/gmail/main` — and a target
- * has one credential store, so two profiles deployed to the same project share
- * a namespace. `https://lanes.sh/docs/link/configuration` admits this in an aside about
- * removing a profile; deploying both at once is where it stops being an aside.
- *
- * The failure is silent and it is the bad kind: `personal`'s Gmail refresh
- * token is overwritten by `work`'s, both profiles go on listing their own
- * account in config, and the first symptom is one of them reading the other's
- * mailbox. Nothing downstream can catch it, because by then there is one
- * credential and it is valid.
- *
- * `profile/token` is deliberately not a collision. Every profile defaults to
- * that ref and the endpoint has exactly one token by design — sharing it is
- * what ADR-009 says happens, rather than an accident.
- */
-export interface Collision {
-  readonly ref: string;
-  readonly profiles: string[];
-}
-
-export async function collidingRefs(
-  workspaceRoot: string,
-  profiles: readonly string[],
-  workspace?: WorkspaceProfiles,
-): Promise<Collision[]> {
-  const loaded = (workspace ?? (await loadWorkspaceProfiles(workspaceRoot))).loaded.filter(
-    (entry) => profiles.includes(entry.profile),
-  );
-
-  const owners = new Map<string, string[]>();
-
-  for (const entry of loaded) {
-    const registry = await buildRegistryWithWorkspace(workspaceRoot, entry.profile);
-    const refs = new Set<string>();
-
-    for (const connection of entry.config.connections) {
-      const manifest = registry.manifest(connection.provider);
-      for (const ref of rotatableCredentialRefsFor(connection, manifest)) refs.add(ref);
-      if (connection.credential_ref) refs.add(connection.credential_ref);
-    }
-
-    for (const ref of refs) {
-      if (ref === entry.config.auth.token_ref) continue;
-      owners.set(ref, [...(owners.get(ref) ?? []), entry.profile]);
-    }
-  }
-
-  return [...owners.entries()]
-    .filter(([, names]) => names.length > 1)
-    .map(([ref, names]) => ({ ref, profiles: names.sort() }))
-    .sort((a, b) => a.ref.localeCompare(b.ref));
-}
-
-/** The refusal, as a block, so the wording is testable without a deploy. */
-export function collisionRefusal(found: readonly Collision[], target: string): string {
-  const rows = found.map((one) => `    ${one.ref}   ${one.profiles.join(', ')}`).join('\n');
-
-  return (
-    `${found.length} credential reference(s) would be written by more than one\n` +
-    `profile into the one credential store "${target}" has:\n\n${rows}\n\n` +
-    '  References are flat, so these are the same secret and the last deploy\n' +
-    '  wins — after which one profile is reading the other\'s account, and\n' +
-    '  both still name their own in config.\n\n' +
-    '  Give the connections different ids, or deploy the profiles to targets\n' +
-    '  in separate projects.'
-  );
-}

--- a/src/deployments/target.ts
+++ b/src/deployments/target.ts
@@ -69,14 +69,14 @@ export async function openSecrets(input: TargetInput): Promise<SecretStore> {
       return createFileSecretStore({
         path: workspacePath(
           root,
-          declared.credentials.path ?? layout.credentials(config.instance.profile),
+          declared.credentials.path ?? layout.credentials(),
         ),
       });
 
     case 'gcp-secret-manager': {
       if (!declared.credentials.project) {
         throw new ConfigError(
-          `targets.${target}.credentials.project is required for the gcp-secret-manager adapter.`,
+          `workspaces.${target}.credentials.project is required for the gcp-secret-manager adapter.`,
         );
       }
       const { GcpSecretManagerStore } = await import('./adapters/gcp-secret-manager.ts');
@@ -97,8 +97,8 @@ export async function openSecrets(input: TargetInput): Promise<SecretStore> {
  * Its own root, `layout.state`, so it is not addressable from a provider's
  * blob namespace — the same containment `openAudit` relies on.
  */
-export function openState(storage: StorageFactory, profile: string): RuntimeState {
-  return createRuntimeState(storage(layout.state(profile)));
+export function openState(storage: StorageFactory): RuntimeState {
+  return createRuntimeState(storage(layout.state()));
 }
 
 /**
@@ -115,8 +115,8 @@ export function openState(storage: StorageFactory, profile: string): RuntimeStat
  * into (`layout.audit`), and that separation is what keeps ADR-007's wall
  * intact.
  */
-export function openAudit(storage: StorageFactory, profile: string): AuditStore {
-  return createBlobAuditStore({ storage: storage(layout.audit(profile)) });
+export function openAudit(storage: StorageFactory): AuditStore {
+  return createBlobAuditStore({ storage: storage(layout.audit()) });
 }
 
 /**
@@ -137,7 +137,7 @@ export async function openAuditSinks(
   secrets: SecretStore,
   log?: (message: string) => void,
 ): Promise<{ sink: AuditSink; reader: AuditReader }> {
-  const durable = openAudit(storage, input.config.instance.profile);
+  const durable = openAudit(storage);
   const declared = input.declared.audit?.sinks ?? [];
   if (declared.length === 0) return { sink: durable, reader: durable };
 
@@ -201,7 +201,7 @@ export async function openStorage(
   switch (declared.storage.adapter) {
     case 'filesystem': {
       const { createFilesystemBlobStore } = await import('./adapters/filesystem.ts');
-      const base = declared.storage.path ?? layout.blobs(config.instance.profile);
+      const base = declared.storage.path ?? layout.blobs();
       return (area) =>
         createFilesystemBlobStore({ root: workspacePath(root, area === undefined ? base : area) });
     }
@@ -214,12 +214,12 @@ export async function openStorage(
       // by hand in a console.
       const { bucket, prefix } = declared.storage;
       if (!bucket) {
-        throw new ConfigError(`targets.${target}.storage.bucket is required for the gcs adapter.`);
+        throw new ConfigError(`workspaces.${target}.storage.bucket is required for the gcs adapter.`);
       }
 
       const { createGcsBlobStore } = await import('./adapters/gcs.ts');
       const base = prefix ?? '';
-      const root = layout.blobs(config.instance.profile);
+      const root = layout.blobs();
 
       return (area) =>
         createGcsBlobStore({
@@ -231,25 +231,25 @@ export async function openStorage(
     case 's3': {
       const { bucket, endpoint, region, prefix } = declared.storage;
       if (!bucket) {
-        throw new ConfigError(`targets.${target}.storage.bucket is required for the s3 adapter.`);
+        throw new ConfigError(`workspaces.${target}.storage.bucket is required for the s3 adapter.`);
       }
 
       const accessKeyId = await requireSecret(
         secrets,
         declared.storage.access_key_id_ref,
-        `targets.${target}.storage.access_key_id_ref`,
+        `workspaces.${target}.storage.access_key_id_ref`,
         target,
       );
       const secretAccessKey = await requireSecret(
         secrets,
         declared.storage.secret_access_key_ref,
-        `targets.${target}.storage.secret_access_key_ref`,
+        `workspaces.${target}.storage.secret_access_key_ref`,
         target,
       );
 
       const { createS3BlobStore } = await import('./adapters/s3.ts');
       const base = prefix ?? '';
-      const root = layout.blobs(config.instance.profile);
+      const root = layout.blobs();
 
       return (area) =>
         createS3BlobStore({
@@ -289,7 +289,7 @@ export async function requireSecret(
   if (!value) {
     throw new ConfigError(
       `${field} names "${ref}", which is not in this target's secret store. ` +
-        `Store it with: lanes link secrets set ${ref} --target ${target}`,
+        `Store it with: lanes link secrets set ${ref} --workspace ${target}`,
     );
   }
   return value;

--- a/src/deployments/upload.ts
+++ b/src/deployments/upload.ts
@@ -1,6 +1,7 @@
 import {
   openTarget,
   DATA_DIR,
+  CONNECTIONS_FILE,
   WORKSPACE_FILE,
   layout,
   listProfiles,
@@ -55,13 +56,18 @@ export function deployedWorkspace(declared: TargetConfig): string | undefined {
  * forgets means an endpoint that will not boot, and a credential this includes
  * by accident means a credential in a bucket. Forgetting is loud.
  *
- * **Two areas inside `data/` are authored rather than accumulated**, since
- * ADR-030 moved skills and provider manifests into the profile that owns them.
- * They have to go up or a deployed instance loses both — the regression ADR-014
- * §2 fixed for skills, reintroduced by where they now live. So this reaches
- * into `data/` for exactly those two, by whole path segment and never by
- * prefix: `data/personal/skills.detour/` is not `skills.d`, and the difference
- * between matching it and not is a credential in a bucket.
+ * **Two areas inside `data/` are authored rather than accumulated.** Skills and
+ * provider manifests have to go up or a deployed instance loses both — the
+ * regression ADR-014 §2 fixed for skills. So this reaches into `data/` for
+ * exactly those two, by whole path segment and never by prefix:
+ * `data/skills.detour/` is not `skills.d`, and the difference between matching
+ * it and not is a credential in a bucket.
+ *
+ * Neither is filtered by the profile set any more. Both are keyed by connection
+ * now rather than by profile (ADR-057, ADR-059), and a connection can be
+ * granted by any profile in the workspace — so sending "only this profile's
+ * skills" is not a thing that can be computed, and withholding them would
+ * deploy an endpoint whose prompts are missing.
  */
 export function isWorkspaceConfig(key: string, profiles?: readonly string[]): boolean {
   // **Never the workspace file.** It was sent, and it is the one file that must
@@ -74,14 +80,19 @@ export function isWorkspaceConfig(key: string, profiles?: readonly string[]): bo
   // the upload is done.
   if (key === WORKSPACE_FILE) return false;
 
+  // **The connections file always goes up.** It is configuration, the endpoint
+  // cannot resolve a single grant without it, and unlike the registry above
+  // there is nothing machine-specific in it — a connection is a connection
+  // wherever the workspace is read from (ADR-057).
+  if (key === CONNECTIONS_FILE) return true;
+
+  if (isAuthoredArea(key)) return true;
+
   // A set rather than one name, because a deploy now sends every profile that
   // declares the target rather than the single one it was told. `undefined`
   // still means the whole workspace, and an *empty* set means nothing — which
   // is a distinction a bare string could not make.
   const wanted = profiles === undefined ? undefined : new Set(profiles);
-
-  const owner = authoredAreaOwner(key);
-  if (owner !== null) return wanted === undefined || wanted.has(owner);
 
   if (!key.startsWith('profiles/') || !key.endsWith('.yaml')) return false;
   const name = key.slice('profiles/'.length, -'.yaml'.length);
@@ -89,22 +100,25 @@ export function isWorkspaceConfig(key: string, profiles?: readonly string[]): bo
 }
 
 /**
- * The profile whose authored area holds `key`, or null for anything else.
+ * Whether `key` is inside one of the two authored areas.
  *
  * Composed back out of `layout` rather than compared against literals, so a
  * renamed directory moves both this and the store that reads it, or neither.
- * Requires a fourth segment: `data/personal/skills.d` names the directory, and
- * a directory is not a file to send.
+ *
+ * The segment counts differ because the layouts do, and both are the "a
+ * directory is not a file to send" rule: a manifest is `data/providers.d/<file>`
+ * and a skill is `data/skills.d/<connection>/<file>`, so requiring one more
+ * segment than the area itself has is what stops the bare directory key
+ * matching.
  */
-function authoredAreaOwner(key: string): string | null {
+function isAuthoredArea(key: string): boolean {
   const segments = key.split('/');
-  if (segments.length < 4 || segments[0] !== DATA_DIR) return null;
+  if (segments.length < 3 || segments[0] !== DATA_DIR) return false;
 
-  const owner = segments[1]!;
-  if (owner.length === 0) return null;
-
-  const area = `${DATA_DIR}/${owner}/${segments[2]}`;
-  return area === layout.skills(owner) || area === layout.providers(owner) ? owner : null;
+  const area = `${DATA_DIR}/${segments[1]}`;
+  if (area === layout.providers()) return segments.length >= 3;
+  if (area === layout.skillsRoot()) return segments.length >= 4;
+  return false;
 }
 
 /**

--- a/src/deployments/upload.ts
+++ b/src/deployments/upload.ts
@@ -171,7 +171,16 @@ export async function publishWorkspace(input: {
   readonly config: Config;
   readonly workspaceRoot: string;
   readonly target: string;
-  readonly profile: string;
+  /**
+   * The profiles this edit touched, not just the one it was run under.
+   *
+   * `disconnect` removes a connection from the workspace and drops the grant
+   * from *every* profile that named it, so publishing one profile left the
+   * bucket holding a `connections.yaml` without the connection and a sibling
+   * profile still granting it — which `assertGrantsResolve` refuses at load, so
+   * `openReconciled` skipped that profile and it silently stopped being served.
+   */
+  readonly profile: string | readonly string[];
 }): Promise<string | null> {
   // Resolution failures are swallowed rather than thrown. The config edit that
   // called this has already succeeded and is on disk; a target that cannot be
@@ -187,6 +196,7 @@ export async function publishWorkspace(input: {
   const destination = deployedWorkspace(declared);
   if (!destination) return null;
 
-  await uploadWorkspace(input.workspaceRoot, destination, [input.profile]);
+  const touched = typeof input.profile === 'string' ? [input.profile] : input.profile;
+  await uploadWorkspace(input.workspaceRoot, destination, touched);
   return destination;
 }

--- a/src/dispatch/deps.ts
+++ b/src/dispatch/deps.ts
@@ -1,0 +1,88 @@
+import type { Principal } from '#auth';
+import type { AuditSink } from '#audit';
+import type { PolicyDocument, ProfilePolicy, RateLimiter } from '#policy';
+import type { Config, ConnectionConfig } from '#profile';
+import type { ProviderRegistry } from '#registry';
+import type { SecretStore } from '#secrets';
+import type { BlobStore } from '#stores/blobs';
+import type { RuntimeState } from '#stores/state';
+import type { AnyConnector } from '#connectivity';
+import type { Logger } from '#connectivity';
+
+/**
+ * What the dispatcher is given, and what it is asked.
+ *
+ * Split from the dispatcher itself so that file stays inside the size budget.
+ * The seam is real rather than arithmetic: everything here is what a *caller*
+ * assembles, and the class next door is the fixed order in which a call is
+ * authorised and run. Reading one has never required reading the other.
+ */
+
+/**
+ * The dispatch path.
+ *
+ * Every invocation goes through here in one fixed order — authenticate,
+ * resolve, authorize, rate-limit, dispatch, audit — with no way around it.
+ * The ordering is not stylistic: policy is evaluated before a provider is
+ * reached, so a provider never sees a request it was not authorised to serve,
+ * and authorization is never something provider code could get wrong.
+ *
+ * Exactly one audit event is written per invocation, on every path including
+ * denials. That is enforced structurally by `finally` rather than by
+ * remembering to call it at each return.
+ */
+
+export interface DispatchDeps {
+  readonly config: Config;
+  /**
+   * The accounts this workspace holds, and the clients it registered (ADR-057).
+   *
+   * Separate from `config` because neither is the profile's to declare. The
+   * *gate* stays policy: a connection that exists and is not granted resolves
+   * and is then denied `denied_default`, which is the same answer a caller gets
+   * for one that does not exist — two shapes of "no" that read alike, so probing
+   * is not an oracle for what the workspace holds.
+   */
+  readonly connections: readonly ConnectionConfig[];
+  readonly oauthApps: readonly string[];
+  readonly registry: ProviderRegistry;
+  /**
+   * Resolve the connector for a provider. Supplied by the caller so core does
+   * not import connector implementations, keeping the dependency direction
+   * intact: infrastructure -> sdk -> core -> connectors.
+   */
+  readonly connectorFor: (providerId: string, connectionId: string) => AnyConnector | undefined;
+  /** Attach whatever the manifest's auth kind requires to an outbound request. */
+  readonly authorizeRequest?: (
+    providerId: string,
+    connectionId: string,
+    request: Request,
+  ) => Promise<Request>;
+  readonly policy: ProfilePolicy;
+  /** Optional instance floor. Empty in M1; composition is tighten-only. */
+  readonly floor?: PolicyDocument;
+  readonly state: RuntimeState;
+  /**
+   * Where events go. Separate from `state` because the log is no longer in
+   * it — and because dispatch only ever writes, so taking the sink rather than
+   * the whole store means this path structurally cannot read the log back.
+   */
+  readonly audit: AuditSink;
+  readonly credentials: SecretStore;
+  readonly storage: BlobStore;
+  readonly limiter: RateLimiter;
+  readonly log: Logger;
+  readonly now?: () => number;
+}
+
+export interface DispatchRequest {
+  readonly principal: Principal;
+  /** Fully qualified, e.g. `example.echo`. */
+  readonly capabilityId: string;
+  /** Fully qualified, e.g. `example.a`. */
+  readonly connectionKey: string;
+  readonly arguments: Readonly<Record<string, unknown>>;
+  /** Self-reported by the client. Observability only — never authorization. */
+  readonly clientLabel?: string | undefined;
+  readonly signal?: AbortSignal;
+}

--- a/src/dispatch/dispatch.test.ts
+++ b/src/dispatch/dispatch.test.ts
@@ -104,28 +104,25 @@ const testProvider = defineLocalProvider({
 });
 
 const CONFIG = parseConfig(`
-contract: 2
+contract: 3
 instance:
   profile: personal
 limits:
   requests_per_minute: 100
   upstream_calls_per_minute: 100
-connections:
-  - id: a
-    provider: example
-    account: A
-  - id: b
-    provider: example
-    account: B
-  - id: c
-    provider: example
-    account: C
-policy:
-  allow:
-    - "example.*"
-  deny:
-    - "example.purge"
+grants:
+  - { connection: example.a, allow: ['example.*'], deny: ['example.purge'] }
+  - { connection: example.b, allow: ['example.*'], deny: ['example.purge'] }
+  - { connection: example.c, allow: ['example.*'], deny: ['example.purge'] }
+members: []
 `).config;
+
+/** The workspace's accounts, which the dispatcher resolves against (ADR-057). */
+const CONNECTIONS = [
+  { id: 'a', provider: 'example', account: 'A' },
+  { id: 'b', provider: 'example', account: 'B' },
+  { id: 'c', provider: 'example', account: 'C' },
+];
 
 const PRINCIPAL = ownerPrincipal('personal');
 const silent = { debug() {}, info() {}, warn() {}, error() {} };
@@ -148,6 +145,8 @@ function harness(overrides: { limits?: { profile: number; connection: number } }
 
   const dispatcher = new Dispatcher({
     config,
+    connections: CONNECTIONS,
+    oauthApps: [],
     registry,
     connectorFor: (providerId): AnyConnector | undefined => {
       const entry = registry.get(providerId);

--- a/src/dispatch/dispatch.ts
+++ b/src/dispatch/dispatch.ts
@@ -1,9 +1,9 @@
 import type { AuditDraft, AuditLogger, AuditSink, AuthorizationResult } from '#audit';
 import { keepKeys, redactAllValues } from '#audit';
-import type { Principal } from '#auth';
+import { mayReach, type Principal } from '#auth';
 import type { SecretStore } from '#secrets';
 import type { RuntimeState } from '#stores/state';
-import type { PolicyDocument } from '#policy';
+import type { PolicyDocument, ProfilePolicy } from '#policy';
 import { RateLimiter, evaluate } from '#policy';
 import type { BlobStore } from '#stores/blobs';
 import type {
@@ -14,69 +14,14 @@ import type {
   Logger,
 } from '#connectivity';
 import { isToolResult, strategyContextFrom, strategyFor } from '#connectivity';
-import type { Config } from '#profile';
+import type { Config, ConnectionConfig } from '#profile';
 import { buildProviderContext, createProviderLogger } from './context.ts';
 import { fetchStaged, stageAttachment } from './staging.ts';
 import type { FetchStagedRequest, StagedAttachment, StageRequest } from './staging.ts';
 import type { ProviderRegistry } from '#registry';
 
-/**
- * The dispatch path.
- *
- * Every invocation goes through here in one fixed order — authenticate,
- * resolve, authorize, rate-limit, dispatch, audit — with no way around it.
- * The ordering is not stylistic: policy is evaluated before a provider is
- * reached, so a provider never sees a request it was not authorised to serve,
- * and authorization is never something provider code could get wrong.
- *
- * Exactly one audit event is written per invocation, on every path including
- * denials. That is enforced structurally by `finally` rather than by
- * remembering to call it at each return.
- */
-
-export interface DispatchDeps {
-  readonly config: Config;
-  readonly registry: ProviderRegistry;
-  /**
-   * Resolve the connector for a provider. Supplied by the caller so core does
-   * not import connector implementations, keeping the dependency direction
-   * intact: infrastructure -> sdk -> core -> connectors.
-   */
-  readonly connectorFor: (providerId: string, connectionId: string) => AnyConnector | undefined;
-  /** Attach whatever the manifest's auth kind requires to an outbound request. */
-  readonly authorizeRequest?: (
-    providerId: string,
-    connectionId: string,
-    request: Request,
-  ) => Promise<Request>;
-  readonly policy: PolicyDocument;
-  /** Optional instance floor. Empty in M1; composition is tighten-only. */
-  readonly floor?: PolicyDocument;
-  readonly state: RuntimeState;
-  /**
-   * Where events go. Separate from `state` because the log is no longer in
-   * it — and because dispatch only ever writes, so taking the sink rather than
-   * the whole store means this path structurally cannot read the log back.
-   */
-  readonly audit: AuditSink;
-  readonly credentials: SecretStore;
-  readonly storage: BlobStore;
-  readonly limiter: RateLimiter;
-  readonly log: Logger;
-  readonly now?: () => number;
-}
-
-export interface DispatchRequest {
-  readonly principal: Principal;
-  /** Fully qualified, e.g. `example.echo`. */
-  readonly capabilityId: string;
-  /** Fully qualified, e.g. `example.a`. */
-  readonly connectionKey: string;
-  readonly arguments: Readonly<Record<string, unknown>>;
-  /** Self-reported by the client. Observability only — never authorization. */
-  readonly clientLabel?: string | undefined;
-  readonly signal?: AbortSignal;
-}
+export type { DispatchDeps, DispatchRequest } from './deps.ts';
+import type { DispatchDeps, DispatchRequest } from './deps.ts';
 
 /**
  * `result` is a union because a capability is not necessarily a tool — a
@@ -198,7 +143,21 @@ export class Dispatcher {
 
       auditArguments = (redact ?? redactAllValues)(request.arguments);
 
-      const declared = config.connections.find(
+      // **Who, before what.** A caller reaches a profile only if that profile's
+      // `members:` names them (ADR-060), and this is checked before the
+      // connection is even resolved: a refusal that first said "no such
+      // connection" would answer a question the caller was not entitled to ask.
+      // The profile is the principal's: the MCP layer routes on the `profile`
+      // argument and builds the principal for it, so this is the same value the
+      // caller named and the one the audit event records.
+      if (!mayReach(request.principal, request.principal.profile)) {
+        return (outcome = deny(
+          'denied_default',
+          `Profile ${request.principal.profile} is not available`,
+        ));
+      }
+
+      const declared = this.#deps.connections.find(
         (connection) => `${connection.provider}.${connection.id}` === request.connectionKey,
       );
       if (!declared || declared.provider !== providerId) {
@@ -311,7 +270,7 @@ export class Dispatcher {
         // Which vendors this profile registered a client of its own for. A
         // provider that could be brokered but is not reads its client from the
         // store, so it has to be able to.
-        ownClients: Object.keys(this.#deps.config.oauth_apps),
+        ownClients: this.#deps.oauthApps,
         ...(entry.manifest.connector.kind === 'local' ? {} : { authorize }),
       });
 

--- a/src/dispatch/strategy.test.ts
+++ b/src/dispatch/strategy.test.ts
@@ -65,19 +65,15 @@ afterAll(async () => {
 });
 
 const CONFIG = parseConfig(`
-contract: 2
+contract: 3
 instance:
   profile: personal
 limits:
   requests_per_minute: 100
   upstream_calls_per_minute: 100
-connections:
-  - id: main
-    provider: acme
-    account: A
-policy:
-  allow:
-    - "acme.*"
+grants:
+  - { connection: acme.main, allow: ['acme.*'], deny: [] }
+members: []
 `).config;
 
 const manifest = defineProvider({
@@ -136,6 +132,10 @@ function harness() {
 
   const dispatcher = new Dispatcher({
     config: CONFIG,
+    // The accounts are the workspace's now (ADR-057), so the dispatcher is
+    // handed them rather than reading them off the profile it is serving.
+    connections: [{ id: 'main', provider: 'acme', account: 'A' }],
+    oauthApps: [],
     registry,
     connectorFor: (): AnyConnector | undefined => connector as unknown as AnyConnector,
     // A strategy provider must never reach this. It throws so the test would

--- a/src/policy/index.test.ts
+++ b/src/policy/index.test.ts
@@ -6,11 +6,25 @@ import {
   evaluate,
   evaluateDocument,
   type PolicyDocument,
+  type ProfilePolicy,
 } from './index.ts';
 
 const OWNER = 'personal:owner';
 
 const doc = (...rules: PolicyDocument['rules']): PolicyDocument => ({ rules });
+
+/**
+ * A profile's policy: the same rules, against every connection a test names.
+ *
+ * Most of these tests predate ADR-058 and are about the capability axis, where
+ * the connection is incidental — so the default is "these rules, everywhere",
+ * which is exactly what the flat block used to mean. The tests that are *about*
+ * the connection axis build the map themselves.
+ */
+const profileOf = (
+  rules: PolicyDocument,
+  connections: readonly string[] = ['gmail.main', 'example.a', 'example.b', 'example.c'],
+): ProfilePolicy => ({ byConnection: new Map(connections.map((one) => [one, rules])) });
 
 describe('capability matching', () => {
   test('matches exactly', () => {
@@ -65,33 +79,70 @@ describe('default deny', () => {
   });
 });
 
-describe('rules govern every account of a provider alike', () => {
-  // The simplification that replaced per-connection rules: a profile's grant
-  // covers all of its accounts for that provider, and separating two accounts
-  // means running two profiles, which share no database and no credential
-  // store. They do share an endpoint, so that separation is enforced per call.
-  const policy = doc({ capability: 'gmail.*', effect: 'allow' });
+describe('a rule governs one account, not every account of its provider', () => {
+  // The reversal ADR-058 makes, and the reason the whole decoupling was worth
+  // doing. Under contract 2 a profile's rules covered every account of a
+  // provider it held, and separating two mailboxes meant running two profiles.
+  // A grant names the connection now, so one profile can read one mailbox and
+  // write another.
+  const readOnly = doc({ capability: 'gmail.search', effect: 'allow' });
+  const readWrite = doc({ capability: 'gmail.*', effect: 'allow' });
 
-  test('every declared account is covered', () => {
-    for (const connection of ['gmail.work', 'gmail.personal']) {
-      expect(
-        evaluateDocument(policy, { principal: OWNER, capability: 'gmail.search', connection })
-          .allowed,
-      ).toBe(true);
-    }
+  const profile: ProfilePolicy = {
+    byConnection: new Map([
+      ['gmail.personal', readOnly],
+      ['gmail.work', readWrite],
+    ]),
+  };
+
+  test('two accounts of one provider can differ', () => {
+    const send = (connection: string) =>
+      evaluate({ principal: OWNER, capability: 'gmail.send', connection }, profile).allowed;
+
+    expect(send('gmail.work')).toBe(true);
+    expect(send('gmail.personal')).toBe(false);
   });
 
-  test('a deny covers every account too', () => {
-    const withDeny = doc(
-      { capability: 'gmail.*', effect: 'allow' },
-      { capability: 'gmail.send', effect: 'deny' },
-    );
-    for (const connection of ['gmail.work', 'gmail.personal']) {
-      expect(
-        evaluateDocument(withDeny, { principal: OWNER, capability: 'gmail.send', connection })
-          .allowed,
-      ).toBe(false);
-    }
+  test('discovery offers only the accounts the capability is granted on', () => {
+    const connections = ['gmail.personal', 'gmail.work'];
+
+    expect(allowedConnections('gmail.search', connections, OWNER, profile)).toEqual(connections);
+    expect(allowedConnections('gmail.send', connections, OWNER, profile)).toEqual(['gmail.work']);
+  });
+
+  test('a connection with no row at all is denied and never offered', () => {
+    // Default deny on the connection axis. Absent is not the same as granted
+    // nothing: the first is unreachable, the second is reachable and permits no
+    // capability, and only the second appears anywhere.
+    expect(
+      evaluate(
+        { principal: OWNER, capability: 'gmail.search', connection: 'gmail.other' },
+        profile,
+      ).reason,
+    ).toBe('denied_default');
+
+    expect(allowedConnections('gmail.search', ['gmail.other'], OWNER, profile)).toEqual([]);
+  });
+
+  test('a deny on one row leaves the other alone', () => {
+    const narrowed: ProfilePolicy = {
+      byConnection: new Map([
+        ['gmail.personal', doc({ capability: 'gmail.*', effect: 'allow' })],
+        [
+          'gmail.work',
+          doc(
+            { capability: 'gmail.*', effect: 'allow' },
+            { capability: 'gmail.send', effect: 'deny' },
+          ),
+        ],
+      ]),
+    };
+
+    const send = (connection: string) =>
+      evaluate({ principal: OWNER, capability: 'gmail.send', connection }, narrowed).allowed;
+
+    expect(send('gmail.personal')).toBe(true);
+    expect(send('gmail.work')).toBe(false);
   });
 });
 
@@ -188,8 +239,8 @@ describe('tighten-only composition', () => {
     const floor = EMPTY_POLICY; // grants nothing
     const profile = doc({ capability: 'gmail.*', effect: 'allow' });
 
-    expect(evaluate(request, profile).allowed).toBe(true); // no floor: allowed
-    expect(evaluate(request, profile, floor).allowed).toBe(false); // floor withholds
+    expect(evaluate(request, profileOf(profile)).allowed).toBe(true); // no floor: allowed
+    expect(evaluate(request, profileOf(profile), floor).allowed).toBe(false); // floor withholds
   });
 
   test('the profile cannot allow what the floor explicitly denied', () => {
@@ -199,7 +250,7 @@ describe('tighten-only composition', () => {
     );
     const profile = doc({ capability: 'gmail.search', effect: 'allow' });
 
-    expect(evaluate(request, profile, floor).allowed).toBe(false);
+    expect(evaluate(request, profileOf(profile), floor).allowed).toBe(false);
   });
 
   test('a profile-level * cannot widen past the floor', () => {
@@ -208,9 +259,9 @@ describe('tighten-only composition', () => {
     const floor = doc({ capability: 'gmail.search', effect: 'allow' });
     const profile = doc({ capability: '*', effect: 'allow' });
 
-    expect(evaluate(request, profile, floor).allowed).toBe(true);
+    expect(evaluate(request, profileOf(profile), floor).allowed).toBe(true);
     expect(
-      evaluate({ ...request, capability: 'gmail.send' }, profile, floor).allowed,
+      evaluate({ ...request, capability: 'gmail.send' }, profileOf(profile), floor).allowed,
     ).toBe(false);
   });
 
@@ -221,9 +272,9 @@ describe('tighten-only composition', () => {
       { capability: 'gmail.search', effect: 'deny' },
     );
 
-    expect(evaluate(request, profile, floor).allowed).toBe(false);
+    expect(evaluate(request, profileOf(profile), floor).allowed).toBe(false);
     expect(
-      evaluate({ ...request, capability: 'gmail.get_message' }, profile, floor).allowed,
+      evaluate({ ...request, capability: 'gmail.get_message' }, profileOf(profile), floor).allowed,
     ).toBe(true);
   });
 });
@@ -234,14 +285,14 @@ describe('discovery filtering', () => {
   test('a granted capability exposes every account; an ungranted one exposes none', () => {
     const policy = doc({ capability: 'example.get_note', effect: 'allow' });
 
-    expect(allowedConnections('example.get_note', connections, OWNER, policy)).toEqual(connections);
-    expect(allowedConnections('example.set_note', connections, OWNER, policy)).toEqual([]);
-    expect(allowedConnections('example.echo', connections, OWNER, EMPTY_POLICY)).toEqual([]);
+    expect(allowedConnections('example.get_note', connections, OWNER, profileOf(policy, connections))).toEqual(connections);
+    expect(allowedConnections('example.set_note', connections, OWNER, profileOf(policy, connections))).toEqual([]);
+    expect(allowedConnections('example.echo', connections, OWNER, { byConnection: new Map() })).toEqual([]);
   });
 
   test('no connections means nothing to expose, rather than an error', () => {
     const policy = doc({ capability: '*', effect: 'allow' });
-    expect(allowedConnections('example.echo', [], OWNER, policy)).toEqual([]);
+    expect(allowedConnections('example.echo', [], OWNER, profileOf(policy))).toEqual([]);
   });
 
   test('a capability only ever offers its own provider’s accounts', () => {
@@ -249,30 +300,33 @@ describe('discovery filtering', () => {
     // Notion account, however broad the grant. Under a catch-all this is the
     // only thing keeping the enum honest.
     const mixed = ['gmail.work', 'gmail.home', 'notion.main', 'example.a'];
-    const policy = doc({ capability: '*', effect: 'allow' });
+    const granted = profileOf(doc({ capability: '*', effect: 'allow' }), mixed);
 
-    expect(allowedConnections('gmail.search', mixed, OWNER, policy)).toEqual([
+    expect(allowedConnections('gmail.search', mixed, OWNER, granted)).toEqual([
       'gmail.work',
       'gmail.home',
     ]);
-    expect(allowedConnections('notion.search', mixed, OWNER, policy)).toEqual(['notion.main']);
-    expect(allowedConnections('drive.search', mixed, OWNER, policy)).toEqual([]);
+    expect(allowedConnections('notion.search', mixed, OWNER, granted)).toEqual(['notion.main']);
+    expect(allowedConnections('drive.search', mixed, OWNER, granted)).toEqual([]);
   });
 
   test('a provider whose name prefixes another is not confused for it', () => {
     // `gmail.` rather than `gmail`, or `gmailx.main` would come along too.
     const policy = doc({ capability: '*', effect: 'allow' });
-    expect(allowedConnections('gmail.search', ['gmailx.main'], OWNER, policy)).toEqual([]);
+    expect(
+      allowedConnections('gmail.search', ['gmailx.main'], OWNER, profileOf(policy, ['gmailx.main'])),
+    ).toEqual([]);
   });
 
   test('discovery uses the same evaluation as invocation', () => {
     // If these could disagree, a leak in discovery would still be a leak.
     const policy = doc({ capability: 'example.echo', effect: 'allow' });
     for (const capability of ['example.echo', 'example.set_note']) {
-      const visible = allowedConnections(capability, connections, OWNER, policy).length > 0;
+      const granted = profileOf(policy, connections);
+      const visible = allowedConnections(capability, connections, OWNER, granted).length > 0;
       const invocable = evaluate(
         { principal: OWNER, capability, connection: 'example.a' },
-        policy,
+        granted,
       ).allowed;
       expect(visible).toBe(invocable);
     }

--- a/src/policy/index.ts
+++ b/src/policy/index.ts
@@ -14,6 +14,11 @@
  *      withheld. The floor is empty in M1 — the invariant is implemented
  *      anyway, because it is what makes delegated access safe to add later,
  *      and retrofitting it once rules exist in the wild is not possible.
+ *
+ * Since contract 3 a profile's rules are grouped by the connection they govern
+ * (ADR-058). Both invariants are unchanged and one is now sharper: a connection
+ * with no rules at all is not merely unmatched, it is absent, so default deny
+ * bites before a capability is even considered.
  */
 
 export type { AuthorizationResult } from '#audit';
@@ -42,6 +47,26 @@ export interface PolicyDocument {
 }
 
 export const EMPTY_POLICY: PolicyDocument = { rules: [] };
+
+/**
+ * A profile's rules, grouped by the connection each governs (ADR-058).
+ *
+ * A map rather than one list carrying a connection per rule, because the
+ * lookup is the decision: a call names exactly one connection, and the rules
+ * for any other are not evidence about it. Flattening them into one list would
+ * mean every evaluation re-filtered, and a filter that was ever wrong would let
+ * one account's `allow` answer for another.
+ *
+ * A connection absent from the map is not granted. That is default deny on the
+ * connection axis, and it is why `grants:` with an empty `allow` is a different
+ * thing from no row at all — the first says "reachable, nothing permitted", the
+ * second says "not reachable".
+ */
+export interface ProfilePolicy {
+  readonly byConnection: ReadonlyMap<string, PolicyDocument>;
+}
+
+export const EMPTY_PROFILE_POLICY: ProfilePolicy = { byConnection: new Map() };
 
 export interface PolicyRequest {
   /**
@@ -131,14 +156,21 @@ export function evaluateDocument(
  */
 export function evaluate(
   request: PolicyRequest,
-  profile: PolicyDocument,
+  profile: ProfilePolicy,
   floor?: PolicyDocument,
 ): PolicyDecision {
   if (floor) {
     const floorDecision = evaluateDocument(floor, request);
     if (!floorDecision.allowed) return floorDecision;
   }
-  return evaluateDocument(profile, request);
+
+  // The floor is still evaluated against the whole request, because a floor is
+  // an instance-wide narrowing and knows nothing about which connections a
+  // profile happens to hold. Only the profile's half is per connection.
+  const granted = profile.byConnection.get(request.connection);
+  if (granted === undefined) return { allowed: false, reason: 'denied_default' };
+
+  return evaluateDocument(granted, request);
 }
 
 /**
@@ -153,7 +185,7 @@ export function allowedConnections(
   capability: string,
   connections: readonly string[],
   principal: string,
-  profile: PolicyDocument,
+  profile: ProfilePolicy,
   floor?: PolicyDocument,
   at?: Date,
 ): string[] {
@@ -164,16 +196,16 @@ export function allowedConnections(
   const provider = capability.slice(0, capability.indexOf('.'));
   const ofProvider = connections.filter((connection) => connection.startsWith(`${provider}.`));
 
-  // All or nothing beyond that, since rules do not discriminate between
-  // accounts. The list shape is kept because it is what the `connection` enum
-  // wants, and because a future principal-scoped rule would restore the
-  // filtering without touching any caller.
-  const first = ofProvider[0];
-  if (first === undefined) return [];
+  // One evaluation per account, where this used to be all-or-nothing. That
+  // difference is the whole of ADR-058 at the discovery boundary: a profile
+  // holding two mailboxes with different rules now advertises the `connection`
+  // enum each capability actually permits, instead of offering both wherever
+  // either was allowed.
+  return ofProvider.filter((connection) => {
+    const request: PolicyRequest = at
+      ? { principal, capability, connection, at }
+      : { principal, capability, connection };
 
-  const request: PolicyRequest = at
-    ? { principal, capability, connection: first, at }
-    : { principal, capability, connection: first };
-
-  return evaluate(request, profile, floor).allowed ? ofProvider : [];
+    return evaluate(request, profile, floor).allowed;
+  });
 }

--- a/src/profile/connections.ts
+++ b/src/profile/connections.ts
@@ -1,0 +1,164 @@
+import { ConfigError, describeRename } from './load.ts';
+import type { Config, ConnectionConfig, GrantConfig } from './schema.ts';
+
+/**
+ * The join between a profile and the workspace it lives in.
+ *
+ * A connection is declared once, in `connections.yaml`, and a profile names the
+ * ones it selects in `grants:` (ADR-057). Nothing downstream should perform
+ * that join itself: `dispatch`, `visibility`, `status`, `setup` and the
+ * reconciler all want the same answer — *which accounts does this profile
+ * reach, and what may be done with each* — and three implementations of one
+ * join is three chances for discovery and enforcement to disagree, which is the
+ * failure `allowedConnections` exists to prevent on the capability axis.
+ *
+ * So this file answers it once and everything else asks.
+ */
+
+/** `<provider>.<id>` — the same string an agent passes as `connection`. */
+export function connectionRefOf(connection: ConnectionConfig): string {
+  return `${connection.provider}.${connection.id}`;
+}
+
+/**
+ * One account this profile reaches, with the rules that govern it.
+ *
+ * The grant travels with the connection deliberately. Every caller that has a
+ * connection in its hand is about to ask what may be done with it, and handing
+ * back a pair removes the second lookup — along with the possibility of pairing
+ * a connection with the wrong profile's grant, which is the one mistake this
+ * shape makes unrepresentable.
+ */
+export interface SelectedConnection {
+  readonly ref: string;
+  readonly connection: ConnectionConfig;
+  readonly grant: GrantConfig;
+}
+
+/**
+ * The connections a profile selects, in the order it declares them.
+ *
+ * Declaration order rather than the workspace's, because the profile is what
+ * this is a view of, and a listing that reordered the owner's own file would be
+ * answering a question nobody asked. A grant naming a connection that does not
+ * exist is skipped here and refused by `assertGrantsResolve` at load — this
+ * function is a view, not a gate, and a view that threw would make every
+ * listing depend on the config being valid.
+ */
+export function selectConnections(
+  config: Config,
+  available: readonly ConnectionConfig[],
+): SelectedConnection[] {
+  const byRef = new Map(available.map((connection) => [connectionRefOf(connection), connection]));
+
+  return config.grants.flatMap((grant) => {
+    const connection = byRef.get(grant.connection);
+    return connection === undefined ? [] : [{ ref: grant.connection, connection, grant }];
+  });
+}
+
+/**
+ * Every reference in a profile resolves, and nothing is granted twice.
+ *
+ * Two failures, and the second is the one worth having a check for. A grant
+ * naming a connection the workspace does not hold is visible the moment anyone
+ * looks — the surface is simply absent. Two grants naming the *same* connection
+ * is not: one of them silently wins, and which one depends on iteration order,
+ * so a profile could deny a capability in one row and allow it in another and
+ * behave differently between releases. Refusing at load is what keeps
+ * `grants:` a set rather than a sequence with precedence.
+ */
+export function assertGrantsResolve(
+  config: Config,
+  available: readonly ConnectionConfig[],
+): void {
+  const refs = new Set(available.map(connectionRefOf));
+
+  const missing = config.grants
+    .map((grant) => grant.connection)
+    .filter((ref) => !refs.has(ref));
+
+  if (missing.length > 0) {
+    throw new ConfigError(
+      `Profile "${config.instance.profile}" grants a connection this workspace does not hold: ` +
+        `${[...new Set(missing)].join(', ')}.\n` +
+        `  Connections live in connections.yaml. Run "lanes link connection list" to see them.`,
+    );
+  }
+
+  const seen = new Set<string>();
+  const duplicated = config.grants
+    .map((grant) => grant.connection)
+    .filter((ref) => (seen.has(ref) ? true : (seen.add(ref), false)));
+
+  if (duplicated.length > 0) {
+    throw new ConfigError(
+      `Profile "${config.instance.profile}" grants the same connection more than once: ` +
+        `${[...new Set(duplicated)].join(', ')}.\n` +
+        `  One row per connection — merge the allow and deny lists into it.`,
+    );
+  }
+}
+
+/**
+ * No two connections in a workspace share a reference.
+ *
+ * `<provider>.<id>` is what a credential ref is derived from and what an agent
+ * names, so a duplicate is two accounts answering to one address. It was
+ * impossible to express before contract 3 only because a profile held its own
+ * list; one workspace-wide list makes it expressible, so it has to be refused.
+ */
+export function assertConnectionsUnique(connections: readonly ConnectionConfig[]): void {
+  const seen = new Set<string>();
+  const duplicated = connections
+    .map(connectionRefOf)
+    .filter((ref) => (seen.has(ref) ? true : (seen.add(ref), false)));
+
+  if (duplicated.length > 0) {
+    throw new ConfigError(
+      `connections.yaml declares the same connection more than once: ` +
+        `${[...new Set(duplicated)].join(', ')}.\n` +
+        `  A connection is addressed as "<provider>.<id>", so two rows sharing one ` +
+        `are two accounts at one address.`,
+    );
+  }
+}
+
+/**
+ * The one connection this profile grants for a single-instance provider.
+ *
+ * `undefined` when it grants none, which is a legitimate state: a profile that
+ * denies `skills.*` reaches no skills, and the surface is absent rather than
+ * empty.
+ */
+export function soleGrantFor(config: Config, provider: string): string | undefined {
+  const prefix = `${provider}.`;
+  const granted = config.grants.find((grant) => grant.connection.startsWith(prefix));
+  return granted?.connection.slice(prefix.length);
+}
+
+/**
+ * A connection whose provider id moved out from under it.
+ *
+ * `tasks` is the built-in task list; Google's is `google_tasks` (ADR-051). A row
+ * that still says `tasks` and names an address rather than the built-in's own
+ * label is somebody's Google account resolving to the wrong provider — and the
+ * failure is silent in the worst way: the row loads, reconcile calls it active,
+ * and every call goes to an empty local store.
+ *
+ * Here rather than in the profile loader, because the evidence is the *account*
+ * and accounts live in this file.
+ */
+export function assertNoRenamedProviders(
+  connections: readonly ConnectionConfig[],
+  repair: string,
+): void {
+  const problems = connections.flatMap((connection, index) => {
+    const renamed = describeRename(connection, repair);
+    return renamed === null ? [] : [`connections[${index}]: ${renamed}`];
+  });
+
+  if (problems.length > 0) {
+    throw new ConfigError(`connections.yaml:\n${problems.map((p) => `  ${p}`).join('\n')}`, problems);
+  }
+}

--- a/src/profile/connections.ts
+++ b/src/profile/connections.ts
@@ -1,5 +1,5 @@
 import { ConfigError, describeRename } from './load.ts';
-import type { Config, ConnectionConfig, GrantConfig } from './schema.ts';
+import type { Config, ConnectionConfig, GrantConfig, TargetConfig } from './schema.ts';
 
 /**
  * The join between a profile and the workspace it lives in.
@@ -135,6 +135,25 @@ export function soleGrantFor(config: Config, provider: string): string | undefin
   const prefix = `${provider}.`;
   const granted = config.grants.find((grant) => grant.connection.startsWith(prefix));
   return granted?.connection.slice(prefix.length);
+}
+
+/**
+ * Where this profile's vault document lives, in one spelling.
+ *
+ * **Two places derived this, and they disagreed.** `openVault` names it per
+ * connection (ADR-059) — `vault/main` for a profile granting `vault.main` — and
+ * the deploy's provisioning step named `vault/document`, the contract-2 constant.
+ * So every deployed workspace that did not hand-write `vault.ref` created and
+ * granted one secret and then asked Secret Manager for another: the revision got
+ * `PERMISSION_DENIED` on the ref nothing had made, exited 1, and never listened
+ * on its port. A deploy that hand-wrote a `ref` worked, which is what kept this
+ * out of sight — a rehearsal that sets one is testing the path nobody takes.
+ *
+ * `ref` still wins where it is written, because a deployment already sealing
+ * under one name has to keep opening it.
+ */
+export function vaultRef(declared: TargetConfig | undefined, config: Config): string {
+  return declared?.vault?.ref ?? `vault/${soleGrantFor(config, 'vault') ?? 'main'}`;
 }
 
 /**

--- a/src/profile/deployments.test.ts
+++ b/src/profile/deployments.test.ts
@@ -9,7 +9,7 @@ import { readRegistry } from './registry.ts';
 /**
  * Writing the target registry.
  *
- * This used to be an *index* beside the profile's own `targets:` block, and
+ * This used to be an *index* beside the profile's own `workspaces:` block, and
  * every test here was about one property: that losing `targets.cloud` from a
  * profile did not lose the deployment. ADR-052 removed the block, so the
  * property is no longer something to preserve — it is the only shape there is.
@@ -34,15 +34,15 @@ afterAll(async () => {
 
 describe('recording where a target lives', () => {
   test('a workspace with no registry reports none, rather than failing', async () => {
-    const root = await workspace('contract: 2\n');
+    const root = await workspace('contract: 3\n');
     expect(await readRegistry(root)).toEqual({});
   });
 
   test('a recorded pointer is found again by target', async () => {
     const root = await workspace();
-    await recordTarget(root, 'cloud', { workspace: 'gs://your-bucket' });
+    await recordTarget(root, 'cloud', { at: 'gs://your-bucket' });
 
-    expect((await readRegistry(root))['cloud']).toMatchObject({ workspace: 'gs://your-bucket' });
+    expect((await readRegistry(root))['cloud']).toMatchObject({ at: 'gs://your-bucket' });
   });
 
   test('a pointer replaces a declaration rather than merging with it', async () => {
@@ -50,10 +50,10 @@ describe('recording where a target lives', () => {
     // An entry carrying both a `workspace:` and adapters is what the schema
     // refuses, so merging here would write a file that cannot be read back.
     const root = await workspace();
-    await recordTarget(root, 'cloud', { workspace: 'gs://your-bucket' });
+    await recordTarget(root, 'cloud', { at: 'gs://your-bucket' });
 
     const entry = (await readRegistry(root))['cloud']!;
-    expect(entry.workspace).toBe('gs://your-bucket');
+    expect(entry.at).toBe('gs://your-bucket');
     expect(entry.credentials).toBeUndefined();
     expect(entry.storage).toBeUndefined();
   });
@@ -61,27 +61,27 @@ describe('recording where a target lives', () => {
   test('redeploying the same target replaces its entry, and does not append', async () => {
     // A second entry would be a history, and a history is a thing to read wrong.
     const root = await workspace();
-    await recordTarget(root, 'cloud', { workspace: 'gs://first-bucket' });
-    await recordTarget(root, 'cloud', { workspace: 'gs://second-bucket' });
+    await recordTarget(root, 'cloud', { at: 'gs://first-bucket' });
+    await recordTarget(root, 'cloud', { at: 'gs://second-bucket' });
 
     const registry = await readRegistry(root);
     expect(Object.keys(registry).filter((name) => name === 'cloud')).toHaveLength(1);
-    expect(registry['cloud']?.workspace).toBe('gs://second-bucket');
+    expect(registry['cloud']?.at).toBe('gs://second-bucket');
   });
 
   test('a declaration replaces a pointer, so a bucket never points at itself', async () => {
     // `deploy` writes the bucket's own registry after the upload. Merging there
-    // left this machine's `workspace:` on the entry — and a bucket pointing at
+    // left this machine's `at:` on the entry — and a bucket pointing at
     // itself is a loop `openTarget` refuses, on the target just deployed.
-    const root = await workspace('contract: 2\n');
-    await recordTarget(root, 'cloud', { workspace: 'gs://your-bucket', primary: 'personal' });
+    const root = await workspace('contract: 3\n');
+    await recordTarget(root, 'cloud', { at: 'gs://your-bucket', primary: 'personal' });
     await recordTarget(root, 'cloud', {
       credentials: { adapter: 'gcp-secret-manager', project: 'p' },
       storage: { adapter: 'gcs', bucket: 'your-bucket' },
     });
 
     const entry = (await readRegistry(root))['cloud']!;
-    expect(entry.workspace).toBeUndefined();
+    expect(entry.at).toBeUndefined();
     expect(entry.storage?.bucket).toBe('your-bucket');
     // The deploy record is the one thing that crosses either way.
     expect(entry.primary).toBe('personal');
@@ -93,11 +93,11 @@ describe('recording where a target lives', () => {
     // rest of the entry is being replaced wholesale.
     const root = await workspace();
     await recordTarget(root, 'cloud', {
-      workspace: 'gs://your-bucket',
+      at: 'gs://your-bucket',
       primary: 'personal',
       last_deploy_version: '0.6.5',
     });
-    await recordTarget(root, 'cloud', { workspace: 'gs://your-bucket' });
+    await recordTarget(root, 'cloud', { at: 'gs://your-bucket' });
 
     const entry = (await readRegistry(root))['cloud']!;
     expect(entry.primary).toBe('personal');
@@ -109,9 +109,9 @@ describe('recording where a target lives', () => {
   });
 
   test('two targets are two entries', async () => {
-    const root = await workspace('contract: 2\n');
-    await recordTarget(root, 'cloud', { workspace: 'gs://one-bucket' });
-    await recordTarget(root, 'staging', { workspace: 'gs://two-bucket' });
+    const root = await workspace('contract: 3\n');
+    await recordTarget(root, 'cloud', { at: 'gs://one-bucket' });
+    await recordTarget(root, 'staging', { at: 'gs://two-bucket' });
 
     expect(Object.keys(await readRegistry(root))).toEqual(['cloud', 'staging']);
   });
@@ -124,8 +124,8 @@ describe('recording where a target lives', () => {
   });
 
   test('the operator’s comments survive being written to', async () => {
-    const root = await workspace('# why this workspace exists\ncontract: 2\n');
-    await recordTarget(root, 'cloud', { workspace: 'gs://your-bucket' });
+    const root = await workspace('# why this workspace exists\ncontract: 3\n');
+    await recordTarget(root, 'cloud', { at: 'gs://your-bucket' });
 
     expect(await readFile(join(root, 'lanes-link.yaml'), 'utf8')).toContain(
       '# why this workspace exists',

--- a/src/profile/deployments.ts
+++ b/src/profile/deployments.ts
@@ -78,12 +78,12 @@ async function editRegistry(
     (await readWorkspaceFile(files, WORKSPACE_FILE)) ?? `contract: ${SUPPORTED_CONTRACT}\n`;
 
   const document = parseDocument(text);
-  const targets = (document.toJSON()?.targets ?? {}) as Record<string, WorkspaceTarget>;
+  const targets = (document.toJSON()?.workspaces ?? {}) as Record<string, WorkspaceTarget>;
 
   edit(targets);
 
-  if (Object.keys(targets).length === 0) document.deleteIn(['targets']);
-  else document.setIn(['targets'], sorted(targets));
+  if (Object.keys(targets).length === 0) document.deleteIn(['workspaces']);
+  else document.setIn(['workspaces'], sorted(targets));
 
   // Validated before it lands, on the rendered tree rather than the input, so
   // what is checked is what would be read back.

--- a/src/profile/identity.test.ts
+++ b/src/profile/identity.test.ts
@@ -14,14 +14,11 @@ import { parseConfig } from './load.ts';
  * directions: prose passes, and a credential pasted into a value does not.
  */
 
-const PROFILE = `contract: 2
+const PROFILE = `contract: 3
 instance:
   profile: personal
-connections:
-  - { id: main, provider: identity, account: Identity }
-policy:
-  allow: [identity.*]
-  deny: []
+grants: []
+members: []
 `;
 
 /** The profile above, with an `identity` block appended. */

--- a/src/profile/index.ts
+++ b/src/profile/index.ts
@@ -48,6 +48,7 @@ export {
   connectionRefOf,
   selectConnections,
   soleGrantFor,
+  vaultRef,
   type SelectedConnection,
 } from './connections.ts';
 

--- a/src/profile/index.ts
+++ b/src/profile/index.ts
@@ -1,10 +1,14 @@
 /**
  * A profile: its file, its schema, and where it lives on disk.
  *
- * **One profile = one config = one database = one credential store.** Profiles
- * share an endpoint and its token (ADR-009); they never share state. This
- * component owns everything about what a profile *is* — the YAML contract, the
- * loader that validates it, and the workspace resolution that finds it.
+ * **A profile is a selection, not an inventory.** Since contract 3 the accounts
+ * live in the workspace's `connections.yaml` and a profile names the ones it
+ * grants (ADR-057), so profiles share an endpoint, its token, the credential
+ * store, and any connection they both select. What they do not share is the
+ * grant: two profiles on one mailbox can permit entirely different things
+ * (ADR-058). This component owns everything about what a profile *is* — the
+ * YAML contract, the loader that validates it, the join onto the workspace's
+ * connections, and the resolution that finds them.
  *
  * What it deliberately does not own: which providers exist (`#registry`) and
  * how a call runs (`#dispatch`). Those were all one package called `core`,
@@ -15,20 +19,37 @@ export {
   DEPLOY_DEFAULTS,
   SUPPORTED_CONTRACT,
   configSchema,
+  SINGLE_INSTANCE_PROVIDERS,
+  connectionsFileSchema,
   declaredTarget,
+  grantSchema,
   isPointer,
+  memberSchema,
   workspaceSchema,
   workspaceTargetSchema,
   type AuthorizationConfig,
   type Config,
   type ConnectionConfig,
+  type ConnectionsFile,
   type DeployConfig,
+  type GrantConfig,
   type IdentityEntry,
+  type MemberConfig,
   type PolicyRuleConfig,
   type TargetConfig,
   type WorkspaceConfig,
   type WorkspaceTarget,
 } from './schema.ts';
+
+export {
+  assertConnectionsUnique,
+  assertGrantsResolve,
+  assertNoRenamedProviders,
+  connectionRefOf,
+  selectConnections,
+  soleGrantFor,
+  type SelectedConnection,
+} from './connections.ts';
 
 export {
   KNOWLEDGE_LAYOUT,
@@ -103,6 +124,8 @@ export {
   writeWorkspaceFile,
 } from './files.ts';
 export {
+  CONNECTIONS_FILE,
+  readConnections,
   type ProfileSelection,
   type Resolution,
   type ResolveOptions,
@@ -111,5 +134,4 @@ export {
 export {
   DATA_DIR,
   layout,
-  profileDir,
 } from './layout.ts';

--- a/src/profile/index.ts
+++ b/src/profile/index.ts
@@ -52,6 +52,8 @@ export {
   type SelectedConnection,
 } from './connections.ts';
 
+export { PAIR_CERT_REF, PAIR_KEY_REF, PAIR_TOKEN_REF } from './pairing.ts';
+
 export {
   KNOWLEDGE_LAYOUT,
   knowledgeRoot,

--- a/src/profile/layout.ts
+++ b/src/profile/layout.ts
@@ -1,123 +1,111 @@
 /**
- * Where a profile's data lives, in one place.
+ * Where a workspace's data lives, in one place.
  *
  * ```
  * ~/.lanes-link/
- * ├── lanes-link.yaml           which profiles exist, which is default
- * ├── profiles/<name>.yaml      each profile's declared config
+ * ├── lanes-link.yaml           the workspaces this machine knows, and the default
+ * ├── connections.yaml          every account authorised in this workspace
+ * ├── profiles/<name>.yaml      which of them a profile selects, and who may use it
  * └── data/
- *     └── <profile>/            everything one profile owns
- *         ├── state.kv/         state, connections, cursors
- *         ├── audit.log/        one object per event
- *         ├── credentials.enc   system credentials, and its .key
- *         ├── vault.enc         the owner's items, its own key
- *         ├── skills.d/         procedures, one <name>/SKILL.md each
- *         ├── providers.d/      the operator's own provider manifests
- *         └── <provider>/<connection>/…   whatever that provider stores
+ *     ├── state.kv/             state, connections, cursors
+ *     ├── audit.log/            one object per event, one chain
+ *     ├── credentials.enc       system credentials, and its .key
+ *     ├── vault.d/<id>.enc      one sealed document per vault connection
+ *     ├── skills.d/<id>/        procedures, one <name>/SKILL.md each
+ *     ├── providers.d/          the operator's own provider manifests
+ *     └── <provider>/<connection>/…   whatever that provider stores
  * ```
  *
- * **One profile, one directory.** Before this, `data/` held
- * `personal.db`, `personal.credentials.enc`, `personal.credentials.enc.key`,
- * `work.db`, and a `personal/` directory, all in one flat listing — three
- * profiles' worth of state interleaved, and no single thing to copy, back up, or
- * delete. Now `rm -r data/work` is exactly "remove the work profile's data" and
- * nothing else.
+ * **Nothing here takes a profile.** It used to take one for everything: a
+ * profile owned a directory, and `rm -r data/work` was the whole answer to
+ * "remove the work profile's data". A connection belongs to the workspace now
+ * (ADR-057) and so do the stores behind the owner layer (ADR-059), so a profile
+ * owns no bytes at all — it owns a selection, and the thing a selection points
+ * at outlives it. `profile remove` prints what survives rather than letting the
+ * difference go unnoticed.
  *
- * **The blob root is the profile directory itself.** It used to be a `files/`
- * subdirectory, which bought nothing and cost a level: a memory entry landed at
- * `data/personal/files/memory/memory/entry/<id>.md`. The provider name and the
- * connection name are the isolation boundary (`scopeBlobStore` namespaces
- * `<provider>/<connection>`) and they are enough on their own, so an entry is
- * now `data/personal/memory/main/<id>.md`. There is no collision risk with the
- * files beside it: a provider id is `[a-z][a-z0-9_]*` and every reserved name
- * here contains a dot.
+ * **The dot is load-bearing, and it is the only thing keeping these apart from
+ * a provider.** The blob root is `data/` and a provider is namespaced
+ * `<provider>/<connection>` under it; a provider id is `[a-z][a-z0-9_]*`, so a
+ * name carrying a dot is one no provider can be scoped into. That is not
+ * hypothetical for three of the five names below — `skills`, `vault` and
+ * `audit` are all real provider ids, and without the dot each would be handed a
+ * store rooted inside the thing it is meant to be walled off from, which is a
+ * hole in ADR-007's wall rather than an untidy filename.
  *
- * **Skills and provider manifests are the profile's too**, which reverses where
- * both used to sit. They were at the workspace root, shared by every profile, on
- * the reasoning that a procedure is not private to a profile the way its
- * knowledge is. That was wrong twice over. A skill is instructions an agent will
- * be handed, and ADR-014 §1 already treats authoring one as a grant worth
- * governing — an odd thing to say about a document every profile reads anyway.
- * And a procedure written for work names work's accounts, its people, and its
- * conventions, so it is exactly as private as the knowledge it operates on.
- * ADR-030 has the argument; ADR-009's "profiles share nothing" is what it
- * restores.
+ * `vault.d/<id>.enc` rather than `vault/<id>.enc` for exactly that reason. The
+ * sealed document is not a blob the vault provider serves, and a `vault/`
+ * prefix shared between the two would put the ciphertext inside the namespace
+ * the provider is given.
  *
- * The `.d` suffix is the dot rule above rather than decoration. A plain
- * `data/<profile>/skills/` is precisely the namespace the skills provider's own
- * blobs scope into, so the one name that could not be used is the obvious one.
- *
- * These are **defaults**. A profile that declares its own paths keeps them.
- *
- * There is no migration from the layout this replaced, deliberately: a
- * workspace is profiles, credentials, and whatever the owner has stored, and
- * re-creating one is `lanes link profile add` plus `lanes link connect` per account. Machinery
- * to move an old one would be more code than the thing it moves, and it would
- * have to keep working forever to be worth having. Skills and manifests left at
- * the old workspace-root paths are the same case: they stop loading, and moving
- * them is one `mv` per profile that should see them.
+ * These are **defaults**. A workspace that declares its own paths keeps them.
  */
 
-/** The directory under the workspace root that holds every profile's data. */
+/** The directory under the workspace root that holds everything the workspace owns. */
 export const DATA_DIR = 'data';
 
 /**
- * Everything one profile owns, relative to the workspace root.
+ * No leading `./` on any of these.
  *
- * No leading `./`. It used to carry one, which `path.resolve` discards and an
- * object key does not: a bucket read `./data/personal/state.kv/x` as a
- * directory literally named `.`, so every deployed key landed one level away
- * from where the config said it did. The visible cost was that the conditioned
- * IAM binding `deployments/gcp/provision.ts` writes — which grants writes under
+ * It used to carry one, which `path.resolve` discards and an object key does
+ * not: a bucket read `./data/state.kv/x` as a directory literally named `.`, so
+ * every deployed key landed one level away from where the config said it did.
+ * The visible cost was that the conditioned IAM binding
+ * `deployments/gcp/provision.ts` writes — which grants writes under
  * `objects/data/` — matched nothing, and the first revision 403'd on its boot
  * reconcile. A relative path is relative without being spelled that way.
  */
-export function profileDir(profile: string): string {
-  return `${DATA_DIR}/${profile}`;
-}
-
 export const layout = {
+  /** Connections, provider state, and cursors: one object per key. */
+  state: (): string => `${DATA_DIR}/state.kv`,
   /**
-   * Connections, provider state, and cursors: one object per key.
+   * System credentials — OAuth refresh tokens, the CI token. Never reachable
+   * from MCP.
    *
-   * The dot is load-bearing, exactly as it is for `audit` below — a provider
-   * is namespaced `<provider>/<connection>` under `blobs`, and a provider id
-   * is `[a-z][a-z0-9_]*`, so a name carrying a dot is one no provider can be
-   * scoped into.
+   * One store for the workspace, where there used to be one per profile. That
+   * is what makes a `credential_ref` unique by construction and retires
+   * `collidingRefs`, the deploy preflight that existed because two profiles
+   * deployed into one project shared this namespace and the collision was
+   * "silent until one profile is reading the other's account" (ADR-043,
+   * ADR-057).
    */
-  state: (profile: string): string => `${profileDir(profile)}/state.kv`,
-  /** System credentials — OAuth tokens, the profile token. Never reachable from MCP. */
-  credentials: (profile: string): string => `${profileDir(profile)}/credentials.enc`,
-  /** The owner's own items, under their own key. */
-  vault: (profile: string): string => `${profileDir(profile)}/vault.enc`,
+  credentials: (): string => `${DATA_DIR}/credentials.enc`,
+  /** Every vault connection's sealed document lives under here. */
+  vaultRoot: (): string => `${DATA_DIR}/vault.d`,
+  /** One sealed document per vault connection, each under its own key. */
+  vault: (connection: string): string => `${DATA_DIR}/vault.d/${connection}.enc`,
   /**
-   * This profile's skills — `<name>.md` or `<name>/SKILL.md`, either layout.
+   * Every skills connection's procedures live under here.
    *
-   * The dot carries the same weight it does for `state` and `audit`, and here
-   * it is not hypothetical: `skills` is a real provider id, so `skills/` under
-   * the blob root is the prefix its own connection blobs would scope into.
+   * The root is exported beside the per-connection path because `deploy` needs
+   * to recognise the *area* without knowing which connections exist — and
+   * `upload.ts` composes its allowlist back out of these rather than comparing
+   * against literals, so a renamed directory moves the store and the thing that
+   * sends it together, or neither.
    */
-  skills: (profile: string): string => `${profileDir(profile)}/skills.d`,
+  skillsRoot: (): string => `${DATA_DIR}/skills.d`,
+  /** One skills connection's procedures — `<name>.md` or `<name>/SKILL.md`, either layout. */
+  skills: (connection: string): string => `${DATA_DIR}/skills.d/${connection}`,
   /**
-   * The provider manifests this profile declares.
+   * The provider manifests this workspace declares.
    *
-   * Per profile for the same reason a connection is. A manifest names a host,
-   * an OpenAPI document, and the credential refs that reach them — which is a
-   * description of somebody's infrastructure, and work's is not personal's to
-   * read.
+   * Workspace-level, where ADR-030 put them in the profile. A manifest names a
+   * host, an OpenAPI document, and the credential refs that reach them — which
+   * is to say it *defines a connection*, and connections do not live in a
+   * profile any more. ADR-030's argument was about a procedure being as private
+   * as the knowledge it operates on; that argument is answered by ADR-059's
+   * instances, not by where a manifest sits.
    */
-  providers: (profile: string): string => `${profileDir(profile)}/providers.d`,
+  providers: (): string => `${DATA_DIR}/providers.d`,
   /** The blob root every provider is namespaced under. */
-  blobs: (profile: string): string => profileDir(profile),
+  blobs: (): string => DATA_DIR,
   /**
-   * The audit log: one object per event, under the profile's blob root.
+   * The audit log: one object per event, one chain for the workspace.
    *
-   * The dot is doing real work. A provider is namespaced to
-   * `<provider>/<connection>` under `blobs` above, and a provider id is
-   * `[a-z][a-z0-9_]*` — so a name carrying a dot is one no provider can be
-   * scoped to. Without it, a provider called `audit` would be handed a store
-   * rooted inside the log, which is a hole in ADR-007's wall rather than an
-   * untidy filename.
+   * One chain rather than one per profile, because one endpoint serves them all
+   * (ADR-009) and every event already records the profile it acted in. It is
+   * also what lets `audit tail` filter where it used to select, and what gives
+   * the dashboard a single log to read.
    */
-  audit: (profile: string): string => `${profileDir(profile)}/audit.log`,
+  audit: (): string => `${DATA_DIR}/audit.log`,
 } as const;

--- a/src/profile/layout.ts
+++ b/src/profile/layout.ts
@@ -75,6 +75,15 @@ export const layout = {
   /** One sealed document per vault connection, each under its own key. */
   vault: (connection: string): string => `${DATA_DIR}/vault.d/${connection}.enc`,
   /**
+   * The same document, keyed relative to the blob store.
+   *
+   * `blobs()` is already rooted at `data/`, so a blob adapter handed the path
+   * above would write `data/data/vault.d/...`. Two spellings of one location is
+   * exactly what this file exists to prevent, so the second one lives here
+   * beside the first rather than being assembled at the call site.
+   */
+  vaultKey: (connection: string): string => `vault.d/${connection}.enc`,
+  /**
    * Every skills connection's procedures live under here.
    *
    * The root is exported beside the per-connection path because `deploy` needs

--- a/src/profile/load.test.ts
+++ b/src/profile/load.test.ts
@@ -3,19 +3,17 @@ import { parse as parseYaml } from 'yaml';
 import { ConfigError, parseConfig, validateConfig } from './load.ts';
 import { legacyTargetSchema } from './legacy.ts';
 import { DEPLOY_DEFAULTS, workspaceSchema } from './schema.ts';
+import { assertNoRenamedProviders } from './connections.ts';
 
 /** A minimal valid config; each test overrides the part it is about. */
 const VALID = `
-contract: 2
+contract: 3
 instance:
   profile: personal
-connections:
-  - id: a
-    provider: example
-    account: Scratch
-policy:
-  allow:
-    - "example.*"
+grants:
+  - connection: example.a
+    allow:
+      - "example.*"
 `;
 
 describe('a valid config', () => {
@@ -30,37 +28,37 @@ describe('a valid config', () => {
     expect(connectionKeys).toEqual(['example.a']);
   });
 
-  test('an absent policy block grants nothing', () => {
-    const { config } = parseConfig(VALID.replace(/policy:[\s\S]*$/, ''));
-    expect(config.policy.allow).toEqual([]);
-    expect(config.policy.deny).toEqual([]);
+  test('an absent grants block grants nothing', () => {
+    const { config } = parseConfig(VALID.replace(/grants:[\s\S]*$/, ''));
+    expect(config.grants).toEqual([]);
+    expect(config.members).toEqual([]);
   });
 });
 
 describe('contract major fails closed', () => {
   test('rejects a newer major outright', () => {
-    expect(() => parseConfig(VALID.replace('contract: 2', 'contract: 3'))).toThrow(
-      /contract 3 is newer than.*Upgrade lanes-link/s,
+    expect(() => parseConfig(VALID.replace('contract: 3', 'contract: 4'))).toThrow(
+      /contract 4 is newer than.*Upgrade lanes-link/s,
     );
   });
 
   test('rejects an older major outright', () => {
-    expect(() => parseConfig(VALID.replace('contract: 2', 'contract: 0'))).toThrow(/older than/);
+    expect(() => parseConfig(VALID.replace('contract: 3', 'contract: 0'))).toThrow(/older than/);
   });
 
   // Contract 1 is the shape this release replaced, and it is refused here rather
   // than read: `profile/legacy.ts` understands it and only the migration uses
   // that, so a profile still carrying `targets:` fails at the boundary with a
   // sentence naming the migration (ADR-052).
-  test('rejects contract 1, which the migration handles instead', () => {
-    expect(() => parseConfig(VALID.replace('contract: 2', 'contract: 1'))).toThrow(
-      /contract 1 is older than/,
+  test('rejects contract 2, which the migration handles instead', () => {
+    expect(() => parseConfig(VALID.replace('contract: 3', 'contract: 2'))).toThrow(
+      /contract 2 is older than/,
     );
   });
 
   test('rejects a missing or non-integer contract', () => {
-    expect(() => parseConfig(VALID.replace('contract: 2\n', ''))).toThrow(/"contract" is required/);
-    expect(() => parseConfig(VALID.replace('contract: 2', 'contract: "2"'))).toThrow(
+    expect(() => parseConfig(VALID.replace('contract: 3\n', ''))).toThrow(/"contract" is required/);
+    expect(() => parseConfig(VALID.replace('contract: 3', 'contract: "2"'))).toThrow(
       /must be an integer/,
     );
   });
@@ -68,7 +66,7 @@ describe('contract major fails closed', () => {
   test('the contract check runs before anything else', () => {
     // A config that is wrong in several ways must report the contract, because
     // under an unknown major we cannot claim to know what the rest means.
-    const broken = VALID.replace('contract: 2', 'contract: 99').replace(
+    const broken = VALID.replace('contract: 3', 'contract: 99').replace(
       'profile: personal',
       'profile: "not an identifier"',
     );
@@ -178,48 +176,88 @@ describe('referential integrity', () => {
   const rejects = (mutate: (yaml: string) => string, pattern: RegExp) =>
     expect(() => parseConfig(mutate(VALID))).toThrow(pattern);
 
-  test('an allow rule naming a provider with no connection fails rather than granting nothing', () => {
-    rejects((y) => y.replace('- "example.*"', '- "gmail.search"'), /has no connection/);
+  // Nothing here checks whether a granted connection *exists*. That question
+  // needs `connections.yaml`, which a single profile cannot see, so
+  // `assertGrantsResolve` answers it once both have been read (ADR-057). What
+  // is checkable from one profile alone is checked here, and only that.
+
+  test('a rule naming another provider is refused rather than matching nothing', () => {
+    // The sharpest of these. `allowedConnections` filters candidates to the
+    // capability's own provider before policy is consulted, so a rule like this
+    // matches nothing, ever, while reading exactly like a grant that works.
+    rejects(
+      (y) => y.replace('- "example.*"', '- "gmail.search"'),
+      /names provider "gmail", but this row grants "example\.a"/,
+    );
   });
 
-  test('a deny rule may name a provider you have not connected yet', () => {
-    // Denying something ahead of connecting it is a reasonable thing to write,
-    // and refusing it would punish the cautious ordering.
-    expect(() =>
-      parseConfig(`${VALID}  deny:\n    - "gmail.send_message"\n`),
-    ).not.toThrow();
-  });
-
-  test('a bare * needs no provider to exist', () => {
+  test('a bare * is allowed, because a row is already scoped to one connection', () => {
     expect(() => parseConfig(VALID.replace('- "example.*"', '- "*"'))).not.toThrow();
   });
 
-  test('duplicate connection ids within a provider fail', () => {
-    const yaml = VALID.replace(
-      '  - id: a\n    provider: example\n    account: Scratch',
-      '  - id: a\n    provider: example\n    account: Scratch\n  - id: a\n    provider: example\n    account: Dupe',
-    );
-    expect(() => parseConfig(yaml)).toThrow(/duplicate connection "example\.a"/);
+  test('two grants for one connection fail rather than one winning silently', () => {
+    const yaml = `${VALID}  - connection: example.a\n    allow:\n      - "example.echo"\n`;
+    expect(() => parseConfig(yaml)).toThrow(/duplicate grant for "example\.a"/);
   });
 
-  test('the same connection id under different providers is fine', () => {
+  test('two accounts of the same provider get their own rows', () => {
     const yaml = VALID.replace(
-      '  - id: a\n    provider: example\n    account: Scratch',
-      '  - id: main\n    provider: example\n    account: Scratch\n  - id: main\n    provider: gmail\n    account: Mail',
-    );
-    expect(() => parseConfig(yaml)).not.toThrow();
-  });
-
-  test('two accounts of the same provider coexist', () => {
-    // The shape that replaced main/main2: distinct ids, distinct accounts, one
-    // rule covering both.
-    const yaml = VALID.replace(
-      '  - id: a\n    provider: example\n    account: Scratch',
-      '  - id: work\n    provider: example\n    account: me@work.example\n  - id: home\n    provider: example\n    account: me@home.example',
+      '  - connection: example.a\n    allow:\n      - "example.*"',
+      '  - connection: example.work\n    allow:\n      - "example.*"\n' +
+        '  - connection: example.home\n    allow:\n      - "example.echo"',
     );
     const { config } = parseConfig(yaml);
-    expect(config.connections.map((c) => c.account)).toEqual(['me@work.example', 'me@home.example']);
-    expect(config.policy.allow).toEqual([{ capability: 'example.*' }]);
+
+    expect(config.grants.map((grant) => grant.connection)).toEqual([
+      'example.work',
+      'example.home',
+    ]);
+    expect(config.grants[1]?.allow).toEqual([{ capability: 'example.echo' }]);
+  });
+
+  test('a subject listed twice fails, because the second row decides nothing', () => {
+    const subject = 'lanes:3QBmAxJLLrYSMTVUIeCN1SKFbdD3';
+    const yaml = `${VALID}members:\n  - { subject: ${subject}, role: owner }\n  - { subject: ${subject}, role: member }\n`;
+    expect(() => parseConfig(yaml)).toThrow(/duplicate subject/);
+  });
+
+  test('a bare subject is refused before the schema even sees it', () => {
+    // Two defences, and the outer one fires first: a Lanes subject is a
+    // 28-character mixed-case alphanumeric string, which is exactly what
+    // `secret-detection.ts` refuses as a high-entropy blob. That is why the
+    // stored form carries a `lanes:` prefix — the colon takes it out of
+    // `OPAQUE_TOKEN`'s character class, so saying which provider vouched for a
+    // subject and being storable at all are the same decision.
+    const yaml = `${VALID}members:\n  - { subject: 3QBmAxJLLrYSMTVUIeCN1SKFbdD3, role: owner }\n`;
+    expect(() => parseConfig(yaml)).toThrow(/high-entropy string, which looks like a credential/);
+  });
+
+  test('and a prefixed one is accepted', () => {
+    const yaml = `${VALID}members:\n  - { subject: lanes:3QBmAxJLLrYSMTVUIeCN1SKFbdD3, role: owner }\n`;
+    expect(parseConfig(yaml).config.members[0]?.role).toBe('owner');
+  });
+
+  test('a subject that is neither is refused by the schema', () => {
+    const yaml = `${VALID}members:\n  - { subject: someone, role: owner }\n`;
+    expect(() => parseConfig(yaml)).toThrow(/lanes:<subject>/);
+  });
+
+  test('one skills grant is fine and two are refused', () => {
+    // Not a limit of the store — a limit of the surface. A skill is a prompt,
+    // selected by flat name with nothing to route on, so two instances would be
+    // one name for two procedures (ADR-059).
+    const one = VALID.replace('example.a', 'skills.main').replace('example.*', 'skills.*');
+    expect(() => parseConfig(one)).not.toThrow();
+
+    const two = `${one}  - connection: skills.work\n    allow:\n      - "skills.*"\n`;
+    expect(() => parseConfig(two)).toThrow(/may grant one "skills" connection/);
+  });
+
+  test('two memory grants are fine, because its tools route on a connection', () => {
+    const yaml =
+      VALID.replace('example.a', 'memory.main').replace('example.*', 'memory.*') +
+      '  - connection: memory.work\n    allow:\n      - "memory.*"\n';
+    expect(() => parseConfig(yaml)).not.toThrow();
   });
 
   test('a default_target naming nothing is harmless, because nothing reads it', () => {
@@ -227,12 +265,8 @@ describe('referential integrity', () => {
     // (ADR-037), so failing `check` on a stale value would teach that it still
     // matters — and every profile written before the change carries one.
     expect(() =>
-      parseConfig(VALID.replace('default_target: local', 'default_target: clod'), 'x.yaml'),
+      parseConfig(`${VALID}default_target: clod\n`, 'x.yaml'),
     ).not.toThrow();
-  });
-
-  test('and so is leaving it out entirely', () => {
-    expect(() => parseConfig(VALID.replace('  default_target: local\n', ''), 'x.yaml')).not.toThrow();
   });
 });
 
@@ -244,68 +278,40 @@ describe('referential integrity', () => {
  * loses their Google Tasks tools with nothing saying why.
  */
 describe('a provider whose id has been renamed', () => {
+  // Moved off the profile with the connections it inspects (ADR-057). The
+  // evidence is the row's *account* — "is this really Google Tasks?" — and an
+  // account lives in connections.yaml, so the check reads it there.
+  const repair = 'lanes link doctor --fix --profile personal --workspace <name>';
+
   const withTasks = (id: string, account: string) =>
-    VALID.replace(
-      '  - id: a\n    provider: example\n    account: Scratch',
-      `  - id: a\n    provider: example\n    account: Scratch\n  - id: ${id}\n    provider: tasks\n    account: ${account}`,
+    assertNoRenamedProviders(
+      [
+        { id: 'a', provider: 'example', account: 'Scratch' },
+        { id, provider: 'tasks', account },
+      ],
+      repair,
     );
 
   test('a tasks row wearing any other label is refused, and names google_tasks', () => {
-    expect(() => parseConfig(withTasks('ada', 'ada.lovelace@example.com'))).toThrow(
-      /set provider to google_tasks/,
-    );
+    expect(() => withTasks('ada', 'ada.lovelace@example.com')).toThrow(/google_tasks/);
   });
 
   test('a label that is not an address is caught too — the case a heuristic missed', () => {
-    // The first version of this check keyed on an `@`, reasoning that `connect`
-    // recorded the address that was typed. What `connect` asks an accountless
-    // provider for is a *label*, and the real profile this was written for holds
-    // `account: personal` — so the heuristic passed it and would have rebound
-    // Google Tasks to the built-in in silence.
-    expect(() => parseConfig(withTasks('personal', 'personal'))).toThrow(
-      /set provider to google_tasks/,
-    );
+    // The check is "does it keep the built-in's own label", not "does it look
+    // like an email". A row called "Work" is exactly as likely to be Google's.
+    expect(() => withTasks('work', 'Work')).toThrow(/google_tasks/);
   });
 
-  test("the built-in's own row is not mistaken for it", () => {
-    expect(() => parseConfig(withTasks('main', 'Tasks'))).not.toThrow();
-  });
-
-  test('a second task list is allowed, as long as it is labelled like the first', () => {
-    // Keying on `id !== "main"` would have refused this forever to catch a
-    // one-release migration. Every accountless provider labels its rows the same
-    // way — every memory connection is `Memory` — so this is the existing shape.
-    expect(() => parseConfig(withTasks('work', 'Tasks'))).not.toThrow();
+  test('the built-in keeps its own label and passes', () => {
+    expect(() => withTasks('main', 'Tasks')).not.toThrow();
   });
 
   test('the refusal offers the other fix too, for a hand-edited built-in row', () => {
-    expect(() => parseConfig(withTasks('work', 'Work'))).toThrow(/set account to Tasks/);
+    expect(() => withTasks('ada', 'ada.lovelace@example.com')).toThrow(/set account to Tasks/);
   });
 
   test('the refusal names the command that applies it, with the selection it needs', () => {
-    // The refusal is at *load*, so it takes every command down with it and the
-    // operator's only way back was to hand-edit YAML. Both flags come off the
-    // document rather than off whatever command tripped over it, because nothing
-    // has resolved anything at this point.
-    expect(() => parseConfig(withTasks('personal', 'personal'))).toThrow(
-      /lanes link doctor --fix --profile personal --target <target>/,
-    );
-  });
-
-  test('the target stays a placeholder, because the profile no longer names one', () => {
-    // It used to read the profile's own `targets:` block and name the target
-    // when there was exactly one. A profile declares none (ADR-052) — it lives
-    // in one — so the honest answer is the placeholder, and whoever is reading
-    // this refusal just typed which target they meant.
-    expect(() => parseConfig(withTasks('personal', 'personal'))).toThrow(/--target <target>/);
-  });
-
-  test('google_tasks itself is fine, which is the whole point', () => {
-    const yaml = VALID.replace(
-      '  - id: a\n    provider: example\n    account: Scratch',
-      '  - id: a\n    provider: example\n    account: Scratch\n  - id: ada\n    provider: google_tasks\n    account: ada.lovelace@example.com',
-    );
-    expect(() => parseConfig(yaml)).not.toThrow();
+    expect(() => withTasks('ada', 'ada.lovelace@example.com')).toThrow(/doctor --fix/);
   });
 });
 
@@ -321,7 +327,7 @@ describe('where a target deploys', () => {
   const withTarget = (block: string) =>
     workspaceSchema.parse(
       parseYaml(
-        'contract: 2\ntargets:\n  cloud:\n' +
+        'contract: 3\nworkspaces:\n  cloud:\n' +
           '    credentials: { adapter: gcp-secret-manager, project: my-project }\n' +
           '    storage: { adapter: s3, bucket: link-blobs }\n' +
           block,
@@ -334,7 +340,7 @@ describe('where a target deploys', () => {
         '      region: europe-west1\n      service: lanes-link\n',
     );
 
-    expect(workspace.targets['cloud']?.deploy).toEqual({
+    expect(workspace.workspaces['cloud']?.deploy).toEqual({
       platform: 'cloudrun',
       project: 'my-project',
       region: 'europe-west1',
@@ -386,7 +392,7 @@ describe('where a target deploys', () => {
       '    cloudrun:\n      project: my-project\n      region: europe-west1\n      service: lanes-link\n',
     );
 
-    expect(workspace.targets['cloud']?.deploy).toBeUndefined();
+    expect(workspace.workspaces['cloud']?.deploy).toBeUndefined();
   });
 
   test('an unknown platform is refused at load, not at deploy', () => {
@@ -444,7 +450,7 @@ describe('policy grammar', () => {
     const { config } = parseConfig(
       VALID.replace('- "example.*"', '- { capability: "example.*", expires_at: "2027-01-01T00:00:00Z" }'),
     );
-    expect(config.policy.allow[0]).toEqual({
+    expect(config.grants[0]?.allow[0]).toEqual({
       capability: 'example.*',
       expires_at: '2027-01-01T00:00:00Z',
     });
@@ -459,7 +465,7 @@ describe('malformed input', () => {
   });
 
   test('reports unparseable YAML as such', () => {
-    expect(() => parseConfig('contract: 2\n  bad: [indent')).toThrow(/could not parse YAML/);
+    expect(() => parseConfig('contract: 3\n  bad: [indent')).toThrow(/could not parse YAML/);
   });
 
   test('rejects an out-of-range port', () => {

--- a/src/profile/load.ts
+++ b/src/profile/load.ts
@@ -1,10 +1,10 @@
 import { parse as parseYaml } from 'yaml';
 import { z } from 'zod';
 import {
+  SINGLE_INSTANCE_PROVIDERS,
   SUPPORTED_CONTRACT,
   configSchema,
   type Config,
-  type PolicyRuleConfig,
 } from './schema.ts';
 import { findSecrets, formatSecretFindings } from './secret-detection.ts';
 
@@ -21,7 +21,7 @@ export class ConfigError extends Error {
 export interface LoadedConfig {
   readonly config: Config;
   readonly source: string;
-  /** `provider.id` for every declared connection, in declaration order. */
+  /** `provider.id` for every connection this profile grants, in declaration order. */
   readonly connectionKeys: readonly string[];
 }
 
@@ -208,7 +208,7 @@ export const RENAMED_PROVIDERS: Readonly<Record<string, ProviderRename>> = {
  * and whoever is reading this refusal just typed which one.
  */
 function repairCommand(config: Config): string {
-  return `lanes link doctor --fix --profile ${config.instance.profile} --target <target>`;
+  return `lanes link doctor --fix --profile ${config.instance.profile} --workspace <name>`;
 }
 
 /** The rename a row is owed, or `null` when it is owed none. */
@@ -221,7 +221,7 @@ export function renamedProviderFor(connection: {
   return moved;
 }
 
-function renamedProvider(
+export function describeRename(
   connection: { provider: string; account: string },
   repair: string,
 ): string | null {
@@ -241,30 +241,74 @@ function renamedProvider(
 function assertReferentialIntegrity(config: Config, source: string): void {
   const problems: string[] = [];
 
-  // There is nothing to check about targets here any more. A profile declares
-  // none (ADR-052): the workspace holding this file declares the one target it
-  // lives in, and `workspaceSchema` is what validates that. A profile is now
-  // portable between targets precisely because it says nothing about them.
+  // Nothing about targets is checked here any more. A profile declares none
+  // (ADR-052): the workspace holding this file declares the one it lives in.
+  //
+  // Nothing about *connections* is either, and that is newer. A connection
+  // belongs to the workspace (ADR-057), so whether a grant names a real one is
+  // a question this file cannot answer on its own — `assertGrantsResolve` in
+  // `./connections.ts` answers it once `connections.yaml` has been read. What
+  // is checkable from one profile alone is checked here, and only that.
 
-  // Connection ids are unique per provider, so `gmail.main` and
-  // `icloud_mail.main` can coexist.
-  const connectionKeys = new Set<string>();
-  const providerNames = new Set(config.connections.map((connection) => connection.provider));
-
-  config.connections.forEach((connection, index) => {
-    const key = `${connection.provider}.${connection.id}`;
-    if (connectionKeys.has(key)) {
-      problems.push(`connections[${index}]: duplicate connection "${key}"`);
+  // A grant names one connection, so every capability in it belongs to that
+  // connection's provider. Worth refusing rather than warning: `allowedConnections`
+  // filters candidates to the capability's own provider before policy is
+  // consulted, so `allow: [calendar.*]` on a row granting `gmail.personal`
+  // matches nothing, ever, while reading exactly like a grant that works.
+  const grantKeys = new Set<string>();
+  config.grants.forEach((grant, index) => {
+    if (grantKeys.has(grant.connection)) {
+      problems.push(`grants[${index}]: duplicate grant for "${grant.connection}"`);
     }
-    connectionKeys.add(key);
+    grantKeys.add(grant.connection);
 
-    const renamed = renamedProvider(connection, repairCommand(config));
-    if (renamed) problems.push(`connections[${index}]: ${renamed}`);
+    const provider = grant.connection.split('.')[0] ?? '';
+
+    // The renamed-provider check is not here any more. It compares a row's
+    // *account* against the label the built-in keeps — "is this really Google
+    // Tasks?" — and an account lives in `connections.yaml` now (ADR-057). A
+    // profile grant carries only the key, so asking here would either need the
+    // other file or answer from nothing; `assertNoRenamedProviders` asks where
+    // the answer is.
+
+    for (const [field, rules] of [
+      ['allow', grant.allow],
+      ['deny', grant.deny],
+    ] as const) {
+      rules.forEach((rule, ruleIndex) => {
+        if (rule.capability === '*') return;
+        const named = rule.capability.split('.')[0] ?? '';
+        if (named === provider) return;
+
+        problems.push(
+          `grants[${index}].${field}[${ruleIndex}]: "${rule.capability}" names provider ` +
+            `"${named}", but this row grants "${grant.connection}". A rule here governs ` +
+            `that connection and nothing else, so it can only name "${provider}.*".`,
+        );
+      });
+    }
   });
 
-  // Same reason as a duplicate connection: two entries with the same kind and
-  // value cannot both be meant, and the one that loses is invisible. It matters
-  // more here than it looks, because the two would usually differ only in their
+  // At most one skills grant and one vault grant, for the reason
+  // `SINGLE_INSTANCE_PROVIDERS` gives: both surface as flat names with no
+  // argument to route on, so a second instance is a collision rather than a
+  // choice.
+  for (const provider of SINGLE_INSTANCE_PROVIDERS) {
+    const granted = config.grants
+      .map((grant) => grant.connection)
+      .filter((ref) => ref.startsWith(`${provider}.`));
+
+    if (granted.length > 1) {
+      problems.push(
+        `grants: ${granted.join(' and ')} — a profile may grant one "${provider}" connection. ` +
+          `It is surfaced by name with nothing to route on, so two would be one name for two things.`,
+      );
+    }
+  }
+
+  // Same reason as a duplicate grant: two entries with the same kind and value
+  // cannot both be meant, and the one that loses is invisible. It matters more
+  // here than it looks, because the two would usually differ only in their
   // `note` — so the discarded one is precisely the guidance someone wrote down
   // to stop an agent picking wrong.
   const identityKeys = new Set<string>();
@@ -276,28 +320,17 @@ function assertReferentialIntegrity(config: Config, source: string): void {
     identityKeys.add(key);
   });
 
-  const checkRules = (rules: readonly PolicyRuleConfig[], field: 'allow' | 'deny'): void => {
-    rules.forEach((rule, index) => {
-      const where = `policy.${field}[${index}]`;
-      if (rule.capability === '*') return;
-
-      // A rule naming a provider with no connection is almost always a typo,
-      // and one that fails open-looking: it reads as a grant while matching
-      // nothing. Worth saying, but not fatal for a `deny` — denying something
-      // you have not connected yet is a perfectly reasonable thing to write
-      // ahead of time.
-      const providerOfCapability = rule.capability.split('.')[0] ?? '';
-      if (field === 'allow' && !providerNames.has(providerOfCapability)) {
-        problems.push(
-          `${where}: "${rule.capability}" names provider "${providerOfCapability}", which has no connection` +
-            (providerNames.size > 0 ? ` (have: ${[...providerNames].join(', ')})` : ''),
-        );
-      }
-    });
-  };
-
-  checkRules(config.policy.allow, 'allow');
-  checkRules(config.policy.deny, 'deny');
+  // A subject listed twice is one row deciding the role and the other doing
+  // nothing, and which one wins is iteration order. Since the two would differ
+  // only in `role`, the silent loser is exactly the line someone added to
+  // promote or demote somebody (ADR-060).
+  const subjects = new Set<string>();
+  config.members.forEach((member, index) => {
+    if (subjects.has(member.subject)) {
+      problems.push(`members[${index}]: duplicate subject "${member.subject}"`);
+    }
+    subjects.add(member.subject);
+  });
 
   if (problems.length > 0) {
     throw new ConfigError(`${source}:\n${problems.map((p) => `  ${p}`).join('\n')}`, problems);
@@ -316,7 +349,7 @@ export function parseConfig(text: string, source = '<config>'): LoadedConfig {
   return {
     config,
     source,
-    connectionKeys: config.connections.map((c) => `${c.provider}.${c.id}`),
+    connectionKeys: config.grants.map((grant) => grant.connection),
   };
 }
 

--- a/src/profile/pairing.ts
+++ b/src/profile/pairing.ts
@@ -1,0 +1,32 @@
+/**
+ * Where the dashboard's pairing credentials live in a workspace's store.
+ *
+ * Here rather than beside the command that writes them, because three
+ * components now read these names and only one of them is the CLI: the server
+ * opens the read surface with them (`#server/read`), and a deploy binds the
+ * token so the revision may read it (`#deployments/prepare.ts`). Importing a
+ * *command* module for a string constant dragged `cli/output.ts`,
+ * `cli/prompt.ts` and the terminal handling behind them into the container's
+ * runtime graph, which is a large amount of the CLI to load in order to learn
+ * three names.
+ *
+ * Underscores, not dots. A secret reference is `[a-z0-9_-]` separated by `/`
+ * (see `isValidSecretRef`), and that is not arbitrary: these names become
+ * Secret Manager entries on a deployed workspace, and Google allows no dots
+ * there either. `workspace/pair.cert` was refused at the moment somebody first
+ * ran the command.
+ */
+
+/** The credential the dashboard presents. Reads everything; can change nothing. */
+export const PAIR_TOKEN_REF = 'workspace/pair_token';
+
+/**
+ * The certificate the loopback read listener terminates TLS with, and its key.
+ *
+ * Loopback only, and deliberately not bound on a deployed workspace: Cloud Run
+ * terminates TLS with a certificate a browser already trusts, so a deployed
+ * revision never calls `serveRead` and never reads either of these. Binding two
+ * secrets nothing reads would say the boundary is wider than it is.
+ */
+export const PAIR_CERT_REF = 'workspace/pair_cert';
+export const PAIR_KEY_REF = 'workspace/pair_key';

--- a/src/profile/primitives.ts
+++ b/src/profile/primitives.ts
@@ -1,7 +1,7 @@
 import { z } from 'zod';
 
 /**
- * The four string shapes the config contract is built out of.
+ * The string shapes the config contract is built out of.
  *
  * Their own file because more than one schema module needs them, and the
  * alternative was either a circular import or a second copy of a regex that
@@ -66,3 +66,37 @@ export const browserOrigin = z.string().refine(
   },
   'must be "*" or an origin with no trailing slash or path, e.g. "https://chat.example"',
 );
+
+/**
+ * `<provider>.<connection>` — how a grant names what it governs.
+ *
+ * One string rather than two fields, because it is one string everywhere else
+ * it appears: the `connection` argument an agent passes, the audit event, the
+ * `setup_overview` listing, and the refusal a mismatched pairing produces.
+ * Splitting it in the config alone would mean every reader joins it back
+ * together.
+ */
+export const connectionRef = z
+  .string()
+  .regex(
+    /^[a-z][a-z0-9_]*\.[a-z0-9][a-z0-9_]*$/,
+    'must be "<provider>.<connection>", e.g. "gmail.personal"',
+  );
+
+/**
+ * Who a profile is delegated to: `lanes:<subject>` (ADR-060).
+ *
+ * The prefix is load-bearing twice over, and the second reason is the one that
+ * would otherwise be found the hard way. A Lanes subject is a 28-character
+ * mixed-case alphanumeric string — which is exactly what `secret-detection.ts`
+ * refuses as a high-entropy blob, so a bare one could not be written into a
+ * profile at all. The colon takes the value out of `OPAQUE_TOKEN`'s character
+ * class, so saying which identity provider vouched for the subject and being
+ * storable are the same decision rather than an exemption list.
+ *
+ * A pasted credential still cannot be smuggled in here: it does not match this
+ * pattern either, which is what makes the fix a narrowing rather than a hole.
+ */
+export const subjectRef = z
+  .string()
+  .regex(/^lanes:[A-Za-z0-9]{6,64}$/, 'must be "lanes:<subject>", as written by lanes auth login');

--- a/src/profile/registry.ts
+++ b/src/profile/registry.ts
@@ -27,7 +27,7 @@ import {
  * A machine reaches a target it does not hold through a **pointer** — a registry
  * entry carrying `workspace:` and nothing else. Following one is a read of that
  * workspace's own file, which is why every function here is async and why
- * `--target cloud` needs the bucket reachable. That is the trade ADR-052 takes
+ * `--workspace cloud` needs the bucket reachable. That is the trade ADR-052 takes
  * deliberately: a cloud target that cannot be read says so, where the shape it
  * replaces answered instantly from a copy that had been wrong for eight hours.
  */
@@ -51,7 +51,7 @@ export interface ResolvedTarget {
 /** Every target the workspace at `root` knows about. Empty when it has no file. */
 export async function readRegistry(root: string): Promise<Record<string, WorkspaceTarget>> {
   const workspace = await readWorkspace(root);
-  return workspace?.targets ?? {};
+  return workspace?.workspaces ?? {};
 }
 
 /**
@@ -66,7 +66,7 @@ export async function resolveTargetWorkspace(root: string, target: string): Prom
   const registry = await readRegistry(root);
   const entry = registry[target];
   if (!entry) throw notInRegistry(target, registry, root);
-  return isPointer(entry) ? entry.workspace.replace(/\/$/, '') : root;
+  return isPointer(entry) ? entry.at.replace(/\/$/, '') : root;
 }
 
 /**
@@ -90,7 +90,7 @@ export async function openTarget(root: string, target: string): Promise<Resolved
     return { target, workspaceRoot: root, declared, entry, remote: false };
   }
 
-  const workspaceRoot = entry.workspace.replace(/\/$/, '');
+  const workspaceRoot = entry.at.replace(/\/$/, '');
   const remoteRegistry = await readRegistry(workspaceRoot);
   const remoteEntry = remoteRegistry[target];
 
@@ -146,7 +146,7 @@ function pointerMissesTarget(
   return new ConfigError(
     `${root} says target "${target}" lives at ${workspaceRoot}, but that workspace does not ` +
       `declare it (it declares: ${there}).\n` +
-      `  Adopt what is really there:  lanes link sync targets --target ${target} --from ${workspaceRoot}`,
+      `  Adopt what is really there:  lanes link sync targets --workspace ${target} --from ${workspaceRoot}`,
   );
 }
 
@@ -176,7 +176,7 @@ function remoteAtContractOne(target: string, workspaceRoot: string): ConfigError
   return new ConfigError(
     `${workspaceRoot} is a contract 1 workspace, so it does not declare "${target}" yet.\n` +
       '  Its profiles still carry their own targets: block, which this version does not read.\n\n' +
-      `  lanes link deploy --target ${target}\n` +
+      `  lanes link deploy --workspace ${target}\n` +
       '  migrates it and rolls the image that can read it, in that order — which is what\n' +
       '  keeps the endpoint in front of it serving throughout (ADR-052).',
   );

--- a/src/profile/schema.ts
+++ b/src/profile/schema.ts
@@ -1,5 +1,12 @@
 import { z } from 'zod';
-import { browserOrigin, capabilityPattern, credentialRef, identifier } from './primitives.ts';
+import {
+  browserOrigin,
+  capabilityPattern,
+  connectionRef,
+  credentialRef,
+  identifier,
+  subjectRef,
+} from './primitives.ts';
 import { authorizationSchema } from './authorization.ts';
 import { identitySchema } from './identity.ts';
 import { knowledgeTargetSchema } from './knowledge.ts';
@@ -35,11 +42,19 @@ import { knowledgeTargetSchema } from './knowledge.ts';
  * workspace *is* a target: it declares its own adapters once, holds the profiles
  * that live in it, and a profile is one copy in one place.
  *
- * A hard cut, and contract 1 is not read here. `./legacy.ts` understands it, and
- * only the migration uses that — a runtime that loaded either shape would be the
- * two-sources-of-truth problem again, one level up.
+ * **3 moved `connections:` out of the profile and into the workspace**
+ * (ADR-057), and replaced the profile's flat `policy:` with `grants:`, one row
+ * per connection (ADR-058). A profile stopped being an inventory of accounts
+ * and became a selection over them, which is what makes "read this mailbox,
+ * write that calendar" a thing that can be written down. It also gained
+ * `members:`, because a profile worth sharing needs to say who may consume it
+ * (ADR-060).
+ *
+ * A hard cut each time, and only the newest is read here. `./legacy.ts`
+ * understands the older shapes and only the migration uses it — a runtime that
+ * loaded either would be the two-sources-of-truth problem again, one level up.
  */
-export const SUPPORTED_CONTRACT = 2;
+export const SUPPORTED_CONTRACT = 3;
 
 /**
  * There is no `database:` block any more.
@@ -136,7 +151,7 @@ export const auditTargetSchema = z.object({
  */
 export const vaultTargetSchema = z.object({
   adapter: z.enum(['file', 'blob', 'secret']),
-  /** File path, or blob key. Defaults to `./data/<profile>.vault.enc` / `vault.enc`. */
+  /** File path, or blob key. Defaults to `data/vault.d/<connection>.enc`. */
   path: z.string().optional(),
   /** `secret` only: where the sealed document lives. Defaults to `vault/document`. */
   ref: credentialRef.optional(),
@@ -328,6 +343,69 @@ export const policySchema = z.object({
 });
 
 /**
+ * Providers a profile may grant at most one instance of.
+ *
+ * Not a limitation of the store — `data/skills.d/<id>/` and
+ * `data/vault.d/<id>.enc` hold as many as anyone makes (ADR-059). It is a
+ * limitation of the surface, and it comes from the protocol rather than from
+ * here.
+ *
+ * Every other owner-layer tool takes a `connection` argument, so two memory
+ * instances are two routes through one tool and the caller says which. These
+ * two have nowhere to put that. A skill is surfaced as an MCP **prompt**, and a
+ * prompt is selected by name with no arguments to route on (ADR-012) — two
+ * `triage` skills in one profile would be one name for two procedures. A vault
+ * item becomes its own `vault.get.<id>` capability, and capability ids are flat
+ * for the same reason: two instances holding `stripe_key` would be one
+ * capability naming two secrets, which is the worst of the three collisions
+ * because the wrong answer is a credential.
+ *
+ * So the refusal is at load, where it names both rows, rather than at call time
+ * where one would silently win.
+ */
+export const SINGLE_INSTANCE_PROVIDERS: readonly string[] = ['skills', 'vault'];
+
+/**
+ * One connection, and what may be done with it (ADR-058).
+ *
+ * The rules are the same `allow`/`deny` pair `policySchema` has always carried;
+ * what is new is that a row names the account they govern. ADR-003 kept rules
+ * connection-blind on the reasoning that "a narrower grant is a narrower
+ * profile" — sound while a connection lived in exactly one profile, because the
+ * second profile *was* the granularity. ADR-057 removed that mechanism, so the
+ * granularity moves into the rule.
+ *
+ * **There is no profile-wide `allow` beside these rows, deliberately.** A
+ * second place a connection could be granted is a second answer to "may this
+ * call proceed", and two answers to one question is the failure ADR-052 exists
+ * to prevent. A profile that wants the same rules on eight connections writes
+ * eight rows; the repetition is the cost of there being one place to look.
+ *
+ * Default deny is unchanged and now bites one step earlier: a connection with
+ * no row is not reachable, and is never advertised.
+ */
+export const grantSchema = z.object({
+  connection: connectionRef,
+  allow: z.array(policyRuleSchema).default([]),
+  deny: z.array(policyRuleSchema).default([]),
+});
+
+/**
+ * Who may consume this profile (ADR-060).
+ *
+ * `role` decides who may edit this list and nothing else. Both roles reach
+ * exactly what the grants above allow, because a role that changed what an
+ * agent could call would be a second policy system beside `grants:`, with
+ * precedence rules between them, answering a question the first one already
+ * answers. Two people needing different scopes is two profiles, which is cheap
+ * now that neither of them re-authorises an account.
+ */
+export const memberSchema = z.object({
+  subject: subjectRef,
+  role: z.enum(['owner', 'member']).default('member'),
+});
+
+/**
  * One authorised account.
  *
  * `account` is the identity as the provider knows it — an email address, a
@@ -412,15 +490,36 @@ export const configSchema = z.object({
     })
     .default({ requests_per_minute: 120, upstream_calls_per_minute: 60 }),
 
-  oauth_apps: z.record(identifier, oauthAppSchema).default({}),
+  /**
+   * What this profile is for, in the owner's own words.
+   *
+   * New in contract 3, and it earns its place because a profile is now a thing
+   * you hand to somebody (ADR-060). "personal-assistant" is a name; "reads my
+   * mail, keeps the calendar, never sends" is what a member needs to know
+   * before accepting it. The dashboard and `setup_overview` show it.
+   */
+  description: z.string().min(1).optional(),
 
   /**
-   * There is no `providers` block. A provider is enabled by having a connection
-   * to it — a second place to say so could only ever disagree with the first,
-   * and everything else a provider needs is in its manifest.
+   * The connections this profile selects, and what may be done with each.
+   *
+   * There is no `connections:` block here any more — a connection belongs to
+   * the workspace (ADR-057), and `connections.yaml` beside this file is where
+   * it lives. A grant naming a connection the workspace does not hold is
+   * refused by `assertReferentialIntegrity` rather than loading and reaching
+   * nothing.
    */
-  connections: z.array(connectionSchema).default([]),
-  policy: policySchema.default({ allow: [], deny: [] }),
+  grants: z.array(grantSchema).default([]),
+
+  /**
+   * Who may consume this profile (ADR-060).
+   *
+   * Empty is not "everyone" — it is nobody, which is default deny applied to
+   * the identity axis. `profile add` writes the signed-in subject as `owner`,
+   * so the empty state is one a hand-edit produces rather than one anybody is
+   * handed.
+   */
+  members: z.array(memberSchema).default([]),
 
   /**
    * Memory and skills, somewhere other than the target's own storage (ADR-041).
@@ -446,8 +545,35 @@ export const configSchema = z.object({
   identity: identitySchema.default([]),
 });
 
+/**
+ * `connections.yaml` — every account authorised in this workspace (ADR-057).
+ *
+ * Its own file rather than a block in `lanes-link.yaml`, because that file is
+ * the registry and is read before anything else can be: resolving which
+ * workspace a command means must not require parsing every connection in it.
+ * And its own file rather than staying in the profile, because authorising an
+ * account and deciding what may be done with it are two acts, and only the
+ * second is a property of a profile.
+ *
+ * `oauth_apps` comes with them. A registered client belongs to the account it
+ * authenticates, not to whichever selection happens to name that account.
+ *
+ * There is still no `providers` block. A provider is enabled by having a
+ * connection to it — a second place to say so could only ever disagree with the
+ * first, and everything else a provider needs is in its manifest.
+ */
+export const connectionsFileSchema = z.object({
+  contract: z.number().int().positive(),
+  connections: z.array(connectionSchema).default([]),
+  oauth_apps: z.record(identifier, oauthAppSchema).default({}),
+});
+
+export type ConnectionsFile = z.infer<typeof connectionsFileSchema>;
+
 export type Config = z.infer<typeof configSchema>;
 export type ConnectionConfig = z.infer<typeof connectionSchema>;
+export type GrantConfig = z.infer<typeof grantSchema>;
+export type MemberConfig = z.infer<typeof memberSchema>;
 export type PolicyRuleConfig = z.infer<typeof policyRuleSchema>;
 export type TargetConfig = z.infer<typeof targetSchema>;
 export type DeployConfig = z.infer<typeof deployTargetSchema>;
@@ -482,8 +608,14 @@ export type { IdentityEntry } from './identity.ts';
  */
 export const workspaceTargetSchema = z
   .object({
-    /** A pointer: where the workspace declaring this target lives. */
-    workspace: z.string().min(1).optional(),
+    /**
+     * A pointer: where the workspace declaring this one lives.
+     *
+     * Spelled `at:` rather than `workspace:` since contract 3. The block is
+     * `workspaces:` now (ADR-061), and `workspaces.cloud.workspace` names the
+     * concept twice and reads as a typo.
+     */
+    at: z.string().min(1).optional(),
     credentials: credentialsTargetSchema.optional(),
     audit: auditTargetSchema.optional(),
     storage: storageTargetSchema.optional(),
@@ -497,6 +629,15 @@ export const workspaceTargetSchema = z
      * gets in — the one question about a deployment that must not be guessed at.
      */
     primary: identifier.optional(),
+    /**
+     * The Lanes workspace this one serves, when it serves one (ADR-060).
+     *
+     * A binding, not an identity: it says whose membership list
+     * `profile members add` validates a subject against. Absent means the
+     * workspace delegates only to the signed-in owner, which is what `local`
+     * does.
+     */
+    lanes_workspace: z.string().min(1).optional(),
     last_deploy: z.string().optional(),
     /**
      * The CLI release that rolled the revision serving this target.
@@ -520,21 +661,21 @@ export const workspaceTargetSchema = z
     // rather than preferring one: a pointer beside a declaration is two answers
     // to "where are this target's bytes", and picking either silently is how the
     // fifteen-connection bucket got reported as seven.
-    if (declares && entry.workspace !== undefined) {
+    if (declares && entry.at !== undefined) {
       ctx.addIssue({
         code: 'custom',
         message:
-          'names a "workspace" and also declares adapters — a target is declared by exactly ' +
+          'names an "at" and also declares adapters — a workspace is declared in exactly ' +
           'one workspace. Keep the adapters here, or keep the pointer and declare them there.',
       });
       return;
     }
 
-    if (!declares && entry.workspace === undefined) {
+    if (!declares && entry.at === undefined) {
       ctx.addIssue({
         code: 'custom',
         message:
-          'declares neither "workspace" nor "credentials" and "storage" — a target either ' +
+          'declares neither "at" nor "credentials" and "storage" — a workspace either ' +
           'lives here or points at where it does.',
       });
       return;
@@ -559,7 +700,17 @@ export const workspaceTargetSchema = z
 export const workspaceSchema = z.object({
   contract: z.number().int().positive(),
   default_profile: identifier.optional(),
-  targets: z.record(z.string(), workspaceTargetSchema).default({}),
+  /**
+   * The workspace a command acts in when `--workspace` is absent (ADR-061).
+   *
+   * The first key in this file that is read rather than parsed and ignored
+   * since ADR-037. What makes it not the resolution chain that decision removed
+   * is that there is one source, it is printed on every command that uses it,
+   * and every command that publishes or destroys refuses it outright. If the
+   * echo is ever dropped for tidiness, ADR-061 has been reversed.
+   */
+  default_workspace: z.string().optional(),
+  workspaces: z.record(z.string(), workspaceTargetSchema).default({}),
 });
 
 export type WorkspaceConfig = z.infer<typeof workspaceSchema>;
@@ -568,8 +719,8 @@ export type WorkspaceTarget = z.infer<typeof workspaceTargetSchema>;
 /** Whether a registry entry points elsewhere rather than declaring the target. */
 export function isPointer(
   entry: WorkspaceTarget,
-): entry is WorkspaceTarget & { workspace: string } {
-  return entry.workspace !== undefined;
+): entry is WorkspaceTarget & { at: string } {
+  return entry.at !== undefined;
 }
 
 /**

--- a/src/profile/targets.test.ts
+++ b/src/profile/targets.test.ts
@@ -37,7 +37,7 @@ const declared = (name: string, deploy = false): Registry[string] => ({
 
 const twoTargets: Registry = {
   local: declared('local'),
-  cloud: { workspace: 'gs://your-bucket' },
+  cloud: { at: 'gs://your-bucket' },
 };
 
 const localOnly: Registry = { local: declared('local') };
@@ -57,7 +57,7 @@ describe('target resolution', () => {
     // The case the whole change exists for. Falling back here is what let an
     // ignored `--target` produce a working command and surface one command
     // later, detached from its cause.
-    expect(() => requireTarget(twoTargets, undefined)).toThrow('--target is required');
+    expect(() => requireTarget(twoTargets, undefined)).toThrow('--workspace is required');
     expect(() => requireTarget(twoTargets, undefined)).toThrow('local');
     expect(() => requireTarget(twoTargets, undefined)).toThrow('cloud');
   });
@@ -110,6 +110,6 @@ describe('target resolution', () => {
 
   test('two deployable targets are both nameable, and neither is a default', () => {
     expect(requireTarget(twoDeployable, 'staging')).toBe('staging');
-    expect(() => requireTarget(twoDeployable, undefined)).toThrow('--target is required');
+    expect(() => requireTarget(twoDeployable, undefined)).toThrow('--workspace is required');
   });
 });

--- a/src/profile/targets.ts
+++ b/src/profile/targets.ts
@@ -16,7 +16,7 @@ import { isPointer, type WorkspaceTarget } from './schema.ts';
  * The chain this replaces resolved `--target`, then the variable, then the key,
  * and printed which of the three it landed on. What that bought was one flag
  * saved per command. What it cost was that an *ignored* flag still produced a
- * working command — `profile add --target cloud` dropped the flag on the floor
+ * working command — `profile add --workspace cloud` dropped the flag on the floor
  * and the next command carried on from a different source, so the mistake
  * surfaced one command later with nothing connecting it to its cause. A
  * resolver with nowhere to fall back to cannot fail that way.
@@ -69,27 +69,39 @@ export function noTargetNamed(
   registry: Registry,
   root?: string,
   env: Record<string, string | undefined> = process.env as Record<string, string | undefined>,
+  options: { refusedDefault?: boolean } = {},
 ): ConfigError {
   const names = Object.keys(registry).sort();
   const where = root ?? 'this workspace';
 
   if (names.length === 0) {
     return new ConfigError(
-      `--target is required, and ${where} declares none.\n` +
-        '  Create one with: lanes link profile add <name> --target local',
+      `--workspace is required, and ${where} declares none.\n` +
+        '  Create one with: lanes link profile add <name> --workspace local',
     );
   }
 
   const stale = env[LEGACY_TARGET_ENV];
 
+  // The refusal a *destructive* command gives is a different sentence, because
+  // the operator has a default set and is entitled to know why it was not used
+  // (ADR-061). Saying only "--workspace is required" to somebody who configured
+  // one reads as a bug in the tool.
+  const because =
+    options.refusedDefault === true
+      ? "--workspace is required. This command publishes or destroys, so the\ndefault is not used for it.\n\n"
+      : "--workspace is required. This command opens a workspace's stores, and\nnothing else selects one.\n\n";
+
   return new ConfigError(
-    '--target is required. This command opens a target\'s stores, and nothing\n' +
-      'else selects one.\n\n' +
-      `  Targets in ${where}\n${rows(registry, names)}\n` +
-      `\n  e.g. lanes link status --target ${names[0]}` +
+    because +
+      `  Workspaces in ${where}\n${rows(registry, names)}\n` +
+      `\n  e.g. lanes link status --workspace ${names[0]}` +
+      (options.refusedDefault === true
+        ? '\n\n  A default is set and is used by every command that only reads.'
+        : '') +
       (stale
         ? `\n\n  ${LEGACY_TARGET_ENV}=${stale} is set in this shell and is no longer read.\n` +
-          '  Unset it, or pass --target.'
+          '  Unset it, or pass --workspace.'
         : ''),
   );
 }
@@ -126,7 +138,7 @@ function rows(registry: Registry, names: readonly string[]): string {
   return names
     .map((name) => {
       const entry = registry[name]!;
-      if (isPointer(entry)) return `    ${name}    ${entry.workspace}`;
+      if (isPointer(entry)) return `    ${name}    ${entry.at}`;
       const adapters = [entry.credentials?.adapter, entry.storage?.adapter]
         .filter(Boolean)
         .join('  ');

--- a/src/profile/testing.ts
+++ b/src/profile/testing.ts
@@ -58,7 +58,7 @@ export function workspaceYaml(
   return (
     `contract: ${SUPPORTED_CONTRACT}\n` +
     (options.defaultProfile ? `default_profile: ${options.defaultProfile}\n` : '') +
-    `targets:\n${blocks}\n`
+    `workspaces:\n${blocks}\n`
   );
 }
 
@@ -73,6 +73,73 @@ export function pointerYaml(
   return (
     `contract: ${SUPPORTED_CONTRACT}\n` +
     (options.defaultProfile ? `default_profile: ${options.defaultProfile}\n` : '') +
-    `targets:\n${local}  ${target}:\n    workspace: ${workspace}\n`
+    `workspaces:\n${local}  ${target}:\n    at: ${workspace}\n`
+  );
+}
+
+/**
+ * A `connections.yaml` holding the owner layer plus whatever a test names.
+ *
+ * Every fixture that opens a runtime needs one now: a profile's grants name rows
+ * in this file, and `assertGrantsResolve` refuses a grant with nothing behind it
+ * (ADR-057). Thirty tests writing the seven owner-layer rows by hand is how a
+ * fixture ends up subtly different from what `newConnectionsTemplate` writes.
+ */
+export function connectionsYaml(
+  extra: readonly { id: string; provider: string; account: string }[] = [],
+): string {
+  const owner = [
+    { id: 'main', provider: 'memory', account: 'Memory' },
+    { id: 'main', provider: 'tasks', account: 'Tasks' },
+    { id: 'main', provider: 'assets', account: 'Assets' },
+    { id: 'main', provider: 'skills', account: 'Skills' },
+    { id: 'main', provider: 'vault', account: 'Vault' },
+    { id: 'main', provider: 'setup', account: 'Setup' },
+    { id: 'main', provider: 'entities', account: 'Entities' },
+  ];
+
+  const rows = [...owner, ...extra]
+    .map((row) => `  - { id: ${row.id}, provider: ${row.provider}, account: ${row.account} }`)
+    .join('\n');
+
+  return `contract: ${SUPPORTED_CONTRACT}\nconnections:\n${rows}\noauth_apps: {}\n`;
+}
+
+/** The owner-layer grant rows a fresh profile carries, plus whatever a test names. */
+export function grantsYaml(
+  extra: readonly { connection: string; allow?: readonly string[]; deny?: readonly string[] }[] = [],
+): string {
+  const owner = ['memory', 'tasks', 'assets', 'skills', 'vault', 'setup', 'entities'].map(
+    (provider) => ({ connection: `${provider}.main`, allow: [`${provider}.*`], deny: [] }),
+  );
+
+  return [...owner, ...extra]
+    .map(
+      (grant) =>
+        `  - { connection: ${grant.connection}, allow: [${(grant.allow ?? []).join(', ')}], ` +
+        `deny: [${(grant.deny ?? []).join(', ')}] }`,
+    )
+    .join('\n');
+}
+
+/** A whole profile document at the current contract, for a test that needs one. */
+export function profileYaml(
+  profile: string,
+  options: {
+    port?: number;
+    grants?: readonly { connection: string; allow?: readonly string[]; deny?: readonly string[] }[];
+    members?: readonly string[];
+  } = {},
+): string {
+  const members = (options.members ?? [])
+    .map((subject) => `  - { subject: ${subject}, role: owner }`)
+    .join('\n');
+
+  return (
+    `contract: ${SUPPORTED_CONTRACT}\n` +
+    `instance:\n  profile: ${profile}\n  port: ${options.port ?? 7337}\n  host: 127.0.0.1\n` +
+    `auth:\n  mode: bearer\n  token_ref: profile/token\n` +
+    `grants:\n${grantsYaml(options.grants ?? [])}\n` +
+    `members:${members ? `\n${members}` : ' []'}\n`
   );
 }

--- a/src/profile/workspace.test.ts
+++ b/src/profile/workspace.test.ts
@@ -98,7 +98,7 @@ describe('naming a profile', () => {
   test('an empty workspace suggests creating a profile, with a target', async () => {
     const root = await workspace([]);
     await expect(resolveSelection({ env: { LANES_LINK_HOME: root } })).rejects.toThrow(
-      /lanes link profile add <name> --target local/,
+      /lanes link profile add <name> --workspace local/,
     );
   });
 });
@@ -143,7 +143,7 @@ describe('reading every profile at once', () => {
    * look vanished from inside one profile.
    */
   const declaring = (profile: string): string =>
-    `contract: 2\ninstance: { profile: ${profile} }\n`;
+    `contract: 3\ninstance: { profile: ${profile} }\n`;
 
   test('loads each profile with its config', async () => {
     const root = await withTargets({
@@ -163,7 +163,7 @@ describe('reading every profile at once', () => {
     // dies on the first bad file stops working exactly when it is needed.
     const root = await withTargets({
       alpha: declaring('alpha'),
-      broken: 'contract: 2\ninstance: {}\n',
+      broken: 'contract: 3\ninstance: {}\n',
     });
 
     const workspace = await loadWorkspaceProfiles(root);

--- a/src/profile/workspace.ts
+++ b/src/profile/workspace.ts
@@ -5,7 +5,16 @@ import { dirname, isAbsolute, join, resolve } from 'node:path';
 import { homedir } from 'node:os';
 import { parse as parseYaml } from 'yaml';
 import { ConfigError } from './load.ts';
-import { workspaceSchema, type Config, type WorkspaceConfig } from './schema.ts';
+import {
+  SUPPORTED_CONTRACT,
+  connectionsFileSchema,
+  workspaceSchema,
+  type Config,
+  type ConnectionsFile,
+  type WorkspaceConfig,
+} from './schema.ts';
+import { assertConnectionsUnique, assertNoRenamedProviders } from './connections.ts';
+import { findSecrets, formatSecretFindings } from './secret-detection.ts';
 
 /**
  * Workspace and profile resolution.
@@ -152,6 +161,52 @@ export async function loadProfileConfig(
   return parseConfig(text, shown);
 }
 
+/** `connections.yaml` sits beside `lanes-link.yaml`, at the workspace root. */
+export const CONNECTIONS_FILE = 'connections.yaml';
+
+/**
+ * Every account authorised in this workspace (ADR-057).
+ *
+ * Absent is not an error. A workspace that has never connected anything has no
+ * file, and returning an empty set rather than throwing is what lets `profile
+ * add`, `status` and `doctor` answer on a fresh install — the same reasoning
+ * `readWorkspace` uses for returning null.
+ *
+ * Read through the workspace store rather than the filesystem, so a deployed
+ * revision whose root is a bucket URL loads it (ADR-049). That was the exact
+ * bug manifests hit: a filesystem read against a `gs://` root silently found
+ * nothing and every custom provider vanished.
+ */
+export async function readConnections(workspaceRoot: string): Promise<ConnectionsFile> {
+  const path = join(workspaceRoot, CONNECTIONS_FILE);
+  const text = await readWorkspaceFile(workspaceFiles(workspaceRoot), CONNECTIONS_FILE);
+  if (text === null) return { contract: SUPPORTED_CONTRACT, connections: [], oauth_apps: {} };
+
+  const raw = parseYaml(text);
+
+  const secrets = findSecrets(raw);
+  if (secrets.length > 0) {
+    throw new ConfigError(
+      `${path}: ${formatSecretFindings(secrets)}`,
+      secrets.map((finding) => finding.path),
+    );
+  }
+
+  const parsed = connectionsFileSchema.safeParse(raw);
+  if (!parsed.success) {
+    throw new ConfigError(
+      `${path}:\n${parsed.error.issues.map((i) => `  ${i.path.join('.')}: ${i.message}`).join('\n')}`,
+    );
+  }
+
+  assertConnectionsUnique(parsed.data.connections);
+  assertNoRenamedProviders(
+    parsed.data.connections,
+    'lanes link doctor --fix --profile <name> --workspace <name>',
+  );
+  return parsed.data;
+}
+
 export async function readWorkspace(workspaceRoot: string): Promise<WorkspaceConfig | null> {
   const path = join(workspaceRoot, WORKSPACE_FILE);
   const text = await readWorkspaceFile(workspaceFiles(workspaceRoot), WORKSPACE_FILE);
@@ -219,7 +274,7 @@ export function noProfileNamed(
   if (available.length === 0) {
     return new ConfigError(
       `--profile is required, and ${workspaceRoot} holds no profiles yet.\n` +
-        '  Create one with: lanes link profile add <name> --target local',
+        '  Create one with: lanes link profile add <name> --workspace local',
     );
   }
 
@@ -230,7 +285,7 @@ export function noProfileNamed(
       'nothing else selects one.\n\n' +
       `  Profiles in ${workspaceRoot}\n` +
       available.map((name) => `    ${name}`).join('\n') +
-      `\n\n  e.g. lanes link status --profile ${available[0]} --target <target>` +
+      `\n\n  e.g. lanes link status --profile ${available[0]} --workspace <name>` +
       (stale
         ? `\n\n  LANES_LINK_PROFILE=${stale} is set in this shell and is no longer read.\n` +
           '  Unset it, or pass --profile.'

--- a/src/providers/custom/index.ts
+++ b/src/providers/custom/index.ts
@@ -12,5 +12,5 @@
  * connectivity type; `load.ts` reads and validates them.
  */
 
-export { loadProfileProviders, parseManifest, type LoadedManifest } from './load.ts';
+export { loadWorkspaceProviders, parseManifest, type LoadedManifest } from './load.ts';
 export { manifestTemplate } from './template.ts';

--- a/src/providers/custom/load.test.ts
+++ b/src/providers/custom/load.test.ts
@@ -5,7 +5,7 @@ import { join } from 'node:path';
 import { layout } from '#profile';
 import { createMemoryBlobStore } from '#stores/blobs/testing.ts';
 import type { BlobStore } from '#stores/blobs';
-import { loadProfileProviders, parseManifest } from './load.ts';
+import { loadWorkspaceProviders, parseManifest } from './load.ts';
 import { manifestTemplate } from './template.ts';
 
 /**
@@ -21,7 +21,7 @@ const PROFILE = 'personal';
 async function workspaceWith(files: Record<string, string>): Promise<string> {
   const root = await mkdtemp(join(tmpdir(), 'lanes-link-manifests-'));
   roots.push(root);
-  const directory = join(root, layout.providers(PROFILE));
+  const directory = join(root, layout.providers());
   await mkdir(directory, { recursive: true });
   for (const [name, contents] of Object.entries(files)) {
     await writeFile(join(directory, name), contents);
@@ -47,7 +47,7 @@ auth:
 
   test('loads from the profile', async () => {
     const root = await workspaceWith({ 'acme.yaml': manifest });
-    const [loaded] = await loadProfileProviders(root, PROFILE);
+    const [loaded] = await loadWorkspaceProviders(root);
 
     expect(loaded?.manifest.id).toBe('acme');
     expect(loaded?.manifest.connector).toMatchObject({
@@ -171,7 +171,7 @@ describe('workspace loading', () => {
   test('an absent providers directory is the normal case, not an error', async () => {
     const root = await mkdtemp(join(tmpdir(), 'lanes-link-empty-'));
     roots.push(root);
-    expect(await loadProfileProviders(root, PROFILE)).toEqual([]);
+    expect(await loadWorkspaceProviders(root)).toEqual([]);
   });
 
   test('ignores non-YAML and example files', async () => {
@@ -181,13 +181,13 @@ describe('workspace loading', () => {
       'template.example.yaml': 'id: bad',
     });
 
-    const loaded = await loadProfileProviders(root, PROFILE);
+    const loaded = await loadWorkspaceProviders(root);
     expect(loaded.map((entry) => entry.manifest.id)).toEqual(['acme']);
   });
 
   test('names the file when one manifest is broken', async () => {
     const root = await workspaceWith({ 'broken.yaml': 'id: acme\nname: Acme' });
-    await expect(loadProfileProviders(root, PROFILE)).rejects.toThrow(/broken\.yaml/);
+    await expect(loadWorkspaceProviders(root)).rejects.toThrow(/broken\.yaml/);
   });
 });
 
@@ -202,10 +202,10 @@ describe('a relative openapi path', () => {
         'connector: { kind: http, base_url: https://api.mything.test, openapi: ./mything.json }',
     });
 
-    const [loaded] = await loadProfileProviders(root, PROFILE);
+    const [loaded] = await loadWorkspaceProviders(root);
     const connector = loaded!.manifest.connector as { openapi: string };
 
-    expect(connector.openapi).toBe(join(root, layout.providers(PROFILE), 'mything.json'));
+    expect(connector.openapi).toBe(join(root, layout.providers(), 'mything.json'));
   });
 
   test('a URL is left alone', async () => {
@@ -215,7 +215,7 @@ describe('a relative openapi path', () => {
         'connector: { kind: http, base_url: https://api.remote.test, openapi: https://api.remote.test/openapi.json }',
     });
 
-    const [loaded] = await loadProfileProviders(root, PROFILE);
+    const [loaded] = await loadWorkspaceProviders(root);
 
     expect((loaded!.manifest.connector as { openapi: string }).openapi).toBe(
       'https://api.remote.test/openapi.json',
@@ -239,7 +239,7 @@ describe('the starting templates are themselves valid', () => {
 async function bucketWith(files: Record<string, string>): Promise<BlobStore> {
   const store = createMemoryBlobStore();
   for (const [name, contents] of Object.entries(files)) {
-    await store.put(`${layout.providers(PROFILE)}/${name}`, new TextEncoder().encode(contents));
+    await store.put(`${layout.providers()}/${name}`, new TextEncoder().encode(contents));
   }
   return store;
 }
@@ -251,24 +251,24 @@ describe('a workspace in a bucket', () => {
   /**
    * The bug this describe block exists for.
    *
-   * `loadProfileProviders` used `join(workspaceRoot, …)` against `node:fs`, and
-   * `join('gs://b', 'data/p/providers.d')` is `gs:/b/data/p/providers.d` — so
+   * `loadWorkspaceProviders` used `join(workspaceRoot, …)` against `node:fs`, and
+   * `join('gs://b', 'data/providers.d')` is `gs:/b/data/providers.d` — so
    * `readdir` threw ENOENT and the catch reported an empty list, which is
    * indistinguishable from a workspace that has no manifests. The manifest was
    * uploaded, the read grant covered it, and it silently did not exist.
    */
   test('loads the manifests a deployed revision was given', async () => {
     const store = await bucketWith({ 'acme.yaml': manifest });
-    const loaded = await loadProfileProviders('gs://your-bucket', PROFILE, store);
+    const loaded = await loadWorkspaceProviders('gs://your-bucket', store);
 
     expect(loaded.map((entry) => entry.manifest.id)).toEqual(['acme']);
   });
 
   test('names the manifest by its bucket URL, so a refusal can be acted on', async () => {
     const store = await bucketWith({ 'acme.yaml': manifest });
-    const [loaded] = await loadProfileProviders('gs://your-bucket', PROFILE, store);
+    const [loaded] = await loadWorkspaceProviders('gs://your-bucket', store);
 
-    expect(loaded?.path).toBe(`gs://your-bucket/${layout.providers(PROFILE)}/acme.yaml`);
+    expect(loaded?.path).toBe(`gs://your-bucket/${layout.providers()}/acme.yaml`);
   });
 
   test('applies the same filters as a directory does', async () => {
@@ -278,7 +278,7 @@ describe('a workspace in a bucket', () => {
       'template.example.yaml': 'id: bad',
     });
 
-    const loaded = await loadProfileProviders('gs://your-bucket', PROFILE, store);
+    const loaded = await loadWorkspaceProviders('gs://your-bucket', store);
     expect(loaded.map((entry) => entry.manifest.id)).toEqual(['acme']);
   });
 
@@ -291,11 +291,11 @@ describe('a workspace in a bucket', () => {
         'connector: { kind: http, base_url: https://api.example.com, openapi: https://api.example.com/openapi.json }\n',
     });
     await store.put(
-      `${layout.providers(PROFILE)}/specs/acme.json`,
+      `${layout.providers()}/specs/acme.json`,
       new TextEncoder().encode('{}'),
     );
 
-    const loaded = await loadProfileProviders('gs://your-bucket', PROFILE, store);
+    const loaded = await loadWorkspaceProviders('gs://your-bucket', store);
     expect(loaded.map((entry) => entry.manifest.id)).toEqual(['acme']);
   });
 
@@ -309,7 +309,7 @@ describe('a workspace in a bucket', () => {
         'connector: { kind: http, base_url: https://api.example.com, openapi: ./acme.json }\n',
     });
 
-    await expect(loadProfileProviders('gs://your-bucket', PROFILE, store)).rejects.toThrow(
+    await expect(loadWorkspaceProviders('gs://your-bucket', store)).rejects.toThrow(
       /relative path.*publish the spec at a URL/s,
     );
   });

--- a/src/providers/custom/load.ts
+++ b/src/providers/custom/load.ts
@@ -38,14 +38,13 @@ export interface LoadedManifest {
   readonly path: string;
 }
 
-export async function loadProfileProviders(
+export async function loadWorkspaceProviders(
   workspaceRoot: string,
-  profile: string,
   /** Injected for tests. A bucket is the case this exists to cover. */
   store?: BlobStore,
 ): Promise<LoadedManifest[]> {
   const files = store ?? workspaceFiles(workspaceRoot);
-  const directory = layout.providers(profile);
+  const directory = layout.providers();
 
   let keys: string[];
   try {

--- a/src/providers/identity/provider.ts
+++ b/src/providers/identity/provider.ts
@@ -128,7 +128,7 @@ function render(
     // Both flags, spelled out. They are required (ADR-037), so a command
     // missing either is one the owner pastes and watches refuse — and this is
     // handed to an agent, which relays it verbatim.
-    const where = `--profile ${profile}${target ? ` --target ${target}` : ''}`;
+    const where = `--profile ${profile}${target ? ` --workspace ${target}` : ''}`;
     return (
       `Profile "${profile}" declares no identity.\n\n` +
       'Nothing here says what name or address to use, so do not invent one — ask. ' +

--- a/src/providers/memory/provider.test.ts
+++ b/src/providers/memory/provider.test.ts
@@ -254,11 +254,26 @@ describe('what reaches the audit log', () => {
     expect(JSON.stringify(redacted)).not.toContain('the secret body');
   });
 
-  test('a search query is withheld entirely, like a mail search', () => {
+  test('a search query is kept, because it is the question rather than the answer', () => {
     const search = memoryProvider.capabilities.find((capability) => capability.name === 'search')!;
+    const redacted = search.redact!({ query: 'salary review', tag: 'work', limit: 10 });
 
-    // No rule declared means the default: names and types, never values.
-    expect(search.redact).toBeUndefined();
+    // What an agent went looking for is the thing this log exists to answer.
+    // Withheld, every search read alike and a calendar lookup could not be told
+    // from a rummage through someone's medical notes.
+    expect(redacted['query']).toBe('salary review');
+    expect(redacted['tag']).toBe('work');
+  });
+
+  test('keeping the query does not start keeping what it found', () => {
+    // The pairing is the whole argument for the line above: the question is
+    // recorded and the answer is not. `entry` and `get` keep an address and an
+    // id, and no capability on this provider keeps a body.
+    const bodies = memoryProvider.capabilities
+      .filter((capability) => capability.name === 'entry' || capability.name === 'get')
+      .map((capability) => capability.redact!({ uri: 'memory://entry/x', id: 'x', body: 'secret' }));
+
+    for (const redacted of bodies) expect(redacted['body']).toBe('<string:6>');
   });
 
   test('a resource read records its address but not its contents', () => {

--- a/src/providers/memory/provider.ts
+++ b/src/providers/memory/provider.ts
@@ -272,8 +272,26 @@ export const memoryProvider: ProviderDefinition = defineLocalProvider({
         tag: z.string().optional().describe('Restrict to entries carrying this tag'),
         limit: z.number().int().min(1).max(50).optional().describe(`Maximum results (default ${DEFAULT_LIMIT})`),
       }),
-      // Nothing kept: a memory query is as revealing as a Gmail search query,
-      // and frequently more so — it is the owner's own material being asked for.
+      // Kept, and this reverses the rule the rest of this file follows.
+      //
+      // The old comment here read "a memory query is as revealing as a Gmail
+      // search query, and frequently more so", which is true and is an argument
+      // about the wrong thing. A search term is not the owner's material: it is
+      // what an *agent* went looking for in that material, which is precisely
+      // the question this log exists to answer. Withholding it leaves a record
+      // saying memory was searched, twice, and matched nothing, with no way to
+      // tell a calendar lookup from a rummage through someone's medical notes.
+      //
+      // The body stays withheld either way — `entry` and `get` keep only `uri`
+      // and `id`, so what was *found* is still not in here. This records the
+      // question, not the answer.
+      //
+      // The reason for the old rule was `audit/fanout.ts`: a workspace may ship
+      // copies to stdout or an OTLP collector, and those leave the machine. That
+      // is a real exposure and it is the operator's to weigh, which is what a
+      // declared sink is. It is not a reason to withhold from the durable log on
+      // the operator's own disk.
+      redact: keepKeys('query', 'tag', 'limit'),
       async handler({ query, tag, limit }, context) {
         const needle = query.toLowerCase();
         const entries = await allEntries(context.storage);

--- a/src/providers/setup/plan.test.ts
+++ b/src/providers/setup/plan.test.ts
@@ -50,14 +50,14 @@ describe('planFor', () => {
     const plan = planFor(KEYED, context);
 
     expect(plan.needsId).toBe(true);
-    expect(plan.command).toBe('lanes link connect thing --profile personal --target local --id <name>');
+    expect(plan.command).toBe('lanes link connect thing --profile personal --workspace local --id <name>');
   });
 
   test('a named connection puts its id in the command instead of a placeholder', () => {
     const plan = planFor(KEYED, context, 'work');
 
     expect(plan.needsId).toBe(false);
-    expect(plan.command).toBe('lanes link connect thing --profile personal --target local --id work');
+    expect(plan.command).toBe('lanes link connect thing --profile personal --workspace local --id work');
     expect(plan.requires[0]?.ref).toBe('thing/work');
   });
 
@@ -131,7 +131,7 @@ describe('a provider whose client somebody else operates', () => {
     expect(plan.brokered).toBe(true);
     expect(plan.clientOperator).toBe('Someone');
     expect(plan.ownClientCommand).toBe(
-      'lanes link connect vendor_mail --profile personal --target local --own-client',
+      'lanes link connect vendor_mail --profile personal --workspace local --own-client',
     );
   });
 
@@ -175,7 +175,7 @@ describe('a provider whose client somebody else operates', () => {
 describe('the target in a command', () => {
   test('names the target beside the profile, always', () => {
     expect(planFor(KEYED, context, 'work').command).toBe(
-      'lanes link connect thing --profile personal --target local --id work',
+      'lanes link connect thing --profile personal --workspace local --id work',
     );
   });
 
@@ -183,7 +183,7 @@ describe('the target in a command', () => {
     const targeted = { ...context, target: 'local' };
 
     expect(planFor(KEYED, targeted).command).toBe(
-      'lanes link connect thing --profile personal --target local --id <name>',
+      'lanes link connect thing --profile personal --workspace local --id <name>',
     );
   });
 
@@ -192,13 +192,13 @@ describe('the target in a command', () => {
     // would send the reader to a different store than the line above it.
     const plan = planFor(BROWSER, { ...context, target: 'cloud' });
 
-    expect(plan.command).toContain('--target cloud');
+    expect(plan.command).toContain('--workspace cloud');
   });
 
   test('every shipped provider carries it', () => {
     for (const plan of planAll(PROVIDER_MANIFESTS, { ...context, target: 'cloud' })) {
-      expect(plan.command).toContain('--target cloud');
-      if (plan.ownClientCommand) expect(plan.ownClientCommand).toContain('--target cloud');
+      expect(plan.command).toContain('--workspace cloud');
+      if (plan.ownClientCommand) expect(plan.ownClientCommand).toContain('--workspace cloud');
     }
   });
 });
@@ -244,7 +244,7 @@ describe('a provider that offers a pasted token as well as a browser', () => {
 
   test('offers the token as a route --auth selects, naming what it asks for', () => {
     expect(plan.tokenCommand).toBe(
-      'lanes link connect vendor_chat --profile personal --target local --auth pasted_token',
+      'lanes link connect vendor_chat --profile personal --workspace local --auth pasted_token',
     );
     expect(plan.pastedCredential).toBe('User token');
   });

--- a/src/providers/setup/plan.ts
+++ b/src/providers/setup/plan.ts
@@ -137,7 +137,7 @@ export function planFor(
   // missing either is one that refuses, or worse, writes a credential into a
   // store the endpoint that asked for it does not read.
   const command =
-    `lanes link connect ${manifest.id} --profile ${context.profile} --target ${context.target}` +
+    `lanes link connect ${manifest.id} --profile ${context.profile} --workspace ${context.target}` +
     (needsId ? ' --id <name>' : connectionId ? ` --id ${connectionId}` : '');
 
   return {

--- a/src/providers/slack/index.ts
+++ b/src/providers/slack/index.ts
@@ -105,12 +105,12 @@ export const slack = defineProvider({
       'Open "OAuth & Permissions" and add the scopes you need under USER TOKEN SCOPES — not Bot Token Scopes; the MCP server reads the user token. The full set this provider asks for in the browser is listed in https://lanes.sh/docs/link/slack.',
       'Choose "Install to Workspace" and approve. A Slack admin may have to approve it for you.',
       'Copy the "User OAuth Token". It starts with xoxp- — not the bot token, which starts with xoxb- and will not work here.',
-      'The token does not expire unless you enable token rotation on the app. If you rotate or reinstall, run: lanes link connect slack --profile personal --target local --auth pasted_token --replace.',
+      'The token does not expire unless you enable token rotation on the app. If you rotate or reinstall, run: lanes link connect slack --profile personal --workspace local --auth pasted_token --replace.',
     ],
     troubleshooting:
       'Slack refused the token. The usual causes are a bot token (xoxb-) pasted where the user token (xoxp-) belongs, ' +
       'a scope missing from USER TOKEN SCOPES, or an app that was reinstalled since — reinstalling mints a new token. ' +
-      'Copy the User OAuth Token from https://api.slack.com/apps and re-run: lanes link connect slack --profile personal --target local --auth pasted_token --replace.',
+      'Copy the User OAuth Token from https://api.slack.com/apps and re-run: lanes link connect slack --profile personal --workspace local --auth pasted_token --replace.',
     prompts: [
       {
         key: 'token',

--- a/src/readme.test.ts
+++ b/src/readme.test.ts
@@ -48,11 +48,20 @@ const README = new URL('../README.md', import.meta.url).pathname;
  * `LANES_DOCS_DIR` points at `src/content/docs/link` in that checkout; unset,
  * the completeness check skips rather than passing by not looking.
  */
+/**
+ * The catalogue page, which is `providers.mdx` and not `connect.mdx`.
+ *
+ * It moved: `connect.mdx` became the guide to *how* connecting works and now
+ * links to the catalogue rather than being it. This pointed at the old file for
+ * long enough that the two checks below reported 105 missing providers on a
+ * website where every one of them is documented, which is the failure mode a
+ * cross-repository test has and a same-repository one does not.
+ */
 const CONNECT = process.env.LANES_DOCS_DIR
-  ? join(process.env.LANES_DOCS_DIR, 'connect.mdx')
+  ? join(process.env.LANES_DOCS_DIR, 'providers.mdx')
   : undefined;
 
-/** The guide's path, for the checks `skipIf` already gates on it existing. */
+/** The catalogue's path, for the checks `skipIf` already gates on it existing. */
 function connectGuide(): string {
   if (CONNECT === undefined) throw new Error('LANES_DOCS_DIR is not set');
   return CONNECT;
@@ -75,7 +84,7 @@ describe('the README', () => {
     expect(readme).toContain('src/providers/README.md');
   });
 
-  test.skipIf(CONNECT === undefined)('the connect guide gives a command for every provider', async () => {
+  test.skipIf(CONNECT === undefined)('the catalogue gives a command for every provider', async () => {
     const named = new Set(connectTargetsIn(await readFile(connectGuide(), 'utf8')));
 
     const missing = PROVIDER_MANIFESTS.map((manifest) => manifest.id).filter(
@@ -85,7 +94,7 @@ describe('the README', () => {
     expect(missing).toEqual([]);
   });
 
-  test.skipIf(CONNECT === undefined)('the connect guide marks exactly the untested providers', async () => {
+  test.skipIf(CONNECT === undefined)('the catalogue marks exactly the untested providers', async () => {
     // A status maintained in two places is a status that is wrong in one of
     // them. `untested.ts` is the source; this is the check that the prose agrees
     // with it, in both directions — an unmarked untested provider overclaims,

--- a/src/registry/policy-bridge.ts
+++ b/src/registry/policy-bridge.ts
@@ -1,21 +1,43 @@
-import type { PolicyDocument, PolicyRule } from '#policy';
-import type { Config } from '#profile';
+import type { PolicyDocument, PolicyRule, ProfilePolicy } from '#policy';
+import type { Config, GrantConfig } from '#profile';
 
 /**
- * Turn the config's `policy` block into the document the policy engine
+ * Turn the config's `grants:` rows into the documents the policy engine
  * evaluates.
  *
- * The config format keeps `allow` and `deny` as separate lists because that is
- * what reads clearly in YAML; the engine wants one list carrying an effect,
- * because evaluation must consider both together to make deny win regardless of
- * ordering. Converting here keeps that difference from leaking either way.
+ * Two format differences are reconciled here, and keeping them in one place is
+ * what stops either leaking into the other side.
+ *
+ * The config keeps `allow` and `deny` as separate lists because that is what
+ * reads clearly in YAML; the engine wants one list carrying an effect, because
+ * evaluation must consider both together to make deny win regardless of
+ * ordering.
+ *
+ * And the config is a *sequence* of rows while the engine wants a lookup by
+ * connection (ADR-058). A profile cannot declare the same connection twice —
+ * `assertGrantsResolve` refuses it at load, precisely so that this conversion
+ * has no collision to resolve and no precedence to invent.
+ *
+ * This is the only place `#profile`'s shape meets `#policy`'s. `#policy` may
+ * not import `#profile` and does not need to: it takes a map of rule lists and
+ * knows nothing about YAML, grants, or where a connection was declared.
  */
-export function toPolicyDocument(config: Config): PolicyDocument {
+export function toPolicyDocument(config: Config): ProfilePolicy {
+  const byConnection = new Map<string, PolicyDocument>();
+
+  for (const grant of config.grants) {
+    byConnection.set(grant.connection, { rules: rulesFor(grant) });
+  }
+
+  return { byConnection };
+}
+
+function rulesFor(grant: GrantConfig): PolicyRule[] {
   const rules: PolicyRule[] = [];
 
   for (const [effect, entries] of [
-    ['allow', config.policy.allow],
-    ['deny', config.policy.deny],
+    ['allow', grant.allow],
+    ['deny', grant.deny],
   ] as const) {
     for (const entry of entries) {
       rules.push({
@@ -28,5 +50,5 @@ export function toPolicyDocument(config: Config): PolicyDocument {
     }
   }
 
-  return { rules };
+  return rules;
 }

--- a/src/registry/reconcile.test.ts
+++ b/src/registry/reconcile.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, test } from 'bun:test';
 import { createMemoryCredentials, createMemoryState } from '#stores/state/testing.ts';
 import { defineProvider } from '#connectivity';
-import { parseConfig } from '#profile';
+import type { ConnectionConfig } from '#profile';
 import { applyReconcile, formatPlan, planIsNoop, planReconcile } from './reconcile.ts';
 
 /**
@@ -21,31 +21,27 @@ const manifestFor = (provider: string) =>
         auth: { kind: 'oauth' },
       });
 
-const config = (body: string) =>
-  parseConfig(`
-contract: 2
-instance:
-  profile: personal
-${body}
-`).config;
+/**
+ * Reconcile takes the accounts, not a profile.
+ *
+ * It always did in substance — every line of it walked `config.connections` —
+ * and ADR-057 made that literal: connections belong to the workspace, so the
+ * function that keeps their state in step is handed the rows rather than a
+ * profile that happens to list them.
+ */
+const EXAMPLE_ONLY: ConnectionConfig[] = [
+  { id: 'a', provider: 'example', account: 'Scratch' },
+];
 
-const EXAMPLE_ONLY = config(`
-connections:
-  - id: a
-    provider: example
-    account: Scratch
-`);
-
-const WITH_GMAIL = config(`
-connections:
-  - id: a
-    provider: example
-    account: Scratch
-  - id: main
-    provider: gmail
-    account: personal@example.com
-    credential_ref: gmail/main
-`);
+const WITH_GMAIL: ConnectionConfig[] = [
+  { id: 'a', provider: 'example', account: 'Scratch' },
+  {
+    id: 'main',
+    provider: 'gmail',
+    account: 'personal@example.com',
+    credential_ref: 'gmail/main',
+  },
+];
 
 describe('first reconcile', () => {
   test('creates every declared connection', async () => {
@@ -182,15 +178,10 @@ describe('drift is reported in both directions', () => {
 
     await applyReconcile(WITH_GMAIL, state, await planReconcile(WITH_GMAIL, state, credentials));
 
-    const other = config(`
-connections:
-  - id: a
-    provider: example
-    account: Scratch
-  - id: b
-    provider: example
-    account: Second
-`);
+    const other: ConnectionConfig[] = [
+    { id: 'a', provider: 'example', account: 'Scratch' },
+    { id: 'b', provider: 'example', account: 'Second' },
+  ];
 
     const plan = await planReconcile(other, state, credentials);
     expect(plan.missingInDatabase).toEqual(['example.b']);
@@ -210,12 +201,9 @@ describe('renaming', () => {
     );
     const created = await state.connections.get('example', 'a');
 
-    const renamed = config(`
-connections:
-  - id: a
-    provider: example
-    account: Renamed
-`);
+    const renamed: ConnectionConfig[] = [
+    { id: 'a', provider: 'example', account: 'Renamed' },
+  ];
 
     const plan = await planReconcile(renamed, state, credentials);
     expect(plan.actions).toEqual([
@@ -231,12 +219,9 @@ connections:
 });
 
 describe('credential refs derive from the connection', () => {
-  const derived = config(`
-connections:
-  - id: ada_lovelace
-    provider: gmail
-    account: ada.lovelace@example.com
-`);
+  const derived: ConnectionConfig[] = [
+    { id: 'ada_lovelace', provider: 'gmail', account: 'ada.lovelace@example.com' },
+  ];
 
   test('an omitted ref resolves to <provider>/<id>', async () => {
     const state = createMemoryState();
@@ -283,13 +268,9 @@ connections:
    * had reintroduced from the other side.
    */
   describe('a hand-placed ref on the connection', () => {
-    const shared = config(`
-connections:
-  - id: ada_lovelace
-    provider: gmail
-    account: ada.lovelace@example.com
-    credential_ref: google/shared
-`);
+    const shared: ConnectionConfig[] = [
+    { id: 'ada_lovelace', provider: 'gmail', account: 'ada.lovelace@example.com', credential_ref: 'google/shared' },
+  ];
 
     test('does not stand in for the credential the connection authenticates with', async () => {
       const plan = await planReconcile(
@@ -323,13 +304,9 @@ connections:
       // A `local` provider authenticates with nothing, so there is no derived
       // ref to disagree with — and `resolveSecretRefs` makes this connection's
       // whole allowlist, which `https://lanes.sh/docs/link/creating-a-provider` says outright.
-      const local = config(`
-connections:
-  - id: a
-    provider: example
-    account: Scratch
-    credential_ref: acme/api_key
-`);
+      const local: ConnectionConfig[] = [
+    { id: 'a', provider: 'example', account: 'Scratch', credential_ref: 'acme/api_key' },
+  ];
 
       const missing = await planReconcile(
         local,
@@ -357,12 +334,9 @@ describe('reconnecting an account already held', () => {
     const state = createMemoryState();
     const credentials = createMemoryCredentials({ 'gmail/ada_lovelace': 'token' });
 
-    const declared = config(`
-connections:
-  - id: ada_lovelace
-    provider: gmail
-    account: ada.lovelace@example.com
-`);
+    const declared: ConnectionConfig[] = [
+    { id: 'ada_lovelace', provider: 'gmail', account: 'ada.lovelace@example.com' },
+  ];
 
     await applyReconcile(
       declared,

--- a/src/registry/reconcile.ts
+++ b/src/registry/reconcile.ts
@@ -144,7 +144,7 @@ export function planIsNoop(plan: ReconcilePlan): boolean {
  * half-configured Gmail account must not stop the other providers from serving.
  */
 export async function planReconcile(
-  config: Config,
+  connections: readonly ConnectionConfig[],
   state: RuntimeState,
   credentials: SecretStore,
   /**
@@ -164,7 +164,7 @@ export async function planReconcile(
   const unauthorized: string[] = [];
   const declared = new Set<string>();
 
-  for (const connection of config.connections) {
+  for (const connection of connections) {
     const key = `${connection.provider}.${connection.id}`;
     declared.add(key);
 
@@ -229,11 +229,11 @@ export async function planReconcile(
 }
 
 export async function applyReconcile(
-  config: Config,
+  connections: readonly ConnectionConfig[],
   state: RuntimeState,
   plan: ReconcilePlan,
 ): Promise<void> {
-  const byKey = new Map(config.connections.map((c) => [`${c.provider}.${c.id}`, c]));
+  const byKey = new Map(connections.map((one) => [`${one.provider}.${one.id}`, one]));
 
   for (const action of plan.actions) {
     if (action.kind === 'unchanged') continue;

--- a/src/server/authorization.ts
+++ b/src/server/authorization.ts
@@ -1,0 +1,94 @@
+import {
+  IssuedTokenAuthenticator,
+  OAuthServer,
+  OAuthStore,
+  OidcAuthenticator,
+  OidcVerifier,
+  lanesFederation,
+  type Authenticator,
+} from '#auth';
+import type { Logger } from '#connectivity';
+import type { Runtime } from '#cli/runtime.ts';
+import { MCP_PATH } from './index.ts';
+import type { AuthorizationSurface } from './oauth.ts';
+
+/**
+ * Deciding how a remote client proves who it is.
+ *
+ * Its own file, away from the lifecycle in `endpoint.ts`, because the two
+ * answer different questions and only one of them is interesting. Starting an
+ * endpoint is bind, serve, reload, stop. This is which of three models the
+ * profile declared — none, an issuer of its own, or somebody else's — and each
+ * arm carries an argument that has to be read to be changed safely.
+ */
+
+/**
+ * The remote-client gate, if this profile declares one.
+ *
+ * Endpoint-scoped rather than per profile, like the bearer token and for the
+ * same reason (ADR-009): one URL serves every profile in the workspace, so
+ * there is one place a client authorises and one set of tokens.
+ *
+ * Returns null when `auth.authorization` is absent, and everything downstream
+ * treats null as "exactly as before" — no metadata published, no pointer on the
+ * `401`, one authenticator instead of a chain.
+ */
+export async function openAuthorization(
+  primary: Runtime,
+  log: Logger,
+  members: (subject: string) => Promise<readonly string[]>,
+): Promise<{ surface: AuthorizationSurface; authenticator: Authenticator } | null> {
+  const declared = primary.config.auth.authorization;
+  if (!declared) return null;
+
+  const profile = primary.resolution.profile;
+
+  if (declared.mode === 'oidc') {
+    const audience = await primary.credentials.get(declared.client_id_ref);
+    if (!audience) {
+      // Refuse rather than verify without an audience. A verifier that cannot
+      // check who a token was issued for accepts every token the issuer minted
+      // for anything, which is the failure this mode exists to prevent.
+      throw new Error(
+        `auth.authorization.client_id_ref names "${declared.client_id_ref}", which is not in ` +
+          `this target's credential store. Store it with: lanes link secrets set ${declared.client_id_ref}`,
+      );
+    }
+
+    const verifier = new OidcVerifier({
+      issuer: declared.issuer,
+      audience,
+      allowedSubjects: declared.allowed_subjects,
+      ...(declared.introspection_endpoint
+        ? { introspectionEndpoint: declared.introspection_endpoint }
+        : {}),
+    });
+
+    return {
+      // The issuer is somebody else's origin, so it is a constant here rather
+      // than derived from the request.
+      surface: { issuer: () => declared.issuer, mcpPath: MCP_PATH, target: primary.target },
+      authenticator: new OidcAuthenticator(verifier, profile),
+    };
+  }
+
+  const store = new OAuthStore(primary.state.kv);
+
+  const server = new OAuthServer({
+    store,
+    accessTokenTtlMs: declared.access_token_ttl_minutes * 60_000,
+    // So a replayed refresh token leaves a line. It is refused rather than
+    // acted on (ADR-035), and a refusal nobody can see is how a connector
+    // losing its authorization came to need log forensics to explain.
+    log,
+    // Identity comes from lanes.sh, not from a credential pasted into a form on
+    // this machine (ADR-062). What this endpoint decides is the half lanes.sh
+    // cannot know: which of *its* profiles name that person.
+    federation: lanesFederation({ profilesFor: members }),
+  });
+
+  return {
+    surface: { server, issuer: (origin) => origin, mcpPath: MCP_PATH, target: primary.target },
+    authenticator: new IssuedTokenAuthenticator(store, profile),
+  };
+}

--- a/src/server/edge.ts
+++ b/src/server/edge.ts
@@ -33,11 +33,20 @@ export const FAILED_AUTH_PER_MINUTE = 30;
  *   - `/authorize` compares against the endpoint token, which is another read of
  *     the credential store.
  *   - `/token` reads and writes bucket objects.
+ *   - `/state` and `/audit` verify the pairing token, which on a deployed
+ *     workspace is a Secret Manager call and has no cache behind it at all.
  *
  * `/health` presented with *no* credential is deliberately free: it reads
  * nothing, and it is what a platform probe and `lanes link outputs` send.
  * Metering it would put a ceiling on the one request that costs nothing to
  * answer.
+ *
+ * The read surface is **not** given that exemption, and the asymmetry is the
+ * point: nothing legitimate calls `/state` without a credential — no probe, no
+ * CLI command — so there is no free request to protect. Metering it
+ * unconditionally also means the ceiling does not depend on `readRoutes`
+ * continuing to parse the header before it asks the store anything. That
+ * short-circuit is an optimisation; this is the guarantee.
  */
 export const UNAUTHENTICATED_PER_MINUTE = 30;
 
@@ -141,6 +150,9 @@ export function unauthenticatedRefusal(input: {
   readonly healthPath: string;
   readonly isAuthorizationPath: (pathname: string) => boolean;
   readonly authorizationEnabled: boolean;
+  /** Passed rather than imported, for the reason `isAuthorizationPath` is. */
+  readonly isReadPath: (pathname: string) => boolean;
+  readonly readEnabled: boolean;
 }): Response | undefined {
   // A `/health` carrying no credential reads nothing and is deliberately free —
   // it is what a platform probe and `lanes link outputs` send, and a ceiling on
@@ -149,7 +161,8 @@ export function unauthenticatedRefusal(input: {
   const costly =
     input.pathname === input.healthPath
       ? input.request.headers.get('authorization') !== null
-      : input.authorizationEnabled && input.isAuthorizationPath(input.pathname);
+      : (input.readEnabled && input.isReadPath(input.pathname)) ||
+        (input.authorizationEnabled && input.isAuthorizationPath(input.pathname));
 
   if (!costly) return undefined;
 

--- a/src/server/endpoint.ts
+++ b/src/server/endpoint.ts
@@ -6,6 +6,8 @@ import type { ProfileRuntime } from './mcp/index.ts';
 import { AuthenticatorChain } from '#auth';
 import { openAuthorization } from './authorization.ts';
 import { openReadListener } from './read/open.ts';
+import { deployedReadDeps } from './read/deployed.ts';
+import { version } from '#cli/version.ts';
 import type { Logger } from '#connectivity';
 import { silentLogger } from './logging.ts';
 import { listProfiles, readConnections } from '#profile';
@@ -259,6 +261,12 @@ export async function startEndpoint(options: EndpointOptions): Promise<RunningEn
       { primary: primary.resolution.profile, log, ...(gate ? { remoteClients: true } : {}) },
     );
 
+    // Read once. `version()` walks up to the install root and parses
+    // `package.json`; doing it per request would put a synchronous file read on
+    // the read surface's hot path to answer a value that cannot change while
+    // this process lives.
+    const runningVersion = version();
+
     const server = serve({
       generations,
       primary: primary.resolution.profile,
@@ -269,6 +277,16 @@ export async function startEndpoint(options: EndpointOptions): Promise<RunningEn
       ...(gate ? { authorization: gate.surface } : {}),
       ...(options.port !== undefined ? { port: options.port } : {}),
       ...(options.host !== undefined ? { host: options.host } : {}),
+      // Offered unconditionally and discarded by `serve()` on a loopback bind,
+      // which is where every other property of the bind address is decided. It
+      // opens nothing and reads no credential, so building it for a bind that
+      // will not use it costs a closure (ADR-064).
+      read: deployedReadDeps({
+        primary,
+        profiles: () => generations.current.profiles,
+        log,
+        version: runningVersion,
+      }),
     });
 
     // After `serve()`, so the record means the socket is bound. Recording it
@@ -279,7 +297,13 @@ export async function startEndpoint(options: EndpointOptions): Promise<RunningEn
     // simply not served — the read surface is opt-in and its absence is the
     // default (ADR-063), so an endpoint that was never paired binds one port
     // exactly as it always did.
-    const read = await openReadListener(primary, server, () => generations.current.profiles, log);
+    const read = await openReadListener(
+      primary,
+      server,
+      () => generations.current.profiles,
+      log,
+      runningVersion,
+    );
 
     return {
       url: server.url,

--- a/src/server/endpoint.ts
+++ b/src/server/endpoint.ts
@@ -1,10 +1,16 @@
-import { MCP_PATH, serve } from './index.ts';
+import { MCP_PATH, serve, type RunningServer } from './index.ts';
 import { serveOverStdio } from './stdio.ts';
 import { Generations, type OpenedWorkspace } from './generations.ts';
 import type { AuthorizationSurface } from './oauth.ts';
 import type { ProfileRuntime } from './mcp/index.ts';
 import { AuthenticatorChain } from '#auth';
 import { openAuthorization } from './authorization.ts';
+import { serveRead, type RunningReadListener } from './read/listener.ts';
+import {
+  PAIR_CERT_REF,
+  PAIR_KEY_REF,
+  PAIR_TOKEN_REF,
+} from '#cli/commands/operate/pair.ts';
 import type { Logger } from '#connectivity';
 import { silentLogger } from './logging.ts';
 import { listProfiles } from '#profile';
@@ -74,6 +80,8 @@ export interface EndpointOptions {
 export interface RunningEndpoint {
   readonly url: string;
   readonly profiles: readonly string[];
+  /** The dashboard read surface, when this workspace is paired (ADR-063). */
+  readonly readUrl?: string | undefined;
   stop(): Promise<void>;
 }
 
@@ -257,14 +265,24 @@ export async function startEndpoint(options: EndpointOptions): Promise<RunningEn
     // from the constructor claimed an endpoint that a failed bind never served.
     generations.announce();
 
+    // Only when `lanes link pair` has provisioned all three. Absent, this is
+    // simply not served — the read surface is opt-in and its absence is the
+    // default (ADR-063), so an endpoint that was never paired binds one port
+    // exactly as it always did.
+    const read = await openReadListener(primary, server, () => generations.current.profiles, log);
+
     return {
       url: server.url,
       profiles: [...runtimes.keys()],
+      ...(read ? { readUrl: read.url } : {}),
       // `server.stop()` closes the request handler, which closes whichever
       // generation is current — and a generation owns the runtimes it opened.
       // Closing `runtimes` here too would reach past a reload and close a set
       // nothing is serving from any more.
-      stop: () => server.stop(),
+      stop: async () => {
+        await read?.stop();
+        await server.stop();
+      },
     };
   } catch (error) {
     await closeAll(runtimes);
@@ -323,5 +341,54 @@ export async function startStdioEndpoint(
   } catch (error) {
     await closeAll(runtimes);
     throw error;
+  }
+}
+
+/**
+ * The dashboard's read surface, if this workspace has been paired.
+ *
+ * Absent by default and absent for every workspace that has not run
+ * `lanes link pair`, which is the whole shape of ADR-063: a browser origin
+ * reaching loopback is a grant somebody makes deliberately, not a property of
+ * running an endpoint. All three pieces must be present — the token and both
+ * halves of the certificate — because a partial pairing would bind a port
+ * serving something no browser will connect to.
+ *
+ * Bound one above the MCP port, and a failure to bind is reported rather than
+ * fatal: the endpoint is what the operator ran this for, and refusing to serve
+ * it because a second port is occupied would be the wrong trade.
+ */
+async function openReadListener(
+  primary: Runtime,
+  server: RunningServer,
+  profiles: () => ReadonlyMap<string, ProfileRuntime>,
+  log: Logger,
+): Promise<RunningReadListener | null> {
+  const [token, cert, key] = await Promise.all([
+    primary.credentials.get(PAIR_TOKEN_REF),
+    primary.credentials.get(PAIR_CERT_REF),
+    primary.credentials.get(PAIR_KEY_REF),
+  ]);
+
+  if (token === null || cert === null || key === null) return null;
+
+  const bound = new URL(server.url);
+
+  try {
+    return serveRead({
+      host: bound.hostname,
+      port: Number(bound.port) + 1,
+      workspace: primary.target,
+      profiles,
+      audit: primary.audit,
+      token,
+      tls: { cert, key },
+    });
+  } catch (error) {
+    log.warn('could not serve the dashboard read surface', {
+      port: Number(bound.port) + 1,
+      reason: error instanceof Error ? error.message : String(error),
+    });
+    return null;
   }
 }

--- a/src/server/endpoint.ts
+++ b/src/server/endpoint.ts
@@ -3,16 +3,8 @@ import { serveOverStdio } from './stdio.ts';
 import { Generations, type OpenedWorkspace } from './generations.ts';
 import type { AuthorizationSurface } from './oauth.ts';
 import type { ProfileRuntime } from './mcp/index.ts';
-import {
-  AuthenticatorChain,
-  IssuedTokenAuthenticator,
-  OAuthServer,
-  OAuthStore,
-  OidcAuthenticator,
-  OidcVerifier,
-  tokensMatch,
-  type Authenticator,
-} from '#auth';
+import { AuthenticatorChain } from '#auth';
+import { openAuthorization } from './authorization.ts';
 import type { Logger } from '#connectivity';
 import { silentLogger } from './logging.ts';
 import { listProfiles } from '#profile';
@@ -180,80 +172,6 @@ function closeAll(runtimes: ReadonlyMap<string, Runtime>): Promise<unknown> {
   return Promise.all([...runtimes.values()].map((runtime) => runtime.close()));
 }
 
-/**
- * The remote-client gate, if this profile declares one.
- *
- * Endpoint-scoped rather than per profile, like the bearer token and for the
- * same reason (ADR-009): one URL serves every profile in the workspace, so
- * there is one place a client authorises and one set of tokens.
- *
- * Returns null when `auth.authorization` is absent, and everything downstream
- * treats null as "exactly as before" — no metadata published, no pointer on the
- * `401`, one authenticator instead of a chain.
- */
-async function openAuthorization(
-  primary: Runtime,
-  log: Logger,
-): Promise<{ surface: AuthorizationSurface; authenticator: Authenticator } | null> {
-  const declared = primary.config.auth.authorization;
-  if (!declared) return null;
-
-  const profile = primary.resolution.profile;
-
-  if (declared.mode === 'oidc') {
-    const audience = await primary.credentials.get(declared.client_id_ref);
-    if (!audience) {
-      // Refuse rather than verify without an audience. A verifier that cannot
-      // check who a token was issued for accepts every token the issuer minted
-      // for anything, which is the failure this mode exists to prevent.
-      throw new Error(
-        `auth.authorization.client_id_ref names "${declared.client_id_ref}", which is not in ` +
-          `this target's credential store. Store it with: lanes link secrets set ${declared.client_id_ref}`,
-      );
-    }
-
-    const verifier = new OidcVerifier({
-      issuer: declared.issuer,
-      audience,
-      allowedSubjects: declared.allowed_subjects,
-      ...(declared.introspection_endpoint
-        ? { introspectionEndpoint: declared.introspection_endpoint }
-        : {}),
-    });
-
-    return {
-      // The issuer is somebody else's origin, so it is a constant here rather
-      // than derived from the request.
-      surface: { issuer: () => declared.issuer, mcpPath: MCP_PATH, target: primary.target },
-      authenticator: new OidcAuthenticator(verifier, profile),
-    };
-  }
-
-  const store = new OAuthStore(primary.state.kv);
-  const expected = primary.config.auth.token_ref;
-
-  const server = new OAuthServer({
-    store,
-    accessTokenTtlMs: declared.access_token_ttl_minutes * 60_000,
-    // So a replayed refresh token leaves a line. It is refused rather than
-    // acted on (ADR-035), and a refusal nobody can see is how a connector
-    // losing its authorization came to need log forensics to explain.
-    log,
-    // Approval is proof of holding the endpoint token, compared the same way
-    // the request path compares it. There is one person behind this endpoint
-    // and they already have exactly one credential; a second one invented for
-    // the consent screen would be a password to lose.
-    verifyOwner: async (presented) => {
-      const token = await primary.credentials.get(expected);
-      return token !== null && tokensMatch(presented, token);
-    },
-  });
-
-  return {
-    surface: { server, issuer: (origin) => origin, mcpPath: MCP_PATH, target: primary.target },
-    authenticator: new IssuedTokenAuthenticator(store, profile),
-  };
-}
 
 export async function startEndpoint(options: EndpointOptions): Promise<RunningEndpoint> {
   const reporter = options.reporter ?? SILENT;
@@ -281,7 +199,20 @@ export async function startEndpoint(options: EndpointOptions): Promise<RunningEn
       }
     }
 
-    const gate = await openAuthorization(primary, log);
+    // Read through a holder rather than closed over `runtimes`, because a
+    // reload replaces that map and the gate is deliberately built once
+    // (ADR-029). Without the indirection, a member added after start would
+    // stay invisible until the endpoint was restarted — which is precisely the
+    // thing `profile members add` tells the operator has taken effect.
+    let serving: ReadonlyMap<string, Runtime> = runtimes;
+
+    const gate = await openAuthorization(primary, log, async (subject) =>
+      [...serving]
+        .filter(([, runtime]) =>
+          runtime.config.members.some((member) => member.subject === subject),
+        )
+        .map(([name]) => name),
+    );
 
     // The authenticator and the authorization gate are built once, from the
     // runtime this endpoint booted with, and are deliberately not part of what
@@ -292,6 +223,7 @@ export async function startEndpoint(options: EndpointOptions): Promise<RunningEn
       { profiles: profileRuntimes(runtimes), close: () => closeAll(runtimes).then(() => {}) },
       async (): Promise<OpenedWorkspace> => {
         const reopened = await openReconciled(options);
+        serving = reopened.runtimes;
         return {
           profiles: profileRuntimes(reopened.runtimes),
           close: () => closeAll(reopened.runtimes).then(() => {}),

--- a/src/server/endpoint.ts
+++ b/src/server/endpoint.ts
@@ -134,19 +134,16 @@ async function openReconciled(options: {
     }
 
     for (const [name, runtime] of runtimes) {
-      const result = await planReconcile(
-        runtime.config,
-        runtime.state,
-        runtime.credentials,
-        runtime.manifestFor,
-      );
+      // The accounts this profile reaches, which is what reconcile is about.
+      const granted = runtime.connections.map(({ connection }) => connection);
+      const result = await planReconcile(granted, runtime.state, runtime.credentials, runtime.manifestFor);
       if (!planIsNoop(result)) {
         reporter.reconciled({
           profile: name,
           plan: formatPlan(result),
           ofMany: runtimes.size > 1,
         });
-        await applyReconcile(runtime.config, runtime.state, result);
+        await applyReconcile(granted, runtime.state, result);
       }
     }
 
@@ -278,7 +275,7 @@ export async function startEndpoint(options: EndpointOptions): Promise<RunningEn
       if (!token) {
         throw new Error(
           `No profile token at "${primary.config.auth.token_ref}" in this target's credential store. ` +
-            'A deployed instance never mints its own — run `lanes link token rotate --target <target>` ' +
+            'A deployed instance never mints its own — run `lanes link token rotate --workspace <name>` ' +
             'from your machine, or `lanes link secrets push --from local --to cloud`, then redeploy.',
         );
       }

--- a/src/server/endpoint.ts
+++ b/src/server/endpoint.ts
@@ -13,7 +13,7 @@ import {
 } from '#cli/commands/operate/pair.ts';
 import type { Logger } from '#connectivity';
 import { silentLogger } from './logging.ts';
-import { listProfiles } from '#profile';
+import { listProfiles, readConnections } from '#profile';
 import {
   applyReconcile,
   formatPlan,
@@ -381,6 +381,8 @@ async function openReadListener(
       workspace: primary.target,
       profiles,
       audit: primary.audit,
+      connections: async () =>
+        (await readConnections(primary.resolution.workspaceRoot)).connections,
       token,
       tls: { cert, key },
     });

--- a/src/server/endpoint.ts
+++ b/src/server/endpoint.ts
@@ -5,12 +5,7 @@ import type { AuthorizationSurface } from './oauth.ts';
 import type { ProfileRuntime } from './mcp/index.ts';
 import { AuthenticatorChain } from '#auth';
 import { openAuthorization } from './authorization.ts';
-import { serveRead, type RunningReadListener } from './read/listener.ts';
-import {
-  PAIR_CERT_REF,
-  PAIR_KEY_REF,
-  PAIR_TOKEN_REF,
-} from '#cli/commands/operate/pair.ts';
+import { openReadListener } from './read/open.ts';
 import type { Logger } from '#connectivity';
 import { silentLogger } from './logging.ts';
 import { listProfiles, readConnections } from '#profile';
@@ -133,18 +128,33 @@ async function openReconciled(options: {
       }
     }
 
-    for (const [name, runtime] of runtimes) {
-      // The accounts this profile reaches, which is what reconcile is about.
-      const granted = runtime.connections.map(({ connection }) => connection);
-      const result = await planReconcile(granted, runtime.state, runtime.credentials, runtime.manifestFor);
-      if (!planIsNoop(result)) {
-        reporter.reconciled({
-          profile: name,
-          plan: formatPlan(result),
-          ofMany: runtimes.size > 1,
-        });
-        await applyReconcile(granted, runtime.state, result);
-      }
+    // Once for the workspace, over every connection the workspace holds.
+    //
+    // Runtime state is one store per workspace since contract 3, and reconcile
+    // disables everything in it that the connection list does not declare — so
+    // running it per profile over that profile's *grants* had each pass disable
+    // the connections only the other profiles granted. Two profiles was enough:
+    // the second pass disabled the first's accounts, every later call was
+    // refused `denied_connection_unauthorized`, and restarting flipped which
+    // profile survived.
+    //
+    // The primary's runtime is used for the stores because they are the same
+    // stores for every profile here. `workspaceConnections` is the whole list,
+    // which is what "undeclared" has to be measured against.
+    const declared = primary.workspaceConnections;
+    const result = await planReconcile(
+      declared,
+      primary.state,
+      primary.credentials,
+      primary.manifestFor,
+    );
+    if (!planIsNoop(result)) {
+      reporter.reconciled({
+        profile: primary.resolution.profile,
+        plan: formatPlan(result),
+        ofMany: false,
+      });
+      await applyReconcile(declared, primary.state, result);
     }
 
     return { primary, runtimes };
@@ -341,56 +351,5 @@ export async function startStdioEndpoint(
   } catch (error) {
     await closeAll(runtimes);
     throw error;
-  }
-}
-
-/**
- * The dashboard's read surface, if this workspace has been paired.
- *
- * Absent by default and absent for every workspace that has not run
- * `lanes link pair`, which is the whole shape of ADR-063: a browser origin
- * reaching loopback is a grant somebody makes deliberately, not a property of
- * running an endpoint. All three pieces must be present — the token and both
- * halves of the certificate — because a partial pairing would bind a port
- * serving something no browser will connect to.
- *
- * Bound one above the MCP port, and a failure to bind is reported rather than
- * fatal: the endpoint is what the operator ran this for, and refusing to serve
- * it because a second port is occupied would be the wrong trade.
- */
-async function openReadListener(
-  primary: Runtime,
-  server: RunningServer,
-  profiles: () => ReadonlyMap<string, ProfileRuntime>,
-  log: Logger,
-): Promise<RunningReadListener | null> {
-  const [token, cert, key] = await Promise.all([
-    primary.credentials.get(PAIR_TOKEN_REF),
-    primary.credentials.get(PAIR_CERT_REF),
-    primary.credentials.get(PAIR_KEY_REF),
-  ]);
-
-  if (token === null || cert === null || key === null) return null;
-
-  const bound = new URL(server.url);
-
-  try {
-    return serveRead({
-      host: bound.hostname,
-      port: Number(bound.port) + 1,
-      workspace: primary.target,
-      profiles,
-      audit: primary.audit,
-      connections: async () =>
-        (await readConnections(primary.resolution.workspaceRoot)).connections,
-      token,
-      tls: { cert, key },
-    });
-  } catch (error) {
-    log.warn('could not serve the dashboard read surface', {
-      port: Number(bound.port) + 1,
-      reason: error instanceof Error ? error.message : String(error),
-    });
-    return null;
   }
 }

--- a/src/server/generation.ts
+++ b/src/server/generation.ts
@@ -189,7 +189,16 @@ export class Generation {
    * a handler outliving its generation is the stale-config bug.
    */
   handlerFor(principal: Principal, clientLabel: string | undefined): McpHttpHandler {
-    const key = `${principal.id}\u0000${clientLabel ?? ''}`;
+    // The delegation list is part of the key, not just the identity.
+    //
+    // `Principal` gained `profiles` this release, and `mergeCapabilities` and
+    // `forProfile` both read it off the *captured* principal — so two tokens for
+    // one subject with different scopes hashed to one entry and whichever
+    // authorized first decided what the other could reach. Removing somebody
+    // from a profile and re-authorizing then served them the profile they had
+    // just lost, or refused one they still had, depending on order.
+    const reach = principal.profiles === undefined ? '*' : [...principal.profiles].sort().join(',');
+    const key = `${principal.id}\u0000${reach}\u0000${clientLabel ?? ''}`;
     const existing = this.#handlers.get(key);
     if (existing) return existing;
 

--- a/src/server/generations.test.ts
+++ b/src/server/generations.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, test } from 'bun:test';
 import { Generations, type OpenedWorkspace } from './generations.ts';
 import { defineProvider, type ProviderManifest } from '#connectivity';
 import { ASSERTION_GRANT, clearMintedTokens, resolveAssertionToken } from '#connectivity/auth/index.ts';
-import { EMPTY_POLICY } from '#policy';
+import { EMPTY_PROFILE_POLICY } from '#policy';
 import type { ProfileRuntime } from './mcp/index.ts';
 
 /**
@@ -27,9 +27,9 @@ const SILENT = { debug() {}, info() {}, warn() {}, error() {} };
  */
 function emptyRuntime(): ProfileRuntime {
   return {
-    config: { connections: [] },
+    config: { grants: [] },
     registry: { revision: 0, capabilities: () => [] },
-    policy: EMPTY_POLICY,
+    policy: EMPTY_PROFILE_POLICY,
   } as unknown as ProfileRuntime;
 }
 

--- a/src/server/harness.ts
+++ b/src/server/harness.ts
@@ -5,7 +5,7 @@ import {
   IssuedTokenAuthenticator,
   OAuthServer,
   OAuthStore,
-  tokensMatch,
+  type Federation,
 } from '#auth';
 import { oneProfile, type ProfileRuntime } from './mcp/index.ts';
 import {
@@ -52,6 +52,9 @@ function harnessConnections(config: Config): ConnectionConfig[] {
 }
 
 export const TEST_TOKEN = 'llk_test_token_value';
+
+/** A signed-in person no profile lists. See the federation stub below. */
+export const STRANGER = 'NOBODY_LISTS_THIS_PERSON';
 
 /**
  * A profile for the harness, from the `allow`/`deny` a test hands over.
@@ -140,6 +143,15 @@ export interface HarnessOptions {
   refreshSkills?: (registry: ProviderRegistry) => Promise<void>;
   /** Serve the `self` authorization flow alongside the bearer token. */
   authorization?: boolean;
+  /**
+   * The identity half of that flow, stubbed.
+   *
+   * The real one talks to lanes.sh and verifies a signature; a test that
+   * exercised it would be testing `AssertionVerifier`, which has its own file
+   * and its own key pair. What a harness test is about is what the endpoint
+   * does *with* an answer, so the answer is injected.
+   */
+  federation?: Partial<Federation>;
   /**
    * What a reload re-reads, standing in for `openReconciled` over a workspace
    * this harness does not have. Throwing is how the "a failed reload keeps
@@ -275,7 +287,19 @@ export function startHarness(options: HarnessOptions): Harness {
             accessTokenTtlMs: 3_600_000,
             log,
             ...(options.now ? { now: options.now } : {}),
-            verifyOwner: (presented) => Promise.resolve(tokensMatch(presented, token)),
+            federation: {
+              consentUrl: 'https://lanes.example/link/authorize',
+              // Anything non-empty verifies, as the subject it spells. Enough to
+              // drive the flow, and obviously not a verifier.
+              verify: async (assertion) =>
+                assertion ? { subject: `lanes:${assertion}`, email: null } : null,
+              // One reserved spelling answers "no profile names them", because
+              // that refusal is a real branch — a person signs in successfully
+              // and still reaches nothing — and there has to be a way to drive it.
+              profilesFor: async (subject) =>
+                subject === `lanes:${STRANGER}` ? [] : [options.profile],
+              ...options.federation,
+            },
           }),
           issuer: (origin: string) => origin,
           mcpPath: '/mcp',

--- a/src/server/harness.ts
+++ b/src/server/harness.ts
@@ -8,7 +8,8 @@ import {
   tokensMatch,
 } from '#auth';
 import { oneProfile, type ProfileRuntime } from './mcp/index.ts';
-import { parseConfig, type Config } from '#profile';
+import {
+  type ConnectionConfig, parseConfig, type Config } from '#profile';
 import { ProviderRegistry, toPolicyDocument } from '#registry';
 import { Dispatcher } from '#dispatch';
 import { createMemoryCredentials, createMemoryState } from '#stores/state/testing.ts';
@@ -33,26 +34,55 @@ import { serveOverStdio } from './stdio.ts';
  * the right calls, and a mocked transport cannot demonstrate that.
  */
 
+/**
+ * The connections a harness config implies, derived from its grants.
+ *
+ * A test config declares grants and no `connections.yaml` — there is no
+ * workspace on disk to read one from. Deriving the rows from the grant refs
+ * keeps the harness honest about the only thing dispatch uses them for, which is
+ * resolving `<provider>.<id>` to a provider and an id. Anything richer (an
+ * account label, a credential ref) belongs to a real workspace and a test that
+ * needs one builds it.
+ */
+function harnessConnections(config: Config): ConnectionConfig[] {
+  return config.grants.map((grant) => {
+    const [provider = '', id = ''] = grant.connection.split('.');
+    return { provider, id, account: grant.connection };
+  });
+}
+
 export const TEST_TOKEN = 'llk_test_token_value';
 
+/**
+ * A profile for the harness, from the `allow`/`deny` a test hands over.
+ *
+ * The two `example` accounts are the point: every test here is about a rule
+ * covering both, or one of them, so the harness gives each its own grant row
+ * carrying the same rules (ADR-058). That is what the flat block used to mean,
+ * which keeps every existing test asserting what it was written to assert.
+ */
 export function configFor(profile: string, port: number, policy: string): Config {
+  const rules = policy
+    .split('\n')
+    .filter((line) => line.trim().length > 0)
+    .map((line) => `    ${line.trim()}`)
+    .join('\n');
+
+  const grant = (id: string): string =>
+    `  - connection: example.${id}\n${rules.replace(/^ {4}(allow|deny):/gm, '    $1:')}`;
+
   return parseConfig(`
-contract: 2
+contract: 3
 instance:
   profile: ${profile}
   port: ${port}
 limits:
   requests_per_minute: 1000
   upstream_calls_per_minute: 1000
-connections:
-  - id: a
-    provider: example
-    account: Scratch A
-  - id: b
-    provider: example
-    account: Scratch B
-policy:
-${policy}
+grants:
+${grant('a')}
+${grant('b')}
+members: []
 `).config;
 }
 
@@ -162,6 +192,8 @@ export function wireProfiles(options: HarnessOptions): WiredProfiles {
 
   const dispatcher = new Dispatcher({
     config,
+    connections: harnessConnections(config),
+    oauthApps: [],
     registry,
     connectorFor: (providerId): AnyConnector | undefined => {
       const entry = registry.get(providerId);
@@ -199,6 +231,8 @@ export function wireProfiles(options: HarnessOptions): WiredProfiles {
       policy: extraPolicy,
       dispatcher: new Dispatcher({
         config: extraConfig,
+        connections: harnessConnections(extraConfig),
+        oauthApps: [],
         registry,
         connectorFor: (providerId): AnyConnector | undefined => {
           const entry = registry.get(providerId);

--- a/src/server/index.test.ts
+++ b/src/server/index.test.ts
@@ -768,17 +768,26 @@ describe('reload', () => {
   /** A config naming exactly these connections, so one can be seen to appear. */
   function configWith(profile: string, port: number, ids: string[], policy: string): Config {
     return parseConfig(`
-contract: 2
+contract: 3
 instance:
   profile: ${profile}
   port: ${port}
 limits:
   requests_per_minute: 1000
   upstream_calls_per_minute: 1000
-connections:
-${ids.map((id) => `  - { id: ${id}, provider: example, account: Scratch ${id} }`).join('\n')}
-policy:
-${policy}
+grants:
+${ids
+  .map(
+    (id) =>
+      `  - connection: example.${id}\n` +
+      policy
+        .split('\n')
+        .filter((line) => line.trim().length > 0)
+        .map((line) => `  ${line}`)
+        .join('\n'),
+  )
+  .join('\n')}
+members: []
 `).config;
 }
 

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -4,6 +4,7 @@ import { capabilityIdForToolName } from '#server/mcp';
 import { ATTACHMENTS_PATH, handleAttachments } from './attachments.ts';
 import { allowedHostnamesFor, rebindingRefusal } from './rebinding.ts';
 import { ANY_ORIGIN, corsAware, type CorsPolicy } from './cors.ts';
+import { isReadPath, readRoutes, type ReadDeps } from './read/routes.ts';
 import type { Generation } from './generation.ts';
 import type { Generations } from './generations.ts';
 import {
@@ -67,6 +68,16 @@ export interface ServerOptions {
    * — a page the owner happens to be visiting — before this would be reached.
    */
   readonly meterUnauthenticated?: boolean | undefined;
+  /**
+   * The dashboard's read surface, when this bind may serve it (ADR-064).
+   *
+   * Another property of the bind address, decided in the same lines of
+   * `serve()` as `cors` and the meter. Absent on loopback, where the TLS
+   * listener in `./read/open.ts` serves it on its own port instead — a
+   * cross-origin grant on `127.0.0.1` is what `./rebinding.ts` refuses
+   * outright, and ADR-039's rule is not being relaxed to fit this in.
+   */
+  readonly read?: ReadDeps | undefined;
 }
 
 export const MCP_PATH = '/mcp';
@@ -155,6 +166,8 @@ export function createRequestHandler(options: ServerOptions): RequestHandler {
           healthPath: HEALTH_PATH,
           isAuthorizationPath,
           authorizationEnabled: options.authorization !== undefined,
+          isReadPath,
+          readEnabled: options.read !== undefined,
         });
         if (refusal) {
           options.log.warn('rejected request', { reason: 'unauthenticated_rate' });
@@ -186,6 +199,17 @@ export function createRequestHandler(options: ServerOptions): RequestHandler {
             ? { profile: options.primary, profiles: options.generations.current.names() }
             : {}),
         });
+      }
+
+      // Above the 404 gate because these are deliberately not in the three-path
+      // set, and never through `options.authenticator`: the pairing token is a
+      // different credential for a different surface, and one shared check
+      // would make each able to do the other's job (ADR-063). Below the meter,
+      // because verifying one costs a credential-store read. Only what
+      // `isReadPath` matched is handed over — `readRoutes` answers everything
+      // it is given, so a wider hand-off would swallow `/mcp`.
+      if (options.read && isReadPath(url.pathname)) {
+        return await readRoutes(request, options.read);
       }
 
       if (
@@ -344,8 +368,15 @@ export function serve(options: ServeOptions): RunningServer {
   const cors: CorsPolicy | undefined = loopback
     ? undefined
     : { allowedOrigins: primary.config.auth.allowed_origins ?? [ANY_ORIGIN] };
+  // The fourth property of this bind address, decided with the other three.
+  // Never on loopback: `./read/open.ts` serves it there over TLS on its own
+  // port, and a deployment-only grant that leaked onto `127.0.0.1` is exactly
+  // what ADR-039 refuses. Discarded rather than overridable, as `cors` is.
+  const read = loopback ? undefined : options.read;
+
   const handler = createRequestHandler({
     ...options,
+    ...(read ? { read } : { read: undefined }),
     // Off on loopback for the same reason `cors` is undefined there, and decided
     // here so every property of the bind address is decided together. An
     // explicit `true` wins, which is how a test drives the deployed behaviour.

--- a/src/server/mcp/build.ts
+++ b/src/server/mcp/build.ts
@@ -1,6 +1,7 @@
 import { McpServer } from '@modelcontextprotocol/server';
 import { isPrompt, isResource, isTool } from '#connectivity';
 import { SERVER_ICONS } from './icon.ts';
+import { GUIDE_TITLE, GUIDE_URI, guideDocument } from './guide.ts';
 import { serverInstructions } from './instructions.ts';
 import { SERVER_NAME } from './naming.ts';
 import { registerPrompt } from './prompts.ts';
@@ -77,10 +78,28 @@ export function buildMcpServer(options: BuildServerOptions): McpServer {
       // server — to be told nothing is there.
       capabilities: {
         tools: { listChanged: false },
-        ...(offers(merged, isResource) ? { resources: { listChanged: false } } : {}),
+        // Unconditional now: `lanes://instructions` is registered below
+        // whatever policy said, so this endpoint always has at least one
+        // resource and gating the capability on the merged set would advertise
+        // nothing while serving something.
+        resources: { listChanged: false },
         ...(offers(merged, isPrompt) ? { prompts: { listChanged: false } } : {}),
       },
     },
+  );
+
+  // Always, and ahead of everything policy decided. This describes the surface
+  // rather than exposing any of it, so there is nothing here to grant — and a
+  // client whose owner has connected nothing at all still gets an account of
+  // what the thing is. It also means `resources` is advertised unconditionally,
+  // which `offers` below no longer decides on its own.
+  server.registerResource(
+    'instructions',
+    GUIDE_URI,
+    { title: GUIDE_TITLE, description: 'What this endpoint is and how to behave against it', mimeType: 'text/markdown' },
+    async (uri: URL) => ({
+      contents: [{ uri: uri.href, mimeType: 'text/markdown', text: guideDocument() }],
+    }),
   );
 
   for (const [id, entry] of merged) {

--- a/src/server/mcp/client-info.test.ts
+++ b/src/server/mcp/client-info.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, test } from 'bun:test';
+import { clientLabelFrom } from './client-info.ts';
+
+/**
+ * Which agent called, read off the request.
+ *
+ * The shape is the SDK's and not ours, so the fixtures here are the real one:
+ * `extra.mcpReq.envelope['io.modelcontextprotocol/clientInfo']`. A test written
+ * against `extra._meta` would have passed against the first attempt at this,
+ * which read nothing on a live endpoint.
+ */
+
+const KEY = 'io.modelcontextprotocol/clientInfo';
+
+function request(envelope: unknown): unknown {
+  return { sessionId: 's', mcpReq: { id: 1, method: 'tools/call', envelope } };
+}
+
+describe('clientLabelFrom', () => {
+  test('reads the name a client repeated on this request', () => {
+    expect(clientLabelFrom(request({ [KEY]: { name: 'Claude Code', version: '5.0' } }))).toBe(
+      'Claude Code',
+    );
+  });
+
+  test('a client that announced itself only at initialize stays anonymous', () => {
+    // The SDK does not backfill the envelope from the handshake, and inferring
+    // one would mean keeping a session table to hold a field nothing may trust.
+    expect(clientLabelFrom(request(undefined))).toBeUndefined();
+  });
+
+  test.each([
+    ['nothing at all', undefined],
+    ['a null', null],
+    ['a string', 'Claude Code'],
+    ['no request', { sessionId: 's' }],
+    ['an envelope that is not an object', request('Claude Code')],
+    ['an entry that is not an object', request({ [KEY]: 'Claude Code' })],
+    ['a name that is not a string', request({ [KEY]: { name: 7 } })],
+    ['an empty name', request({ [KEY]: { name: '' } })],
+  ])('undefined rather than a throw for %s', (_what, input) => {
+    // Untrusted input on a path whose failure would otherwise be an exception
+    // inside a tool call that was going to succeed. The worst honest outcome is
+    // the empty field that already existed.
+    expect(clientLabelFrom(input)).toBeUndefined();
+  });
+});

--- a/src/server/mcp/client-info.ts
+++ b/src/server/mcp/client-info.ts
@@ -1,0 +1,54 @@
+/**
+ * Which agent is calling, read off the request rather than off a header.
+ *
+ * The audit log's `clientLabel` field has always said it holds "the MCP
+ * `clientInfo` name". It did not. Over HTTP it read an `x-mcp-client` header,
+ * which is not part of MCP and which no client sends; over a pipe nothing set
+ * it at all. So the one field that exists to say *who made this call* was empty
+ * on every event this endpoint has ever written.
+ *
+ * The protocol does carry it. A client announces itself at `initialize` and the
+ * SDK repeats that announcement in every later request, in `_meta` under
+ * `io.modelcontextprotocol/clientInfo`, which the server surfaces on the
+ * request envelope. Reading it there rather than from the handshake is what
+ * makes it work at all here: streamable HTTP is stateless on this endpoint, a
+ * fresh `McpServer` is built and discarded per request (`build.ts`), and a
+ * handshake captured on one instance is gone before the next arrives.
+ *
+ * **A client that announces itself only at `initialize` and never repeats it is
+ * still anonymous**, and that is the honest outcome rather than a gap worth
+ * papering over. The SDK does not backfill the envelope from the session, so
+ * inferring one would mean this endpoint keeping its own session table to hold
+ * a field it is not allowed to trust anyway.
+ *
+ * **Self-reported, and labelled as such wherever it surfaces.** A client may
+ * call itself anything. It is recorded so a reader can see which agent made a
+ * call and is never consulted to decide what that agent may do — the same rule
+ * the field carried when it was a header, and the reason widening it is safe.
+ */
+
+/** Where the SDK puts the client's own `Implementation` on each request. */
+const CLIENT_INFO_META_KEY = 'io.modelcontextprotocol/clientInfo';
+
+/**
+ * The name the client gave for itself, or undefined.
+ *
+ * Deliberately tolerant. This is untrusted input on a path whose failure mode
+ * would otherwise be an exception inside a tool call that was going to succeed,
+ * and the worst honest outcome is the empty field that already exists.
+ */
+export function clientLabelFrom(extra: unknown): string | undefined {
+  if (typeof extra !== 'object' || extra === null) return undefined;
+
+  const request = (extra as { mcpReq?: unknown }).mcpReq;
+  if (typeof request !== 'object' || request === null) return undefined;
+
+  const envelope = (request as { envelope?: unknown }).envelope;
+  if (typeof envelope !== 'object' || envelope === null) return undefined;
+
+  const info = (envelope as Record<string, unknown>)[CLIENT_INFO_META_KEY];
+  if (typeof info !== 'object' || info === null) return undefined;
+
+  const name = (info as { name?: unknown }).name;
+  return typeof name === 'string' && name.length > 0 ? name : undefined;
+}

--- a/src/server/mcp/guide.ts
+++ b/src/server/mcp/guide.ts
@@ -1,0 +1,120 @@
+import { RESERVED_PROVIDER_IDS } from '#connectivity';
+
+/**
+ * The long form of what this endpoint is, served as a resource.
+ *
+ * `initialize.instructions` has a budget it pays on every request forever, so it
+ * carries only the habits that must arrive everywhere. This is the document a
+ * client reads once when it wants the whole account, and it is served always,
+ * without a tool grant, because it describes the surface rather than exposing
+ * any of it.
+ *
+ * **Why a resource rather than a longer `instructions`.** A client caches
+ * `initialize` for the life of its registration, so guidance improved after
+ * somebody connected never reaches them. A resource is fetched when it is read,
+ * so this can be corrected without anybody reconnecting.
+ *
+ * **No vendor may be named here.** `src/architecture.test.ts` forbids it
+ * anywhere under `server/`, and rightly: what an owner has connected is theirs,
+ * and prose naming one provider would be wrong for everybody else.
+ */
+
+export const GUIDE_URI = 'lanes://instructions';
+
+export const GUIDE_TITLE = 'How this endpoint works';
+
+/**
+ * The document.
+ *
+ * Fixed prose, deliberately: it describes the model rather than this workspace,
+ * and the per-principal facts are in `initialize.instructions`, which is
+ * computed. Two documents with different lifetimes, and mixing them would make
+ * this one wrong the moment a connection was added.
+ */
+export function guideDocument(): string {
+  return `# Lanes Link
+
+One endpoint in front of everything its owner has chosen to expose. It
+authenticates, applies permissions per call, and records what happened.
+
+## The three words
+
+**Connection.** One authorised account or store, named \`<provider>.<id>\`. It
+belongs to the workspace, so the same account can be reached from more than one
+profile without being authorised twice.
+
+**Profile.** A selection of connections, with the capabilities allowed on each,
+and the people who may consume it. This is how someone keeps work and personal
+apart, and how they hand you one mailbox read-only while another is writable.
+
+**Workspace.** Where connections and profiles live, and which credential store
+opens them. You never name one; the endpoint you are talking to is already in it.
+
+## Routing
+
+Every tool takes \`profile\` and \`connection\`. Both are enums, and both are
+already narrowed to what you may reach, so anything offered is something you are
+allowed to use.
+
+**When it is ambiguous which profile is meant, ask.** Do not default to whichever
+is listed first. A profile is a boundary somebody drew on purpose, and crossing
+it is the failure this design exists to prevent.
+
+A connection belongs to a profile. Naming one from a different profile is
+refused, and the refusal lists what is available where you asked.
+
+## The owner's own material
+
+${RESERVED_PROVIDER_IDS.join(', ')} are not third-party services. They are the
+owner's own stores, and each is a connection like any other, so a profile decides
+which instances it can reach and what it may do with them.
+
+**Memory and tasks are different stores.** Search memory before concluding you do
+not know something about this person or their work. A thing to *do* is a task,
+and it has a status; "remember to..." is a task, not a memory. Both are served
+back to every later session, so write when asked rather than by habit.
+
+**Skills are the owner's procedures**, surfaced as prompts rather than tools.
+That is deliberate: a procedure is selected by the person, not chosen by the
+model, and you cannot read one's body. If a task has a skill for it, say so and
+let them invoke it rather than improvising your own version.
+
+**Vault values are credentials.** Use one to do the thing that needs it. Do not
+quote it back, summarise it, or write it anywhere.
+
+**Entities are the people, companies and projects this owner deals with.** Before
+using anyone's address or handle, look them up. A lookup returns every match and
+never chooses: more than one means ask which is meant, not take the first.
+
+## What is set up is answerable
+
+Before saying something cannot be reached, or that an account must be added, ask
+the setup surface. It reports what exists and what is missing, and it gives the
+exact command for the missing thing.
+
+**Running that command is the owner's to do, and inventing one is not.** Every
+change to what exists here is a command a person runs; nothing on this surface
+adds a connection, edits a profile, or changes who may consume it. That is not an
+omission to work around.
+
+## When a call is refused
+
+A refusal is information, not an obstacle. Three kinds, and they mean different
+things:
+
+- **The profile is not available.** You are not a member of it. Nothing you can
+  do; its owner adds you.
+- **The connection is not part of this profile.** Look at what is, in the enum.
+- **The capability is denied.** The profile allows a narrower set than the tool
+  suggests. Say what was refused and let the owner decide whether to widen it.
+
+Retrying a refusal unchanged produces the same refusal and one more line in the
+owner's audit log.
+
+## Files are named, not carried
+
+Where a tool takes attachments, give a path, an HTTPS URL, or an attachment
+already on another message. Do not base64 a file into an argument: it is recorded
+in the audit log, and the log is something the owner reads.
+`;
+}

--- a/src/server/mcp/instructions.ts
+++ b/src/server/mcp/instructions.ts
@@ -53,7 +53,7 @@ import type { MergedCapability } from './visibility.ts';
  */
 const OPENING = `This endpoint is one place to reach what its owner has chosen to expose. It
 authenticates, applies permissions, and records what happened, so you do not
-have to.`;
+have to. Read \`lanes://instructions\` for the whole account of how it works.`;
 
 const ROUTING = `**Routing.** Every tool takes \`profile\` and \`connection\`. A profile is how
 someone separates work from personal — when it is ambiguous which one is meant,

--- a/src/server/mcp/prompts.ts
+++ b/src/server/mcp/prompts.ts
@@ -1,4 +1,5 @@
 import { forProfile } from '#auth';
+import { clientLabelFrom } from './client-info.ts';
 import type { McpServer } from '@modelcontextprotocol/server';
 import { z } from 'zod';
 import { isPromptResult } from '#connectivity';
@@ -49,17 +50,19 @@ export function registerPrompt(
       description: describeWithConnections(capability.description, entry.reachable),
       argsSchema: z.object(shape),
     },
-    async (args: Record<string, unknown>) => {
+    async (args: Record<string, unknown>, extra?: unknown) => {
       const { profile, connection, ...rest } = args;
       const scope = resolveScope(entry, profile, connection);
       if ('error' in scope) throw new Error(scope.error);
+
+      const label = clientLabelFrom(extra) ?? options.clientLabel;
 
       const outcome = await options.profiles.get(scope.profile)!.dispatcher.invoke({
         principal: forProfile(options.principal, scope.profile),
         capabilityId: id,
         connectionKey: scope.connectionKey,
         arguments: rest,
-        clientLabel: options.clientLabel,
+        ...(label ? { clientLabel: label } : {}),
       });
 
       // A prompt has no `isError` to carry a refusal in, so a denial is a

--- a/src/server/mcp/prompts.ts
+++ b/src/server/mcp/prompts.ts
@@ -1,3 +1,4 @@
+import { forProfile } from '#auth';
 import type { McpServer } from '@modelcontextprotocol/server';
 import { z } from 'zod';
 import { isPromptResult } from '#connectivity';
@@ -54,7 +55,7 @@ export function registerPrompt(
       if ('error' in scope) throw new Error(scope.error);
 
       const outcome = await options.profiles.get(scope.profile)!.dispatcher.invoke({
-        principal: options.principal,
+        principal: forProfile(options.principal, scope.profile),
         capabilityId: id,
         connectionKey: scope.connectionKey,
         arguments: rest,

--- a/src/server/mcp/resources.ts
+++ b/src/server/mcp/resources.ts
@@ -1,3 +1,4 @@
+import { forProfile } from '#auth';
 import { ResourceTemplate, type McpServer } from '@modelcontextprotocol/server';
 import { isResourceListResult, isResourceResult } from '#connectivity';
 import type { DispatchOutcome } from '#dispatch';
@@ -30,7 +31,7 @@ export function registerResource(
 
       const dispatch = (args: Record<string, unknown>): Promise<DispatchOutcome> =>
         runtime.dispatcher.invoke({
-          principal: options.principal,
+          principal: forProfile(options.principal, profile),
           capabilityId: id,
           connectionKey,
           arguments: args,

--- a/src/server/mcp/resources.ts
+++ b/src/server/mcp/resources.ts
@@ -1,4 +1,5 @@
 import { forProfile } from '#auth';
+import { clientLabelFrom } from './client-info.ts';
 import { ResourceTemplate, type McpServer } from '@modelcontextprotocol/server';
 import { isResourceListResult, isResourceResult } from '#connectivity';
 import type { DispatchOutcome } from '#dispatch';
@@ -29,14 +30,20 @@ export function registerResource(
       const scope = { profile, connectionId };
       const scoped = scopeResourceUri(capability.uriTemplate, scope);
 
-      const dispatch = (args: Record<string, unknown>): Promise<DispatchOutcome> =>
-        runtime.dispatcher.invoke({
+      const dispatch = (
+        args: Record<string, unknown>,
+        extra?: unknown,
+      ): Promise<DispatchOutcome> => {
+        const label = clientLabelFrom(extra) ?? options.clientLabel;
+
+        return runtime.dispatcher.invoke({
           principal: forProfile(options.principal, profile),
           capabilityId: id,
           connectionKey,
           arguments: args,
-          clientLabel: options.clientLabel,
+          ...(label ? { clientLabel: label } : {}),
         });
+      };
 
       const metadata = {
         description: `${capability.description} (${profile}: ${connectionKey})`,
@@ -45,8 +52,8 @@ export function registerResource(
 
       // `uri` is the whole argument — the provider recovers its own template
       // variables from it and never sees the routing segments core prepended.
-      const read = async (uri: URL) => {
-        const outcome = await dispatch({ uri: uri.href });
+      const read = async (uri: URL, _variables?: unknown, extra?: unknown) => {
+        const outcome = await dispatch({ uri: uri.href }, extra);
         if (!outcome.ok) throw new Error(outcome.message);
         if (!isResourceResult(outcome.result)) {
           throw new Error(`${id} did not return resource contents`);
@@ -84,8 +91,8 @@ export function registerResource(
           // rather than an oversight. A provider omits `list` when its resource
           // space is unbounded.
           list: capability.list
-            ? async () => {
-                const outcome = await dispatch({});
+            ? async (extra?: unknown) => {
+                const outcome = await dispatch({}, extra);
                 if (!outcome.ok) throw new Error(outcome.message);
                 if (!isResourceListResult(outcome.result)) return { resources: [] };
 

--- a/src/server/mcp/tools.ts
+++ b/src/server/mcp/tools.ts
@@ -2,6 +2,7 @@ import { forProfile } from '#auth';
 import { fromJsonSchema, type McpServer } from '@modelcontextprotocol/server';
 import { z } from 'zod';
 import { isToolResult } from '#connectivity';
+import { clientLabelFrom } from './client-info.ts';
 import { toolNameFor } from './naming.ts';
 import { resourceLinkRouter } from './routing.ts';
 import { sanitizeSchema } from './schema.ts';
@@ -112,8 +113,12 @@ export function registerLocalTool(
 function makeHandler(capabilityId: string, entry: MergedCapability, options: BuildServerOptions) {
   // `unknown` because the JSON-Schema overload types it that way; the schema
   // has already validated the shape by the time this runs.
-  return async (args: unknown) => {
+  return async (args: unknown, extra?: unknown) => {
     const { profile, connection, ...rest } = (args ?? {}) as Record<string, unknown>;
+
+    // The request first, then whatever the transport knew before the call —
+    // which on a stateless POST is nothing, and is why the request is asked.
+    const label = clientLabelFrom(extra) ?? options.clientLabel;
 
     const name = String(profile);
     const runtime = options.profiles.get(name);
@@ -152,7 +157,7 @@ function makeHandler(capabilityId: string, entry: MergedCapability, options: Bui
       capabilityId,
       connectionKey: String(connection),
       arguments: rest,
-      clientLabel: options.clientLabel,
+      ...(label ? { clientLabel: label } : {}),
     });
 
     if (!outcome.ok) {

--- a/src/server/mcp/tools.ts
+++ b/src/server/mcp/tools.ts
@@ -1,3 +1,4 @@
+import { forProfile } from '#auth';
 import { fromJsonSchema, type McpServer } from '@modelcontextprotocol/server';
 import { z } from 'zod';
 import { isToolResult } from '#connectivity';
@@ -147,7 +148,7 @@ function makeHandler(capabilityId: string, entry: MergedCapability, options: Bui
     }
 
     const outcome = await runtime.dispatcher.invoke({
-      principal: options.principal,
+      principal: forProfile(options.principal, name),
       capabilityId,
       connectionKey: String(connection),
       arguments: rest,

--- a/src/server/mcp/visibility.ts
+++ b/src/server/mcp/visibility.ts
@@ -3,8 +3,9 @@ import type { Principal } from '#auth';
 import type { Config } from '#profile';
 import type { ProviderRegistry } from '#registry';
 import type { Dispatcher } from '#dispatch';
-import type { PolicyDocument } from '#policy';
+import type { PolicyDocument, ProfilePolicy } from '#policy';
 import { allowedConnections } from '#policy';
+import { mayReach } from '#auth';
 
 /**
  * What this principal can see, and therefore what gets registered at all.
@@ -25,7 +26,7 @@ export interface ProfileRuntime {
   readonly config: Config;
   readonly registry: ProviderRegistry;
   readonly dispatcher: Dispatcher;
-  readonly policy: PolicyDocument;
+  readonly policy: ProfilePolicy;
   readonly floor?: PolicyDocument | undefined;
   /**
    * Re-read the skills into `registry`, if they have changed on the store.
@@ -72,8 +73,16 @@ export function oneProfile(
   return new Map([[name, runtime]]);
 }
 
+/**
+ * The connections this profile can reach at all, before policy narrows further.
+ *
+ * The grant rows *are* the answer (ADR-058). A profile reaches what it grants
+ * and nothing else, so this needs no view of the workspace's connections — which
+ * is the useful half of decoupling them: what a profile can see is written in
+ * the profile, and cannot widen when somebody connects a new account.
+ */
 function connectionsOf(runtime: ProfileRuntime): string[] {
-  return runtime.config.connections.map((connection) => `${connection.provider}.${connection.id}`);
+  return runtime.config.grants.map((grant) => grant.connection);
 }
 
 /**
@@ -94,6 +103,12 @@ export function mergeCapabilities(options: BuildServerOptions): Map<string, Merg
   const merged = new Map<string, MergedCapability>();
 
   for (const [name, runtime] of options.profiles) {
+    // The same list the dispatcher enforces with. A member does not merely fail
+    // to call a profile they are not on — it is absent from the `profile` enum,
+    // so they never learn it exists (ADR-060). Discovery and enforcement share
+    // one answer here for the same reason they share `allowedConnections`.
+    if (!mayReach(options.principal, name)) continue;
+
     const connections = connectionsOf(runtime);
 
     for (const { id, capability, discovered } of runtime.registry.capabilities()) {

--- a/src/server/oauth.test.ts
+++ b/src/server/oauth.test.ts
@@ -1,6 +1,6 @@
 import { afterAll, beforeAll, describe, expect, test } from 'bun:test';
 import { pkceChallengeFor } from '#auth';
-import { allocatePort, startHarness, TEST_TOKEN, type Harness } from './harness.ts';
+import { allocatePort, startHarness, STRANGER, TEST_TOKEN, type Harness } from './harness.ts';
 
 /**
  * The flow a remote connector actually drives.
@@ -71,28 +71,54 @@ async function register(redirectUris: string[] = [REDIRECT]): Promise<string> {
   return ((await response.json()) as { client_id: string }).client_id;
 }
 
-/** Walk authorize -> approve and return whatever came back on the redirect. */
+/**
+ * The whole browser leg: `/authorize`, off to Lanes, back through the callback.
+ *
+ * The middle hop is where a person signs in, and the harness's federation
+ * believes any assertion and spells it back as a subject — so `who` stands in
+ * for a whole sign-in. That is the right seam here: what this file is about is
+ * the endpoint's half, and everything about *verifying* an assertion is tested
+ * against a real key pair in `auth/lanes/assertion.test.ts`.
+ *
+ * Returns whatever the last hop produced, so a refusal at either end is
+ * inspectable rather than swallowed.
+ */
 async function authorise(
   clientId: string,
   overrides: Record<string, string> = {},
-  token = TEST_TOKEN,
+  who = 'THEOWNER',
 ): Promise<Response> {
-  const form = new URLSearchParams({
+  const sent = await start(clientId, overrides);
+  if (sent.status !== 302) return sent;
+
+  return complete(sent, who);
+}
+
+/** The first hop, which now ends at Lanes rather than at a form. */
+function start(clientId: string, overrides: Record<string, string> = {}): Promise<Response> {
+  const params = new URLSearchParams({
+    response_type: 'code',
     client_id: clientId,
     redirect_uri: REDIRECT,
     code_challenge: pkceChallengeFor(VERIFIER),
+    code_challenge_method: 'S256',
     scope: 'mcp',
     state: 'opaque-state',
-    token,
     ...overrides,
   });
 
-  return fetch(`${origin}/authorize`, {
-    method: 'POST',
-    headers: { 'content-type': 'application/x-www-form-urlencoded' },
-    body: form.toString(),
-    redirect: 'manual',
-  });
+  return fetch(`${origin}/authorize?${params}`, { redirect: 'manual' });
+}
+
+/** The browser coming back, as a top-level navigation carrying an assertion. */
+function complete(sent: Response, who: string, nonce?: string): Promise<Response> {
+  const consent = new URL(sent.headers.get('location')!);
+  const back = new URL(consent.searchParams.get('return')!);
+
+  back.searchParams.set('nonce', nonce ?? consent.searchParams.get('nonce')!);
+  back.searchParams.set('assertion', who);
+
+  return fetch(back, { redirect: 'manual' });
 }
 
 /**
@@ -243,7 +269,7 @@ describe('discovery', () => {
 });
 
 describe('the authorization code flow', () => {
-  test('register, approve, exchange, and the token opens the endpoint', async () => {
+  test('register, sign in, exchange, and the token opens the endpoint', async () => {
     const clientId = await register();
 
     const redirect = await authorise(clientId);
@@ -272,56 +298,67 @@ describe('the authorization code flow', () => {
     expect(call.status).not.toBe(401);
   });
 
-  test('the consent screen names the client and where the code would go', async () => {
+  test('there is no consent page here at all — the browser is sent to Lanes', async () => {
+    // The point of ADR-062. This endpoint used to render a form asking for the
+    // one credential that opens everything, on loopback, where any page on the
+    // machine could reach it. Now `/authorize` is a redirect and there is
+    // nothing local to phish.
+    const sent = await start(await register());
+
+    expect(sent.status).toBe(302);
+    const consent = new URL(sent.headers.get('location')!);
+    expect(consent.origin).toBe('https://lanes.example');
+    expect(consent.pathname).toBe('/link/authorize');
+  });
+
+  test('it carries what the person has to see, and where to come back to', async () => {
     // Registration is open, so the name is self-reported and proves nothing.
     // The redirect host is the part an impostor cannot change, and the spec
-    // requires showing it for exactly that reason.
-    const clientId = await register();
-    const page = await fetch(
-      `${origin}/authorize?response_type=code&client_id=${clientId}` +
-        `&redirect_uri=${encodeURIComponent(REDIRECT)}` +
-        `&code_challenge=${pkceChallengeFor(VERIFIER)}&code_challenge_method=S256`,
-    );
+    // requires showing it for exactly that reason — so both are handed to the
+    // page that will show them.
+    const sent = await start(await register());
+    const consent = new URL(sent.headers.get('location')!);
 
-    const html = await page.text();
-    expect(html).toContain('Test Client');
-    expect(html).toContain('claude.ai');
-    // And which target's store the token it asks for lives in. The endpoint
-    // knows; the shell the reader runs the command in does not.
-    expect(html).toContain('lanes link outputs --show --workspace local');
+    expect(consent.searchParams.get('client')).toBe('Test Client');
+    expect(consent.searchParams.get('redirect_host')).toBe('claude.ai');
+    expect(consent.searchParams.get('resource')).toBe(`${origin}/mcp`);
+    expect(consent.searchParams.get('return')).toBe(`${origin}/authorize/callback`);
+    expect(consent.searchParams.get('nonce')).toBeTruthy();
   });
 
-  test('a client name cannot inject markup into the approval page', async () => {
-    const response = await fetch(`${origin}/register`, {
-      method: 'POST',
-      headers: { 'content-type': 'application/json' },
-      body: JSON.stringify({
-        redirect_uris: [REDIRECT],
-        client_name: '<script>alert(1)</script>',
-      }),
-    });
-    const clientId = ((await response.json()) as { client_id: string }).client_id;
+  test('a nonce is single use, because it travels through a browser', async () => {
+    // It reaches history, referrers, and anything watching the address bar.
+    // Consuming it on read is what stops one assertion being spent twice.
+    const clientId = await register();
+    const sent = await start(clientId);
 
-    const page = await fetch(
-      `${origin}/authorize?response_type=code&client_id=${clientId}` +
-        `&redirect_uri=${encodeURIComponent(REDIRECT)}` +
-        `&code_challenge=${pkceChallengeFor(VERIFIER)}&code_challenge_method=S256`,
-    );
+    expect((await complete(sent, 'THEOWNER')).status).toBe(302);
 
-    const html = await page.text();
-    expect(html).not.toContain('<script>alert(1)</script>');
-    expect(html).toContain('&lt;script&gt;');
+    const replayed = await complete(sent, 'THEOWNER');
+    expect(replayed.status).toBe(400);
+    expect(await replayed.text()).toContain('expired or was already used');
   });
 
-  test('the wrong endpoint token re-renders the form rather than redirecting', async () => {
-    // The client has no business being told whether the owner typed their token
-    // correctly, and a redirected error would end the flow on the first typo.
-    const clientId = await register();
-    const response = await authorise(clientId, {}, 'llk_not_the_token');
+  test('a nonce this endpoint never minted authorises nothing', async () => {
+    const sent = await start(await register());
+    const forged = await complete(sent, 'THEOWNER', 'lln_invented');
 
-    expect(response.status).toBe(401);
-    expect(response.headers.get('location')).toBeNull();
-    expect(await response.text()).toContain('not accepted');
+    expect(forged.status).toBe(400);
+    expect(forged.headers.get('location')).toBeNull();
+  });
+
+  test('a stranger who signs in successfully is refused, and told what to ask for', async () => {
+    // The interesting refusal, and the reason it renders a page. They are
+    // signed in; nothing is wrong with their identity. No profile here names
+    // them, and "sign in again" would be advice that cannot work.
+    const refused = await authorise(await register(), {}, STRANGER);
+
+    expect(refused.status).toBe(403);
+    expect(refused.headers.get('location')).toBeNull();
+
+    const html = await refused.text();
+    expect(html).toContain('no profile on this endpoint lists you');
+    expect(html).toContain(`lanes link profile members add lanes:${STRANGER}`);
   });
 
   test('a code is single use', async () => {
@@ -422,40 +459,36 @@ describe('the authorization code flow', () => {
     expect(response.headers.get('location')).toStartWith('http://localhost:51763/callback?');
   });
 
-  test('the consent page permits the redirect its own approval performs', async () => {
-    // Chrome and Safari re-check `form-action` when a form submission redirects,
-    // so a policy naming only `'self'` blocks the 302 that ends the flow: the
-    // POST is accepted, the code is minted, and the browser then refuses to
-    // deliver it. Nothing about that is visible in the page or the response —
-    // the spinner simply never stops.
-    //
-    // So this asks the policy the consent page was served with about the
-    // destination that page's own approval produces, rather than asserting a
-    // string. The string was right; what it named was not enough.
+  test('nothing the browser carries back decides anything', async () => {
+    // Everything the client asked for is held here under the nonce, so a
+    // callback that names a different client and a different destination is
+    // ignored on both counts. This is what makes the return leg safe to run as
+    // a bare GET from an off-machine redirect.
     const clientId = await register();
-    const consent = await fetch(
-      `${origin}/authorize?response_type=code&client_id=${clientId}` +
-        `&redirect_uri=${encodeURIComponent(REDIRECT)}` +
-        `&code_challenge=${pkceChallengeFor(VERIFIER)}&code_challenge_method=S256`,
-    );
-    const approved = await authorise(clientId);
+    const other = await register(['https://evil.example/steal']);
 
-    expect(approved.status).toBe(302);
-    expect(formActionOf(consent)).toContain(new URL(approved.headers.get('location')!).origin);
+    const sent = await start(clientId);
+    const consent = new URL(sent.headers.get('location')!);
+    const back = new URL(consent.searchParams.get('return')!);
+    back.searchParams.set('nonce', consent.searchParams.get('nonce')!);
+    back.searchParams.set('assertion', 'THEOWNER');
+    back.searchParams.set('client_id', other);
+    back.searchParams.set('redirect_uri', 'https://evil.example/steal');
+
+    const done = await fetch(back, { redirect: 'manual' });
+
+    expect(done.status).toBe(302);
+    expect(done.headers.get('location')).toStartWith(REDIRECT);
   });
 
-  test('a native client on loopback is permitted the port it actually bound', async () => {
-    // The registered URI has no port and the redirect has one, so a policy
-    // built from what was registered would name an origin the browser never
-    // navigates to. It has to come from the request being approved.
-    const clientId = await register(['http://localhost/callback']);
-    const consent = await fetch(
-      `${origin}/authorize?response_type=code&client_id=${clientId}` +
-        `&redirect_uri=${encodeURIComponent('http://localhost:51763/callback')}` +
-        `&code_challenge=${pkceChallengeFor(VERIFIER)}&code_challenge_method=S256`,
-    );
+  test('the whole CSP widening the consent form needed is gone with it', async () => {
+    // `form-action` had to name the client origin, because Chrome and Safari
+    // re-check it when a form submission redirects — a policy naming only
+    // `'self'` minted the code and then blocked its delivery. No form, no
+    // submission, no widening: the one page left here submits nothing.
+    const refused = await authorise(await register(), {}, STRANGER);
 
-    expect(formActionOf(consent)).toContain('http://localhost:51763');
+    expect(formActionOf(refused)).toEqual(["'self'"]);
   });
 });
 

--- a/src/server/oauth.test.ts
+++ b/src/server/oauth.test.ts
@@ -288,7 +288,7 @@ describe('the authorization code flow', () => {
     expect(html).toContain('claude.ai');
     // And which target's store the token it asks for lives in. The endpoint
     // knows; the shell the reader runs the command in does not.
-    expect(html).toContain('lanes link outputs --show --target local');
+    expect(html).toContain('lanes link outputs --show --workspace local');
   });
 
   test('a client name cannot inject markup into the approval page', async () => {

--- a/src/server/oauth.ts
+++ b/src/server/oauth.ts
@@ -1,11 +1,10 @@
 import {
   authorizationServerMetadata,
   protectedResourceMetadata,
-  type AuthorizeRequest,
   type OAuthResult,
   type OAuthServer,
 } from '#auth';
-import { approvalPage } from '#cli/callback-page.ts';
+import { noticePage } from '#cli/callback-page.ts';
 
 /**
  * The HTTP surface of the authorization flow.
@@ -24,6 +23,7 @@ export const PROTECTED_RESOURCE_PATH = '/.well-known/oauth-protected-resource';
 export const AUTHORIZATION_SERVER_PATH = '/.well-known/oauth-authorization-server';
 const REGISTER_PATH = '/register';
 const AUTHORIZE_PATH = '/authorize';
+const CALLBACK_PATH = '/authorize/callback';
 const TOKEN_PATH = '/token';
 
 export interface AuthorizationSurface {
@@ -50,6 +50,7 @@ export function isAuthorizationPath(pathname: string): boolean {
     pathname === AUTHORIZATION_SERVER_PATH ||
     pathname === REGISTER_PATH ||
     pathname === AUTHORIZE_PATH ||
+    pathname === CALLBACK_PATH ||
     pathname === TOKEN_PATH
   );
 }
@@ -125,35 +126,37 @@ export async function handleAuthorization(
   if (!server) return new Response('Not found', { status: 404 });
 
   if (path === REGISTER_PATH && request.method === 'POST') {
-    return render(await server.register(await safeJson(request)), request, surface.target);
+    return render(await server.register(await safeJson(request)), request);
   }
 
-  if (path === AUTHORIZE_PATH) {
-    if (request.method === 'GET') {
-      return render(await server.authorize(url.searchParams), request, surface.target);
-    }
-    if (request.method === 'POST') {
-      const form = new URLSearchParams(await request.text());
-      return render(
-        await server.approve(requestFromForm(form), form.get('token') ?? ''),
-        request,
-        surface.target,
-      );
-    }
+  // Who this endpoint is, from the point of view of *this* request. Derived
+  // from `Host` rather than config for the reason `publicOrigin` gives: a
+  // deployed instance's hostname is assigned at deploy time, and an assertion
+  // whose audience does not match exactly is refused.
+  const endpoint = {
+    resource: `${origin}${surface.mcpPath}`,
+    callbackUrl: `${origin}${CALLBACK_PATH}`,
+  };
+
+  if (path === AUTHORIZE_PATH && request.method === 'GET') {
+    return render(await server.authorize(url.searchParams, endpoint), request);
+  }
+
+  // The browser returning from lanes.sh. A GET, because it arrives as a
+  // top-level navigation from a 302 — which is also why nothing here reads
+  // `Origin`: a navigation carries none. See `rebinding.ts`.
+  if (path === CALLBACK_PATH && request.method === 'GET') {
+    return render(await server.callback(url.searchParams, endpoint), request);
   }
 
   if (path === TOKEN_PATH && request.method === 'POST') {
-    return render(
-      await server.token(new URLSearchParams(await request.text())),
-      request,
-      surface.target,
-    );
+    return render(await server.token(new URLSearchParams(await request.text())), request);
   }
 
   return new Response('Method not allowed', { status: 405 });
 }
 
-function render(result: OAuthResult, request: Request, target: string): Response {
+function render(result: OAuthResult, request: Request): Response {
   switch (result.kind) {
     case 'json':
       return json(result.body, result.status);
@@ -161,95 +164,12 @@ function render(result: OAuthResult, request: Request, target: string): Response
     case 'redirect':
       return new Response(null, { status: 302, headers: { location: result.location } });
 
-    case 'consent':
-      return approvalPage({
-        // The name if it gave one, the identifier if not. Either way the
-        // redirect host goes on the screen beside it — a client may call itself
-        // anything, but it cannot change where the code is sent.
-        client: result.clientName ?? result.request.clientId,
-        redirectHost: hostOf(result.request.redirectUri),
-        // The page's policy has to admit the redirect the page's own approval
-        // ends in, or the browser blocks it. See `formActionFor`.
-        ...formActionFor(result.request.redirectUri),
-        action: `${publicOrigin(request)}${AUTHORIZE_PATH}`,
-        fields: formFromRequest(result.request),
-        retry: result.retry,
-        target,
-      });
-
     case 'error':
-      return new Response(result.message, { status: result.status });
-  }
-}
-
-/**
- * The authorization request, carried through the approval form.
- *
- * Round-tripped through hidden fields rather than held in a server-side session:
- * the deployed endpoint replaces instances between requests, so a session begun
- * on one and submitted to another would be gone. Nothing here is a secret — the
- * client sent all of it in the query string — and none of it is trusted on the
- * way back, because `approve` re-checks the client and the redirect URI against
- * what is registered before it mints anything.
- */
-function formFromRequest(request: AuthorizeRequest): Record<string, string> {
-  return {
-    client_id: request.clientId,
-    redirect_uri: request.redirectUri,
-    code_challenge: request.codeChallenge,
-    scope: request.scope,
-    ...(request.state !== undefined ? { state: request.state } : {}),
-    ...(request.resource !== undefined ? { resource: request.resource } : {}),
-  };
-}
-
-function requestFromForm(form: URLSearchParams): AuthorizeRequest {
-  return {
-    clientId: form.get('client_id') ?? '',
-    redirectUri: form.get('redirect_uri') ?? '',
-    codeChallenge: form.get('code_challenge') ?? '',
-    scope: form.get('scope') ?? '',
-    state: form.get('state') ?? undefined,
-    resource: form.get('resource') ?? undefined,
-  };
-}
-
-function hostOf(uri: string): string {
-  try {
-    return new URL(uri).host;
-  } catch {
-    return uri;
-  }
-}
-
-/**
- * The redirect target as a CSP source, for the consent page's `form-action`.
- *
- * Chrome and Safari check that directive against the redirect a form submission
- * produces, so the page has to name where its own approval is about to send the
- * browser — `'self'` alone mints the code and then blocks its delivery.
- *
- * Taken from the request being approved rather than from what the client
- * registered, because the two legitimately differ: a native client registers
- * `http://localhost/callback` and binds whatever port it got (RFC 8252), and
- * the origin the browser navigates to is the one carrying that port. It is
- * already checked against the registration — by `authorize` before this page is
- * rendered, and again by `approve` before anything is minted — and it cannot
- * move the token, because the form's `action` is built here rather than read
- * from the request.
- *
- * An origin and nothing else, because `isSafeRedirect` registers nothing else:
- * https, or http on loopback. A private-use scheme — `vscode:`, the other shape
- * RFC 8252 allows — would need a scheme-source here, and is refused two steps
- * earlier, so a branch for it would be a branch nothing can reach.
- */
-function formActionFor(uri: string): { formAction?: string } {
-  try {
-    const { protocol, origin } = new URL(uri);
-    if (protocol !== 'http:' && protocol !== 'https:') return {};
-    return { formAction: origin };
-  } catch {
-    return {};
+      // A page rather than a bare string, because the audience changed. These
+      // used to be read by a client following a redirect; now the interesting
+      // ones — "no profile lists you" — are read by a person in a browser who
+      // has just signed in and needs to know what to do next.
+      return noticePage(result.message, result.status);
   }
 }
 

--- a/src/server/owner.test.ts
+++ b/src/server/owner.test.ts
@@ -40,27 +40,61 @@ async function seededVault(): Promise<VaultStore> {
 
 const vaultStore = await seededVault();
 
+/**
+ * The three owner-layer rows a test grants, each carrying the same rules.
+ *
+ * A grant lives inside the row that names one connection now (ADR-058), so the
+ * flat block each test writes is indented once more and repeated per row —
+ * which is exactly what the flat block used to mean, and keeps every assertion
+ * in this file asserting what it was written to assert.
+ */
 function ownerConfig(profile: string, port: number, policy: string) {
+  // Split per row, and filtered to the row's own provider. A rule governs the
+  // connection it sits under and nothing else, so `skills.*` on the memory row
+  // is not a broader grant — it is one the loader refuses.
+  const lines = policy.split('\n').filter((line) => line.trim().length > 0);
+
+  const grants = ['memory', 'skills', 'vault']
+    .map((provider) => {
+      let field = 'allow';
+      const kept: string[] = [];
+
+      for (const line of lines) {
+        const trimmed = line.trim();
+        if (trimmed === 'allow:' || trimmed === 'deny:') {
+          field = trimmed.slice(0, -1);
+          continue;
+        }
+        const capability = trimmed.replace(/^-\s*/, '').replace(/"/g, '');
+        if (capability.split('.')[0] !== provider) continue;
+        kept.push(`    ${field}: [${capability}]`);
+      }
+
+      const merged = new Map<string, string[]>();
+      for (const entry of kept) {
+        const [, name = '', value = ''] = /^\s*(\w+): \[(.*)\]$/.exec(entry) ?? [];
+        merged.set(name, [...(merged.get(name) ?? []), value]);
+      }
+
+      const body = ['allow', 'deny']
+        .map((name) => `    ${name}: [${(merged.get(name) ?? []).join(', ')}]`)
+        .join('\n');
+
+      return `  - connection: ${provider}.owner\n${body}`;
+    })
+    .join('\n');
+
   return parseConfig(`
-contract: 2
+contract: 3
 instance:
   profile: ${profile}
   port: ${port}
 limits:
   requests_per_minute: 1000
   upstream_calls_per_minute: 1000
-connections:
-  - id: owner
-    provider: memory
-    account: Owner
-  - id: owner
-    provider: skills
-    account: Owner
-  - id: owner
-    provider: vault
-    account: Owner
-policy:
-${policy}
+grants:
+${grants}
+members: []
 `).config;
 }
 

--- a/src/server/read/credential.test.ts
+++ b/src/server/read/credential.test.ts
@@ -1,0 +1,129 @@
+import { describe, expect, test } from 'bun:test';
+import { cachedPairingCredential, directPairingCredential } from './credential.ts';
+
+/**
+ * Verifying the pairing token, and what each bind pays for the answer.
+ *
+ * The clock is injected rather than slept through, so raising the window fails
+ * a test instead of passing more slowly.
+ */
+
+const TOKEN = 'llp_a-pairing-token';
+const NEXT = 'llp_the-rotated-one';
+
+describe('on loopback, every presentation reads', () => {
+  test('a rotation lands at once, which is what `pair --rotate` promises', async () => {
+    let current = TOKEN;
+    const credential = directPairingCredential({ read: async () => current });
+
+    expect(await credential.verify(TOKEN)).toBe(true);
+
+    current = NEXT;
+    expect(await credential.verify(TOKEN)).toBe(false);
+    expect(await credential.verify(NEXT)).toBe(true);
+  });
+
+  test('a store with no version is unpaired rather than open', async () => {
+    const credential = directPairingCredential({ read: async () => null });
+    expect(await credential.verify(TOKEN)).toBe(false);
+  });
+
+  test('an empty value is unpaired too — that is the shape a deploy creates', async () => {
+    const credential = directPairingCredential({ read: async () => '' });
+    expect(await credential.verify('')).toBe(false);
+  });
+
+  test('a throwing store refuses rather than propagating', async () => {
+    const reasons: string[] = [];
+    const credential = directPairingCredential({
+      read: async () => {
+        throw new Error('permission denied');
+      },
+      onError: (reason) => reasons.push(reason),
+    });
+
+    expect(await credential.verify(TOKEN)).toBe(false);
+    expect(reasons).toEqual(['permission denied']);
+  });
+});
+
+describe('on a deployed endpoint, one read is cached', () => {
+  function fixture(initial: string | null) {
+    let current = initial;
+    let reads = 0;
+    let clock = 1_000;
+
+    const credential = cachedPairingCredential({
+      read: async () => {
+        reads += 1;
+        return current;
+      },
+      ttlMs: 5_000,
+      now: () => clock,
+    });
+
+    return {
+      credential,
+      reads: () => reads,
+      advance: (ms: number) => {
+        clock += ms;
+      },
+      rotate: (next: string | null) => {
+        current = next;
+      },
+    };
+  }
+
+  test('a valid token inside the window costs nothing after the first read', async () => {
+    const it = fixture(TOKEN);
+
+    expect(await it.credential.verify(TOKEN)).toBe(true);
+    expect(await it.credential.verify(TOKEN)).toBe(true);
+    expect(await it.credential.verify(TOKEN)).toBe(true);
+
+    // The whole reason this exists: `GcpSecretManagerStore` has no cache, so
+    // without this a dashboard polling `/state` is one network round trip per
+    // poll for as long as the page is open.
+    expect(it.reads()).toBe(1);
+  });
+
+  test('a token rotated in works on its first presentation', async () => {
+    const it = fixture(TOKEN);
+
+    await it.credential.verify(TOKEN);
+    it.rotate(NEXT);
+
+    // A mismatch against a cached value is ambiguous — wrong, or just rotated —
+    // and exactly one re-read separates them.
+    expect(await it.credential.verify(NEXT)).toBe(true);
+  });
+
+  test('a wrong token buys exactly one extra read, not one per attempt', async () => {
+    const it = fixture(TOKEN);
+
+    await it.credential.verify(TOKEN);
+    expect(it.reads()).toBe(1);
+
+    expect(await it.credential.verify('llp_wrong')).toBe(false);
+    expect(it.reads()).toBe(2);
+
+    // The re-read refreshed the cache, so the next wrong guess is answered
+    // from it: a caller presenting garbage cannot spend a store read per
+    // request.
+    expect(await it.credential.verify('llp_wrong')).toBe(false);
+    expect(it.reads()).toBe(2);
+  });
+
+  test('a token rotated away stops working within the window', async () => {
+    const it = fixture(TOKEN);
+
+    await it.credential.verify(TOKEN);
+    it.rotate(NEXT);
+
+    // The honest cost, stated as a test: still accepted until the window ends.
+    expect(await it.credential.verify(TOKEN)).toBe(true);
+
+    it.advance(5_000);
+    expect(await it.credential.verify(TOKEN)).toBe(false);
+  });
+});

--- a/src/server/read/credential.ts
+++ b/src/server/read/credential.ts
@@ -1,0 +1,134 @@
+import { timingSafeEqual } from 'node:crypto';
+
+/**
+ * Whether a presented credential is this workspace's pairing token.
+ *
+ * A verifier rather than the token itself, because the two binds pay very
+ * different prices for the answer and only the verifier can know that. On
+ * loopback the credential store holds a decrypted copy and a read is a map
+ * lookup; on a deployed workspace `GcpSecretManagerStore` has no cache at all
+ * and every `get()` is a network round trip. A shared `token: () => Promise`
+ * thunk hid that difference behind one signature, and the comment that used to
+ * sit above it — "this is a map lookup in the ordinary case" — was true of one
+ * store and false of the other.
+ */
+export interface PairingCredential {
+  /** Never throws. A store that failed is a refusal, not a `500`. */
+  verify(presented: string): Promise<boolean>;
+}
+
+/**
+ * Constant-time, after a length check.
+ *
+ * The length is compared first and separately because `timingSafeEqual` throws
+ * on a mismatch rather than returning false. The length of a token is not the
+ * secret; its contents are.
+ */
+function matches(presented: string, expected: string): boolean {
+  const a = Buffer.from(presented);
+  const b = Buffer.from(expected);
+  return a.length === b.length && timingSafeEqual(a, b);
+}
+
+export interface CredentialSource {
+  /** `null` for a secret that exists with no version — the never-paired case. */
+  readonly read: () => Promise<string | null>;
+  /** Drops a cached decrypted copy, because the rotation was written elsewhere. */
+  readonly refresh?: (() => void) | undefined;
+  /** Why a read failed, for an operator. Never the credential itself. */
+  readonly onError?: ((reason: string) => void) | undefined;
+}
+
+function reasonOf(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+/**
+ * Loopback: read on every presentation, so a rotation lands immediately.
+ *
+ * `pair --rotate` says "the previous pairing link no longer works", and captured
+ * at boot that was false — the live listener went on accepting the old token
+ * until the endpoint restarted. Reading per request is what makes the command
+ * tell the truth, and it is affordable here because the store is a local file.
+ */
+export function directPairingCredential(source: CredentialSource): PairingCredential {
+  return {
+    async verify(presented) {
+      try {
+        source.refresh?.();
+        const expected = await source.read();
+        return expected !== null && expected !== '' && matches(presented, expected);
+      } catch (error) {
+        source.onError?.(reasonOf(error));
+        return false;
+      }
+    },
+  };
+}
+
+/** How long a deployed endpoint may keep an answer. Matches the bearer's own window. */
+const CACHE_TTL_MS = 5_000;
+
+/**
+ * Deployed: one cached read, and a mismatch buys exactly one more.
+ *
+ * The same trade `BearerAuthenticator` already takes for the MCP bearer, over a
+ * strictly weaker credential and with the same five seconds. Without it a
+ * dashboard polling `/state` is one Secret Manager call per poll for as long as
+ * the page is open, and a stranger sending a wrong token is one call per
+ * request — which is the ADR-054 hazard in its purest form, a costly read
+ * performed on behalf of a caller who has presented nothing valid.
+ *
+ * What the re-read on mismatch preserves is the property that mattered: a
+ * token rotated *in* works on its first presentation, because a mismatch
+ * against a cached value is ambiguous and exactly one re-read separates
+ * "rotated" from "wrong". What it costs is that a token rotated *away* keeps
+ * reading for up to the window rather than stopping at once — bounded, where
+ * the failure `open.ts` records was unbounded until a restart.
+ */
+export function cachedPairingCredential(
+  source: CredentialSource & { readonly ttlMs?: number; readonly now?: () => number },
+): PairingCredential {
+  const ttl = source.ttlMs ?? CACHE_TTL_MS;
+  const now = source.now ?? (() => Date.now());
+
+  let cached: string | null = null;
+  // Both start "infinitely stale", so the first call reads and the first
+  // mismatch is always given its one re-read.
+  let readAt = -Infinity;
+  let missAt = -Infinity;
+
+  const reread = async (): Promise<void> => {
+    source.refresh?.();
+    cached = await source.read();
+    readAt = now();
+  };
+
+  const hit = (presented: string): boolean =>
+    cached !== null && cached !== '' && matches(presented, cached);
+
+  return {
+    async verify(presented) {
+      try {
+        if (now() - readAt >= ttl) await reread();
+        if (hit(presented)) return true;
+
+        // A miss against a cached value is ambiguous: the token may be wrong,
+        // or it may be the one a rotation has just written. One re-read tells
+        // them apart — and **one per window**, tracked separately from the
+        // ordinary refresh above. Keying it on `readAt` instead meant the
+        // re-read refreshed the very clock that decided whether to re-read, so
+        // every wrong guess bought its own Secret Manager call and the ceiling
+        // this cache exists to impose was not there at all.
+        if (now() - missAt < ttl) return false;
+        missAt = now();
+        await reread();
+
+        return hit(presented);
+      } catch (error) {
+        source.onError?.(reasonOf(error));
+        return false;
+      }
+    },
+  };
+}

--- a/src/server/read/deployed.test.ts
+++ b/src/server/read/deployed.test.ts
@@ -1,0 +1,302 @@
+import { describe, expect, test } from 'bun:test';
+import { BearerAuthenticator } from '#auth';
+import { allocatePort, wireProfiles, TEST_TOKEN } from '../harness.ts';
+import { createRequestHandler, MCP_PATH, serve } from '../index.ts';
+import { ATTACHMENTS_PATH } from '../attachments.ts';
+import { ANY_ORIGIN, corsAware } from '../cors.ts';
+import { Generations } from '../generations.ts';
+import { silentLogger } from '../logging.ts';
+import { cachedPairingCredential, directPairingCredential } from './credential.ts';
+import type { AuditTail, ReadDeps } from './routes.ts';
+
+/**
+ * The read surface on a deployed endpoint (ADR-064).
+ *
+ * A handler rather than a socket, for the tradeoff `cors.test.ts` states and
+ * which applies here with even more force: reaching `serve()`'s non-loopback
+ * branch means binding `0.0.0.0` and a macOS firewall prompt on every
+ * `bun test`, and what it would buy is the socket — where on loopback TLS was
+ * the thing under test, here the platform terminates it.
+ *
+ * But the *composition* is the real one. Every case below runs through
+ * `corsAware` wrapping `createRequestHandler`, exactly as `serve()` composes
+ * them off loopback, and the CORS policy handed in is the deployment default of
+ * `['*']`. Driving bare `readRoutes` would pass while `corsAware` quietly
+ * overwrote its headers, which is the single most likely way this regresses.
+ */
+
+const ORIGIN = 'https://lanes.sh';
+const HOSTILE = 'https://evil.example';
+const PAIR_TOKEN = 'llp_a-deployed-pairing-token';
+
+const AUDIT: AuditTail = {
+  tail: async () => [
+    {
+      id: 'evt_1',
+      timestamp: new Date('2026-01-01T00:00:00.000Z'),
+      profile: 'personal',
+      principal: 'lanes:HER',
+      provider: 'memory',
+      capability: 'memory.search',
+      arguments: {},
+      authorization: 'allowed',
+      status: 'ok',
+      durationMs: 42,
+    },
+  ],
+};
+
+function readDeps(overrides: Partial<ReadDeps> = {}): ReadDeps {
+  return {
+    workspace: 'cloud',
+    profiles: () => new Map(),
+    audit: AUDIT,
+    connections: async () => [],
+    credential: directPairingCredential({ read: async () => PAIR_TOKEN }),
+    endpoint: { kind: 'deployed', version: '0.0.0-test', certificateExpiresAt: null },
+    ...overrides,
+  };
+}
+
+/**
+ * A handler wired as a deployment, with the read surface on.
+ *
+ * `allowedOrigins: [ANY_ORIGIN]` is deliberately the hostile setting for the
+ * assertion in "one origin, named": the surrounding policy is a wildcard, and
+ * the read routes must still answer with a named origin.
+ */
+function deployed(read: ReadDeps | undefined): (request: Request) => Promise<Response> {
+  const { profiles, credentials } = wireProfiles({
+    profile: 'personal',
+    port: allocatePort(),
+    policy: `  allow:\n    - "example.*"`,
+  });
+
+  const nothing = () => Promise.resolve();
+  const log = silentLogger();
+
+  const handler = createRequestHandler({
+    generations: new Generations(
+      { profiles, close: nothing },
+      async () => ({ profiles, close: nothing }),
+      { primary: 'personal', log },
+    ),
+    primary: 'personal',
+    authenticator: new BearerAuthenticator({
+      profile: 'personal',
+      tokenRef: 'profile/token',
+      credentials,
+    }),
+    log,
+    meterUnauthenticated: true,
+    ...(read ? { read } : {}),
+  });
+
+  return corsAware((request) => handler.fetch(request), [MCP_PATH, ATTACHMENTS_PATH], {
+    allowedOrigins: [ANY_ORIGIN],
+  });
+}
+
+function get(path: string, headers: Record<string, string> = {}): Request {
+  return new Request(`https://endpoint.example${path}`, { headers });
+}
+
+const paired = (path: string, origin = ORIGIN): Request =>
+  get(path, { origin, authorization: `Bearer ${PAIR_TOKEN}` });
+
+describe('one origin, named, never a wildcard', () => {
+  test('the dashboard origin is echoed exactly', async () => {
+    const response = await deployed(readDeps())(paired('/state'));
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get('access-control-allow-origin')).toBe(ORIGIN);
+    expect(response.headers.get('vary')).toBe('Origin');
+  });
+
+  test('the surrounding policy is a wildcard and this surface is still not', async () => {
+    // The test that fails the day somebody adds `/state` to the `credentialed`
+    // array in `serve()`. `corsAware` would then overwrite the echo with `*`,
+    // and every test driving `readRoutes` directly would still pass.
+    const response = await deployed(readDeps())(paired('/state'));
+
+    expect(response.headers.get('access-control-allow-origin')).not.toBe(ANY_ORIGIN);
+  });
+
+  test('another origin is refused, and told nothing', async () => {
+    const response = await deployed(readDeps())(paired('/state', HOSTILE));
+
+    expect(response.status).toBe(403);
+    expect(response.headers.get('access-control-allow-origin')).toBeNull();
+    // On the refusal too: without it a cache between here and the page can
+    // serve one origin's answer to another.
+    expect(response.headers.get('vary')).toBe('Origin');
+  });
+});
+
+describe('a credential that cannot call a tool', () => {
+  test('the MCP bearer does not open the read surface', async () => {
+    const response = await deployed(readDeps())(
+      get('/state', { origin: ORIGIN, authorization: `Bearer ${TEST_TOKEN}` }),
+    );
+
+    expect(response.status).toBe(401);
+    expect(await response.json()).toEqual({ error: 'unpaired', run: 'lanes link pair' });
+  });
+
+  test('the pairing token does not open the endpoint', async () => {
+    const response = await deployed(readDeps())(
+      new Request(`https://endpoint.example${MCP_PATH}`, {
+        method: 'POST',
+        headers: { origin: ORIGIN, authorization: `Bearer ${PAIR_TOKEN}` },
+      }),
+    );
+
+    // The pair a single shared `authenticate()` would silently collapse.
+    expect(response.status).toBe(401);
+    expect(response.headers.get('www-authenticate')).not.toBeNull();
+  });
+
+  test('no credential at all is refused before the store is asked anything', async () => {
+    let reads = 0;
+    const response = await deployed(
+      readDeps({
+        credential: directPairingCredential({
+          read: async () => {
+            reads += 1;
+            return PAIR_TOKEN;
+          },
+        }),
+      }),
+    )(get('/state', { origin: ORIGIN }));
+
+    expect(response.status).toBe(401);
+    // On a deployed workspace a store read is a Secret Manager round trip, so
+    // a stranger sending no header must not be able to provoke one.
+    expect(reads).toBe(0);
+  });
+});
+
+describe('never ambient', () => {
+  test('credentials are never allowed, on any answer', async () => {
+    const answers = await Promise.all([
+      deployed(readDeps())(paired('/state')),
+      deployed(readDeps())(get('/state', { origin: ORIGIN })),
+      deployed(readDeps())(paired('/state', HOSTILE)),
+      deployed(readDeps())(
+        new Request('https://endpoint.example/state', {
+          method: 'OPTIONS',
+          headers: { origin: ORIGIN },
+        }),
+      ),
+    ]);
+
+    for (const answer of answers) {
+      expect(answer.headers.get('access-control-allow-credentials')).toBeNull();
+    }
+  });
+});
+
+describe('reads only, ever', () => {
+  test('a write to a read path is not found rather than not allowed', async () => {
+    const response = await deployed(readDeps())(
+      new Request('https://endpoint.example/state', {
+        method: 'POST',
+        headers: { origin: ORIGIN, authorization: `Bearer ${PAIR_TOKEN}` },
+      }),
+    );
+
+    // Not 405: that would confirm a Lanes read surface is here to a caller who
+    // has not presented a credential.
+    expect(response.status).toBe(404);
+  });
+
+  test('the surface is exactly two paths', async () => {
+    const response = await deployed(readDeps())(paired('/connections'));
+
+    expect(response.status).toBe(404);
+  });
+});
+
+describe('a deployment-only grant stays one', () => {
+  test('a loopback bind does not serve the read routes', async () => {
+    // What stops this becoming the thing ADR-039 refuses. `serve()` discards
+    // `read` on loopback exactly as it discards `cors`, and the TLS listener on
+    // the port above is what serves a paired local workspace instead.
+    const { profiles, credentials } = wireProfiles({
+      profile: 'personal',
+      port: allocatePort(),
+      policy: `  allow:\n    - "example.*"`,
+    });
+
+    const nothing = () => Promise.resolve();
+    const log = silentLogger();
+
+    const server = serve({
+      generations: new Generations(
+        { profiles, close: nothing },
+        async () => ({ profiles, close: nothing }),
+        { primary: 'personal', log },
+      ),
+      primary: 'personal',
+      authenticator: new BearerAuthenticator({
+        profile: 'personal',
+        tokenRef: 'profile/token',
+        credentials,
+      }),
+      log,
+      host: '127.0.0.1',
+      port: allocatePort(),
+      read: readDeps(),
+    });
+
+    try {
+      const response = await fetch(`${server.url.replace(MCP_PATH, '')}/state`, {
+        headers: { authorization: `Bearer ${PAIR_TOKEN}` },
+      });
+
+      expect(response.status).toBe(404);
+    } finally {
+      await server.stop();
+    }
+  });
+});
+
+describe('the never-paired workspace', () => {
+  test('a secret with no version is unpaired, not an error', async () => {
+    // What `readableRefs` buys. A bound secret with no version answers 404 and
+    // reads back as null; unbound it would be a 403 the adapter throws on.
+    const response = await deployed(
+      readDeps({ credential: cachedPairingCredential({ read: async () => null }) }),
+    )(paired('/state'));
+
+    expect(response.status).toBe(401);
+    expect(await response.json()).toEqual({ error: 'unpaired', run: 'lanes link pair' });
+  });
+
+  test('a store that throws is a refusal, not a 500', async () => {
+    // The other half. Even with the binding, a wrong project or an expired
+    // metadata token still throws — and uncaught that is a 500 on a public URL.
+    const response = await deployed(
+      readDeps({
+        credential: cachedPairingCredential({
+          read: async () => {
+            throw new Error('permission denied on projects/my-project/secrets/pair_token');
+          },
+        }),
+      }),
+    )(paired('/state'));
+
+    expect(response.status).toBe(401);
+  });
+});
+
+describe('what the endpoint says about itself', () => {
+  test('a deployed bind names itself, and claims no certificate of its own', async () => {
+    const response = await deployed(readDeps())(paired('/state'));
+
+    expect(await response.json()).toMatchObject({
+      workspace: 'cloud',
+      endpoint: { kind: 'deployed', version: '0.0.0-test', certificateExpiresAt: null },
+    });
+  });
+});

--- a/src/server/read/deployed.ts
+++ b/src/server/read/deployed.ts
@@ -1,0 +1,56 @@
+import { PAIR_TOKEN_REF, readConnections } from '#profile';
+import type { Runtime } from '#cli/runtime.ts';
+import type { Logger } from '#connectivity';
+import type { ProfileRuntime } from '../mcp/visibility.ts';
+import { cachedPairingCredential } from './credential.ts';
+import type { ReadDeps } from './routes.ts';
+
+/**
+ * The same read surface, on a deployed endpoint's own port (ADR-064).
+ *
+ * Its sibling `./open.ts` binds a second TLS listener and cannot be used here:
+ * Cloud Run routes exactly one port. So this returns dependencies rather than a
+ * socket, and the router serves the two paths in front of its own bearer gate —
+ * the pairing token never passes through the endpoint's authenticator, because
+ * one shared check would make each credential able to do the other's job.
+ *
+ * **Nothing here reads a credential.** That is the structural half of the fix
+ * `./open.ts` describes: the pairing token is read per request, behind a
+ * verifier, so a Secret Manager rejection can fail a request and can no longer
+ * fail a boot. Adding `PAIR_TOKEN_REF` to `readableRefs` is the other half, and
+ * it stops the rejection happening at all — a bound secret with no version
+ * answers 404 and reads back as `null`, which is the never-paired case and
+ * renders as an ordinary `401`.
+ *
+ * Handed to `serve()`, which discards it on a loopback bind — beside `cors`,
+ * `allowedHostnames` and `meterUnauthenticated`, because it is the same kind of
+ * fact about the same address.
+ */
+export function deployedReadDeps(input: {
+  readonly primary: Runtime;
+  readonly profiles: () => ReadonlyMap<string, ProfileRuntime>;
+  readonly log: Logger;
+  readonly version: string;
+}): ReadDeps {
+  const { primary, log } = input;
+
+  return {
+    workspace: primary.target,
+    profiles: input.profiles,
+    audit: primary.audit,
+    connections: async () =>
+      (await readConnections(primary.resolution.workspaceRoot)).connections,
+    // Cached, unlike loopback's. `GcpSecretManagerStore` holds nothing between
+    // calls, so a dashboard polling `/state` would be one network round trip per
+    // poll and a stranger sending a wrong token one per request — which is the
+    // ADR-054 hazard exactly: a costly read performed for a caller who has
+    // presented nothing valid.
+    credential: cachedPairingCredential({
+      read: () => primary.credentials.get(PAIR_TOKEN_REF),
+      refresh: () => primary.credentials.refresh?.(),
+      onError: (reason) => log.warn('could not read the pairing credential', { reason }),
+    }),
+    endpoint: { kind: 'deployed', version: input.version, certificateExpiresAt: null },
+    log,
+  };
+}

--- a/src/server/read/listener.test.ts
+++ b/src/server/read/listener.test.ts
@@ -80,6 +80,7 @@ beforeAll(() => {
     workspace: 'local',
     profiles: () => PROFILES,
     audit: AUDIT,
+    connections: async () => [],
     token: TOKEN,
     tls: selfSigned(),
   });

--- a/src/server/read/listener.test.ts
+++ b/src/server/read/listener.test.ts
@@ -19,6 +19,9 @@ const ORIGIN = 'https://lanes.sh';
 const TOKEN = 'llp_a-pairing-token';
 
 let listener: RunningReadListener;
+
+/** The token the listener will accept, so a rotation can be driven mid-test. */
+let current: string = TOKEN;
 let base: string;
 
 /**
@@ -81,7 +84,7 @@ beforeAll(() => {
     profiles: () => PROFILES,
     audit: AUDIT,
     connections: async () => [],
-    token: TOKEN,
+    token: async () => current,
     tls: selfSigned(),
   });
   base = listener.url;
@@ -216,5 +219,39 @@ describe('what can be reached', () => {
     const response = await read('/state', { method: 'POST' });
 
     expect(response.status).toBe(404);
+  });
+});
+
+describe('rotating the pairing token', () => {
+  test('the new one is accepted and the old one stops, without a restart', async () => {
+    // `lanes link pair --rotate` writes a new token and tells the operator the
+    // previous link no longer works. Captured at boot it did neither: the live
+    // listener kept accepting the old token and refused the new one until the
+    // endpoint was restarted, so a stolen credential went on reading the whole
+    // workspace while the command that was meant to take it back reported
+    // success.
+    expect((await read('/state')).status).toBe(200);
+
+    current = 'llp_rotated';
+
+    const old = await read('/state');
+    expect(old.status).toBe(401);
+
+    const rotated = await read('/state', {
+      headers: { authorization: 'Bearer llp_rotated' },
+    });
+    expect(rotated.status).toBe(200);
+
+    current = TOKEN;
+  });
+
+  test('an unpaired workspace refuses rather than admitting anything', async () => {
+    // `--rotate` between the read and the write, or a credential store that
+    // cannot be opened. Null is not a token to compare against.
+    current = null as unknown as string;
+
+    expect((await read('/state')).status).toBe(401);
+
+    current = TOKEN;
   });
 });

--- a/src/server/read/listener.test.ts
+++ b/src/server/read/listener.test.ts
@@ -1,0 +1,219 @@
+import { afterAll, beforeAll, describe, expect, test } from 'bun:test';
+import { serveRead, type AuditTail, type RunningReadListener } from './listener.ts';
+import type { ProfileRuntime } from '../mcp/visibility.ts';
+
+/**
+ * The one surface a browser origin may read on loopback (ADR-063).
+ *
+ * ADR-039 refuses cross-origin access here, and this narrows that refusal
+ * rather than lifting it. So every test below is about the *narrowness*: one
+ * origin, one credential that cannot call a tool, nothing ambient, and no
+ * mutation reachable at all.
+ *
+ * Driven over real TLS against a real listener, because the properties in
+ * question are headers on a wire. A unit test of the handler would pass while
+ * the browser refused every request.
+ */
+
+const ORIGIN = 'https://lanes.sh';
+const TOKEN = 'llp_a-pairing-token';
+
+let listener: RunningReadListener;
+let base: string;
+
+/**
+ * A self-signed certificate, generated once.
+ *
+ * `mkcert` is what `lanes link pair` uses, because a browser has to trust the
+ * result. Nothing here is a browser, so this only has to be a valid certificate
+ * — `Bun.fetch` is told not to check it, which is the one place that is
+ * acceptable and is why it is spelled out rather than configured globally.
+ */
+function selfSigned(): { cert: string; key: string } {
+  const key = Bun.spawnSync(['openssl', 'req', '-x509', '-newkey', 'rsa:2048', '-nodes',
+    '-keyout', '/dev/stdout', '-out', '/dev/stdout', '-days', '1',
+    '-subj', '/CN=127.0.0.1', '-addext', 'subjectAltName=IP:127.0.0.1']);
+
+  const out = key.stdout.toString();
+  const keyStart = out.indexOf('-----BEGIN PRIVATE KEY-----');
+  const keyEnd = out.indexOf('-----END PRIVATE KEY-----') + '-----END PRIVATE KEY-----'.length;
+  const certStart = out.indexOf('-----BEGIN CERTIFICATE-----');
+  const certEnd = out.indexOf('-----END CERTIFICATE-----') + '-----END CERTIFICATE-----'.length;
+
+  return { key: out.slice(keyStart, keyEnd), cert: out.slice(certStart, certEnd) };
+}
+
+const AUDIT: AuditTail = {
+  tail: async () => [
+    {
+      id: 'evt_1',
+      timestamp: new Date('2026-01-01T00:00:00.000Z'),
+      profile: 'personal',
+      principal: 'lanes:HER',
+      provider: 'gmail',
+      connection: 'gmail.personal',
+      capability: 'gmail.users.messages.list',
+      arguments: { q: '<redacted>' },
+      authorization: 'allowed',
+    },
+    {
+      id: 'evt_2',
+      timestamp: new Date('2026-01-01T00:01:00.000Z'),
+      profile: 'work',
+      principal: 'lanes:HER',
+      provider: 'gmail',
+      capability: 'gmail.users.messages.get',
+      arguments: {},
+      authorization: 'denied_default',
+    },
+  ],
+};
+
+/** No profiles: this file is about the wire, and `state.test.ts` is about the body. */
+const PROFILES = new Map<string, ProfileRuntime>();
+
+beforeAll(() => {
+  listener = serveRead({
+    host: '127.0.0.1',
+    // Zero lets the kernel pick, so a suite run twice at once does not collide.
+    port: 0,
+    workspace: 'local',
+    profiles: () => PROFILES,
+    audit: AUDIT,
+    token: TOKEN,
+    tls: selfSigned(),
+  });
+  base = listener.url;
+});
+
+afterAll(() => listener.stop());
+
+function at(path: string): string {
+  return `${base}${path}`;
+}
+
+function read(path: string, init: RequestInit = {}): Promise<Response> {
+  return fetch(at(path), {
+    ...init,
+    headers: { origin: ORIGIN, authorization: `Bearer ${TOKEN}`, ...(init.headers ?? {}) },
+    tls: { rejectUnauthorized: false },
+  } as RequestInit);
+}
+
+describe('the credential', () => {
+  test('a paired page reads the workspace', async () => {
+    const response = await read('/state');
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toMatchObject({ workspace: 'local' });
+  });
+
+  test('no token reads nothing, and is told the one command that fixes it', async () => {
+    // Every local failure looks identical from a browser: an expired
+    // certificate, a rotated token, a listener that is not running. So the
+    // answer is always the command that fixes all of them.
+    const response = await read('/state', { headers: { authorization: '' } });
+
+    expect(response.status).toBe(401);
+    expect(await response.json()).toEqual({ error: 'unpaired', run: 'lanes link pair' });
+  });
+
+  test('a rotated-away token reads nothing', async () => {
+    const response = await read('/state', {
+      headers: { authorization: 'Bearer llp_the-previous-one' },
+    });
+
+    expect(response.status).toBe(401);
+  });
+
+  test('no cookie is ever accepted, so nothing is ambient', async () => {
+    // The safety of this surface rests on the credential being one the page
+    // must already hold. `access-control-allow-credentials` would undo that,
+    // so its absence is asserted rather than assumed.
+    const response = await read('/state');
+
+    expect(response.headers.get('access-control-allow-credentials')).toBeNull();
+  });
+});
+
+describe('the origin', () => {
+  test('is echoed, never wildcarded', async () => {
+    // A deployed endpoint may wildcard because it is already publicly
+    // reachable. Loopback is not, so a page reaching it is stealing
+    // reachability that nothing else has.
+    const response = await read('/state');
+
+    expect(response.headers.get('access-control-allow-origin')).toBe(ORIGIN);
+  });
+
+  test('any other origin is refused before the surface answers', async () => {
+    const response = await read('/state', { headers: { origin: 'https://evil.example' } });
+
+    expect(response.status).toBe(403);
+    expect(response.headers.get('access-control-allow-origin')).toBeNull();
+  });
+
+  test('Vary: Origin is set even on a refusal', async () => {
+    // Without it a cache between here and the page can serve one origin's
+    // answer to another, which is the whole grant leaking through an
+    // intermediary.
+    const refused = await read('/state', { headers: { origin: 'https://evil.example' } });
+
+    expect(refused.headers.get('vary')).toBe('Origin');
+  });
+
+  test('a preflight is answered without a credential, because it carries none', async () => {
+    const response = await fetch(at('/state'), {
+      method: 'OPTIONS',
+      headers: { origin: ORIGIN },
+      tls: { rejectUnauthorized: false },
+    } as RequestInit);
+
+    expect(response.status).toBe(204);
+    expect(response.headers.get('access-control-allow-headers')).toBe('authorization');
+  });
+
+  test('a preflight from anywhere else is refused', async () => {
+    const response = await fetch(at('/state'), {
+      method: 'OPTIONS',
+      headers: { origin: 'https://evil.example' },
+      tls: { rejectUnauthorized: false },
+    } as RequestInit);
+
+    expect(response.status).toBe(403);
+  });
+});
+
+describe('what can be reached', () => {
+  test('the audit log, most recent entries, already redacted', async () => {
+    const response = await read('/audit?limit=10');
+    const body = (await response.json()) as { events: { id: string; arguments: unknown }[] };
+
+    expect(body.events).toHaveLength(2);
+    // Redacted where it was written, and not redacted again here: a second rule
+    // would be a second answer to what is sensitive.
+    expect(body.events[0]?.arguments).toEqual({ q: '<redacted>' });
+  });
+
+  test('the log narrows to one profile', async () => {
+    const response = await read('/audit?profile=work');
+    const body = (await response.json()) as { events: { id: string }[] };
+
+    expect(body.events.map((event) => event.id)).toEqual(['evt_2']);
+  });
+
+  test('nothing else, and an unknown path does not confirm what this is', async () => {
+    const response = await read('/anything');
+
+    expect(response.status).toBe(404);
+  });
+
+  test('no method but GET, and a write is a 404 rather than a 405', async () => {
+    // A `405` would confirm to any page on the machine that a Lanes read
+    // listener is here. There is no mutation to allow, so there is nothing for
+    // "method not allowed" to mean.
+    const response = await read('/state', { method: 'POST' });
+
+    expect(response.status).toBe(404);
+  });
+});

--- a/src/server/read/listener.test.ts
+++ b/src/server/read/listener.test.ts
@@ -1,5 +1,6 @@
 import { afterAll, beforeAll, describe, expect, test } from 'bun:test';
 import { serveRead, type AuditTail, type RunningReadListener } from './listener.ts';
+import { directPairingCredential } from './credential.ts';
 import type { ProfileRuntime } from '../mcp/visibility.ts';
 
 /**
@@ -91,7 +92,11 @@ beforeAll(() => {
     profiles: () => PROFILES,
     audit: AUDIT,
     connections: async () => [],
-    token: async () => current,
+    // The real loopback composition, not a stub: `open.ts` builds exactly this,
+    // so a change to how a rotation lands is caught here rather than only in
+    // production. `current` is the mutable half a rotation test moves.
+    credential: directPairingCredential({ read: async () => current }),
+    endpoint: { kind: 'local', version: '0.0.0-test', certificateExpiresAt: null },
     tls: selfSigned(),
   });
   base = listener.url;

--- a/src/server/read/listener.test.ts
+++ b/src/server/read/listener.test.ts
@@ -58,6 +58,8 @@ const AUDIT: AuditTail = {
       capability: 'gmail.users.messages.list',
       arguments: { q: '<redacted>' },
       authorization: 'allowed',
+      status: 'ok',
+      durationMs: 42,
     },
     {
       id: 'evt_2',
@@ -68,6 +70,11 @@ const AUDIT: AuditTail = {
       capability: 'gmail.users.messages.get',
       arguments: {},
       authorization: 'denied_default',
+      // Allowed and then failed is the state the wire could not express before
+      // these three fields, so one of the two rows carries it.
+      status: 'error',
+      durationMs: 7,
+      error: { kind: 'upstream', message: 'the mailbox said no' },
     },
   ],
 };
@@ -197,6 +204,32 @@ describe('what can be reached', () => {
     // Redacted where it was written, and not redacted again here: a second rule
     // would be a second answer to what is sensitive.
     expect(body.events[0]?.arguments).toEqual({ q: '<redacted>' });
+  });
+
+  test('a call that was allowed and then failed says so', async () => {
+    // `authorization` and `status` answer different questions, and a surface
+    // carrying only the first reports a failed call as a successful one. The
+    // detail view in the dashboard is built on these three.
+    const response = await read('/audit?limit=10');
+    const body = (await response.json()) as {
+      events: {
+        authorization: string;
+        status: string;
+        durationMs: number;
+        error: { kind: string; message: string } | null;
+      }[];
+    };
+
+    expect(body.events[0]).toMatchObject({
+      authorization: 'allowed',
+      status: 'ok',
+      durationMs: 42,
+      error: null,
+    });
+    expect(body.events[1]).toMatchObject({
+      status: 'error',
+      error: { kind: 'upstream', message: 'the mailbox said no' },
+    });
   });
 
   test('the log narrows to one profile', async () => {

--- a/src/server/read/listener.ts
+++ b/src/server/read/listener.ts
@@ -55,6 +55,9 @@ export interface AuditTail {
       readonly capability: string;
       readonly arguments: Readonly<Record<string, unknown>>;
       readonly authorization: string;
+      readonly status: string;
+      readonly durationMs: number;
+      readonly error?: { readonly kind: string; readonly message: string } | undefined;
     }[]
   >;
 }
@@ -194,6 +197,12 @@ async function handle(
           // to what is sensitive, and the log's own would stop being the truth.
           arguments: event.arguments,
           authorization: event.authorization,
+          // Authorised and then failed is a state the four fields above cannot
+          // express, and it is the one worth seeing: a call the policy allowed
+          // and the provider refused reads as a successful call without these.
+          status: event.status,
+          durationMs: event.durationMs,
+          error: event.error ?? null,
         })),
       },
       200,

--- a/src/server/read/listener.ts
+++ b/src/server/read/listener.ts
@@ -1,0 +1,214 @@
+import { timingSafeEqual } from 'node:crypto';
+import type { ProfileRuntime } from '../mcp/visibility.ts';
+import { readState } from './state.ts';
+
+/**
+ * The one surface a browser on `lanes.sh` may read (ADR-063).
+ *
+ * Its own listener, on its own port, over TLS, with its own credential, and no
+ * route in common with the endpoint. Each of those is answering a specific
+ * sentence in ADR-039, which refuses cross-origin access on loopback and says
+ * so in terms that anticipated this decision. **The rule that refusal protects
+ * is not being relaxed** — `/mcp` gains no CORS, no new route and no change to
+ * the rebinding guard. This is a different surface, not a hole in that one.
+ *
+ * Five properties, and dropping any one of them makes the others decorative:
+ *
+ *  - **One origin, named, never `*`.** Echoed with `Vary: Origin`. A deployed
+ *    endpoint may wildcard because it is already publicly reachable; loopback is
+ *    not, so a page reaching it is stealing reachability nothing else has.
+ *  - **A credential that cannot call a tool.** The pairing token, minted by
+ *    `lanes link pair`, stored under its own ref, rotatable on its own. It is
+ *    not the MCP bearer and not an OAuth token.
+ *  - **Never ambient.** An `Authorization` header the page must already hold,
+ *    obtained by the owner running a command. No cookie, no session, so
+ *    `credentials: 'include'` buys an attacker nothing.
+ *  - **Reads only, ever.** No mutation is reachable from here at all. Editing a
+ *    profile from a browser would put control-plane mutation behind a CORS
+ *    grant, and ADR-007 does not move for a convenience.
+ *  - **TLS.** Not for confidentiality on a loopback socket, but because Safari
+ *    will not let an HTTPS page fetch `http://127.0.0.1` and offers no flag that
+ *    changes it. Without this the surface does not exist for a Safari user.
+ */
+
+/** Where the dashboard lives, and where it lives while somebody is building it. */
+export const READ_ORIGINS: readonly string[] = ['https://lanes.sh', 'http://localhost:3000'];
+
+/**
+ * The half of the audit log this reads, declared rather than imported.
+ *
+ * `server` may not depend on `#audit`, and widening that table for one `tail`
+ * would be the wrong direction to resolve it: this listener does not know how
+ * the log is chained, stored, or verified, and nothing here should be able to
+ * find out. What it needs is the last N entries, so that is what it asks for.
+ */
+export interface AuditTail {
+  tail(options?: { limit?: number }): Promise<
+    readonly {
+      readonly id: string;
+      readonly timestamp: Date;
+      readonly profile: string;
+      readonly principal: string;
+      readonly clientLabel?: string | undefined;
+      readonly provider: string;
+      readonly connection?: string | undefined;
+      readonly capability: string;
+      readonly arguments: Readonly<Record<string, unknown>>;
+      readonly authorization: string;
+    }[]
+  >;
+}
+
+export interface ReadListenerOptions {
+  readonly host: string;
+  readonly port: number;
+  readonly workspace: string;
+  /** The current generation's profiles, read through a thunk so a reload lands. */
+  readonly profiles: () => ReadonlyMap<string, ProfileRuntime>;
+  readonly audit: AuditTail;
+  /** The pairing token, compared in constant time. */
+  readonly token: string;
+  readonly tls: { readonly cert: string; readonly key: string };
+  readonly allowedOrigins?: readonly string[] | undefined;
+}
+
+export interface RunningReadListener {
+  readonly url: string;
+  stop(): Promise<void>;
+}
+
+export function serveRead(options: ReadListenerOptions): RunningReadListener {
+  const origins = options.allowedOrigins ?? READ_ORIGINS;
+
+  const server = Bun.serve({
+    hostname: options.host,
+    port: options.port,
+    tls: { cert: options.tls.cert, key: options.tls.key },
+    fetch: (request) => handle(request, options, origins),
+  });
+
+  return {
+    // The port the kernel assigned, not the one that was asked for. They differ
+    // whenever `port: 0` is passed, and a URL naming 0 is one nothing can reach.
+    url: `https://${options.host}:${server.port}`,
+    stop: () => server.stop(true),
+  };
+}
+
+async function handle(
+  request: Request,
+  options: ReadListenerOptions,
+  origins: readonly string[],
+): Promise<Response> {
+  const origin = request.headers.get('origin');
+  const allowed = origin !== null && origins.includes(origin);
+
+  // Answered before the credential is checked, because a preflight carries no
+  // credential — that is what it is for. It carries no data either, so
+  // answering one reveals only that something is listening, which the TCP
+  // connection already revealed.
+  if (request.method === 'OPTIONS') {
+    return new Response(null, { status: allowed ? 204 : 403, headers: cors(origin, allowed) });
+  }
+
+  // Not `405`. A surface that answered "method not allowed" would be confirming
+  // to any page on the machine that a Lanes read listener is here; a page that
+  // is not the dashboard learns nothing it did not send.
+  if (request.method !== 'GET') {
+    return json({ error: 'not_found' }, 404, cors(origin, allowed));
+  }
+
+  if (origin !== null && !allowed) {
+    return json({ error: 'origin_not_allowed' }, 403, cors(origin, false));
+  }
+
+  if (!authorised(request, options.token)) {
+    return json(
+      {
+        error: 'unpaired',
+        // The page shows this verbatim. Every local failure looks the same from
+        // a browser — an expired certificate, a rotated token, a listener that
+        // is not running — so the answer is always the command that fixes all
+        // of them rather than a diagnosis the page cannot make.
+        run: 'lanes link pair',
+      },
+      401,
+      cors(origin, allowed),
+    );
+  }
+
+  const url = new URL(request.url);
+
+  if (url.pathname === '/state') {
+    return json(readState(options.workspace, options.profiles()), 200, cors(origin, allowed));
+  }
+
+  if (url.pathname === '/audit') {
+    const limit = Math.min(Number(url.searchParams.get('limit') ?? 100) || 100, 500);
+    const profile = url.searchParams.get('profile');
+
+    const events = await options.audit.tail({ limit });
+    const shown = profile ? events.filter((event) => event.profile === profile) : events;
+
+    return json(
+      {
+        events: shown.map((event) => ({
+          id: event.id,
+          timestamp: event.timestamp.toISOString(),
+          profile: event.profile,
+          principal: event.principal,
+          clientLabel: event.clientLabel ?? null,
+          provider: event.provider,
+          connection: event.connection ?? null,
+          capability: event.capability,
+          // Already redacted where it was written. This does not redact again,
+          // and must not start to: a second rule here would be a second answer
+          // to what is sensitive, and the log's own would stop being the truth.
+          arguments: event.arguments,
+          authorization: event.authorization,
+        })),
+      },
+      200,
+      cors(origin, allowed),
+    );
+  }
+
+  return json({ error: 'not_found' }, 404, cors(origin, allowed));
+}
+
+function authorised(request: Request, expected: string): boolean {
+  const header = request.headers.get('authorization') ?? '';
+  if (!header.toLowerCase().startsWith('bearer ')) return false;
+
+  const presented = Buffer.from(header.slice(7).trim());
+  const known = Buffer.from(expected);
+
+  // Length is compared first and separately, because `timingSafeEqual` throws
+  // on a mismatch rather than returning false. The length of a token is not the
+  // secret; its contents are.
+  return presented.length === known.length && timingSafeEqual(presented, known);
+}
+
+function cors(origin: string | null, allowed: boolean): Record<string, string> {
+  // `Vary: Origin` unconditionally, including on a refusal. Without it a cache
+  // between here and the page can serve one origin's answer to another, which
+  // is the whole grant leaking through an intermediary.
+  const headers: Record<string, string> = { vary: 'Origin' };
+  if (!allowed || origin === null) return headers;
+
+  headers['access-control-allow-origin'] = origin;
+  headers['access-control-allow-headers'] = 'authorization';
+  headers['access-control-allow-methods'] = 'GET, OPTIONS';
+  headers['access-control-max-age'] = '600';
+  // Deliberately absent: `access-control-allow-credentials`. The token is sent
+  // explicitly by the page, so allowing cookies would add an ambient credential
+  // to a surface whose safety rests on there not being one.
+  return headers;
+}
+
+function json(body: unknown, status: number, headers: Record<string, string>): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { ...headers, 'content-type': 'application/json', 'cache-control': 'no-store' },
+  });
+}

--- a/src/server/read/listener.ts
+++ b/src/server/read/listener.ts
@@ -1,97 +1,32 @@
-import { timingSafeEqual } from 'node:crypto';
-import type { ProfileRuntime } from '../mcp/visibility.ts';
-import { readState, type ConnectionRow } from './state.ts';
+import { readRoutes, type ReadDeps } from './routes.ts';
 
 /**
- * The one surface a browser on `lanes.sh` may read (ADR-063).
+ * The read surface on loopback: its own port, over TLS (ADR-063).
  *
- * Its own listener, on its own port, over TLS, with its own credential, and no
- * route in common with the endpoint. Each of those is answering a specific
- * sentence in ADR-039, which refuses cross-origin access on loopback and says
- * so in terms that anticipated this decision. **The rule that refusal protects
- * is not being relaxed** — `/mcp` gains no CORS, no new route and no change to
- * the rebinding guard. This is a different surface, not a hole in that one.
+ * The routes themselves live in `./routes.ts`, shared with the deployed bind,
+ * so the four properties they enforce cannot come to differ between the two.
+ * What is decided *here* is the fifth, and it is the one that is genuinely
+ * about this bind rather than about the routes:
  *
- * Five properties, and dropping any one of them makes the others decorative:
+ * **TLS.** Not for confidentiality on a loopback socket, but because Safari
+ * will not let an HTTPS page fetch `http://127.0.0.1` and offers no header,
+ * flag or opt-in that changes it. Without this the surface does not exist for a
+ * Safari user. It is also the whole reason for a second port: the MCP listener
+ * must keep answering `http://127.0.0.1:7337` for every registration that
+ * already exists.
  *
- *  - **One origin, named, never `*`.** Echoed with `Vary: Origin`. A deployed
- *    endpoint may wildcard because it is already publicly reachable; loopback is
- *    not, so a page reaching it is stealing reachability nothing else has.
- *  - **A credential that cannot call a tool.** The pairing token, minted by
- *    `lanes link pair`, stored under its own ref, rotatable on its own. It is
- *    not the MCP bearer and not an OAuth token.
- *  - **Never ambient.** An `Authorization` header the page must already hold,
- *    obtained by the owner running a command. No cookie, no session, so
- *    `credentials: 'include'` buys an attacker nothing.
- *  - **Reads only, ever.** No mutation is reachable from here at all. Editing a
- *    profile from a browser would put control-plane mutation behind a CORS
- *    grant, and ADR-007 does not move for a convenience.
- *  - **TLS.** Not for confidentiality on a loopback socket, but because Safari
- *    will not let an HTTPS page fetch `http://127.0.0.1` and offers no flag that
- *    changes it. Without this the surface does not exist for a Safari user.
+ * A deployed workspace needs none of this — Cloud Run terminates TLS with a
+ * certificate a browser already trusts, and routes exactly one port — so it
+ * takes the routes through the endpoint's own router instead. See
+ * `./deployed.ts`.
  */
 
-/** Where the dashboard lives, and where it lives while somebody is building it. */
-export const READ_ORIGINS: readonly string[] = ['https://lanes.sh', 'http://localhost:3000'];
+export { READ_ORIGINS, type AuditTail, type ReadDeps } from './routes.ts';
 
-/**
- * The half of the audit log this reads, declared rather than imported.
- *
- * `server` may not depend on `#audit`, and widening that table for one `tail`
- * would be the wrong direction to resolve it: this listener does not know how
- * the log is chained, stored, or verified, and nothing here should be able to
- * find out. What it needs is the last N entries, so that is what it asks for.
- */
-export interface AuditTail {
-  tail(options?: { limit?: number }): Promise<
-    readonly {
-      readonly id: string;
-      readonly timestamp: Date;
-      readonly profile: string;
-      readonly principal: string;
-      readonly clientLabel?: string | undefined;
-      readonly provider: string;
-      readonly connection?: string | undefined;
-      readonly capability: string;
-      readonly arguments: Readonly<Record<string, unknown>>;
-      readonly authorization: string;
-      readonly status: string;
-      readonly durationMs: number;
-      readonly error?: { readonly kind: string; readonly message: string } | undefined;
-    }[]
-  >;
-}
-
-export interface ReadListenerOptions {
+export interface ReadListenerOptions extends ReadDeps {
   readonly host: string;
   readonly port: number;
-  readonly workspace: string;
-  /** The current generation's profiles, read through a thunk so a reload lands. */
-  readonly profiles: () => ReadonlyMap<string, ProfileRuntime>;
-  readonly audit: AuditTail;
-  /**
-   * The workspace's connection rows, read per request.
-   *
-   * A thunk rather than a value because a connection added while the endpoint
-   * runs should appear without a restart — the same reason `profiles` is one.
-   * Read from `connections.yaml` rather than derived from the grants, because
-   * a label and an account live on the connection and a grant carries neither.
-   */
-  readonly connections: () => Promise<readonly ConnectionRow[]>;
-  /**
-   * The pairing token, read per request and compared in constant time.
-   *
-   * A thunk rather than a value, because `lanes link pair --rotate` writes a new
-   * one into the credential store and says "the previous pairing link no longer
-   * works". Captured at boot it did neither: the live listener went on accepting
-   * the old token and refusing the new one until the endpoint was restarted, so
-   * a stolen credential kept reading every connection, profile and audit entry
-   * in the workspace — while the command that was supposed to take it back
-   * reported success.
-   */
-  readonly token: () => Promise<string | null>;
   readonly tls: { readonly cert: string; readonly key: string };
-  readonly allowedOrigins?: readonly string[] | undefined;
 }
 
 export interface RunningReadListener {
@@ -100,13 +35,14 @@ export interface RunningReadListener {
 }
 
 export function serveRead(options: ReadListenerOptions): RunningReadListener {
-  const origins = options.allowedOrigins ?? READ_ORIGINS;
-
   const server = Bun.serve({
     hostname: options.host,
     port: options.port,
     tls: { cert: options.tls.cert, key: options.tls.key },
-    fetch: (request) => handle(request, options, origins),
+    // Everything, because this owns a whole port. The router on the deployed
+    // side passes only what `isReadPath` matched — handing an unmatched path to
+    // `readRoutes` there would swallow `/mcp`.
+    fetch: (request) => readRoutes(request, options),
   });
 
   return {
@@ -115,137 +51,4 @@ export function serveRead(options: ReadListenerOptions): RunningReadListener {
     url: `https://${options.host}:${server.port}`,
     stop: () => server.stop(true),
   };
-}
-
-async function handle(
-  request: Request,
-  options: ReadListenerOptions,
-  origins: readonly string[],
-): Promise<Response> {
-  const origin = request.headers.get('origin');
-  const allowed = origin !== null && origins.includes(origin);
-
-  // Answered before the credential is checked, because a preflight carries no
-  // credential — that is what it is for. It carries no data either, so
-  // answering one reveals only that something is listening, which the TCP
-  // connection already revealed.
-  if (request.method === 'OPTIONS') {
-    return new Response(null, { status: allowed ? 204 : 403, headers: cors(origin, allowed) });
-  }
-
-  // Not `405`. A surface that answered "method not allowed" would be confirming
-  // to any page on the machine that a Lanes read listener is here; a page that
-  // is not the dashboard learns nothing it did not send.
-  if (request.method !== 'GET') {
-    return json({ error: 'not_found' }, 404, cors(origin, allowed));
-  }
-
-  if (origin !== null && !allowed) {
-    return json({ error: 'origin_not_allowed' }, 403, cors(origin, false));
-  }
-
-  // Re-read per request. The store caches its own decrypted copy, so this is a
-  // map lookup in the ordinary case and a re-read only after a rotation.
-  const expected = await options.token();
-
-  if (expected === null || !authorised(request, expected)) {
-    return json(
-      {
-        error: 'unpaired',
-        // The page shows this verbatim. Every local failure looks the same from
-        // a browser — an expired certificate, a rotated token, a listener that
-        // is not running — so the answer is always the command that fixes all
-        // of them rather than a diagnosis the page cannot make.
-        run: 'lanes link pair',
-      },
-      401,
-      cors(origin, allowed),
-    );
-  }
-
-  const url = new URL(request.url);
-
-  if (url.pathname === '/state') {
-    const rows = await options.connections().catch(() => []);
-    return json(
-      readState(options.workspace, options.profiles(), rows),
-      200,
-      cors(origin, allowed),
-    );
-  }
-
-  if (url.pathname === '/audit') {
-    const limit = Math.min(Number(url.searchParams.get('limit') ?? 100) || 100, 500);
-    const profile = url.searchParams.get('profile');
-
-    const events = await options.audit.tail({ limit });
-    const shown = profile ? events.filter((event) => event.profile === profile) : events;
-
-    return json(
-      {
-        events: shown.map((event) => ({
-          id: event.id,
-          timestamp: event.timestamp.toISOString(),
-          profile: event.profile,
-          principal: event.principal,
-          clientLabel: event.clientLabel ?? null,
-          provider: event.provider,
-          connection: event.connection ?? null,
-          capability: event.capability,
-          // Already redacted where it was written. This does not redact again,
-          // and must not start to: a second rule here would be a second answer
-          // to what is sensitive, and the log's own would stop being the truth.
-          arguments: event.arguments,
-          authorization: event.authorization,
-          // Authorised and then failed is a state the four fields above cannot
-          // express, and it is the one worth seeing: a call the policy allowed
-          // and the provider refused reads as a successful call without these.
-          status: event.status,
-          durationMs: event.durationMs,
-          error: event.error ?? null,
-        })),
-      },
-      200,
-      cors(origin, allowed),
-    );
-  }
-
-  return json({ error: 'not_found' }, 404, cors(origin, allowed));
-}
-
-function authorised(request: Request, expected: string): boolean {
-  const header = request.headers.get('authorization') ?? '';
-  if (!header.toLowerCase().startsWith('bearer ')) return false;
-
-  const presented = Buffer.from(header.slice(7).trim());
-  const known = Buffer.from(expected);
-
-  // Length is compared first and separately, because `timingSafeEqual` throws
-  // on a mismatch rather than returning false. The length of a token is not the
-  // secret; its contents are.
-  return presented.length === known.length && timingSafeEqual(presented, known);
-}
-
-function cors(origin: string | null, allowed: boolean): Record<string, string> {
-  // `Vary: Origin` unconditionally, including on a refusal. Without it a cache
-  // between here and the page can serve one origin's answer to another, which
-  // is the whole grant leaking through an intermediary.
-  const headers: Record<string, string> = { vary: 'Origin' };
-  if (!allowed || origin === null) return headers;
-
-  headers['access-control-allow-origin'] = origin;
-  headers['access-control-allow-headers'] = 'authorization';
-  headers['access-control-allow-methods'] = 'GET, OPTIONS';
-  headers['access-control-max-age'] = '600';
-  // Deliberately absent: `access-control-allow-credentials`. The token is sent
-  // explicitly by the page, so allowing cookies would add an ambient credential
-  // to a surface whose safety rests on there not being one.
-  return headers;
-}
-
-function json(body: unknown, status: number, headers: Record<string, string>): Response {
-  return new Response(JSON.stringify(body), {
-    status,
-    headers: { ...headers, 'content-type': 'application/json', 'cache-control': 'no-store' },
-  });
 }

--- a/src/server/read/listener.ts
+++ b/src/server/read/listener.ts
@@ -75,8 +75,18 @@ export interface ReadListenerOptions {
    * a label and an account live on the connection and a grant carries neither.
    */
   readonly connections: () => Promise<readonly ConnectionRow[]>;
-  /** The pairing token, compared in constant time. */
-  readonly token: string;
+  /**
+   * The pairing token, read per request and compared in constant time.
+   *
+   * A thunk rather than a value, because `lanes link pair --rotate` writes a new
+   * one into the credential store and says "the previous pairing link no longer
+   * works". Captured at boot it did neither: the live listener went on accepting
+   * the old token and refusing the new one until the endpoint was restarted, so
+   * a stolen credential kept reading every connection, profile and audit entry
+   * in the workspace — while the command that was supposed to take it back
+   * reported success.
+   */
+  readonly token: () => Promise<string | null>;
   readonly tls: { readonly cert: string; readonly key: string };
   readonly allowedOrigins?: readonly string[] | undefined;
 }
@@ -131,7 +141,11 @@ async function handle(
     return json({ error: 'origin_not_allowed' }, 403, cors(origin, false));
   }
 
-  if (!authorised(request, options.token)) {
+  // Re-read per request. The store caches its own decrypted copy, so this is a
+  // map lookup in the ordinary case and a re-read only after a rotation.
+  const expected = await options.token();
+
+  if (expected === null || !authorised(request, expected)) {
     return json(
       {
         error: 'unpaired',

--- a/src/server/read/listener.ts
+++ b/src/server/read/listener.ts
@@ -1,6 +1,6 @@
 import { timingSafeEqual } from 'node:crypto';
 import type { ProfileRuntime } from '../mcp/visibility.ts';
-import { readState } from './state.ts';
+import { readState, type ConnectionRow } from './state.ts';
 
 /**
  * The one surface a browser on `lanes.sh` may read (ADR-063).
@@ -66,6 +66,15 @@ export interface ReadListenerOptions {
   /** The current generation's profiles, read through a thunk so a reload lands. */
   readonly profiles: () => ReadonlyMap<string, ProfileRuntime>;
   readonly audit: AuditTail;
+  /**
+   * The workspace's connection rows, read per request.
+   *
+   * A thunk rather than a value because a connection added while the endpoint
+   * runs should appear without a restart — the same reason `profiles` is one.
+   * Read from `connections.yaml` rather than derived from the grants, because
+   * a label and an account live on the connection and a grant carries neither.
+   */
+  readonly connections: () => Promise<readonly ConnectionRow[]>;
   /** The pairing token, compared in constant time. */
   readonly token: string;
   readonly tls: { readonly cert: string; readonly key: string };
@@ -140,7 +149,12 @@ async function handle(
   const url = new URL(request.url);
 
   if (url.pathname === '/state') {
-    return json(readState(options.workspace, options.profiles()), 200, cors(origin, allowed));
+    const rows = await options.connections().catch(() => []);
+    return json(
+      readState(options.workspace, options.profiles(), rows),
+      200,
+      cors(origin, allowed),
+    );
   }
 
   if (url.pathname === '/audit') {

--- a/src/server/read/open.ts
+++ b/src/server/read/open.ts
@@ -1,17 +1,14 @@
-import { readConnections } from '#profile';
+import { X509Certificate } from 'node:crypto';
+import { PAIR_CERT_REF, PAIR_KEY_REF, PAIR_TOKEN_REF, readConnections } from '#profile';
 import type { Runtime } from '#cli/runtime.ts';
-import {
-  PAIR_CERT_REF,
-  PAIR_KEY_REF,
-  PAIR_TOKEN_REF,
-} from '#cli/commands/operate/pair.ts';
 import type { Logger } from '#connectivity';
 import type { RunningServer } from '../index.ts';
 import type { ProfileRuntime } from '../mcp/visibility.ts';
+import { directPairingCredential } from './credential.ts';
 import { serveRead, type RunningReadListener } from './listener.ts';
 
 /**
- * The dashboard's read surface, if this workspace has been paired.
+ * The dashboard's read surface on loopback, if this workspace has been paired.
  *
  * Absent by default and absent for every workspace that has not run
  * `lanes link pair`, which is the whole shape of ADR-063: a browser origin
@@ -29,20 +26,22 @@ export async function openReadListener(
   server: RunningServer,
   profiles: () => ReadonlyMap<string, ProfileRuntime>,
   log: Logger,
+  version: string,
 ): Promise<RunningReadListener | null> {
   // Loopback only, and checked before a single credential is read.
   //
-  // Pairing exists so a browser can read an endpoint on *this machine*
-  // (ADR-063); a deployed endpoint is already reachable by URL and `lanes link
-  // pair` refuses to provision one. Reading the three refs regardless meant a
-  // deployed revision asked Secret Manager for secrets no IAM binding covered —
-  // and Secret Manager answers a missing binding with 403 rather than 404, so
-  // the rejection escaped this function's try block, which wraps only
-  // `serveRead`, and the revision never went healthy.
+  // A second TLS listener one port above the endpoint is a loopback-only
+  // object: Cloud Run routes exactly one port, so there is nowhere for it to
+  // bind. Reading the three refs regardless meant a deployed revision asked
+  // Secret Manager for secrets no IAM binding covered — and Secret Manager
+  // answers a missing binding with 403 rather than 404, so the rejection
+  // escaped this function's try block, which wraps only `serveRead`, and the
+  // revision never went healthy.
   //
-  // Deriving the set for the IAM binding instead would have meant opening a
-  // credential store inside `readableRefs`, which `--dry-run` reaches and must
-  // not do.
+  // A deployed workspace now serves the same routes through the endpoint's own
+  // router (`./deployed.ts`), which reads no credential at boot at all — so
+  // that failure cannot recur there by construction, and `readableRefs` binds
+  // the token so the read itself stops being a rejection.
   const bound = new URL(server.url);
   if (!['127.0.0.1', 'localhost', '::1', '[::1]'].includes(bound.hostname)) return null;
 
@@ -63,13 +62,17 @@ export async function openReadListener(
       audit: primary.audit,
       connections: async () =>
         (await readConnections(primary.resolution.workspaceRoot)).connections,
-      // Re-read rather than captured, so `pair --rotate` takes effect on a
-      // running endpoint. `refresh()` drops the store's decrypted copy first,
-      // because the rotation was written by a different process.
-      token: async () => {
-        primary.credentials.refresh?.();
-        return primary.credentials.get(PAIR_TOKEN_REF);
-      },
+      // Read on every presentation, so `pair --rotate` takes effect on a
+      // running endpoint. Affordable here because the store is a local file;
+      // the deployed bind caches for exactly this reason. `refresh()` drops the
+      // store's decrypted copy first, because the rotation was written by a
+      // different process.
+      credential: directPairingCredential({
+        read: () => primary.credentials.get(PAIR_TOKEN_REF),
+        refresh: () => primary.credentials.refresh?.(),
+        onError: (reason) => log.warn('could not read the pairing credential', { reason }),
+      }),
+      endpoint: { kind: 'local', version, certificateExpiresAt: expiryOf(cert) },
       tls: { cert, key },
     });
   } catch (error) {
@@ -77,6 +80,22 @@ export async function openReadListener(
       port: Number(bound.port) + 1,
       reason: error instanceof Error ? error.message : String(error),
     });
+    return null;
+  }
+}
+
+/**
+ * When the pairing certificate stops working, as an ISO instant.
+ *
+ * `null` rather than a throw for a certificate that cannot be parsed: the
+ * surface it protects is already serving by the time anyone reads this, and
+ * refusing to answer `/state` because an expiry could not be formatted would
+ * take down the working thing to report on the broken one.
+ */
+function expiryOf(certificate: string): string | null {
+  try {
+    return new X509Certificate(certificate).validToDate.toISOString();
+  } catch {
     return null;
   }
 }

--- a/src/server/read/open.ts
+++ b/src/server/read/open.ts
@@ -63,7 +63,13 @@ export async function openReadListener(
       audit: primary.audit,
       connections: async () =>
         (await readConnections(primary.resolution.workspaceRoot)).connections,
-      token,
+      // Re-read rather than captured, so `pair --rotate` takes effect on a
+      // running endpoint. `refresh()` drops the store's decrypted copy first,
+      // because the rotation was written by a different process.
+      token: async () => {
+        primary.credentials.refresh?.();
+        return primary.credentials.get(PAIR_TOKEN_REF);
+      },
       tls: { cert, key },
     });
   } catch (error) {

--- a/src/server/read/open.ts
+++ b/src/server/read/open.ts
@@ -1,0 +1,76 @@
+import { readConnections } from '#profile';
+import type { Runtime } from '#cli/runtime.ts';
+import {
+  PAIR_CERT_REF,
+  PAIR_KEY_REF,
+  PAIR_TOKEN_REF,
+} from '#cli/commands/operate/pair.ts';
+import type { Logger } from '#connectivity';
+import type { RunningServer } from '../index.ts';
+import type { ProfileRuntime } from '../mcp/visibility.ts';
+import { serveRead, type RunningReadListener } from './listener.ts';
+
+/**
+ * The dashboard's read surface, if this workspace has been paired.
+ *
+ * Absent by default and absent for every workspace that has not run
+ * `lanes link pair`, which is the whole shape of ADR-063: a browser origin
+ * reaching loopback is a grant somebody makes deliberately, not a property of
+ * running an endpoint. All three pieces must be present — the token and both
+ * halves of the certificate — because a partial pairing would bind a port
+ * serving something no browser will connect to.
+ *
+ * Bound one above the MCP port, and a failure to bind is reported rather than
+ * fatal: the endpoint is what the operator ran this for, and refusing to serve
+ * it because a second port is occupied would be the wrong trade.
+ */
+export async function openReadListener(
+  primary: Runtime,
+  server: RunningServer,
+  profiles: () => ReadonlyMap<string, ProfileRuntime>,
+  log: Logger,
+): Promise<RunningReadListener | null> {
+  // Loopback only, and checked before a single credential is read.
+  //
+  // Pairing exists so a browser can read an endpoint on *this machine*
+  // (ADR-063); a deployed endpoint is already reachable by URL and `lanes link
+  // pair` refuses to provision one. Reading the three refs regardless meant a
+  // deployed revision asked Secret Manager for secrets no IAM binding covered —
+  // and Secret Manager answers a missing binding with 403 rather than 404, so
+  // the rejection escaped this function's try block, which wraps only
+  // `serveRead`, and the revision never went healthy.
+  //
+  // Deriving the set for the IAM binding instead would have meant opening a
+  // credential store inside `readableRefs`, which `--dry-run` reaches and must
+  // not do.
+  const bound = new URL(server.url);
+  if (!['127.0.0.1', 'localhost', '::1', '[::1]'].includes(bound.hostname)) return null;
+
+  const [token, cert, key] = await Promise.all([
+    primary.credentials.get(PAIR_TOKEN_REF),
+    primary.credentials.get(PAIR_CERT_REF),
+    primary.credentials.get(PAIR_KEY_REF),
+  ]);
+
+  if (token === null || cert === null || key === null) return null;
+
+  try {
+    return serveRead({
+      host: bound.hostname,
+      port: Number(bound.port) + 1,
+      workspace: primary.target,
+      profiles,
+      audit: primary.audit,
+      connections: async () =>
+        (await readConnections(primary.resolution.workspaceRoot)).connections,
+      token,
+      tls: { cert, key },
+    });
+  } catch (error) {
+    log.warn('could not serve the dashboard read surface', {
+      port: Number(bound.port) + 1,
+      reason: error instanceof Error ? error.message : String(error),
+    });
+    return null;
+  }
+}

--- a/src/server/read/routes.ts
+++ b/src/server/read/routes.ts
@@ -1,0 +1,247 @@
+import type { Logger } from '#connectivity';
+import type { ProfileRuntime } from '../mcp/visibility.ts';
+import type { PairingCredential } from './credential.ts';
+import { readState, type ConnectionRow, type ReadEndpoint } from './state.ts';
+
+/**
+ * The two routes a browser origin may read, and everything that guards them.
+ *
+ * One implementation, two binds. On loopback `./listener.ts` gives them a port
+ * of their own over TLS; on a deployed workspace `./deployed.ts` hands them to
+ * the endpoint's own router, because Cloud Run routes exactly one port. The
+ * split is deliberate and the sharing is the point: four of ADR-063's five
+ * properties are decided in this file, so the two surfaces cannot drift into
+ * two answers about what a pairing token may reach.
+ *
+ * Four properties, and dropping any one makes the others decorative:
+ *
+ *  - **One origin, named, never `*`.** Echoed with `Vary: Origin`. A deployment
+ *    may wildcard `/mcp` because it is already publicly reachable and a `curl`
+ *    has that reach already — but this returns every connection, every profile
+ *    and the whole audit log, and `cors.ts`'s wildcard was buying the absence of
+ *    a required setup step that does not exist here. So it is named.
+ *  - **A credential that cannot call a tool.** The pairing token, minted by
+ *    `lanes link pair`, under its own ref, rotatable on its own. It is not the
+ *    MCP bearer and not an OAuth token, and it never passes through the
+ *    endpoint's authenticator — one shared check would make each able to do the
+ *    other's job.
+ *  - **Never ambient.** An `Authorization` header the page must already hold.
+ *    No cookie, no session, so `credentials: 'include'` buys an attacker
+ *    nothing.
+ *  - **Reads only, ever.** No mutation is reachable from here at all. Editing a
+ *    profile from a browser would put control-plane mutation behind a CORS
+ *    grant, and ADR-007 does not move for a convenience.
+ *
+ * The fifth — TLS — belongs to the bind rather than to the routes, and
+ * `./listener.ts` carries it.
+ */
+
+/** Where the dashboard lives, and where it lives while somebody is building it. */
+export const READ_ORIGINS: readonly string[] = ['https://lanes.sh', 'http://localhost:3000'];
+
+export const STATE_PATH = '/state';
+export const AUDIT_PATH = '/audit';
+
+/**
+ * Whether the router should hand this path over.
+ *
+ * A predicate rather than an exported array, so the router owns no literal of
+ * its own and cannot come to disagree with the handler about which paths these
+ * are. `isAuthorizationPath` is the same shape for the same reason.
+ */
+export function isReadPath(pathname: string): boolean {
+  return pathname === STATE_PATH || pathname === AUDIT_PATH;
+}
+
+/** The most entries `/audit` will return, however many are asked for. */
+const AUDIT_CEILING = 500;
+const AUDIT_DEFAULT = 100;
+
+/**
+ * The half of the audit log this reads, declared rather than imported.
+ *
+ * `server` may not depend on `#audit`, and widening that table for one `tail`
+ * would be the wrong direction to resolve it: these routes do not know how the
+ * log is chained, stored, or verified, and nothing here should be able to find
+ * out. What they need is the last N entries, so that is what they ask for.
+ */
+export interface AuditTail {
+  tail(options?: { limit?: number }): Promise<
+    readonly {
+      readonly id: string;
+      readonly timestamp: Date;
+      readonly profile: string;
+      readonly principal: string;
+      readonly clientLabel?: string | undefined;
+      readonly provider: string;
+      readonly connection?: string | undefined;
+      readonly capability: string;
+      readonly arguments: Readonly<Record<string, unknown>>;
+      readonly authorization: string;
+      readonly status: string;
+      readonly durationMs: number;
+      readonly error?: { readonly kind: string; readonly message: string } | undefined;
+    }[]
+  >;
+}
+
+export interface ReadDeps {
+  readonly workspace: string;
+  /** The current generation's profiles, read through a thunk so a reload lands. */
+  readonly profiles: () => ReadonlyMap<string, ProfileRuntime>;
+  readonly audit: AuditTail;
+  /**
+   * The workspace's connection rows, read per request.
+   *
+   * A thunk rather than a value because a connection added while the endpoint
+   * runs should appear without a restart — the same reason `profiles` is one.
+   * Read from `connections.yaml` rather than derived from the grants, because
+   * a label and an account live on the connection and a grant carries neither.
+   */
+  readonly connections: () => Promise<readonly ConnectionRow[]>;
+  readonly credential: PairingCredential;
+  /** What this endpoint says about itself. Fixed for the life of the bind. */
+  readonly endpoint: ReadEndpoint;
+  readonly allowedOrigins?: readonly string[] | undefined;
+  readonly log?: Logger | undefined;
+}
+
+/**
+ * Answer a read request, whatever it turns out to be.
+ *
+ * This answers **every** request handed to it, including its own `404` for an
+ * unknown path — which is what lets `serveRead` pass a whole port through it.
+ * The router must therefore hand over only what `isReadPath` matched: given an
+ * unmatched path this would swallow `/mcp`.
+ */
+export async function readRoutes(request: Request, deps: ReadDeps): Promise<Response> {
+  const origins = deps.allowedOrigins ?? READ_ORIGINS;
+  const origin = request.headers.get('origin');
+  const allowed = origin !== null && origins.includes(origin);
+
+  // Answered before the credential is checked, because a preflight carries no
+  // credential — that is what it is for. It carries no data either, so
+  // answering one reveals only that something is listening, which the TCP
+  // connection already revealed.
+  if (request.method === 'OPTIONS') {
+    return new Response(null, { status: allowed ? 204 : 403, headers: cors(origin, allowed) });
+  }
+
+  // Not `405`. A surface that answered "method not allowed" would be confirming
+  // to any page that a Lanes read surface is here; a page that is not the
+  // dashboard learns nothing it did not send.
+  if (request.method !== 'GET') {
+    return json({ error: 'not_found' }, 404, cors(origin, allowed));
+  }
+
+  if (origin !== null && !allowed) {
+    return json({ error: 'origin_not_allowed' }, 403, cors(origin, false));
+  }
+
+  // The header is parsed before the store is asked anything. A request carrying
+  // no bearer cannot be the dashboard, and on a deployed workspace a store read
+  // is a network call — so answering it from the request alone is the
+  // difference between a stranger costing nothing and a stranger costing a
+  // Secret Manager round trip. `BearerAuthenticator` orders itself the same way
+  // for the same reason.
+  const presented = bearer(request);
+
+  if (presented === null || !(await deps.credential.verify(presented))) {
+    return json(
+      {
+        error: 'unpaired',
+        // The page shows this verbatim. Every failure looks the same from a
+        // browser — an expired certificate, a rotated token, a listener that is
+        // not running — so the answer is always the command that fixes all of
+        // them rather than a diagnosis the page cannot make.
+        run: 'lanes link pair',
+      },
+      401,
+      cors(origin, allowed),
+    );
+  }
+
+  const url = new URL(request.url);
+
+  if (url.pathname === STATE_PATH) {
+    const rows = await deps.connections().catch(() => []);
+    return json(
+      readState(deps.workspace, deps.profiles(), rows, deps.endpoint),
+      200,
+      cors(origin, allowed),
+    );
+  }
+
+  if (url.pathname === AUDIT_PATH) {
+    const limit = Math.min(
+      Number(url.searchParams.get('limit') ?? AUDIT_DEFAULT) || AUDIT_DEFAULT,
+      AUDIT_CEILING,
+    );
+    const profile = url.searchParams.get('profile');
+
+    const events = await deps.audit.tail({ limit });
+    const shown = profile ? events.filter((event) => event.profile === profile) : events;
+
+    return json(
+      {
+        events: shown.map((event) => ({
+          id: event.id,
+          timestamp: event.timestamp.toISOString(),
+          profile: event.profile,
+          principal: event.principal,
+          clientLabel: event.clientLabel ?? null,
+          provider: event.provider,
+          connection: event.connection ?? null,
+          capability: event.capability,
+          // Already redacted where it was written. This does not redact again,
+          // and must not start to: a second rule here would be a second answer
+          // to what is sensitive, and the log's own would stop being the truth.
+          arguments: event.arguments,
+          authorization: event.authorization,
+          // Authorised and then failed is a state the four fields above cannot
+          // express, and it is the one worth seeing: a call the policy allowed
+          // and the provider refused reads as a successful call without these.
+          status: event.status,
+          durationMs: event.durationMs,
+          error: event.error ?? null,
+        })),
+      },
+      200,
+      cors(origin, allowed),
+    );
+  }
+
+  return json({ error: 'not_found' }, 404, cors(origin, allowed));
+}
+
+function bearer(request: Request): string | null {
+  const header = request.headers.get('authorization') ?? '';
+  if (!header.toLowerCase().startsWith('bearer ')) return null;
+
+  const presented = header.slice(7).trim();
+  return presented === '' ? null : presented;
+}
+
+function cors(origin: string | null, allowed: boolean): Record<string, string> {
+  // `Vary: Origin` unconditionally, including on a refusal. Without it a cache
+  // between here and the page can serve one origin's answer to another, which
+  // is the whole grant leaking through an intermediary.
+  const headers: Record<string, string> = { vary: 'Origin' };
+  if (!allowed || origin === null) return headers;
+
+  headers['access-control-allow-origin'] = origin;
+  headers['access-control-allow-headers'] = 'authorization';
+  headers['access-control-allow-methods'] = 'GET, OPTIONS';
+  headers['access-control-max-age'] = '600';
+  // Deliberately absent: `access-control-allow-credentials`. The token is sent
+  // explicitly by the page, so allowing cookies would add an ambient credential
+  // to a surface whose safety rests on there not being one.
+  return headers;
+}
+
+function json(body: unknown, status: number, headers: Record<string, string>): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { ...headers, 'content-type': 'application/json', 'cache-control': 'no-store' },
+  });
+}

--- a/src/server/read/state.test.ts
+++ b/src/server/read/state.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, test } from 'bun:test';
+import { readState, type ConnectionRow } from './state.ts';
+import type { ProfileRuntime } from '../mcp/visibility.ts';
+
+/**
+ * What the dashboard is told the workspace holds.
+ *
+ * One property carries this file: **the workspace's connection list decides
+ * which connections exist, and the grants decide only who can reach them.**
+ * Deriving the list from the grants instead made an account that no profile
+ * grants invisible — which is exactly the state `lanes link connect` leaves one
+ * in when it is run without `--profile`, so a freshly authorised account did
+ * not appear at all.
+ */
+
+const ROWS: ConnectionRow[] = [
+  { provider: 'memory', id: 'main', account: 'Memory' },
+  { provider: 'gmail', id: 'ada', account: 'ada@example.com', label: 'Work mail' },
+  { provider: 'gmail', id: 'rin', account: 'rin@example.com' },
+];
+
+/** A profile runtime with only what `readState` reads. */
+function profile(grants: string[]): ProfileRuntime {
+  return {
+    config: {
+      description: 'A profile',
+      grants: grants.map((connection) => ({ connection, allow: [], deny: [] })),
+      members: [{ subject: 'lanes:HER', role: 'owner' }],
+    },
+    // Empty, so `reachable` is empty everywhere and the capability axis stays
+    // out of a test about which rows exist.
+    registry: { capabilities: () => [] },
+    policy: { byConnection: new Map() },
+  } as unknown as ProfileRuntime;
+}
+
+describe('which connections exist', () => {
+  test('every one the workspace holds, granted or not', () => {
+    // The bug this file exists for. `gmail.rin` is authorised and no profile
+    // grants it; it is still a connection, and a dashboard that hid it would be
+    // telling somebody their `connect` did nothing.
+    const state = readState('local', new Map([['personal', profile(['memory.main', 'gmail.ada'])]]), ROWS);
+
+    expect(state.connections.map((one) => one.ref).sort()).toEqual([
+      'gmail.ada',
+      'gmail.rin',
+      'memory.main',
+    ]);
+  });
+
+  test('an ungranted one says so, rather than being absent', () => {
+    const state = readState('local', new Map([['personal', profile(['memory.main'])]]), ROWS);
+    const rin = state.connections.find((one) => one.ref === 'gmail.rin');
+
+    expect(rin?.profiles).toEqual([]);
+  });
+
+  test('carries the label and the account, which are what a reader is shown', () => {
+    const state = readState('local', new Map(), ROWS);
+    const ada = state.connections.find((one) => one.ref === 'gmail.ada');
+
+    expect(ada?.label).toBe('Work mail');
+    expect(ada?.account).toBe('ada@example.com');
+  });
+
+  test('a row with no label says null rather than inventing one', () => {
+    const state = readState('local', new Map(), ROWS);
+
+    expect(state.connections.find((one) => one.ref === 'gmail.rin')?.label).toBeNull();
+  });
+
+  test('with no profiles at all, the workspace still lists what it holds', () => {
+    // The state a workspace is in between `connect` and the first `profile add`.
+    const state = readState('local', new Map(), ROWS);
+
+    expect(state.connections).toHaveLength(3);
+    expect(state.profiles).toEqual([]);
+  });
+});
+
+describe('who can reach one', () => {
+  test('names every profile that grants it', () => {
+    const state = readState(
+      'local',
+      new Map([
+        ['personal', profile(['gmail.ada'])],
+        ['work', profile(['gmail.ada'])],
+      ]),
+      ROWS,
+    );
+
+    expect([...(state.connections.find((one) => one.ref === 'gmail.ada')?.profiles ?? [])].sort()).toEqual([
+      'personal',
+      'work',
+    ]);
+  });
+
+  test('a grant naming a connection the workspace does not hold still appears', () => {
+    // `assertGrantsResolve` refuses this at load, so it is unreachable through
+    // the CLI. The read surface describes what is there rather than assuming,
+    // because a row that appeared only in a grant would otherwise vanish from
+    // the listing while still governing a profile.
+    const state = readState('local', new Map([['personal', profile(['ghost.one'])]]), ROWS);
+
+    expect(state.connections.find((one) => one.ref === 'ghost.one')?.profiles).toEqual([
+      'personal',
+    ]);
+  });
+});

--- a/src/server/read/state.test.ts
+++ b/src/server/read/state.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from 'bun:test';
-import { readState, type ConnectionRow } from './state.ts';
+import { readState, type ConnectionRow, type ReadEndpoint } from './state.ts';
 import type { ProfileRuntime } from '../mcp/visibility.ts';
 
 /**
@@ -18,6 +18,13 @@ const ROWS: ConnectionRow[] = [
   { provider: 'gmail', id: 'ada', account: 'ada@example.com', label: 'Work mail' },
   { provider: 'gmail', id: 'rin', account: 'rin@example.com' },
 ];
+
+/** What the bind says about itself. Fixed for a test about which rows exist. */
+const ENDPOINT: ReadEndpoint = {
+  kind: 'local',
+  version: '0.0.0-test',
+  certificateExpiresAt: null,
+};
 
 /** A profile runtime with only what `readState` reads. */
 function profile(grants: string[]): ProfileRuntime {
@@ -39,7 +46,7 @@ describe('which connections exist', () => {
     // The bug this file exists for. `gmail.rin` is authorised and no profile
     // grants it; it is still a connection, and a dashboard that hid it would be
     // telling somebody their `connect` did nothing.
-    const state = readState('local', new Map([['personal', profile(['memory.main', 'gmail.ada'])]]), ROWS);
+    const state = readState('local', new Map([['personal', profile(['memory.main', 'gmail.ada'])]]), ROWS, ENDPOINT);
 
     expect(state.connections.map((one) => one.ref).sort()).toEqual([
       'gmail.ada',
@@ -49,14 +56,14 @@ describe('which connections exist', () => {
   });
 
   test('an ungranted one says so, rather than being absent', () => {
-    const state = readState('local', new Map([['personal', profile(['memory.main'])]]), ROWS);
+    const state = readState('local', new Map([['personal', profile(['memory.main'])]]), ROWS, ENDPOINT);
     const rin = state.connections.find((one) => one.ref === 'gmail.rin');
 
     expect(rin?.profiles).toEqual([]);
   });
 
   test('carries the label and the account, which are what a reader is shown', () => {
-    const state = readState('local', new Map(), ROWS);
+    const state = readState('local', new Map(), ROWS, ENDPOINT);
     const ada = state.connections.find((one) => one.ref === 'gmail.ada');
 
     expect(ada?.label).toBe('Work mail');
@@ -64,14 +71,14 @@ describe('which connections exist', () => {
   });
 
   test('a row with no label says null rather than inventing one', () => {
-    const state = readState('local', new Map(), ROWS);
+    const state = readState('local', new Map(), ROWS, ENDPOINT);
 
     expect(state.connections.find((one) => one.ref === 'gmail.rin')?.label).toBeNull();
   });
 
   test('with no profiles at all, the workspace still lists what it holds', () => {
     // The state a workspace is in between `connect` and the first `profile add`.
-    const state = readState('local', new Map(), ROWS);
+    const state = readState('local', new Map(), ROWS, ENDPOINT);
 
     expect(state.connections).toHaveLength(3);
     expect(state.profiles).toEqual([]);
@@ -87,6 +94,7 @@ describe('who can reach one', () => {
         ['work', profile(['gmail.ada'])],
       ]),
       ROWS,
+      ENDPOINT,
     );
 
     expect([...(state.connections.find((one) => one.ref === 'gmail.ada')?.profiles ?? [])].sort()).toEqual([
@@ -100,7 +108,7 @@ describe('who can reach one', () => {
     // the CLI. The read surface describes what is there rather than assuming,
     // because a row that appeared only in a grant would otherwise vanish from
     // the listing while still governing a profile.
-    const state = readState('local', new Map([['personal', profile(['ghost.one'])]]), ROWS);
+    const state = readState('local', new Map([['personal', profile(['ghost.one'])]]), ROWS, ENDPOINT);
 
     expect(state.connections.find((one) => one.ref === 'ghost.one')?.profiles).toEqual([
       'personal',

--- a/src/server/read/state.ts
+++ b/src/server/read/state.ts
@@ -74,8 +74,13 @@ export function readState(
   profiles: ReadonlyMap<string, ProfileRuntime>,
   rows: readonly ConnectionRow[] = [],
 ): ReadState {
-  const declared = new Map(rows.map((row) => [`${row.provider}.${row.id}`, row]));
-  const connections = new Map<string, ReadConnection & { profiles: string[] }>();
+  // The workspace's own list is the source of truth for *which connections
+  // exist*. Deriving it from the grants instead made an account that no profile
+  // grants invisible — and that is precisely the state `connect` leaves one in
+  // when it is run without `--profile`, so a freshly authorised account did not
+  // appear at all. Grants say who can reach a connection, not whether it is
+  // there.
+  const grantedBy = new Map<string, string[]>();
   const described: ReadProfile[] = [];
 
   for (const [name, runtime] of profiles) {
@@ -83,22 +88,7 @@ export function readState(
 
     for (const grant of runtime.config.grants) {
       const ref = grant.connection;
-      const [provider = ref, id = ''] = ref.split('.');
-
-      const existing = connections.get(ref);
-      if (existing) {
-        existing.profiles.push(name);
-      } else {
-        const row = declared.get(ref);
-        connections.set(ref, {
-          ref,
-          provider,
-          id,
-          label: row?.label ?? null,
-          account: row?.account ?? null,
-          profiles: [name],
-        });
-      }
+      grantedBy.set(ref, [...(grantedBy.get(ref) ?? []), name]);
 
       const reachable = runtime.registry
         .capabilities()
@@ -122,5 +112,36 @@ export function readState(
     });
   }
 
-  return { workspace, connections: [...connections.values()], profiles: described };
+  const connections: ReadConnection[] = rows.map((row) => {
+    const ref = `${row.provider}.${row.id}`;
+    return {
+      ref,
+      provider: row.provider,
+      id: row.id,
+      label: row.label ?? null,
+      account: row.account ?? null,
+      profiles: grantedBy.get(ref) ?? [],
+    };
+  });
+
+  // A grant naming a connection the workspace no longer holds. `assertGrantsResolve`
+  // refuses this at load, so it is unreachable through the CLI — but the read
+  // surface should describe what is there rather than assume, and a row that
+  // appeared only in a grant would otherwise vanish from the listing while
+  // still governing a profile.
+  const known = new Set(connections.map((one) => one.ref));
+  for (const ref of grantedBy.keys()) {
+    if (known.has(ref)) continue;
+    const [provider = ref, id = ''] = ref.split('.');
+    connections.push({
+      ref,
+      provider,
+      id,
+      label: null,
+      account: null,
+      profiles: grantedBy.get(ref) ?? [],
+    });
+  }
+
+  return { workspace, connections, profiles: described };
 }

--- a/src/server/read/state.ts
+++ b/src/server/read/state.ts
@@ -18,8 +18,26 @@ export interface ReadConnection {
   readonly ref: string;
   readonly provider: string;
   readonly id: string;
+  /**
+   * The operator's own word for it, and what a reader should be shown.
+   *
+   * `gmail.ada_lovelace` is an address, not a name. A dashboard listing refs is
+   * asking somebody to read identifiers when they gave the thing a label
+   * precisely so they would not have to.
+   */
+  readonly label: string | null;
+  /** The identity the provider reported at connect time. */
+  readonly account: string | null;
   /** Which profiles grant this connection at all. */
   readonly profiles: readonly string[];
+}
+
+/** The connection rows as `connections.yaml` holds them. */
+export interface ConnectionRow {
+  readonly provider: string;
+  readonly id: string;
+  readonly account?: string | undefined;
+  readonly label?: string | undefined;
 }
 
 export interface ReadGrant {
@@ -54,7 +72,9 @@ export interface ReadState {
 export function readState(
   workspace: string,
   profiles: ReadonlyMap<string, ProfileRuntime>,
+  rows: readonly ConnectionRow[] = [],
 ): ReadState {
+  const declared = new Map(rows.map((row) => [`${row.provider}.${row.id}`, row]));
   const connections = new Map<string, ReadConnection & { profiles: string[] }>();
   const described: ReadProfile[] = [];
 
@@ -66,8 +86,19 @@ export function readState(
       const [provider = ref, id = ''] = ref.split('.');
 
       const existing = connections.get(ref);
-      if (existing) existing.profiles.push(name);
-      else connections.set(ref, { ref, provider, id, profiles: [name] });
+      if (existing) {
+        existing.profiles.push(name);
+      } else {
+        const row = declared.get(ref);
+        connections.set(ref, {
+          ref,
+          provider,
+          id,
+          label: row?.label ?? null,
+          account: row?.account ?? null,
+          profiles: [name],
+        });
+      }
 
       const reachable = runtime.registry
         .capabilities()

--- a/src/server/read/state.ts
+++ b/src/server/read/state.ts
@@ -1,0 +1,95 @@
+import { allowedConnections } from '#policy';
+import type { ProfileRuntime } from '../mcp/visibility.ts';
+
+/**
+ * What the dashboard is shown, assembled.
+ *
+ * Read-only by construction rather than by convention: this produces plain data
+ * and holds nothing that can mutate. Every field is something the CLI already
+ * prints — `status`, `connection list` and `profile show` in one document — so
+ * nothing here is readable that a person at this machine could not already read.
+ *
+ * **No credential is in it.** Not a connection's tokens, not a vault value, not
+ * the contents of a secret ref. What is here is the shape of the workspace:
+ * which accounts exist, which profiles select them, and what each allows.
+ */
+
+export interface ReadConnection {
+  readonly ref: string;
+  readonly provider: string;
+  readonly id: string;
+  /** Which profiles grant this connection at all. */
+  readonly profiles: readonly string[];
+}
+
+export interface ReadGrant {
+  readonly connection: string;
+  /** The capability ids reachable on it, after the floor and the profile's rules. */
+  readonly reachable: readonly string[];
+}
+
+export interface ReadProfile {
+  readonly name: string;
+  readonly description: string | null;
+  readonly grants: readonly ReadGrant[];
+  /** Subjects only. An email is a fact about a person that is not held here. */
+  readonly members: readonly { subject: string; role: string }[];
+}
+
+export interface ReadState {
+  readonly workspace: string;
+  readonly connections: readonly ReadConnection[];
+  readonly profiles: readonly ReadProfile[];
+}
+
+/**
+ * The workspace as the dashboard sees it.
+ *
+ * `reachable` comes from `allowedConnections`, the same call discovery and
+ * enforcement make. That is the point rather than a convenience: a dashboard
+ * that decided visibility its own way would eventually disagree with the
+ * endpoint about what a profile can do, and the version a person reads would be
+ * the wrong one.
+ */
+export function readState(
+  workspace: string,
+  profiles: ReadonlyMap<string, ProfileRuntime>,
+): ReadState {
+  const connections = new Map<string, ReadConnection & { profiles: string[] }>();
+  const described: ReadProfile[] = [];
+
+  for (const [name, runtime] of profiles) {
+    const grants: ReadGrant[] = [];
+
+    for (const grant of runtime.config.grants) {
+      const ref = grant.connection;
+      const [provider = ref, id = ''] = ref.split('.');
+
+      const existing = connections.get(ref);
+      if (existing) existing.profiles.push(name);
+      else connections.set(ref, { ref, provider, id, profiles: [name] });
+
+      const reachable = runtime.registry
+        .capabilities()
+        .filter(
+          ({ id: capability }) =>
+            allowedConnections(capability, [ref], name, runtime.policy, runtime.floor).length > 0,
+        )
+        .map(({ id: capability }) => capability);
+
+      grants.push({ connection: ref, reachable });
+    }
+
+    described.push({
+      name,
+      description: runtime.config.description ?? null,
+      grants,
+      members: runtime.config.members.map((member) => ({
+        subject: member.subject,
+        role: member.role,
+      })),
+    });
+  }
+
+  return { workspace, connections: [...connections.values()], profiles: described };
+}

--- a/src/server/read/state.ts
+++ b/src/server/read/state.ts
@@ -54,8 +54,31 @@ export interface ReadProfile {
   readonly members: readonly { subject: string; role: string }[];
 }
 
+/**
+ * What the endpoint says about itself.
+ *
+ * Added because the dashboard now reads more than one kind of endpoint and had
+ * no way to tell which it was looking at — the page derived "local" from the
+ * fact that the only address it could reach was a loopback one, which stopped
+ * being true the moment a deployed workspace became readable.
+ *
+ * `certificateExpiresAt` is loopback's alone. ADR-063 promised that an expiry
+ * would be reported and nothing reported it; an expired certificate fails in
+ * the browser with an error the page cannot read, so the one place it can
+ * usefully appear is inside a response sent while the certificate still works.
+ * A deployed endpoint has none of its own — the platform terminates TLS — and
+ * says `null` rather than inventing one.
+ */
+export interface ReadEndpoint {
+  readonly kind: 'local' | 'deployed';
+  /** The version serving this request, so a page can say what it is reading. */
+  readonly version: string;
+  readonly certificateExpiresAt: string | null;
+}
+
 export interface ReadState {
   readonly workspace: string;
+  readonly endpoint: ReadEndpoint;
   readonly connections: readonly ReadConnection[];
   readonly profiles: readonly ReadProfile[];
 }
@@ -72,7 +95,8 @@ export interface ReadState {
 export function readState(
   workspace: string,
   profiles: ReadonlyMap<string, ProfileRuntime>,
-  rows: readonly ConnectionRow[] = [],
+  rows: readonly ConnectionRow[],
+  endpoint: ReadEndpoint,
 ): ReadState {
   // The workspace's own list is the source of truth for *which connections
   // exist*. Deriving it from the grants instead made an account that no profile
@@ -143,5 +167,5 @@ export function readState(
     });
   }
 
-  return { workspace, connections, profiles: described };
+  return { workspace, endpoint, connections, profiles: described };
 }

--- a/src/server/setup-surface.test.ts
+++ b/src/server/setup-surface.test.ts
@@ -40,24 +40,56 @@ const CATALOGUE = [
   }),
 ];
 
+/**
+ * The flat `allow`/`deny` a test writes, split into one row per connection.
+ *
+ * A rule lives inside the row that names one connection now (ADR-058), and may
+ * only name that row's own provider — so the block is filtered as well as
+ * repeated. That filtering is exactly what the flat block meant when it said
+ * rules cover every account of a provider, which keeps these tests asserting
+ * what they were written to assert.
+ */
+function grantsFrom(policy: string, connections: readonly string[]): string {
+  const lines = policy.split('\n').filter((line) => line.trim().length > 0);
+
+  return connections
+    .map((connection) => {
+      const provider = connection.split('.')[0];
+      const held: Record<string, string[]> = { allow: [], deny: [] };
+      let field = 'allow';
+
+      for (const line of lines) {
+        const trimmed = line.trim();
+        if (trimmed === 'allow:' || trimmed === 'deny:') {
+          field = trimmed.slice(0, -1);
+          continue;
+        }
+        const capability = trimmed.replace(/^-\s*/, '').replace(/"/g, '');
+        if (capability !== '*' && capability.split('.')[0] !== provider) continue;
+        held[field]?.push(capability);
+      }
+
+      return (
+        `  - connection: ${connection}\n` +
+        `    allow: [${held['allow']?.join(', ') ?? ''}]\n` +
+        `    deny: [${held['deny']?.join(', ') ?? ''}]`
+      );
+    })
+    .join('\n');
+}
+
 function config(profile: string, port: number, policy: string) {
   return parseConfig(`
-contract: 2
+contract: 3
 instance:
   profile: ${profile}
   port: ${port}
 limits:
   requests_per_minute: 1000
   upstream_calls_per_minute: 1000
-connections:
-  - id: main
-    provider: setup
-    account: Setup
-  - id: a
-    provider: example
-    account: someone@example.test
-policy:
-${policy}
+grants:
+${grantsFrom(policy, ['setup.main', 'example.a'])}
+members: []
 `).config;
 }
 
@@ -116,20 +148,16 @@ const never = startHarness({
   token: 'llk_never_token_value',
   providers: providersFor('never', []),
   config: parseConfig(`
-contract: 2
+contract: 3
 instance:
   profile: never
   port: ${neverPort}
 limits:
   requests_per_minute: 1000
   upstream_calls_per_minute: 1000
-connections:
-  - id: main
-    provider: setup
-    account: Setup
-policy:
-  allow:
-    - "setup.*"
+grants:
+  - { connection: setup.main, allow: ['setup.*'], deny: [] }
+members: []
 `).config,
 });
 

--- a/src/server/skills-authoring.test.ts
+++ b/src/server/skills-authoring.test.ts
@@ -69,19 +69,17 @@ function skillsFixture(): { store: BlobStore; refresh: (registry: ProviderRegist
 
 function config(profile: string, port: number, policy: string) {
   return parseConfig(`
-contract: 2
+contract: 3
 instance:
   profile: ${profile}
   port: ${port}
 limits:
   requests_per_minute: 1000
   upstream_calls_per_minute: 1000
-connections:
-  - id: owner
-    provider: skills
-    account: Owner
-policy:
-${policy}
+grants:
+  - connection: skills.owner
+${policy.split('\n').filter((line) => line.trim().length > 0).map((line) => `  ${line}`).join('\n')}
+members: []
 `).config;
 }
 


### PR DESCRIPTION
Config contract 2 → 3, with an automatic migration. This is the release the other three repositories' branches of the same name are for.

## What changes, and why each one

**A connection belongs to the workspace, and a profile selects it.** A connection used to live inside one profile, invisible to its siblings, so reaching the same mailbox from two profiles meant authorising it twice. Now you authorise once and any profile may reference it. `data/` moved up with them: a credential store per profile stopped making sense once the credentials were the workspace's.

**A grant names a connection.** `connections:` and `policy:` are replaced by `grants:`, one row per connection with its own `allow` and `deny`. Under contract 2 every account of a provider within a profile was governed identically, so "read this mailbox, write that calendar" was not expressible and the only way to separate two accounts was a second profile. A connection with no row is *absent* rather than denied: it never appears in a tool's `connection` enum, so an agent does not learn it exists.

**The owner layer is instances.** `memory.main` and `memory.acme` are two stores, selected per profile. `skills` and `vault` may only be granted once per profile, because each backs one directory and one sealed file.

**A caller is a person.** `members:` declares who may consume a profile, and empty means nobody. It is a *selection from* the Lanes workspace rather than a second list beside it: a workspace bound with `lanes_workspace:` is asked who it holds, so somebody added on the dashboard appears the moment they accept, and a pending invitation is listed, marked, and refused because there is no subject yet to write down.

**Identity comes from lanes.sh.** `/authorize` used to render a form asking the owner to paste the endpoint's bearer token. That proves possession of a secret rather than identity, so a profile could not say *who* may consume it; and a page on loopback asking for the one credential that opens everything is what ADR-039 named as the most valuable thing a hostile local page could reach. Now `/authorize` mints a nonce and redirects to lanes.sh; `/authorize/callback` verifies the assertion that comes back against the API's published key and resolves the subject to the profiles that list it. There is no form on loopback left to phish.

**A workspace is the only word.** "Target" named the thing a workspace already was. `--target` survives one minor as an alias that warns, and passing both spellings with different values is refused rather than resolved.

**One browser origin may read a loopback endpoint.** `lanes link pair` provisions a TLS listener one port above the endpoint that `https://lanes.sh` may read: connections, profiles, grants, members, and the audit log. Read-only, its own credential, nothing ambient, and no route in common with `/mcp`.

## Two things worth arguing about in review

**`lanes link start` now requires a Lanes session, on a local endpoint too.** That is a real dependency on lanes.sh for a self-hostable tool. The alternative is local profiles that cannot express delegation at all, which means two models instead of one. What is *not* required is the network per request: a machine offline for a day keeps serving, and `lanes auth status` says how long that has left. The CI token stays, scoped exactly as before, because a headless runner has no browser.

**ADR-063 is a narrowing of ADR-039 and asks for a security review.** The ADR argues it rather than asserting it, and states what it costs: a certificate in the machine's trust store, a second port, and a credential that reads the whole workspace. Every property is tested over a real TLS listener.

## Migration

Automatic, on `start` and `update`, in one pass per workspace: connections hoisted and merged on `(provider, account)`, credentials written and read back *before* the old stores are touched, blobs copy-verify-deleted, each profile rewritten with the grants its old flat policy implied, and the registry rewritten. Two profiles each holding `gmail.main` for *different* accounts keep both, one suffixed, and the rename is reported. `lanes link migrate --dry-run` prints the whole plan first.

A token minted before this release keeps working: an issued token with no subject resolves to the owner, so nobody is logged out by upgrading.

## Two defects found on the way

- The principal handed to `Dispatcher.invoke` carried the endpoint's *primary* profile rather than the one the call named, so the `mayReach` check read the wrong profile and the audit event recorded it. `forProfile` scopes it at each of the three dispatch sites.
- An unknown JWKS key id refetched on every request, which made every endpoint an amplifier pointed at the API for anyone willing to send invented key ids. Found by a test asserting the opposite of what the code did; bounded to one refetch a minute.

## ADRs

057 through 063, each amending a decision that was argued rather than quietly contradicting it. 062 and 063 were filed as proposals while the first half was built around them and are now accepted.

## Verification

`bun test` 2863 passing, `tsc --noEmit` clean, `src/architecture.test.ts` green. Also run with `LANES_DOCS_DIR` pointed at the web branch, which is where four checks only run: 2867 passing. Two of those had been failing before this branch, because `readme.test.ts` still looked for the provider catalogue in `connect.mdx` after it moved to `providers.mdx`, and had been reporting 105 missing providers on a site that documents every one.

Not run: nothing that touches a real account, and no endpoint started against `~/.lanes-link`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JGnspV4kZLg79mWFtjQzeg


---

## Added since this was opened

**ADR-064: a deployed endpoint is read over its own URL.** ADR-063 stated the deployed case as a decision rather than an oversight — "a deployed endpoint is already reachable by URL and `lanes link pair` refuses to provision one" — so this amends it rather than quietly reversing it. What that refusal was about is provisioning a certificate for an address this machine does not answer on, which is still true and still refused. A deployed endpoint needs no certificate, because the platform terminates TLS. What it needs is a token and an address, and neither was the thing being refused. The ADR states what it costs plainly: a pairing token now exists in Secret Manager, and it reads the whole workspace over a public URL.

**The read routes are extracted so the two surfaces cannot drift.** `handle` was already transport-agnostic; it moves to `server/read/routes.ts` as `readRoutes`, and `listener.ts` keeps `serveRead`, `READ_ORIGINS` and the option types and delegates. The five ADR-063 properties — one named origin and never `*`, a credential that cannot call a tool, never ambient, reads only, the token re-read per request — then hold on both surfaces because there is one implementation of them. Two copies would be two answers.

Cloud Run routes one port, so a second listener is impossible there: `/state` and `/audit` mount on the main handler, before the 404 gate, inside the meter, and **not** through `options.authenticator` — the pairing token is not the MCP bearer and neither is accepted as the other. Loopback keeps its separate listener and its non-loopback guard exactly as they were; this adds a path rather than generalising that one.

**`pair` learns the deployed case.** Loopback is unchanged down to the printed text. Deployed skips `ensureCertificate`, mints or reuses `PAIR_TOKEN_REF` in that workspace's store, resolves the address with `deployedUrl`, and prints a link carrying both. `deployedUrl` degrades to `null`, and a link with no address reads nothing, so a `null` refuses and names `lanes link outputs` rather than printing half a link.

**`deploy` grants the revision its pair token** — `PAIR_TOKEN_REF` joins `readableRefs`, not `rotatableRefs`, because the revision never writes it; `pair --rotate` does, as the operator. The container is created with an empty version at deploy time, because Secret Manager answers a missing binding with 403 rather than 404 and that is the failure this file has already recorded twice. No real token is minted there: ADR-063 holds that pairing is a grant somebody makes deliberately, not a property of running an endpoint.

**`ReadState` gained an `endpoint` block** — the version, whether the bind is loopback or deployed, and the certificate expiry where there is one. ADR-063 promised the expiry would be reported and nothing reported it; an expired certificate fails in the browser with an error the page cannot read, so the one place it can usefully appear is a response sent while the certificate still works.

**The middle deployment target is called Self-Hosted** in the README's comparison table. That table is the copy of record `web`'s `app/link/_data/content.tsx` mirrors, so the rename lands in both branches together. `docs/link/deploy.mdx` is still titled "Deploy to your own cloud" and four pages link to it by that title; that sweep is deliberately not in this.

The deployed half is covered by tests over a real listener, the way `listener.test.ts` drives the loopback one. It has **not** been exercised against a real Cloud Run deployment — that needs a real Google Cloud project and is the operator's call, not something to run unattended.

`bun test` 2953 passing, `bun run typecheck` clean, `ci` green.


**A loopback pairing link carries its port.** `pair` printed `#pair=<token>` alone for loopback, on the reasoning that a local address is derivable — it is not, because the read listener sits one port above `instance.port`. A workspace on any port but the default printed a link the dashboard read at 7338, found nothing, and reported unreachable while the endpoint was answering on the port printed two lines above. Every failure a browser sees here is the same opaque network error, so the page could not have said "wrong port" even if asked. `at=` is now emitted for loopback too and the parameter is required rather than optional, so the shape cannot come back by omission. `pairingLink` is exported and asserted on — the whole defect was a shape nothing tested, in a command whose output no test read.
