### PR TITLE
feat: emerald is the accent, and a new footer tagline

### DIFF
--- a/src/cli/brand.test.ts
+++ b/src/cli/brand.test.ts
@@ -19,7 +19,9 @@ import { completionPage, noticePage } from './callback-page.ts';
 
 const SRC = new URL('.', import.meta.url).pathname;
 
-/** The eight tokens, plus the four tints derived from the two constant accents. */
+/** The eight tokens, plus the six tints. The accent is no longer constant across
+ *  themes: emerald needs a brighter value on the dark ground, so it and its two
+ *  tints appear twice. */
 const DECLARED = [
   '#EBEAE7',
   '#171717',
@@ -28,11 +30,14 @@ const DECLARED = [
   '#E2E1DD',
   '#202329',
   '#A8A29E',
-  '#A1845A',
+  '#059669',
+  '#34D399',
   '#A06060',
   'rgba(120,113,108,0.2)',
-  'rgba(161,132,90,0.1)',
-  'rgba(161,132,90,0.25)',
+  'rgba(5,150,105,0.1)',
+  'rgba(5,150,105,0.25)',
+  'rgba(52,211,153,0.1)',
+  'rgba(52,211,153,0.25)',
   'rgba(160,96,96,0.1)',
   'rgba(160,96,96,0.25)',
 ];
@@ -100,7 +105,7 @@ describe('colour comes from the tokens', () => {
       '--foreground',
       '--muted-foreground',
       '--border',
-      '--accent-gold',
+      '--accent-brand',
       '--destructive',
     ]) {
       expect(brand).toContain(`var(${token})`);
@@ -155,7 +160,7 @@ describe('what a browser actually receives', () => {
     test(`${name} carries the tokens and all three faces`, async () => {
       const body = await response.text();
 
-      expect(body).toContain('--accent-gold: #A1845A');
+      expect(body).toContain('--accent-brand: #059669');
       expect(body).toContain('prefers-color-scheme: dark');
       expect(body).toContain('background: var(--background)');
       // One request, three families: Lora heads, Geist speaks, Geist Mono for

--- a/src/cli/brand.ts
+++ b/src/cli/brand.ts
@@ -13,17 +13,19 @@
  * Values are transcribed from https://lanes.sh/design/foundations. The rules
  * they express, which the CSS below encodes rather than restates:
  *
- * - **Gold is the only accent.** "Gold for positive, neutral tokens otherwise."
- *   That is why there is no green here: a connection that works is `positive`,
- *   which is gold, and everything else is one of two neutrals. `--destructive`
- *   is for errors, not for a state that merely needs attention.
+ * - **Emerald is the only accent.** "Accent for positive, neutral tokens
+ *   otherwise." A connection that works is `positive`, which is the accent, and
+ *   everything else is one of two neutrals. `--destructive` is for errors, not
+ *   for a state that merely needs attention. The accent was gold until emerald
+ *   replaced it site-wide; there is still only one.
  * - **Two weights, 400 and 500.** Nothing else is available in the loaded faces,
  *   so a heavier rule would silently synthesise.
  * - **Lora heads, Geist speaks, Geist Mono for code and eyebrow labels.**
  *
- * `--border`, `--accent-gold` and `--destructive` are constant across themes.
- * Only the five neutrals swap, which is why the dark block below is five lines
- * rather than a second stylesheet.
+ * `--border` and `--destructive` are constant across themes. The five neutrals
+ * swap, and so does `--accent-brand`: the deep emerald goes illegible on the
+ * dark ground, so dark mode takes the brighter value. That is why the dark block
+ * below is six lines rather than a second stylesheet.
  */
 
 /**
@@ -61,7 +63,7 @@ export const FONTS =
 
 /** The one-row footer, identical to the one the Lanes API's own pages carry. */
 export const FOOTER =
-  '<div class="footer"><p>Your unfair advantage in parallel AI coding. ' +
+  '<div class="footer"><p>Run many agents at once. Connect them to your tools once - ' +
   '<a href="https://lanes.sh/">lanes.sh</a></p></div>';
 
 /**
@@ -85,13 +87,13 @@ export const TOKENS = `
   --foreground: #171717;
   --muted-foreground: #202329;
   --border: rgba(120,113,108,0.2);
-  --accent-gold: #A1845A;
+  --accent-brand: #059669;
   --destructive: #A06060;
   /* The two tints the badge variants need. Spelled as rgba rather than
      color-mix because the consent screen opens in whatever browser a phone
      happens to use, and both accents are constant across themes anyway. */
-  --gold-fill: rgba(161,132,90,0.1);
-  --gold-ring: rgba(161,132,90,0.25);
+  --brand-fill: rgba(5,150,105,0.1);
+  --brand-ring: rgba(5,150,105,0.25);
   --destructive-fill: rgba(160,96,96,0.1);
   --destructive-ring: rgba(160,96,96,0.25);
   --sans: "Geist", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
@@ -105,6 +107,9 @@ export const TOKENS = `
     --muted: #202329;
     --foreground: #EBEAE7;
     --muted-foreground: #A8A29E;
+    --accent-brand: #34D399;
+    --brand-fill: rgba(52,211,153,0.1);
+    --brand-ring: rgba(52,211,153,0.25);
   }
 }
 * { box-sizing: border-box; }
@@ -124,21 +129,21 @@ a { color: inherit; }
 /* Surfaces are dashed and 10px; controls are 6px; pills are round. */
 .surface { background: var(--card); border: 1px dashed var(--border); border-radius: 10px; }
 
-/* The four badge variants, as the design system defines them: gold for
+/* The four badge variants, as the design system defines them: the accent for
    positive, neutral tokens otherwise, destructive for an error only. The ring
    is an inset shadow so it costs no layout, exactly as \`ring-inset\` does. */
 .pill { display: inline-flex; align-items: center; flex: none; white-space: nowrap;
         font-size: 11px; font-weight: 500; letter-spacing: 0.02em;
         padding: 2px 8px; border-radius: 999px; box-shadow: inset 0 0 0 1px var(--border); }
-.pill.positive { background: var(--gold-fill); color: var(--accent-gold);
-                 box-shadow: inset 0 0 0 1px var(--gold-ring); }
+.pill.positive { background: var(--brand-fill); color: var(--accent-brand);
+                 box-shadow: inset 0 0 0 1px var(--brand-ring); }
 .pill.neutral { background: var(--muted); color: var(--muted-foreground); }
 .pill.quiet { background: transparent; color: var(--muted-foreground); opacity: 0.7; }
 .pill.negative { background: var(--destructive-fill); color: var(--destructive);
                  box-shadow: inset 0 0 0 1px var(--destructive-ring); }
 
 /* Ghost is the variant every button on these pages is: muted until it is
-   wanted, and never gold, because gold is reserved for saying a thing is good. */
+   wanted, and never the accent, which is reserved for saying a thing is good. */
 .btn { font: inherit; font-size: 12px; font-weight: 500; line-height: 1;
        padding: 6px 9px; border-radius: 6px; cursor: pointer;
        background: transparent; color: var(--muted-foreground);

--- a/src/cli/callback-page.test.ts
+++ b/src/cli/callback-page.test.ts
@@ -90,18 +90,20 @@ describe('light and dark', () => {
     expect(body).not.toContain('#C08080');
   });
 
-  test('the success mark is gold, because gold is the only accent', async () => {
-    // The check used to be emerald, matching the tick the Lanes app puts against
-    // a connected integration. The design system is explicit — "gold for
-    // positive, neutral tokens otherwise" — so the green was the odd one out
-    // rather than the match it was meant to be.
+  test('the success mark carries the accent, because there is only one', async () => {
+    // This went the long way round. The check was emerald to match the tick the
+    // Lanes app puts against a connected integration, was changed to gold
+    // because the design system allowed exactly one accent and gold was it, and
+    // is emerald again now that emerald is that one accent. What is pinned here
+    // is the rule, not the hue: the mark takes the accent token and no colour of
+    // its own, so it moves when the token moves. The old gold must be gone.
     const body = await html(completionPage({ heading: 'Connected', detail: '.', ok: true }));
 
     expect(body).toContain('class="icon"');
-    expect(body).toContain('--accent-gold: #A1845A');
-    expect(body).toContain('.icon { display: block; margin: 0 auto 18px; color: var(--accent-gold); }');
-    expect(body).not.toContain('#059669');
-    expect(body).not.toContain('#34D399');
+    expect(body).toContain('--accent-brand: #059669');
+    expect(body).toContain('.icon { display: block; margin: 0 auto 18px; color: var(--accent-brand); }');
+    expect(body).not.toContain('#A1845A');
+    expect(body).not.toContain('#C2A373');
   });
 
   test('a failure is never marked as a success', async () => {

--- a/src/cli/callback-page.ts
+++ b/src/cli/callback-page.ts
@@ -16,11 +16,12 @@
  *   hardcoded `#0d1117` that read as a black rectangle on a light machine. The
  *   system names a background per mode, so the fix is now to paint the right
  *   one. `color-scheme` stays, for form controls and scrollbars.
- * - **The success mark is gold, not green.** It was lucide's `check` at
- *   `#059669`, chosen to match the tick the Lanes app puts against a connected
- *   integration. The design system is explicit that gold is the only accent and
- *   "gold for positive, neutral tokens otherwise", so the green was the odd one
- *   out rather than the match it was meant to be.
+ * - **The success mark carries the accent.** It is lucide's `check` at
+ *   `--accent-brand`, which matches the tick the Lanes app puts against a
+ *   connected integration. This went the long way round: the mark was `#059669`,
+ *   was changed to gold because the design system allowed one accent and gold
+ *   was it, and is emerald again now that emerald is that one accent. The rule
+ *   never moved, only the colour it points at.
  *
  * What has not changed is that colour is reserved for status and spent nowhere
  * else — not on emphasis, and not on the heading.
@@ -49,14 +50,14 @@ body { display: flex; align-items: center; justify-content: center;
 .label { margin: 0 0 6px; font-size: 15px; font-weight: 500; color: var(--muted-foreground); }
 h1 { margin: 0 0 18px; }
 .detail { margin: 0; font-size: 15px; line-height: 1.6; color: var(--muted-foreground); }
-.icon { display: block; margin: 0 auto 18px; color: var(--accent-gold); }
+.icon { display: block; margin: 0 auto 18px; color: var(--accent-brand); }
 .err h1 { color: var(--destructive); }
 `.trim();
 
 /**
  * The success mark, above the label.
  *
- * lucide's `check`, in `--accent-gold` — which is what "gold for positive"
+ * lucide's `check`, in `--accent-brand` - which is what "accent for positive"
  * means when the positive thing is a connection that now works. It carries no
  * colour of its own; `.icon` sets it, so it follows the token if the token moves.
  *


### PR DESCRIPTION
## What

Two changes to the two modules that render CSS on a served page, `brand.ts` and `callback-page.ts`.

**1. Gold becomes emerald.** Gold (`#A1845A`) was the signature colour across Lanes and is now emerald. This is link's half of a change also landing in [web], [core] and [api].

| Token | Before | After (light) | After (dark) |
|---|---|---|---|
| `--accent-brand` (was `--accent-gold`) | `#A1845A` both | `#059669` | `#34D399` |
| `--brand-fill` (was `--gold-fill`) | `rgba(161,132,90,0.1)` | `rgba(5,150,105,0.1)` | `rgba(52,211,153,0.1)` |
| `--brand-ring` (was `--gold-ring`) | `rgba(161,132,90,0.25)` | `rgba(5,150,105,0.25)` | `rgba(52,211,153,0.25)` |

The accent used to be constant across themes; it no longer is, because the deep emerald goes illegible on the dark ground. That is why the dark block gained three lines.

**2. The footer tagline.** "Your unfair advantage in parallel AI coding." was a claim the reader has to take on trust, on a page whose only job is to confirm something worked. It now reads "Run many agents at once. Connect them to your tools once - lanes.sh", matching api and core.

## The success mark has been round the houses

Worth stating plainly, because the docstrings and tests encoded the old rule:

1. It was `#059669`, matching the tick the Lanes app puts against a connected integration.
2. It was changed to gold, because the design system allowed exactly one accent and gold was it. `brand.ts` said so outright: *"that is why there is no green here"*.
3. It is emerald again, now that emerald **is** that one accent.

The rule never moved, only the colour it points at. There is still exactly one accent. The docstrings in both modules were rewritten to say that rather than the old thing, and the pill comment ("never gold, because gold is reserved…") now reads "never the accent".

## Tests

Nine assertions pinned the old colour, and **two of them actively forbade the new one**:

```
callback-page.test.ts
-   expect(body).not.toContain('#059669');
-   expect(body).not.toContain('#34D399');
+   expect(body).not.toContain('#A1845A');
+   expect(body).not.toContain('#C2A373');
```

Those two inverted. The rest moved to the new token and values, and `DECLARED` in `brand.test.ts` gained the second accent plus its two extra tints, since the accent is no longer one value.

What the test now pins is the **rule, not the hue**: the mark takes the accent token and carries no colour of its own, so it moves when the token moves, and the old gold must be absent.

## Verification

- `bun test` — **3048 pass, 0 fail**, rebased onto current `develop`.
- `grep` for `A1845A` / `161,132,90` / `accent-gold` across `src/` returns nothing (except the deliberate negative assertion).

## Note for the reviewer

The commit on this branch is titled "feat: update ui callback", which undersells it — it was committed mid-session from a shared working tree. Squash-merging with the PR title is probably what you want.

🤖 Generated with [Claude Code](https://claude.com/claude-code)