### PR TITLE
fix: the migration left the registry saying contract 3

### DIFF
--- a/src/cli/config-repair-sweep.test.ts
+++ b/src/cli/config-repair-sweep.test.ts
@@ -1,0 +1,119 @@
+import { SUPPORTED_CONTRACT } from '#profile';
+import { afterAll, describe, expect, test } from 'bun:test';
+import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { parse } from 'yaml';
+import { ensureRegistryContract, repairOwnerLayer } from './config-repair-sweep.ts';
+
+/**
+ * The sweep, against a real workspace on disk.
+ *
+ * `config-edit.test.ts` covers the decision — what one profile is missing — as
+ * a pure function of two documents. This covers what only the sweep can get
+ * wrong: the file it writes, whether a second run is silent, and what it says
+ * when a profile will not open.
+ */
+
+const homes: string[] = [];
+
+const REGISTRY = (contract: number): string =>
+  `contract: ${contract}\nworkspaces:\n  local:\n    credentials: { adapter: file }\n` +
+  '    storage: { adapter: filesystem }\n';
+
+async function workspace(
+  registry: string | null,
+  profile: string | null = null,
+): Promise<string> {
+  const root = await mkdtemp(join(tmpdir(), 'lanes-sweep-'));
+  homes.push(root);
+
+  if (registry !== null) await writeFile(join(root, 'workspaces.yaml'), registry);
+  await writeFile(join(root, 'connections.yaml'), 'contract: 4\nconnections: []\noauth_apps: {}\n');
+
+  if (profile !== null) {
+    await mkdir(join(root, 'profiles', 'personal'), { recursive: true });
+    await writeFile(join(root, 'profiles', 'personal', 'profile.yaml'), profile);
+  }
+
+  return root;
+}
+
+const registryOf = async (root: string): Promise<{ contract?: number }> =>
+  parse(await readFile(join(root, 'workspaces.yaml'), 'utf8')) as { contract?: number };
+
+afterAll(async () => {
+  await Promise.all(homes.map((root) => rm(root, { recursive: true, force: true })));
+});
+
+describe('the registry contract stamp', () => {
+  test('a registry left behind at 3 is brought to the current contract', async () => {
+    // The state 0.9.0's migration produced: `renameRegistry` copies
+    // `lanes-link.yaml` byte for byte, which is what makes an interruption
+    // survivable, and carried the old `contract:` across with everything else.
+    const root = await workspace(REGISTRY(3));
+
+    expect(await ensureRegistryContract(root)).toBe(true);
+    expect((await registryOf(root)).contract).toBe(SUPPORTED_CONTRACT);
+  });
+
+  test('a second run changes nothing and says nothing', async () => {
+    const root = await workspace(REGISTRY(3));
+    await ensureRegistryContract(root);
+
+    expect(await ensureRegistryContract(root)).toBe(false);
+  });
+
+  test('a workspace with no registry is left alone rather than given one', async () => {
+    // A `gs://` root mid-migration, or a directory that is not a workspace at
+    // all. Writing a registry here would invent a workspace declaring nothing.
+    const root = await workspace(null);
+
+    expect(await ensureRegistryContract(root)).toBe(false);
+  });
+
+  test('the stamp is a one-field edit, not a rewrite', async () => {
+    const root = await workspace(REGISTRY(3));
+
+    await ensureRegistryContract(root);
+
+    // Losing this file is losing the address of every target, so the edit has
+    // to go through the document rather than regenerate it.
+    const registry = (await registryOf(root)) as {
+      workspaces?: Record<string, { storage?: { adapter?: string } }>;
+    };
+    expect(registry.workspaces?.['local']?.storage?.adapter).toBe('filesystem');
+  });
+
+  test('the sweep reports the stamp it applied', async () => {
+    const root = await workspace(REGISTRY(3));
+    const said: string[] = [];
+
+    await repairOwnerLayer(root, undefined, { report: (line) => said.push(line) });
+
+    expect(said.join('\n')).toContain('workspaces.yaml');
+    expect(said.join('\n')).toContain(`contract ${SUPPORTED_CONTRACT}`);
+  });
+});
+
+describe('what it says when a profile will not open', () => {
+  test('the warning names the reason, not just the path', async () => {
+    // It was `error.message.split('\n')[0]`, and a `ConfigError` from a schema
+    // failure is `<path>:\n  <field>: <reason>` — so an upgrade printed "could
+    // not give personal its owner layer: /…/personal.yaml:" and named no reason
+    // at all. Seen for real, twice, with nothing after the colon.
+    const root = await workspace(
+      REGISTRY(SUPPORTED_CONTRACT),
+      'contract: 4\ninstance:\n  profile: personal\ngrants:\n' +
+        '  - { connection: 12345, allow: 7 }\nmembers: []\n',
+    );
+    const said: string[] = [];
+
+    await repairOwnerLayer(root, undefined, { report: (line) => said.push(line) });
+
+    const warning = said.find((line) => line.includes('could not give'));
+    expect(warning).toBeDefined();
+    expect(warning).toContain('connection');
+    expect(warning?.trimEnd().endsWith(':')).toBe(false);
+  });
+});

--- a/src/cli/config-repair-sweep.ts
+++ b/src/cli/config-repair-sweep.ts
@@ -1,4 +1,11 @@
-import { CONNECTIONS_FILE, listProfiles, workspaceFiles, writeWorkspaceFile } from '#profile';
+import {
+  CONNECTIONS_FILE,
+  listProfiles,
+  SUPPORTED_CONTRACT,
+  WORKSPACE_FILE,
+  workspaceFiles,
+  writeWorkspaceFile,
+} from '#profile';
 import { newConnectionsTemplate } from './config-templates.ts';
 import { ConfigDocument } from './config-edit.ts';
 import { ok, print, style, warn } from './output.ts';
@@ -13,6 +20,56 @@ import { DEFAULT_SURFACES, ensureOwnerLayer, repairLines, repaired } from './con
  * documents and is tested as one; the sweep is all filesystem, ordering and
  * what to say when a profile will not open.
  */
+
+/**
+ * Stamp the registry with the contract the workspace is actually in.
+ *
+ * `renameRegistry` copies `lanes-link.yaml` to `workspaces.yaml` byte for byte,
+ * which is what makes an interruption survivable — but it carried the old
+ * `contract:` across with everything else, so a migrated workspace sat at 3
+ * while every profile in it said 4, and a workspace `profile add` created said
+ * 4 from the start. Two workspaces at the same contract disagreeing about which
+ * one they are in.
+ *
+ * Cosmetic in most commands, which read the profiles. Not in `isUnmigrated`
+ * (`src/profile/registry.ts`), the one place a registry's own contract is read:
+ * it compares against `SUPPORTED_CONTRACT` to tell a pointer at an out-of-date
+ * bucket from a pointer at the wrong target, so a stale stamp there answers a
+ * question about contract 4 with a refusal naming *contract 1* and sends the
+ * operator to a `deploy` that changes nothing.
+ *
+ * Called from the migration, so its output needs no repair, and from the sweep,
+ * for the workspaces 0.9.0 already migrated. One spelling, for the reason the
+ * template and `ensureOwnerLayer` share one: two would have to agree forever.
+ */
+export async function ensureRegistryContract(workspaceRoot: string): Promise<boolean> {
+  const files = workspaceFiles(workspaceRoot);
+  if (!(await files.has(WORKSPACE_FILE))) return false;
+
+  const document = await ConfigDocument.openKey(workspaceRoot, WORKSPACE_FILE);
+  if (document.getIn(['contract']) === SUPPORTED_CONTRACT) return false;
+
+  document.setIn(['contract'], SUPPORTED_CONTRACT);
+  await document.save();
+  return true;
+}
+
+/**
+ * The first line of an error that actually says something.
+ *
+ * `message.split('\n')[0]` was the whole of this, and a `ConfigError` from a
+ * schema failure is `<path>:\n  <field>: <reason>` — so the warning rendered as
+ * "could not give personal its owner layer: /…/personal.yaml:" and named no
+ * reason at all. Seen for real on an upgrade, twice, with nothing after the
+ * colon.
+ */
+function reasonOf(error: unknown): string {
+  if (!(error instanceof Error)) return String(error);
+
+  const lines = error.message.split('\n').map((line) => line.trim());
+  const said = lines.find((line) => line !== '' && !line.endsWith(':'));
+  return said ?? lines.find((line) => line !== '') ?? error.message;
+}
 
 /** `memory, tasks, assets, skills, vault, setup and entities`, in repair order. */
 function listSurfaces(): string {
@@ -109,11 +166,18 @@ export async function repairOwnerLayer(
     } catch (error) {
       say(
         warn(
-          `could not give ${name} its owner layer: ${error instanceof Error ? error.message.split('\n')[0] : String(error)}`,
+          `could not give ${name} its owner layer: ${reasonOf(error)}`,
         ),
       );
     }
   }
 
   if (connectionsChanged) await connections.save();
+
+  // After the profiles, so a workspace that could not be repaired is not told
+  // it is current. The stamp says what the workspace is; the profiles are what
+  // makes it true.
+  if (await ensureRegistryContract(workspaceRoot)) {
+    say(ok(`stamped ${style.bold(WORKSPACE_FILE)} as contract ${SUPPORTED_CONTRACT}`));
+  }
 }

--- a/src/cli/contract4.test.ts
+++ b/src/cli/contract4.test.ts
@@ -745,3 +745,41 @@ describe('several sources merging onto one owner id', () => {
     expect(await read(root, 'profiles/personal/lanes_memory/lan1/from-main.md')).toBe('MAIN');
   });
 });
+
+/**
+ * The registry's own contract stamp, which the byte-for-byte rename carried
+ * across unchanged.
+ *
+ * Found on the upgrade that shipped 0.9.0: every profile said 4 and the
+ * registry beside them said 3, while a workspace `profile add` created said 4
+ * from the start. `isUnmigrated` is the one place a registry's own contract is
+ * read, and a stale stamp there answers a question about contract 4 with a
+ * refusal naming contract 1.
+ */
+describe('the contract it stamps on the registry', () => {
+  test('the migrated registry says what the profiles say', async () => {
+    const root = await workspace({ personal: ['memory.main'] });
+
+    await migrateToContract4(root, { apply: true });
+
+    const registry = parse(await read(root, 'workspaces.yaml')) as { contract: number };
+    const profile = parse(await read(root, 'profiles/personal/profile.yaml')) as {
+      contract: number;
+    };
+    expect(registry.contract).toBe(SUPPORTED_CONTRACT);
+    expect(registry.contract).toBe(profile.contract);
+  });
+
+  test('and everything else in it is left alone', async () => {
+    const root = await workspace({ personal: ['memory.main'] });
+
+    await migrateToContract4(root, { apply: true });
+
+    // The stamp is a one-field edit, not a rewrite: losing this file is losing
+    // the address of every target.
+    const registry = parse(await read(root, 'workspaces.yaml')) as {
+      workspaces: Record<string, { storage?: { adapter?: string } }>;
+    };
+    expect(registry.workspaces['local']?.storage?.adapter).toBe('filesystem');
+  });
+});

--- a/src/cli/contract4.ts
+++ b/src/cli/contract4.ts
@@ -14,6 +14,7 @@ import { ConfigDocument } from './config-edit.ts';
 import { C3 } from './contract3-layout.ts';
 import { grantingProfiles, planMoves, type DataPlan, type Renames } from './contract4-data.ts';
 import { planRenames } from './contract4-rename.ts';
+import { ensureRegistryContract } from './config-repair-sweep.ts';
 import {
   assertConnectionsSavable,
   readConnectionRows,
@@ -153,6 +154,12 @@ export async function migrateToContract4(
   }
 
   await renameRegistry(workspaceRoot);
+
+  // The registry's own stamp, which the byte-for-byte rename carries across
+  // unchanged. Here rather than inside `renameRegistry` because that function
+  // returns early on a workspace already holding `workspaces.yaml`, which is
+  // exactly the workspace whose stamp is stale.
+  await ensureRegistryContract(workspaceRoot);
   await applyMoves(files, plan.moves);
 
   // Credentials before the rows: a ref is derived from the id, so the rows must


### PR DESCRIPTION
Found verifying the 0.9.0 release on a real workspace: every profile said `contract: 4` and the `workspaces.yaml` beside them said `3`, while a workspace `lanes link profile add` created said `4` from the start.

`renameRegistry` copies `lanes-link.yaml` to `workspaces.yaml` byte for byte — which is what makes an interruption survivable — and carried the old `contract:` across with everything else.

## Why it matters

Cosmetic in most commands, which read the profiles. Not in `isUnmigrated` (`src/profile/registry.ts:172`), the one place a registry's own contract is read: it compares against `SUPPORTED_CONTRACT` to tell *a pointer at an out-of-date bucket* from *a pointer at the wrong target*. A stale stamp there answers a question about contract 4 with a refusal naming **contract 1**, and sends the operator to a `deploy` that changes nothing.

## The fix

One helper, `ensureRegistryContract`, called from two places:

- **the migration**, so its output needs no repair;
- **the repair sweep** `start`, `deploy` and `update` already run, for the workspaces 0.9.0 has already migrated — including any bucket.

One spelling, for the reason the template and `ensureOwnerLayer` share one. Deliberately *not* folded into `renameRegistry`, which returns early on a workspace already holding `workspaces.yaml` — that is exactly the workspace whose stamp is stale. It is a one-field document edit rather than a rewrite: losing this file is losing the address of every target.

## Why no test caught it

`config-edit.test.ts`'s "a fresh profile and workspace need no repair at all" compares **profile** documents only. The registry now has its own parity test: a migrated one must say what the profiles say.

## Also in here

The same upgrade printed this, twice:

```
warn  could not give personal its owner layer: /Users/…/profiles/personal.yaml:
```

The path, a colon, and no reason. The sweep took `error.message.split('\n')[0]`, and a `ConfigError` from a schema failure is `<path>:\n  <field>: <reason>` — so the first line is only ever the path. It now takes the first line that says something, and prints `grants.0.connection: Invalid input: expected string, received number`.

## Verification

`bun test` 3056 pass / 12 skip / 0 fail across 180 files; `bun run typecheck` clean. Each fix confirmed by reintroducing it: dropping the migration's stamp fails the parity test, making the helper a no-op fails three, and restoring `split('\n')[0]` fails the warning test.

Checked against a copy of a real 0.9.0-migrated workspace: the sweep stamps it, reports `stamped workspaces.yaml as contract 4`, and a second run is silent.