### PR TITLE
chore: 0.9.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lanes-sh/link",
-  "version": "0.9.2",
+  "version": "0.9.3",
   "description": "A self-hostable MCP gateway for all your connections, memory, tasks, files, and secrets",
   "license": "Apache-2.0",
   "homepage": "https://lanes.sh/link",


### PR DESCRIPTION
Sets the version on `develop` ahead of the release pull request to `main`.

0.9.2 is already tagged, so a merge to `main` carrying it would run `release.yml`'s *propose* path — which puts the bump on a side branch that merges into `main` only, leaving `develop` a version commit behind. An untagged version publishes directly and both branches end up on the same tree.

Carries #144, #146, #147 and #148.