### PR TITLE
fix: the contract-3 migration could not migrate a workspace with two profiles

### DIFF
--- a/src/cli/commands/operate/serve.ts
+++ b/src/cli/commands/operate/serve.ts
@@ -2,7 +2,7 @@ import { readSession } from '#auth/lanes/session.ts';
 import { ConfigError } from '#profile';
 import { startEndpoint } from '#server/endpoint.ts';
 import { streamLogger } from '#server/logging.ts';
-import { repairOwnerLayer } from '../../config-repair.ts';
+import { repairOwnerLayer } from '../../config-repair-sweep.ts';
 import { announce, ok, print, style, warn } from '../../output.ts';
 import { staleNudge } from '../../release.ts';
 import { primaryProfile, resolveProfile, type GlobalFlags } from '../../runtime.ts';

--- a/src/cli/commands/update.ts
+++ b/src/cli/commands/update.ts
@@ -1,9 +1,9 @@
 import { homedir } from 'node:os';
 import { join, sep } from 'node:path';
 import { installRoot, resolveWorkspaceRoot } from '#profile';
-import { repairOwnerLayer } from '../config-repair.ts';
-import { migrateToCurrentContract, type ContractMigration } from '../workspace-migrate.ts';
-import type { Contract3Migration } from '../contract3.ts';
+import { repairOwnerLayer } from '../config-repair-sweep.ts';
+import { migrateToCurrentContract, needsMigration, type ContractMigration } from '../workspace-migrate.ts';
+import { needsContract3, type Contract3Migration } from '../contract3.ts';
 import { emit, fail, ok, print, printErr, progress, style, warn } from '../output.ts';
 import { PACKAGE, release, type ReleaseState } from '../release.ts';
 import { version } from '../version.ts';
@@ -186,16 +186,10 @@ export async function update(flags: UpdateFlags): Promise<void> {
     // same breath.
     const migrated = await migrateLocal(root, flags.json === true ? progress : print);
 
-    // Only on a workspace the migration actually finished.
-    //
-    // The repair writes contract-3 shapes — a `connections.yaml`, a `grants:`
-    // block — and running it after a refusal put both into a workspace still at
-    // contract 2, behind a message that had just said nothing was written. The
-    // stray `connections.yaml` it created then read as a partly-migrated
-    // workspace to everything that opened it afterwards.
-    //
-    // A refusal must not be followed by a write. The next run repairs it once
-    // the migration succeeds, which is the same courtesy one command later.
+    // Only on a workspace that is actually at the current contract — see
+    // `migrateLocal`. The repair writes contract-3 shapes, and writing them
+    // after a refusal that said nothing had been written is what left a stray
+    // `connections.yaml` in a contract-2 workspace.
     if (migrated) {
       await repairOwnerLayer(root, undefined, {
         ...(flags.json === true ? { report: progress } : {}),
@@ -362,9 +356,24 @@ async function migrateLocal(root: string, say: (line: string) => void): Promise<
     return true;
   } catch (error) {
     say(`could not migrate this workspace: ${error instanceof Error ? error.message : String(error)}`);
-    say('  the owner-layer repair is skipped until it does — nothing else was changed');
-    return false;
+
+    // **Still behind, not "something threw".** Keying the repair on the throw
+    // suppressed it for the whole workspace when one profile failed to
+    // migrate — so the others, already current, never received a newly shipped
+    // surface, which is the case `update` runs the repair for at all. One
+    // unreadable profile is a per-profile warning, which the repair already
+    // gives it.
+    const behind = await stillBehind(root);
+    if (behind) say('  the owner-layer repair is skipped until it does');
+    return !behind;
   }
+}
+
+/** Anything still below the current contract. Unreadable counts as behind. */
+function stillBehind(root: string): Promise<boolean> {
+  return needsMigration(root)
+    .then(async (one) => one || (await needsContract3(root)))
+    .catch(() => true);
 }
 
 /** Contract 1 to contract 2: targets move from the profile to the workspace. */

--- a/src/cli/commands/update.ts
+++ b/src/cli/commands/update.ts
@@ -184,11 +184,23 @@ export async function update(flags: UpdateFlags): Promise<void> {
     // a contract it does not implement until someone redeploys. `deploy` is what
     // migrates a bucket, because it is the command that ships the image in the
     // same breath.
-    await migrateLocal(root, flags.json === true ? progress : print);
+    const migrated = await migrateLocal(root, flags.json === true ? progress : print);
 
-    await repairOwnerLayer(root, undefined, {
-      ...(flags.json === true ? { report: progress } : {}),
-    });
+    // Only on a workspace the migration actually finished.
+    //
+    // The repair writes contract-3 shapes — a `connections.yaml`, a `grants:`
+    // block — and running it after a refusal put both into a workspace still at
+    // contract 2, behind a message that had just said nothing was written. The
+    // stray `connections.yaml` it created then read as a partly-migrated
+    // workspace to everything that opened it afterwards.
+    //
+    // A refusal must not be followed by a write. The next run repairs it once
+    // the migration succeeds, which is the same courtesy one command later.
+    if (migrated) {
+      await repairOwnerLayer(root, undefined, {
+        ...(flags.json === true ? { report: progress } : {}),
+      });
+    }
   }
 
   const report = {
@@ -330,7 +342,7 @@ function sayContract3(migration: Contract3Migration, say: (line: string) => void
   say(`  The old per-profile credential stores are left in place; remove them once this works.`);
 }
 
-async function migrateLocal(root: string, say: (line: string) => void): Promise<void> {
+async function migrateLocal(root: string, say: (line: string) => void): Promise<boolean> {
   try {
     // One call, both steps, in order — a workspace that predates both walks
     // through them rather than jumping, so each step's reasoning applies to the
@@ -347,8 +359,11 @@ async function migrateLocal(root: string, say: (line: string) => void): Promise<
 
     if (migration.legacy) sayLegacyTargets(migration.legacy, say);
     if (migration.contract3) sayContract3(migration.contract3, say);
+    return true;
   } catch (error) {
     say(`could not migrate this workspace: ${error instanceof Error ? error.message : String(error)}`);
+    say('  the owner-layer repair is skipped until it does — nothing else was changed');
+    return false;
   }
 }
 

--- a/src/cli/config-edit.test.ts
+++ b/src/cli/config-edit.test.ts
@@ -508,3 +508,45 @@ oauth_apps: {}
     expect(repairLines(ensureOwnerLayer(again.connections, again.profile))).toEqual([]);
   });
 });
+
+describe('appending to a key that is not there yet', () => {
+  test('a second append lands, and the sequence is written as a block', () => {
+    // `addTo` used to create the sequence by setting a plain JS array. That is
+    // not a collection the document API will traverse — the hazard `setIn`
+    // documents one method above — so the *first* append landed and the second
+    // found a value with no `.add` and threw `existing.add is not a function`.
+    // `#expand` reads `.items` and was silently a no-op for the same reason,
+    // leaving the sequence in flow style.
+    //
+    // Latent for as long as every path this is called with already existed.
+    // `grants:` is genuinely absent on a contract-2 profile being repaired,
+    // which is what finally made the second append reachable — and what turned
+    // one upgrade into three warnings and an unrepaired workspace.
+    const document = ConfigDocument.fromText('contract: 3\n');
+
+    document.addTo(['grants'], { connection: 'example.a', allow: ['example.*'], deny: [] });
+    document.addTo(['grants'], { connection: 'example.b', allow: ['example.*'], deny: [] });
+
+    const rows = (document.getIn(['grants']) as { items?: unknown[] })?.items ?? [];
+    expect(rows).toHaveLength(2);
+    expect(document.toString()).toContain('grants:\n  - connection: example.a');
+    expect(document.toString()).toContain('  - connection: example.b');
+  });
+
+  test('the whole owner layer is granted to a profile with no grants block', () => {
+    // The path that actually broke: seven surfaces, appended one at a time, to
+    // a profile that has never had a `grants:` key. The first surface used to
+    // succeed and the second threw, so the profile was left with one grant of
+    // seven and the command reported a warning instead of a repair.
+    const connections = ConfigDocument.fromText(newConnectionsTemplate(), CONNECTIONS_FILE);
+    const profile = ConfigDocument.fromText('contract: 3\n');
+
+    const repair = ensureOwnerLayer(connections, profile);
+
+    const rows = (profile.getIn(['grants']) as { items?: unknown[] })?.items ?? [];
+    expect(rows).toHaveLength(DEFAULT_SURFACES.length);
+    for (const surface of DEFAULT_SURFACES) {
+      expect(repair.granted).toContain(`${surface}.*`);
+    }
+  });
+});

--- a/src/cli/config-edit.test.ts
+++ b/src/cli/config-edit.test.ts
@@ -550,3 +550,73 @@ describe('appending to a key that is not there yet', () => {
     }
   });
 });
+
+describe('the repair reads this profile\'s grants, not the workspace\'s first row', () => {
+  const workspaceRows = [
+    'contract: 3',
+    'connections:',
+    '  - { id: main, provider: memory, account: Memory }',
+    '  - { id: demo, provider: memory, account: Memory }',
+    '  - { id: main, provider: vault, account: Vault }',
+    '  - { id: demo, provider: vault, account: Vault }',
+    '',
+  ].join('\n');
+
+  test('a profile that already has its own instance is left alone', () => {
+    // Contract 3 puts every profile's owner layer in one file, so "the first
+    // row for this provider" is whichever profile sorts first. The repair asked
+    // whether this profile granted *that* row, saw that it did not, and set
+    // about adding it — which for vault and skills the schema refuses, and for
+    // memory, tasks, assets, setup and entities it does not: the profile would
+    // have been handed another profile's notes and task list, which is the one
+    // outcome ADR-059 exists to prevent.
+    const connections = ConfigDocument.fromText(workspaceRows, CONNECTIONS_FILE);
+    const profile = ConfigDocument.fromText(
+      [
+        'contract: 3',
+        'grants:',
+        '  - { connection: memory.demo, allow: [memory.*], deny: [] }',
+        '  - { connection: vault.demo, allow: [vault.*], deny: [] }',
+        '',
+      ].join('\n'),
+    );
+
+    const repair = ensureReservedConnection(connections, profile, 'memory');
+
+    expect(repair.changes).toEqual([]);
+    expect(repair.granted).toEqual([]);
+  });
+
+  test('a surface the profile grants nothing for is still repaired', () => {
+    // The case this was written for: a surface that did not exist when the
+    // profile was written. Nothing about the fix above may turn that into a
+    // no-op, or a release adding a surface would never reach an existing
+    // profile.
+    const connections = ConfigDocument.fromText(workspaceRows, CONNECTIONS_FILE);
+    const profile = ConfigDocument.fromText('contract: 3\ngrants: []\n');
+
+    const repair = ensureReservedConnection(connections, profile, 'memory');
+
+    expect(repair.granted).toEqual(['memory.*']);
+  });
+
+  test('a deny on the profile\'s own instance still blocks the repair', () => {
+    // A deny beats an allow, so writing the rule would widen nothing while
+    // announcing that an agent can now read the surface. Read off the wrong row
+    // this was invisible, and the repair undid a deliberate switch-off.
+    const connections = ConfigDocument.fromText(workspaceRows, CONNECTIONS_FILE);
+    const profile = ConfigDocument.fromText(
+      [
+        'contract: 3',
+        'grants:',
+        '  - { connection: memory.demo, allow: [], deny: [memory.*] }',
+        '',
+      ].join('\n'),
+    );
+
+    expect(ensureReservedConnection(connections, profile, 'memory')).toEqual({
+      changes: [],
+      granted: [],
+    });
+  });
+});

--- a/src/cli/config-edit.test.ts
+++ b/src/cli/config-edit.test.ts
@@ -6,14 +6,8 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { ConfigDocument } from './config-edit.ts';
 import { CONNECTIONS_FILE } from '#profile';
-import {
-  DEFAULT_SURFACES,
-  ensureOwnerLayer,
-  repairOwnerLayer,
-  ensureReservedConnection,
-  repairLines,
-  type SurfaceRepair,
-} from './config-repair.ts';
+import { DEFAULT_SURFACES, ensureOwnerLayer, ensureReservedConnection, repairLines, type SurfaceRepair } from './config-repair.ts';
+import { repairOwnerLayer } from './config-repair-sweep.ts';
 
 /**
  * The config file is the source of truth, and an operator is meant to be able
@@ -618,5 +612,67 @@ describe('the repair reads this profile\'s grants, not the workspace\'s first ro
       changes: [],
       granted: [],
     });
+  });
+});
+
+describe('a profile granting two instances of one surface', () => {
+  const twoInstances = [
+    'contract: 3',
+    'connections:',
+    '  - { id: team, provider: memory, account: Memory }',
+    '  - { id: personal, provider: memory, account: Memory }',
+    '',
+  ].join('\n');
+
+  test('a deny on either of them switches the surface off', () => {
+    // Reading only the first matching row let a deny be stepped around: the
+    // repair widened the other instance and reported the surface granted, which
+    // is the one thing `ensureReservedConnection` says it must never do.
+    const connections = ConfigDocument.fromText(twoInstances, CONNECTIONS_FILE);
+    const profile = ConfigDocument.fromText(
+      [
+        'contract: 3',
+        'grants:',
+        '  - { connection: memory.team, allow: [], deny: [] }',
+        '  - { connection: memory.personal, allow: [], deny: [memory.*] }',
+        '',
+      ].join('\n'),
+    );
+
+    expect(ensureReservedConnection(connections, profile, 'memory')).toEqual({
+      changes: [],
+      granted: [],
+    });
+  });
+
+  test('a grant on either of them counts as having the surface', () => {
+    const connections = ConfigDocument.fromText(twoInstances, CONNECTIONS_FILE);
+    const profile = ConfigDocument.fromText(
+      [
+        'contract: 3',
+        'grants:',
+        '  - { connection: memory.team, allow: [], deny: [] }',
+        '  - { connection: memory.personal, allow: [memory.*], deny: [] }',
+        '',
+      ].join('\n'),
+    );
+
+    expect(ensureReservedConnection(connections, profile, 'memory').granted).toEqual([]);
+  });
+
+  test('a connection value with no dot in it matches no provider', () => {
+    // These rows are raw unvalidated YAML. Slicing at the dot answered -1 for a
+    // dotless value, and `'vaults'.slice(0, -1)` is `'vault'` — so a typo was
+    // widened while the real surface stayed unreachable.
+    const connections = ConfigDocument.fromText(
+      'contract: 3\nconnections:\n  - { id: main, provider: vault, account: Vault }\n',
+      CONNECTIONS_FILE,
+    );
+    const profile = ConfigDocument.fromText(
+      'contract: 3\ngrants:\n  - { connection: vaults, allow: [], deny: [] }\n',
+    );
+
+    const repair = ensureReservedConnection(connections, profile, 'vault');
+    expect(repair.changes).toEqual(['grants += vault.main']);
   });
 });

--- a/src/cli/config-edit.ts
+++ b/src/cli/config-edit.ts
@@ -1,5 +1,5 @@
 import { rename, writeFile } from 'node:fs/promises';
-import { Document, parseDocument, type Node } from 'yaml';
+import { Document, parseDocument, YAMLSeq, type Node } from 'yaml';
 import {
   CONNECTIONS_FILE,
   ConfigError,
@@ -199,7 +199,20 @@ export class ConfigDocument {
     // difference decided whether a command explained itself or crashed.
     const existing = this.#document.getIn(path as (string | number)[]);
     if (existing === undefined || existing === null) {
-      this.#document.setIn(path as (string | number)[], [node]);
+      // A `YAMLSeq` rather than the plain `[node]` this used to set. The array
+      // is not a collection the document API will traverse — the same hazard
+      // `setIn` above documents — so the *first* append landed and the second
+      // found a value with no `.add` and threw `existing.add is not a
+      // function`. `#expand` below reads `.items` and was silently a no-op for
+      // the same reason, leaving the sequence in flow style.
+      //
+      // Latent until contract 3: every path this was called with
+      // (`connections`, `policy.allow`) already existed, so the branch ran at
+      // most once per document. `grants:` is genuinely absent on a profile
+      // being repaired, which is what made the second append reachable.
+      const created = new YAMLSeq();
+      created.add(node);
+      this.#document.setIn(path as (string | number)[], created);
     } else {
       (existing as { add(item: unknown): void }).add(node);
     }

--- a/src/cli/config-repair-sweep.ts
+++ b/src/cli/config-repair-sweep.ts
@@ -1,0 +1,119 @@
+import { CONNECTIONS_FILE, listProfiles, workspaceFiles, writeWorkspaceFile } from '#profile';
+import { newConnectionsTemplate } from './config-templates.ts';
+import { ConfigDocument } from './config-edit.ts';
+import { ok, print, style, warn } from './output.ts';
+import { DEFAULT_SURFACES, ensureOwnerLayer, repairLines, repaired } from './config-repair.ts';
+
+/**
+ * Applying the owner-layer repair across a whole workspace.
+ *
+ * Split from `config-repair.ts` when that file outgrew the budget, on the seam
+ * it already had: that file decides what one profile is missing, and this one
+ * walks the workspace applying it. The decision is a pure function of two
+ * documents and is tested as one; the sweep is all filesystem, ordering and
+ * what to say when a profile will not open.
+ */
+
+/** `memory, tasks, assets, skills, vault, setup and entities`, in repair order. */
+function listSurfaces(): string {
+  const names = [...DEFAULT_SURFACES];
+  const last = names.pop();
+  return names.length === 0 ? String(last) : `${names.join(', ')} and ${last}`;
+}
+
+/** The workspace's connections document, written from the template if missing. */
+async function openOrCreateConnections(workspaceRoot: string): Promise<ConfigDocument> {
+  try {
+    return await ConfigDocument.openKey(workspaceRoot, CONNECTIONS_FILE);
+  } catch {
+    await writeWorkspaceFile(
+      workspaceFiles(workspaceRoot),
+      CONNECTIONS_FILE,
+      newConnectionsTemplate(),
+    );
+    return ConfigDocument.openKey(workspaceRoot, CONNECTIONS_FILE);
+  }
+}
+
+/**
+ * Apply that repair across a workspace, saving and reporting what changed.
+ *
+ * Here rather than in `#deployments`, where it was, because `start` needs it as
+ * much as `deploy` does — more, in fact: `start` is the one command an existing
+ * install runs without being asked to, so it is the path by which a profile
+ * written before ADR-050 gets the layer at all. Two copies of a function that
+ * widens a policy is not a thing to have.
+ *
+ * **The caller scopes it**, and for `deploy` that is exactly the set being
+ * uploaded: a profile it sends is a profile the endpoint will serve, so
+ * repairing a narrower set would leave a served profile without the surfaces.
+ * Note what a `--profile` flag does not mean — it is the flag alone, so a
+ * profile resolved from the environment leaves it undefined and that reads as
+ * the whole workspace.
+ *
+ * *Which files are profiles* comes from `listProfiles`, never from an allowlist
+ * of what is safe to copy: that would happily hand over a committed
+ * `personal.example.yaml` or a nested `profiles/archive/old.yaml`, and this
+ * opens and validates what it is given — which once turned a template into a
+ * `ConfigError` aborting a deploy after provisioning had made cloud resources.
+ *
+ * A profile that cannot be read is warned about rather than fatal: the repair is
+ * a courtesy on the way past, and the caller's real work should still happen.
+ * Not silent, though — nothing else widens a policy without being asked.
+ *
+ * CLI-side by construction, like everything else in this file: a deployed
+ * revision holds `objectViewer` on `profiles/` (ADR-023) and could not write
+ * this even if the code let it.
+ */
+export async function repairOwnerLayer(
+  workspaceRoot: string,
+  profiles: readonly string[] | undefined,
+  options: { report?: (line: string) => void } = {},
+): Promise<void> {
+  // stdout by default, because every caller but one is printing a report a
+  // person reads. `update --json` passes `progress` instead: what it produces is
+  // a document, and a line of prose in front of it corrupts whatever is parsing.
+  // Routed rather than silenced — nothing else here widens a policy without
+  // saying so, and this must not be the exception.
+  const say = options.report ?? print;
+  const wanted = profiles === undefined ? undefined : new Set(profiles);
+
+  // One connections document for the whole sweep. The owner layer is the
+  // workspace's now (ADR-059), so repairing three profiles must not add three
+  // `memory.main` rows — opening it once and saving it once is what makes the
+  // second profile see what the first one created.
+  // Created if absent rather than refused. A contract-3 workspace always has
+  // one, but a hand-made or half-migrated one may not — and this is the repair,
+  // so the file it needs is a thing to write rather than a reason to stop.
+  const connections = await openOrCreateConnections(workspaceRoot);
+  let connectionsChanged = false;
+
+  for (const name of await listProfiles(workspaceRoot)) {
+    if (wanted !== undefined && !wanted.has(name)) continue;
+
+    try {
+      const document = await ConfigDocument.open(workspaceRoot, name);
+      const repair = ensureOwnerLayer(connections, document);
+      if (!repaired(repair)) continue;
+
+      connectionsChanged = true;
+      await document.save();
+
+      say(ok(`gave ${style.bold(name)} its own owner layer`));
+      for (const change of repairLines(repair)) say(`      ${style.dim(change)}`);
+      // Built from `DEFAULT_SURFACES` rather than typed out. The typed-out
+      // version still named six after a seventh had been added, so a person
+      // watching a deploy was told entities had arrived on the line above and
+      // that the layer was six things on the line below.
+      say(`      ${style.dim(`${listSurfaces()} — your own material, no account behind any of them`)}`);
+    } catch (error) {
+      say(
+        warn(
+          `could not give ${name} its owner layer: ${error instanceof Error ? error.message.split('\n')[0] : String(error)}`,
+        ),
+      );
+    }
+  }
+
+  if (connectionsChanged) await connections.save();
+}

--- a/src/cli/config-repair.ts
+++ b/src/cli/config-repair.ts
@@ -121,18 +121,41 @@ export function ensureReservedConnection(
   const rows = Array.isArray(workspace?.connections) ? workspace.connections : [];
   const held_grants = Array.isArray(config?.grants) ? config.grants : [];
 
-  // The row this profile would use. Any instance of the provider will do, and
-  // the *first* one is taken rather than `main` specifically: an operator who
-  // renamed theirs should not get a second one bolted on beside it.
-  const existing = rows.find(
+  // **This profile's own grant comes first.** Any instance of the provider will
+  // do, and the *first* one is taken rather than `main` specifically: an
+  // operator who renamed theirs should not get a second one bolted on beside
+  // it. That reasoning was right and the lookup implementing it was not — it
+  // read the workspace's first row, which under contract 2 was this profile's
+  // because a profile carried its own connections, and under contract 3 is
+  // whichever profile sorts first.
+  //
+  // So the repair asked whether `personal` granted `memory.main` — demo's — saw
+  // that it did not, and set about adding it. For `vault` and `skills` the
+  // schema refuses a second grant and the save failed loudly, which is how this
+  // was found. For `memory`, `tasks`, `assets`, `setup` and `entities` nothing
+  // refuses it, and the profile would quietly have been granted another
+  // profile's notes and another profile's task list — the outcome ADR-059
+  // exists to prevent, arriving from the repair rather than the migration.
+  const owned = held_grants.find((row) => {
+    const connection = (row as { connection?: unknown } | null)?.connection;
+    return typeof connection === 'string' && connection.slice(0, connection.indexOf('.')) === provider;
+  }) as { connection?: string; allow?: unknown; deny?: unknown } | undefined;
+
+  // Only when this profile grants no instance of the provider at all is the
+  // workspace consulted, which is the case this was written for: a surface that
+  // did not exist when the profile was written.
+  const declared = rows.find(
     (row) => (row as { provider?: unknown } | null)?.provider === provider,
   ) as { id?: unknown } | undefined;
-  const id = typeof existing?.id === 'string' ? existing.id : 'main';
-  const key = `${provider}.${id}`;
 
-  const held = held_grants.find(
-    (row) => (row as { connection?: unknown } | null)?.connection === key,
-  ) as { allow?: unknown; deny?: unknown } | undefined;
+  const key =
+    owned?.connection ?? `${provider}.${typeof declared?.id === 'string' ? declared.id : 'main'}`;
+
+  // Whether the *workspace* needs a row, which is a separate question from
+  // which one this profile grants: a profile cannot grant a connection that is
+  // not declared, so `owned` implies `declared`.
+  const existing = declared;
+  const held = owned;
 
   // Denied on purpose, and a deny beats an allow — so writing the rule would
   // widen nothing while announcing that an agent can now read the surface,

--- a/src/cli/config-repair.ts
+++ b/src/cli/config-repair.ts
@@ -1,7 +1,4 @@
-import { newConnectionsTemplate } from './config-templates.ts';
-import { CONNECTIONS_FILE, listProfiles, workspaceFiles, writeWorkspaceFile } from '#profile';
 import { ConfigDocument } from './config-edit.ts';
-import { ok, print, style, warn } from './output.ts';
 
 /**
  * Giving a profile a reserved provider it is missing, without undoing a choice.
@@ -136,10 +133,43 @@ export function ensureReservedConnection(
   // refuses it, and the profile would quietly have been granted another
   // profile's notes and another profile's task list — the outcome ADR-059
   // exists to prevent, arriving from the repair rather than the migration.
-  const owned = held_grants.find((row) => {
+  //
+  // **Every** instance, not the first one matched. A profile may grant two —
+  // `memory.team` and `memory.personal` — and reading only the first let a deny
+  // on the other be stepped around: the repair widened the undenied row and
+  // reported the surface granted, which is the one thing the paragraph below
+  // says it must never do.
+  //
+  // `startsWith` rather than slicing at the dot, because these rows are raw
+  // unvalidated YAML: `indexOf` answers -1 for a value with no dot at all, and
+  // `'vaults'.slice(0, -1)` is `'vault'` — so a typo'd `connection: vaults`
+  // matched the vault surface and was widened while the real one stayed
+  // unreachable.
+  const mine = held_grants.filter((row) => {
     const connection = (row as { connection?: unknown } | null)?.connection;
-    return typeof connection === 'string' && connection.slice(0, connection.indexOf('.')) === provider;
-  }) as { connection?: string; allow?: unknown; deny?: unknown } | undefined;
+    return typeof connection === 'string' && connection.startsWith(`${provider}.`);
+  }) as { connection?: string; allow?: unknown; deny?: unknown }[];
+
+  // Denied on purpose, and a deny beats an allow — so writing the rule would
+  // widen nothing while announcing that an agent can now read the surface,
+  // which would be false. Deleting the row no longer removes the surface
+  // either, because the next `connect` or `deploy` puts it back; a deny is the
+  // way it stays off, so it is the one thing this must not undo.
+  //
+  // Only a rule covering the whole surface counts. `deny: [setup.provider]` is
+  // an operator narrowing it, not switching it off, and that narrowing survives
+  // the repair untouched — which is the point of denying one capability.
+  if (mine.some((row) => patternsIn(row.deny).some(covers))) return { changes: [], granted: [] };
+
+  // The instance already carrying the rule, if any. Not an early return: the
+  // workspace row can be missing while the grant is present — a profile written
+  // before the surface existed, repaired once against a `connections.yaml` that
+  // has since been hand-edited — and repairing one half only is what this
+  // function exists to prevent.
+  const allowed = mine.find((row) => patternsIn(row.allow).some(covers));
+
+  // Otherwise the first row that exists and grants nothing is the one to widen.
+  const owned = allowed ?? mine[0];
 
   // Only when this profile grants no instance of the provider at all is the
   // workspace consulted, which is the case this was written for: a surface that
@@ -156,17 +186,6 @@ export function ensureReservedConnection(
   // not declared, so `owned` implies `declared`.
   const existing = declared;
   const held = owned;
-
-  // Denied on purpose, and a deny beats an allow — so writing the rule would
-  // widen nothing while announcing that an agent can now read the surface,
-  // which would be false. Deleting the row no longer removes the surface
-  // either, because the next `connect` or `deploy` puts it back; a deny is the
-  // way it stays off, so it is the one thing this must not undo.
-  //
-  // Only a rule covering the whole surface counts. `deny: [setup.provider]` is
-  // an operator narrowing it, not switching it off, and that narrowing survives
-  // the repair untouched — which is the point of denying one capability.
-  if (patternsIn(held?.deny).some(covers)) return { changes: [], granted: [] };
 
   const changes: string[] = [];
   const granted: string[] = [];
@@ -189,7 +208,7 @@ export function ensureReservedConnection(
     profile.addTo(['grants'], { connection: key, allow: [rule], deny: [] }, { inline: true });
     changes.push(`grants += ${key}`);
     granted.push(rule);
-  } else if (!patternsIn(held.allow).some(covers)) {
+  } else if (allowed === undefined) {
     // A row that exists and grants nothing is a surface that is present and
     // silent. Widening it back is the repair; the deny check above is what stops
     // this undoing a deliberate narrowing.
@@ -201,28 +220,7 @@ export function ensureReservedConnection(
   return { changes, granted };
 }
 
-/** The workspace's connections document, written from the template if missing. */
-async function openOrCreateConnections(workspaceRoot: string): Promise<ConfigDocument> {
-  try {
-    return await ConfigDocument.openKey(workspaceRoot, CONNECTIONS_FILE);
-  } catch {
-    await writeWorkspaceFile(
-      workspaceFiles(workspaceRoot),
-      CONNECTIONS_FILE,
-      newConnectionsTemplate(),
-    );
-    return ConfigDocument.openKey(workspaceRoot, CONNECTIONS_FILE);
-  }
-}
-
 /** Whether a repair did anything, without a caller adding up two lists. */
-/** `memory, tasks, assets, skills, vault, setup and entities`, in repair order. */
-function listSurfaces(): string {
-  const names = [...DEFAULT_SURFACES];
-  const last = names.pop();
-  return names.length === 0 ? String(last) : `${names.join(', ')} and ${last}`;
-}
-
 export function repaired(repair: SurfaceRepair): boolean {
   return repair.changes.length > 0 || repair.granted.length > 0;
 }
@@ -312,85 +310,3 @@ export function ensureIdentityConnection(
   return ensureReservedConnection(connections, profile, 'identity');
 }
 
-/**
- * Apply that repair across a workspace, saving and reporting what changed.
- *
- * Here rather than in `#deployments`, where it was, because `start` needs it as
- * much as `deploy` does — more, in fact: `start` is the one command an existing
- * install runs without being asked to, so it is the path by which a profile
- * written before ADR-050 gets the layer at all. Two copies of a function that
- * widens a policy is not a thing to have.
- *
- * **The caller scopes it**, and for `deploy` that is exactly the set being
- * uploaded: a profile it sends is a profile the endpoint will serve, so
- * repairing a narrower set would leave a served profile without the surfaces.
- * Note what a `--profile` flag does not mean — it is the flag alone, so a
- * profile resolved from the environment leaves it undefined and that reads as
- * the whole workspace.
- *
- * *Which files are profiles* comes from `listProfiles`, never from an allowlist
- * of what is safe to copy: that would happily hand over a committed
- * `personal.example.yaml` or a nested `profiles/archive/old.yaml`, and this
- * opens and validates what it is given — which once turned a template into a
- * `ConfigError` aborting a deploy after provisioning had made cloud resources.
- *
- * A profile that cannot be read is warned about rather than fatal: the repair is
- * a courtesy on the way past, and the caller's real work should still happen.
- * Not silent, though — nothing else widens a policy without being asked.
- *
- * CLI-side by construction, like everything else in this file: a deployed
- * revision holds `objectViewer` on `profiles/` (ADR-023) and could not write
- * this even if the code let it.
- */
-export async function repairOwnerLayer(
-  workspaceRoot: string,
-  profiles: readonly string[] | undefined,
-  options: { report?: (line: string) => void } = {},
-): Promise<void> {
-  // stdout by default, because every caller but one is printing a report a
-  // person reads. `update --json` passes `progress` instead: what it produces is
-  // a document, and a line of prose in front of it corrupts whatever is parsing.
-  // Routed rather than silenced — nothing else here widens a policy without
-  // saying so, and this must not be the exception.
-  const say = options.report ?? print;
-  const wanted = profiles === undefined ? undefined : new Set(profiles);
-
-  // One connections document for the whole sweep. The owner layer is the
-  // workspace's now (ADR-059), so repairing three profiles must not add three
-  // `memory.main` rows — opening it once and saving it once is what makes the
-  // second profile see what the first one created.
-  // Created if absent rather than refused. A contract-3 workspace always has
-  // one, but a hand-made or half-migrated one may not — and this is the repair,
-  // so the file it needs is a thing to write rather than a reason to stop.
-  const connections = await openOrCreateConnections(workspaceRoot);
-  let connectionsChanged = false;
-
-  for (const name of await listProfiles(workspaceRoot)) {
-    if (wanted !== undefined && !wanted.has(name)) continue;
-
-    try {
-      const document = await ConfigDocument.open(workspaceRoot, name);
-      const repair = ensureOwnerLayer(connections, document);
-      if (!repaired(repair)) continue;
-
-      connectionsChanged = true;
-      await document.save();
-
-      say(ok(`gave ${style.bold(name)} its own owner layer`));
-      for (const change of repairLines(repair)) say(`      ${style.dim(change)}`);
-      // Built from `DEFAULT_SURFACES` rather than typed out. The typed-out
-      // version still named six after a seventh had been added, so a person
-      // watching a deploy was told entities had arrived on the line above and
-      // that the layer was six things on the line below.
-      say(`      ${style.dim(`${listSurfaces()} — your own material, no account behind any of them`)}`);
-    } catch (error) {
-      say(
-        warn(
-          `could not give ${name} its owner layer: ${error instanceof Error ? error.message.split('\n')[0] : String(error)}`,
-        ),
-      );
-    }
-  }
-
-  if (connectionsChanged) await connections.save();
-}

--- a/src/cli/contract3-credentials.ts
+++ b/src/cli/contract3-credentials.ts
@@ -23,11 +23,8 @@ import { createFileSecretStore } from '#secrets';
  */
 export interface CredentialPlan {
   readonly profile: string;
-  /**
-   * `${provider}/${oldId}` → `${provider}/${newId}`, for every connection the
-   * hoist renamed.
-   */
-  readonly renames: ReadonlyMap<string, string>;
+  /** Every connection-derived credential ref, and where it is going. */
+  readonly renames: ReadonlyMap<string, RefTarget>;
   /** This profile's endpoint token ref, which is deliberately not migrated. */
   readonly tokenRef: string;
 }
@@ -40,34 +37,49 @@ export interface CredentialMerge {
   readonly tokens: readonly string[];
 }
 
+/** Where a credential ref is going, and which connection it belongs to after. */
+export interface RefTarget {
+  readonly to: string;
+  /** The settled `provider.id` this ref's connection became. */
+  readonly connection: string;
+}
+
 /**
- * The credential refs a set of connection renames implies.
+ * The credential ref of every connection the hoist touched, renamed or not.
  *
- * `credentialRefForConnection` derives `${provider}/${connectionId}` for every
- * auth kind that has a per-connection credential, and `hoistConnections`
- * renames the connection with `{ ...connection, id }` — which leaves the
- * derived ref pointing at the old id. So a profile whose `github.main` became
- * `github.main_2` still claimed `github/main`, and two profiles claiming one
- * ref with two different tokens is what aborted the migration.
+ * `credentialRefForConnection` derives `${app ?? provider}/${connectionId}` for
+ * every auth kind that has a per-connection credential, and `hoistConnections`
+ * renames the connection with `{ ...connection, id }` — which leaves the derived
+ * ref pointing at the old id. So a profile whose `github.main` became
+ * `github.main_2` still claimed `github/main`, and two profiles claiming one ref
+ * with two different tokens is what aborted the migration.
  *
- * Only the derived form is renamed. A row carrying an explicit `credential_ref`
- * placed it by hand, and an `app`-scoped ref (`auth.app ?? manifest.id`) is
- * shared across a vendor's connections on purpose; neither is keyed on the
- * connection id, so neither follows a rename. A conflict either of those causes
- * is refused by the plan below with the ref named.
+ * **Unrenamed connections are in here too**, which is not redundancy: the
+ * `connection` half is what tells `readMerged` that two refs landing on one
+ * target belong to the same connection and are therefore a merge rather than a
+ * clash. Without it a single profile declaring `gmail.main` and `gmail.archive`
+ * for one mailbox — legal under contract 2, and the reason tokens are
+ * per-connection at all, since the scopes differ — was hoisted into one row and
+ * then refused with "Two profiles hold different values", naming one profile
+ * twice and prescribing a rename that cannot help.
+ *
+ * Only the `<provider>/<id>` spelling is derived here. A provider declaring
+ * `auth.app` stores under `<app>/<id>` and a row carrying an explicit
+ * `credential_ref` stores wherever it says — neither is reconstructable without
+ * the manifest, which this migration does not load. Those refs are carried
+ * across untouched, and a genuine clash between two of them is refused by name.
  */
-export function refRenames(mapping: ReadonlyMap<string, string>): Map<string, string> {
-  const refs = new Map<string, string>();
+export function connectionRefs(mapping: ReadonlyMap<string, string>): Map<string, RefTarget> {
+  const refs = new Map<string, RefTarget>();
 
   for (const [from, to] of mapping) {
-    if (from === to) continue;
     const before = from.indexOf('.');
     const after = to.indexOf('.');
     if (before < 0 || after < 0) continue;
-    refs.set(
-      `${from.slice(0, before)}/${from.slice(before + 1)}`,
-      `${to.slice(0, after)}/${to.slice(after + 1)}`,
-    );
+    refs.set(`${from.slice(0, before)}/${from.slice(before + 1)}`, {
+      to: `${to.slice(0, after)}/${to.slice(after + 1)}`,
+      connection: to,
+    });
   }
 
   return refs;
@@ -100,7 +112,11 @@ async function readMerged(
   plans: readonly CredentialPlan[],
 ): Promise<{ merged: Map<string, string>; tokens: Set<string> }> {
   const merged = new Map<string, string>();
-  const held = new Map<string, string>();
+  const held = new Map<string, { profile: string; connection?: string }>();
+  // One entry per endpoint-token ref, holding what each profile had under it.
+  // Decided after the walk, because whether it can be carried across depends on
+  // whether the profiles agree — which is not known until they have all been read.
+  const endpoint = new Map<string, Map<string, string>>();
   const tokens = new Set<string>();
 
   if (isRemoteWorkspace(root)) return { merged, tokens };
@@ -132,11 +148,6 @@ async function readMerged(
       // first time a command asks, and the old stores are not deleted — so the
       // cost is re-registering a client, and no account has to be authorised
       // again.
-      if (ref === plan.tokenRef) {
-        tokens.add(ref);
-        continue;
-      }
-
       let value: string | null;
       try {
         value = await store.get(ref);
@@ -145,25 +156,76 @@ async function readMerged(
       }
       if (value === null) continue;
 
-      const target = plan.renames.get(ref) ?? ref;
+      // The endpoint's own bearer token, held under one ref by every profile
+      // because `authSchema` defaults `token_ref` to `profile/token`. Set aside
+      // rather than merged here; see below.
+      if (ref === plan.tokenRef) {
+        const seen = endpoint.get(ref) ?? new Map<string, string>();
+        seen.set(plan.profile, value);
+        endpoint.set(ref, seen);
+        continue;
+      }
+
+      const mapped = plan.renames.get(ref);
+      const target = mapped?.to ?? ref;
       const first = merged.get(target);
 
       if (first !== undefined) {
         if (first === value) continue;
+
+        // Two refs on one target whose connections are the same connection.
+        // That is the hoist merging two rows for one account — legal under
+        // contract 2, where `gmail.main` and `gmail.archive` could hold the
+        // same mailbox at different scopes — and there is one connection now,
+        // so one token. The first row is the one that survived the hoist, so
+        // its credential is the one that belongs to it.
+        const owner = held.get(target);
+        if (mapped !== undefined && owner?.connection === mapped.connection) continue;
+
         throw new ConfigError(
-          `Two profiles hold different values for the credential "${target}", and this ` +
-            `migration cannot choose between them.\n` +
-            `  ${held.get(target) ?? 'another profile'} and ${plan.profile} both hold it. Both ` +
-            `are real credentials for different accounts, and picking either would point a ` +
-            `connection at the wrong one.\n` +
-            `  Nothing has been written. Rename one connection before migrating, so its ` +
-            `credential ref differs.`,
+          `Two credentials want to be at "${target}", and this migration cannot choose ` +
+            `between them.\n` +
+            `  ${owner?.profile ?? 'another profile'} and ${plan.profile} both hold one. Both ` +
+            `are real credentials, and picking either would point a connection at the wrong ` +
+            `account.\n` +
+            `  Nothing has been written. Give one of them its own credential_ref before ` +
+            `migrating.`,
         );
       }
 
       merged.set(target, value);
-      held.set(target, plan.profile);
+      held.set(target, {
+        profile: plan.profile,
+        ...(mapped === undefined ? {} : { connection: mapped.connection }),
+      });
     }
+  }
+
+  // **A token is only left behind when the profiles disagree about it.**
+  //
+  // Under contract 2 each profile had its own store, so one ref meant one value
+  // per profile and contract 3's single store cannot hold three of them. But a
+  // workspace with one profile — or three that were registered from the same
+  // token — has nothing to choose between, and dropping it there was gratuitous:
+  // every client registered against that endpoint started getting 401s after a
+  // routine `update`, for a conflict that did not exist.
+  //
+  // Where they do disagree it is still left behind rather than picked between.
+  // It is minted locally rather than granted by anybody, `ensureProfileToken`
+  // writes a fresh one the first time a command asks, and the old stores are not
+  // deleted — so the cost is re-registering a client, and no account has to be
+  // authorised again.
+  for (const [ref, byProfile] of endpoint) {
+    const values = new Set(byProfile.values());
+    const agreed = values.size === 1 ? [...values][0] : undefined;
+
+    if (agreed === undefined || merged.has(ref)) {
+      tokens.add(ref);
+      continue;
+    }
+
+    merged.set(ref, agreed);
+    held.set(ref, { profile: [...byProfile.keys()].join(', ') });
   }
 
   return { merged, tokens };

--- a/src/cli/contract3-credentials.ts
+++ b/src/cli/contract3-credentials.ts
@@ -1,0 +1,231 @@
+import { ConfigError, DATA_DIR, isRemoteWorkspace, layout } from '#profile';
+import { createFileSecretStore } from '#secrets';
+
+/**
+ * The credential half of the contract-3 migration.
+ *
+ * Split from `contract3-data.ts` when that file outgrew the budget, on the seam
+ * the migration already had: objects move, credentials merge, and the two obey
+ * different rules. A moved object has one home and the move is reversible by
+ * moving it back. A merged credential has to survive two profiles claiming one
+ * ref, and the wrong resolution points a live connection at somebody else's
+ * account — so nothing here picks between two values, ever.
+ *
+ * The whole file is ordered around one promise: every refusal happens before
+ * the first write.
+ */
+
+/**
+ * What this migration needs to know about one profile's credentials.
+ *
+ * Assembled by `contract3.ts` from the hoist, because the two facts below are
+ * decisions that file already made and this one must not make differently.
+ */
+export interface CredentialPlan {
+  readonly profile: string;
+  /**
+   * `${provider}/${oldId}` → `${provider}/${newId}`, for every connection the
+   * hoist renamed.
+   */
+  readonly renames: ReadonlyMap<string, string>;
+  /** This profile's endpoint token ref, which is deliberately not migrated. */
+  readonly tokenRef: string;
+}
+
+/** What the merged credential store will hold, and what was left out of it. */
+export interface CredentialMerge {
+  /** Refs the merged store will hold, sorted. */
+  readonly refs: readonly string[];
+  /** Endpoint token refs left behind rather than merged, sorted. */
+  readonly tokens: readonly string[];
+}
+
+/**
+ * The credential refs a set of connection renames implies.
+ *
+ * `credentialRefForConnection` derives `${provider}/${connectionId}` for every
+ * auth kind that has a per-connection credential, and `hoistConnections`
+ * renames the connection with `{ ...connection, id }` — which leaves the
+ * derived ref pointing at the old id. So a profile whose `github.main` became
+ * `github.main_2` still claimed `github/main`, and two profiles claiming one
+ * ref with two different tokens is what aborted the migration.
+ *
+ * Only the derived form is renamed. A row carrying an explicit `credential_ref`
+ * placed it by hand, and an `app`-scoped ref (`auth.app ?? manifest.id`) is
+ * shared across a vendor's connections on purpose; neither is keyed on the
+ * connection id, so neither follows a rename. A conflict either of those causes
+ * is refused by the plan below with the ref named.
+ */
+export function refRenames(mapping: ReadonlyMap<string, string>): Map<string, string> {
+  const refs = new Map<string, string>();
+
+  for (const [from, to] of mapping) {
+    if (from === to) continue;
+    const before = from.indexOf('.');
+    const after = to.indexOf('.');
+    if (before < 0 || after < 0) continue;
+    refs.set(
+      `${from.slice(0, before)}/${from.slice(before + 1)}`,
+      `${to.slice(0, after)}/${to.slice(after + 1)}`,
+    );
+  }
+
+  return refs;
+}
+
+/**
+ * Every credential the merged store will hold, addressed as contract 3 will
+ * address it.
+ *
+ * One walk, shared by the preview and the apply, because the two disagreeing is
+ * the defect this replaces: `planCredentials` collected the union of ref *names*
+ * and never compared values, so a clash it could not see aborted
+ * `mergeCredentials` — at which point `rewriteRegistry` and `writeConnections`
+ * had already run, and the workspace was half-migrated behind a message saying
+ * nothing had been written.
+ *
+ * Read-only. Everything that can refuse, refuses here.
+ *
+ * **A workspace in a bucket has nothing to merge, and this says so rather than
+ * finding out.** `workspacePath` refuses a filesystem adapter against a remote
+ * root, so the only credential store such a workspace can declare is
+ * `gcp-secret-manager` — whose refs were never scoped by profile, and are
+ * therefore already what contract 3 wants. Without the guard the path below is
+ * built by string interpolation into `gs://bucket/data/<profile>/credentials.enc`
+ * and handed to `Bun.file`, where the failure is swallowed by the `catch` and
+ * reads exactly like a workspace with no credentials in it.
+ */
+async function readMerged(
+  root: string,
+  plans: readonly CredentialPlan[],
+): Promise<{ merged: Map<string, string>; tokens: Set<string> }> {
+  const merged = new Map<string, string>();
+  const held = new Map<string, string>();
+  const tokens = new Set<string>();
+
+  if (isRemoteWorkspace(root)) return { merged, tokens };
+
+  for (const plan of plans) {
+    const store = createFileSecretStore({
+      path: `${root}/${DATA_DIR}/${plan.profile}/credentials.enc`,
+    });
+
+    let refs: string[];
+    try {
+      refs = await store.list();
+    } catch {
+      // A store that will not open is reported by `doctor`, not here. This runs
+      // as a preview too, and must not fail on a workspace that is already
+      // broken.
+      continue;
+    }
+
+    for (const ref of refs) {
+      // The endpoint's own bearer token, which every profile keeps under the
+      // same ref because `authSchema` defaults `token_ref` to `profile/token`.
+      // Under contract 2 that was unambiguous — one store per profile. Under
+      // contract 3 there is one store, so three profiles' tokens are three
+      // values for one key, and there is no merge that means anything.
+      //
+      // Left behind rather than picked between. It is minted locally rather
+      // than granted by anybody, `ensureProfileToken` writes a fresh one the
+      // first time a command asks, and the old stores are not deleted — so the
+      // cost is re-registering a client, and no account has to be authorised
+      // again.
+      if (ref === plan.tokenRef) {
+        tokens.add(ref);
+        continue;
+      }
+
+      let value: string | null;
+      try {
+        value = await store.get(ref);
+      } catch {
+        continue;
+      }
+      if (value === null) continue;
+
+      const target = plan.renames.get(ref) ?? ref;
+      const first = merged.get(target);
+
+      if (first !== undefined) {
+        if (first === value) continue;
+        throw new ConfigError(
+          `Two profiles hold different values for the credential "${target}", and this ` +
+            `migration cannot choose between them.\n` +
+            `  ${held.get(target) ?? 'another profile'} and ${plan.profile} both hold it. Both ` +
+            `are real credentials for different accounts, and picking either would point a ` +
+            `connection at the wrong one.\n` +
+            `  Nothing has been written. Rename one connection before migrating, so its ` +
+            `credential ref differs.`,
+        );
+      }
+
+      merged.set(target, value);
+      held.set(target, plan.profile);
+    }
+  }
+
+  return { merged, tokens };
+}
+
+/**
+ * What the merge will do, computed before anything is written.
+ *
+ * The report an operator confirms is therefore the real one, and a refusal
+ * leaves the workspace exactly as it was.
+ */
+export async function planCredentials(
+  root: string,
+  plans: readonly CredentialPlan[],
+): Promise<CredentialMerge> {
+  const { merged, tokens } = await readMerged(root, plans);
+  return { refs: [...merged.keys()].sort(), tokens: [...tokens].sort() };
+}
+
+/**
+ * Copy every profile's credentials into the workspace store.
+ *
+ * Written and read back before the old stores are touched, which is the whole
+ * of the safety argument: a half-finished merge that has not deleted anything is
+ * recoverable by running it again, and one that deleted first is not.
+ *
+ * The old stores are left in place regardless. They are a few kilobytes, they
+ * are the only copy of anything if this went wrong, and `doctor` names them so
+ * an operator can remove them once the endpoint has served a request.
+ *
+ * Skipped entirely for a workspace in a bucket, for the reason `readMerged`
+ * gives: its credentials are in Secret Manager under refs that were never
+ * per-profile, so there is no second store to fold in.
+ */
+export async function mergeCredentials(
+  root: string,
+  plans: readonly CredentialPlan[],
+): Promise<void> {
+  if (isRemoteWorkspace(root)) return;
+
+  const { merged } = await readMerged(root, plans);
+  const destination = createFileSecretStore({ path: `${root}/${layout.credentials()}` });
+
+  for (const [ref, value] of merged) {
+    const already = await destination.get(ref);
+    if (already !== null) {
+      // Already copied, by a run that did not get to the end. Anything else is
+      // a store that disagrees with the profiles it was built from, which is
+      // not something to overwrite silently.
+      if (already === value) continue;
+      throw new ConfigError(
+        `${layout.credentials()} already holds a different value for "${ref}" than the profile ` +
+          `stores do. Nothing has been deleted; resolve it and run this again.`,
+      );
+    }
+
+    await destination.set(ref, value);
+    if ((await destination.get(ref)) !== value) {
+      throw new ConfigError(
+        `The credential "${ref}" did not read back after being written to ` +
+          `${layout.credentials()}. Nothing has been deleted; fix the store and run this again.`,
+      );
+    }
+  }
+}

--- a/src/cli/contract3-data.ts
+++ b/src/cli/contract3-data.ts
@@ -26,6 +26,19 @@ export interface Move {
    * `upsert` would write a second record beside it.
    */
   readonly rewrite?: (data: Uint8Array) => Uint8Array;
+  /**
+   * Write only where the destination is empty; leave the source alone if not.
+   *
+   * For the objects two profiles can legitimately both hold — a connection they
+   * share, a provider-keyed cache, one custom manifest — where a second copy is
+   * a duplicate rather than a clash. `claim` drops the loser from the plan, but
+   * only within one run: the winner's source is deleted and the loser's is not,
+   * so a rerun saw a different first claimant, found the destination holding
+   * somebody else's bytes, and threw. Permanently — and `rewriteProfiles` stamps
+   * the contract *after* the moves, so an interruption during them forces
+   * exactly that rerun.
+   */
+  readonly whenAbsent?: boolean;
 }
 
 /**
@@ -88,8 +101,16 @@ export async function planMoves(
         });
         continue;
       }
+      // Under ADR-030 a manifest lived in the profile, so an operator using
+      // their own connector in two profiles holds two copies of one file. They
+      // are the same manifest; refusing byte-identical files and asking for the
+      // data directory's layout was not a useful answer.
       if (head === 'providers.d') {
-        moves.push({ from: blob.key, to: `${layout.providers()}/${tail.join('/')}` });
+        const move = claim(claimed, {
+          from: blob.key,
+          to: `${layout.providers()}/${tail.join('/')}`,
+        });
+        if (move !== null) moves.push(move);
         continue;
       }
       // One object per event, under a key that already carries the timestamp
@@ -183,7 +204,8 @@ function stateMove(
     return { from, to: here };
   }
 
-  const namespace = tail.slice(0, -1).map(decodeSegment).join('/');
+  const segments = tail.slice(0, -1).map(decodeSegment);
+  const namespace = segments.join('/');
   const key = decodeSegment(leaf.slice(0, -'.json'.length));
 
   // A cache keyed on the provider id, not on a connection — so two profiles
@@ -192,6 +214,19 @@ function stateMove(
   // alike as "not discovered yet", and `connect` refreshes it. First one wins.
   if (namespace === 'discovery') {
     return claim(claimed, { from, to: here });
+  }
+
+  // `<provider>/<connection>` — a provider's own state, keyed on the connection
+  // exactly as its blobs are. Left out of the first pass, so two profiles
+  // holding one provider's fixed-name object (`dav`'s home, `bunq`'s session)
+  // still aimed at one key.
+  if (segments.length === 2) {
+    const [provider, connection] = segments as [string, string];
+    const settled = mapping.get(`${provider}.${connection}`);
+    if (settled === undefined) return { from, to: here };
+
+    const id = settled.slice(settled.indexOf('.') + 1);
+    return claim(claimed, { from, to: `${layout.state()}/${objectKey(`${provider}/${id}`, key)}` });
   }
 
   if (namespace !== CONNECTIONS_NAMESPACE) return { from, to: here };
@@ -223,7 +258,7 @@ function stateMove(
 function claim(claimed: Set<string>, move: Move): Move | null {
   if (claimed.has(move.to)) return null;
   claimed.add(move.to);
-  return move;
+  return { ...move, whenAbsent: true };
 }
 
 /**
@@ -324,7 +359,11 @@ async function applyMove(files: BlobStore, move: Move): Promise<void> {
     // Raced away between the two calls, so there is nothing there after all and
     // the ordinary path below is still the right one.
     if (held !== null) {
+      // Another instance of the same connection, or another profile's copy of
+      // one shared cache, got there first. Left where it is rather than
+      // refused — and rerunnable, which is the whole point.
       if (!sameBytes(held, data)) {
+        if (move.whenAbsent === true) return;
         throw new ConfigError(
           `Two objects want to be at ${move.to}, and this migration cannot merge them.\n` +
             `  ${move.from} is the second, and what is already there is not a copy of it.\n` +

--- a/src/cli/contract3-data.ts
+++ b/src/cli/contract3-data.ts
@@ -1,6 +1,6 @@
-import { ConfigError, DATA_DIR, isRemoteWorkspace, layout } from '#profile';
-import { createFileSecretStore } from '#secrets';
+import { ConfigError, DATA_DIR, layout } from '#profile';
 import type { BlobStore } from '#stores/blobs';
+import { CONNECTIONS_NAMESPACE, decodeSegment, objectKey } from '#stores/state';
 
 /**
  * The half of the contract-3 migration that moves bytes rather than YAML.
@@ -15,104 +15,17 @@ import type { BlobStore } from '#stores/blobs';
 export interface Move {
   readonly from: string;
   readonly to: string;
-}
-
-/** `gmail.main` — how a connection is addressed in every file after this. */
-function keyOf(connection: { provider: string; id: string }): string {
-  return `${connection.provider}.${connection.id}`;
-}
-
-/**
- * Which credential refs the merged store will hold.
- *
- * Read-only, and it runs before anything is written so the report an operator
- * confirms is the real one. A ref present in two profiles' stores with two
- * different values is the one thing this cannot resolve, and it is reported
- * rather than merged: both are real credentials, and picking either would point
- * a connection at the wrong account's token.
- *
- * **A workspace in a bucket has nothing to merge, and this says so rather than
- * finding out.** `workspacePath` refuses a filesystem adapter against a remote
- * root, so the only credential store such a workspace can declare is
- * `gcp-secret-manager` — whose refs were never scoped by profile, and are
- * therefore already what contract 3 wants. Without the guard the path below is
- * built by string interpolation into `gs://bucket/data/<profile>/credentials.enc`
- * and handed to `Bun.file`, where the failure is swallowed by the `catch` and
- * reads exactly like a workspace with no credentials in it.
- */
-export async function planCredentials(root: string, profiles: readonly string[]): Promise<string[]> {
-  if (isRemoteWorkspace(root)) return [];
-
-  const refs = new Set<string>();
-
-  for (const profile of profiles) {
-    const store = createFileSecretStore({ path: `${root}/${DATA_DIR}/${profile}/credentials.enc` });
-    try {
-      for (const ref of await store.list()) refs.add(ref);
-    } catch {
-      // A store that will not open is reported by `doctor`, not here. This is a
-      // preview and must not fail on a workspace that is already broken.
-    }
-  }
-
-  return [...refs].sort();
-}
-
-/**
- * Copy every profile's credentials into the workspace store.
- *
- * Written and read back before the old stores are touched, which is the whole
- * of the safety argument: a half-finished merge that has not deleted anything is
- * recoverable by running it again, and one that deleted first is not.
- *
- * The old stores are left in place regardless. They are a few kilobytes, they
- * are the only copy of anything if this went wrong, and `doctor` names them so
- * an operator can remove them once the endpoint has served a request.
- *
- * Skipped entirely for a workspace in a bucket, for the reason `planCredentials`
- * gives: its credentials are in Secret Manager under refs that were never
- * per-profile, so there is no second store to fold in.
- */
-export async function mergeCredentials(root: string, profiles: readonly string[]): Promise<void> {
-  if (isRemoteWorkspace(root)) return;
-
-  const destination = createFileSecretStore({ path: `${root}/${layout.credentials()}` });
-
-  for (const profile of profiles) {
-    const source = createFileSecretStore({ path: `${root}/${DATA_DIR}/${profile}/credentials.enc` });
-
-    let refs: string[];
-    try {
-      refs = await source.list();
-    } catch {
-      continue;
-    }
-
-    for (const ref of refs) {
-      const value = await source.get(ref);
-      if (value === null) continue;
-
-      const held = await destination.get(ref);
-      if (held !== null) {
-        if (held === value) continue;
-        throw new ConfigError(
-          `Two profiles hold different values for the credential "${ref}", and this migration ` +
-            `cannot choose between them.\n` +
-            `  Both are real credentials for different accounts, and picking either would point a ` +
-            `connection at the wrong one.\n` +
-            `  Rename one connection before migrating, so its credential ref differs.`,
-        );
-      }
-
-      await destination.set(ref, value);
-      if ((await destination.get(ref)) !== value) {
-        throw new ConfigError(
-          `The credential "${ref}" did not read back after being written to ` +
-            `${layout.credentials()}. Nothing has been deleted; fix the store and run this again.`,
-        );
-      }
-    }
-  }
+  /**
+   * Rewrite the object's bytes on the way across.
+   *
+   * Only a connection record needs this, and it needs it for a reason a plain
+   * copy cannot serve: `ConnectionRepository.list` reads `provider` and `id`
+   * out of the record *body*, not out of the key it was stored under. A renamed
+   * connection whose bytes were copied verbatim would sit at
+   * `connections.v1/vault.work` still calling itself `vault.main`, and the next
+   * `upsert` would write a second record beside it.
+   */
+  readonly rewrite?: (data: Uint8Array) => Uint8Array;
 }
 
 /**
@@ -136,6 +49,10 @@ export async function planMoves(
   perProfile: ReadonlyMap<string, ReadonlyMap<string, string>>,
 ): Promise<Move[]> {
   const moves: Move[] = [];
+  // Destinations inside `state.kv` that an earlier profile already claimed, for
+  // the two namespaces where a second claim is a duplicate rather than a
+  // conflict. See `stateMove`.
+  const claimed = new Set<string>();
 
   for (const profile of profiles) {
     const mapping = perProfile.get(profile) ?? new Map<string, string>();
@@ -147,9 +64,7 @@ export async function planMoves(
       if (head === undefined) continue;
 
       // The credential store is merged rather than moved, and the old copy is
-      // deliberately left behind. `state.kv` and `audit.log` are per profile and
-      // become the workspace's, but their contents already carry the profile in
-      // every record, so they are concatenated by moving the objects across.
+      // deliberately left behind.
       if (head === 'credentials.enc' || head === 'credentials.enc.key') continue;
 
       // The instance this profile's single-instance surfaces became. Both are
@@ -177,8 +92,16 @@ export async function planMoves(
         moves.push({ from: blob.key, to: `${layout.providers()}/${tail.join('/')}` });
         continue;
       }
-      if (head === 'state.kv' || head === 'audit.log') {
-        moves.push({ from: blob.key, to: `${DATA_DIR}/${head}/${tail.join('/')}` });
+      // One object per event, under a key that already carries the timestamp
+      // and the profile in every record — so concatenating three profiles' logs
+      // is exactly moving the objects across, with nothing to reconcile.
+      if (head === 'audit.log') {
+        moves.push({ from: blob.key, to: `${DATA_DIR}/audit.log/${tail.join('/')}` });
+        continue;
+      }
+      if (head === 'state.kv') {
+        const move = stateMove(blob.key, tail, mapping, claimed);
+        if (move !== null) moves.push(move);
         continue;
       }
 
@@ -217,12 +140,116 @@ function assertOneObjectPerDestination(moves: readonly Move[]): void {
       throw new ConfigError(
         `Two objects want to be at ${move.to}, and this migration cannot merge them.\n` +
           `  ${first} and ${move.from}. Nothing has been written.\n` +
-          '  This should be unreachable: the hoist gives every profile its own instance of ' +
-          'each owner-layer surface. Please report it with the layout of your data directory.',
+          '  Please report it with the layout of your data directory.',
       );
     }
     seen.set(move.to, move.from);
   }
+}
+
+/**
+ * Where one object under a profile's `state.kv` is going.
+ *
+ * `state.kv` used to be moved verbatim, on the grounds that its records "already
+ * carry the profile". They do not. `connections.v1` is keyed on
+ * `<provider>.<id>` — precisely what the hoist renames — so every profile's
+ * owner layer wrote `connections.v1/vault.main`, and three profiles aimed three
+ * objects at one key. That is the collision `assertOneObjectPerDestination`
+ * called unreachable, and it was reachable from any workspace with two profiles
+ * in it.
+ *
+ * Keys are decoded rather than pattern-matched. On disk the namespace and key
+ * are percent-encoded per segment (`connections%2Ev1/vault%2Emain.json`), and
+ * reassembling that by hand at this call site would be the second spelling of
+ * an encoding that must have exactly one.
+ *
+ * `null` means leave it where it is. Nothing is deleted by not moving it, the
+ * old `data/<profile>/` tree survives the migration either way, and `doctor`
+ * names what is left.
+ */
+function stateMove(
+  from: string,
+  tail: readonly string[],
+  mapping: ReadonlyMap<string, string>,
+  claimed: Set<string>,
+): Move | null {
+  const here = `${layout.state()}/${tail.join('/')}`;
+  const leaf = tail[tail.length - 1];
+
+  // Not an object this module wrote: moved as it is, and still held to the
+  // one-object-per-destination rule, because an unrecognised collision is a
+  // thing to refuse rather than to resolve by guessing.
+  if (tail.length < 2 || leaf === undefined || !leaf.endsWith('.json')) {
+    return { from, to: here };
+  }
+
+  const namespace = tail.slice(0, -1).map(decodeSegment).join('/');
+  const key = decodeSegment(leaf.slice(0, -'.json'.length));
+
+  // A cache keyed on the provider id, not on a connection — so two profiles
+  // that both connected the same vendor hold two entries under one key. They
+  // describe the same manifest, `open.ts` treats a miss and a corrupt entry
+  // alike as "not discovered yet", and `connect` refreshes it. First one wins.
+  if (namespace === 'discovery') {
+    return claim(claimed, { from, to: here });
+  }
+
+  if (namespace !== CONNECTIONS_NAMESPACE) return { from, to: here };
+
+  // This profile's old key, through this profile's mapping — the same lookup
+  // the provider-blob branch does, and wrong in the same way if it is skipped.
+  const settled = mapping.get(key);
+
+  // A record for a connection the profile no longer declares. It was orphaned
+  // under contract 2 already — no row, and `hoistConnections` reads rows — so
+  // hoisting it would manufacture a connection that nothing grants and no
+  // credential backs, and its key can collide with a rename that is real.
+  if (settled === undefined) return null;
+
+  const to = `${layout.state()}/${objectKey(CONNECTIONS_NAMESPACE, settled)}`;
+
+  // Two profiles that connected the same account merge into one row, so both
+  // hold a record for it. They describe one connection; the second differs only
+  // in when it was last written.
+  if (settled === key) return claim(claimed, { from, to });
+
+  const dot = settled.indexOf('.');
+  const provider = settled.slice(0, dot);
+  const id = settled.slice(dot + 1);
+  return claim(claimed, { from, to, rewrite: (data) => retarget(data, provider, id) });
+}
+
+/** First claim on a destination wins; a later one is left where it is. */
+function claim(claimed: Set<string>, move: Move): Move | null {
+  if (claimed.has(move.to)) return null;
+  claimed.add(move.to);
+  return move;
+}
+
+/**
+ * A connection record, told what it is now called.
+ *
+ * Spread rather than assigned field by field so the operator's key order — and
+ * anything a later version added that this one does not know about — survives
+ * the rewrite.
+ *
+ * Bytes that are not a JSON object are returned untouched. This is a migration,
+ * and refusing to move something because it could not be parsed would strand it
+ * under a profile directory nothing reads.
+ */
+function retarget(data: Uint8Array, provider: string, id: string): Uint8Array {
+  let record: unknown;
+  try {
+    record = JSON.parse(new TextDecoder().decode(data));
+  } catch {
+    return data;
+  }
+
+  if (record === null || typeof record !== 'object' || Array.isArray(record)) return data;
+
+  return new TextEncoder().encode(
+    JSON.stringify({ ...(record as Record<string, unknown>), provider, id }),
+  );
 }
 
 /**
@@ -282,8 +309,14 @@ export async function applyMoves(files: BlobStore, moves: readonly Move[]): Prom
 
 /** One object, moved or finished. Never deletes before the copy reads back. */
 async function applyMove(files: BlobStore, move: Move): Promise<void> {
-  const data = await files.get(move.from);
-  if (data === null) return;
+  const source = await files.get(move.from);
+  if (source === null) return;
+
+  // Before the comparison below as well as before the write. Comparing the
+  // *source* bytes against a destination that holds the rewritten ones would
+  // read an already-finished move as a collision, and refuse the one rerun this
+  // file promises.
+  const data = move.rewrite === undefined ? source : move.rewrite(source);
 
   if (await files.has(move.to)) {
     const held = await files.get(move.to);
@@ -295,9 +328,8 @@ async function applyMove(files: BlobStore, move: Move): Promise<void> {
         throw new ConfigError(
           `Two objects want to be at ${move.to}, and this migration cannot merge them.\n` +
             `  ${move.from} is the second, and what is already there is not a copy of it.\n` +
-            '  Nothing has been deleted. This should be unreachable: the hoist gives every ' +
-            'profile its own instance of each owner-layer surface. Please report it with the ' +
-            'layout of your data directory.',
+            '  Nothing has been deleted. Please report it with the layout of your data ' +
+            'directory.',
         );
       }
 

--- a/src/cli/contract3-data.ts
+++ b/src/cli/contract3-data.ts
@@ -31,12 +31,11 @@ export interface Move {
    *
    * For the objects two profiles can legitimately both hold — a connection they
    * share, a provider-keyed cache, one custom manifest — where a second copy is
-   * a duplicate rather than a clash. `claim` drops the loser from the plan, but
-   * only within one run: the winner's source is deleted and the loser's is not,
-   * so a rerun saw a different first claimant, found the destination holding
-   * somebody else's bytes, and threw. Permanently — and `rewriteProfiles` stamps
-   * the contract *after* the moves, so an interruption during them forces
-   * exactly that rerun.
+   * a duplicate rather than a clash. `claim` drops the loser within one run, but
+   * deletes the winner's source and leaves the loser's: the rerun then saw a
+   * different first claimant, found foreign bytes at the destination, and threw,
+   * permanently. `rewriteProfiles` stamps the contract *after* the moves, so an
+   * interruption during them forces exactly that rerun.
    */
   readonly whenAbsent?: boolean;
 }
@@ -113,9 +112,8 @@ export async function planMoves(
         if (move !== null) moves.push(move);
         continue;
       }
-      // One object per event, under a key that already carries the timestamp
-      // and the profile in every record — so concatenating three profiles' logs
-      // is exactly moving the objects across, with nothing to reconcile.
+      // One object per event under a key already carrying the timestamp, so
+      // concatenating three profiles' logs is exactly moving them across.
       if (head === 'audit.log') {
         moves.push({ from: blob.key, to: `${DATA_DIR}/audit.log/${tail.join('/')}` });
         continue;
@@ -179,14 +177,12 @@ function assertOneObjectPerDestination(moves: readonly Move[]): void {
  * called unreachable, and it was reachable from any workspace with two profiles
  * in it.
  *
- * Keys are decoded rather than pattern-matched. On disk the namespace and key
- * are percent-encoded per segment (`connections%2Ev1/vault%2Emain.json`), and
- * reassembling that by hand at this call site would be the second spelling of
- * an encoding that must have exactly one.
+ * Keys are decoded rather than pattern-matched: on disk both halves are
+ * percent-encoded per segment (`connections%2Ev1/vault%2Emain.json`), and
+ * respelling that here would be a second copy of an encoding that must have one.
  *
- * `null` means leave it where it is. Nothing is deleted by not moving it, the
- * old `data/<profile>/` tree survives the migration either way, and `doctor`
- * names what is left.
+ * `null` means leave it where it is — nothing is deleted by not moving it, and
+ * `doctor` names what is left.
  */
 function stateMove(
   from: string,
@@ -204,14 +200,23 @@ function stateMove(
     return { from, to: here };
   }
 
-  const segments = tail.slice(0, -1).map(decodeSegment);
+  // `decodeSegment` is `decodeURIComponent`, which throws `URIError` on a stray
+  // `%`. Aborting somebody's whole migration on `URI error`, naming no file, is
+  // not an answer — an undecodable key is one this does not understand, and
+  // those are moved as they are.
+  let segments: string[];
+  let key: string;
+  try {
+    segments = tail.slice(0, -1).map(decodeSegment);
+    key = decodeSegment(leaf.slice(0, -'.json'.length));
+  } catch {
+    return { from, to: here };
+  }
   const namespace = segments.join('/');
-  const key = decodeSegment(leaf.slice(0, -'.json'.length));
 
-  // A cache keyed on the provider id, not on a connection — so two profiles
-  // that both connected the same vendor hold two entries under one key. They
-  // describe the same manifest, `open.ts` treats a miss and a corrupt entry
-  // alike as "not discovered yet", and `connect` refreshes it. First one wins.
+  // Keyed on the provider id, not a connection, so two profiles on the same
+  // vendor hold two entries under one key. `open.ts` treats a miss and a corrupt
+  // entry alike as "not discovered yet" and `connect` refreshes it: first wins.
   if (namespace === 'discovery') {
     return claim(claimed, { from, to: here });
   }
@@ -235,17 +240,15 @@ function stateMove(
   // the provider-blob branch does, and wrong in the same way if it is skipped.
   const settled = mapping.get(key);
 
-  // A record for a connection the profile no longer declares. It was orphaned
-  // under contract 2 already — no row, and `hoistConnections` reads rows — so
-  // hoisting it would manufacture a connection that nothing grants and no
-  // credential backs, and its key can collide with a rename that is real.
+  // Orphaned under contract 2 already — no row, and `hoistConnections` reads
+  // rows — so hoisting it would manufacture a connection nothing grants, and its
+  // key can collide with a rename that is real.
   if (settled === undefined) return null;
 
   const to = `${layout.state()}/${objectKey(CONNECTIONS_NAMESPACE, settled)}`;
 
-  // Two profiles that connected the same account merge into one row, so both
-  // hold a record for it. They describe one connection; the second differs only
-  // in when it was last written.
+  // Two profiles on one account merge into one row, so both hold a record for
+  // it. One connection; the second differs only in when it was written.
   if (settled === key) return claim(claimed, { from, to });
 
   const dot = settled.indexOf('.');
@@ -264,13 +267,10 @@ function claim(claimed: Set<string>, move: Move): Move | null {
 /**
  * A connection record, told what it is now called.
  *
- * Spread rather than assigned field by field so the operator's key order — and
- * anything a later version added that this one does not know about — survives
- * the rewrite.
- *
- * Bytes that are not a JSON object are returned untouched. This is a migration,
- * and refusing to move something because it could not be parsed would strand it
- * under a profile directory nothing reads.
+ * Spread rather than assigned field by field, so key order and anything a later
+ * version added survive. Bytes that are not a JSON object are returned
+ * untouched: refusing to move what would not parse strands it under a profile
+ * directory nothing reads.
  */
 function retarget(data: Uint8Array, provider: string, id: string): Uint8Array {
   let record: unknown;

--- a/src/cli/contract3-shape.ts
+++ b/src/cli/contract3-shape.ts
@@ -166,7 +166,20 @@ export function grantsFor(
     return pattern === '*' || pattern.startsWith(`${provider}.`);
   };
 
-  return (config.connections ?? []).map((connection) => {
+  // Keyed on the *settled* connection, because two rows can become one. A
+  // profile could hold `gmail.main` and `gmail.archive` for the same mailbox at
+  // different scopes — which is legal under contract 2, and the reason tokens
+  // are per connection at all — and the hoist keys on provider-plus-account, so
+  // both settle on one row. Emitting a grant per original row then wrote the
+  // same `connection:` twice and `assertGrantsUnique` refused the profile,
+  // failing the migration on a merge it had just performed itself.
+  //
+  // The rules are unioned rather than picked between. Both rows were in force
+  // before, the connection they describe is now one connection, and dropping
+  // either would narrow a policy the operator never narrowed.
+  const rows = new Map<string, { connection: string; allow: Rule[]; deny: Rule[] }>();
+
+  for (const connection of config.connections ?? []) {
     const provider = connection.provider;
     // A bare `*` becomes the provider wildcard rather than being copied
     // through. It would still mean the same thing inside a row, which is
@@ -177,10 +190,22 @@ export function grantsFor(
       return rule.capability === '*' ? { ...rule, capability: `${provider}.*` } : rule;
     };
 
-    return {
-      connection: mapping.get(keyOf(connection)) ?? keyOf(connection),
-      allow: allow.filter((rule) => covers(rule, provider)).map(widen),
-      deny: deny.filter((rule) => covers(rule, provider)).map(widen),
-    };
-  });
+    const key = mapping.get(keyOf(connection)) ?? keyOf(connection);
+    const row = rows.get(key) ?? { connection: key, allow: [], deny: [] };
+
+    row.allow = union(row.allow, allow.filter((rule) => covers(rule, provider)).map(widen));
+    row.deny = union(row.deny, deny.filter((rule) => covers(rule, provider)).map(widen));
+    rows.set(key, row);
+  }
+
+  return [...rows.values()];
+}
+
+/** Rules from two merged rows, keeping the first spelling of each capability. */
+function union(held: readonly Rule[], adding: readonly Rule[]): Rule[] {
+  const merged = [...held];
+  for (const rule of adding) {
+    if (!merged.some((one) => capabilityOf(one) === capabilityOf(rule))) merged.push(rule);
+  }
+  return merged;
 }

--- a/src/cli/contract3.test.ts
+++ b/src/cli/contract3.test.ts
@@ -885,3 +885,55 @@ describe('the registry a half-recorded deploy left behind', () => {
     expect((await readYaml(root, 'lanes-link.yaml'))['default_workspace']).toBe('local');
   });
 });
+
+describe('a rerun after the profile stamps were interrupted', () => {
+  test("does not rebuild connections.yaml from the profiles that are left", async () => {
+    // `rewriteProfiles` stamps profiles one at a time and runs last, so an
+    // interruption part way through leaves some at contract 3 and some at 2.
+    // `legacy` then holds only the stragglers, and rebuilding the file from
+    // them deleted the already-migrated rows — while their grants still named
+    // those connections.
+    //
+    // The shape that bites: two profiles hold `gmail.main` for different
+    // mailboxes and hoist to `gmail.main` and `gmail.main_2`. Rebuild from the
+    // second alone and `gmail.main` comes back naming the *other* mailbox, with
+    // the first profile's surviving grant pointing at it. Nothing errors.
+    const root = await workspace({
+      personal: legacy({
+        profile: 'personal',
+        connections: '  - { id: main, provider: gmail, account: ada@example.com }',
+      }),
+      work: legacy({
+        profile: 'work',
+        connections: '  - { id: main, provider: gmail, account: sam@example.com }',
+      }),
+    });
+
+    await migrateToContract3(root, { apply: true });
+    const after = await refs(root);
+    expect(after).toContain('gmail.main');
+    expect(after).toContain('gmail.main_2');
+
+    // Put `work` back to contract 2 — exactly what an interruption between the
+    // two profile saves leaves behind — and run it again.
+    const stalled = (await readFile(join(root, 'profiles', 'work.yaml'), 'utf8')).replace(
+      'contract: 3',
+      'contract: 2',
+    );
+    await writeFile(join(root, 'profiles', 'work.yaml'), stalled);
+
+    await migrateToContract3(root, { apply: true });
+
+    const rows = (
+      (await readYaml(root, 'connections.yaml')) as {
+        connections?: { provider: string; id: string; account?: string }[];
+      }
+    ).connections;
+
+    // personal's mailbox is still the one `gmail.main` names.
+    expect(rows?.find((row) => row.provider === 'gmail' && row.id === 'main')?.account).toBe(
+      'ada@example.com',
+    );
+    expect(await refs(root)).toContain('gmail.main_2');
+  });
+});

--- a/src/cli/contract3.test.ts
+++ b/src/cli/contract3.test.ts
@@ -5,8 +5,11 @@ import { join } from 'node:path';
 import { parse } from 'yaml';
 import { migrateToContract3 } from './contract3.ts';
 import { migrateToCurrentContract } from './workspace-migrate.ts';
-import { applyMoves, planCredentials, planMoves } from './contract3-data.ts';
+import { applyMoves, planMoves } from './contract3-data.ts';
+import { planCredentials } from './contract3-credentials.ts';
 import { createMemoryBlobStore } from '#stores/blobs/testing.ts';
+import { createFileSecretStore } from '#secrets';
+import { objectKey } from '#stores/state';
 
 /**
  * Contract 2 to contract 3, against a real workspace on disk.
@@ -375,7 +378,8 @@ describe('a workspace in a bucket', () => {
     // `gs://.../data/personal/credentials.enc`, handed it to `Bun.file`, and let
     // the catch report an empty list, which is the same answer for the wrong
     // reason and would have hidden a real store that would not open.
-    expect(await planCredentials('gs://your-bucket', ['personal'])).toEqual([]);
+    const plan = { profile: 'personal', renames: new Map(), tokenRef: 'profile/token' };
+    expect(await planCredentials('gs://your-bucket', [plan])).toEqual({ refs: [], tokens: [] });
   });
 });
 
@@ -401,5 +405,219 @@ describe('the contract stamp is the record that this finished', () => {
     expect(await readFile(join(root, 'data', 'personal', 'memory', 'main', 'a.md'), 'utf8')).toBe(
       'mine',
     );
+  });
+});
+
+describe('state.kv', () => {
+  const bytes = (text: string) => new TextEncoder().encode(text);
+  const record = (provider: string, id: string) =>
+    bytes(JSON.stringify({ provider, id, status: 'active', createdAt: '2026-01-01T00:00:00.000Z' }));
+  const under = (profile: string, namespace: string, key: string) =>
+    `data/${profile}/state.kv/${objectKey(namespace, key)}`;
+  const hoisted = (namespace: string, key: string) =>
+    `data/state.kv/${objectKey(namespace, key)}`;
+
+  async function body(files: ReturnType<typeof createMemoryBlobStore>, key: string) {
+    const raw = await files.get(key);
+    return raw === null ? null : (JSON.parse(new TextDecoder().decode(raw)) as Record<string, unknown>);
+  }
+
+  test('a renamed connection takes its record with it, key and body', async () => {
+    // The defect this whole file was reopened for. `state.kv` was moved
+    // verbatim on the grounds that its records "already carry the profile" —
+    // but `connections.v1` is keyed on `<provider>.<id>`, which is exactly what
+    // the hoist renames, so every profile's owner layer aimed an object at
+    // `connections.v1/vault.main` and the migration refused.
+    //
+    // The body matters as much as the key: `ConnectionRepository.list` reads
+    // `provider` and `id` out of the record, so a verbatim copy would sit at
+    // `vault.work` still calling itself `vault.main`.
+    const files = createMemoryBlobStore();
+    await files.put(under('personal', 'connections.v1', 'vault.main'), record('vault', 'main'));
+    await files.put(under('work', 'connections.v1', 'vault.main'), record('vault', 'main'));
+
+    const moves = await planMoves(
+      files,
+      ['personal', 'work'],
+      new Map([
+        ['personal', new Map([['vault.main', 'vault.main']])],
+        ['work', new Map([['vault.main', 'vault.work']])],
+      ]),
+    );
+    await applyMoves(files, moves);
+
+    expect(await body(files, hoisted('connections.v1', 'vault.main'))).toMatchObject({
+      provider: 'vault',
+      id: 'main',
+    });
+    expect(await body(files, hoisted('connections.v1', 'vault.work'))).toMatchObject({
+      provider: 'vault',
+      id: 'work',
+    });
+    // Everything else the record carried survives the retarget.
+    expect(await body(files, hoisted('connections.v1', 'vault.work'))).toMatchObject({
+      createdAt: '2026-01-01T00:00:00.000Z',
+    });
+    expect(await files.has(under('work', 'connections.v1', 'vault.main'))).toBe(false);
+  });
+
+  test('a record for a connection the profile no longer declares is left where it is', async () => {
+    // No row means the hoist never saw it, so there is nothing to map it to.
+    // Moving it anyway would manufacture a connection that nothing grants and
+    // no credential backs — and its key can collide with a rename that is real.
+    const files = createMemoryBlobStore();
+    await files.put(under('personal', 'connections.v1', 'tasks.main'), record('tasks', 'main'));
+    await files.put(under('personal', 'connections.v1', 'gmail.old'), record('gmail', 'old'));
+
+    const moves = await planMoves(
+      files,
+      ['personal'],
+      new Map([['personal', new Map([['tasks.main', 'tasks.personal']])]]),
+    );
+    await applyMoves(files, moves);
+
+    expect(await files.has(hoisted('connections.v1', 'tasks.personal'))).toBe(true);
+    expect(await files.has(hoisted('connections.v1', 'gmail.old'))).toBe(false);
+    // Left, not deleted. Nothing this migration does not understand is lost.
+    expect(await files.has(under('personal', 'connections.v1', 'gmail.old'))).toBe(true);
+  });
+
+  test('two profiles that share one account keep one record between them', async () => {
+    // Same provider, same account: the hoist merges them into one row, so both
+    // profiles map to the same key and both hold a record describing it. One
+    // connection, one record — this is a duplicate, not a collision.
+    const files = createMemoryBlobStore();
+    await files.put(under('personal', 'connections.v1', 'gmail.main'), record('gmail', 'main'));
+    await files.put(under('work', 'connections.v1', 'gmail.main'), record('gmail', 'main'));
+
+    const shared = new Map([
+      ['personal', new Map([['gmail.main', 'gmail.main']])],
+      ['work', new Map([['gmail.main', 'gmail.main']])],
+    ]);
+
+    await applyMoves(files, await planMoves(files, ['personal', 'work'], shared));
+
+    expect(await files.has(hoisted('connections.v1', 'gmail.main'))).toBe(true);
+    expect(await files.has(under('work', 'connections.v1', 'gmail.main'))).toBe(true);
+  });
+
+  test('the discovery cache is keyed on the provider, so the first profile wins', async () => {
+    // Not per connection: `open.ts` reads it by manifest id, and a miss or a
+    // corrupt entry both mean "not discovered yet", which `connect` refreshes.
+    const files = createMemoryBlobStore();
+    await files.put(under('personal', 'discovery', 'gmail'), bytes('["personal"]'));
+    await files.put(under('work', 'discovery', 'gmail'), bytes('["work"]'));
+
+    await applyMoves(files, await planMoves(files, ['personal', 'work'], new Map()));
+
+    expect(await files.get(hoisted('discovery', 'gmail'))).toEqual(bytes('["personal"]'));
+    expect(await files.has(under('work', 'discovery', 'gmail'))).toBe(true);
+  });
+
+  test('the audit log is still concatenated object by object', async () => {
+    // One object per event under a key that already carries the timestamp, so
+    // three profiles' logs merge by moving them and nothing collides.
+    const files = createMemoryBlobStore();
+    await files.put('data/personal/audit.log/2026/01/a.json', bytes('one'));
+    await files.put('data/work/audit.log/2026/01/b.json', bytes('two'));
+
+    await applyMoves(files, await planMoves(files, ['personal', 'work'], new Map()));
+
+    expect(await files.get('data/audit.log/2026/01/a.json')).toEqual(bytes('one'));
+    expect(await files.get('data/audit.log/2026/01/b.json')).toEqual(bytes('two'));
+  });
+});
+
+describe('merging credentials', () => {
+  async function credentials(root: string, profile: string) {
+    await mkdir(join(root, 'data', profile), { recursive: true });
+    return createFileSecretStore({ path: join(root, 'data', profile, 'credentials.enc') });
+  }
+
+  const withGithub = (profile: string, account: string) =>
+    legacy({
+      profile,
+      connections: `  - { id: main, provider: github, account: ${account} }`,
+    });
+
+  test("a renamed connection's credential ref follows the rename", async () => {
+    // `credentialRefForConnection` derives `<provider>/<id>`, and the hoist
+    // renamed the connection with `{ ...connection, id }` — leaving the derived
+    // ref behind. Two profiles then claimed `github/main` with two different
+    // tokens, which aborted the migration on a rename it had just made itself.
+    const root = await workspace({
+      personal: withGithub('personal', 'example-org'),
+      work: withGithub('work', 'example-user'),
+    });
+
+    await (await credentials(root, 'personal')).set('github/main', 'token-for-org');
+    await (await credentials(root, 'work')).set('github/main', 'token-for-user');
+
+    await migrateToContract3(root, { apply: true });
+
+    expect(await refs(root)).toContain('github.main');
+    expect(await refs(root)).toContain('github.main_2');
+
+    const merged = createFileSecretStore({ path: join(root, 'data', 'credentials.enc') });
+    expect(await merged.get('github/main')).toBe('token-for-org');
+    expect(await merged.get('github/main_2')).toBe('token-for-user');
+  });
+
+  test('the endpoint token is left behind rather than picked between', async () => {
+    // Every profile keeps it under one ref because the schema defaults
+    // `token_ref` to `profile/token`. One store now, so three profiles are
+    // three values for one key and no merge means anything. It is minted
+    // locally, `ensureProfileToken` writes a fresh one on the next command, and
+    // the old stores are not deleted — so nothing has to be authorised again.
+    const root = await workspace({
+      personal: legacy({ profile: 'personal' }),
+      work: legacy({ profile: 'work' }),
+    });
+
+    await (await credentials(root, 'personal')).set('profile/token', 'llk_personal');
+    await (await credentials(root, 'work')).set('profile/token', 'llk_work');
+
+    const migration = await migrateToContract3(root, { apply: true });
+
+    const merged = createFileSecretStore({ path: join(root, 'data', 'credentials.enc') });
+    expect(await merged.get('profile/token')).toBe(null);
+    expect(migration.changes.join('\n')).toContain('profile/token');
+    // Not deleted: the old store is the only copy, and it stays one.
+    expect(await (await credentials(root, 'personal')).get('profile/token')).toBe('llk_personal');
+  });
+
+  test('a ref two profiles genuinely disagree on refuses before anything is written', async () => {
+    // Same provider and account, so the hoist merges them into one row and
+    // there is no rename to separate the refs. Both values are real, and this
+    // must not pick. The refusal has to land in the *plan*: it used to throw
+    // from `mergeCredentials`, by which point `rewriteRegistry` had already
+    // stamped the workspace at contract 3.
+    const root = await workspace({
+      personal: withGithub('personal', 'example-org'),
+      work: withGithub('work', 'example-org'),
+    });
+
+    await (await credentials(root, 'personal')).set('github/main', 'one');
+    await (await credentials(root, 'work')).set('github/main', 'two');
+
+    await expect(migrateToContract3(root, { apply: true })).rejects.toThrow(
+      /cannot choose between them/,
+    );
+
+    expect((await readYaml(root, 'lanes-link.yaml'))['contract']).toBe(2);
+    expect((await readYaml(root, 'profiles/personal.yaml'))['contract']).toBe(2);
+  });
+
+  test('the preview reports the same refs the apply writes', async () => {
+    const root = await workspace({ personal: legacy({ profile: 'personal' }) });
+    await (await credentials(root, 'personal')).set('memory/main', 'value');
+    await (await credentials(root, 'personal')).set('profile/token', 'llk_one');
+
+    const preview = await migrateToContract3(root, { apply: false });
+    expect(preview.credentials).toEqual(['memory/main']);
+
+    await migrateToContract3(root, { apply: true });
+    const merged = createFileSecretStore({ path: join(root, 'data', 'credentials.enc') });
+    expect(await merged.get('memory/main')).toBe('value');
   });
 });

--- a/src/cli/contract3.test.ts
+++ b/src/cli/contract3.test.ts
@@ -586,12 +586,11 @@ describe('merging credentials', () => {
     expect(await (await credentials(root, 'personal')).get('profile/token')).toBe('llk_personal');
   });
 
-  test('a ref two profiles genuinely disagree on refuses before anything is written', async () => {
-    // Same provider and account, so the hoist merges them into one row and
-    // there is no rename to separate the refs. Both values are real, and this
-    // must not pick. The refusal has to land in the *plan*: it used to throw
-    // from `mergeCredentials`, by which point `rewriteRegistry` had already
-    // stamped the workspace at contract 3.
+  test('two profiles sharing one account keep one credential between them', async () => {
+    // Same provider and account, so `hoistConnections` merges them into a single
+    // row — and a single row has a single credential. This used to refuse with
+    // "Two profiles hold different values", which was a refusal on a merge the
+    // migration had just performed itself.
     const root = await workspace({
       personal: withGithub('personal', 'example-org'),
       work: withGithub('work', 'example-org'),
@@ -599,6 +598,29 @@ describe('merging credentials', () => {
 
     await (await credentials(root, 'personal')).set('github/main', 'one');
     await (await credentials(root, 'work')).set('github/main', 'two');
+
+    await migrateToContract3(root, { apply: true });
+
+    expect((await refs(root)).filter((key) => key.startsWith('github.'))).toEqual(['github.main']);
+    const merged = createFileSecretStore({ path: join(root, 'data', 'credentials.enc') });
+    expect(await merged.get('github/main')).toBe('one');
+  });
+
+  test('a credential neither connection owns refuses before anything is written', async () => {
+    // An OAuth *client* is registered per profile and stored under a ref keyed
+    // on the app, not on a connection — so no rename can separate two of them
+    // and there is nothing to merge. Both are real, and this must not pick.
+    //
+    // The refusal has to land in the plan: it used to throw from
+    // `mergeCredentials`, by which point `rewriteRegistry` had already stamped
+    // the workspace at contract 3.
+    const root = await workspace({
+      personal: legacy({ profile: 'personal' }),
+      work: legacy({ profile: 'work' }),
+    });
+
+    await (await credentials(root, 'personal')).set('google/client_id', 'one');
+    await (await credentials(root, 'work')).set('google/client_id', 'two');
 
     await expect(migrateToContract3(root, { apply: true })).rejects.toThrow(
       /cannot choose between them/,
@@ -614,7 +636,10 @@ describe('merging credentials', () => {
     await (await credentials(root, 'personal')).set('profile/token', 'llk_one');
 
     const preview = await migrateToContract3(root, { apply: false });
-    expect(preview.credentials).toEqual(['memory/main']);
+    // `profile/token` among them: one profile cannot disagree with itself, so
+    // there is nothing to leave behind and dropping it would have logged every
+    // client out for a conflict that does not exist.
+    expect(preview.credentials).toEqual(['memory/main', 'profile/token']);
 
     await migrateToContract3(root, { apply: true });
     const merged = createFileSecretStore({ path: join(root, 'data', 'credentials.enc') });
@@ -717,5 +742,146 @@ describe('a registry carrying both blocks', () => {
     expect(registry.workspaces?.['cloud']?.last_deploy_version).toBe('0.8.0');
     // And the entry only `targets:` knew about is still carried across.
     expect(registry.workspaces?.['local']).toBeDefined();
+  });
+});
+
+describe('running the migration again after it was interrupted', () => {
+  const bytes = (text: string) => new TextEncoder().encode(text);
+  const under = (profile: string, namespace: string, key: string) =>
+    `data/${profile}/state.kv/${objectKey(namespace, key)}`;
+
+  test('a shared connection\'s duplicate does not wedge the rerun', async () => {
+    // `claim` drops the loser within one run, but the winner's source is deleted
+    // and the loser's is not — so the rerun saw a different first claimant,
+    // found the destination holding somebody else's bytes, and threw. Every
+    // subsequent run reproduced it, and `rewriteProfiles` stamps the contract
+    // *after* the moves, so an interruption during them forces exactly this.
+    const files = createMemoryBlobStore();
+    await files.put(under('personal', 'connections.v1', 'gmail.main'), bytes('{"id":"main","u":"A"}'));
+    await files.put(under('work', 'connections.v1', 'gmail.main'), bytes('{"id":"main","u":"B"}'));
+
+    const shared = new Map([
+      ['personal', new Map([['gmail.main', 'gmail.main']])],
+      ['work', new Map([['gmail.main', 'gmail.main']])],
+    ]);
+
+    for (let run = 0; run < 3; run += 1) {
+      await applyMoves(files, await planMoves(files, ['personal', 'work'], shared));
+    }
+
+    expect(await files.has(`data/state.kv/${objectKey('connections.v1', 'gmail.main')}`)).toBe(true);
+  });
+
+  test("a provider's own state follows the connection rename, like its blobs do", async () => {
+    // `state.kv/<provider>/<connection>` is keyed on the connection exactly as
+    // `data/<provider>/<connection>/` is. Left out of the first pass, so two
+    // profiles holding one provider's fixed-name object — `dav`'s home,
+    // `bunq`'s session — still aimed at one key.
+    const files = createMemoryBlobStore();
+    await files.put(under('personal', 'icloud_mail/main', 'dav.home'), bytes('home-personal'));
+    await files.put(under('work', 'icloud_mail/main', 'dav.home'), bytes('home-work'));
+
+    await applyMoves(
+      files,
+      await planMoves(
+        files,
+        ['personal', 'work'],
+        new Map([
+          ['personal', new Map([['icloud_mail.main', 'icloud_mail.main']])],
+          ['work', new Map([['icloud_mail.main', 'icloud_mail.work']])],
+        ]),
+      ),
+    );
+
+    expect(await files.get(`data/state.kv/${objectKey('icloud_mail/main', 'dav.home')}`)).toEqual(
+      bytes('home-personal'),
+    );
+    expect(await files.get(`data/state.kv/${objectKey('icloud_mail/work', 'dav.home')}`)).toEqual(
+      bytes('home-work'),
+    );
+  });
+
+  test('one custom manifest held by two profiles is a duplicate, not a refusal', async () => {
+    // Under ADR-030 a manifest lived in the profile, so an operator using their
+    // own connector in two profiles has two copies of one file.
+    const files = createMemoryBlobStore();
+    await files.put('data/personal/providers.d/mything.yaml', bytes('id: mything'));
+    await files.put('data/work/providers.d/mything.yaml', bytes('id: mything'));
+
+    await applyMoves(files, await planMoves(files, ['personal', 'work'], new Map()));
+
+    expect(await files.get('data/providers.d/mything.yaml')).toEqual(bytes('id: mything'));
+  });
+});
+
+describe('the registry a half-recorded deploy left behind', () => {
+  test('a field only the stale targets: entry carries is not dropped', async () => {
+    // Merging per entry rather than per field discarded `primary` — which
+    // schema.ts calls the one question about a deployment that must not be
+    // guessed at — along with `last_deploy` and the `deploy:` block naming the
+    // project and region. Preserving the record is the whole point of the merge.
+    const root = await mkdtemp(join(tmpdir(), 'lanes-c3-'));
+    homes.push(root);
+
+    await writeFile(
+      join(root, 'lanes-link.yaml'),
+      [
+        'contract: 2',
+        'targets:',
+        '  cloud:',
+        '    workspace: gs://your-bucket',
+        '    primary: personal',
+        '    last_deploy_version: 0.7.2',
+        'workspaces:',
+        '  cloud:',
+        '    at: gs://your-bucket',
+        '    last_deploy_version: 0.8.0',
+        '',
+      ].join('\n'),
+    );
+    await mkdir(join(root, 'profiles'), { recursive: true });
+    await writeFile(join(root, 'profiles', 'personal.yaml'), legacy({ profile: 'personal' }));
+
+    await migrateToContract3(root, { apply: true });
+
+    const cloud = (
+      (await readYaml(root, 'lanes-link.yaml')) as {
+        workspaces?: Record<string, { primary?: string; last_deploy_version?: string }>;
+      }
+    ).workspaces?.['cloud'];
+
+    expect(cloud?.last_deploy_version).toBe('0.8.0');
+    expect(cloud?.primary).toBe('personal');
+  });
+
+  test('a cloud target surveyed but never rolled out is not made the default', async () => {
+    // `bootstrap` writes the surveyed adapters into the local registry before
+    // the rollout, and only `recordDeployment` later replaces them with a
+    // pointer. A deploy that failed at build or IAM therefore leaves a *declared*
+    // cloud entry with no `at:` — so reading "no at:" as "on this machine" chose
+    // the bucket, which is the 403 this was written to prevent.
+    const root = await mkdtemp(join(tmpdir(), 'lanes-c3-'));
+    homes.push(root);
+
+    await writeFile(
+      join(root, 'lanes-link.yaml'),
+      [
+        'contract: 2',
+        'targets:',
+        '  cloud:',
+        '    credentials: { adapter: gcp-secret-manager, project: my-project }',
+        '    storage: { adapter: gcs, bucket: your-bucket }',
+        '  local:',
+        '    credentials: { adapter: file }',
+        '    storage: { adapter: filesystem }',
+        '',
+      ].join('\n'),
+    );
+    await mkdir(join(root, 'profiles'), { recursive: true });
+    await writeFile(join(root, 'profiles', 'personal.yaml'), legacy({ profile: 'personal' }));
+
+    await migrateToContract3(root, { apply: true });
+
+    expect((await readYaml(root, 'lanes-link.yaml'))['default_workspace']).toBe('local');
   });
 });

--- a/src/cli/contract3.test.ts
+++ b/src/cli/contract3.test.ts
@@ -669,3 +669,53 @@ describe('the sticky default workspace', () => {
     expect((await readYaml(root, 'lanes-link.yaml'))['default_workspace']).toBe('cloud');
   });
 });
+
+describe('a registry carrying both blocks', () => {
+  test('the newer workspaces: entry survives, rather than being rebuilt from stale targets:', async () => {
+    // What `editRegistry` used to leave behind: a deploy recorded into a
+    // contract-2 file wrote `workspaces:` without touching `targets:`, so the
+    // two disagreed. Rebuilding `workspaces:` from `targets:` then reverted a
+    // recorded deployment to whatever the last contract-2 command had written,
+    // silently — which is how a deploy that had genuinely happened came to read
+    // as a version older than the one serving it.
+    //
+    // Same rule the 1-to-2 migration states: anything already in the file wins
+    // over what is re-derived, because a workspace part way through this has
+    // entries that are already right.
+    const root = await mkdtemp(join(tmpdir(), 'lanes-c3-'));
+    homes.push(root);
+
+    await writeFile(
+      join(root, 'lanes-link.yaml'),
+      [
+        'contract: 2',
+        'targets:',
+        '  cloud:',
+        '    workspace: gs://your-bucket',
+        '    last_deploy_version: 0.7.2',
+        '  local:',
+        '    credentials: { adapter: file }',
+        '    storage: { adapter: filesystem }',
+        'workspaces:',
+        '  cloud:',
+        '    at: gs://your-bucket',
+        '    last_deploy_version: 0.8.0',
+        '',
+      ].join('\n'),
+    );
+    await mkdir(join(root, 'profiles'), { recursive: true });
+    await writeFile(join(root, 'profiles', 'personal.yaml'), legacy({ profile: 'personal' }));
+
+    await migrateToContract3(root, { apply: true });
+
+    const registry = (await readYaml(root, 'lanes-link.yaml')) as {
+      targets?: unknown;
+      workspaces?: Record<string, { last_deploy_version?: string; at?: string }>;
+    };
+
+    expect(registry.targets).toBeUndefined();
+    expect(registry.workspaces?.['cloud']?.last_deploy_version).toBe('0.8.0');
+    // And the entry only `targets:` knew about is still carried across.
+    expect(registry.workspaces?.['local']).toBeDefined();
+  });
+});

--- a/src/cli/contract3.test.ts
+++ b/src/cli/contract3.test.ts
@@ -621,3 +621,51 @@ describe('merging credentials', () => {
     expect(await merged.get('memory/main')).toBe('value');
   });
 });
+
+describe('the sticky default workspace', () => {
+  test('is the one on this machine, not whichever key sorts first', async () => {
+    // The registry is written sorted, so a workspace that had ever deployed
+    // came out of the 1-to-2 migration with `cloud` ahead of `local`. Taking
+    // the first key then pointed every command at a bucket, and a bucket is the
+    // one kind of workspace that can be unreachable — the next `status`
+    // answered with a 403 instead of the profiles sitting on the disk.
+    const root = await mkdtemp(join(tmpdir(), 'lanes-c3-'));
+    homes.push(root);
+
+    await writeFile(
+      join(root, 'lanes-link.yaml'),
+      [
+        'contract: 2',
+        'targets:',
+        '  cloud:',
+        '    workspace: gs://your-bucket',
+        '  local:',
+        '    credentials: { adapter: file }',
+        '    storage: { adapter: filesystem }',
+        '',
+      ].join('\n'),
+    );
+    await mkdir(join(root, 'profiles'), { recursive: true });
+    await writeFile(join(root, 'profiles', 'personal.yaml'), legacy({ profile: 'personal' }));
+
+    await migrateToContract3(root, { apply: true });
+
+    expect((await readYaml(root, 'lanes-link.yaml'))['default_workspace']).toBe('local');
+  });
+
+  test('falls back to the first when every workspace is a pointer', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'lanes-c3-'));
+    homes.push(root);
+
+    await writeFile(
+      join(root, 'lanes-link.yaml'),
+      'contract: 2\ntargets:\n  cloud:\n    workspace: gs://your-bucket\n',
+    );
+    await mkdir(join(root, 'profiles'), { recursive: true });
+    await writeFile(join(root, 'profiles', 'personal.yaml'), legacy({ profile: 'personal' }));
+
+    await migrateToContract3(root, { apply: true });
+
+    expect((await readYaml(root, 'lanes-link.yaml'))['default_workspace']).toBe('cloud');
+  });
+});

--- a/src/cli/contract3.ts
+++ b/src/cli/contract3.ts
@@ -276,6 +276,7 @@ async function rewriteRegistry(root: string): Promise<void> {
   const registry = document.toJSON() as {
     contract?: number;
     targets?: Record<string, { workspace?: string }>;
+    workspaces?: Record<string, unknown>;
   } | null;
 
   const targets = registry?.targets;
@@ -291,7 +292,19 @@ async function rewriteRegistry(root: string): Promise<void> {
       workspaces[name] = workspace === undefined ? rest : { at: workspace, ...rest };
     }
 
-    document.setIn(['workspaces'], workspaces);
+    // **Anything already under `workspaces:` wins over what `targets:` says**,
+    // which is the same rule the 1-to-2 migration states for the same reason: a
+    // workspace part way through this has entries that are already right, and
+    // re-deriving them from a stale block would undo a correction.
+    //
+    // It is not hypothetical here. `editRegistry` used to write `workspaces:`
+    // into a contract-2 file without touching its `targets:`, so a deploy from
+    // an unmigrated laptop left two registries disagreeing — and this
+    // overwrote the newer one with the older, silently reverting a recorded
+    // deployment to whatever the last contract-2 command had written. That
+    // write is fixed at source, and this is what repairs a file already
+    // carrying both.
+    document.setIn(['workspaces'], { ...workspaces, ...(registry?.workspaces ?? {}) });
     document.removeIn(['targets']);
   }
 

--- a/src/cli/contract3.ts
+++ b/src/cli/contract3.ts
@@ -1,5 +1,11 @@
 import { newConnectionsTemplate } from './config-templates.ts';
-import { applyMoves, mergeCredentials, planCredentials, planMoves, type Move } from './contract3-data.ts';
+import { applyMoves, planMoves, type Move } from './contract3-data.ts';
+import {
+  mergeCredentials,
+  planCredentials,
+  refRenames,
+  type CredentialPlan,
+} from './contract3-credentials.ts';
 import { parseDocument } from 'yaml';
 import {
   CONNECTIONS_FILE,
@@ -73,7 +79,17 @@ export interface LegacyProfile {
   readonly connections?: LegacyConnection[];
   readonly policy?: { allow?: unknown[]; deny?: unknown[] };
   readonly oauth_apps?: Record<string, unknown>;
+  /**
+   * Read for `token_ref` alone, and read raw rather than through `authSchema`:
+   * this walks profiles that have not been validated, and a profile that fails
+   * validation for an unrelated reason still has an endpoint token to leave
+   * behind.
+   */
+  readonly auth?: { token_ref?: string };
 }
+
+/** The schema default, and what every profile written by the CLI carries. */
+const DEFAULT_TOKEN_REF = 'profile/token';
 
 /** Whether this workspace still holds anything at contract 2. */
 export async function needsContract3(workspaceRoot: string): Promise<boolean> {
@@ -129,7 +145,14 @@ export async function migrateToContract3(
 
   // Everything that can be computed is computed before the first write, so a
   // refusal leaves the workspace exactly as it was.
-  const credentials = await planCredentials(workspaceRoot, [...legacy.keys()]);
+  const plans: CredentialPlan[] = [...legacy].map(([profile, config]) => ({
+    profile,
+    renames: refRenames(perProfile.get(profile) ?? new Map()),
+    tokenRef:
+      typeof config.auth?.token_ref === 'string' ? config.auth.token_ref : DEFAULT_TOKEN_REF,
+  }));
+
+  const credentials = await planCredentials(workspaceRoot, plans);
   const moves = await planMoves(files, [...legacy.keys()], perProfile);
 
   const changes: string[] = [
@@ -137,8 +160,14 @@ export async function migrateToContract3(
     ...renames.map((rename) => `renamed ${rename.from} to ${rename.to} (${rename.reason})`),
     ...[...legacy.keys()].map((profile) => `profiles/${profile}.yaml: contract 3, grants`),
   ];
-  if (credentials.length > 0) {
-    changes.push(`${layout.credentials()}: ${credentials.length} credential(s) merged`);
+  if (credentials.refs.length > 0) {
+    changes.push(`${layout.credentials()}: ${credentials.refs.length} credential(s) merged`);
+  }
+  if (credentials.tokens.length > 0) {
+    changes.push(
+      `${credentials.tokens.join(', ')}: left behind — one endpoint token per workspace now, ` +
+        'and a fresh one is minted on the next command',
+    );
   }
   if (moves.length > 0) changes.push(`${moves.length} object(s) moved to their connection`);
 
@@ -147,7 +176,7 @@ export async function migrateToContract3(
     profiles: [...legacy.keys()],
     connections: rows.map(keyOf),
     renames,
-    credentials,
+    credentials: credentials.refs,
     moved: moves.map((move) => move.to),
     changes,
     alreadyCurrent: false,
@@ -170,7 +199,7 @@ export async function migrateToContract3(
   // workspace" and there was no way back.
   await rewriteRegistry(workspaceRoot);
   await writeConnections(workspaceRoot, rows, legacy);
-  await mergeCredentials(workspaceRoot, [...legacy.keys()]);
+  await mergeCredentials(workspaceRoot, plans);
 
   // **The bytes move before the profile says they have.**
   //

--- a/src/cli/contract3.ts
+++ b/src/cli/contract3.ts
@@ -3,7 +3,7 @@ import { applyMoves, planMoves, type Move } from './contract3-data.ts';
 import {
   mergeCredentials,
   planCredentials,
-  refRenames,
+  connectionRefs,
   type CredentialPlan,
 } from './contract3-credentials.ts';
 import { parseDocument } from 'yaml';
@@ -11,6 +11,7 @@ import {
   CONNECTIONS_FILE,
   ConfigError,
   DATA_DIR,
+  isRemoteWorkspace,
   WORKSPACE_FILE,
   layout,
   listProfiles,
@@ -147,7 +148,7 @@ export async function migrateToContract3(
   // refusal leaves the workspace exactly as it was.
   const plans: CredentialPlan[] = [...legacy].map(([profile, config]) => ({
     profile,
-    renames: refRenames(perProfile.get(profile) ?? new Map()),
+    renames: connectionRefs(perProfile.get(profile) ?? new Map()),
     tokenRef:
       typeof config.auth?.token_ref === 'string' ? config.auth.token_ref : DEFAULT_TOKEN_REF,
   }));
@@ -304,7 +305,21 @@ async function rewriteRegistry(root: string): Promise<void> {
     // deployment to whatever the last contract-2 command had written. That
     // write is fixed at source, and this is what repairs a file already
     // carrying both.
-    document.setIn(['workspaces'], { ...workspaces, ...(registry?.workspaces ?? {}) });
+    const merged: Record<string, unknown> = { ...workspaces };
+    for (const [name, entry] of Object.entries(registry?.workspaces ?? {})) {
+      const derived = merged[name];
+      // Per field, not per entry. The newer block is what `editRegistry` wrote
+      // when it could not see `targets:`, and `sync` writes only `{ at }` — so
+      // replacing the entry wholesale discarded `primary` (which schema.ts calls
+      // the one question about a deployment that must not be guessed at),
+      // `last_deploy`, and the whole `deploy:` block carrying project and
+      // region. Preserving the record was the entire point of the merge.
+      merged[name] =
+        derived !== null && typeof derived === 'object' && entry !== null && typeof entry === 'object'
+          ? { ...(derived as Record<string, unknown>), ...(entry as Record<string, unknown>) }
+          : entry;
+    }
+    document.setIn(['workspaces'], merged);
     document.removeIn(['targets']);
   }
 
@@ -327,9 +342,20 @@ async function rewriteRegistry(root: string): Promise<void> {
   // A pointer carries `at:`; a workspace declaring its own adapters does not.
   if (document.getIn(['default_workspace']) === undefined) {
     const names = Object.keys(workspaces);
-    const here = names.find(
-      (name) => (workspaces[name] as { at?: unknown } | undefined)?.at === undefined,
-    );
+    const here = names.find((name) => {
+      const entry = workspaces[name] as
+        | { at?: unknown; storage?: { adapter?: unknown } }
+        | undefined;
+      // A pointer is here when it points at a path rather than a bucket:
+      // `resolveTargetWorkspace` follows a local one just as happily.
+      if (typeof entry?.at === 'string') return !isRemoteWorkspace(entry.at);
+      // Otherwise it declares its own adapters, and only a filesystem one is on
+      // this machine. Reading "no `at:`" as "local" missed that a cloud target
+      // surveyed by `bootstrap` but never rolled out is a *declaration* — so a
+      // deploy that failed at build or IAM left the same 403 default this was
+      // written to prevent.
+      return entry?.storage?.adapter === 'filesystem';
+    });
     const chosen = here ?? names[0];
     if (chosen !== undefined) document.setIn(['default_workspace'], chosen);
   }

--- a/src/cli/contract3.ts
+++ b/src/cli/contract3.ts
@@ -299,12 +299,26 @@ async function rewriteRegistry(root: string): Promise<void> {
   const workspaces = (document.toJSON() as { workspaces?: Record<string, unknown> } | null)
     ?.workspaces ?? {};
 
-  // The first workspace in the registry, which for every workspace this
-  // migration will ever see is `local`. Written rather than left absent so the
-  // sticky default is on from the first command after upgrading (ADR-061).
+  // The workspace on this machine, and only the *first* one when there is no
+  // such thing. Written rather than left absent so the sticky default is on
+  // from the first command after upgrading (ADR-061).
+  //
+  // This used to take the first key outright, on the stated grounds that "for
+  // every workspace this migration will ever see" that is `local`. It is not:
+  // the registry is written sorted, so a workspace that had ever deployed came
+  // out of the 1-to-2 migration with `cloud` ahead of `local`. Upgrading then
+  // pointed every subsequent command at a bucket — which is the one kind of
+  // workspace that can be unreachable, and was: the next `status` answered with
+  // a 403 from GCS rather than with the profiles sitting on the disk.
+  //
+  // A pointer carries `at:`; a workspace declaring its own adapters does not.
   if (document.getIn(['default_workspace']) === undefined) {
-    const first = Object.keys(workspaces)[0];
-    if (first !== undefined) document.setIn(['default_workspace'], first);
+    const names = Object.keys(workspaces);
+    const here = names.find(
+      (name) => (workspaces[name] as { at?: unknown } | undefined)?.at === undefined,
+    );
+    const chosen = here ?? names[0];
+    if (chosen !== undefined) document.setIn(['default_workspace'], chosen);
   }
 
   await document.save();

--- a/src/cli/contract3.ts
+++ b/src/cli/contract3.ts
@@ -222,7 +222,25 @@ export async function migrateToContract3(
   return result;
 }
 
-/** The hoisted rows, plus every profile's `oauth_apps` merged into one block. */
+/**
+ * The hoisted rows, plus every profile's `oauth_apps` merged into one block.
+ *
+ * **Anything already in the file survives**, which is the rule `writeRegistry`
+ * states for the same reason: a workspace part way through this has entries that
+ * are already right, and re-deriving them from what is left would undo a
+ * correction.
+ *
+ * Not a tidiness argument here. `rewriteProfiles` stamps profiles one at a time
+ * and `legacy` holds only those still at contract 2, so an interruption part way
+ * through it left a rerun hoisting a *subset* — and this overwrote the file with
+ * it, deleting the already-migrated profiles' rows. Their grants named those
+ * connections still. In the shape that actually bites, two profiles held
+ * `gmail.main` for different mailboxes and were hoisted to `gmail.main` and
+ * `gmail.main_2`; the rerun rebuilt the file from the second profile alone, so
+ * `gmail.main` came back naming the *other* person's mailbox and the first
+ * profile's surviving grant pointed at it. Nothing errored, and
+ * `loadProfileConfig` returned ok.
+ */
 async function writeConnections(
   root: string,
   rows: readonly LegacyConnection[],
@@ -231,9 +249,25 @@ async function writeConnections(
   const apps: Record<string, unknown> = {};
   for (const config of legacy.values()) Object.assign(apps, config.oauth_apps ?? {});
 
+  const held = await readWorkspaceFile(workspaceFiles(root), CONNECTIONS_FILE);
+  const current = held === null ? null : ConfigDocument.fromText(held, CONNECTIONS_FILE);
+  const previous = ((current?.toJSON() as { connections?: unknown } | null)?.connections ??
+    []) as LegacyConnection[];
+
+  const merged = new Map<string, LegacyConnection>();
+  for (const row of rows) merged.set(keyOf(row), row);
+  // Second, so a row this run re-derived does not displace the one already
+  // written for it.
+  for (const row of previous) {
+    if (typeof row?.provider === 'string' && typeof row?.id === 'string') merged.set(keyOf(row), row);
+  }
+
   const document = ConfigDocument.fromText(newConnectionsTemplate(), CONNECTIONS_FILE);
-  document.setIn(['connections'], rows);
-  document.setIn(['oauth_apps'], apps);
+  document.setIn(['connections'], [...merged.values()]);
+  document.setIn(['oauth_apps'], {
+    ...((current?.toJSON() as { oauth_apps?: Record<string, unknown> } | null)?.oauth_apps ?? {}),
+    ...apps,
+  });
 
   await writeWorkspaceFile(workspaceFiles(root), CONNECTIONS_FILE, document.toString());
 }

--- a/src/deployments/deploy.test.ts
+++ b/src/deployments/deploy.test.ts
@@ -11,7 +11,7 @@ import {
   publishWorkspace,
   uploadWorkspace,
 } from './upload.ts';
-import { repairOwnerLayer } from '#cli/config-repair.ts';
+import { repairOwnerLayer } from '#cli/config-repair-sweep.ts';
 import { layout, parseConfig, workspaceFiles } from '#profile';
 
 const roots: string[] = [];

--- a/src/deployments/deploy.ts
+++ b/src/deployments/deploy.ts
@@ -14,7 +14,7 @@ import { recordDeployment, type DeploymentRecord } from './record.ts';
 import { printSteps, runSteps } from './steps.ts';
 import { driverFor } from './drivers.ts';
 import { prepareSecrets, readableRefs, rotatableRefs } from './prepare.ts';
-import { repairOwnerLayer } from '#cli/config-repair.ts';
+import { repairOwnerLayer } from '#cli/config-repair-sweep.ts';
 import { migrateToCurrentContract } from '#cli/workspace-migrate.ts';
 import { deployedWorkspace, uploadWorkspace } from './upload.ts';
 import { servingProfiles } from './serving.ts';

--- a/src/profile/deployments.test.ts
+++ b/src/profile/deployments.test.ts
@@ -142,3 +142,62 @@ describe('recording where a target lives', () => {
     await expect(recordTarget(root, 'brand_new', { primary: 'personal' })).rejects.toThrow();
   });
 });
+
+describe('a registry that is still at contract 2', () => {
+  const contract2 = [
+    'contract: 2',
+    'default_profile: personal',
+    'targets:',
+    '  cloud:',
+    '    workspace: gs://your-bucket',
+    '    primary: personal',
+    '    last_deploy_version: 0.7.2',
+    '  local:',
+    '    credentials: { adapter: file }',
+    '    storage: { adapter: filesystem }',
+    '',
+  ].join('\n');
+
+  test('is updated in place, rather than growing a second registry beside it', async () => {
+    // `deploy` migrates the *target* workspace, never the local one — so
+    // deploying to a bucket from a laptop that has not run `update` yet lands
+    // here with a contract-2 file. This read and wrote `workspaces:`
+    // unconditionally, found no registry under it, and wrote a second block
+    // beside the first. `workspaceSchema` has no `targets` key and zod strips
+    // what it does not declare, so the hybrid validated and landed.
+    const root = await workspace(contract2);
+
+    await recordTarget(root, 'cloud', {
+      at: 'gs://your-bucket',
+      primary: 'personal',
+      last_deploy_version: '0.8.0',
+    });
+
+    const text = await readFile(join(root, 'lanes-link.yaml'), 'utf8');
+    expect(text).not.toContain('workspaces:');
+    expect(text).toContain('last_deploy_version: 0.8.0');
+    expect(text).not.toContain('0.7.2');
+  });
+
+  test('keeps the spelling its own contract uses for a pointer', async () => {
+    // Contract 2 spells it `workspace:`; `at:` arrived with contract 3. Writing
+    // the new spelling into the old block would leave a pointer that contract's
+    // own schema does not recognise.
+    const root = await workspace(contract2);
+
+    await recordTarget(root, 'cloud', { at: 'gs://your-bucket', primary: 'personal' });
+
+    const text = await readFile(join(root, 'lanes-link.yaml'), 'utf8');
+    expect(text).toContain('workspace: gs://your-bucket');
+    expect(text).not.toContain('at: gs://your-bucket');
+  });
+
+  test('carries forward a field the caller did not mention', async () => {
+    // The merge `recordTarget` promises, on the legacy path too.
+    const root = await workspace(contract2);
+
+    await recordTarget(root, 'cloud', { at: 'gs://your-bucket', last_deploy: 'now' });
+
+    expect(await readFile(join(root, 'lanes-link.yaml'), 'utf8')).toContain('primary: personal');
+  });
+});

--- a/src/profile/deployments.ts
+++ b/src/profile/deployments.ts
@@ -78,12 +78,36 @@ async function editRegistry(
     (await readWorkspaceFile(files, WORKSPACE_FILE)) ?? `contract: ${SUPPORTED_CONTRACT}\n`;
 
   const document = parseDocument(text);
-  const targets = (document.toJSON()?.workspaces ?? {}) as Record<string, WorkspaceTarget>;
+  const raw = (document.toJSON() ?? {}) as {
+    workspaces?: Record<string, WorkspaceTarget>;
+    targets?: Record<string, LegacyTargetEntry>;
+  };
+
+  // **Whichever block this file already keeps its registry in.**
+  //
+  // This read and wrote `workspaces:` unconditionally. A contract-2 file keeps
+  // it under `targets:`, so recording a deploy into one found no registry,
+  // added the entry to an empty object, and wrote a *second* block beside the
+  // first. `workspaceSchema` has no `targets` key and zod strips what it does
+  // not declare, so the hybrid validated and landed.
+  //
+  // That is reachable from an ordinary command: `deploy` migrates the target
+  // workspace, never the local one, so deploying to a bucket from a laptop that
+  // has not run `update` yet does exactly this. The result is a file whose two
+  // registries disagree — and `rewriteRegistry` then rebuilds `workspaces:`
+  // from the stale `targets:`, discarding the newer record without a word.
+  //
+  // Writing into the block the file already has keeps it coherent at whatever
+  // contract it is, and leaves converting the two to the migration that owns
+  // that job.
+  const legacy = raw.workspaces === undefined && raw.targets !== undefined;
+  const block = legacy ? 'targets' : 'workspaces';
+  const targets = legacy ? current(raw.targets ?? {}) : (raw.workspaces ?? {});
 
   edit(targets);
 
-  if (Object.keys(targets).length === 0) document.deleteIn(['workspaces']);
-  else document.setIn(['workspaces'], sorted(targets));
+  if (Object.keys(targets).length === 0) document.deleteIn([block]);
+  else document.setIn([block], sorted(legacy ? asLegacy(targets) : targets));
 
   // Validated before it lands, on the rendered tree rather than the input, so
   // what is checked is what would be read back.
@@ -92,6 +116,35 @@ async function editRegistry(
   await writeWorkspaceFile(files, WORKSPACE_FILE, String(document));
 }
 
-function sorted(targets: Record<string, WorkspaceTarget>): Record<string, WorkspaceTarget> {
+function sorted<T>(targets: Record<string, T>): Record<string, T> {
   return Object.fromEntries(Object.entries(targets).sort(([a], [b]) => a.localeCompare(b)));
+}
+
+/**
+ * A contract-2 entry spelled a pointer `workspace:`; contract 3 spells it `at:`.
+ *
+ * Normalised on the way in and back on the way out, so `edit` and `pick` see one
+ * shape and never have to ask which contract they are looking at — and so a
+ * legacy file keeps the spelling its own schema expects.
+ */
+interface LegacyTargetEntry extends Omit<WorkspaceTarget, 'at'> {
+  workspace?: string;
+}
+
+function current(targets: Record<string, LegacyTargetEntry>): Record<string, WorkspaceTarget> {
+  return Object.fromEntries(
+    Object.entries(targets).map(([name, entry]) => {
+      const { workspace, ...rest } = entry;
+      return [name, workspace === undefined ? rest : { at: workspace, ...rest }];
+    }),
+  );
+}
+
+function asLegacy(targets: Record<string, WorkspaceTarget>): Record<string, LegacyTargetEntry> {
+  return Object.fromEntries(
+    Object.entries(targets).map(([name, entry]) => {
+      const { at, ...rest } = entry;
+      return [name, at === undefined ? rest : { workspace: at, ...rest }];
+    }),
+  );
 }

--- a/src/profile/deployments.ts
+++ b/src/profile/deployments.ts
@@ -1,6 +1,11 @@
 import { parseDocument } from 'yaml';
 import { readWorkspaceFile, workspaceFiles, writeWorkspaceFile } from './files.ts';
-import { SUPPORTED_CONTRACT, workspaceSchema, type WorkspaceTarget } from './schema.ts';
+import {
+  SUPPORTED_CONTRACT,
+  workspaceSchema,
+  workspaceTargetSchema,
+  type WorkspaceTarget,
+} from './schema.ts';
 import { WORKSPACE_FILE } from './workspace.ts';
 
 /**
@@ -111,7 +116,15 @@ async function editRegistry(
 
   // Validated before it lands, on the rendered tree rather than the input, so
   // what is checked is what would be read back.
-  workspaceSchema.parse(document.toJSON());
+  //
+  // `workspaceSchema` declares no `targets` key and zod strips what it does not
+  // declare, so on the legacy branch parsing the whole document checks nothing
+  // at all — an entry that is neither pointer nor declaration, or one trying to
+  // be both, landed silently and only surfaced weeks later when the migration
+  // converted it and refused. The entries are checked directly there, in the
+  // contract-3 shape `current` normalised them to.
+  if (legacy) for (const entry of Object.values(targets)) workspaceTargetSchema.parse(entry);
+  else workspaceSchema.parse(document.toJSON());
 
   await writeWorkspaceFile(files, WORKSPACE_FILE, String(document));
 }

--- a/src/stores/state/index.ts
+++ b/src/stores/state/index.ts
@@ -26,6 +26,11 @@
 import type { BlobStore } from '../blobs/index.ts';
 import { keyFromEntry, namespacePrefix, objectKey } from './keys.ts';
 
+// Re-exported because the contract-3 migration has to address objects this
+// module wrote, and deriving `connections%2Ev1/gmail%2Emain.json` by hand at the
+// call site is the second spelling of an encoding that must not have two.
+export { decodeSegment, encodeSegment, objectKey } from './keys.ts';
+
 export type ConnectionStatus =
   | 'active'
   /** Declared, but its credential is missing or rejected. Does not block startup. */
@@ -94,7 +99,7 @@ export interface RuntimeState {
  * contain. The same rule keeps `audit.log` and `state.kv` out of reach in
  * `#profile`'s layout.
  */
-const CONNECTIONS = 'connections.v1';
+export const CONNECTIONS_NAMESPACE = 'connections.v1';
 const CURSORS = 'cursors.v1';
 
 export function createRuntimeState(
@@ -104,7 +109,7 @@ export function createRuntimeState(
   const kv = createKeyValue(blobs);
 
   const readConnection = async (provider: string, id: string): Promise<ConnectionRecord | null> =>
-    decodeConnection(await kv.get(CONNECTIONS, connectionKey(provider, id)));
+    decodeConnection(await kv.get(CONNECTIONS_NAMESPACE, connectionKey(provider, id)));
 
   const connections: ConnectionRepository = {
     async upsert(record) {
@@ -116,7 +121,7 @@ export function createRuntimeState(
         createdAt: existing?.createdAt ?? now(),
         updatedAt: now(),
       };
-      await kv.set(CONNECTIONS, connectionKey(record.provider, record.id), encodeConnection(stored));
+      await kv.set(CONNECTIONS_NAMESPACE, connectionKey(record.provider, record.id), encodeConnection(stored));
       return stored;
     },
 
@@ -124,8 +129,8 @@ export function createRuntimeState(
 
     async list() {
       const records: ConnectionRecord[] = [];
-      for (const key of await kv.keys(CONNECTIONS)) {
-        const record = decodeConnection(await kv.get(CONNECTIONS, key));
+      for (const key of await kv.keys(CONNECTIONS_NAMESPACE)) {
+        const record = decodeConnection(await kv.get(CONNECTIONS_NAMESPACE, key));
         if (record) records.push(record);
       }
       return records.sort(
@@ -137,7 +142,7 @@ export function createRuntimeState(
       const existing = await readConnection(provider, id);
       if (!existing) return;
       await kv.set(
-        CONNECTIONS,
+        CONNECTIONS_NAMESPACE,
         connectionKey(provider, id),
         encodeConnection({ ...existing, status, updatedAt: now() }),
       );


### PR DESCRIPTION
Upgrading to 0.8.0 on a workspace with three profiles refused with

```
could not migrate this workspace: Two objects want to be at
data/state.kv/connections%2Ev1/assets%2Emain.json, and this migration cannot merge them.
  This should be unreachable: the hoist gives every profile its own instance of each
  owner-layer surface. Please report it with the layout of your data directory.
```

followed by three `could not give <profile> its owner layer: existing.add is not a
function` warnings. It was not unreachable. Seven defects stood between a
multi-profile workspace and contract 3, and fixing each one exposed the next —
the last two were found by running the migration end to end against a real
workspace rather than by reading.

Every one of them needs **two or more profiles in one workspace**, which is why a
deployed bucket sailed through: it holds the profiles of one deploy, and
`isRemoteWorkspace` skips the credential merge there outright.

### 1. `planMoves` moved `state.kv` verbatim

Justified in a comment by "their contents already carry the profile in every
record". True of `audit.log`, whose objects are one per event. Not true of
`connections.v1`, which is keyed on `<provider>.<id>` — exactly what
`hoistConnections` renames. Every contract-2 profile carried the same owner layer
from a fixed table, so three profiles aimed three objects at
`connections.v1/vault.main`.

The collision was the symptom; the records were never remapped at all.
`ConnectionRepository.list` reads `provider` and `id` out of the record *body*, so
a verbatim copy would have sat at `connections.v1/vault.work` still calling itself
`vault.main`, and the next `upsert` would have written a second record beside it.

`Move` now carries an optional rewrite, applied before the write **and** before the
same-bytes comparison, so an interrupted move is still finished rather than
refused. A record for a connection the profile no longer declares is left where it
is — it was orphaned under contract 2 already. `discovery` is a provider-keyed
cache, so the first profile's entry wins.

### 2. A rename did not carry its credential ref

`credentialRefForConnection` derives `<provider>/<id>`; `hoistConnections` renames
with `{ ...connection, id }`. So a profile whose `github.main` became
`github.main_2` still claimed `github/main`, and the migration aborted on a rename
it had just made itself. Refs now follow the rename.

The endpoint token is left behind rather than picked between: every profile keeps
it under one ref because the schema defaults `token_ref` to `profile/token`, one
store means three values for one key, and it is minted locally — so
`ensureProfileToken` writes a fresh one on the next command and nothing has to be
authorised again.

### 3. That refusal arrived after the first write

It threw from `mergeCredentials`, by which point `rewriteRegistry` had stamped the
workspace at contract 3 — half-migrated, behind a message reading "Nothing has been
written". `planCredentials` collected the union of ref *names* and never compared
values, so the preview could not see it. Both now share one read.

### 4. `ConfigDocument.addTo` created a plain JS array

Not a collection the document API will traverse — the hazard `setIn` documents one
method above. The first append landed and the second threw `existing.add is not a
function`; `#expand` was silently a no-op for the same reason. Latent while every
path it was called with already existed, and `grants:` is genuinely absent on a
profile being repaired.

`update` also no longer runs `repairOwnerLayer` after a migration that refused: it
writes contract-3 shapes, and doing so on a contract-2 workspace left a stray
`connections.yaml` that everything opening it afterwards read as partly migrated.

### 5. The owner-layer repair read the wrong document

`ensureReservedConnection` picked the first row in `connections.yaml` for the
provider. That was this profile's row under contract 2. Under contract 3 they are
all in one file, so the repair asked whether `personal` granted `memory.main` —
demo's — and set about adding it. `vault` and `skills` are capped at one grant per
profile so the save failed loudly; `memory`, `tasks`, `assets`, `setup` and
`entities` are not, and the profile would silently have been granted another
profile's notes and task list. That is what ADR-059 exists to prevent, arriving
from the repair rather than from the migration.

### 6. Recording a deploy into a contract-2 registry wrote a second one beside it

`editRegistry` read and wrote `workspaces:` unconditionally. A contract-2 file
keeps its registry under `targets:`, so recording a deployment into one found no
registry and wrote a *second* block beside the first. `workspaceSchema` declares
no `targets` key and zod strips what it does not declare, so the hybrid validated
and landed.

Reachable from an ordinary command: `deploy` migrates the *target* workspace and
never the local one, so deploying to a bucket from a laptop that has not run
`update` yet lands here every time. `rewriteRegistry` then rebuilt `workspaces:`
from the stale `targets:` and discarded the newer record without a word — a
deployment that had genuinely happened came back reading as the version before
it, which reads as "that deploy never ran".

Fixed at both ends, because the second is not repaired by the first:
`editRegistry` writes into whichever block the file already has, keeping the
pointer spelling that contract uses (`workspace:` at 2, `at:` since 3); and
`rewriteRegistry` prefers an entry already under `workspaces:` over one
re-derived from `targets:` — the rule the 1-to-2 migration already states for the
same reason.

### 7. The default workspace became a bucket

`rewriteRegistry` took the first key, on the stated grounds that it is always
`local`. The registry is written sorted, so any workspace that had ever deployed
had `cloud` first — and the first `status` after a *successful* migration answered
with a 403 from GCS instead of the profiles on the local disk.

---

`contract3-data.ts` split into `contract3-data.ts` and `contract3-credentials.ts`
on the seam it already had — objects move, credentials merge, and the two obey
different rules — because the fix took it past the file-size budget.

## Tests

`contract3.test.ts` had no `state.kv` coverage at all, which is why this shipped.
20 new tests across `contract3.test.ts`, `config-edit.test.ts` and
`deployments.test.ts`. Each was
confirmed to fail with its fix reverted and pass with it in place.

## Verification

`bun test` 2973 pass / 0 fail, `bun run typecheck` clean.

Rehearsed against a copy of a real three-profile workspace that reproduced the
original failure: migrates clean with no warnings, 39 connections hoisted, all 39
connection records land with bodies matching their keys, 17 credentials merged
with both GitHub accounts keeping their own token, 148 audit objects intact,
`profile/token` correctly absent, and a re-run is byte-for-byte identical.

---

## Review pass

A max-effort review of the four commits above found most of its material in the
fixes themselves. Three of them broke workspaces the old code migrated fine, and
all three are now covered by a test that fails without the fix.

- **A merge is not a clash.** Routing refs through the rename made two connections
  the hoist had *just merged* collide. One profile declaring `gmail.main` and
  `gmail.archive` for the same mailbox at different scopes — legal under contract
  2, and the reason tokens are per connection at all — was refused with "Two
  profiles hold different values … personal and personal both hold it". One
  profile, one account, and the prescribed rename could not help. `connectionRefs`
  now carries which connection each ref belongs to. `grantsFor` had the same hole
  and refused the profile it had just written; grants are keyed on the settled
  connection now, rules unioned.
- **The endpoint token is only left behind when the profiles disagree.** The skip
  was unconditional, so a single-profile workspace lost a token with nothing to
  collide with and every client against it got 401s after a routine `update`.
- **A deny could be stepped around.** Reading the first grant row matching the
  provider let a profile granting two instances have the deny on one bypassed
  through the other. Every instance is considered now. `'vaults'.slice(0, -1)` is
  `'vault'`, so a dotless typo was widened too — `startsWith` instead.
- **A rerun could wedge the workspace permanently.** `claim` deleted the winner's
  source and left the loser's, so the next run picked a different claimant, found
  foreign bytes at the destination, and threw — for good. Those moves are marked
  `whenAbsent` and step aside.

Four gaps rather than regressions, all in code these commits had already rewritten:
`state.kv/<provider>/<connection>` was never remapped (`dav`'s home, `bunq`'s
session still collided); one custom manifest in two profiles refused byte-identical
files; `rewriteRegistry` merged per entry not per field, discarding the `primary`
and `deploy:` block it existed to preserve; and a cloud target surveyed but never
rolled out has no `at:`, so the 403 default was still reachable.

One severe finding predating this branch was fixed too, because of what it costs:
`writeConnections` overwrote `connections.yaml` with rows hoisted from only the
profiles still at contract 2. `rewriteProfiles` saves profiles one at a time and
runs last, so an interruption part way through left a rerun rebuilding the file
from a subset — deleting the already-migrated rows while their grants still named
them. Two profiles holding `gmail.main` for different mailboxes hoist to
`gmail.main` and `gmail.main_2`; rebuild from the second alone and `gmail.main`
comes back naming the *other* mailbox, with the first profile's grant pointing at
it. Nothing errors. Anything already in the file survives now — the same rule
`writeRegistry` states, and the third place on this branch that needed it.

Plus: `update` gates the repair on the workspace being current rather than on
nothing having thrown, and the legacy registry branch validates its entries.
`config-repair.ts` split into decision and sweep after the fix took it past the
budget.

`bun test` 2973 pass / 0 fail, typecheck clean. Re-rehearsed against the same
three-profile workspace: byte-identical output to the pre-review run, so the
corrections change nothing for a workspace that was already migrating cleanly.

