### PR TITLE
fix: an unnamed connection is called after its provider, not its id

### DIFF
--- a/src/cli/commands/connect/declare.test.ts
+++ b/src/cli/commands/connect/declare.test.ts
@@ -11,6 +11,11 @@ import { declareConnection } from './declare.ts';
  * and are not: one is a name the operator chose and the other is an identity
  * three things read as one. A row that confused them was renameable exactly
  * once, after which `connect` no longer recognised the account it had renamed.
+ *
+ * A label equal to `defaultLabel` is not written. Every reader derives that
+ * string for itself, so recording it would be a line saying what the two lines
+ * above it say — the rule that used to be spelled against the account, back
+ * when the account was what an unnamed row was called.
  */
 
 const EMPTY = `contract: 4
@@ -29,7 +34,10 @@ function declaring(connections: readonly ConnectionConfig[], over: Record<string
     providerId: 'gmail',
     connectionId: 'ada',
     account: 'ada@example.com',
-    label: 'ada@example.com',
+    // What `settleIdentity` settles on when the operator presses Enter, and
+    // what it hands the writer to compare against.
+    label: 'Gmail (ada)',
+    defaultLabel: 'Gmail (ada)',
     method: undefined,
     config: {},
     ...over,
@@ -43,7 +51,7 @@ function declaring(connections: readonly ConnectionConfig[], over: Record<string
 }
 
 describe('declaring a new connection', () => {
-  test('writes no label when the label is only the account again', () => {
+  test('writes no label when it is the one every reader derives anyway', () => {
     const { written } = declaring([]);
 
     expect(written.connections[0]).toEqual({
@@ -53,7 +61,7 @@ describe('declaring a new connection', () => {
     });
   });
 
-  test('writes one when the operator said something the account does not', () => {
+  test('writes one when the operator said something the derived name does not', () => {
     const { written } = declaring([], { label: 'Work mail' });
 
     expect(written.connections[0]).toEqual({

--- a/src/cli/commands/connect/declare.ts
+++ b/src/cli/commands/connect/declare.ts
@@ -22,6 +22,14 @@ export function declareConnection(input: {
   readonly connectionId: string;
   readonly account: string;
   readonly label: string;
+  /**
+   * What the row is called with nobody's word for it, from `settleIdentity`.
+   *
+   * The provider's name and the account composed by `defaultConnectionLabel`,
+   * which is what every reader falls back to. A label equal to it is a line
+   * saying what the two lines above it already say, so it is not written.
+   */
+  readonly defaultLabel: string;
   /** Which route in, where the provider offered a choice. */
   readonly method: string | undefined;
   /**
@@ -34,6 +42,7 @@ export function declareConnection(input: {
   readonly config: Readonly<Record<string, string>>;
 }): readonly string[] {
   const { document, connections, providerId, connectionId, account, label, method } = input;
+  const derived = input.defaultLabel;
   const config = input.config;
 
   const key = `${providerId}.${connectionId}`;
@@ -45,14 +54,14 @@ export function declareConnection(input: {
     // where the OAuth provider already looks. Writing it would add a line per
     // connection that can only ever agree or be a bug.
     //
-    // No `label` either, when it is the account. Pressing Enter at the prompt is
-    // the common answer, and a line repeating the address above it is a line to
-    // read past forever.
+    // No `label` either, when it is the one every reader derives anyway.
+    // Pressing Enter at the prompt is the common answer, and a line repeating
+    // the provider and the address above it is a line to read past forever.
     document.addTo(['connections'], {
       id: connectionId,
       provider: providerId,
       account,
-      ...(label === account ? {} : { label }),
+      ...(label === derived ? {} : { label }),
       ...(Object.keys(config).length > 0 ? { config } : {}),
     });
     changes.push(`connections += ${key} (${account})`);
@@ -69,10 +78,10 @@ export function declareConnection(input: {
     changes.push(`connections.${key}.account = ${account}`);
   }
 
-  // Compared against what the row is *called*, which is the account until
+  // Compared against what the row is *called*, which is the derived name until
   // somebody names it otherwise. Without the fallback, every reconnect of an
-  // unlabelled connection writes a label that says what the line above it says.
-  if ((declared?.label ?? declared?.account) !== label) {
+  // unlabelled connection writes a label that says what the lines above it say.
+  if ((declared?.label ?? derived) !== label) {
     document.setIn(['connections', index, 'label'], label);
     changes.push(`connections.${key}.label = ${label}`);
   }

--- a/src/cli/commands/connect/index.ts
+++ b/src/cli/commands/connect/index.ts
@@ -237,7 +237,7 @@ export async function runConnect(
     //    adding a new one. Without it, a retried connect appends a second row
     //    rather than repairing the first — which is how `main2` and `main3`
     //    ended up in a config describing two mailboxes.
-    const { connectionId, account, label } = await settleIdentity({
+    const settled = await settleIdentity({
       manifest,
       provisionalId,
       explicitId: named,
@@ -246,6 +246,7 @@ export async function runConnect(
       runtime: { ...runtime, connectorFor: address.connectorFor },
       prompter,
     });
+    const { connectionId, account, label } = settled;
 
     const connectionKey = `${providerId}.${connectionId}`;
 
@@ -277,9 +278,8 @@ export async function runConnect(
         document: connectionsDocument,
         connections: runtime.workspaceConnections,
         providerId,
-        connectionId,
-        account,
-        label,
+        // The settled identity as one value: the row, the account, the name.
+        ...settled,
         method: method.id,
         config: address.values,
       }),

--- a/src/cli/commands/connect/settle.test.ts
+++ b/src/cli/commands/connect/settle.test.ts
@@ -118,16 +118,19 @@ const settle = (over: Partial<Parameters<typeof settleIdentity>[0]> = {}) =>
   });
 
 describe('the label a connection is given at connect time', () => {
-  test('is asked for every time, offering the account that was just resolved', async () => {
+  test('is asked for every time, offering the provider and the account', async () => {
     const asking = prompter('');
 
     const settled = await settle({ prompter: asking });
 
     expect(asking.asked).toHaveLength(1);
-    // The account is in the question, so pressing Enter is an informed answer
-    // rather than a blank one.
-    expect(asking.asked[0]).toContain('ada@example.com');
-    expect(settled.label).toBe('ada@example.com');
+    // The suggestion is in the question, so pressing Enter is an informed
+    // answer rather than a blank one. It names the provider as well as the
+    // account, because the account alone was a second copy of the line beside
+    // it and left every reader of an unlabelled row with nothing to show.
+    expect(asking.asked[0]).toContain('Acme Mail (ada)');
+    expect(settled.label).toBe('Acme Mail (ada)');
+    expect(settled.defaultLabel).toBe('Acme Mail (ada)');
   });
 
   test('takes the operator words, and leaves the account they replace alone', async () => {
@@ -156,10 +159,10 @@ describe('the label a connection is given at connect time', () => {
     expect(settled.connectionId).toBe('ada');
   });
 
-  test('falls back to the account where there is nobody to ask', async () => {
+  test('falls back to the derived name where there is nobody to ask', async () => {
     const settled = await settle({ prompter: silent });
 
-    expect(settled.label).toBe('ada@example.com');
+    expect(settled.label).toBe('Acme Mail (ada)');
   });
 
   test('is not asked for when it was given', async () => {
@@ -171,7 +174,7 @@ describe('the label a connection is given at connect time', () => {
     expect(settled.label).toBe('Work mail');
   });
 
-  test('takes the account when the terminal it was promised turns out not to exist', async () => {
+  test('takes the derived name when the terminal it was promised turns out not to exist', async () => {
     // `terminalPrompter` says `interactive: true` and discovers otherwise only
     // when asked. By then the browser has opened and the credential is stored,
     // so throwing over a display name fails a connect that has already happened.
@@ -186,7 +189,7 @@ describe('the label a connection is given at connect time', () => {
 
     const settled = await settle({ prompter: noTerminal });
 
-    expect(settled.label).toBe('ada@example.com');
+    expect(settled.label).toBe('Acme Mail (ada)');
   });
 
   test('lets Ctrl-C stop the command rather than answering for it', async () => {
@@ -215,6 +218,6 @@ describe('the label a connection is given at connect time', () => {
     // confirm it against itself is the second half of a question they answered.
     expect(asking.asked).toHaveLength(1);
     expect(settled.account).toBe('Ada at Acme');
-    expect(settled.label).toBe('Ada at Acme');
+    expect(settled.label).toBe('Acme Mail (Ada at Acme)');
   });
 });

--- a/src/cli/commands/connect/settle.ts
+++ b/src/cli/commands/connect/settle.ts
@@ -1,6 +1,7 @@
 import { createMcpConnector } from '#connectivity/transports';
 import { bearerTokenAsStored } from '#connectivity/auth/index.ts';
 import type { SecretStore } from '#secrets';
+import { defaultConnectionLabel } from '#profile';
 import type { ConnectionConfig, Config } from '#profile';
 import type { AnyConnector, ProviderManifest } from '#connectivity';
 import { nextConnectionId, resolveAccount } from '../../identity.ts';
@@ -46,7 +47,21 @@ export async function settleIdentity(input: {
     authorizeRequest(providerId: string, connectionId: string, request: Request): Promise<Request>;
   };
   prompter?: Prompter;
-}): Promise<{ connectionId: string; account: string; label: string }> {
+}): Promise<{
+  connectionId: string;
+  account: string;
+  label: string;
+  /**
+   * What this row is called with nobody's word for it, carried to the writer.
+   *
+   * `declareConnection` writes no label equal to it, for the reason it never
+   * wrote one equal to the account: a line saying what the two lines above it
+   * say is a line to read past forever. Returned rather than derived twice, so
+   * the string the operator was offered and the string compared against it
+   * cannot come apart.
+   */
+  defaultLabel: string;
+}> {
   const { manifest, provisionalId, explicitId, runtime } = input;
   const prompter = input.prompter ?? terminalPrompter;
 
@@ -169,17 +184,20 @@ export async function settleIdentity(input: {
           (candidate) => candidate.account.toLowerCase() === account!.toLowerCase(),
         )?.id ?? nextConnectionId(taken, false)));
 
+  const defaultLabel = defaultConnectionLabel(manifest.name, account);
+
   return {
     connectionId,
     account,
+    defaultLabel,
     label: await settleLabel({
       given: input.label,
+      fallback: defaultLabel,
       // What the row this is about to land on is already called. Looked up
       // across the whole vendor account rather than this provider alone, for the
       // reason `accountSiblings` exists: `connect icloud_calendar` adopts iCloud
       // Mail's id, and should adopt the name that goes with it too.
       declared: siblings.find((candidate) => candidate.id === connectionId)?.label,
-      account,
       typed,
       prompter,
     }),
@@ -198,21 +216,29 @@ export async function settleIdentity(input: {
  * The suggestion is in the question and an empty answer takes it, so the cost of
  * always asking is one keystroke. Nothing addresses a connection by its label,
  * so there is no answer here that can break anything.
+ *
+ * **The suggestion is the provider and the account, not the account.** It was
+ * the address alone, which made the label a second copy of the field beside it
+ * — and left every surface that shows a name without one, because a default
+ * that only repeats another line is a default nothing writes down.
+ * `defaultConnectionLabel` is the whole rule and every reader derives the same
+ * string from it.
  */
 async function settleLabel(input: {
   given: string | undefined;
   declared: string | undefined;
-  account: string;
+  /** What this row is called when nobody says otherwise. */
+  fallback: string;
   typed: boolean;
   prompter: Prompter;
 }): Promise<string> {
-  const { given, declared, account, typed, prompter } = input;
+  const { given, declared, fallback, typed, prompter } = input;
 
   if (given) return given;
 
-  // A label already chosen wins over the account, so re-authorising an expired
-  // credential does not quietly undo the operator's own word for the row.
-  const suggestion = declared ?? account;
+  // A label already chosen wins over the derived one, so re-authorising an
+  // expired credential does not quietly undo the operator's own word for the row.
+  const suggestion = declared ?? fallback;
 
   if (typed || !prompter.interactive) return suggestion;
 

--- a/src/cli/commands/connection-list.ts
+++ b/src/cli/commands/connection-list.ts
@@ -1,12 +1,15 @@
 import { RESERVED_PROVIDER_IDS } from '#connectivity';
+import { PROVIDER_MANIFESTS } from '#providers/index.ts';
 import {
   connectionRefOf,
+  defaultConnectionLabel,
   listProfiles,
   loadProfileConfig,
   readConnections,
   resolveTargetWorkspace,
   resolveWorkspaceRoot,
 } from '#profile';
+import { RESERVED_SURFACES } from '../config-repair.ts';
 import { emit, heading, print, style, table } from '../output.ts';
 import type { GlobalFlags } from '../runtime.ts';
 
@@ -104,6 +107,20 @@ export async function connectionList(flags: GlobalFlags & { json?: boolean }): P
   });
 }
 
+/**
+ * What each provider is called, by id.
+ *
+ * The catalogue's manifests plus the owner layer, which is registered separately
+ * and is deliberately absent from `PROVIDERS`. A workspace-local manifest is not
+ * here: this command reads files rather than building a registry, and one custom
+ * provider falling back to its account is a smaller price than a registry build
+ * on a listing.
+ */
+const PROVIDER_NAMES = new Map<string, string>([
+  ...PROVIDER_MANIFESTS.map((manifest): [string, string] => [manifest.id, manifest.name]),
+  ...Object.entries(RESERVED_SURFACES),
+]);
+
 function row(one: ConnectionSummary): string[] {
   // "granted to nobody" is said rather than left blank, because a blank column
   // reads as "not loaded yet" and this is a fact about the config.
@@ -112,5 +129,12 @@ function row(one: ConnectionSummary): string[] {
       ? style.dim('no profile grants it')
       : one.grantedTo.join(', ');
 
-  return [`  ${style.bold(one.key)}`, one.label ?? one.account, reach];
+  // The account was this column's fallback, which meant an unlabelled row read
+  // as its address and said nothing about which service the address is at. The
+  // derived name says both, and is the one the dashboard and the connect prompt
+  // show for the same row.
+  const named = PROVIDER_NAMES.get(one.provider);
+  const label = one.label ?? (named ? defaultConnectionLabel(named, one.account) : one.account);
+
+  return [`  ${style.bold(one.key)}`, label, reach];
 }

--- a/src/cli/config-repair.ts
+++ b/src/cli/config-repair.ts
@@ -18,7 +18,7 @@ import { nextConnectionId } from './identity.ts';
  */
 
 /** Lanes' own provider ids, and the label each row carries. */
-const RESERVED_SURFACES = {
+export const RESERVED_SURFACES = {
   lanes_memory: 'Memory',
   lanes_tasks: 'Tasks',
   lanes_assets: 'Assets',

--- a/src/profile/connections.test.ts
+++ b/src/profile/connections.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, test } from 'bun:test';
+import { defaultConnectionLabel } from './connections.ts';
+
+/**
+ * What a connection is called when nobody has named it.
+ *
+ * One rule, read by four surfaces: the label `connect` offers, the label it
+ * declines to write because it offered it, the name `connection list` prints,
+ * and the name the dashboard shows. They agreed on the account before this
+ * existed, which is why an unlabelled row read as its address in one place and
+ * as `con8` in another.
+ */
+describe('defaultConnectionLabel', () => {
+  test('is the provider and the account, so two mailboxes are two names', () => {
+    expect(defaultConnectionLabel('Gmail', 'ada@example.com')).toBe('Gmail (ada)');
+    expect(defaultConnectionLabel('Gmail', 'rin@example.com')).toBe('Gmail (rin)');
+  });
+
+  test('takes the local part, because the domain repeats on every address at one', () => {
+    expect(defaultConnectionLabel('iCloud Mail', 'ada@example.test')).toBe('iCloud Mail (ada)');
+  });
+
+  test('keeps an account that is not an address whole', () => {
+    // `Lanes HQ` cut at the space is `Lanes`, which is a different workspace's
+    // name as often as not. There is no first part to guess at here.
+    expect(defaultConnectionLabel('Notion', 'Acme HQ')).toBe('Notion (Acme HQ)');
+    expect(defaultConnectionLabel('GitHub', 'acme-sh')).toBe('GitHub (acme-sh)');
+  });
+
+  test('is the provider alone where there is no account behind it', () => {
+    // The owner layer. Its rows carry the proper noun in `account` already, so
+    // composing the two would read `Memory (Memory)`.
+    expect(defaultConnectionLabel('Memory', 'Memory')).toBe('Memory');
+    expect(defaultConnectionLabel('Vault', null)).toBe('Vault');
+    expect(defaultConnectionLabel('Setup', undefined)).toBe('Setup');
+  });
+
+  test('an empty account is no account', () => {
+    expect(defaultConnectionLabel('Gmail', '')).toBe('Gmail');
+    // And an address with nothing before the `@` falls back to the whole of it
+    // rather than to `Gmail ()`.
+    expect(defaultConnectionLabel('Gmail', '@example.com')).toBe('Gmail (@example.com)');
+  });
+});

--- a/src/profile/connections.ts
+++ b/src/profile/connections.ts
@@ -21,6 +21,38 @@ export function connectionRefOf(connection: ConnectionConfig): string {
 }
 
 /**
+ * What to call a connection nobody has named.
+ *
+ * `label` is the operator's own word for a row and is usually unset: `connect`
+ * offers a default and does not write one that only repeats a line above it, so
+ * most rows are an id, a provider and an account and nothing else. Every reader
+ * then has to decide what to show, and each of them picked the id — which is the
+ * one field that says nothing. It is opaque on purpose (`nextConnectionId`), so
+ * `con8` tells a reader strictly less about a row than any other line of it.
+ *
+ * The provider is what somebody is asking about, and the account is what tells
+ * two rows of the same provider apart, so the name is both: `Gmail (ada)`. The
+ * local part only — every address a person holds at one domain repeats it, and
+ * the account itself is on the line beside this everywhere this is shown.
+ *
+ * A connection with no account behind it is its provider and nothing else. That
+ * is the owner layer, whose rows carry the proper noun in `account` already, so
+ * composing the two would read `Memory (Memory)`.
+ */
+export function defaultConnectionLabel(
+  providerName: string,
+  account: string | null | undefined,
+): string {
+  if (!account || account === providerName) return providerName;
+
+  // Split on `@` and nothing else. A handle, an IBAN or a workspace name has no
+  // "first part" that is safe to guess at: `Lanes HQ` cut at the space is
+  // `Lanes`, which is a different workspace's name as often as not.
+  const local = account.split('@')[0];
+  return `${providerName} (${local || account})`;
+}
+
+/**
  * One account this profile reaches, with the rules that govern it.
  *
  * The grant travels with the connection deliberately. Every caller that has a

--- a/src/profile/index.ts
+++ b/src/profile/index.ts
@@ -46,6 +46,7 @@ export {
   assertGrantsResolve,
   assertNoRenamedProviders,
   connectionRefOf,
+  defaultConnectionLabel,
   selectConnections,
   soleGrantFor,
   vaultRef,

--- a/src/server/read/deployed.ts
+++ b/src/server/read/deployed.ts
@@ -40,6 +40,10 @@ export function deployedReadDeps(input: {
     audit: primary.audit,
     connections: async () =>
       (await readConnections(primary.resolution.workspaceRoot)).connections,
+    // The names the dashboard shows for a row nobody has labelled. From the
+    // registry rather than a catalogue, so the owner layer, the vendors and a
+    // workspace's own manifests are all named the same way.
+    providerName: (id) => primary.registry.manifest(id)?.name,
     // Cached, unlike loopback's. `GcpSecretManagerStore` holds nothing between
     // calls, so a dashboard polling `/state` would be one network round trip per
     // poll and a stranger sending a wrong token one per request — which is the

--- a/src/server/read/open.ts
+++ b/src/server/read/open.ts
@@ -62,6 +62,10 @@ export async function openReadListener(
       audit: primary.audit,
       connections: async () =>
         (await readConnections(primary.resolution.workspaceRoot)).connections,
+      // The names the dashboard shows for a row nobody has labelled. From the
+      // registry rather than a catalogue, so the owner layer, the vendors and a
+      // workspace's own manifests are all named the same way.
+      providerName: (id) => primary.registry.manifest(id)?.name,
       // Read on every presentation, so `pair --rotate` takes effect on a
       // running endpoint. Affordable here because the store is a local file;
       // the deployed bind caches for exactly this reason. `refresh()` drops the

--- a/src/server/read/routes.ts
+++ b/src/server/read/routes.ts
@@ -1,7 +1,12 @@
 import type { Logger } from '#connectivity';
 import type { ProfileRuntime } from '../mcp/visibility.ts';
 import type { PairingCredential } from './credential.ts';
-import { readState, type ConnectionRow, type ReadEndpoint } from './state.ts';
+import {
+  readState,
+  type ConnectionRow,
+  type ProviderNames,
+  type ReadEndpoint,
+} from './state.ts';
 
 /**
  * The two routes a browser origin may read, and everything that guards them.
@@ -100,6 +105,14 @@ export interface ReadDeps {
    */
   readonly connections: () => Promise<readonly ConnectionRow[]>;
   readonly credential: PairingCredential;
+  /**
+   * What each provider is called, for the row nobody has labelled.
+   *
+   * Optional so a harness can omit it: absent, an unlabelled row reports a null
+   * label and its reader falls back to the id, which is what every reader did
+   * before. Both real binds pass their runtime's registry.
+   */
+  readonly providerName?: ProviderNames | undefined;
   /** What this endpoint says about itself. Fixed for the life of the bind. */
   readonly endpoint: ReadEndpoint;
   readonly allowedOrigins?: readonly string[] | undefined;
@@ -166,7 +179,7 @@ export async function readRoutes(request: Request, deps: ReadDeps): Promise<Resp
   if (url.pathname === STATE_PATH) {
     const rows = await deps.connections().catch(() => []);
     return json(
-      readState(deps.workspace, deps.profiles(), rows, deps.endpoint),
+      readState(deps.workspace, deps.profiles(), rows, deps.endpoint, deps.providerName),
       200,
       cors(origin, allowed),
     );

--- a/src/server/read/state.test.ts
+++ b/src/server/read/state.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, test } from 'bun:test';
-import { readState, type ConnectionRow, type ReadEndpoint } from './state.ts';
+import {
+  readState,
+  type ConnectionRow,
+  type ProviderNames,
+  type ReadEndpoint,
+} from './state.ts';
 import type { ProfileRuntime } from '../mcp/visibility.ts';
 
 /**
@@ -18,6 +23,16 @@ const ROWS: ConnectionRow[] = [
   { provider: 'gmail', id: 'ada', account: 'ada@example.com', label: 'Work mail' },
   { provider: 'gmail', id: 'rin', account: 'rin@example.com' },
 ];
+
+/**
+ * What the two providers in `ROWS` are called, as a registry would say.
+ *
+ * A closure rather than the real registry: `readState` takes the lookup because
+ * the read surface may not import the catalogue, and a test supplying two names
+ * exercises the same path a bind does.
+ */
+const NAMES: ProviderNames = (provider) =>
+  ({ gmail: 'Gmail', lanes_memory: 'Memory' })[provider];
 
 /** What the bind says about itself. Fixed for a test about which rows exist. */
 const ENDPOINT: ReadEndpoint = {
@@ -63,17 +78,36 @@ describe('which connections exist', () => {
   });
 
   test('carries the label and the account, which are what a reader is shown', () => {
-    const state = readState('local', new Map(), ROWS, ENDPOINT);
+    const state = readState('local', new Map(), ROWS, ENDPOINT, NAMES);
     const ada = state.connections.find((one) => one.ref === 'gmail.ada');
 
     expect(ada?.label).toBe('Work mail');
     expect(ada?.account).toBe('ada@example.com');
   });
 
-  test('a row with no label says null rather than inventing one', () => {
-    const state = readState('local', new Map(), ROWS, ENDPOINT);
+  test('a row with no label is named after its provider and its account', () => {
+    // `con8` is what this showed before, which is the one field on a row that
+    // says nothing: the id is opaque on purpose. Every reader fell back to it,
+    // so a dashboard's whole Label column read as keys.
+    const state = readState('local', new Map(), ROWS, ENDPOINT, NAMES);
 
-    expect(state.connections.find((one) => one.ref === 'gmail.rin')?.label).toBeNull();
+    expect(state.connections.find((one) => one.ref === 'gmail.rin')?.label).toBe('Gmail (rin)');
+  });
+
+  test('a built-in is its proper noun, not its noun twice', () => {
+    // The owner layer carries the name in `account` already, so composing the
+    // two would read `Memory (Memory)`.
+    const state = readState('local', new Map(), ROWS, ENDPOINT, NAMES);
+
+    expect(state.connections.find((one) => one.ref === 'lanes_memory.main')?.label).toBe('Memory');
+  });
+
+  test('a provider nothing can name says null rather than guessing', () => {
+    // A grant pointing at a connection the workspace no longer holds, and the
+    // one row left with nothing to derive a name from.
+    const state = readState('local', new Map([['personal', profile(['ghost.one'])]]), ROWS, ENDPOINT, NAMES);
+
+    expect(state.connections.find((one) => one.ref === 'ghost.one')?.label).toBeNull();
   });
 
   test('with no profiles at all, the workspace still lists what it holds', () => {

--- a/src/server/read/state.ts
+++ b/src/server/read/state.ts
@@ -1,4 +1,5 @@
 import { allowedConnections } from '#policy';
+import { defaultConnectionLabel } from '#profile';
 import type { ProfileRuntime } from '../mcp/visibility.ts';
 
 /**
@@ -19,11 +20,20 @@ export interface ReadConnection {
   readonly provider: string;
   readonly id: string;
   /**
-   * The operator's own word for it, and what a reader should be shown.
+   * What a reader should be shown: the operator's own word for it, or the name
+   * derived from the provider and the account when they never gave one.
    *
    * `gmail.ada_lovelace` is an address, not a name. A dashboard listing refs is
    * asking somebody to read identifiers when they gave the thing a label
    * precisely so they would not have to.
+   *
+   * **Filled rather than left null**, which reverses what this said. Null meant
+   * "they never gave one" and every consumer answered it the same way, by
+   * showing the id — so a dashboard's whole Label column read `con8`, `lan7`,
+   * `con5`. `connect` writes no label that only repeats the lines above it
+   * (`declareConnection`), so an unlabelled row is the ordinary case and not an
+   * omission worth reporting. `null` survives for the row nothing can name: a
+   * grant pointing at a connection the workspace no longer holds.
    */
   readonly label: string | null;
   /** The identity the provider reported at connect time. */
@@ -31,6 +41,20 @@ export interface ReadConnection {
   /** Which profiles grant this connection at all. */
   readonly profiles: readonly string[];
 }
+
+/**
+ * What a provider is called, asked of whoever built the registry.
+ *
+ * A function rather than a catalogue, because `server` may not import
+ * `#providers` — the read surface has no business knowing the vendor list, and
+ * the rule that says so is `architecture.test.ts`. Both binds already hold a
+ * `Runtime`, whose registry names the owner layer, the catalogue and a
+ * workspace's own manifests alike, so the caller passes a closure over that.
+ *
+ * Defaulted to naming nothing. A caller that supplies none gets `label: null`
+ * on an unlabelled row, which is what every reader saw before this existed.
+ */
+export type ProviderNames = (provider: string) => string | undefined;
 
 /** The connection rows as `connections.yaml` holds them. */
 export interface ConnectionRow {
@@ -97,6 +121,7 @@ export function readState(
   profiles: ReadonlyMap<string, ProfileRuntime>,
   rows: readonly ConnectionRow[],
   endpoint: ReadEndpoint,
+  providerName: ProviderNames = () => undefined,
 ): ReadState {
   // The workspace's own list is the source of truth for *which connections
   // exist*. Deriving it from the grants instead made an account that no profile
@@ -138,11 +163,14 @@ export function readState(
 
   const connections: ReadConnection[] = rows.map((row) => {
     const ref = `${row.provider}.${row.id}`;
+    const named = providerName(row.provider);
     return {
       ref,
       provider: row.provider,
       id: row.id,
-      label: row.label ?? null,
+      // The same rule `connect` offers and `connection list` prints, so one
+      // connection is called one thing wherever somebody reads it.
+      label: row.label ?? (named ? defaultConnectionLabel(named, row.account) : null),
       account: row.account ?? null,
       profiles: grantedBy.get(ref) ?? [],
     };


### PR DESCRIPTION
Every row in a real `connections.yaml` is an id, a provider and an account and nothing else. `connect` defaults the label to the account, and `declareConnection` then declines to write one that only repeats the line above it, so `label` is almost never set.

That left every reader to decide what an unnamed row is called, and each of them picked the id. The id is opaque on purpose (`nextConnectionId`), so the dashboard's Label column reads `con8`, `lan7`, `con5`, and `connection list` prints the address without saying which service it is an address at.

## One rule

`defaultConnectionLabel`, beside `connectionRefOf` because the two answer the pair of questions about a row: what addresses it, and what it is called.

```
Gmail (ada)        provider and account, so two mailboxes are two names
Notion (Acme HQ)   an account that is not an address stays whole
Memory             no account behind it: the owner layer, whose rows carry
                   the proper noun in `account` already
```

Read by four surfaces, which is the point of it being one function: the label `connect` offers, the label it declines to write because it offered it, the name `connection list` prints, and the label `/state` reports.

Against a scratch workspace:

```console
$ lanes link connection list --workspace local
Accounts (4)
  gmail.con1   Gmail (ada)       no profile grants it
  gmail.con2   Gmail (rin)       no profile grants it
  notion.con3  Notion (Acme HQ)  no profile grants it
  gmail.con4   Shared inbox      no profile grants it

Your own material (2)
  lanes_memory.lan1  Memory  no profile grants it
  lanes_vault.lan2   Vault   no profile grants it
```

## One reversal, named

`ReadConnection.label` said `null` meant "they never gave one". It is filled now. No consumer ever distinguished null from a name: every one fell through to the id, so the field reported a distinction nobody could use at the cost of the column it fills. `null` survives for the row nothing can name, a grant pointing at a connection the workspace no longer holds, and `state.test.ts` covers that case.

The read surface may not import `#providers` and should not, so the name lookup arrives as a closure over the registry both binds already hold. That names a workspace's own manifests as readily as the catalogue's.

## Also

`settleIdentity` returns the derived default alongside the settled label, so the string the operator was offered and the string compared against it cannot come apart. The settled identity then travels to `declareConnection` as one value rather than three properties re-listed at the call site, which is what kept `connect/index.ts` inside the 400-line budget.

## Verification

- `bun test`: 3077 pass, 0 fail (3070 at the baseline; 7 new).
- `bun run typecheck` clean.
- `connection list` run against a scratch `LANES_LINK_HOME`, output above.
- `/state` end to end is not run here: it needs a paired endpoint, and `lanes link pair` installs a certificate into the trust store. `state.test.ts` covers the derivation and both binds pass the same lookup.

Pairs with lanes-sh/web#44, which fixes the `lanes_` marks and adds the Provider column. Either can land first.