### PR TITLE
fix: the bundled instructions taught the ids 0.9.0 replaced

### DIFF
--- a/instructions/agents/lanes-link-scout.md
+++ b/instructions/agents/lanes-link-scout.md
@@ -38,10 +38,10 @@ then a narrower fragment, before concluding something is not there.
 Tasks are worth the second look rather than an afterthought: an open one is often
 the actual answer to "what do we already know about X", and it carries something
 memory cannot — that the matter is unfinished. Say so when it is, and say which
-status: *blocked since June* is a different answer from *open*. `tasks.list`
+status: *blocked since June* is a different answer from *open*. `lanes_tasks_list`
 hides finished work by default, so ask for `done` when the question is historical.
 
-**Assets are a listing, not a corpus.** `assets.list` tells you a file exists,
+**Assets are a listing, not a corpus.** `lanes_assets_list` tells you a file exists,
 its type and its size; only a text one reads back. Report that a document is
 there and let the main thread decide what to do with it — do not try to get at
 the contents of a binary, and never ask for it as base64.
@@ -67,7 +67,7 @@ to every future session.
 stops a write is policy on the endpoint:
 
 ```console
-$ lanes link policy deny memory.write --connection memory.main --profile <name> --workspace <name>
+$ lanes link policy deny lanes_memory.write --connection lanes_memory.lan1 --profile <name> --workspace <name>
 $ lanes link policy list --profile <name> --workspace <name>
 ```
 

--- a/instructions/skills/lanes-link/SKILL.md
+++ b/instructions/skills/lanes-link/SKILL.md
@@ -43,6 +43,12 @@ workspace*. A profile lives in exactly one, so `personal` on `local` and
 `personal` on `cloud` are two profiles that share a name rather than one profile
 in two places.
 
+**A profile owns its data.** Two profiles granting the same connection — every
+profile grants `lanes_memory.lan1` — still read and write different notes,
+tasks, files and entities, because the profile is part of where they are kept.
+So there is nothing to be found in one by asking another, and a note taken under
+`work` is not available under `personal`.
+
 **What a command must be told is never inferred from a profile — but the
 workspace may have a default.** `lanes set-workspace <name>` writes one, every
 command that uses it echoes the name it resolved, and the commands where being
@@ -74,12 +80,19 @@ disagree with it.
 When you write a command out for the owner, fill in what that command needs or
 leave it as `<name>` for them to complete — never drop a required one.
 
-A `connection` names an account the profile grants. One profile may grant
-several of the same kind and govern each differently, so `gmail.work` may be
-readable where `gmail.personal` is writable. Naming a connection the profile does
-not grant is refused rather than guessed at, and a connection it does not grant
-is absent from the enum entirely: if you cannot see it there, it was not
-withheld by accident.
+A `connection` names an account the profile grants, and it is a **fully
+qualified** `<provider>.<id>` — `lanes_memory.lan1`, not `lan1`. The bare id is
+refused, so take the value out of the enum rather than assembling one.
+
+Ids are opaque: `con1`, `con2` for accounts and `lan1`, `lan2` for Lanes' own
+surfaces. They carry no meaning and are not worth guessing at — the enum prints
+each one's account and label beside it, and that is what tells `con1` from
+`con2`. One profile may grant several of the same kind and govern each
+differently, so `gmail.con1` may be readable where `gmail.con2` is writable.
+
+Naming a connection the profile does not grant is refused rather than guessed
+at, and one it does not grant is absent from the enum entirely: if you cannot
+see it there, it was not withheld by accident.
 
 ## Which store a thing goes in
 
@@ -107,7 +120,7 @@ when Y", that is a skill they should write, not a memory entry describing it.
 
 ## Reach for memory before answering from nothing
 
-`lanes_memory.search` before concluding you do not know something about this person or
+`lanes_memory_search` before concluding you do not know something about this person or
 their work. It is a substring search over their own notes, not a ranked index —
 try more than one wording before deciding it is not there.
 
@@ -118,7 +131,7 @@ entries with `lanes link memory list --profile <name> --workspace <name>` and a 
 
 ## Tasks have a status, so finish them rather than deleting them
 
-`lanes_tasks.list` answers what is outstanding. It shows `in_progress`, `open` and
+`lanes_tasks_list` answers what is outstanding. It shows `in_progress`, `open` and
 `blocked` and hides the rest, so a listing is what is left to do rather than
 everything that ever was — name a status to see more.
 
@@ -133,7 +146,7 @@ Six of them, and the two that are easy to confuse are worth learning:
 | `done` | finished |
 | `dropped` | decided against, which is not the same as finished |
 
-**Closing a task is `lanes_tasks.update` with a status, never `lanes_tasks.remove`.** The
+**Closing a task is `lanes_tasks_update` with a status, never `lanes_tasks_remove`.** The
 record of having done it is the useful half, and it is what stops the same thing
 being suggested again next week. Remove is for something recorded by mistake.
 

--- a/src/cli/commands/mcp/harnesses.test.ts
+++ b/src/cli/commands/mcp/harnesses.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, describe, expect, test } from 'bun:test';
 import { join } from 'node:path';
+import { tokenNote } from './register.ts';
 import { harnessCommands } from './harnesses.ts';
 import { plannedAssets } from './assets.ts';
 
@@ -45,7 +46,7 @@ describe('claude', () => {
     expect(claude.remove('lanes-link')).toEqual(['mcp', 'remove', 'lanes-link']);
   });
 
-  test('it stores the token, so a rotation invalidates the registration', () => {
+  test('it can store a token, which is not the same as having stored one', () => {
     expect(claude.storesToken).toBe(true);
   });
 });
@@ -156,5 +157,32 @@ describe('the documents each harness will take', () => {
     const codex = harnessCommands('codex')!;
 
     expect(plannedAssets(codex, 'local')).toEqual(plannedAssets(codex, 'user'));
+  });
+});
+
+/**
+ * What the operator is told about the token, which is not the same question as
+ * whether the client is able to hold one.
+ */
+describe('the note about the token', () => {
+  const claude = { storesToken: true, label: 'Claude Code' };
+
+  test('says a rotate needs a re-register, when a token was stored', () => {
+    expect(tokenNote(claude, 'llk_secret').join(' ')).toContain('--force');
+  });
+
+  test('says nothing was stored, when the client will sign itself in', () => {
+    // The ordinary path against a deployed endpoint: the bare URL is
+    // registered and the client discovers the protected-resource document.
+    // Keyed on `storesToken` alone, this claimed a token had been stored and
+    // that a rotate meant re-registering — neither of which was true.
+    const said = tokenNote(claude, undefined).join(' ');
+
+    expect(said).toContain('No token was stored');
+    expect(said).not.toContain('--force');
+  });
+
+  test('and says nothing at all for a client that holds no token', () => {
+    expect(tokenNote({ storesToken: false, label: 'Codex' }, undefined)).toEqual([]);
   });
 });

--- a/src/cli/commands/mcp/register.ts
+++ b/src/cli/commands/mcp/register.ts
@@ -45,6 +45,41 @@ export interface McpAddOptions extends GlobalFlags {
   readonly headless?: boolean | undefined;
 }
 
+/**
+ * What to say about the token, which depends on whether one was actually stored.
+ *
+ * **`token`, not `harness.storesToken`.** The harness property says the client
+ * *can* hold a token; whether one was passed is a different question, and only
+ * the headless path passes one — the ordinary path registers the bare URL and
+ * lets the client discover the protected-resource document and run the
+ * authorization itself. Keyed on the property, this told an operator who had
+ * just registered against a deployed endpoint that "the token was stored" and
+ * that a rotate meant re-registering, when nothing had been stored and a rotate
+ * would not touch that entry at all.
+ *
+ * A separate function so the decision can be tested without spawning a client
+ * binary, which is the only reason the branch above it cannot be.
+ */
+export function tokenNote(
+  harness: { readonly storesToken: boolean; readonly label: string },
+  token: string | undefined,
+): readonly string[] {
+  if (!harness.storesToken) return [];
+
+  if (token) {
+    return [
+      'The token was stored as a value, not a command, so "lanes link token rotate"',
+      'means running this again with --force.',
+    ];
+  }
+
+  return [
+    `No token was stored: ${harness.label} reads the endpoint's own`,
+    'protected-resource document and signs you in. A "lanes link token rotate"',
+    'does not affect this registration.',
+  ];
+}
+
 export async function mcpAdd(target: string | undefined, options: McpAddOptions): Promise<void> {
   // No harness named: every one that is actually installed. Registering with
   // whatever is present is what someone means by "add my mcp", and naming one
@@ -174,14 +209,7 @@ async function register(
 
   if (!options.noSkill) await installFor(harness, input.scope, {});
 
-  if (harness.storesToken) {
-    print(
-      style.dim(
-        '      The token was stored as a value, not a command, so "lanes link token rotate"\n' +
-          '      means running this again with --force.',
-      ),
-    );
-  }
+  for (const line of tokenNote(harness, input.token)) print(style.dim(`      ${line}`));
 
   const after = harness.afterAdd?.(input);
   if (after) {

--- a/src/cli/instructions.test.ts
+++ b/src/cli/instructions.test.ts
@@ -3,6 +3,7 @@ import type { Flags } from './argv.ts';
 import { ASSETS, readAsset } from './commands/mcp/assets.ts';
 import { assertKnownFlags, requirementFor, selectionKey } from './selection.ts';
 import { PROGRAM, USAGE } from './usage.ts';
+import { RESERVED_PROVIDER_IDS } from '#connectivity/manifest/provider.ts';
 
 /**
  * The documents we install into someone's agent must describe this CLI.
@@ -288,3 +289,75 @@ describe('the skill covers the lifecycle, not only the calls', () => {
     expect(wanted.filter((command) => !named.has(command))).toEqual([]);
   });
 });
+
+/**
+ * The values in an example, not just the command and its flags.
+ *
+ * The tests above check that a document names a real command and passes it
+ * flags it accepts. They passed while the scout agent told an agent to run
+ * `policy deny memory.write --connection memory.main` — a real command, real
+ * flags, and two arguments naming a provider that had been renamed to
+ * `lanes_memory` and an id scheme that had become `lan1`. Copy-pasteable and
+ * guaranteed to fail.
+ *
+ * So the refs get checked too: whatever appears after `--connection`, and
+ * whatever is written as an owner-layer capability, has to name a provider that
+ * exists. The next rename fails here rather than shipping.
+ */
+describe.each(ASSETS.map((asset) => [asset.label, asset] as const))(
+  'the refs the bundled %s writes out',
+  (_label, asset) => {
+    const owners = new Set<string>(RESERVED_PROVIDER_IDS);
+
+    test('every --connection value names a provider that exists', async () => {
+      const text = await readAsset(asset);
+      const refs = [...text.matchAll(/--connection\s+<?([a-z_]+)>?\.<?([a-z0-9_]+)>?/g)];
+      const bare = new Set([...RESERVED_PROVIDER_IDS].map((id) => id.replace('lanes_', '')));
+
+      // A placeholder is fine — `<provider>.<id>` is how a document tells the
+      // owner to fill one in. Anything named has to be nameable: an owner
+      // surface without its prefix is a provider that no longer exists, and
+      // `main` is the id scheme 0.9.0 replaced with `con1` and `lan1`.
+      const wrong = refs
+        .map((match) => ({ provider: match[1]!, id: match[2]! }))
+        .filter(({ provider }) => provider !== 'provider')
+        .filter(
+          ({ provider, id }) =>
+            bare.has(provider) ||
+            (provider.startsWith('lanes_') && !owners.has(provider)) ||
+            id === 'main',
+        );
+
+      expect(wrong).toEqual([]);
+    });
+
+    test('no owner surface is named without its lanes_ prefix', async () => {
+      const text = await readAsset(asset);
+      const bare = [...RESERVED_PROVIDER_IDS].map((id) => id.replace('lanes_', ''));
+
+      // Backticked only. Unquoted prose ends sentences with these words, and
+      // "then tasks.**" in bold is not a reference to anything — matching it
+      // made this fail on a document that was right.
+      const found = bare.flatMap((surface) => [
+        ...text.matchAll(new RegExp(`\`${surface}\\.[a-z_*]+\``, 'g')),
+      ]);
+
+      expect(found.map((match) => match[0])).toEqual([]);
+    });
+
+    test('an owner tool is named with underscores, not as a capability id', async () => {
+      const text = await readAsset(asset);
+
+      // `lanes_memory.search` is the capability id a policy rule grants; the
+      // tool an agent calls is `lanes_memory_search`. Both are real, and a
+      // document saying "call `lanes_memory.search`" is telling an agent to
+      // call something that is not in its tool list.
+      const verbs = 'search|list|get|write|add|update|remove|store|forget|find|link|overview|provider|put';
+      const dotted = [
+        ...text.matchAll(new RegExp(`\`(${[...owners].join('|')})\\.(${verbs})\``, 'g')),
+      ];
+
+      expect(dotted.map((match) => match[0])).toEqual([]);
+    });
+  },
+);

--- a/src/deployments/adapters/audit-blob.test.ts
+++ b/src/deployments/adapters/audit-blob.test.ts
@@ -150,3 +150,71 @@ describe('audit-blob: the keys it writes', () => {
     expect(report.runs).toBe(1);
   });
 });
+
+/**
+ * What the operating system leaves in the directory, which is not an event.
+ *
+ * `verify` enumerates the whole prefix and fed every non-marker key to the
+ * chain, so a `.DS_Store` that Finder dropped in the audit directory came back
+ * as `malformed run ? at seq -1` and the whole log as **BROKEN** — on a real
+ * workspace, where the file had ridden through two contract migrations. The one
+ * command whose job is to say whether the log was tampered with, crying wolf
+ * because somebody opened the folder.
+ */
+describe('audit-blob: a dotfile in the audit directory', () => {
+  const draft = {
+    profile: 'personal',
+    principal: 'personal:owner',
+    provider: 'gmail',
+    connection: 'gmail.con1',
+    capability: 'gmail.users_messages_list',
+    arguments: {},
+    authorization: 'allowed',
+    status: 'ok',
+    durationMs: 1,
+  } as const;
+
+  const seeded = async (): Promise<ReturnType<typeof createMemoryBlobStore>> => {
+    const storage = createMemoryBlobStore();
+    const sink = createBlobAuditStore({
+      storage,
+      now: () => new Date(Date.UTC(2026, 7, 12, 10, 4, 31, 221)),
+    });
+    await sink.append(draft);
+    await sink.append(draft);
+    return storage;
+  };
+
+  test('does not break the chain', async () => {
+    const storage = await seeded();
+    await storage.put('.DS_Store', new Uint8Array([0, 1, 2, 3]));
+    await storage.put('2026/.DS_Store', new Uint8Array([0, 1, 2, 3]));
+    await storage.put('2026/08/.DS_Store', new Uint8Array([0, 1, 2, 3]));
+
+    const verified = await createBlobAuditStore({ storage }).verify();
+
+    expect(verified.ok).toBe(true);
+    expect(verified.events).toBe(2);
+  });
+
+  test('and is not returned as an event by tail', async () => {
+    const storage = await seeded();
+    await storage.put('2026/.DS_Store', new Uint8Array([0, 1, 2, 3]));
+
+    const tailed = await createBlobAuditStore({
+      storage,
+      now: () => new Date(Date.UTC(2026, 7, 12, 10, 4, 31, 221)),
+    }).tail({ limit: 10 });
+
+    expect(tailed).toHaveLength(2);
+  });
+
+  test('but a real event that will not decode still fails, loudly', async () => {
+    // The rule is "not ours", not "does not look like an event". Reporting ok
+    // for a record it could not read is the one thing verify must never do.
+    const storage = await seeded();
+    await storage.put('2026/08/12/20260812T100431999Z-broken.json', new Uint8Array([9, 9, 9]));
+
+    expect((await createBlobAuditStore({ storage }).verify()).ok).toBe(false);
+  });
+});

--- a/src/deployments/adapters/audit-blob.ts
+++ b/src/deployments/adapters/audit-blob.ts
@@ -59,6 +59,25 @@ const TAIL_YEAR_WINDOW = 10;
 
 const MARKER_PREFIX = 'runs.closed/';
 
+/**
+ * Whether a key is something this store wrote, rather than something the OS did.
+ *
+ * `verify` enumerates the whole prefix and feeds every non-marker key to the
+ * chain, so a `.DS_Store` that Finder dropped in the audit directory arrived as
+ * a record, failed to decode, and was reported as `malformed run ? at seq -1` —
+ * the whole log **BROKEN** because somebody opened the folder. Seen on a real
+ * workspace, where the file had ridden through two contract migrations.
+ *
+ * A dotfile is the narrowest rule that covers it: no key this store writes
+ * begins with a dot, in either segment. Deliberately not "does it look like an
+ * event" — a corrupt event must still fail loudly, because reporting `ok` for a
+ * record it could not read is the one thing `verify` must never do.
+ */
+function isOurs(key: string): boolean {
+  return !key.split('/').some((segment) => segment.startsWith('.'));
+}
+
+
 export interface BlobAuditOptions {
   /** Scoped to the audit root — `data/<profile>/audit.log` or its bucket prefix. */
   readonly storage: BlobStore;
@@ -113,7 +132,7 @@ export function createBlobAuditStore(options: BlobAuditOptions): AuditStore {
       for (let year = start; year >= floor && found.length < limit; year -= 1) {
         const keys = (await storage.list(`${year}/`))
           .map((entry) => entry.key)
-          .filter((key) => !key.startsWith(MARKER_PREFIX))
+          .filter((key) => !key.startsWith(MARKER_PREFIX) && isOurs(key))
           // Keys are compact ISO within a day and the day is in the path, so
           // lexicographic order is chronological — no parsing to sort.
           .sort((a, b) => (a < b ? 1 : a > b ? -1 : 0));
@@ -160,6 +179,8 @@ export function createBlobAuditStore(options: BlobAuditOptions): AuditStore {
       const markers: RunMarker[] = [];
 
       for (const entry of await storage.list('')) {
+        if (!isOurs(entry.key)) continue;
+
         const bytes = await storage.get(entry.key);
         if (bytes === null) continue;
 


### PR DESCRIPTION
Five things, found by pointing a real agent at a real endpoint after the 0.9.0 upgrade.

## The instructions

**The skill named connection ids that no longer exist** — `gmail.work`, `gmail.personal`, when 0.9.0 made ids opaque (`con1`, `con2`) precisely so nothing trusts a descriptive one.

**It never said `connection` takes the fully qualified `<provider>.<id>`.** Passing the bare `lan1` is refused with `expected "lanes_memory.lan1"`. Every agent would hit it; I did.

**It said nothing about a profile owning its data** — the whole of what the release changed.

**It mixed the two spellings of a name.** `lanes_memory.search` and `lanes_tasks.list` read as instructions to call a tool; the tools are `lanes_memory_search` and `lanes_tasks_list`, and the dotted form is the capability id a policy rule grants. The same document used the correct form elsewhere.

**The scout agent shipped a command that could not work:**

```console
$ lanes link policy deny memory.write --connection memory.main --profile <name> --workspace <name>
```

A real command, real flags, and two arguments naming a provider that had been renamed and an id scheme that had been replaced.

### Why the existing test passed

`instructions.test.ts` checked that a document names a real command and passes it flags the command accepts — never the *values*. It checks those now:

- whatever follows `--connection` must name a nameable provider (an owner surface without its `lanes_` prefix, or the literal `main` id, fails);
- an owner surface may not appear backticked without its prefix;
- a tool may not be written as a capability id.

Two of the three catch the scout agent's line. The `--connection` check needed broadening twice before it did — reverting the line passed my first version, which is why each is confirmed by reintroducing the defect.

## Two adjacent one-liners

**`audit verify` reported a whole log BROKEN because of a `.DS_Store`.** It enumerates the prefix and fed every non-marker key to the chain, so a file Finder dropped in the audit directory came back as `malformed run ? at seq -1`. Seen on a real workspace, where it had ridden through two contract migrations — the one command whose job is to say whether the log was tampered with, crying wolf because somebody opened the folder.

Keys whose segments start with a dot are skipped. Deliberately *not* "does it look like an event": a corrupt event still fails loudly, and there is a test for that, because reporting `ok` for a record it could not read is the one thing `verify` must never do.

**`mcp add` said "the token was stored" when nothing was stored.** Keyed on `harness.storesToken` — which says the client *can* hold a token — rather than on whether one was passed, and only the headless path passes one. So an operator registering against a deployed endpoint was told a rotate meant re-registering, when the entry holds no token and a rotate does not touch it. The decision is a function now, testable without spawning a client binary.

## Verification

`bun test` 3068 pass / 12 skip / 0 fail across 180 files; `bun run typecheck` clean. Each of the five confirmed by reintroducing it and watching a named test fail.