### PR TITLE
A deploy tells an already-registered client to re-add

### DIFF
--- a/src/deployments/deploy.test.ts
+++ b/src/deployments/deploy.test.ts
@@ -5,6 +5,7 @@ import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { readableRefs, rotatableRefs } from './prepare.ts';
+import { registerLine } from './report.ts';
 import {
   deployedWorkspace,
   isWorkspaceConfig,
@@ -623,3 +624,23 @@ describe('the allowlist against a real workspace listing', () => {
  * a deploy that reports success followed by a service that will not start, and
  * nothing in either points at the profile that caused it.
  */
+
+/**
+ * What a deploy tells an operator whose clients are already registered.
+ *
+ * ADR-032 covers the first deploy: register before the accounts exist and the
+ * client holds a two-tool surface. The case it left unsaid is every deploy after
+ * that one, and 0.9.0 is what made it expensive — renaming the owner layer's
+ * provider ids renamed their tools, so a registered client went on calling
+ * `setup_overview` against an endpoint serving `lanes_setup_overview` and read as
+ * a broken endpoint rather than a stale list. `sayContract4` says it when the
+ * migration runs; a deploy is when it reaches anybody.
+ */
+describe('the deploy report names the re-add', () => {
+  test('an already-registered client is told, and given the command', () => {
+    const line = registerLine('personal', 'cloud');
+
+    expect(line).toContain('registered before this deploy');
+    expect(line).toContain('lanes link mcp add');
+  });
+});

--- a/src/deployments/report.ts
+++ b/src/deployments/report.ts
@@ -22,14 +22,14 @@ import { heading, ok, print, style, warn } from '#cli/output.ts';
  * `tools/list` when it connects and keeps it: this endpoint is stateless, so
  * there is no stream on which to send `notifications/tools/list_changed`, and
  * `buildMcpServer` no longer pretends otherwise. A first deploy necessarily
- * publishes a profile whose only connection is `setup.main` — the accounts come
+ * publishes a profile whose only connection is `lanes_setup.lan1` — the accounts come
  * after — so a connector registered in that window captures a two-tool surface
  * and holds it. The endpoint is right, every reload lands, and the client shows
  * two tools until someone removes and re-adds it.
  *
  * Unconditional, and that is the correction that matters. This was gated on
  * `prepared.warnings.length`, which is zero in precisely the case it describes:
- * a fresh profile declares only `setup.main`, `setup` is a local provider with
+ * a fresh profile declares only `lanes_setup.lan1`, and it is a local provider with
  * no credential, so `prepareSecrets` has nothing to warn about. The advice
  * appeared only on a later re-deploy, by which point the connector is usually
  * registered and the ordering is no longer available to get right.
@@ -39,7 +39,10 @@ export function registerLine(profile: string, target: string): string {
     `  Connect your accounts first, then register with:\n` +
       `    lanes link outputs --profile ${profile} --workspace ${target}\n` +
       '  A client keeps the tool list it fetched when it connected, so one registered\n' +
-      '  before the accounts holds a surface without them until it is re-added.',
+      '  before the accounts holds a surface without them until it is re-added.\n' +
+      '  One registered before this deploy holds the list from before it, so a version\n' +
+      '  that renamed a provider or an id leaves it calling names that are gone:\n' +
+      '    lanes link mcp add',
   );
 }
 


### PR DESCRIPTION
Follow-up to #144, which recorded what the contract-4 rename cost a registered client but left this gap open.

## Why

`registerLine` covers the *first* deploy: register before the accounts exist and the client holds a two-tool surface (ADR-032). It says nothing about every deploy after that one — which is the case 0.9.0 made expensive. Renaming the owner layer's provider ids renamed their tools, so a client registered before the deploy went on calling `setup_overview` at an endpoint serving `lanes_setup_overview`, and read as a broken endpoint rather than a stale list.

`sayContract4` prints this when the migration runs. A deploy is when it reaches anybody, and `update-migration.ts:10-12` says the paths that report migration facts may not disagree about what is worth mentioning.

## What it prints now

```
  Connect your accounts first, then register with:
    lanes link outputs --profile personal --workspace cloud
  A client keeps the tool list it fetched when it connected, so one registered
  before the accounts holds a surface without them until it is re-added.
  One registered before this deploy holds the list from before it, so a version
  that renamed a provider or an id leaves it calling names that are gone:
    lanes link mcp add
```

Two lines and the command, in the block that already exists for it. **Not** gated on a version comparison: `lastDeployVersion` lives in the `status` summary (`src/cli/commands/target.ts:79`) rather than the deploy flow, and threading it through to suppress one dim line is not worth the seam.

`registerLine` had no test at all; there is one now. The docstring's `setup.main` is `lanes_setup.lan1` since contract 4, corrected in passing.

## Verification

- Watched the test fail before the line and pass after
- `bun run typecheck` — clean
- `bun test` — 3070 pass, 12 skip, 0 fail