### PR TITLE
The contract-4 rename: what it cost a registered client, and the annotation it broke

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -104,35 +104,42 @@ selecting it (ADR-043). Everything acting on one account still names both. The t
 `src/cli/selection.ts` is the whole rule, and `selection.test.ts` reads the dispatch files to
 check a new command cannot be added without appearing in it.
 
-## The owner layer is eight ids, and `tasks` is not Google's
+## The owner layer is eight `lanes_` ids, and the prefix reaches the wire
 
-`RESERVED_PROVIDER_IDS` is `memory`, `tasks`, `assets`, `skills`, `vault`, `setup`, `identity`,
-`entities`. Three things an agent gets wrong here:
+`RESERVED_PROVIDER_IDS` is `lanes_memory`, `lanes_tasks`, `lanes_assets`, `lanes_skills`,
+`lanes_vault`, `lanes_setup`, `lanes_identity`, `lanes_entities`. The `lanes_` is part of the id,
+not a display prefix, and `toolNameFor` only swaps `.` for `_` — so the capability
+`lanes_setup.overview` is the tool `lanes_setup_overview`, and renaming these ids in 0.9.0 renamed
+every tool the owner layer advertises. ADR-066 records what that cost a client that had already
+fetched the old list. Three things an agent gets wrong here:
 
-- **`tasks` is the built-in task list; Google Tasks is `google_tasks`.** The rename was forced —
-  `buildRegistry` registers the owner layer before `PROVIDERS`, so a manifest holding a reserved id
-  throws rather than being shadowed (ADR-051). Its redaction keys carry Google's whole operationId
+- **`lanes_tasks` is the built-in task list; Google Tasks is `google_tasks`; plain `tasks` is
+  nobody's.** The rename was forced while the built-in still held the bare id, and it stands:
+  `Registry.register` refuses a reserved id outright unless the registry was built with
+  `allowReserved`, so a manifest can neither claim one nor shadow one
+  (`src/registry/registry.ts:79`, ADR-051). Google Tasks' redaction keys carry its whole operationId
   (`tasks.tasks.patch`) because `shortenName` strips the *provider id* and the API namespaces under
   its own name. A key that misses does not error; it withholds every argument and reads exactly like
   working redaction.
-- **A profile arrives with all of them granted except `identity`** (ADR-050). So there is no
-  `lanes link connect memory` step to suggest, and a surface that is missing was denied on purpose.
+- **A profile arrives with all of them granted except `lanes_identity`** (ADR-050). So there is no
+  `lanes link connect lanes_memory` step to suggest, and a surface that is missing was denied on
+  purpose.
   `ensureOwnerLayer` in `src/cli/config-repair.ts` repairs an older profile from `start`, `connect`
   and `deploy`; the template in `config-edit.ts` and that repair must write a row in **one**
   spelling, which `config-edit.test.ts` checks by asserting a fresh profile needs no repair.
-- **`identity` and `entities` differ on writability and on the default grant, and the reason is one
-  test.** It is not "is it empty" — memory arrives empty and is granted. It is *can it be filled in
-  from here*: identity is configuration and changed in the CLI (ADR-007), so an agent able to edit
-  it could edit the one fact that stops it signing as the wrong person. Everyone else's details
-  accumulate on the same surface that reads them, so `entities` is agent-writable and granted like
-  memory (ADR-056). Do not "fix" the asymmetry.
+- **`lanes_identity` and `lanes_entities` differ on writability and on the default grant, and the
+  reason is one test.** It is not "is it empty" — memory arrives empty and is granted. It is *can it
+  be filled in from here*: identity is configuration and changed in the CLI (ADR-007), so an agent
+  able to edit it could edit the one fact that stops it signing as the wrong person. Everyone else's
+  details accumulate on the same surface that reads them, so `lanes_entities` is agent-writable and
+  granted like memory (ADR-056). Do not "fix" the asymmetry.
 
-`entities.find` returns **every** match and sets no error on more than one, deliberately. If you
-change how it ranks, the rule to keep is that ordering is not selection: there is no scoring inside
-a rank, because a tiebreak that promoted one of two exact alias matches would turn a question for
-the owner into a silent pick. Its derived `_index.json` is a cache stamped with a `key:size`
-fingerprint of the entity files — not `key:size:mtime`, because the GitHub adapter reports the
-branch tip for every file and the stamp would never match twice.
+`lanes_entities.find` returns **every** match and sets no error on more than one, deliberately. If
+you change how it ranks, the rule to keep is that ordering is not selection: there is no scoring
+inside a rank, because a tiebreak that promoted one of two exact alias matches would turn a
+question for the owner into a silent pick. Its derived `_index.json` is a cache stamped with a
+`key:size` fingerprint of the entity files — not `key:size:mtime`, because the GitHub adapter
+reports the branch tip for every file and the stamp would never match twice.
 
 `src/architecture.test.ts` asserts the four rules the layout expresses: dependency
 direction between components, no vendor name in the code a request passes through, a

--- a/docs/detailed/adr/066-a-profile-owns-its-data-again.md
+++ b/docs/detailed/adr/066-a-profile-owns-its-data-again.md
@@ -94,6 +94,23 @@ of notes is not reversible and picking one profile's would take the other's away
 operator is told and deletes what they do not want. That is the only step in the migration that
 is theirs rather than ours, and it exists because the shipped default made the shared case common.
 
+**Every client registered before the migration holds a tool list that no longer resolves.** The
+owner layer's provider ids gained `lanes_`, and `toolNameFor` only swaps `.` for `_`, so renaming
+the provider renamed the tool: `setup_overview` is `lanes_setup_overview` now. The connection ids
+were renumbered alongside them, and those are the `connection` enum on every tool in the list. A
+client that re-reads is unaffected and sees both. A client that cached answers
+`Tool setup_overview not found` for each `lanes_*` tool and has every `connection` value it was
+given refused — while the vendor tools, whose ids did not change, keep their names and fail only on
+that argument. Half the surface working is what makes it read as a broken endpoint rather than a
+stale list, from the only side anybody is looking at.
+
+This is the cost `What is unchanged` below does not cover, and the reason it was missed: no file's
+shape changes at contract 4, so nothing in the migration looks like a wire change. The ids *are*
+the wire. [ADR-032](032-a-stateless-endpoint-does-not-announce-its-tools.md) settles what can be
+done about it — the endpoint declares `listChanged: false` so a client has no reason not to ask, and
+that is the whole of what it can do. `update` prints the one step that is the operator's:
+`lanes link mcp add`.
+
 ## What is unchanged
 
 - **Connections are the workspace's** (ADR-057) — one authorisation per account, one credential

--- a/src/connectivity/manifest/provider.ts
+++ b/src/connectivity/manifest/provider.ts
@@ -109,7 +109,15 @@ export const RESERVED_PROVIDER_IDS: readonly string[] = [
   'lanes_entities',
 ];
 
-/** Old id to new, for the contract-4 migration and for a refusal that names it. */
+/**
+ * Old id to new, for a refusal that can name what a stale client is asking for.
+ *
+ * Nothing consumes it yet. The migration builds its own map from
+ * `C3_OWNER_PROVIDERS` (`src/cli/contract4-rename.ts`), and a `tools/call` on a
+ * pre-0.9.0 name is answered by the SDK's exact-match lookup before anything
+ * here sees it — so the refusal this exists for is still unwritten. ADR-066
+ * records the failure it would address.
+ */
 export const RENAMED_OWNER_PROVIDERS: ReadonlyMap<string, string> = new Map(
   RESERVED_PROVIDER_IDS.map((id) => [id.slice('lanes_'.length), id]),
 );

--- a/src/server/mcp/connection-choice.test.ts
+++ b/src/server/mcp/connection-choice.test.ts
@@ -33,7 +33,7 @@ describe('the connection argument says which account it is', () => {
   test('two ids that differ by a digit carry the addresses that differ by a domain', () => {
     const described = describeWithConnections(
       'Read a message.',
-      new Map([['personal', ['ada_lovelace', 'ada_lovelace2']]]),
+      new Map([['personal', ['gmail.ada_lovelace', 'gmail.ada_lovelace2']]]),
       accountsByProfile(
         options([
           connection('ada_lovelace', 'ada.lovelace@example.com'),
@@ -42,18 +42,31 @@ describe('the connection argument says which account it is', () => {
       ),
     );
 
-    expect(described).toContain('ada_lovelace — ada.lovelace@example.com');
-    expect(described).toContain('ada_lovelace2 — ada.lovelace@example.org');
+    expect(described).toContain('gmail.ada_lovelace — ada.lovelace@example.com');
+    expect(described).toContain('gmail.ada_lovelace2 — ada.lovelace@example.org');
+  });
+
+  test('keyed on the grant ref, which is what the enum carries', () => {
+    // The guard on the bug the tests below hid. `connectionsOf` fills the enum
+    // from the grant rows, so `reachable` holds `gmail.ada_lovelace`; a map keyed
+    // on the bare `connection.id` missed every lookup and no served description
+    // ever showed an account, while these tests passed the bare id by hand and
+    // went green. Both sides read `ref` now, so they cannot drift.
+    const accounts = accountsByProfile(
+      options([connection('ada_lovelace', 'ada.lovelace@example.com')]),
+    );
+
+    expect([...accounts.get('personal')!.keys()]).toEqual(['gmail.ada_lovelace']);
   });
 
   test("the operator's label comes too, where they set one", () => {
     const described = describeWithConnections(
       'Read a message.',
-      new Map([['personal', ['ada_lovelace']]]),
+      new Map([['personal', ['gmail.ada_lovelace']]]),
       accountsByProfile(options([connection('ada_lovelace', 'ada.lovelace@example.com', 'Work')])),
     );
 
-    expect(described).toContain('ada_lovelace — ada.lovelace@example.com (Work)');
+    expect(described).toContain('gmail.ada_lovelace — ada.lovelace@example.com (Work)');
   });
 
   test('grouped by profile, because the two arguments are not independent', () => {

--- a/src/server/mcp/visibility.ts
+++ b/src/server/mcp/visibility.ts
@@ -185,7 +185,14 @@ export function visibleToolCount(options: BuildServerOptions): number {
  * entities: ordering is not selection, and a caller that cannot tell two
  * candidates apart must be given what tells them apart.
  *
- * The enum stays bare ids, because the id is what the caller passes.
+ * **The enum is the qualified ref, and this join does not land.** `reachable`
+ * carries `gmail.con1` — the grant row (ADR-058) — while `accountsByProfile`
+ * keys on the bare `con1`, so `known.get(id)` always misses and the annotation
+ * this block describes never reaches a live tool description.
+ * `connection-choice.test.ts` passes bare ids in by hand, which is why it
+ * passes. Contract 4 made that worse rather than academic: the ids used to
+ * carry the account (`gmail.<local-part>`) and are `con1`, `con2` now, so the
+ * id says nothing and the field meant to say it is switched off.
  */
 export function describeWithConnections(
   description: string,

--- a/src/server/mcp/visibility.ts
+++ b/src/server/mcp/visibility.ts
@@ -185,14 +185,15 @@ export function visibleToolCount(options: BuildServerOptions): number {
  * entities: ordering is not selection, and a caller that cannot tell two
  * candidates apart must be given what tells them apart.
  *
- * **The enum is the qualified ref, and this join does not land.** `reachable`
- * carries `gmail.con1` — the grant row (ADR-058) — while `accountsByProfile`
- * keys on the bare `con1`, so `known.get(id)` always misses and the annotation
- * this block describes never reaches a live tool description.
- * `connection-choice.test.ts` passes bare ids in by hand, which is why it
- * passes. Contract 4 made that worse rather than academic: the ids used to
- * carry the account (`gmail.<local-part>`) and are `con1`, `con2` now, so the
- * id says nothing and the field meant to say it is switched off.
+ * **The key is the grant ref, not the bare id.** `connectionsOf` fills the enum
+ * from the grant rows (ADR-058), so `reachable` carries `gmail.con1`, and
+ * `accountsByProfile` keys on that same `ref` — one string from one source, so
+ * the two sides cannot drift. Keyed on `connection.id` instead it missed every
+ * lookup, and no served description carried an account at all, while
+ * `connection-choice.test.ts` passed bare ids in by hand and stayed green.
+ * Contract 4 is what turned that from cosmetic into a real loss: the ids used to
+ * carry the account and are `con1`, `con2` now, so the id says nothing about
+ * which mailbox it is and this annotation is the only thing that does.
  */
 export function describeWithConnections(
   description: string,
@@ -222,9 +223,9 @@ export function accountsByProfile(
 
   for (const [name, runtime] of options.profiles) {
     const rows = new Map<string, string>();
-    for (const { connection } of runtime.connections ?? []) {
+    for (const { ref, connection } of runtime.connections ?? []) {
       rows.set(
-        connection.id,
+        ref,
         connection.label === undefined
           ? connection.account
           : `${connection.account} (${connection.label})`,


### PR DESCRIPTION
## Why

A deploy of 0.9.1 left a ChatGPT connector unable to call the endpoint while claude.ai kept working against the same URL. Contract 4 (#135) renamed two things that are visible in **every tool schema**, and neither was recorded as a cost:

| | before 0.9.0 | now |
|---|---|---|
| owner-layer provider ids | `setup`, `memory`, `tasks`… | `lanes_setup`, `lanes_memory`, `lanes_tasks`… |
| → so wire tool names | `setup_overview` | `lanes_setup_overview` |
| connection ids | `<provider>.<account-slug>` | `gmail.con1`, `lanes_memory.lan2` |

`toolNameFor` only swaps `.` for `_`, so a provider-id change *is* a tool-name change. The connection ids are the `connection` enum on all 96 tools.

A client that re-reads its list is fine. A client that cached answers `Tool setup_overview not found` for each `lanes_*` tool and has every `connection` value refused — while the vendor tools, whose ids did not change, keep their names and fail only on that argument. Half the surface working is what makes it read as a broken endpoint rather than a stale list. ADR-032 already settles what the endpoint can do about it (declare `listChanged: false`, and no more), and `sayContract4` already prints the operator's step.

Tracing it turned up a second, worse consequence of the same rename, fixed in the third commit.

## Commits

**1 · `docs:` record what the rename costs a registered client.** ADR-066 gains the cost it never stated, including why it was missed — its own "What is unchanged" correctly says no *file's* shape changes at contract 4. The ids are the wire. **CLAUDE.md** still listed `RESERVED_PROVIDER_IDS` as `memory`, `tasks`, `assets`… which is how an agent reading it today writes the wrong id into a tool name; its mechanism was stale too (the guard is an explicit reserved-id check in `Registry.register`, not registration order). The `google_tasks` rename was forced while the built-in held the bare `tasks`; that id is nobody's now and the rename stands. The redaction-key warning about Google's operationIds is kept verbatim.

**2 · `docs:` two comments describing behaviour the code does not have.** `RENAMED_OWNER_PROVIDERS` says it is for "a refusal that names it" — it has no importer, and a stale-name `tools/call` is answered by the SDK's exact-match lookup before this package sees it. The second is the bug commit 3 fixes.

**3 · `fix:` a tool description says which account each connection id is.** `accountsByProfile` keyed on the bare `connection.id` while the enum carries the qualified grant ref, so the join missed every lookup and **no served tool description has ever carried an account**. Both sides read `SelectedConnection.ref` now — one string from one source. Contract 4 made this a real loss rather than a cosmetic one: the ids used to carry the account, so a bare enum still told a caller which mailbox it was choosing; `con1` and `con2` say nothing. A model picking between two mailboxes of one vendor was choosing on the digit alone — the failure `describeWithConnections`' own docstring is about, and ADR-056's rule that a caller which cannot tell two candidates apart must be given what tells them apart.

Three tests in `connection-choice.test.ts` were passing bare ids into `reachable` by hand, which is why they went green against a join that could not land; updating them to the shape `connectionsOf` produces is most of that diff. The added test pins the map key rather than the rendered line, so a revert fails on what was actually wrong.

## Verification

- `bun run typecheck` — clean
- `bun test` — 3049 pass, 12 skip, 0 fail (baseline on this branch was 3048; the new test is the difference)
- All three affected assertions watched failing before the fix and passing after
- `lanes link tools` against the deployed endpoint confirmed the advertised names and `listChanged: false`

Commits 1 and 2 are documentation only. Commit 3 is the one behaviour change and is droppable on its own if you would rather ship the record first.