### PR TITLE
chore: 0.9.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lanes-sh/link",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "description": "A self-hostable MCP gateway for all your connections, memory, tasks, files, and secrets",
   "license": "Apache-2.0",
   "homepage": "https://lanes.sh/link",


### PR DESCRIPTION
A minor. `lanes-sh/link#135` moves every owner-layer byte into the profile that owns it and renames every connection id, so the first command after the upgrade runs a migration that a downgrade does not undo.

Set on `develop` before the release pull request, deliberately: an untagged version merged into `main` takes the *publish* path and both branches end up on the same tree. A version that already has a tag takes the *propose* path instead, which puts the bump on a side branch merging only into `main` and leaves `develop` a version commit behind.

Verified in the release worktree: `bun test` 3048 pass / 12 skip / 0 fail, `bun run typecheck` clean, both before and after the bump.