### PR TITLE
chore: 0.9.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lanes-sh/link",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "description": "A self-hostable MCP gateway for all your connections, memory, tasks, files, and secrets",
   "license": "Apache-2.0",
   "homepage": "https://lanes.sh/link",


### PR DESCRIPTION
A patch for #139: the migration left `workspaces.yaml` saying `contract: 3` while every profile in it said 4, and the repair sweep's failure warning named a path and no reason.

Set on `develop` before the release pull request: untagged, so the merge to `main` takes the *publish* path and both branches end on the same tree.

`bun test` 3056 pass / 12 skip / 0 fail; `bun run typecheck` clean.