### PR TITLE
chore: 0.9.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lanes-sh/link",
-  "version": "0.9.1",
+  "version": "0.9.2",
   "description": "A self-hostable MCP gateway for all your connections, memory, tasks, files, and secrets",
   "license": "Apache-2.0",
   "homepage": "https://lanes.sh/link",


### PR DESCRIPTION
A patch for #142: the bundled skill and scout agent taught connection ids that 0.9.0 replaced, `audit verify` reported a whole log BROKEN because of a `.DS_Store`, and `mcp add` claimed a token had been stored when none was.

Set on `develop` before the release pull request: untagged, so the merge to `main` takes the *publish* path and both branches end on the same tree.

`bun test` 3068 pass / 12 skip / 0 fail; `bun run typecheck` clean.