### PR TITLE
0.9.3

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -104,35 +104,42 @@ selecting it (ADR-043). Everything acting on one account still names both. The t
 `src/cli/selection.ts` is the whole rule, and `selection.test.ts` reads the dispatch files to
 check a new command cannot be added without appearing in it.
 
-## The owner layer is eight ids, and `tasks` is not Google's
+## The owner layer is eight `lanes_` ids, and the prefix reaches the wire
 
-`RESERVED_PROVIDER_IDS` is `memory`, `tasks`, `assets`, `skills`, `vault`, `setup`, `identity`,
-`entities`. Three things an agent gets wrong here:
+`RESERVED_PROVIDER_IDS` is `lanes_memory`, `lanes_tasks`, `lanes_assets`, `lanes_skills`,
+`lanes_vault`, `lanes_setup`, `lanes_identity`, `lanes_entities`. The `lanes_` is part of the id,
+not a display prefix, and `toolNameFor` only swaps `.` for `_` — so the capability
+`lanes_setup.overview` is the tool `lanes_setup_overview`, and renaming these ids in 0.9.0 renamed
+every tool the owner layer advertises. ADR-066 records what that cost a client that had already
+fetched the old list. Three things an agent gets wrong here:
 
-- **`tasks` is the built-in task list; Google Tasks is `google_tasks`.** The rename was forced —
-  `buildRegistry` registers the owner layer before `PROVIDERS`, so a manifest holding a reserved id
-  throws rather than being shadowed (ADR-051). Its redaction keys carry Google's whole operationId
+- **`lanes_tasks` is the built-in task list; Google Tasks is `google_tasks`; plain `tasks` is
+  nobody's.** The rename was forced while the built-in still held the bare id, and it stands:
+  `Registry.register` refuses a reserved id outright unless the registry was built with
+  `allowReserved`, so a manifest can neither claim one nor shadow one
+  (`src/registry/registry.ts:79`, ADR-051). Google Tasks' redaction keys carry its whole operationId
   (`tasks.tasks.patch`) because `shortenName` strips the *provider id* and the API namespaces under
   its own name. A key that misses does not error; it withholds every argument and reads exactly like
   working redaction.
-- **A profile arrives with all of them granted except `identity`** (ADR-050). So there is no
-  `lanes link connect memory` step to suggest, and a surface that is missing was denied on purpose.
+- **A profile arrives with all of them granted except `lanes_identity`** (ADR-050). So there is no
+  `lanes link connect lanes_memory` step to suggest, and a surface that is missing was denied on
+  purpose.
   `ensureOwnerLayer` in `src/cli/config-repair.ts` repairs an older profile from `start`, `connect`
   and `deploy`; the template in `config-edit.ts` and that repair must write a row in **one**
   spelling, which `config-edit.test.ts` checks by asserting a fresh profile needs no repair.
-- **`identity` and `entities` differ on writability and on the default grant, and the reason is one
-  test.** It is not "is it empty" — memory arrives empty and is granted. It is *can it be filled in
-  from here*: identity is configuration and changed in the CLI (ADR-007), so an agent able to edit
-  it could edit the one fact that stops it signing as the wrong person. Everyone else's details
-  accumulate on the same surface that reads them, so `entities` is agent-writable and granted like
-  memory (ADR-056). Do not "fix" the asymmetry.
+- **`lanes_identity` and `lanes_entities` differ on writability and on the default grant, and the
+  reason is one test.** It is not "is it empty" — memory arrives empty and is granted. It is *can it
+  be filled in from here*: identity is configuration and changed in the CLI (ADR-007), so an agent
+  able to edit it could edit the one fact that stops it signing as the wrong person. Everyone else's
+  details accumulate on the same surface that reads them, so `lanes_entities` is agent-writable and
+  granted like memory (ADR-056). Do not "fix" the asymmetry.
 
-`entities.find` returns **every** match and sets no error on more than one, deliberately. If you
-change how it ranks, the rule to keep is that ordering is not selection: there is no scoring inside
-a rank, because a tiebreak that promoted one of two exact alias matches would turn a question for
-the owner into a silent pick. Its derived `_index.json` is a cache stamped with a `key:size`
-fingerprint of the entity files — not `key:size:mtime`, because the GitHub adapter reports the
-branch tip for every file and the stamp would never match twice.
+`lanes_entities.find` returns **every** match and sets no error on more than one, deliberately. If
+you change how it ranks, the rule to keep is that ordering is not selection: there is no scoring
+inside a rank, because a tiebreak that promoted one of two exact alias matches would turn a
+question for the owner into a silent pick. Its derived `_index.json` is a cache stamped with a
+`key:size` fingerprint of the entity files — not `key:size:mtime`, because the GitHub adapter
+reports the branch tip for every file and the stamp would never match twice.
 
 `src/architecture.test.ts` asserts the four rules the layout expresses: dependency
 direction between components, no vendor name in the code a request passes through, a

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ $ bun install -g @lanes-sh/link                # puts `lanes` on your PATH
 $ lanes auth login                             # opens a browser once
 $ lanes link profile add personal --workspace local
 $ lanes link profile members add --me --profile personal --workspace local
-$ lanes link start --profile personal --workspace local
+$ lanes link start --workspace local
 ok    serving http://127.0.0.1:7337/mcp
       profiles: personal
 ```
@@ -63,7 +63,7 @@ ok    serving http://127.0.0.1:7337/mcp
 Then, in another shell:
 
 ```console
-$ lanes link mcp add --profile personal --workspace local     # every agent installed; or name one: claude, codex
+$ lanes link mcp add --workspace local     # every agent installed; or name one: claude, codex
 ok    registered lanes-link with Claude Code (user scope)
 ok    registered lanes-link with Codex
 ```
@@ -75,8 +75,14 @@ Mail and calendar are the next step. **[Full quickstart →](https://lanes.sh/do
 **Why the sign-in.** A profile declares who may consume it, and there is nothing to check that
 against if the endpoint has no idea who is asking. That is a real dependency for a self-hostable
 tool and worth stating plainly; what it is not is a dependency per request. The network is needed
-to sign in and to refresh, and a machine offline for a day keeps serving. `lanes link token
-show` still mints a static token for CI, which has no browser to sign in with.
+to sign in and to refresh, and a machine offline for a day keeps serving.
+
+**Why `mcp add` names no profile.** One endpoint serves every profile in the workspace, and each
+call names one in its `profile` argument — so registering is about the endpoint, not a profile.
+Which profiles a client actually reaches is decided when its owner signs in: every profile whose
+`members:` lists them, and no others. A credential is an identity here, not a selection. For a
+runner with no browser, `lanes link token issue --me` mints a static token that reaches exactly
+what its subject is a member of.
 
 ## What you keep in it
 

--- a/docs/detailed/adr/066-a-profile-owns-its-data-again.md
+++ b/docs/detailed/adr/066-a-profile-owns-its-data-again.md
@@ -94,6 +94,23 @@ of notes is not reversible and picking one profile's would take the other's away
 operator is told and deletes what they do not want. That is the only step in the migration that
 is theirs rather than ours, and it exists because the shipped default made the shared case common.
 
+**Every client registered before the migration holds a tool list that no longer resolves.** The
+owner layer's provider ids gained `lanes_`, and `toolNameFor` only swaps `.` for `_`, so renaming
+the provider renamed the tool: `setup_overview` is `lanes_setup_overview` now. The connection ids
+were renumbered alongside them, and those are the `connection` enum on every tool in the list. A
+client that re-reads is unaffected and sees both. A client that cached answers
+`Tool setup_overview not found` for each `lanes_*` tool and has every `connection` value it was
+given refused — while the vendor tools, whose ids did not change, keep their names and fail only on
+that argument. Half the surface working is what makes it read as a broken endpoint rather than a
+stale list, from the only side anybody is looking at.
+
+This is the cost `What is unchanged` below does not cover, and the reason it was missed: no file's
+shape changes at contract 4, so nothing in the migration looks like a wire change. The ids *are*
+the wire. [ADR-032](032-a-stateless-endpoint-does-not-announce-its-tools.md) settles what can be
+done about it — the endpoint declares `listChanged: false` so a client has no reason not to ask, and
+that is the whole of what it can do. `update` prints the one step that is the operator's:
+`lanes link mcp add`.
+
 ## What is unchanged
 
 - **Connections are the workspace's** (ADR-057) — one authorisation per account, one credential

--- a/docs/detailed/adr/068-a-credential-names-a-person.md
+++ b/docs/detailed/adr/068-a-credential-names-a-person.md
@@ -1,0 +1,155 @@
+# ADR-068: A credential names a person, and the profiles follow from that
+
+**Status:** accepted · **Completes** [ADR-060](060-a-caller-is-a-person.md)'s
+`kind: 'machine'` · **Closes** [ADR-009](009-one-endpoint-per-workspace.md)'s stated gap ·
+**Amends** [ADR-043](043-a-target-scoped-command-acts-on-the-target.md),
+[ADR-057](057-a-connection-belongs-to-the-workspace.md) · **Contract 5**
+
+## Context
+
+`lanes link mcp add` required `--profile`. Tracing what it did with it turns up something larger
+than a stray flag.
+
+It did two things, and neither is a per-profile fact. It read
+`runtime.config.auth.token_ref` — a ref whose template default is the **constant** `profile/token`
+for every profile, out of a credential store that has been one per workspace since ADR-057 — and
+it interpolated the name into one Codex hint string. Two different `--profile` values against the
+same workspace produced byte-identical harness commands.
+
+`profile/removal.ts` records what that shared constant already cost. Removing one profile deleted
+the endpoint token its siblings were being served by, and the deployed revision then refused every
+request. The fix at the time was a survivor check: do not delete a ref another profile also
+declares. That works and it is the wrong shape, because the token was never a profile's to declare.
+
+**The deeper thing is that this endpoint had two credentials answering two different questions.**
+ADR-060 and ADR-062 built the model: a caller authenticates as a person, and the profiles they
+reach are every profile whose `members:` names their subject. `mayReach` is the check,
+`visibility.ts` filters the `profile` enum from the same list, and `Dispatcher.invoke` refuses
+ahead of policy. An OAuth token has gone through that since 0.8.
+
+The static `llk_` token did not. It resolved to `ownerPrincipal` of whichever profile was primary,
+with `profiles: undefined` — which `mayReach` reads as *all of them*. So it was the one credential
+here that answered **what may I open** without ever answering **who are you**. ADR-060 described
+the principal that would fix this, named it `kind: 'machine'`, and nothing ever minted one.
+
+That is ADR-009's gap, and it is why every command whose subject is the endpoint had to name a
+profile: not because the endpoint is per-profile — it is not, one endpoint serves every profile in
+the workspace — but because finding the credential meant resolving one.
+
+## Decision
+
+**A credential names a person. What it reaches follows from that, and from nothing else.**
+
+The endpoint's tokens move to `tokens:` in `connections.yaml`, one row per token:
+
+```yaml
+tokens:
+  - { id: tok1, subject: lanes:<subject>, ref: tokens/tok1, label: ci }
+```
+
+`auth.token_ref` leaves the profile schema. A profile declares no endpoint credential.
+
+**Resolution goes through the member lists, exactly as OAuth does.** `BearerAuthenticator` is
+handed the rows and a `profilesFor(subject)` resolver — the same closure shape `server/endpoint.ts`
+already builds for the authorization gate — and returns `machinePrincipal(subject, primary,
+profiles)`. `mayReach` and the enum filter need **no change**: the bearer path joins the path that
+already worked, rather than getting a second mechanism beside it.
+
+**Membership is resolved per request for a static token**, and that is a difference worth stating.
+An OAuth token's profile list is fixed when the code is minted (ADR-060) because there is a mint to
+read it at. A static token has none, so this is the only place the question can be asked — which
+makes `profile members remove` take effect within the authenticator's cache window rather than on
+the next rotation. A resolver that throws fails closed; falling back to "every profile" would
+restore precisely what this removes, at the moment something is already wrong.
+
+**`--profile` goes from every command whose subject is the endpoint.** `mcp add`, `mcp stdio`,
+`outputs` and the whole `token` family move to `workspace` in `src/cli/selection.ts`. The three
+token commands that could only ever have been misread — `show`, `rotate`, `revoke` — **refuse**
+the flag rather than accept and ignore it: somebody passing `--profile work` believes they scoped
+the credential, and the member lists are what decide. That is the rule `selection.ts` was written
+for.
+
+**`start` and `deploy` stop minting or demanding a token.** Both halves go for the same reason.
+Minting: `start` did it because there was one token per endpoint and it had to exist for anything
+to connect; a token names a person now, and `start` does not know who is about to connect, so
+inventing one would bind a credential to a subject nobody chose. Demanding: a deployed revision
+refused to boot without one, on the reasoning that an endpoint whose token nobody holds is no use.
+Since ADR-062 that is backwards — a client discovers the protected-resource document, signs its
+owner in, and comes back with a token of its own. **Zero rows is the ordinary state of a healthy
+endpoint**, and refusing to serve was refusing the case the endpoint is now built for.
+
+`token issue`, `token list` and `token revoke` are the commands that follow from rows existing.
+
+## What this costs, stated plainly
+
+**A CI runner that relied on one token opening the whole workspace needs a subject that is a member
+of each profile it uses.** This is the point of the change rather than an incidental cost, and it
+is the one thing that can break an existing headless caller. The migration binds the existing token
+to an owner of a profile that held it, so a single-profile workspace is unaffected; a runner
+reaching three profiles needs that subject on all three.
+
+**The migration cannot invent a subject, and refuses rather than guessing.** A row bound to the
+wrong subject is worse than no row: it looks issued and reaches nothing, or reaches somebody
+else's profiles. So the subject comes from the owner-role member of a profile that actually held
+the token, and where there is none — a workspace migrated by contract 3 while signed out has
+`members: []` — contract 5 stops and names `profile members add --me`.
+
+**The credential is not re-keyed.** A row may name any ref, and the migrated row keeps
+`profile/token`. Renaming it to `tokens/tok1` would read better and would mean copying a live
+credential in a store that may be Secret Manager, then deleting the original — two writes and a
+window where a deployed revision reads neither. The one thing that must not break during an
+upgrade is an endpoint that was working before it.
+
+**`ProviderContext` gains a field**, and that interface is deliberately narrow. `profiles` is the
+caller's reachable set. The argument for it is that it is not a handle: it is the same routing fact
+the client already holds in the `profile` enum on every tool it was shown, and a provider still
+acts in exactly one profile per dispatch. It is there because a surface that describes what a
+caller can reach has to be given the caller's answer rather than the workspace's.
+
+**No client needs re-adding.** ADR-066's lesson is that the provider ids are the wire; this renames
+no id, no tool and no connection. `update` should not grow another "re-add every client" line for
+this.
+
+## Two things found on the way, and both were live
+
+**`lanes_setup.overview` named every profile on disk.** It was handed `listProfiles(root)` and
+printed `This endpoint also serves: …`, so a delegated member read the names of profiles `mayReach`
+deliberately keeps out of the `profile` enum they were shown. It now renders the caller's set and
+says only *how many* it is withholding — a count is not a leak, and it is what stops an agent
+concluding the others do not exist.
+
+**`/health` did the same thing.** Authenticated, it returned every profile the endpoint serves to
+anybody holding any credential. Same rule as discovery, in the one place that had its own answer.
+
+**`ensureRegistryContract` stamped the newest contract mid-chain.** After the contract-4 step the
+registry claimed 5 while its profiles said 4, and `isUnmigrated` reads exactly that field — so it
+would have reported a finished migration with a step still to run. Each step now stamps the
+contract it produces.
+
+## What was considered and rejected
+
+**Keeping the token where it was and only dropping the flags.** Smaller, and it leaves the actual
+defect in place: the credential would still reach every profile regardless of who holds it, and
+the flags would be gone without the reason they existed being gone. ADR-009's gap would survive in
+the one place nobody was looking at.
+
+**Per-profile tokens** — ADR-060 considered and rejected these, and the reasoning holds: a token is
+a bearer string, so per-profile tokens buy isolation without buying attribution, and the audit log
+would still record which profile rather than which person.
+
+**Deriving the subject at authentication time from the token's own bytes** — a token that encodes
+its subject needs no registry. It also cannot be revoked without one, cannot be listed, and changes
+the token format, which invalidates every existing credential on upgrade.
+
+**Caching the resolved profile list beside the token value.** One fewer read per request. It also
+makes `profile members remove` take effect on the next rotation rather than in seconds, which is
+the property the per-request resolution is for.
+
+## What this does not do
+
+It does not change that the `profile` argument is client-supplied per call. ADR-009's remaining
+concern — that cross-profile access is a matter of what the model passes — is *narrowed* by this
+and not closed: a caller can still name any profile they are a member of. It does not change what a
+grant means; who may call and what they may call are still two questions answered in two places.
+And it does not make roles decide anything at the MCP boundary (ADR-060), because nothing here
+needed a second policy system.

--- a/docs/detailed/adr/README.md
+++ b/docs/detailed/adr/README.md
@@ -83,6 +83,7 @@ Run.
 | [065](065-the-app-provisions-this-cli.md) | The desktop app installs and updates this CLI on its own lifecycle, and a foreign install is replaced rather than argued with |
 | [066](066-a-profile-owns-its-data-again.md) | A profile owns its data again: the bytes go back in front of the connection, and two profiles granting one instance share nothing |
 | [067](067-one-directory-per-profile.md) | One directory per profile, `data/` goes, and a connection id becomes opaque |
+| [068](068-a-credential-names-a-person.md) | A credential names a person, and the profiles follow from that; the endpoint token becomes the workspace's |
 
 Where an ADR departs from init.md, it says so at the top. Three are significant:
 
@@ -287,3 +288,14 @@ Where an ADR departs from init.md, it says so at the top. Three are significant:
   the whole of the `connection` enum a model chooses from. An id that half describes its account
   is worse than one that does not. Note also that dropping `data/` does not remove the IAM
   exclusion it existed for; it moves it, and turns a denylist into an allowlist.
+
+- **ADR-068** finishes what ADR-060 started. A credential names a person, and what it reaches
+  follows from the member lists — for the static `llk_` token as well as for an OAuth one. The
+  endpoint token moves from `auth.token_ref` on every profile to `tokens:` on the workspace, which
+  is contract 5.
+
+  The part to read is why every endpoint command was asking for a profile. Not because the
+  endpoint is per-profile — one serves every profile in the workspace — but because the token's
+  ref defaulted to the constant `profile/token`, so finding it meant resolving one. The same
+  constant is why removing a profile once deleted the token its siblings were served by, and the
+  fix is not the survivor check that was added then: the token was never a profile's to declare.

--- a/docs/detailed/init.md
+++ b/docs/detailed/init.md
@@ -146,7 +146,7 @@ Credentials follow the target, because each target has its own credential store.
 ### Example (`config/personal.example.yaml`)
 
 ```yaml
-contract: 4
+contract: 5
 
 instance:
   profile: personal
@@ -185,11 +185,12 @@ grants:
 members:
   - { subject: lanes:SUBJECT, role: owner }
 
-# The bearer token is for CI. A person signs in instead: a client that asks for
+# No token here. A profile declares no endpoint credential (ADR-068): the
+# workspace does, in "tokens:" in connections.yaml, one row per person one was
+# issued to. A person signs in rather than holding one — a client that asks for
 # authorization is sent to the Lanes login and comes back as somebody (ADR-062).
 auth:
   mode: bearer
-  token_ref: profile/token
   authorization:
     mode: self
 ```
@@ -197,7 +198,7 @@ auth:
 ### Example (`connections.yaml`)
 
 ```yaml
-contract: 4
+contract: 5
 
 # One entry per authorised account. "account" is the identity the provider
 # reports, resolved at connect time, and the id derives from it — so this list
@@ -224,6 +225,14 @@ oauth_apps:
   google:
     client_id_ref: google/client_id
     client_secret_ref: google/client_secret
+
+# Static endpoint tokens, one row per person one was issued to (ADR-068). Empty
+# is the ordinary state: a client registers against the bare URL and signs in,
+# so nothing needs one until something headless does. A row reaches whatever its
+# subject is a member of — never more, which is what "the token is an identity"
+# means in practice.
+tokens:
+  - { id: tok1, subject: lanes:SUBJECT, ref: tokens/tok1, label: ci }
 ```
 
 A rule names a capability of its row's own provider: `gmail.*` covers everything Gmail offers *for

--- a/instructions/skills/lanes-link/SKILL.md
+++ b/instructions/skills/lanes-link/SKILL.md
@@ -346,9 +346,11 @@ changed, so a capability for a freshly connected account is not callable until
 the client reconnects. Say that, rather than reporting the connection as missing
 or asking them to connect again.
 
-One exception, and it is the one that matters here: the authenticator is built
-once at boot and is not re-read, so a `lanes link token rotate` does need the
-endpoint restarted before the new token opens anything.
+One exception used to be here — that a `token rotate` needed the endpoint
+restarted. It does not: the authenticator re-reads both the issued rows and
+their values on a seconds-long cache window, so `token issue`, `token rotate`
+and `token revoke` all take effect on a running endpoint. So does a change to a
+profile's `members:`, which is what decides where a token reaches.
 
 ## Operating the workspace
 
@@ -413,17 +415,35 @@ in the workspace and could be given it. Somebody with an unaccepted invitation
 has no subject yet, so they are listed, marked, and refused; the answer there is
 for them to accept, not for anyone to invent a subject.
 
-Removing somebody does not end a session they already hold: membership is read
-when a token is minted. Rotating the endpoint token closes that
-window now, and it names both flags: `lanes link token rotate --profile <name>
---workspace <name>`.
+Removing somebody does not end a browser session they already hold: membership
+is read when that token is minted. A **static** token is different — its
+membership is resolved on every call, so removing somebody takes effect within
+seconds for anything holding one.
 
-**A client is not given a token any more.** `lanes link mcp add` registers the
-bare URL, and the client discovers the endpoint, sends its owner to sign in, and
-comes back with a token of its own. The static token is for CI, which has no
-browser, and `--headless` is what writes it into a registration. If you are
-writing a registration command for somebody, do not add an `Authorization`
-header: it is no longer how a client connects.
+**A credential is an identity, not a selection.** Whether it arrived through a
+browser sign-in or is a static `llk_` token, it names a person, and what it
+reaches is every profile whose `members:` lists that person. There is nothing to
+scope at registration time and nothing to scope at deploy time; the member lists
+are the whole mechanism. `lanes link token show`, `rotate` and `revoke` refuse
+`--profile` outright rather than accept and ignore it.
+
+**A client is not given a token any more.** `lanes link mcp add --workspace
+<name>` registers the bare URL — no `--profile`, because one endpoint serves
+every profile and each call names one in its `profile` argument. The client
+discovers the endpoint, sends its owner to sign in, and comes back with a token
+of its own. If you are writing a registration command for somebody, do not add
+an `Authorization` header: it is no longer how a client connects.
+
+**For a runner with no browser**, issue one and say who it is for:
+
+```
+lanes link token issue --me --workspace <name>
+lanes link token list --workspace <name>
+```
+
+`--headless` on `mcp add` is what writes such a token into a registration. A
+workspace that has issued none is the ordinary healthy state, and `start` and
+`deploy` no longer mint or demand one.
 
 ## Deploying, and what it decides
 
@@ -437,14 +457,16 @@ resources that cost money, it implements no `--json` to inspect instead, and tha
 plan is the only place the consequences are visible while they are still
 avoidable.
 
-Two things it refuses to guess, and both are the owner's to answer:
+One thing it refuses to guess, and it is the owner's to answer:
 
-- **Whose bearer token opens the endpoint.** One token reaches every profile
-  behind that workspace, so this decides who gets in. With several candidates and
-  nothing recorded, it refuses and prints the command that names one.
 - **A first deploy.** A workspace that does not exist yet has nothing to derive
   a set from, so `--profile` is required there. It may be repeated, and the first
-  one named is the primary.
+  one named is the primary — which now decides only which profile's host and
+  port the endpoint binds, not who gets in.
+
+It used to refuse a second thing — *whose bearer token opens the endpoint* — and
+that question no longer has a subject. A token names a person and reaches what
+they are a member of, so there is no per-deploy choice of who gets in.
 
 **Never pass `--yes`, `--non-interactive`, `--access public` or
 `--service-account` yourself.** Each settles a question about who can reach their
@@ -474,45 +496,47 @@ existed in two copies that could disagree, and there is one copy now.
 
 ## Registering it, and re-registering it
 
-`lanes link mcp add --profile <name> --workspace <name>` runs each harness's own registration command and installs
-this skill where that harness keeps them. With no argument it does every harness
-installed; name one (`claude`, `codex`) to be specific. Run it again after
-`lanes link token rotate --profile <name> --workspace <name>` — add `--force`, since Claude Code stores the token as
-a value rather than a command.
+`lanes link mcp add --workspace <name>` runs each harness's own registration
+command and installs this skill where that harness keeps them. With no argument
+it does every harness installed; name one (`claude`, `codex`) to be specific.
 
-**Never paste the token.** There is a right way and a wrong way, and the
-difference matters:
+**It names no profile, and adding one changes nothing about who gets in.** One
+endpoint serves every profile in the workspace and each call names one in its
+`profile` argument, so a registration was never per-profile. What a client
+reaches is decided when its owner signs in: every profile whose `members:` lists
+them.
 
-```bash
-# RIGHT — the token goes from the CLI to the harness. You never see it.
-claude mcp add --transport http lanes-link http://127.0.0.1:7337/mcp \
-  --header "Authorization: Bearer $(lanes link token show --raw --profile <name> --workspace <name>)"
-
-# WRONG — the token is now in your context, and in the transcript, forever.
-lanes link token show --show          # then copying the value into the command
-```
-
-The token reaches every account of every profile the endpoint serves. Use the
-substitution form. If you have already printed one by accident, say so and offer
-`lanes link token rotate --profile <name> --workspace <name>`.
-
-Prefer `lanes link mcp add --profile <name> --workspace <name>` to writing the command yourself: it checks the
-endpoint is reachable, refuses to silently shadow an existing registration, and
-cannot mistype the token. For a harness it does not know, take the command from
-`lanes link outputs --profile <name> --workspace <name>` rather than writing it blind — that command checks whether
-`lanes` resolves on this machine and prints a longer working form if it does
-not, where guessing gives you an empty substitution, a `Bearer ` header, and a
-401 that reads as a bad token.
-
-If you register Codex, tell the user to export the token — Codex stores only the
-variable name, so nothing works until it is set:
+**Do not write an `Authorization` header.** The registration is a bare URL:
 
 ```bash
-export LANES_LINK_TOKEN="$(lanes link token show --raw --profile <name> --workspace <name>)"
+claude mcp add --transport http lanes-link http://127.0.0.1:7337/mcp
 ```
+
+The client reads this endpoint's protected-resource document, sends its owner to
+sign in, and comes back holding a token of its own. That is why a re-registration
+is not needed after a rotate, and why a harness config in a dotfiles repository
+is not a leak.
+
+**A static token is CI's, and it belongs to a person.** For a runner with no
+browser, issue one and let the shell substitute it — never paste it, because a
+pasted token passes through the agent's context and into the transcript:
+
+```bash
+lanes link token issue --me --workspace <name>
+export LANES_LINK_TOKEN="$(lanes link token show --raw --workspace <name>)"
+```
+
+`--headless` on `mcp add` writes such a token into a registration. If you have
+printed one by accident, say so and offer `lanes link token rotate --workspace
+<name>` — no `--profile`, which those commands refuse.
+
+Prefer `lanes link mcp add --workspace <name>` to writing the command yourself:
+it checks the endpoint is reachable and refuses to silently shadow an existing
+registration. For a harness it does not know, take the command from `lanes link
+outputs --workspace <name>` rather than writing it blind.
 
 One registration covers every profile. Do not add one per profile; they share a
-URL and a token.
+URL.
 
 `lanes link mcp list` needs neither flag and reports whether the registration and
 this document are current, out of date, or absent. That is the cheap first
@@ -521,8 +545,9 @@ copy means the rules you are reading are not the ones that shipped.
 
 Claude Desktop cannot be handed a URL, so it spawns the endpoint over stdio
 instead. That one is named in the client's own config file rather than registered
-by a command, as `lanes link mcp stdio --profile <name> --workspace <name>`; both
-flags are required, and nothing may be written to stdout.
+by a command, as `lanes link mcp stdio --workspace <name>`; the workspace is
+required, `--only --profile <name>` narrows what it serves, and nothing may be
+written to stdout.
 
 ## When it is not running
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lanes-sh/link",
-  "version": "0.9.2",
+  "version": "0.9.3",
   "description": "A self-hostable MCP gateway for all your connections, memory, tasks, files, and secrets",
   "license": "Apache-2.0",
   "homepage": "https://lanes.sh/link",

--- a/src/auth/index.test.ts
+++ b/src/auth/index.test.ts
@@ -6,7 +6,8 @@ import { createFileSecretStore, generateCredentialKey, type SecretStore } from '
 import {
   BearerAuthenticator,
   generateProfileToken,
-  ownerPrincipal,
+  machinePrincipal,
+  mayReach,
   parseBearer,
   tokensMatch,
 } from './index.ts';
@@ -74,18 +75,114 @@ describe('generated tokens', () => {
 });
 
 describe('authentication', () => {
-  const options = {
-    profile: 'personal',
-    tokenRef: 'profile/token',
-    credentials: storeWith({ 'profile/token': 'llk_correct' }),
-  };
+  const SUBJECT = 'lanes:abc123';
 
-  test('accepts the profile token and resolves the owner principal', async () => {
+  /** One issued row, and the profiles its subject is a member of. */
+  const issued = (
+    overrides: {
+      credentials?: ReturnType<typeof storeWith>;
+      profilesFor?: (subject: string) => Promise<readonly string[]>;
+      now?: () => number;
+      rows?: readonly { id: string; subject: string; ref: string }[];
+    } = {},
+  ) => ({
+    profile: 'personal',
+    tokens: async () =>
+      overrides.rows ?? [{ id: 'tok1', subject: SUBJECT, ref: 'tokens/tok1' }],
+    credentials: overrides.credentials ?? storeWith({ 'tokens/tok1': 'llk_correct' }),
+    profilesFor: overrides.profilesFor ?? (async () => ['personal']),
+    ...(overrides.now ? { now: overrides.now } : {}),
+  });
+
+  const options = issued();
+
+  test('accepts an issued token and resolves the subject it names', async () => {
     const auth = new BearerAuthenticator(options);
     const outcome = await auth.authenticate('Bearer llk_correct');
 
     expect(outcome.ok).toBe(true);
-    if (outcome.ok) expect(outcome.principal).toEqual(ownerPrincipal('personal'));
+    // The whole of ADR-068: a static token is a person, with the profiles their
+    // membership gives them — not an owner with `profiles: undefined`, which is
+    // what it used to be and reached everything.
+    if (outcome.ok) {
+      expect(outcome.principal).toEqual(machinePrincipal(SUBJECT, 'personal', ['personal']));
+    }
+  });
+
+  test('reaches only the profiles its subject is a member of', async () => {
+    const auth = new BearerAuthenticator(
+      issued({ profilesFor: async () => ['personal', 'shared'] }),
+    );
+    const outcome = await auth.authenticate('Bearer llk_correct');
+
+    expect(outcome.ok).toBe(true);
+    if (outcome.ok) {
+      expect(outcome.principal.profiles).toEqual(['personal', 'shared']);
+      // Not "all of them". `mayReach` reads `undefined` as unrestricted, so a
+      // machine principal that carried it would restore what this removed.
+      expect(outcome.principal.profiles).not.toBeUndefined();
+      expect(mayReach(outcome.principal, 'work')).toBe(false);
+    }
+  });
+
+  test('a subject no profile lists reaches nothing, rather than everything', async () => {
+    const auth = new BearerAuthenticator(issued({ profilesFor: async () => [] }));
+    const outcome = await auth.authenticate('Bearer llk_correct');
+
+    expect(outcome.ok).toBe(true);
+    if (outcome.ok) {
+      expect(outcome.principal.profiles).toEqual([]);
+      expect(mayReach(outcome.principal, 'personal')).toBe(false);
+    }
+  });
+
+  test('a resolver that throws fails closed', async () => {
+    // Falling back to "every profile" here would restore the old behaviour at
+    // exactly the moment something is already wrong.
+    const auth = new BearerAuthenticator(
+      issued({
+        profilesFor: async () => {
+          throw new Error('members unreadable');
+        },
+      }),
+    );
+    expect(await auth.authenticate('Bearer llk_correct')).toEqual({
+      ok: false,
+      reason: 'invalid',
+    });
+  });
+
+  test('several rows each authenticate as their own subject', async () => {
+    const auth = new BearerAuthenticator(
+      issued({
+        rows: [
+          { id: 'tok1', subject: 'lanes:aaaaaa', ref: 'tokens/tok1' },
+          { id: 'tok2', subject: 'lanes:bbbbbb', ref: 'tokens/tok2' },
+        ],
+        credentials: storeWith({ 'tokens/tok1': 'llk_one', 'tokens/tok2': 'llk_two' }),
+        profilesFor: async (subject) => (subject === 'lanes:aaaaaa' ? ['personal'] : ['work']),
+      }),
+    );
+
+    const one = await auth.authenticate('Bearer llk_one');
+    const two = await auth.authenticate('Bearer llk_two');
+
+    expect(one.ok && one.principal.id).toBe('lanes:aaaaaa');
+    expect(one.ok && one.principal.profiles).toEqual(['personal']);
+    expect(two.ok && two.principal.id).toBe('lanes:bbbbbb');
+    expect(two.ok && two.principal.profiles).toEqual(['work']);
+  });
+
+  test('a row whose credential is missing matches nothing', async () => {
+    // What a half-finished `secrets push` leaves: the row travels with
+    // connections.yaml and the value does not.
+    const auth = new BearerAuthenticator(
+      issued({ credentials: storeWith({ 'tokens/tok2': 'llk_other' }) }),
+    );
+    expect(await auth.authenticate('Bearer llk_other')).toEqual({
+      ok: false,
+      reason: 'not_configured',
+    });
   });
 
   test('rejects a wrong token, a missing header, and a malformed one distinctly', async () => {
@@ -96,25 +193,21 @@ describe('authentication', () => {
     expect(await auth.authenticate('Basic xyz')).toEqual({ ok: false, reason: 'malformed' });
   });
 
-  test('fails closed when the profile has no token configured', async () => {
-    const auth = new BearerAuthenticator({ ...options, credentials: storeWith({}) });
+  test('fails closed when nothing has been issued', async () => {
+    const auth = new BearerAuthenticator(issued({ rows: [] }));
     expect(await auth.authenticate('Bearer anything')).toEqual({
       ok: false,
       reason: 'not_configured',
     });
   });
 
-  test("a token from one profile does not authenticate another profile's endpoint", async () => {
-    const personal = new BearerAuthenticator({
-      profile: 'personal',
-      tokenRef: 'profile/token',
-      credentials: storeWith({ 'profile/token': 'llk_personal' }),
-    });
-    const work = new BearerAuthenticator({
-      profile: 'work',
-      tokenRef: 'profile/token',
-      credentials: storeWith({ 'profile/token': 'llk_work' }),
-    });
+  test("a token from one workspace does not open another's endpoint", async () => {
+    const personal = new BearerAuthenticator(
+      issued({ credentials: storeWith({ 'tokens/tok1': 'llk_personal' }) }),
+    );
+    const work = new BearerAuthenticator(
+      issued({ credentials: storeWith({ 'tokens/tok1': 'llk_work' }) }),
+    );
 
     expect((await personal.authenticate('Bearer llk_work')).ok).toBe(false);
     expect((await work.authenticate('Bearer llk_personal')).ok).toBe(false);
@@ -122,12 +215,12 @@ describe('authentication', () => {
   });
 
   test('rotation is picked up once the cache is invalidated', async () => {
-    const credentials = storeWith({ 'profile/token': 'llk_old' });
-    const auth = new BearerAuthenticator({ ...options, credentials });
+    const credentials = storeWith({ 'tokens/tok1': 'llk_old' });
+    const auth = new BearerAuthenticator(issued({ credentials }));
 
     expect((await auth.authenticate('Bearer llk_old')).ok).toBe(true);
 
-    await credentials.set('profile/token', 'llk_new');
+    await credentials.set('tokens/tok1', 'llk_new');
     expect((await auth.authenticate('Bearer llk_old')).ok).toBe(true); // still cached
 
     auth.invalidateCache();
@@ -138,12 +231,12 @@ describe('authentication', () => {
   test('a rotated-in token is accepted without an explicit invalidation', async () => {
     // Nothing in production calls invalidateCache(), so a token the cache has
     // never seen has to be able to prove itself. The mismatch is the signal.
-    const credentials = storeWith({ 'profile/token': 'llk_old' });
-    const auth = new BearerAuthenticator({ ...options, credentials });
+    const credentials = storeWith({ 'tokens/tok1': 'llk_old' });
+    const auth = new BearerAuthenticator(issued({ credentials }));
 
     expect((await auth.authenticate('Bearer llk_old')).ok).toBe(true);
 
-    await credentials.set('profile/token', 'llk_new');
+    await credentials.set('tokens/tok1', 'llk_new');
     expect((await auth.authenticate('Bearer llk_new')).ok).toBe(true);
   });
 
@@ -153,12 +246,12 @@ describe('authentication', () => {
     // An attacker holding a leaked token is precisely the caller who never
     // produces a mismatch, so the cache also has to age out.
     let clock = 1_000;
-    const credentials = storeWith({ 'profile/token': 'llk_old' });
-    const auth = new BearerAuthenticator({ ...options, credentials, now: () => clock });
+    const credentials = storeWith({ 'tokens/tok1': 'llk_old' });
+    const auth = new BearerAuthenticator(issued({ credentials, now: () => clock }));
 
     expect((await auth.authenticate('Bearer llk_old')).ok).toBe(true);
 
-    await credentials.set('profile/token', 'llk_new');
+    await credentials.set('tokens/tok1', 'llk_new');
     expect((await auth.authenticate('Bearer llk_old')).ok).toBe(true); // inside the window
 
     clock += 10_000;
@@ -178,17 +271,18 @@ describe('rotation by another process', () => {
     const key = new Uint8Array(Buffer.from(generateCredentialKey(), 'base64'));
 
     const serving = createFileSecretStore({ path, key });
-    await serving.set('profile/token', 'llk_old');
+    await serving.set('tokens/tok1', 'llk_old');
 
     const auth = new BearerAuthenticator({
       profile: 'personal',
-      tokenRef: 'profile/token',
+      tokens: async () => [{ id: 'tok1', subject: 'lanes:abc123', ref: 'tokens/tok1' }],
       credentials: serving,
+      profilesFor: async () => ['personal'],
     });
     expect((await auth.authenticate('Bearer llk_old')).ok).toBe(true);
 
     // The CLI, in its own process, over the same file.
-    await createFileSecretStore({ path, key }).set('profile/token', 'llk_new');
+    await createFileSecretStore({ path, key }).set('tokens/tok1', 'llk_new');
 
     expect((await auth.authenticate('Bearer llk_new')).ok).toBe(true);
     expect((await auth.authenticate('Bearer llk_old')).ok).toBe(false);

--- a/src/auth/index.ts
+++ b/src/auth/index.ts
@@ -32,10 +32,12 @@ export interface Principal {
   /**
    * Every profile this caller may reach, or `undefined` for "all of them".
    *
-   * `undefined` is the machine token and the stdio pipe: neither is a person,
-   * both reach the whole workspace, and saying so explicitly is better than
-   * enumerating a list that would then need keeping in step. A `member` always
-   * carries a list, because the list *is* the delegation (ADR-060).
+   * `undefined` is the stdio pipe and nothing else now (ADR-068). The pipe is
+   * its own proof — a process that can write to it already has the operator's
+   * shell — so there is no credential to carry a subject and no member list to
+   * match. Every token, static or issued, carries a list: a `member`'s because
+   * the list *is* the delegation (ADR-060), and a `machine`'s because a bearer
+   * token names the person it was issued to rather than opening everything.
    */
   readonly profiles?: readonly string[] | undefined;
 }
@@ -59,6 +61,25 @@ export function memberPrincipal(
   profiles: readonly string[],
 ): Principal {
   return { id: subject, profile, kind: 'member', profiles };
+}
+
+/**
+ * A static token's holder, and the profiles whose `members:` name them.
+ *
+ * The same shape as `memberPrincipal` and deliberately so — `kind` is the only
+ * difference, and it exists for the audit log rather than for policy. ADR-060
+ * described this principal and nothing minted one: the static token resolved to
+ * `ownerPrincipal`, reaching every profile in the workspace, which made it the
+ * one credential here that never had to say who was holding it. A row in
+ * `tokens:` names a subject (ADR-068), so this resolves the same way an OAuth
+ * token does and `mayReach` gets no special case.
+ */
+export function machinePrincipal(
+  subject: string,
+  profile: string,
+  profiles: readonly string[],
+): Principal {
+  return { id: subject, profile, kind: 'machine', profiles };
 }
 
 /**
@@ -161,10 +182,39 @@ export function tokensMatch(a: string, b: string): boolean {
   return timingSafeEqual(hash(a), hash(b));
 }
 
+/**
+ * One issued token, as the authenticator needs it.
+ *
+ * Structurally what `connections.yaml` holds, declared here rather than
+ * imported: `auth` may not reach `#profile` (the architecture test enforces the
+ * direction), and the rows arrive as a closure for the same reason
+ * `profilesFor` does.
+ */
+export interface IssuedToken {
+  readonly id: string;
+  readonly subject: string;
+  readonly ref: SecretRef;
+}
+
 export interface AuthenticatorOptions {
+  /**
+   * The primary, which is what `principal.profile` starts as.
+   *
+   * Not what the token reaches — that is `profilesFor(subject)`. It is where
+   * the connection was opened, and every dispatch rewrites it with `forProfile`.
+   */
   readonly profile: string;
-  readonly tokenRef: SecretRef;
+  /** The workspace's issued tokens. Re-read on every reload, so a revoke lands. */
+  readonly tokens: () => Promise<readonly IssuedToken[]>;
   readonly credentials: SecretStore;
+  /**
+   * Which profiles list this subject as a member.
+   *
+   * The same resolver the OAuth path is handed (`server/endpoint.ts`), passed in
+   * rather than reached for, so discovery and enforcement cannot disagree about
+   * a subject's reach.
+   */
+  readonly profilesFor: (subject: string) => Promise<readonly string[]>;
   /** Injectable for tests. Only the cache window reads it. */
   readonly now?: () => number;
 }
@@ -183,10 +233,16 @@ export interface AuthenticatorOptions {
  */
 const CACHE_TTL_MS = 5_000;
 
+/** An issued row, with its value read out of the store. */
+interface LoadedToken {
+  readonly subject: string;
+  readonly value: string;
+}
+
 export class BearerAuthenticator implements Authenticator {
   readonly #options: AuthenticatorOptions;
   readonly #now: () => number;
-  #cached: string | null = null;
+  #cached: readonly LoadedToken[] | null = null;
   #readAt = 0;
 
   constructor(options: AuthenticatorOptions) {
@@ -195,48 +251,79 @@ export class BearerAuthenticator implements Authenticator {
   }
 
   async authenticate(authorizationHeader: string | null | undefined): Promise<AuthOutcome> {
-    const { profile } = this.#options;
-
     const presented = parseBearer(authorizationHeader);
     if (presented === null) {
       return { ok: false, reason: authorizationHeader ? 'malformed' : 'missing' };
     }
 
     const fresh = this.#cached !== null && this.#now() - this.#readAt < CACHE_TTL_MS;
-    let expected = fresh ? this.#cached : await this.#reload();
+    let rows = fresh ? this.#cached! : await this.#reload();
+    let matched = find(presented, rows);
 
-    // A mismatch against a *cached* value is ambiguous: either the credential is
+    // A miss against a *cached* set is ambiguous: either the credential is
     // wrong, or it is the right one and this process has not seen the rotation
-    // that produced it. One re-read separates the two, and it is what makes a
-    // rotated-in token work on its first call rather than after the window.
-    // Only a cached comparison can be wrong this way, so a fresh read never
-    // pays for a second one — which is what keeps a wrong token from costing a
-    // store read per attempt.
-    if (fresh && (expected === null || !tokensMatch(presented, expected))) {
-      expected = await this.#reload();
+    // or the issue that produced it. One re-read separates the two, and it is
+    // what makes a rotated-in token work on its first call rather than after
+    // the window. Only a cached comparison can be wrong this way, so a fresh
+    // read never pays for a second one — which is what keeps a wrong token from
+    // costing a store read per attempt.
+    if (fresh && matched === null) {
+      rows = await this.#reload();
+      matched = find(presented, rows);
     }
 
-    if (expected === null) {
-      // The profile has no token yet. Fail closed and let `lanes link doctor` explain.
+    if (rows.length === 0) {
+      // No token has been issued. Fail closed, and distinctly from a wrong one:
+      // `lanes link doctor` reads this to say "issue one" rather than "check it".
       return { ok: false, reason: 'not_configured' };
     }
 
-    return tokensMatch(presented, expected)
-      ? { ok: true, principal: ownerPrincipal(profile) }
-      : { ok: false, reason: 'invalid' };
+    if (matched === null) return { ok: false, reason: 'invalid' };
+
+    // **Resolved per request, not cached with the value.** Membership is read
+    // when a token is minted for an OAuth client (ADR-060) because there is a
+    // mint to read it at; a static token has none, so this is the only place
+    // the question can be asked. It is what makes `profile members remove`
+    // take effect on the next call rather than on the next rotation.
+    //
+    // A resolver that throws fails closed. The alternative — falling back to
+    // "every profile" — would restore exactly the behaviour ADR-068 removes,
+    // and would do it precisely when something is already wrong.
+    let profiles: readonly string[];
+    try {
+      profiles = await this.#options.profilesFor(matched.subject);
+    } catch {
+      return { ok: false, reason: 'invalid' };
+    }
+
+    return {
+      ok: true,
+      principal: machinePrincipal(matched.subject, this.#options.profile, profiles),
+    };
   }
 
-  async #reload(): Promise<string | null> {
+  async #reload(): Promise<readonly LoadedToken[]> {
     // Both caches, or neither: the store holds its own decrypted copy, so
     // re-reading without dropping that first re-reads the same stale value.
     this.#options.credentials.refresh?.();
-    this.#cached = await this.#options.credentials.get(this.#options.tokenRef);
+
+    const rows = await this.#options.tokens();
+    const loaded: LoadedToken[] = [];
+    for (const row of rows) {
+      const value = await this.#options.credentials.get(row.ref);
+      // A row whose credential is gone is not an error to report here. It is
+      // what a half-finished `secrets push` looks like, and the row simply
+      // matches nothing — `doctor` is where that is worth a sentence.
+      if (value) loaded.push({ subject: row.subject, value });
+    }
+
+    this.#cached = loaded;
     this.#readAt = this.#now();
-    return this.#cached;
+    return loaded;
   }
 
   /**
-   * Drop the cached value immediately.
+   * Drop the cached set immediately.
    *
    * The window above already bounds how long a rotation goes unnoticed, so this
    * is an optimisation rather than the mechanism — nothing's correctness may
@@ -245,6 +332,20 @@ export class BearerAuthenticator implements Authenticator {
   invalidateCache(): void {
     this.#cached = null;
   }
+}
+
+/**
+ * The row a presented token matches, or null.
+ *
+ * Every row is compared even after one matches. Returning early would make the
+ * time taken describe *which* row answered, and the whole point of
+ * `tokensMatch` is that a comparison here leaks nothing about the value it is
+ * comparing against.
+ */
+function find(presented: string, rows: readonly LoadedToken[]): LoadedToken | null {
+  let found: LoadedToken | null = null;
+  for (const row of rows) if (tokensMatch(presented, row.value)) found = row;
+  return found;
 }
 
 /**

--- a/src/cli/accepts.ts
+++ b/src/cli/accepts.ts
@@ -68,8 +68,14 @@ export const ACCEPTS: Record<string, readonly string[]> = {
   'target show': ['workspace'],
   'mcp install-instructions': ['client'],
   pair: ['print', 'rotate', 'yes'],
-  'token show': ['show', 'raw'],
-  'token rotate': ['show', 'raw', 'yes'],
+  // `--id` names which row, and is required once more than one is issued.
+  // `--subject`/`--me` say who a new one is for, which is the whole of ADR-068.
+  token: ['json'],
+  'token list': ['json'],
+  'token issue': ['show', 'subject', 'me', 'label'],
+  'token show': ['show', 'raw', 'id'],
+  'token rotate': ['show', 'raw', 'yes', 'id'],
+  'token revoke': ['yes', 'id'],
   'audit tail': ['limit', 'denied-only', 'format'],
   'audit verify': ['limit', 'format'],
   attach: ['connection'],
@@ -77,7 +83,11 @@ export const ACCEPTS: Record<string, readonly string[]> = {
   start: ['port', 'only'],
   'mcp stdio': ['only'],
   'mcp add': ['name', 'scope', 'token-env', 'dry-run', 'force', 'no-skill', 'headless'],
-  'mcp skill': ['print', 'force'],
+  // No `--force`: `mcp skill` prints a path or the document and writes nothing,
+  // so there was nothing for it to force. It was accepted and ignored, which is
+  // the defect `selection.ts` exists to prevent. `mcp add --force` is the flag
+  // that replaces a registration.
+  'mcp skill': ['print'],
   'mcp list': ['name', 'scope'],
   // `--yes` because it installs the app when nothing answers the scheme, and
   // that is the one prompt in this CLI that puts an application on the machine.

--- a/src/cli/commands/connect/custom/index.test.ts
+++ b/src/cli/commands/connect/custom/index.test.ts
@@ -20,7 +20,7 @@ import { connectCustom, type ConnectCustomOptions } from './index.ts';
  * `check`, whose whole job is catching that, does not read the directory at all.
  */
 
-const PROFILE = `contract: 4
+const PROFILE = `contract: 5
 
 instance:
   profile: personal

--- a/src/cli/commands/connect/declare.test.ts
+++ b/src/cli/commands/connect/declare.test.ts
@@ -11,6 +11,11 @@ import { declareConnection } from './declare.ts';
  * and are not: one is a name the operator chose and the other is an identity
  * three things read as one. A row that confused them was renameable exactly
  * once, after which `connect` no longer recognised the account it had renamed.
+ *
+ * A label equal to `defaultLabel` is not written. Every reader derives that
+ * string for itself, so recording it would be a line saying what the two lines
+ * above it say — the rule that used to be spelled against the account, back
+ * when the account was what an unnamed row was called.
  */
 
 const EMPTY = `contract: 4
@@ -29,7 +34,10 @@ function declaring(connections: readonly ConnectionConfig[], over: Record<string
     providerId: 'gmail',
     connectionId: 'ada',
     account: 'ada@example.com',
-    label: 'ada@example.com',
+    // What `settleIdentity` settles on when the operator presses Enter, and
+    // what it hands the writer to compare against.
+    label: 'Gmail (ada)',
+    defaultLabel: 'Gmail (ada)',
     method: undefined,
     config: {},
     ...over,
@@ -43,7 +51,7 @@ function declaring(connections: readonly ConnectionConfig[], over: Record<string
 }
 
 describe('declaring a new connection', () => {
-  test('writes no label when the label is only the account again', () => {
+  test('writes no label when it is the one every reader derives anyway', () => {
     const { written } = declaring([]);
 
     expect(written.connections[0]).toEqual({
@@ -53,7 +61,7 @@ describe('declaring a new connection', () => {
     });
   });
 
-  test('writes one when the operator said something the account does not', () => {
+  test('writes one when the operator said something the derived name does not', () => {
     const { written } = declaring([], { label: 'Work mail' });
 
     expect(written.connections[0]).toEqual({

--- a/src/cli/commands/connect/declare.test.ts
+++ b/src/cli/commands/connect/declare.test.ts
@@ -18,7 +18,7 @@ import { declareConnection } from './declare.ts';
  * when the account was what an unnamed row was called.
  */
 
-const EMPTY = `contract: 4
+const EMPTY = `contract: 5
 instance:
   profile: personal
   host: 127.0.0.1

--- a/src/cli/commands/connect/declare.ts
+++ b/src/cli/commands/connect/declare.ts
@@ -22,6 +22,14 @@ export function declareConnection(input: {
   readonly connectionId: string;
   readonly account: string;
   readonly label: string;
+  /**
+   * What the row is called with nobody's word for it, from `settleIdentity`.
+   *
+   * The provider's name and the account composed by `defaultConnectionLabel`,
+   * which is what every reader falls back to. A label equal to it is a line
+   * saying what the two lines above it already say, so it is not written.
+   */
+  readonly defaultLabel: string;
   /** Which route in, where the provider offered a choice. */
   readonly method: string | undefined;
   /**
@@ -34,6 +42,7 @@ export function declareConnection(input: {
   readonly config: Readonly<Record<string, string>>;
 }): readonly string[] {
   const { document, connections, providerId, connectionId, account, label, method } = input;
+  const derived = input.defaultLabel;
   const config = input.config;
 
   const key = `${providerId}.${connectionId}`;
@@ -45,14 +54,14 @@ export function declareConnection(input: {
     // where the OAuth provider already looks. Writing it would add a line per
     // connection that can only ever agree or be a bug.
     //
-    // No `label` either, when it is the account. Pressing Enter at the prompt is
-    // the common answer, and a line repeating the address above it is a line to
-    // read past forever.
+    // No `label` either, when it is the one every reader derives anyway.
+    // Pressing Enter at the prompt is the common answer, and a line repeating
+    // the provider and the address above it is a line to read past forever.
     document.addTo(['connections'], {
       id: connectionId,
       provider: providerId,
       account,
-      ...(label === account ? {} : { label }),
+      ...(label === derived ? {} : { label }),
       ...(Object.keys(config).length > 0 ? { config } : {}),
     });
     changes.push(`connections += ${key} (${account})`);
@@ -69,10 +78,10 @@ export function declareConnection(input: {
     changes.push(`connections.${key}.account = ${account}`);
   }
 
-  // Compared against what the row is *called*, which is the account until
+  // Compared against what the row is *called*, which is the derived name until
   // somebody names it otherwise. Without the fallback, every reconnect of an
-  // unlabelled connection writes a label that says what the line above it says.
-  if ((declared?.label ?? declared?.account) !== label) {
+  // unlabelled connection writes a label that says what the lines above it say.
+  if ((declared?.label ?? derived) !== label) {
     document.setIn(['connections', index, 'label'], label);
     changes.push(`connections.${key}.label = ${label}`);
   }

--- a/src/cli/commands/connect/index.ts
+++ b/src/cli/commands/connect/index.ts
@@ -237,7 +237,7 @@ export async function runConnect(
     //    adding a new one. Without it, a retried connect appends a second row
     //    rather than repairing the first — which is how `main2` and `main3`
     //    ended up in a config describing two mailboxes.
-    const { connectionId, account, label } = await settleIdentity({
+    const settled = await settleIdentity({
       manifest,
       provisionalId,
       explicitId: named,
@@ -246,6 +246,7 @@ export async function runConnect(
       runtime: { ...runtime, connectorFor: address.connectorFor },
       prompter,
     });
+    const { connectionId, account, label } = settled;
 
     const connectionKey = `${providerId}.${connectionId}`;
 
@@ -277,9 +278,8 @@ export async function runConnect(
         document: connectionsDocument,
         connections: runtime.workspaceConnections,
         providerId,
-        connectionId,
-        account,
-        label,
+        // The settled identity as one value: the row, the account, the name.
+        ...settled,
         method: method.id,
         config: address.values,
       }),

--- a/src/cli/commands/connect/settle.test.ts
+++ b/src/cli/commands/connect/settle.test.ts
@@ -118,16 +118,19 @@ const settle = (over: Partial<Parameters<typeof settleIdentity>[0]> = {}) =>
   });
 
 describe('the label a connection is given at connect time', () => {
-  test('is asked for every time, offering the account that was just resolved', async () => {
+  test('is asked for every time, offering the provider and the account', async () => {
     const asking = prompter('');
 
     const settled = await settle({ prompter: asking });
 
     expect(asking.asked).toHaveLength(1);
-    // The account is in the question, so pressing Enter is an informed answer
-    // rather than a blank one.
-    expect(asking.asked[0]).toContain('ada@example.com');
-    expect(settled.label).toBe('ada@example.com');
+    // The suggestion is in the question, so pressing Enter is an informed
+    // answer rather than a blank one. It names the provider as well as the
+    // account, because the account alone was a second copy of the line beside
+    // it and left every reader of an unlabelled row with nothing to show.
+    expect(asking.asked[0]).toContain('Acme Mail (ada)');
+    expect(settled.label).toBe('Acme Mail (ada)');
+    expect(settled.defaultLabel).toBe('Acme Mail (ada)');
   });
 
   test('takes the operator words, and leaves the account they replace alone', async () => {
@@ -156,10 +159,10 @@ describe('the label a connection is given at connect time', () => {
     expect(settled.connectionId).toBe('ada');
   });
 
-  test('falls back to the account where there is nobody to ask', async () => {
+  test('falls back to the derived name where there is nobody to ask', async () => {
     const settled = await settle({ prompter: silent });
 
-    expect(settled.label).toBe('ada@example.com');
+    expect(settled.label).toBe('Acme Mail (ada)');
   });
 
   test('is not asked for when it was given', async () => {
@@ -171,7 +174,7 @@ describe('the label a connection is given at connect time', () => {
     expect(settled.label).toBe('Work mail');
   });
 
-  test('takes the account when the terminal it was promised turns out not to exist', async () => {
+  test('takes the derived name when the terminal it was promised turns out not to exist', async () => {
     // `terminalPrompter` says `interactive: true` and discovers otherwise only
     // when asked. By then the browser has opened and the credential is stored,
     // so throwing over a display name fails a connect that has already happened.
@@ -186,7 +189,7 @@ describe('the label a connection is given at connect time', () => {
 
     const settled = await settle({ prompter: noTerminal });
 
-    expect(settled.label).toBe('ada@example.com');
+    expect(settled.label).toBe('Acme Mail (ada)');
   });
 
   test('lets Ctrl-C stop the command rather than answering for it', async () => {
@@ -215,6 +218,6 @@ describe('the label a connection is given at connect time', () => {
     // confirm it against itself is the second half of a question they answered.
     expect(asking.asked).toHaveLength(1);
     expect(settled.account).toBe('Ada at Acme');
-    expect(settled.label).toBe('Ada at Acme');
+    expect(settled.label).toBe('Acme Mail (Ada at Acme)');
   });
 });

--- a/src/cli/commands/connect/settle.ts
+++ b/src/cli/commands/connect/settle.ts
@@ -1,6 +1,7 @@
 import { createMcpConnector } from '#connectivity/transports';
 import { bearerTokenAsStored } from '#connectivity/auth/index.ts';
 import type { SecretStore } from '#secrets';
+import { defaultConnectionLabel } from '#profile';
 import type { ConnectionConfig, Config } from '#profile';
 import type { AnyConnector, ProviderManifest } from '#connectivity';
 import { nextConnectionId, resolveAccount } from '../../identity.ts';
@@ -46,7 +47,21 @@ export async function settleIdentity(input: {
     authorizeRequest(providerId: string, connectionId: string, request: Request): Promise<Request>;
   };
   prompter?: Prompter;
-}): Promise<{ connectionId: string; account: string; label: string }> {
+}): Promise<{
+  connectionId: string;
+  account: string;
+  label: string;
+  /**
+   * What this row is called with nobody's word for it, carried to the writer.
+   *
+   * `declareConnection` writes no label equal to it, for the reason it never
+   * wrote one equal to the account: a line saying what the two lines above it
+   * say is a line to read past forever. Returned rather than derived twice, so
+   * the string the operator was offered and the string compared against it
+   * cannot come apart.
+   */
+  defaultLabel: string;
+}> {
   const { manifest, provisionalId, explicitId, runtime } = input;
   const prompter = input.prompter ?? terminalPrompter;
 
@@ -169,17 +184,20 @@ export async function settleIdentity(input: {
           (candidate) => candidate.account.toLowerCase() === account!.toLowerCase(),
         )?.id ?? nextConnectionId(taken, false)));
 
+  const defaultLabel = defaultConnectionLabel(manifest.name, account);
+
   return {
     connectionId,
     account,
+    defaultLabel,
     label: await settleLabel({
       given: input.label,
+      fallback: defaultLabel,
       // What the row this is about to land on is already called. Looked up
       // across the whole vendor account rather than this provider alone, for the
       // reason `accountSiblings` exists: `connect icloud_calendar` adopts iCloud
       // Mail's id, and should adopt the name that goes with it too.
       declared: siblings.find((candidate) => candidate.id === connectionId)?.label,
-      account,
       typed,
       prompter,
     }),
@@ -198,21 +216,29 @@ export async function settleIdentity(input: {
  * The suggestion is in the question and an empty answer takes it, so the cost of
  * always asking is one keystroke. Nothing addresses a connection by its label,
  * so there is no answer here that can break anything.
+ *
+ * **The suggestion is the provider and the account, not the account.** It was
+ * the address alone, which made the label a second copy of the field beside it
+ * — and left every surface that shows a name without one, because a default
+ * that only repeats another line is a default nothing writes down.
+ * `defaultConnectionLabel` is the whole rule and every reader derives the same
+ * string from it.
  */
 async function settleLabel(input: {
   given: string | undefined;
   declared: string | undefined;
-  account: string;
+  /** What this row is called when nobody says otherwise. */
+  fallback: string;
   typed: boolean;
   prompter: Prompter;
 }): Promise<string> {
-  const { given, declared, account, typed, prompter } = input;
+  const { given, declared, fallback, typed, prompter } = input;
 
   if (given) return given;
 
-  // A label already chosen wins over the account, so re-authorising an expired
-  // credential does not quietly undo the operator's own word for the row.
-  const suggestion = declared ?? account;
+  // A label already chosen wins over the derived one, so re-authorising an
+  // expired credential does not quietly undo the operator's own word for the row.
+  const suggestion = declared ?? fallback;
 
   if (typed || !prompter.interactive) return suggestion;
 

--- a/src/cli/commands/connection-list.ts
+++ b/src/cli/commands/connection-list.ts
@@ -1,12 +1,15 @@
 import { RESERVED_PROVIDER_IDS } from '#connectivity';
+import { PROVIDER_MANIFESTS } from '#providers/index.ts';
 import {
   connectionRefOf,
+  defaultConnectionLabel,
   listProfiles,
   loadProfileConfig,
   readConnections,
   resolveTargetWorkspace,
   resolveWorkspaceRoot,
 } from '#profile';
+import { RESERVED_SURFACES } from '../config-repair.ts';
 import { emit, heading, print, style, table } from '../output.ts';
 import type { GlobalFlags } from '../runtime.ts';
 
@@ -104,6 +107,20 @@ export async function connectionList(flags: GlobalFlags & { json?: boolean }): P
   });
 }
 
+/**
+ * What each provider is called, by id.
+ *
+ * The catalogue's manifests plus the owner layer, which is registered separately
+ * and is deliberately absent from `PROVIDERS`. A workspace-local manifest is not
+ * here: this command reads files rather than building a registry, and one custom
+ * provider falling back to its account is a smaller price than a registry build
+ * on a listing.
+ */
+const PROVIDER_NAMES = new Map<string, string>([
+  ...PROVIDER_MANIFESTS.map((manifest): [string, string] => [manifest.id, manifest.name]),
+  ...Object.entries(RESERVED_SURFACES),
+]);
+
 function row(one: ConnectionSummary): string[] {
   // "granted to nobody" is said rather than left blank, because a blank column
   // reads as "not loaded yet" and this is a fact about the config.
@@ -112,5 +129,12 @@ function row(one: ConnectionSummary): string[] {
       ? style.dim('no profile grants it')
       : one.grantedTo.join(', ');
 
-  return [`  ${style.bold(one.key)}`, one.label ?? one.account, reach];
+  // The account was this column's fallback, which meant an unlabelled row read
+  // as its address and said nothing about which service the address is at. The
+  // derived name says both, and is the one the dashboard and the connect prompt
+  // show for the same row.
+  const named = PROVIDER_NAMES.get(one.provider);
+  const label = one.label ?? (named ? defaultConnectionLabel(named, one.account) : one.account);
+
+  return [`  ${style.bold(one.key)}`, label, reach];
 }

--- a/src/cli/commands/knowledge/knowledge.test.ts
+++ b/src/cli/commands/knowledge/knowledge.test.ts
@@ -30,7 +30,7 @@ import { probe } from './setup.ts';
 const roots: string[] = [];
 const previousHome = process.env['LANES_LINK_HOME'];
 
-const PROFILE = `contract: 4
+const PROFILE = `contract: 5
 
 instance:
   profile: personal

--- a/src/cli/commands/mcp/harnesses.ts
+++ b/src/cli/commands/mcp/harnesses.ts
@@ -45,14 +45,17 @@ export interface AddInput {
   readonly tokenEnv: string;
   readonly scope: string;
   /**
-   * Which selection this registration is for.
+   * Which workspace this registration is for.
    *
-   * Not part of the URL — a deployed endpoint serves every profile in its bucket
-   * and each call names one. It is here because the shell commands a harness is
-   * told to run afterwards do need it, and a `lanes link token show` without it
-   * substitutes to nothing.
+   * Not part of the URL — one endpoint serves every profile in the workspace and
+   * each call names one in its `profile` argument. It is here because the shell
+   * commands a harness is told to run afterwards do need it, and a `lanes link
+   * token show` without it substitutes to nothing.
+   *
+   * There is no `profile` beside it any more (ADR-068). It was here for exactly
+   * one reader — the `export` line below — and what that line names is a token,
+   * which is the workspace's.
    */
-  readonly profile: string;
   readonly target: string;
 }
 
@@ -142,14 +145,18 @@ export const HARNESSES: readonly Harness[] = [
     scoped: false,
     storesToken: false,
     home: CODEX_HOME,
-    add: ({ name, url, tokenEnv }) => [
+    // The env var only under `--headless`, which is what the header comment
+    // above claims and this did not do: it was passed unconditionally, so every
+    // Codex registration was a token registration while `storesToken: false`
+    // said otherwise and `afterAdd` told the operator to export a variable an
+    // OAuth-capable client would never read.
+    add: ({ name, url, tokenEnv, token }) => [
       'mcp',
       'add',
       name,
       '--url',
       url,
-      '--bearer-token-env-var',
-      tokenEnv,
+      ...(token ? ['--bearer-token-env-var', tokenEnv] : []),
     ],
     get: (name) => ['mcp', 'get', name],
     remove: (name) => ['mcp', 'remove', name],
@@ -157,19 +164,26 @@ export const HARNESSES: readonly Harness[] = [
     // installs to both unchanged. Codex has no subagent directory, so it gets
     // the skill and not the scout — and `mcp add` says which it did.
     skills: () => join(CODEX_HOME(), 'skills'),
-    afterAdd: ({ tokenEnv, profile, target }) => [
-      `Codex reads the token from $${tokenEnv} when it starts, so set it where Codex will see it:`,
-      '',
-      // Both flags, and this line is the reason they matter more here than
-      // anywhere else: an unresolvable substitution yields the empty string, the
-      // header becomes "Bearer ", and the only symptom is a 401 that reads as a
-      // bad token rather than a command that refused.
-      `    export ${tokenEnv}="$(lanes link token show --raw --profile ${profile} --workspace ${target})"`,
-      '',
-      'Add that to your shell profile. This is the better half of the bargain: the token never',
-      'reaches ~/.codex/config.toml, and a "lanes link token rotate" is picked up on next launch',
-      'with no re-registration.',
-    ],
+    afterAdd: ({ tokenEnv, target, token }) =>
+      // Nothing to say unless a token is actually in play. Without `--headless`
+      // this registration is a bare URL like Claude Code's, and telling somebody
+      // to export a variable nothing reads was the instruction that made
+      // `storesToken: false` read as a contradiction.
+      token === undefined
+        ? []
+        : [
+            `Codex reads the token from $${tokenEnv} when it starts, so set it where Codex will see it:`,
+            '',
+            // `--workspace`, and this line is the reason it matters more here
+            // than anywhere else: an unresolvable substitution yields the empty
+            // string, the header becomes "Bearer ", and the only symptom is a
+            // 401 that reads as a bad token rather than a command that refused.
+            `    export ${tokenEnv}="$(lanes link token show --raw --workspace ${target})"`,
+            '',
+            'Add that to your shell profile. This is the better half of the bargain: the token never',
+            'reaches ~/.codex/config.toml, and a "lanes link token rotate" is picked up on next launch',
+            'with no re-registration.',
+          ],
   },
 ];
 

--- a/src/cli/commands/mcp/register.ts
+++ b/src/cli/commands/mcp/register.ts
@@ -1,6 +1,7 @@
+import { anyIssuedToken } from '#profile';
 import { endpointUrl } from '../../endpoint-url.ts';
 import { fail, ok, print, style, warn } from '../../output.ts';
-import { ensureProfileToken, openRuntime, type GlobalFlags } from '../../runtime.ts';
+import { openWorkspaceRuntime, type GlobalFlags } from '../../runtime.ts';
 import { installFor } from './assets.ts';
 import { HARNESSES, type AddInput, type Harness } from './harnesses.ts';
 
@@ -114,13 +115,32 @@ export async function mcpAdd(target: string | undefined, options: McpAddOptions)
   const scope = options.scope ?? 'user';
   const tokenEnv = options.tokenEnv ?? 'LANES_LINK_TOKEN';
 
-  const runtime = await openRuntime(options);
+  // **The workspace, not a profile** (ADR-068). One endpoint serves every
+  // profile in the workspace and each call names one in its `profile` argument,
+  // so a registration was never per-profile: two different `--profile` values
+  // produced byte-identical harness commands. What kept the flag required was
+  // that the endpoint's token lived at `auth.token_ref` on a profile — a ref
+  // whose default was the same constant for all of them — and reading it meant
+  // resolving one. The token is the workspace's now, so there is nothing left
+  // to ask. `--profile` is still accepted, and narrows nothing here.
+  const runtime = await openWorkspaceRuntime(options);
 
   try {
-    // Minted either way. The endpoint needs one to serve at all, and `outputs`
-    // prints it; what `--headless` decides is whether it is written into
-    // somebody's agent config.
-    const { token } = await ensureProfileToken(runtime.credentials, runtime.config.auth.token_ref);
+    // **Only for `--headless`, and only if one has been issued.** The ordinary
+    // path registers a bare URL and the client authorises itself (ADR-062).
+    // Nothing is minted here: a token names the person it was issued to, and
+    // `mcp add` does not know who — which is what `token issue` is for.
+    const token = options.headless === true
+      ? (await anyIssuedToken(runtime.resolution.workspaceRoot, runtime.credentials))?.value
+      : undefined;
+
+    if (options.headless === true && token === undefined) {
+      throw new Error(
+        'No static token is issued in this workspace, so --headless has nothing to write.\n' +
+          `  Issue one: lanes link token issue --me --workspace ${runtime.target}\n` +
+          '  Without --headless the client signs in for itself and needs none.',
+      );
+    }
 
     // The target's own address, not the local one. This built
     // `http://<host>:<port>/mcp` unconditionally, so `mcp add --workspace cloud`
@@ -130,10 +150,9 @@ export async function mcpAdd(target: string | undefined, options: McpAddOptions)
     const input: AddInput = {
       name,
       url,
-      ...(options.headless === true ? { token } : {}),
+      ...(token === undefined ? {} : { token }),
       tokenEnv,
       scope,
-      profile: runtime.resolution.profile,
       target: runtime.resolution.target,
     };
 

--- a/src/cli/commands/mcp/stdio.ts
+++ b/src/cli/commands/mcp/stdio.ts
@@ -48,7 +48,6 @@ export async function mcpStdio(
       reconciled: ({ profile, plan, ofMany }) =>
         printErr(`${ofMany ? `${profile}\n` : ''}${plan}`),
       // Unreachable: this path never mints a token, because it never needs one.
-      tokenMinted: () => {},
     },
     log: {
       debug() {},

--- a/src/cli/commands/operate.test.ts
+++ b/src/cli/commands/operate.test.ts
@@ -39,22 +39,24 @@ describe('audit markdown cells', () => {
 });
 
 /**
- * The token command `outputs` hands over, and the two flags it must carry.
+ * The token command `outputs` hands over, and the flag it must carry.
  *
- * A token is per-target. Printing a bare `token show --raw` beside a deployed
+ * A token is per-workspace. Printing a bare `token show --raw` beside a deployed
  * URL hands over the *local* token — a credential that looks like an answer and
  * fails as a wrong password, which is the failure mode this whole helper was
  * written to avoid and reintroduced one flag lower down.
+ *
+ * It used to name a profile too, and must not now: the token stopped being a
+ * profile's at ADR-068 and `token show` refuses the flag.
  */
 describe('the token command outputs prints', () => {
-  test('names both the profile and the target, on either path', async () => {
-    // Whichever branch is taken — a `lanes` on PATH that matches, or the
-    // checkout-relative fallback — the selection has to survive into the line
-    // somebody pastes.
-    const invocation = await tokenInvocation('a-token-no-endpoint-will-match', 'work', 'cloud');
+  test('names the workspace and not a profile, on either path', async () => {
+    // Whichever branch is taken — a `lanes` on PATH, or the checkout-relative
+    // fallback — the selection has to survive into the line somebody pastes.
+    const invocation = await tokenInvocation('cloud');
 
-    expect(invocation.command).toContain('--profile work');
     expect(invocation.command).toContain('--workspace cloud');
+    expect(invocation.command).not.toContain('--profile');
     expect(invocation.command).toContain('token show --raw');
   });
 });

--- a/src/cli/commands/operate.ts
+++ b/src/cli/commands/operate.ts
@@ -30,5 +30,11 @@ export { pair, PAIR_CERT_REF, PAIR_KEY_REF, PAIR_TOKEN_REF, type PairFlags } fro
 export { desktop, settingsUrl, type DesktopFlags } from './operate/desktop.ts';
 export { auditTail, auditVerify, markdownCell } from './operate/audit.ts';
 export { attachFile } from './operate/attach.ts';
-export { tokenRotate, tokenShow } from './operate/token.ts';
+export {
+  tokenIssue,
+  tokenList,
+  tokenRevoke,
+  tokenRotate,
+  tokenShow,
+} from './operate/token.ts';
 export { configShow, policyList, policyRule } from './operate/policy.ts';

--- a/src/cli/commands/operate/inspect.ts
+++ b/src/cli/commands/operate/inspect.ts
@@ -1,5 +1,5 @@
 import { formatPlan, planIsNoop, planReconcile } from '#registry';
-import type { ConnectionConfig, SelectedConnection } from '#profile';
+import { readEndpointTokens, type ConnectionConfig, type SelectedConnection } from '#profile';
 import { DEFAULT_SURFACES } from '../../config-repair.ts';
 import { announce, announceProfile, emit, fail, ok, print, warn } from '../../output.ts';
 import { staleNudge } from '../../release.ts';
@@ -120,16 +120,27 @@ export async function doctor(flags: DoctorFlags): Promise<void> {
     checks.push('config is valid');
     checks.push('state store is reachable');
 
-    const token = await runtime.credentials.get(runtime.config.auth.token_ref);
-    if (token) {
-      checks.push(`profile token present (${runtime.config.auth.token_ref})`);
-    } else {
-      // Not a failure: `lanes link start` mints one. Reporting it as a problem would
-      // make every fresh profile fail doctor for something that fixes itself.
+    // **A row whose value is missing, not a missing token** (ADR-068). Having
+    // issued none is the healthy default — a client signs in for itself — so
+    // reporting that as a problem would make every working workspace fail
+    // doctor. What is genuinely broken is a row pointing at nothing: it matches
+    // no credential, and from the client's side reads exactly like a wrong
+    // token. That is what a half-finished `secrets push` leaves behind.
+    const issued = await readEndpointTokens(runtime.resolution.workspaceRoot);
+    const orphaned: string[] = [];
+    for (const row of issued) {
+      if ((await runtime.credentials.get(row.ref)) === null) orphaned.push(row.id);
+    }
+
+    if (issued.length > 0 && orphaned.length === 0) {
+      checks.push(`${issued.length} endpoint token(s) present`);
+    }
+
+    for (const id of orphaned) {
       warnings.push({
-        kind: 'no_profile_token',
-        message: 'no profile token yet — lanes link start will mint one, or run: lanes link token rotate',
-        fix: forSelection('lanes link token rotate'),
+        kind: 'orphaned_endpoint_token',
+        message: `token "${id}" has a row but no value in this workspace's store — it matches nothing`,
+        fix: `lanes link token rotate --id ${id} --workspace ${runtime.resolution.target}`,
       });
     }
 

--- a/src/cli/commands/operate/outputs.ts
+++ b/src/cli/commands/operate/outputs.ts
@@ -1,8 +1,8 @@
-import { listProfiles } from '#profile';
+import { anyIssuedToken, listProfiles } from '#profile';
 import { fileURLToPath } from 'node:url';
 import { deployedUrl, endpointHealth, localUrl } from '../../endpoint-url.ts';
-import { announce, heading, print, style, warn } from '../../output.ts';
-import { ensureProfileToken, openRuntime, type GlobalFlags } from '../../runtime.ts';
+import { announceWorkspace, heading, print, style, warn } from '../../output.ts';
+import { openWorkspaceRuntime, type GlobalFlags } from '../../runtime.ts';
 
 export interface OutputsFlags extends GlobalFlags {
   readonly show?: boolean | undefined;
@@ -23,18 +23,27 @@ export interface OutputsFlags extends GlobalFlags {
  * the harness's business.
  */
 export async function outputs(flags: OutputsFlags): Promise<void> {
-  const runtime = await openRuntime(flags);
+  // The workspace, matching what this command's own subject has always been
+  // (ADR-068). It asked for a profile only to find the endpoint's token, and
+  // that token is the workspace's.
+  const runtime = await openWorkspaceRuntime(flags);
 
   try {
-    const { token } = await ensureProfileToken(runtime.credentials, runtime.config.auth.token_ref);
+    // Whatever has been issued, or nothing — which is the ordinary state.
+    // Nothing is minted: `outputs` reports, and a token names a person.
+    const held = await anyIssuedToken(runtime.resolution.workspaceRoot, runtime.credentials);
+    const token = held?.value;
     const declared = runtime.declared.deploy;
     const deployed = await deployedUrl(declared);
     // Not `endpointUrl`, which would ask the platform a second time for an
     // answer this line already has.
     const url = deployed ?? localUrl(runtime.config);
 
+    // Unauthenticated when nothing is issued. `/health` answers either way; what
+    // it withholds without a credential is the profile list, so `mine` below is
+    // then decided by the endpoint answering at all.
     const live = await endpointHealth(url, token);
-    const mine = live?.profile === runtime.resolution.profile;
+    const mine = live !== null;
 
     // Live if it is up, otherwise every profile in this target's workspace.
     // Those are the same set now: a profile lives in exactly one target
@@ -51,9 +60,8 @@ export async function outputs(flags: OutputsFlags): Promise<void> {
             running: mine,
             deployed: deployed !== null,
             target: runtime.target,
-            primary: runtime.resolution.profile,
             profiles,
-            ...(flags.show ? { token } : {}),
+            ...(flags.show && token !== undefined ? { token } : {}),
           },
           null,
           2,
@@ -62,7 +70,7 @@ export async function outputs(flags: OutputsFlags): Promise<void> {
       return;
     }
 
-    announce(runtime.resolution);
+    announceWorkspace(runtime.resolution);
 
     heading('Endpoint');
     print(
@@ -75,21 +83,19 @@ export async function outputs(flags: OutputsFlags): Promise<void> {
       print(style.dim(`  ${declared.platform} service "${declared.service}" for target "${runtime.target}".`));
     }
 
-    if (live && !mine) {
-      // Two workspaces can assign the same port. Saying so beats reporting an
-      // endpoint as up when it belongs to something else entirely.
-      print(warn(`something else is serving this port: profile "${live.profile}"`));
-    }
+    heading(`Profiles served by it (${profiles.length})`);
+    for (const profile of profiles) print(`  ${profile}`);
+    print(
+      style.dim(
+        '  Each call names one, in its `profile` argument. Which of these a client\n' +
+          '  actually reaches is decided by who signs in — every profile whose members\n' +
+          '  list them, and no others.',
+      ),
+    );
 
-    heading(`Profiles reachable through it (${profiles.length})`);
-    for (const profile of profiles) {
-      print(`  ${profile}${profile === runtime.resolution.profile ? style.dim('  (endpoint owner)') : ''}`);
-    }
-    print(style.dim('  Each call names one, in its `profile` argument.'));
-
-    if (flags.show) {
+    if (flags.show && token !== undefined) {
       heading('Token');
-      print(`  ${token}`);
+      print(`  ${token}  ${style.dim(`(${held?.id})`)}`);
     }
 
     heading('Register with your agent');
@@ -100,36 +106,59 @@ export async function outputs(flags: OutputsFlags): Promise<void> {
     );
     print('');
 
-    const invocation = await tokenInvocation(
-      token,
-      runtime.resolution.profile,
-      runtime.resolution.target,
-    );
-
-    print(
-      `  claude mcp add --transport http lanes-link ${url} \\\n` +
-        `    --header "Authorization: Bearer $(${invocation.command})"`,
-    );
+    // **The bare URL, and no header** (ADR-062). This printed the
+    // `Authorization: Bearer $(…)` form unconditionally, which was the shape
+    // before every endpoint ran the authorization flow — a registration that
+    // carries a credential, bypasses consent and expiry, and leaves a long-lived
+    // token in a harness config. The client discovers
+    // `/.well-known/oauth-protected-resource` from the 401 and signs its owner
+    // in instead.
+    print(`  claude mcp add --transport http lanes-link ${url}`);
     print('');
-
-    if (!invocation.onPath) {
-      // The failure this prevents is nasty: an unresolvable command substitutes
-      // to the empty string, the header becomes "Bearer ", and the only symptom
-      // is a 401 that looks like a bad token rather than a missing binary.
-      print(warn('lanes is not on your PATH, so the short form would substitute to nothing.'));
-      print(style.dim('  The command above uses this checkout instead. To shorten it permanently:'));
-      print(`      cd ${process.cwd()} && bun link`);
-      print('');
-    }
-
     print(
       style.dim(
-        '  One registration covers every profile above. The $(…) keeps the token out of your\n' +
-          '  agent\'s context and out of the transcript — but note it is resolved once, when you\n' +
-          '  run the command, and stored as a literal. After "lanes link token rotate" you have to\n' +
-          '  register again. Other harnesses take the same two facts — URL and bearer token.',
+        '  No credential goes into that command. The client reads this endpoint\'s\n' +
+          '  protected-resource document, sends its owner to sign in, and comes back\n' +
+          '  holding a token of its own — so a config file synced to a dotfiles repo\n' +
+          '  is not a leak, and rotating a static token does not invalidate it.',
       ),
     );
+
+    heading('For a machine with no browser');
+    if (token === undefined) {
+      print(style.dim('  No static token is issued in this workspace.'));
+      print(
+        style.dim(
+          `      lanes link token issue --me --workspace ${runtime.target}\n` +
+            '  It reaches the profiles that list your subject as a member, and nothing else.',
+        ),
+      );
+    } else {
+      const invocation = await tokenInvocation(runtime.resolution.target);
+      print(
+        `  claude mcp add --transport http lanes-link ${url} \\\n` +
+          `    --header "Authorization: Bearer $(${invocation.command})"`,
+      );
+      print('');
+      if (!invocation.onPath) {
+        // The failure this prevents is nasty: an unresolvable command
+        // substitutes to the empty string, the header becomes "Bearer ", and
+        // the only symptom is a 401 that looks like a bad token rather than a
+        // missing binary.
+        print(warn('lanes is not on your PATH, so the short form would substitute to nothing.'));
+        print(style.dim('  The command above uses this checkout instead. To shorten it permanently:'));
+        print(`      cd ${process.cwd()} && bun link`);
+        print('');
+      }
+      print(
+        style.dim(
+          '  CI only, and it is narrower than it looks: the token reaches the profiles\n' +
+            '  its subject is a member of. The $(…) keeps it out of your agent\'s context\n' +
+            '  and out of the transcript, but it resolves once and is stored as a literal —\n' +
+            '  so a rotate means registering again.',
+        ),
+      );
+    }
   } finally {
     await runtime.close();
   }
@@ -146,28 +175,32 @@ export async function outputs(flags: OutputsFlags): Promise<void> {
  * checkout, which always works.
  */
 export async function tokenInvocation(
-  expected: string,
-  profile: string,
   target: string,
 ): Promise<{ command: string; onPath: boolean }> {
-  // Both, always, and from the *resolved* selection rather than the flags. A
-  // token is per-target, so `outputs --workspace cloud` printing a bare
-  // `token show --raw` hands over the local one beside a deployed URL — a
-  // credential that looks like an answer and fails as a wrong password. Naming
-  // the profile as well makes the line pasteable into any shell rather than
-  // only into one where the same default happens to resolve.
-  const selection = ` --profile ${profile} --workspace ${target}`;
+  // `--workspace`, always, and from the *resolved* selection rather than the
+  // flags. A token is per-workspace, so `outputs --workspace cloud` printing a
+  // bare `token show --raw` hands over the local one beside a deployed URL — a
+  // credential that looks like an answer and fails as a wrong password.
+  //
+  // No `--profile` any more (ADR-068): `token show` refuses one, so printing it
+  // here would emit a line that cannot be pasted.
+  const selection = ` --workspace ${target}`;
   const short = `lanes link token show --raw${selection}`;
-  const argv = ['link', 'token', 'show', '--raw', '--profile', profile, '--workspace', target];
+  const argv = ['link', 'token', 'show', '--raw', '--workspace', target];
 
   const resolved = Bun.which('lanes');
   if (resolved) {
     try {
       const result = Bun.spawnSync([resolved, ...argv]);
-      // Compared against the token rather than merely checking it exited zero:
-      // a `lanes` on PATH could belong to a different workspace entirely,
-      // and would hand the harness a token this endpoint rejects.
-      if (result.success && new TextDecoder().decode(result.stdout).trim() === expected) {
+      // Exit status and a plausible token, rather than a comparison against a
+      // known value. This used to be handed the expected token and check for
+      // equality, which caught a `lanes` on PATH belonging to a different
+      // workspace. It cannot now: with several rows issued, `token show`
+      // refuses without `--id` — so demanding one value back would reject a
+      // correctly-installed binary. What survives is the check that matters for
+      // the failure this function exists to prevent, which is a substitution
+      // that yields nothing at all.
+      if (result.success && new TextDecoder().decode(result.stdout).trim().startsWith('llk_')) {
         return { command: short, onPath: true };
       }
     } catch {

--- a/src/cli/commands/operate/serve.ts
+++ b/src/cli/commands/operate/serve.ts
@@ -61,7 +61,6 @@ export async function start(
     flags: resolved,
     port: flags.port,
     only: flags.only,
-    mintToken: true,
     // Stderr, not stdout: `--json` and `--raw` callers parse the other stream.
     // A refused credential is the event worth seeing while this runs in the
     // foreground, and until now nothing printed it.
@@ -71,9 +70,6 @@ export async function start(
         if (ofMany) print(style.dim(`  ${profile}`));
         print(plan);
         print(ok(`reconciled ${ofMany ? profile : ''}`.trim()));
-      },
-      tokenMinted({ target }) {
-        print(warn(`minted a token — run: lanes link outputs --show --workspace ${target}`));
       },
     },
   });

--- a/src/cli/commands/operate/token.ts
+++ b/src/cli/commands/operate/token.ts
@@ -1,70 +1,340 @@
-import { announce, ok, print, style, warn } from '../../output.ts';
-import { ensureProfileToken, openRuntime, type GlobalFlags } from '../../runtime.ts';
+import { CONNECTIONS_FILE, nextTokenId, readConnections, tokenRef } from '#profile';
+import { readSession } from '#auth/lanes/session.ts';
+import { ConfigError } from '#profile';
+import { ConfigDocument } from '../../config-edit.ts';
+import { openOrCreateConnections } from '../../config-repair-sweep.ts';
+import { heading, ok, print, style, warn } from '../../output.ts';
+import { openWorkspaceRuntime, type GlobalFlags } from '../../runtime.ts';
 
-/** `lanes link token` — the one bearer token this endpoint accepts. */
+/**
+ * `lanes link token` — the static tokens this workspace has issued.
+ *
+ * **A token names a person, and the workspace holds it** (ADR-068). Both halves
+ * changed at contract 5. It used to be one credential at `auth.token_ref`,
+ * whose default was the constant `profile/token` for every profile in a store
+ * that is one per workspace — so `--profile` was asked for and could not affect
+ * the answer, and removing a profile deleted the token its siblings were served
+ * by. And it resolved to the primary profile's owner with "every profile" as
+ * its reach, which made it the one credential on this endpoint that never said
+ * who was holding it.
+ *
+ * So `issue` takes a subject and `show`/`rotate`/`revoke` take a row id. What
+ * the token then reaches is whatever that subject is a member of, resolved on
+ * every call — the same rule an OAuth token has followed since ADR-060.
+ *
+ * These are for a machine with no browser. A person registers a client against
+ * the bare URL and signs in (ADR-062); `--headless` is the flag that says
+ * otherwise, and it is why this family still exists.
+ */
 
-/** The token, or enough of it to recognise. One shape, so the two commands agree. */
+export interface TokenFlags extends GlobalFlags {
+  readonly show?: boolean | undefined;
+  readonly raw?: boolean | undefined;
+  readonly id?: string | undefined;
+  readonly subject?: string | undefined;
+  readonly me?: boolean | undefined;
+  readonly label?: string | undefined;
+  readonly json?: boolean | undefined;
+}
+
+/** The token, or enough of it to recognise. One shape, so every command agrees. */
 function show(token: string, reveal: boolean | undefined): string {
   return reveal ? token : `${token.slice(0, 8)}…  ${style.dim('(--show to reveal)')}`;
 }
 
-export async function tokenShow(
-  flags: GlobalFlags & { show?: boolean | undefined; raw?: boolean | undefined },
-): Promise<void> {
-  const runtime = await openRuntime(flags);
-  try {
-    const { token, created } = await ensureProfileToken(
-      runtime.credentials,
-      runtime.config.auth.token_ref,
+/**
+ * Which subject a row is being issued to.
+ *
+ * `--me` reads the signed-in session rather than asking, because typing your own
+ * subject out of `lanes auth status` is a transcription step with a silent
+ * failure mode: a mistyped subject is a valid-looking row that matches no
+ * member, and the token it holds then reaches nothing for a reason nothing
+ * prints. Neither flag is a guess — one of the two is required.
+ */
+async function subjectFor(flags: TokenFlags): Promise<string> {
+  if (flags.subject !== undefined && flags.me === true) {
+    throw new ConfigError(
+      '--subject and --me both name who the token is for, so pass one.\n' +
+        '  --me reads the subject you are signed in as.',
     );
+  }
+
+  if (flags.subject !== undefined) return flags.subject;
+
+  if (flags.me !== true) {
+    throw new ConfigError(
+      'A token is issued to somebody, so say who.\n' +
+        '  --me                 the subject you are signed in as\n' +
+        '  --subject lanes:<id> somebody else, as "lanes members list" reports them\n' +
+        '  What it reaches is whatever that subject is a member of, and nothing else.',
+    );
+  }
+
+  const session = await readSession().catch(() => null);
+  if (!session?.subject) {
+    throw new ConfigError(
+      '--me needs a signed-in session, and there is none.\n' +
+        '  Run: lanes auth login',
+    );
+  }
+  return session.subject;
+}
+
+/**
+ * Refuse a `--profile` that can no longer mean anything.
+ *
+ * The alternative is accepting and ignoring it, which `selection.ts` names as
+ * the defect it exists to prevent: an operator who passes `--profile work` here
+ * believes they scoped the token to one profile, and it is the member list that
+ * decides. Saying so is the whole fix.
+ */
+function assertNoProfile(flags: TokenFlags, command: string): void {
+  if (flags.profile === undefined) return;
+  throw new ConfigError(
+    `--profile does not scope "lanes link token ${command}" (ADR-068).\n` +
+      '  A token names the person it was issued to, and reaches every profile whose\n' +
+      '  members list them. To narrow what one reaches, edit the member lists:\n' +
+      '    lanes link profile members remove --subject <id> --profile <name> --workspace <name>',
+  );
+}
+
+export async function tokenIssue(flags: TokenFlags): Promise<void> {
+  assertNoProfile(flags, 'issue');
+  const subject = await subjectFor(flags);
+
+  const runtime = await openWorkspaceRuntime(flags);
+  try {
+    const root = runtime.resolution.workspaceRoot;
+    const existing = (await readConnections(root)).tokens;
+    const id = nextTokenId(existing.map((row) => row.id));
+    const ref = tokenRef(id);
+
+    const { generateProfileToken } = await import('#auth');
+    const token = generateProfileToken();
+
+    // The credential first, then the row. The other order leaves a row naming a
+    // ref with nothing behind it, which reads to the authenticator as a token
+    // that matches nothing — a working-looking registry whose token is refused.
+    await runtime.credentials.set(ref, token);
+
+    // Created from the template if absent, which is what a workspace whose
+    // profiles predate `connections.yaml` looks like — and `token issue` is a
+    // plausible first write into a fresh one.
+    const document = await openOrCreateConnections(root);
+    document.addTo(['tokens'], {
+      id,
+      subject,
+      ref,
+      ...(flags.label === undefined ? {} : { label: flags.label }),
+      issued_at: new Date().toISOString(),
+    });
+    await document.save();
+
+    print(ok(`issued ${style.bold(id)} to ${subject}`));
+    print(`  ${show(token, flags.show)}`);
+    print();
+
+    const reaches = await profilesFor(root, subject);
+    if (reaches.length === 0) {
+      print(warn('no profile in this workspace lists that subject, so this token reaches nothing'));
+      print(
+        style.dim(
+          '  Add them: lanes link profile members add --subject ' +
+            `${subject} --profile <name> --workspace ${runtime.target}`,
+        ),
+      );
+    } else {
+      print(style.dim(`  Reaches: ${reaches.join(', ')} — every profile listing that subject.`));
+    }
+  } finally {
+    await runtime.close();
+  }
+}
+
+export async function tokenList(flags: TokenFlags): Promise<void> {
+  const runtime = await openWorkspaceRuntime(flags);
+  try {
+    const root = runtime.resolution.workspaceRoot;
+    const rows = (await readConnections(root)).tokens;
+
+    if (flags.json) {
+      const payload = await Promise.all(
+        rows.map(async (row) => ({
+          id: row.id,
+          subject: row.subject,
+          ...(row.label === undefined ? {} : { label: row.label }),
+          ...(row.issued_at === undefined ? {} : { issued_at: row.issued_at }),
+          reaches: await profilesFor(root, row.subject),
+          present: (await runtime.credentials.get(row.ref)) !== null,
+        })),
+      );
+      print(JSON.stringify({ target: runtime.target, tokens: payload }, null, 2));
+      return;
+    }
+
+    if (rows.length === 0) {
+      print('No token has been issued in this workspace.');
+      print(
+        style.dim(
+          '  A person does not need one: a client registers against the bare URL and signs in.\n' +
+            `  For a machine with no browser: lanes link token issue --me --workspace ${runtime.target}`,
+        ),
+      );
+      return;
+    }
+
+    heading(`Tokens (${rows.length})`);
+    for (const row of rows) {
+      const reaches = await profilesFor(root, row.subject);
+      // A row whose credential is gone matches nothing, and reads exactly like a
+      // wrong token from the client's side. Naming it here is the cheap half of
+      // what `doctor` says at length.
+      const missing = (await runtime.credentials.get(row.ref)) === null;
+      print(
+        `  ${row.id}  ${row.subject}` +
+          (row.label ? `  ${style.dim(`(${row.label})`)}` : '') +
+          `  ${reaches.length > 0 ? reaches.join(', ') : style.dim('reaches nothing')}` +
+          (missing ? `  ${style.dim('— value missing from the store')}` : ''),
+      );
+    }
+    print(style.dim('  What each reaches is every profile whose members list its subject.'));
+  } finally {
+    await runtime.close();
+  }
+}
+
+export async function tokenShow(flags: TokenFlags): Promise<void> {
+  assertNoProfile(flags, 'show');
+  const runtime = await openWorkspaceRuntime(flags);
+  try {
+    const root = runtime.resolution.workspaceRoot;
+    const row = pick((await readConnections(root)).tokens, flags, runtime.target);
+    const token = await runtime.credentials.get(row.ref);
+
+    if (token === null) {
+      throw new ConfigError(
+        `Token "${row.id}" has a row but no value at "${row.ref}" in this workspace's store.\n` +
+          `  Re-mint it: lanes link token rotate --id ${row.id} --workspace ${runtime.target}`,
+      );
+    }
 
     // `--raw` prints the token and nothing else, for command substitution:
     //
-    //   claude mcp add … --header "Authorization: Bearer $(lanes link token show --raw)"
+    //   export LANES_LINK_TOKEN="$(lanes link token show --raw --workspace local)"
     //
-    // That is the recommended way to register an instance, and the reason is
-    // not convenience. A token pasted from `--show` passes through the agent's
-    // context and into its transcript; substituted by the shell it goes from
-    // this process to the harness and is never seen by the model at all.
+    // A token pasted from `--show` passes through the agent's context and into
+    // its transcript; substituted by the shell it goes from this process to the
+    // consumer and is never seen by the model at all.
     if (flags.raw) {
       process.stdout.write(`${token}\n`);
       return;
     }
 
-    announce(runtime.resolution);
-    if (created) print(warn('no token existed; a new one was minted'));
+    print(`${row.id}  ${row.subject}`);
     print(show(token, flags.show));
   } finally {
     await runtime.close();
   }
 }
 
-export async function tokenRotate(
-  flags: GlobalFlags & { show?: boolean | undefined },
-): Promise<void> {
-  const runtime = await openRuntime(flags);
+export async function tokenRotate(flags: TokenFlags): Promise<void> {
+  assertNoProfile(flags, 'rotate');
+  const runtime = await openWorkspaceRuntime(flags);
   try {
-    announce(runtime.resolution);
+    const root = runtime.resolution.workspaceRoot;
+    const row = pick((await readConnections(root)).tokens, flags, runtime.target);
 
     const { generateProfileToken } = await import('#auth');
     const token = generateProfileToken();
-    await runtime.credentials.set(runtime.config.auth.token_ref, token);
+    await runtime.credentials.set(row.ref, token);
 
-    print(ok('token rotated'));
-    // Gated the way `tokenShow` gates it, and for the reason given above: a
-    // token printed here goes into the transcript of whatever ran the command.
+    print(ok(`rotated ${style.bold(row.id)}`));
+    // Gated the way `tokenShow` gates it, and for the same reason: a token
+    // printed here goes into the transcript of whatever ran the command.
     // Rotating is what an operator does *because* a token leaked, so printing
     // the replacement unasked is the one moment it costs the most.
     print(`  ${show(token, flags.show)}`);
     print();
-    // Rotating invalidates every agent using this endpoint, which is the cost
-    // of one token per endpoint rather than one per agent. Say so plainly —
-    // and say how, because `claude mcp add` stores the substituted value rather
-    // than the command, so nothing re-reads this on its own.
-    print(warn('every agent configured with the old token must be re-registered'));
-    print(style.dim('  A harness stores the token it was given, not the command that produced it.'));
-    print(style.dim('  Run: lanes link outputs with this profile and target for the command to re-run.'));
+    // Narrower than it used to be, and worth saying so. A rotate used to
+    // invalidate every agent on the endpoint, because there was one token and
+    // every registration carried it. Registrations do not carry one now
+    // (ADR-062), so this affects only what was given *this* row's value.
+    print(warn(`anything holding ${row.id} must be given the new value`));
+    print(style.dim('  Clients that signed in through a browser are unaffected — they hold their own tokens.'));
   } finally {
     await runtime.close();
   }
+}
+
+export async function tokenRevoke(flags: TokenFlags): Promise<void> {
+  assertNoProfile(flags, 'revoke');
+  const runtime = await openWorkspaceRuntime(flags);
+  try {
+    const root = runtime.resolution.workspaceRoot;
+    const rows = (await readConnections(root)).tokens;
+    const row = pick(rows, flags, runtime.target);
+
+    // The row first, then the credential. This is the reverse of `issue` and
+    // for the same reason read the other way: what must never survive a partial
+    // failure is a *usable* token, so the thing that makes it usable goes last.
+    const document = await ConfigDocument.openKey(root, CONNECTIONS_FILE);
+    document.removeFrom(['tokens'], rows.indexOf(row));
+    await document.save();
+
+    await runtime.credentials.delete(row.ref);
+
+    print(ok(`revoked ${style.bold(row.id)}`));
+    print(style.dim('  It is refused within the authenticator\'s cache window, which is seconds.'));
+  } finally {
+    await runtime.close();
+  }
+}
+
+/**
+ * The row a command acts on.
+ *
+ * With one row and no `--id`, that row: naming it would be ceremony, and the
+ * common workspace has exactly one. With several, it refuses and lists them —
+ * the `deploy` rule, for the same reason. Nothing is chosen from among
+ * candidates.
+ */
+function pick(
+  rows: readonly { id: string; subject: string; ref: string }[],
+  flags: TokenFlags,
+  target: string,
+): { id: string; subject: string; ref: string } {
+  if (rows.length === 0) {
+    throw new ConfigError(
+      'No token has been issued in this workspace.\n' +
+        `  Issue one: lanes link token issue --me --workspace ${target}`,
+    );
+  }
+
+  if (flags.id !== undefined) {
+    const found = rows.find((row) => row.id === flags.id);
+    if (!found) {
+      throw new ConfigError(
+        `No token "${flags.id}" in this workspace. Have: ${rows.map((row) => row.id).join(', ')}.`,
+      );
+    }
+    return found;
+  }
+
+  if (rows.length > 1) {
+    throw new ConfigError(
+      `This workspace has ${rows.length} tokens, so this command needs --id.\n` +
+        rows.map((row) => `    ${row.id}  ${row.subject}`).join('\n'),
+    );
+  }
+
+  return rows[0]!;
+}
+
+/** Every profile in this workspace whose `members:` names a subject. */
+async function profilesFor(root: string, subject: string): Promise<string[]> {
+  const { loadWorkspaceProfiles } = await import('#profile');
+  const { loaded } = await loadWorkspaceProfiles(root);
+  return loaded
+    .filter((entry) => entry.config.members.some((member) => member.subject === subject))
+    .map((entry) => entry.profile);
 }

--- a/src/cli/commands/operate/tools.ts
+++ b/src/cli/commands/operate/tools.ts
@@ -1,7 +1,8 @@
 import { capabilityIdForToolName } from '#server/mcp';
+import { anyIssuedToken } from '#profile';
 import { deployedUrl, endpointHealth, localUrl } from '../../endpoint-url.ts';
 import { announce, emit, heading, print, style, warn } from '../../output.ts';
-import { ensureProfileToken, openRuntime, type GlobalFlags } from '../../runtime.ts';
+import { openRuntime, type GlobalFlags } from '../../runtime.ts';
 
 export interface ToolsFlags extends GlobalFlags {
   readonly json?: boolean | undefined;
@@ -27,7 +28,12 @@ export async function tools(flags: ToolsFlags): Promise<void> {
   const runtime = await openRuntime(flags);
 
   try {
-    const { token } = await ensureProfileToken(runtime.credentials, runtime.config.auth.token_ref);
+    // Any token the workspace holds, or none (ADR-068). `tools` reports a
+    // profile's resolved surface, so it still names one — what it no longer
+    // does is mint a credential in order to read.
+    const token = (
+      await anyIssuedToken(runtime.resolution.workspaceRoot, runtime.credentials)
+    )?.value;
     const declared = runtime.declared.deploy;
     const deployed = await deployedUrl(declared);
     // Not `endpointUrl`, which asks the platform a second time for an answer
@@ -40,9 +46,26 @@ export async function tools(flags: ToolsFlags): Promise<void> {
     // token that works. Reporting that as the deployed endpoint's surface is
     // the failure `endpoint-url.ts` calls "silent in the worst way".
     const live = await endpointHealth(url, token);
-    const mine = live?.profile === runtime.resolution.profile;
+    const mine =
+      token === undefined ? live !== null : live?.profile === runtime.resolution.profile;
 
-    const surface = await askEndpoint(url, token);
+    // **Nothing to ask with** is a reportable state rather than a failure
+    // (ADR-068). Asking the endpoint for its tool list means being a client of
+    // it, and a client authenticates; a workspace that has issued no static
+    // token has nothing this command can present, and minting one would bind a
+    // credential to a subject nobody chose. What is still true without it is
+    // everything on the left of the comparison — the capabilities this
+    // *config* resolves to — which is most of what the command is for.
+    const surface =
+      token === undefined
+        ? {
+            reachable: false,
+            reason:
+              'no static token is issued in this workspace, so the endpoint cannot be queried',
+            names: [],
+            bytes: 0,
+          }
+        : await askEndpoint(url, token);
     const providers = [...new Set(runtime.registry.capabilities().map(({ id }) => id))];
 
     await emit(

--- a/src/cli/commands/owner.test.ts
+++ b/src/cli/commands/owner.test.ts
@@ -29,7 +29,7 @@ import { openCatalogue } from '#providers/entities/catalogue.ts';
 const roots: string[] = [];
 const previousHome = process.env['LANES_LINK_HOME'];
 
-const PROFILE = `contract: 4
+const PROFILE = `contract: 5
 
 instance:
   profile: personal
@@ -49,7 +49,7 @@ members: []
 // Labelled the way the CLI writes them: the provider's own name. A tasks row
 // under any other label is refused, because that is the only signal a config
 // carries that it used to be Google Tasks (ADR-051).
-const CONNECTIONS = `contract: 4
+const CONNECTIONS = `contract: 5
 connections:
   - { id: owner, provider: lanes_memory, account: Memory }
   - { id: owner, provider: lanes_tasks,  account: Tasks }

--- a/src/cli/commands/profile.test.ts
+++ b/src/cli/commands/profile.test.ts
@@ -157,7 +157,7 @@ describe('createProfile', () => {
     const text = await readFile(created.path, 'utf8');
 
     expect(created.targets).toEqual(['local']);
-    expect(text).toContain('contract: 4');
+    expect(text).toContain('contract: 5');
     expect(text).not.toContain('targets:');
     expect(text).not.toContain('credentials:');
   });

--- a/src/cli/commands/profile/removal.test.ts
+++ b/src/cli/commands/profile/removal.test.ts
@@ -31,19 +31,24 @@ const target = (over: Partial<TargetConfig> = {}): TargetConfig =>
 
 const config = (over: Partial<Config> = {}): Config =>
   ({
-    contract: 4,
+    contract: 5,
     instance: { profile: 'personal' },
-    auth: { mode: 'bearer', token_ref: 'profile/token' },
+    auth: { mode: 'bearer' },
     grants: [{ connection: 'gmail.someone', allow: [], deny: [] }],
     members: [],
     ...over,
   }) as unknown as Config;
 
 describe('declaredRefs', () => {
-  test("covers the profile's own token, and nothing an account owns", () => {
+  test('covers nothing an account owns, and no endpoint token', () => {
     const refs = declaredRefs(config(), target());
 
-    expect(refs).toContain('profile/token');
+    // **Not the endpoint token.** It is the workspace's since ADR-068, so a
+    // profile declares none and removing one cannot reach it. This is the fix
+    // for the bug the survivor check existed to work around: removing a profile
+    // used to delete the token its siblings were being served by.
+    expect(refs).not.toContain('profile/token');
+    expect(refs.some((ref) => ref.startsWith('tokens/'))).toBe(false);
 
     // **Not the connection, and not the OAuth client.** Both belong to the
     // workspace now (ADR-057), and every one of them may be granted by a profile
@@ -59,7 +64,6 @@ describe('declaredRefs', () => {
       config({
         auth: {
           mode: 'bearer',
-          token_ref: 'profile/token',
           authorization: {
             mode: 'oidc',
             issuer: 'https://issuer.example',
@@ -107,7 +111,6 @@ describe('declaredRefs', () => {
     const refs = declaredRefs(gone, target());
 
     expect(refs).not.toContain('no_such_provider/x');
-    expect(refs).toContain('profile/token');
   });
 
   test('the vault key is still the profile\'s to lose, and the connections are not', () => {
@@ -127,35 +130,27 @@ describe('declaredRefs', () => {
       target({ vault: { adapter: 'secret', ref: 'vault/document' } } as never),
     );
 
-    expect(refs).toEqual(['profile/token', 'vault/document']);
+    expect(refs).toEqual(['vault/document']);
   });
 
   test('a ref a surviving profile also declares is left alone', () => {
-    // The credential store is one file per workspace since contract 3, and
-    // every profile takes the template default `token_ref: profile/token`. So
-    // removing one profile deleted the endpoint token the others are served by,
-    // and the deployed revision then refused every request with "No profile
-    // token in this target's credential store". The vault ref is read off the
-    // target and is identical for every profile there, which made the sibling's
-    // sealed items unrecoverable in the same command.
+    // The vault ref is read off the target and is identical for every profile
+    // there, which once made a sibling's sealed items unrecoverable in this
+    // command. The endpoint token used to be the other half of this test and is
+    // no longer a case at all: it is not a profile's to declare (ADR-068).
     const sealed = target({ vault: { adapter: 'secret', ref: 'vault/document' } } as never);
 
     expect(declaredRefs(config(), sealed, [config()])).toEqual([]);
   });
 
-  test('with nobody staying, it is still the profile\'s to lose', () => {
+  test('with nobody staying, the vault is still the profile\'s to lose', () => {
     // The last profile in a workspace: there is no survivor to share with, so
-    // the token and the vault go with it.
+    // the vault goes with it. The endpoint token does not, and that is the
+    // point — a workspace can outlive its last profile's removal with its
+    // issued tokens intact, because they were never that profile's.
     const sealed = target({ vault: { adapter: 'secret', ref: 'vault/document' } } as never);
 
-    expect(declaredRefs(config(), sealed, [])).toEqual(['profile/token', 'vault/document']);
-  });
-
-  test('a survivor with a different token ref does not protect this one', () => {
-    // Sharing is the reason to keep a ref, not the mere existence of a sibling.
-    const other = config({ auth: { mode: 'bearer', token_ref: 'other/token' } } as never);
-
-    expect(declaredRefs(config(), target(), [other])).toContain('profile/token');
+    expect(declaredRefs(config(), sealed, [])).toEqual(['vault/document']);
   });
 });
 
@@ -235,7 +230,11 @@ describe('removalPlan', () => {
     // `profile add` of the same name.
     expect(ids(plan, 'file')).toEqual(['profiles/personal']);
 
-    expect(ids(plan, 'secret')).toContain('profile/token');
+    // Nothing. A profile with a plain target declares no credential of its own
+    // since ADR-068 — the endpoint token is the workspace's, and a connection's
+    // belongs to the account. The vault is the one that can still be here, and
+    // this target seals nothing.
+    expect(ids(plan, 'secret')).toEqual([]);
     expect(plan.items.some((item) => item.kind === 'config')).toBe(true);
   });
 
@@ -372,15 +371,24 @@ describe('removalPlan', () => {
   });
 
   test('a ref the profile does not declare is reported, never planned', async () => {
-    const plan = await removalPlan(config(), '/ws', 'personal', registry, {
-      target: 'local',
-      declared: target(),
-      disposition: { kind: 'delete' as const },
-      openSecrets: async () => fakeSecrets(['profile/token', 'gmail/someone_else']),
-      openBlobs: async () => fakeBlobs([]),
-    });
+    // The vault document, which is the profile's remaining declared credential:
+    // sealed per target and named by it, so it goes with the removal. Contrasted
+    // against an account's, which outlives the profile whatever the profile said.
+    const plan = await removalPlan(
+      config(),
+      '/ws',
+      'personal',
+      registry,
+      {
+        target: 'local',
+        declared: target({ vault: { adapter: 'secret', ref: 'vault/document' } } as never),
+        disposition: { kind: 'delete' as const },
+        openSecrets: async () => fakeSecrets(['vault/document', 'gmail/someone_else']),
+        openBlobs: async () => fakeBlobs([]),
+      },
+    );
 
-    expect(ids(plan, 'secret')).toContain('profile/token');
+    expect(ids(plan, 'secret')).toContain('vault/document');
     expect(ids(plan, 'secret')).not.toContain('gmail/someone_else');
     expect(plan.untouched.flatMap((u) => u.refs)).toContain('gmail/someone_else');
   });

--- a/src/cli/commands/profile/removal.ts
+++ b/src/cli/commands/profile/removal.ts
@@ -51,17 +51,19 @@ export function declaredRefs(
    * What the profiles that are staying declare.
    *
    * Nothing in here is deleted, however plainly the profile being removed also
-   * declares it. The credential store is one file per *workspace* since
-   * contract 3, and every profile takes the template default
-   * `token_ref: profile/token` — so removing one profile deleted the endpoint
-   * token the others are served by, and the deployed revision then refused every
-   * request with "No profile token in this target's credential store". The vault
-   * ref is read off the target and is identical for every profile there, which
-   * made the sibling's sealed items unrecoverable in the same command.
+   * declares it. The vault ref is read off the target and is identical for every
+   * profile there, which once made a sibling's sealed items unrecoverable in
+   * this command.
+   *
+   * **The endpoint token was the sharpest case here and is no longer a case.**
+   * Every profile took the default `token_ref: profile/token` out of one
+   * per-workspace store, so removing one deleted the token its siblings were
+   * served by. What fixed it is not a better survivor check: the token was never
+   * a profile's to declare (ADR-068), so removing one cannot reach it now.
    */
   survivors: readonly Config[] = [],
 ): string[] {
-  const refs = new Set<string>([config.auth.token_ref]);
+  const refs = new Set<string>();
 
   // Read off the *target*, not the profile. `vaultTargetSchema` sits inside
   // `targetSchema`, so two targets may seal the same items in different places;
@@ -100,7 +102,6 @@ export function declaredRefs(
   // declare" has to have one answer.
   const kept = new Set(
     survivors.flatMap((other) => [
-      other.auth.token_ref,
       ...(declared.vault?.adapter === 'secret' ? [vaultRef(declared, other)] : []),
       ...(other.auth.authorization?.mode === 'oidc'
         ? [other.auth.authorization.client_id_ref]

--- a/src/cli/commands/target.test.ts
+++ b/src/cli/commands/target.test.ts
@@ -19,7 +19,7 @@ const roots: string[] = [];
 const previousHome = process.env['LANES_LINK_HOME'];
 const previousTarget = process.env['LANES_LINK_TARGET'];
 
-const PROFILE = `contract: 4
+const PROFILE = `contract: 5
 
 instance:
   profile: personal
@@ -35,7 +35,7 @@ instance:
  * once per profile (ADR-052). `cloud` deploys and `staging` does not, which is
  * the distinction the listing below is about.
  */
-const TARGETS = `contract: 4
+const TARGETS = `contract: 5
 default_profile: personal
 
 workspaces:
@@ -206,7 +206,7 @@ describe('a pointer, which is what a deployed target looks like from here', () =
     const { root, env } = await workspace();
     await writeFile(
       join(root, 'workspaces.yaml'),
-      `contract: 4
+      `contract: 5
 
 workspaces:
   cloud:

--- a/src/cli/config-edit.test.ts
+++ b/src/cli/config-edit.test.ts
@@ -131,7 +131,7 @@ describe('comments and ordering survive an edit', () => {
     // and its allow rule. Reading the starting state from the template would
     // leave this asserting nothing the day that changed, which is the day it
     // most needs to hold.
-    const { root, path } = await profileFile(`contract: 4
+    const { root, path } = await profileFile(`contract: 5
 
 instance:
   profile: personal
@@ -269,7 +269,7 @@ describe('repairing a profile that predates the setup surface', () => {
     ensureReservedConnection(p.connections, p.profile, 'lanes_setup');
 
   /** A profile as it was written before the surface, and as this operator's is. */
-  const OLD = `contract: 4
+  const OLD = `contract: 5
 instance:
   profile: personal
   port: 7337
@@ -279,7 +279,7 @@ members: []
 `;
 
   /** The workspace it lives in, with no owner-layer row in it. */
-  const OLD_CONNECTIONS = `contract: 4
+  const OLD_CONNECTIONS = `contract: 5
 connections:
   - { id: ada_lovelace, provider: gmail, account: ada.lovelace@example.com }
 oauth_apps: {}
@@ -385,7 +385,7 @@ oauth_apps: {}
 
   describe('a hand-edited file that no schema has seen', () => {
     test('a missing grants block is created rather than crashed on', async () => {
-      const p = await pair(`contract: 4\ninstance:\n  profile: personal\n`, OLD_CONNECTIONS);
+      const p = await pair(`contract: 5\ninstance:\n  profile: personal\n`, OLD_CONNECTIONS);
 
       expect(repairLines(ensureSetup(p))).toEqual([
         'connections.yaml += lanes_setup.lan1',
@@ -399,7 +399,7 @@ oauth_apps: {}
       // but `validateConfig` is what should say so, on the whole file, rather
       // than this dying on `.some`.
       const p = await pair(
-        `contract: 4\ninstance:\n  profile: personal\ngrants:\n  a: { connection: gmail.x }\n`,
+        `contract: 5\ninstance:\n  profile: personal\ngrants:\n  a: { connection: gmail.x }\n`,
         OLD_CONNECTIONS,
       );
 
@@ -448,7 +448,7 @@ oauth_apps: {}
  * shaped to prevent.
  */
 describe('repairing a profile that predates the owner layer', () => {
-  const OLD = `contract: 4
+  const OLD = `contract: 5
 instance:
   profile: personal
   port: 7337
@@ -457,7 +457,7 @@ grants:
 members: []
 `;
 
-  const OLD_CONNECTIONS = `contract: 4
+  const OLD_CONNECTIONS = `contract: 5
 connections:
   - { id: ada_lovelace, provider: gmail, account: ada.lovelace@example.com }
 oauth_apps: {}
@@ -519,7 +519,7 @@ describe('appending to a key that is not there yet', () => {
     // `grants:` is genuinely absent on a contract-2 profile being repaired,
     // which is what finally made the second append reachable — and what turned
     // one upgrade into three warnings and an unrepaired workspace.
-    const document = ConfigDocument.fromText('contract: 4\n');
+    const document = ConfigDocument.fromText('contract: 5\n');
 
     document.addTo(['grants'], { connection: 'example.a', allow: ['example.*'], deny: [] });
     document.addTo(['grants'], { connection: 'example.b', allow: ['example.*'], deny: [] });
@@ -536,7 +536,7 @@ describe('appending to a key that is not there yet', () => {
     // succeed and the second threw, so the profile was left with one grant of
     // seven and the command reported a warning instead of a repair.
     const connections = ConfigDocument.fromText(newConnectionsTemplate(), CONNECTIONS_FILE);
-    const profile = ConfigDocument.fromText('contract: 4\n');
+    const profile = ConfigDocument.fromText('contract: 5\n');
 
     const repair = ensureOwnerLayer(connections, profile);
 
@@ -550,7 +550,7 @@ describe('appending to a key that is not there yet', () => {
 
 describe('the repair reads this profile\'s grants, not the workspace\'s first row', () => {
   const workspaceRows = [
-    'contract: 4',
+    'contract: 5',
     'connections:',
     '  - { id: main, provider: lanes_memory, account: Memory }',
     '  - { id: demo, provider: lanes_memory, account: Memory }',
@@ -570,7 +570,7 @@ describe('the repair reads this profile\'s grants, not the workspace\'s first ro
     const connections = ConfigDocument.fromText(workspaceRows, CONNECTIONS_FILE);
     const profile = ConfigDocument.fromText(
       [
-        'contract: 4',
+        'contract: 5',
         'grants:',
         '  - { connection: lanes_memory.demo, allow: [lanes_memory.*], deny: [] }',
         '  - { connection: vault.demo, allow: [lanes_vault.*], deny: [] }',
@@ -590,7 +590,7 @@ describe('the repair reads this profile\'s grants, not the workspace\'s first ro
     // no-op, or a release adding a surface would never reach an existing
     // profile.
     const connections = ConfigDocument.fromText(workspaceRows, CONNECTIONS_FILE);
-    const profile = ConfigDocument.fromText('contract: 4\ngrants: []\n');
+    const profile = ConfigDocument.fromText('contract: 5\ngrants: []\n');
 
     const repair = ensureReservedConnection(connections, profile, 'lanes_memory');
 
@@ -604,7 +604,7 @@ describe('the repair reads this profile\'s grants, not the workspace\'s first ro
     const connections = ConfigDocument.fromText(workspaceRows, CONNECTIONS_FILE);
     const profile = ConfigDocument.fromText(
       [
-        'contract: 4',
+        'contract: 5',
         'grants:',
         '  - { connection: lanes_memory.demo, allow: [], deny: [lanes_memory.*] }',
         '',
@@ -620,7 +620,7 @@ describe('the repair reads this profile\'s grants, not the workspace\'s first ro
 
 describe('a profile granting two instances of one surface', () => {
   const twoInstances = [
-    'contract: 4',
+    'contract: 5',
     'connections:',
     '  - { id: team, provider: lanes_memory, account: Memory }',
     '  - { id: personal, provider: lanes_memory, account: Memory }',
@@ -634,7 +634,7 @@ describe('a profile granting two instances of one surface', () => {
     const connections = ConfigDocument.fromText(twoInstances, CONNECTIONS_FILE);
     const profile = ConfigDocument.fromText(
       [
-        'contract: 4',
+        'contract: 5',
         'grants:',
         '  - { connection: lanes_memory.team, allow: [], deny: [] }',
         '  - { connection: lanes_memory.personal, allow: [], deny: [lanes_memory.*] }',
@@ -652,7 +652,7 @@ describe('a profile granting two instances of one surface', () => {
     const connections = ConfigDocument.fromText(twoInstances, CONNECTIONS_FILE);
     const profile = ConfigDocument.fromText(
       [
-        'contract: 4',
+        'contract: 5',
         'grants:',
         '  - { connection: lanes_memory.team, allow: [], deny: [] }',
         '  - { connection: lanes_memory.personal, allow: [lanes_memory.*], deny: [] }',
@@ -668,11 +668,11 @@ describe('a profile granting two instances of one surface', () => {
     // dotless value, and `'vaults'.slice(0, -1)` is `'vault'` — so a typo was
     // widened while the real surface stayed unreachable.
     const connections = ConfigDocument.fromText(
-      'contract: 4\nconnections:\n  - { id: main, provider: lanes_vault, account: Vault }\n',
+      'contract: 5\nconnections:\n  - { id: main, provider: lanes_vault, account: Vault }\n',
       CONNECTIONS_FILE,
     );
     const profile = ConfigDocument.fromText(
-      'contract: 4\ngrants:\n  - { connection: vaults, allow: [], deny: [] }\n',
+      'contract: 5\ngrants:\n  - { connection: vaults, allow: [], deny: [] }\n',
     );
 
     const repair = ensureReservedConnection(connections, profile, 'lanes_vault');

--- a/src/cli/config-repair-sweep.test.ts
+++ b/src/cli/config-repair-sweep.test.ts
@@ -29,7 +29,7 @@ async function workspace(
   homes.push(root);
 
   if (registry !== null) await writeFile(join(root, 'workspaces.yaml'), registry);
-  await writeFile(join(root, 'connections.yaml'), 'contract: 4\nconnections: []\noauth_apps: {}\n');
+  await writeFile(join(root, 'connections.yaml'), 'contract: 5\nconnections: []\noauth_apps: {}\n');
 
   if (profile !== null) {
     await mkdir(join(root, 'profiles', 'personal'), { recursive: true });
@@ -104,7 +104,7 @@ describe('what it says when a profile will not open', () => {
     // at all. Seen for real, twice, with nothing after the colon.
     const root = await workspace(
       REGISTRY(SUPPORTED_CONTRACT),
-      'contract: 4\ninstance:\n  profile: personal\ngrants:\n' +
+      'contract: 5\ninstance:\n  profile: personal\ngrants:\n' +
         '  - { connection: 12345, allow: 7 }\nmembers: []\n',
     );
     const said: string[] = [];

--- a/src/cli/config-repair-sweep.ts
+++ b/src/cli/config-repair-sweep.ts
@@ -42,14 +42,28 @@ import { DEFAULT_SURFACES, ensureOwnerLayer, repairLines, repaired } from './con
  * for the workspaces 0.9.0 already migrated. One spelling, for the reason the
  * template and `ensureOwnerLayer` share one: two would have to agree forever.
  */
-export async function ensureRegistryContract(workspaceRoot: string): Promise<boolean> {
+export async function ensureRegistryContract(
+  workspaceRoot: string,
+  /**
+   * The contract to stamp, which is the one the caller is *producing*.
+   *
+   * Defaulted to the newest for the repair sweep, and passed explicitly by each
+   * migration step. A step that stamped the newest would put the registry ahead
+   * of the profiles it just wrote — and `isUnmigrated` reads exactly this field,
+   * so the registry would report the workspace as migrated with a later step
+   * still to run. That is the same defect the note on
+   * `the contract it stamps on the registry` describes, in the direction that
+   * fails silently rather than loudly.
+   */
+  contract: number = SUPPORTED_CONTRACT,
+): Promise<boolean> {
   const files = workspaceFiles(workspaceRoot);
   if (!(await files.has(WORKSPACE_FILE))) return false;
 
   const document = await ConfigDocument.openKey(workspaceRoot, WORKSPACE_FILE);
-  if (document.getIn(['contract']) === SUPPORTED_CONTRACT) return false;
+  if (document.getIn(['contract']) === contract) return false;
 
-  document.setIn(['contract'], SUPPORTED_CONTRACT);
+  document.setIn(['contract'], contract);
   await document.save();
   return true;
 }
@@ -79,7 +93,7 @@ function listSurfaces(): string {
 }
 
 /** The workspace's connections document, written from the template if missing. */
-async function openOrCreateConnections(workspaceRoot: string): Promise<ConfigDocument> {
+export async function openOrCreateConnections(workspaceRoot: string): Promise<ConfigDocument> {
   try {
     return await ConfigDocument.openKey(workspaceRoot, CONNECTIONS_FILE);
   } catch {

--- a/src/cli/config-repair.ts
+++ b/src/cli/config-repair.ts
@@ -18,7 +18,7 @@ import { nextConnectionId } from './identity.ts';
  */
 
 /** Lanes' own provider ids, and the label each row carries. */
-const RESERVED_SURFACES = {
+export const RESERVED_SURFACES = {
   lanes_memory: 'Memory',
   lanes_tasks: 'Tasks',
   lanes_assets: 'Assets',

--- a/src/cli/config-templates.ts
+++ b/src/cli/config-templates.ts
@@ -27,7 +27,7 @@ export function newProfileTemplate(profile: string, port: number, subject?: stri
 #
 # Edit it by hand or through the CLI; both are supported, and CLI edits preserve
 # your comments and ordering.
-contract: 4
+contract: 5
 
 instance:
   profile: ${profile}
@@ -47,12 +47,13 @@ instance:
 #
 #     lanes link status --profile ${profile} --workspace <name>
 #
-# The bearer token below is for CI. People sign in instead: a client that asks
-# for authorization is sent to the Lanes login, and comes back as somebody
-# (ADR-062). "lanes link token show" is for a runner with no browser.
+# No token here. A profile declares no endpoint credential (ADR-068) — the
+# workspace does, in "tokens:" in connections.yaml, one row per person it was
+# issued to. People sign in rather than holding one: a client that asks for
+# authorization is sent to the Lanes login and comes back as somebody
+# (ADR-062). "lanes link token issue" is for a runner with no browser.
 auth:
   mode: bearer
-  token_ref: profile/token
   authorization:
     mode: self
 
@@ -146,7 +147,7 @@ export function newWorkspaceTemplate(): string {
 # uses it prints which one it got. Commands that publish or destroy — deploy,
 # sync, secrets push, profile remove, disconnect, token rotate — refuse it and
 # make you type the name (ADR-061).
-contract: 4
+contract: 5
 default_workspace: local
 workspaces:
   local:
@@ -182,7 +183,7 @@ export function newConnectionsTemplate(): string {
 # still keeps its own bytes — what you write through one profile is absent in
 # another (ADR-066). A second instance is for holding two of something in one
 # profile: "lanes link connect lanes_memory --id lan9".
-contract: 4
+contract: 5
 
 connections:
   - { id: lan1, provider: lanes_memory, account: Memory }
@@ -195,6 +196,12 @@ connections:
 
 # App registrations, shared by every connection of that vendor.
 oauth_apps: {}
+
+# Static endpoint tokens, one row per person one was issued to (ADR-068). Empty
+# is the ordinary state: a client registers against the bare URL and signs in,
+# so nothing needs one until something headless does. A row reaches whatever its
+# subject is a member of — "lanes link token issue --me --workspace <name>".
+tokens: []
 `;
 }
 

--- a/src/cli/contract3-credentials.ts
+++ b/src/cli/contract3-credentials.ts
@@ -145,10 +145,10 @@ async function readMerged(
       // values for one key, and there is no merge that means anything.
       //
       // Left behind rather than picked between. It is minted locally rather
-      // than granted by anybody, `ensureProfileToken` writes a fresh one the
-      // first time a command asks, and the old stores are not deleted — so the
-      // cost is re-registering a client, and no account has to be authorised
-      // again.
+      // than granted by anybody and the old stores are not deleted, so the cost
+      // is re-registering a client and no account has to be authorised again.
+      // Contract 5 ends this problem rather than solving it: the token is the
+      // workspace's, so there are no longer several to merge (ADR-068).
       let value: string | null;
       try {
         value = await store.get(ref);
@@ -212,10 +212,10 @@ async function readMerged(
   // routine `update`, for a conflict that did not exist.
   //
   // Where they do disagree it is still left behind rather than picked between.
-  // It is minted locally rather than granted by anybody, `ensureProfileToken`
-  // writes a fresh one the first time a command asks, and the old stores are not
-  // deleted — so the cost is re-registering a client, and no account has to be
-  // authorised again.
+  // It is minted locally rather than granted by anybody and the old stores are
+  // not deleted, so the cost is re-registering a client and no account has to be
+  // authorised again. Contract 5 removes the possibility of the disagreement:
+  // one token registry per workspace (ADR-068).
   for (const [ref, byProfile] of endpoint) {
     const values = new Set(byProfile.values());
     const agreed = values.size === 1 ? [...values][0] : undefined;

--- a/src/cli/contract4.test.ts
+++ b/src/cli/contract4.test.ts
@@ -507,7 +507,10 @@ describe('what it stamps, and when', () => {
       contract: number;
       grants: unknown[];
     };
-    expect(config.contract).toBe(SUPPORTED_CONTRACT);
+    // Four, not the newest. This step produces contract 4 and stops; reaching
+    // the current contract is `migrateToCurrentContract`'s job, and asserting
+    // the newest here would pass only until the next contract existed.
+    expect(config.contract).toBe(4);
     // Nothing about the file's *shape* changes — only where it lives.
     expect(config.grants).toHaveLength(1);
     expect(has(root, 'profiles/personal.yaml')).toBe(false);
@@ -766,7 +769,10 @@ describe('the contract it stamps on the registry', () => {
     const profile = parse(await read(root, 'profiles/personal/profile.yaml')) as {
       contract: number;
     };
-    expect(registry.contract).toBe(SUPPORTED_CONTRACT);
+    // The invariant is that the two agree, not that either names the newest:
+    // a registry stamped ahead of its profiles makes `isUnmigrated` report a
+    // finished migration with a later step still to run.
+    expect(registry.contract).toBe(4);
     expect(registry.contract).toBe(profile.contract);
   });
 

--- a/src/cli/contract4.ts
+++ b/src/cli/contract4.ts
@@ -159,7 +159,9 @@ export async function migrateToContract4(
   // unchanged. Here rather than inside `renameRegistry` because that function
   // returns early on a workspace already holding `workspaces.yaml`, which is
   // exactly the workspace whose stamp is stale.
-  await ensureRegistryContract(workspaceRoot);
+  // Four, not the newest: contract 5 runs after this, and a registry claiming it
+  // makes `isUnmigrated` report a finished migration with a step still to go.
+  await ensureRegistryContract(workspaceRoot, 4);
   await applyMoves(files, plan.moves);
 
   // Credentials before the rows: a ref is derived from the id, so the rows must
@@ -185,7 +187,10 @@ export async function migrateToContract4(
   for (const profile of profiles) {
     const document = await ConfigDocument.openKey(workspaceRoot, layout.profileConfig(profile));
     document.setIn(['contract'], 4);
-    await document.save();
+    // The contract it is *producing*, which is not the newest one any more:
+    // contract 5 exists, so a bare `save()` here validates this document
+    // against a schema it is one step short of and refuses its own output.
+    await document.save({ contract: 4 });
   }
 
   return {

--- a/src/cli/contract5.test.ts
+++ b/src/cli/contract5.test.ts
@@ -1,0 +1,267 @@
+import { afterAll, describe, expect, test } from 'bun:test';
+import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { parse } from 'yaml';
+import { migrateToContract5, needsContract5 } from './contract5.ts';
+
+/**
+ * Contract 4 to contract 5, against a real workspace on disk.
+ *
+ * Written against outcomes rather than internals, for the reason
+ * `contract4.test.ts` states: the defects the last two migrations shipped all
+ * lost or misrouted something *while reporting success*.
+ *
+ * The one this migration can get wrong is the subject. A row bound to the wrong
+ * one is worse than no row — it looks issued and reaches nothing, or reaches
+ * somebody else's profiles — so most of what is asserted here is about where
+ * the subject came from and what happens when there is none.
+ */
+
+const homes: string[] = [];
+
+afterAll(async () => {
+  for (const home of homes) await rm(home, { recursive: true, force: true });
+});
+
+const PROFILE = (name: string, members: string, tokenRef?: string): string =>
+  `contract: 4\ninstance:\n  profile: ${name}\n` +
+  `auth:\n  mode: bearer\n${tokenRef ? `  token_ref: ${tokenRef}\n` : ''}` +
+  `grants: []\nmembers:\n${members}`;
+
+async function workspace(
+  profiles: Record<string, { members: string; tokenRef?: string }>,
+): Promise<string> {
+  const root = await mkdtemp(join(tmpdir(), 'lanes-c5-'));
+  homes.push(root);
+
+  await writeFile(
+    join(root, 'workspaces.yaml'),
+    'contract: 4\nworkspaces:\n  local:\n    credentials: { adapter: file }\n' +
+      '    storage: { adapter: filesystem }\n',
+  );
+  await writeFile(join(root, 'connections.yaml'), 'contract: 4\nconnections: []\noauth_apps: {}\n');
+
+  for (const [name, spec] of Object.entries(profiles)) {
+    await mkdir(join(root, 'profiles', name), { recursive: true });
+    await writeFile(
+      join(root, 'profiles', name, 'profile.yaml'),
+      PROFILE(name, spec.members, spec.tokenRef),
+    );
+  }
+
+  return root;
+}
+
+const read = (root: string, key: string): Promise<string> => readFile(join(root, key), 'utf8');
+
+const OWNER = '  - { subject: lanes:ownersubject, role: owner }\n';
+const MEMBER = '  - { subject: lanes:membersubject, role: member }\n';
+
+interface Rows {
+  tokens?: { id: string; subject: string; ref: string; label?: string }[];
+}
+
+describe('what contract 5 moves', () => {
+  test('the token becomes a workspace row naming the profile owner', async () => {
+    const root = await workspace({ personal: { members: OWNER } });
+
+    expect(await needsContract5(root)).toBe(true);
+    const migration = await migrateToContract5(root);
+
+    const connections = parse(await read(root, 'connections.yaml')) as Rows;
+    expect(connections.tokens).toHaveLength(1);
+    expect(connections.tokens?.[0]?.subject).toBe('lanes:ownersubject');
+
+    // **The ref is not renamed.** A row may name any ref, and re-keying means
+    // copying a live credential then deleting the original — two writes and a
+    // window where a deployed revision reads neither.
+    expect(connections.tokens?.[0]?.ref).toBe('profile/token');
+
+    const profile = parse(await read(root, 'profiles/personal/profile.yaml')) as {
+      contract: number;
+      auth: Record<string, unknown>;
+    };
+    expect(profile.contract).toBe(5);
+    expect(profile.auth['token_ref']).toBeUndefined();
+    expect(migration.issued).toEqual([{ id: 'tok1', subject: 'lanes:ownersubject' }]);
+  });
+
+  test('connections.yaml is stamped, so the next migration is not misled', async () => {
+    // Nothing reads it — every contract check is on a profile — which is
+    // exactly why it goes stale. Found by running the migration against a real
+    // contract-4 workspace: the profiles and the registry said 5 and this said 4.
+    const root = await workspace({ personal: { members: OWNER } });
+
+    await migrateToContract5(root);
+
+    expect((parse(await read(root, 'connections.yaml')) as { contract: number }).contract).toBe(5);
+  });
+
+  test('the registry is stamped too, and never ahead of the profiles', async () => {
+    // `isUnmigrated` reads the registry's contract and nothing else, so a stamp
+    // ahead of the profiles reports a finished migration with a step to run.
+    const root = await workspace({ personal: { members: OWNER } });
+
+    await migrateToContract5(root);
+
+    const registry = parse(await read(root, 'workspaces.yaml')) as { contract: number };
+    const profile = parse(await read(root, 'profiles/personal/profile.yaml')) as {
+      contract: number;
+    };
+    expect(registry.contract).toBe(5);
+    expect(registry.contract).toBe(profile.contract);
+  });
+
+  test('profiles sharing the template default get one row, not one each', async () => {
+    // The whole reason this contract exists: `token_ref` defaulted to the same
+    // constant for every profile out of one per-workspace store, so "three
+    // profiles' tokens" were always one credential.
+    const root = await workspace({
+      personal: { members: OWNER },
+      work: { members: OWNER },
+      shared: { members: OWNER },
+    });
+
+    await migrateToContract5(root);
+
+    const connections = parse(await read(root, 'connections.yaml')) as Rows;
+    expect(connections.tokens).toHaveLength(1);
+
+    for (const name of ['personal', 'work', 'shared']) {
+      const profile = parse(await read(root, `profiles/${name}/profile.yaml`)) as {
+        contract: number;
+      };
+      expect(profile.contract).toBe(5);
+    }
+  });
+
+  test('a profile that overrode token_ref keeps its own credential', async () => {
+    // Rare, and a real separate credential: dropping it would take a working
+    // endpoint down.
+    const root = await workspace({
+      personal: { members: OWNER },
+      work: { members: OWNER, tokenRef: 'other/token' },
+    });
+
+    await migrateToContract5(root);
+
+    const refs = (parse(await read(root, 'connections.yaml')) as Rows).tokens?.map((r) => r.ref);
+    expect(refs?.sort()).toEqual(['other/token', 'profile/token']);
+  });
+
+  test('an owner is preferred over a plain member', async () => {
+    // `owner` is who may edit the member list (ADR-060), so it is the one role
+    // that cannot have been delegated a narrower reach than the token had.
+    const root = await workspace({ personal: { members: MEMBER + OWNER } });
+
+    await migrateToContract5(root);
+
+    const rows = (parse(await read(root, 'connections.yaml')) as Rows).tokens;
+    expect(rows?.[0]?.subject).toBe('lanes:ownersubject');
+  });
+
+  test('a member with no owner is still somebody this belonged to', async () => {
+    const root = await workspace({ personal: { members: MEMBER } });
+
+    await migrateToContract5(root);
+
+    const rows = (parse(await read(root, 'connections.yaml')) as Rows).tokens;
+    expect(rows?.[0]?.subject).toBe('lanes:membersubject');
+  });
+
+  test('a passed subject wins, which is what `update` hands it', async () => {
+    const root = await workspace({ personal: { members: OWNER } });
+
+    await migrateToContract5(root, { apply: true, subject: 'lanes:signedinnow' });
+
+    const rows = (parse(await read(root, 'connections.yaml')) as Rows).tokens;
+    expect(rows?.[0]?.subject).toBe('lanes:signedinnow');
+  });
+});
+
+describe('what it says when the row reaches nothing', () => {
+  test('a subject no profile lists is named as a warning, not left silent', async () => {
+    // Found by running the migration: a signed-in operator upgrading a
+    // workspace whose `members:` is empty gets a row bound to themselves that
+    // the endpoint then refuses, with a 401 that reads as a bad credential.
+    const root = await workspace({ personal: { members: '  []\n' } });
+
+    const migration = await migrateToContract5(root, {
+      apply: true,
+      subject: 'lanes:signedinnow',
+    });
+
+    const lines = migration.changes.join('\n');
+    expect(lines).toContain('no profile lists lanes:signedinnow');
+    expect(lines).toContain('reaches nothing until one does');
+    expect(lines).toContain('members add --me');
+  });
+
+  test('and says nothing when the subject is listed', async () => {
+    const root = await workspace({ personal: { members: OWNER } });
+
+    const migration = await migrateToContract5(root);
+
+    expect(migration.changes.join('\n')).not.toContain('reaches nothing');
+  });
+});
+
+describe('what it refuses rather than guesses', () => {
+  test('a workspace whose profiles list nobody stops, and says which command fixes it', async () => {
+    // `members: []` is what contract 3 wrote when it ran signed out, and it is
+    // legitimate — default deny on the identity axis. What it is not is a
+    // subject, and a row bound to nobody looks issued and reaches nothing.
+    const root = await workspace({ personal: { members: '  []\n' } });
+
+    await expect(migrateToContract5(root)).rejects.toThrow(/no profile holding it lists an owner/);
+    await expect(migrateToContract5(root)).rejects.toThrow(/members add --me/);
+
+    // And it left the file alone: a refusal that half-migrated would be worse
+    // than the state it refused.
+    const profile = parse(await read(root, 'profiles/personal/profile.yaml')) as {
+      contract: number;
+    };
+    expect(profile.contract).toBe(4);
+  });
+});
+
+describe('reruns and previews', () => {
+  test('a second run finds nothing to do', async () => {
+    const root = await workspace({ personal: { members: OWNER } });
+
+    await migrateToContract5(root);
+    expect(await needsContract5(root)).toBe(false);
+
+    const again = await migrateToContract5(root);
+    expect(again.alreadyCurrent).toBe(true);
+    expect((parse(await read(root, 'connections.yaml')) as Rows).tokens).toHaveLength(1);
+  });
+
+  test('a row already written is not written twice, which is what an interruption leaves', async () => {
+    // The row is written before the profiles are stamped, so a crash between
+    // the two leaves a workspace whose rerun must not duplicate it.
+    const root = await workspace({ personal: { members: OWNER } });
+    await writeFile(
+      join(root, 'connections.yaml'),
+      'contract: 4\nconnections: []\noauth_apps: {}\n' +
+        'tokens:\n  - { id: tok1, subject: lanes:ownersubject, ref: profile/token }\n',
+    );
+
+    await migrateToContract5(root);
+
+    expect((parse(await read(root, 'connections.yaml')) as Rows).tokens).toHaveLength(1);
+  });
+
+  test('a preview writes nothing and still says what it would do', async () => {
+    const root = await workspace({ personal: { members: OWNER } });
+
+    const preview = await migrateToContract5(root, { apply: false });
+
+    expect(preview.alreadyCurrent).toBe(false);
+    expect(preview.changes.join('\n')).toContain('tokens += a row for "profile/token"');
+    expect(preview.changes.join('\n')).toContain('auth.token_ref removed');
+    expect((parse(await read(root, 'connections.yaml')) as Rows).tokens ?? []).toHaveLength(0);
+    expect(await needsContract5(root)).toBe(true);
+  });
+});

--- a/src/cli/contract5.ts
+++ b/src/cli/contract5.ts
@@ -1,0 +1,234 @@
+import {
+  CONNECTIONS_FILE,
+  layout,
+  listProfiles,
+  readWorkspaceFile,
+  workspaceFiles,
+} from '#profile';
+import { parseDocument } from 'yaml';
+import { ConfigDocument } from './config-edit.ts';
+import { openOrCreateConnections } from './config-repair-sweep.ts';
+import { ensureRegistryContract } from './config-repair-sweep.ts';
+
+/**
+ * Contract 4 to contract 5: the endpoint token becomes a person's.
+ *
+ * Contract 4 left `auth.token_ref` on every profile, defaulting to the constant
+ * `profile/token` out of a credential store that has been one per workspace
+ * since contract 3. So "the profile's token" was the workspace's wearing a
+ * per-profile name, which is why `profile remove` once deleted the token its
+ * siblings were being served by, and why every command whose subject is the
+ * endpoint had to name a profile in order to find it. ADR-068 moves it to
+ * `tokens:` in `connections.yaml`, one row per token, each naming the Lanes
+ * subject it was issued to.
+ *
+ * **The subject is what this migration cannot invent.** A row exists so a
+ * bearer token can resolve through `members:` the way an OAuth token does, and
+ * a row with the wrong subject is worse than no row: it is a credential that
+ * looks issued and reaches nothing, or reaches somebody else's profiles. So the
+ * subject comes from the profiles themselves — the owner-role member of a
+ * profile that actually holds the token — and when there is no such member this
+ * refuses and says which command fixes it.
+ *
+ * Three steps, ordered so a crash between any two leaves a workspace that still
+ * opens and a rerun that still finishes:
+ *
+ *   1. The row is written into `connections.yaml`, pointing at the ref the
+ *      value is *already* under. Nothing moves in the credential store, which
+ *      is what makes this safe to interrupt: the old key and the new row name
+ *      the same bytes.
+ *   2. `auth.token_ref` is removed from each profile.
+ *   3. Each profile is stamped `contract: 5`.
+ *
+ * **The stamp is last**, for the reason contract 4 records: contract 3 shipped
+ * with it first, which left profiles claiming the new contract with every byte
+ * at the old path and a rerun that read the stamp and found nothing to do.
+ *
+ * **The ref is not renamed to `tokens/tok1`.** It would read better and it
+ * would mean copying a live credential in a store that may be Secret Manager,
+ * then deleting the original — two writes and a window where a deployed
+ * revision reads neither. A row may name any ref; `profile/token` is a
+ * perfectly good one, and the one thing that must not break here is an endpoint
+ * that was working before the upgrade.
+ */
+
+export interface Contract5Migration {
+  readonly workspaceRoot: string;
+  readonly profiles: readonly string[];
+  readonly changes: readonly string[];
+  /** Written into `tokens:`, as `id → subject`. Empty when there was no token. */
+  readonly issued: readonly { readonly id: string; readonly subject: string }[];
+  readonly alreadyCurrent: boolean;
+}
+
+interface RawProfile {
+  readonly contract?: number;
+  readonly auth?: { readonly token_ref?: unknown };
+  readonly members?: readonly { readonly subject?: unknown; readonly role?: unknown }[];
+}
+
+/** Whether this workspace still holds anything at contract 4. */
+export async function needsContract5(workspaceRoot: string): Promise<boolean> {
+  for (const profile of await listProfiles(workspaceRoot)) {
+    const raw = await readProfile(workspaceRoot, profile);
+    if (raw !== null && (raw.contract ?? 0) === 4) return true;
+  }
+  return false;
+}
+
+export async function migrateToContract5(
+  workspaceRoot: string,
+  options: { apply: boolean; subject?: string } = { apply: true },
+): Promise<Contract5Migration> {
+  const legacy = new Map<string, RawProfile>();
+
+  for (const profile of await listProfiles(workspaceRoot)) {
+    const raw = await readProfile(workspaceRoot, profile);
+    if (raw !== null && (raw.contract ?? 0) === 4) legacy.set(profile, raw);
+  }
+
+  if (legacy.size === 0) {
+    return { workspaceRoot, profiles: [], changes: [], issued: [], alreadyCurrent: true };
+  }
+
+  const profiles = [...legacy.keys()];
+  const changes: string[] = [];
+  const issued: { id: string; subject: string }[] = [];
+
+  // Every distinct ref the profiles held, in the order they are declared. Almost
+  // always one — the template's constant — but a profile that overrode
+  // `token_ref` had a genuinely separate credential, and dropping it would take
+  // a working endpoint down.
+  const refs = new Map<string, string[]>();
+  for (const [profile, raw] of legacy) {
+    const ref = typeof raw.auth?.token_ref === 'string' ? raw.auth.token_ref : 'profile/token';
+    refs.set(ref, [...(refs.get(ref) ?? []), profile]);
+  }
+
+  if (!options.apply) {
+    for (const [ref, holders] of refs) {
+      changes.push(`${CONNECTIONS_FILE}: tokens += a row for "${ref}" (${holders.join(', ')})`);
+    }
+    for (const profile of profiles) changes.push(`${profile}: auth.token_ref removed`);
+    return { workspaceRoot, profiles, changes, issued: [], alreadyCurrent: false };
+  }
+
+  // **The one thing this cannot guess.** `--subject` from `update`, else the
+  // owner-role member of a profile that held the ref. Refusing beats writing a
+  // row nobody can use: a token bound to the wrong subject reaches the wrong
+  // profiles, and one bound to nobody reaches none while looking issued.
+  const document = await openOrCreateConnections(workspaceRoot);
+  // Through `toJSON`, not `getIn`. `getIn` hands back YAML nodes, so reading
+  // `row.ref` off one is `undefined` — the idempotence check below silently
+  // never matched, and a rerun after an interruption wrote the row twice.
+  const existing = asRows((document.toJSON() as { tokens?: unknown } | null)?.tokens);
+  let next = existing.length + 1;
+
+  for (const [ref, holders] of refs) {
+    // Already migrated, which is what an interrupted run looks like from here.
+    if (existing.some((row) => row.ref === ref)) continue;
+
+    const subject = options.subject ?? ownerSubject(legacy, holders);
+    if (subject === undefined) {
+      throw new ContractError(
+        `Cannot migrate the endpoint token at "${ref}": a token now names the person it was\n` +
+          'issued to (ADR-068), and no profile holding it lists an owner.\n' +
+          `  Holding it: ${holders.join(', ')}\n` +
+          '  Sign in and say who you are, then run this again:\n' +
+          '    lanes auth login\n' +
+          `    lanes link profile members add --me --profile ${holders[0]} --workspace <name>`,
+      );
+    }
+
+    const id = `tok${next++}`;
+    document.addTo(['tokens'], { id, subject, ref, label: 'migrated' });
+    issued.push({ id, subject });
+    changes.push(`${CONNECTIONS_FILE}: tokens += ${id} → ${subject} ("${ref}")`);
+
+    // **Say so when the row reaches nothing.** A subject that no profile lists
+    // is a token the endpoint refuses, and the operator's CI would fail with a
+    // 401 that reads as a bad credential. It happens on the path a signed-in
+    // operator upgrades a workspace whose `members:` is empty — legitimate, and
+    // contract 3 only fills that in for workspaces it migrates itself.
+    if (!listedAnywhere(legacy, subject)) {
+      changes.push(
+        `  warning: no profile lists ${subject}, so ${id} reaches nothing until one does — ` +
+          'lanes link profile members add --me --profile <name> --workspace <name>',
+      );
+    }
+  }
+
+  // The stamp, for the reason contract 4 gives where it does the same: nothing
+  // reads this field — every contract check is on a profile — which is exactly
+  // why it goes stale, and a marker that lies is worse than no marker for
+  // whoever writes the next migration.
+  document.setIn(['contract'], 5);
+
+  await document.save();
+
+  for (const profile of profiles) {
+    const config = await ConfigDocument.open(workspaceRoot, profile);
+    config.removeIn(['auth', 'token_ref']);
+    // Last, and the record that this profile finished.
+    config.setIn(['contract'], 5);
+    await config.save({ contract: 5 });
+    changes.push(`${profile}: auth.token_ref removed, contract 5`);
+  }
+
+  // After the profiles, so the registry never claims a contract they have not
+  // reached — `isUnmigrated` reads this field and nothing else.
+  await ensureRegistryContract(workspaceRoot, 5);
+
+  return { workspaceRoot, profiles, changes, issued, alreadyCurrent: false };
+}
+
+/** Raised so `doctor` and `update` can print it rather than a stack. */
+export class ContractError extends Error {}
+
+/** Whether any profile being migrated lists this subject as a member. */
+function listedAnywhere(legacy: ReadonlyMap<string, RawProfile>, subject: string): boolean {
+  for (const raw of legacy.values()) {
+    if ((raw.members ?? []).some((member) => member.subject === subject)) return true;
+  }
+  return false;
+}
+
+/**
+ * The subject to bind a ref to: an owner of a profile that held it.
+ *
+ * `owner` rather than any member, because `owner` is who may edit the member
+ * list (ADR-060) and is therefore the one role that cannot have been delegated
+ * a narrower reach than the token used to have. Falls back to any member, since
+ * a profile with members and no owner still has somebody this belonged to, and
+ * a workspace migrated by contract 3 while signed out has neither.
+ */
+function ownerSubject(
+  legacy: ReadonlyMap<string, RawProfile>,
+  holders: readonly string[],
+): string | undefined {
+  for (const role of ['owner', undefined]) {
+    for (const profile of holders) {
+      for (const member of legacy.get(profile)?.members ?? []) {
+        if (typeof member.subject !== 'string') continue;
+        if (role === undefined || member.role === role) return member.subject;
+      }
+    }
+  }
+  return undefined;
+}
+
+function asRows(value: unknown): readonly { ref?: string }[] {
+  return Array.isArray(value) ? (value as { ref?: string }[]) : [];
+}
+
+async function readProfile(root: string, profile: string): Promise<RawProfile | null> {
+  const text = await readWorkspaceFile(workspaceFiles(root), layout.profileConfig(profile));
+  if (text === null) return null;
+  try {
+    return parseDocument(text).toJSON() as RawProfile;
+  } catch {
+    // A file that will not parse is not this migration's problem to report;
+    // `check` has a better sentence for it than "needs migrating" would.
+    return null;
+  }
+}

--- a/src/cli/emitted.test.ts
+++ b/src/cli/emitted.test.ts
@@ -66,10 +66,13 @@ describe('what setup tells someone to run', () => {
 });
 
 describe('what outputs tells someone to run', () => {
-  test('the token command names both, on whichever path it takes', async () => {
-    const invocation = await tokenInvocation('a-token-no-endpoint-will-match', 'work', 'cloud');
+  test('the token command names the workspace, and never a profile', async () => {
+    const invocation = await tokenInvocation('cloud');
 
-    expect(invocation.command).toContain('--profile work');
     expect(invocation.command).toContain('--workspace cloud');
+    // A token is the workspace's since ADR-068 and `token show` refuses
+    // `--profile` outright, so emitting one here would print a line that cannot
+    // be pasted — which is the class of failure this file exists to catch.
+    expect(invocation.command).not.toContain('--profile');
   });
 });

--- a/src/cli/endpoint-url.ts
+++ b/src/cli/endpoint-url.ts
@@ -42,19 +42,33 @@ export function localUrl(config: Config): string {
  *
  * Anonymous would be enough to prove a socket is bound, but the profile list is
  * behind the token, and the profile is the whole point of asking.
+ *
+ * **The token is optional** since ADR-068, because a healthy workspace may have
+ * issued none: a person's client signs in for itself and needs no static
+ * credential. Without one this still tells a caller whether anything is
+ * answering, which is the half every caller uses; `profiles` comes back empty
+ * rather than absent, so a caller cannot mistake "withheld" for "none served".
  */
-export async function endpointHealth(url: string, token: string): Promise<EndpointHealth | null> {
+export async function endpointHealth(
+  url: string,
+  token?: string | undefined,
+): Promise<EndpointHealth | null> {
   try {
     const probe = new URL(url);
     probe.pathname = '/health';
     const response = await fetch(probe, {
-      headers: { authorization: `Bearer ${token}` },
+      ...(token === undefined ? {} : { headers: { authorization: `Bearer ${token}` } }),
       signal: AbortSignal.timeout(700),
     });
     if (!response.ok) return null;
 
     const body = (await response.json()) as Partial<EndpointHealth>;
-    return body.profile ? { profile: body.profile, profiles: body.profiles ?? [body.profile] } : null;
+    if (body.profile) {
+      return { profile: body.profile, profiles: body.profiles ?? [body.profile] };
+    }
+    // Answered, but withheld the list — which is what an unauthenticated probe
+    // gets. Reporting the endpoint as absent would be wrong: it is up.
+    return token === undefined ? { profile: '', profiles: [] } : null;
   } catch {
     return null;
   }

--- a/src/cli/lanes.test.ts
+++ b/src/cli/lanes.test.ts
@@ -96,7 +96,7 @@ describe('the fallback token invocation', () => {
     await writeFile(join(root, 'workspaces.yaml'), workspaceYaml(['local'], {defaultProfile: 'scratch'}));
     await writeFile(
       join(root, 'profiles', 'scratch', 'profile.yaml'),
-      `contract: 4
+      `contract: 5
 
 instance:
   profile: scratch
@@ -104,18 +104,31 @@ instance:
 `,
     );
 
-    // The exact shape outputs.ts builds: the bin, the area token, the command,
-    // and the two flags that now name where the token lives.
+    const env = { ...process.env, LANES_LINK_HOME: root };
+
+    // A token has to be issued before it can be shown, and issuing names the
+    // person it is for (ADR-068). `--subject` rather than `--me`, so the test
+    // does not depend on a signed-in session.
+    const issued = Bun.spawnSync(
+      [
+        'bun', 'run', BIN, 'link', 'token', 'issue',
+        '--subject', 'lanes:scratch000', '--workspace', 'local',
+      ],
+      { env },
+    );
+    expect(issued.exitCode).toBe(0);
+
+    // The exact shape outputs.ts builds: the bin, the command, and the one flag
+    // that names where the token lives. No `--profile` — `token show` refuses
+    // it, so a line carrying one would not run at all.
     const result = Bun.spawnSync(
-      ['bun', 'run', BIN, 'link', 'token', 'show', '--raw', '--profile', 'scratch', '--target', 'local'],
-      {
-        env: { ...process.env, LANES_LINK_HOME: root },
-      },
+      ['bun', 'run', BIN, 'link', 'token', 'show', '--raw', '--workspace', 'local'],
+      { env },
     );
 
     const token = new TextDecoder().decode(result.stdout).trim();
     expect(result.exitCode).toBe(0);
-    expect(token.length).toBeGreaterThan(0);
+    expect(token.startsWith('llk_')).toBe(true);
   });
 });
 
@@ -126,18 +139,24 @@ describe('token rotate', () => {
     await Promise.all(homes.map((home) => rm(home, { recursive: true, force: true })));
   });
 
-  async function workspace(): Promise<(args: string[]) => { stdout: string; stderr: string }> {
+  async function workspace(): Promise<
+    (args: string[]) => { stdout: string; stderr: string; exitCode: number }
+  > {
     const home = await mkdtemp(join(tmpdir(), 'lanes-link-rotate-'));
     homes.push(home);
     const env = { ...process.env, LANES_LINK_HOME: home };
-    const run = (args: string[]): { stdout: string; stderr: string } => {
+    const run = (args: string[]): { stdout: string; stderr: string; exitCode: number } => {
       const result = Bun.spawnSync(['bun', 'run', BIN, ...args], { env });
       return {
         stdout: new TextDecoder().decode(result.stdout),
         stderr: new TextDecoder().decode(result.stderr),
+        exitCode: result.exitCode ?? 0,
       };
     };
     run(['link', 'profile', 'add', 'scratch', '--target', 'local']);
+    // A row to rotate. Issuing names the person it is for (ADR-068), and
+    // `--subject` keeps this off a signed-in session.
+    run(['link', 'token', 'issue', '--subject', 'lanes:scratch000', '--workspace', 'local']);
     return run;
   }
 
@@ -149,27 +168,45 @@ describe('token rotate', () => {
     // leak.
     const run = await workspace();
 
-    const rotated = run(['link', 'token', 'rotate', '--profile', 'scratch', '--target', 'local']);
-    const minted = run(['link', 'token', 'show', '--raw', '--profile', 'scratch', '--target', 'local']).stdout.trim();
+    const rotated = run(['link', 'token', 'rotate', '--workspace', 'local']);
+    const minted = run(['link', 'token', 'show', '--raw', '--workspace', 'local']).stdout.trim();
 
     expect(minted).toStartWith('llk_');
-    expect(rotated.stdout).toContain('token rotated');
+    expect(rotated.stdout).toContain('rotated tok1');
     expect(rotated.stdout).not.toContain(minted);
   });
 
   test('prints it with --show, the way `token show` does', async () => {
     const run = await workspace();
 
-    const rotated = run(['link', 'token', 'rotate', '--show', '--profile', 'scratch', '--target', 'local']);
-    const minted = run(['link', 'token', 'show', '--raw', '--profile', 'scratch', '--target', 'local']).stdout.trim();
+    const rotated = run(['link', 'token', 'rotate', '--show', '--workspace', 'local']);
+    const minted = run(['link', 'token', 'show', '--raw', '--workspace', 'local']).stdout.trim();
 
     expect(rotated.stdout).toContain(minted);
   });
 
-  test('still says every agent must be re-registered', async () => {
+  test('says what holds the old value, and no longer overstates it', async () => {
     // The part that has to stay loud: nothing re-reads the token on its own.
+    // Narrower than it was, and deliberately — a rotate used to invalidate every
+    // agent on the endpoint because every registration carried the token.
+    // Registrations do not carry one since ADR-062, so this affects only what
+    // was handed this row's value.
     const run = await workspace();
-    expect(run(['link', 'token', 'rotate', '--profile', 'scratch', '--target', 'local']).stdout).toContain('re-registered');
+    const rotated = run(['link', 'token', 'rotate', '--workspace', 'local']).stdout;
+
+    expect(rotated).toContain('tok1');
+    expect(rotated).toContain('must be given the new value');
+    expect(rotated).toContain('signed in through a browser are unaffected');
+  });
+
+  test('refuses --profile, rather than accepting and ignoring it', async () => {
+    // Somebody passing it believes they scoped the credential to one profile,
+    // and it is the member lists that decide (ADR-068).
+    const run = await workspace();
+    const refused = run(['link', 'token', 'rotate', '--profile', 'scratch', '--workspace', 'local']);
+
+    expect(refused.exitCode).not.toBe(0);
+    expect(`${refused.stdout}${refused.stderr}`).toContain('does not scope');
   });
 });
 

--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -21,6 +21,9 @@ import {
   policyRule,
   start,
   status,
+  tokenIssue,
+  tokenList,
+  tokenRevoke,
   tokenRotate,
   tokenShow,
   tools,
@@ -284,16 +287,37 @@ export async function run(argv: readonly string[]): Promise<void> {
           throw new Error(`Unknown: ${PROGRAM} policy ${second}`);
       }
 
-    case 'token':
+    case 'token': {
+      const row = {
+        ...global,
+        show,
+        raw,
+        ...(typeof flags['id'] === 'string' ? { id: flags['id'] } : {}),
+        ...(typeof flags['subject'] === 'string' ? { subject: flags['subject'] } : {}),
+        me: flags['me'] === true,
+        ...(typeof flags['label'] === 'string' ? { label: flags['label'] } : {}),
+        json: flags['json'] === true,
+      };
       switch (second) {
-        case 'show':
+        // A bare `token` lists rather than showing one. It used to show, because
+        // there was one token and nothing to list; there are several now, and a
+        // command that printed a credential when asked for an inventory would be
+        // the wrong default in the more expensive direction.
+        case 'list':
         case undefined:
-          return tokenShow({ ...global, show, raw });
+          return tokenList(row);
+        case 'issue':
+          return tokenIssue(row);
+        case 'show':
+          return tokenShow(row);
         case 'rotate':
-          return tokenRotate({ ...global, show });
+          return tokenRotate(row);
+        case 'revoke':
+          return tokenRevoke(row);
         default:
           throw new Error(`Unknown: ${PROGRAM} token ${second}`);
       }
+    }
 
     case 'pair':
       return pair({

--- a/src/cli/publish.ts
+++ b/src/cli/publish.ts
@@ -1,5 +1,5 @@
 import type { SecretStore } from '#secrets';
-import { openTarget, type Config } from '#profile';
+import { anyIssuedToken, openTarget, type Config } from '#profile';
 import { publishWorkspace } from '#deployments/upload.ts';
 import { openSecretStoreFor, type Runtime } from './runtime.ts';
 import { endpointUrl } from './endpoint-url.ts';
@@ -131,14 +131,23 @@ async function notifyReload(input: {
     return { served: false, reason: `could not work out where the endpoint is: ${message(error)}` };
   }
 
-  const token = await input.credentials.get(input.config.auth.token_ref);
-  if (!token) {
+  // Any row the workspace holds (ADR-068). Which one is not a choice worth
+  // making here: this is the operator's own command reaching the operator's own
+  // endpoint, and `/reload` cares that the caller is authenticated rather than
+  // who they are.
+  const held = await anyIssuedToken(input.workspaceRoot, input.credentials);
+  if (!held) {
     return {
       served: false,
       url,
-      reason: `no profile token at "${input.config.auth.token_ref}" to authenticate with`,
+      // Not a failure to fix in most cases, which is why it reads as a reason
+      // rather than an error. An endpoint serving browser clients needs no
+      // static token; what it costs is that a config change is picked up on the
+      // next reconcile instead of immediately.
+      reason: 'no static token is issued in this workspace, so the endpoint cannot be notified',
     };
   }
+  const token = held.value;
 
   try {
     const response = await fetch(url, {

--- a/src/cli/runtime.test.ts
+++ b/src/cli/runtime.test.ts
@@ -19,7 +19,7 @@ import { openSecretStoreFor, openRuntime, resolveProfile } from './runtime.ts';
 const roots: string[] = [];
 const previousHome = process.env['LANES_LINK_HOME'];
 
-const PROFILE = `contract: 4
+const PROFILE = `contract: 5
 
 instance:
   profile: personal
@@ -39,7 +39,7 @@ members: []
  * by the workspace that is them — which is exactly the shape this file is here
  * to exercise.
  */
-const TARGETS = `contract: 4
+const TARGETS = `contract: 5
 default_profile: personal
 
 workspaces:

--- a/src/cli/runtime.ts
+++ b/src/cli/runtime.ts
@@ -17,7 +17,6 @@
  */
 
 export {
-  ensureProfileToken,
   openBlobStoreFor,
   openSecretStoreFor,
   ownerPrincipal,

--- a/src/cli/runtime/discovery.test.ts
+++ b/src/cli/runtime/discovery.test.ts
@@ -27,7 +27,7 @@ import { DISCOVERY_NAMESPACE } from '#stores/state';
 const roots: string[] = [];
 const previousHome = process.env['LANES_LINK_HOME'];
 
-const PROFILE = `contract: 4
+const PROFILE = `contract: 5
 
 instance:
   profile: personal

--- a/src/cli/runtime/open.ts
+++ b/src/cli/runtime/open.ts
@@ -9,6 +9,7 @@ import {
   assertGrantsResolve,
   layout,
   listProfiles,
+  membersResolver,
   readConnections,
   selectConnections,
   soleGrantFor,
@@ -190,7 +191,12 @@ export async function openRuntime(
   // Lazy for the same reason `refreshSkills` is: it reads the registry it is
   // registered into. Per call rather than a snapshot, so a policy the runtime
   // was opened with is re-evaluated rather than remembered.
-  const reachable = (): ReadonlyArray<{ key: string; provider: string; account: string }> =>
+  const reachable = (): ReadonlyArray<{
+    key: string;
+    provider: string;
+    providerName: string;
+    account: string;
+  }> =>
     selected
       .filter(({ ref, connection }) =>
         registry
@@ -204,6 +210,11 @@ export async function openRuntime(
       .map(({ ref, connection }) => ({
         key: ref,
         provider: connection.provider,
+        // The manifest's display name, not the id. `defaultConnectionLabel`
+        // composes "Gmail (ada)" and needs the name — handed the id it produces
+        // "gmail (ada)", and for the owner layer, whose `account` is already the
+        // proper noun, "lanes_memory (Memory)".
+        providerName: registry.manifest(connection.provider)?.name ?? connection.provider,
         account: connection.account,
         ...(connection.label ? { label: connection.label } : {}),
       }));
@@ -329,10 +340,16 @@ export async function openRuntime(
     registry,
     refreshSkills,
     dispatcher,
+    // The workspace's issued tokens, not a profile's (ADR-068). The rows are
+    // re-read on every reload so a `token revoke` lands inside the cache
+    // window, and the subject on the matching row is resolved through
+    // `members:` — so a bearer token reaches what its holder is a member of
+    // rather than everything the workspace holds.
     authenticator: new BearerAuthenticator({
       profile: config.instance.profile,
-      tokenRef: config.auth.token_ref,
+      tokens: async () => (await readConnections(root)).tokens,
       credentials,
+      profilesFor: membersResolver(root),
     }),
     connectorFor,
     authorizeRequest,

--- a/src/cli/runtime/scoping.test.ts
+++ b/src/cli/runtime/scoping.test.ts
@@ -36,7 +36,7 @@ import { openRuntime, type Runtime } from '../runtime.ts';
 const roots: string[] = [];
 const previousHome = process.env['LANES_LINK_HOME'];
 
-const profileConfig = (name: string, skills = name): string => `contract: 4
+const profileConfig = (name: string, skills = name): string => `contract: 5
 
 instance:
   profile: ${name}
@@ -48,7 +48,7 @@ members: []
 `;
 
 /** The workspace's rows: one skills instance per profile, plus the owner layer. */
-const CONNECTIONS = `contract: 4
+const CONNECTIONS = `contract: 5
 connections:
   - { id: personal, provider: lanes_skills, account: Skills }
   - { id: work, provider: lanes_skills, account: Skills }

--- a/src/cli/runtime/select.test.ts
+++ b/src/cli/runtime/select.test.ts
@@ -17,7 +17,7 @@ import { openBlobStoreFor } from './select.ts';
 
 const config = (): Config =>
   ({
-    contract: 4,
+    contract: 5,
     instance: { profile: 'personal' },
     connections: [],
     policy: { allow: [] },
@@ -36,7 +36,7 @@ async function workspace(storage?: string): Promise<string> {
   const root = await mkdtemp(join(tmpdir(), 'lanes-link-select-'));
   await writeFile(
     join(root, 'workspaces.yaml'),
-    'contract: 4\nworkspaces:\n  local:\n' +
+    'contract: 5\nworkspaces:\n  local:\n' +
       '    credentials: { adapter: file }\n' +
       `    storage: { adapter: filesystem${storage ? `, path: ${storage}` : ''} }\n`,
   );

--- a/src/cli/runtime/select.ts
+++ b/src/cli/runtime/select.ts
@@ -159,17 +159,5 @@ export async function openBlobStoreFor(
   return area === undefined ? storage() : storage(area);
 }
 
-/** Mint the profile token if it does not exist yet. Returns it either way. */
-export async function ensureProfileToken(
-  credentials: SecretStore,
-  tokenRef: string,
-): Promise<{ token: string; created: boolean }> {
-  const existing = await credentials.get(tokenRef);
-  if (existing) return { token: existing, created: false };
-
-  const token = generateProfileToken();
-  await credentials.set(tokenRef, token);
-  return { token, created: true };
-}
 
 export { ownerPrincipal };

--- a/src/cli/selection.ts
+++ b/src/cli/selection.ts
@@ -145,7 +145,14 @@ export const SELECTION: Record<string, Requires> = {
   // ignored, which is the defect this whole file exists for.
   'connect custom': 'workspace',
   setup: 'profile+workspace',
-  token: 'profile+workspace',
+  // A token belongs to the workspace and names the person it was issued to
+  // (ADR-068). It used to sit at `auth.token_ref` on a profile, whose default
+  // was the same constant for every profile in a store that is one per
+  // workspace — so `--profile` was demanded here and could not change the
+  // answer. These commands refuse it outright rather than accept and ignore it:
+  // somebody passing `--profile work` believes they scoped the credential, and
+  // it is the member lists that decide.
+  token: 'workspace',
   // One chain per workspace since contract 3, so the workspace is the subject
   // and `--profile` filters the rows rather than choosing which log to read.
   audit: 'workspace',
@@ -160,7 +167,14 @@ export const SELECTION: Record<string, Requires> = {
   auth: 'workspace',
   // Target-scoped: see the note above. `--profile` narrows each to one profile.
   status: 'workspace',
-  outputs: 'profile+workspace',
+  // Its subject has always been the endpoint rather than a profile — its own
+  // doc comment said so — and one endpoint serves every profile in the
+  // workspace. It named a profile only to find the endpoint's token. `--profile`
+  // stays accepted and picks whose `instance.port` the local URL names, which
+  // is the one thing profiles can still disagree about here.
+  outputs: 'workspace',
+  // Unlike the two above: this reports what *one profile's* policy resolves to,
+  // beside what the endpoint advertises. The profile is the subject.
   tools: 'profile+workspace',
   // It resolves nothing and opens nothing — it hands macOS a URL (ADR-053).
   // `target list` is the precedent for a `'none'` command that still takes a
@@ -171,8 +185,9 @@ export const SELECTION: Record<string, Requires> = {
   desktop: 'none',
   attach: 'profile+workspace',
   // One endpoint serves every profile in the workspace (ADR-009), so naming one
-  // described a slice of what it does. `--profile` picks the primary, whose
-  // token opens it, and `--only` is what narrows what is served.
+  // described a slice of what it does. `--profile` picks the primary — which is
+  // now only whose host and port it binds, since the token stopped being a
+  // profile's (ADR-068) — and `--only` is what narrows what is served.
   start: 'workspace',
   deploy: 'workspace',
   // Both spellings: `sync` alone is `sync targets`, which is the only thing
@@ -193,14 +208,24 @@ export const SELECTION: Record<string, Requires> = {
   // which profile was a question with no answer. `--profile` still narrows, and
   // is how a port is chosen when profiles disagree about one.
   pair: 'workspace',
-  'token show': 'profile+workspace',
-  'token rotate': 'profile+workspace',
+  'token show': 'workspace',
+  'token rotate': 'workspace',
+  'token issue': 'workspace',
+  'token list': 'workspace',
+  'token revoke': 'workspace',
   'audit tail': 'workspace',
   'audit verify': 'workspace',
   'secrets set': 'workspace',
   'secrets list': 'workspace',
-  'mcp add': 'profile+workspace',
-  'mcp stdio': 'profile+workspace',
+  // One registration serves every profile, and each call names one in its
+  // `profile` argument — so two `--profile` values produced byte-identical
+  // harness commands. What kept the flag required was reading the endpoint's
+  // token, which is the workspace's now (ADR-068). `--profile` still picks
+  // whose port the local URL names.
+  'mcp add': 'workspace',
+  // Matches `start`, which it is: the pipe serves every profile in the
+  // workspace and `--only` is what narrows that to one.
+  'mcp stdio': 'workspace',
   memory: 'profile+workspace',
   tasks: 'profile+workspace',
   assets: 'profile+workspace',
@@ -230,7 +255,7 @@ const SUBCOMMANDS: Record<string, readonly string[]> = {
   target: ['list', 'use', 'show'],
   policy: ['list', 'allow', 'deny'],
   identity: ['add', 'list', 'remove'],
-  token: ['show', 'rotate'],
+  token: ['show', 'rotate', 'issue', 'list', 'revoke'],
   audit: ['tail', 'verify'],
   config: ['show'],
   setup: ['plan'],
@@ -242,7 +267,12 @@ const SUBCOMMANDS: Record<string, readonly string[]> = {
   // No `list`: a bare `entities` is a listing, which is `find` with no
   // criteria. One concept, one word.
   entities: ['find', 'get', 'write', 'link', 'forget', 'reindex'],
-  mcp: ['skill', 'add', 'stdio', 'list'],
+  // `install-instructions` was absent, which is not cosmetic: `dispatchWillRefuse`
+  // returns true for a second word it does not know, and both `assertKnownFlags`
+  // and `requireSelection` then return early — so `mcp install-instructions
+  // --bogus` was accepted and ignored, which is the defect this whole file
+  // exists to prevent.
+  mcp: ['skill', 'add', 'stdio', 'list', 'install-instructions'],
   secrets: ['push', 'set', 'list'],
   knowledge: ['show', 'use'],
   sync: ['targets', 'workspaces'],

--- a/src/cli/usage.ts
+++ b/src/cli/usage.ts
@@ -62,10 +62,10 @@ ${style.bold('Profiles')}
   ${PROGRAM} profile list [--json]
   ${PROGRAM} profile remove <name> [--workspace <name>] [--dry-run] [--yes] [--json]
                                  [--delete-data | --migrate-to <profile>]
-                                 the profile and its own token. Say which of
-                                 --delete-data or --migrate-to for its memory,
-                                 tasks, assets and skills — there is no default.
-                                 Accounts outlive it; disconnect removes those.
+                                 Say which of --delete-data or --migrate-to for
+                                 its memory, tasks, assets and skills — there is
+                                 no default. Accounts outlive it; disconnect
+                                 removes those, and token revoke the tokens.
 
 ${style.bold('Workspaces')}
   ${PROGRAM} workspace list [--urls]   every workspace this one knows
@@ -90,8 +90,13 @@ ${style.bold('Permissions')}
   ${PROGRAM} profile members list       who may consume this profile, and who could
   ${PROGRAM} profile members add <subject>|--me [--role owner|member]
   ${PROGRAM} profile members remove <subject>
-  ${PROGRAM} token show [--show|--raw]  CI only: --raw prints only the token, for $(…)
-  ${PROGRAM} token rotate [--show]      also ends every session a member holds
+  ${PROGRAM} token list [--json]        static tokens, and what each one reaches
+  ${PROGRAM} token issue --me|--subject <id> [--label <t>]
+                                 CI only: a token for one person. It reaches
+                                 every profile whose members list them
+  ${PROGRAM} token show [--id t] [--show|--raw]   --raw prints only it, for $(…)
+  ${PROGRAM} token rotate [--id t] [--show]
+  ${PROGRAM} token revoke --id <t>
 
 ${style.bold('Your own context')}
   ${PROGRAM} memory list [--tag t]      what you have stored
@@ -146,7 +151,7 @@ ${style.bold('Deploying')}
                                  set up, build, and roll one revision serving
                                  every profile that declares the target
   ${PROGRAM} deploy --workspace <name> --profile a --profile b
-                                 only these; the first owns the endpoint token
+                                 only these; the first is the primary
   ${PROGRAM} deploy --non-interactive   take the stored answers, never prompt
   ${PROGRAM} deploy --access iam|public who gets past the platform's own door
   ${PROGRAM} secrets list               credential references in this target

--- a/src/cli/workspace-migrate.ts
+++ b/src/cli/workspace-migrate.ts
@@ -1,4 +1,5 @@
 import { migrateToContract4, type Contract4Migration } from './contract4.ts';
+import { migrateToContract5, type Contract5Migration } from './contract5.ts';
 import { migrateToContract3, needsContract3, type Contract3Migration } from './contract3.ts';
 import { readSession } from '#auth/lanes/session.ts';
 import { parseDocument } from 'yaml';
@@ -196,6 +197,8 @@ export interface ContractMigration {
   /** The contract 2 → 3 half, when this workspace needed one. */
   readonly contract3: Contract3Migration | null;
   readonly contract4: Contract4Migration | null;
+  /** The contract 4 → 5 half: the endpoint token becomes a person's (ADR-068). */
+  readonly contract5: Contract5Migration | null;
   /** Every profile either half rewrote, deduplicated. */
   readonly profiles: readonly string[];
   /** Targets written into the registry by the contract 1 → 2 half. */
@@ -250,10 +253,10 @@ export async function migrateToCurrentContract(
 
   const subject = options.subject ?? (await readSession().catch(() => null))?.subject;
 
-  const contract3 = await migrateToContract3(workspaceRoot, {
-    apply: options.apply,
-    ...(subject === undefined ? {} : { subject }),
-  });
+  // Contract 3 writes `members:` from it; contract 5 binds the token to it.
+  const signed = { apply: options.apply, ...(subject === undefined ? {} : { subject }) };
+
+  const contract3 = await migrateToContract3(workspaceRoot, signed);
 
   // In sequence, not in parallel: contract 4 moves what contract 3 produced, so
   // it has to run against the tree the previous step left. With `apply: false`
@@ -264,20 +267,23 @@ export async function migrateToCurrentContract(
     ...(options.target === undefined ? {} : { target: options.target }),
   });
 
+  // In sequence again, for contract 4's reason.
+  const contract5 = await migrateToContract5(workspaceRoot, signed);
+
+  // Collected, not spelled out per step: a step left out of `alreadyCurrent`
+  // reports a migration as finished when it is not.
+  const steps = [legacy, contract3, contract4, contract5].filter((s) => s !== null);
+
   return {
     workspaceRoot,
     legacy: legacy !== null && !legacy.alreadyCurrent ? legacy : null,
     contract3: contract3.alreadyCurrent ? null : contract3,
     contract4: contract4.alreadyCurrent ? null : contract4,
-    profiles: [
-      ...new Set([...(legacy?.profiles ?? []), ...contract3.profiles, ...contract4.profiles]),
-    ],
+    contract5: contract5.alreadyCurrent ? null : contract5,
+    profiles: [...new Set(steps.flatMap((step) => step.profiles))],
     targets: legacy?.targets ?? [],
-    changes: [...(legacy?.changes ?? []), ...contract3.changes, ...contract4.changes],
-    alreadyCurrent:
-      (legacy === null || legacy.alreadyCurrent) &&
-      contract3.alreadyCurrent &&
-      contract4.alreadyCurrent,
+    changes: steps.flatMap((step) => step.changes),
+    alreadyCurrent: steps.every((step) => step.alreadyCurrent),
   };
 }
 

--- a/src/connectivity/context.ts
+++ b/src/connectivity/context.ts
@@ -53,6 +53,23 @@ export interface ConnectionInfo {
  */
 export interface ProviderContext {
   readonly connection: ConnectionInfo;
+  /**
+   * Every profile this caller may reach, this one included.
+   *
+   * The narrowest widening of this interface that could carry it, and worth
+   * saying why it belongs at all given the rule above. It is not a backend, a
+   * credential or a store: it is the same routing fact the client already holds
+   * in the `profile` enum on every tool it was shown, which `visibility.ts`
+   * filters by `mayReach`. A provider cannot *act* in any of these — dispatch
+   * still resolves one profile per call — so this grants no reach.
+   *
+   * It exists because a surface that describes what a caller can get to has to
+   * be given the caller's answer rather than the workspace's.
+   * `lanes_setup.overview` was handed every profile on disk and named them all,
+   * which told a delegated member about profiles `mayReach` deliberately hides
+   * from their enum (ADR-068).
+   */
+  readonly profiles: readonly string[];
   readonly state: ScopedStore;
   readonly storage: BlobStore;
   readonly credentials: ScopedSecrets;

--- a/src/connectivity/manifest/provider.ts
+++ b/src/connectivity/manifest/provider.ts
@@ -109,7 +109,15 @@ export const RESERVED_PROVIDER_IDS: readonly string[] = [
   'lanes_entities',
 ];
 
-/** Old id to new, for the contract-4 migration and for a refusal that names it. */
+/**
+ * Old id to new, for a refusal that can name what a stale client is asking for.
+ *
+ * Nothing consumes it yet. The migration builds its own map from
+ * `C3_OWNER_PROVIDERS` (`src/cli/contract4-rename.ts`), and a `tools/call` on a
+ * pre-0.9.0 name is answered by the SDK's exact-match lookup before anything
+ * here sees it — so the refusal this exists for is still unwritten. ADR-066
+ * records the failure it would address.
+ */
 export const RENAMED_OWNER_PROVIDERS: ReadonlyMap<string, string> = new Map(
   RESERVED_PROVIDER_IDS.map((id) => [id.slice('lanes_'.length), id]),
 );

--- a/src/deployments/bootstrap.test.ts
+++ b/src/deployments/bootstrap.test.ts
@@ -93,7 +93,7 @@ describe('a target the workspace already answers', () => {
     roots.push(root);
     await writeFile(
       join(root, 'workspaces.yaml'),
-      'contract: 4\nworkspaces:\n  cloud:\n' +
+      'contract: 5\nworkspaces:\n  cloud:\n' +
         '    credentials: { adapter: gcp-secret-manager, project: p }\n' +
         '    storage: { adapter: gcs, bucket: b }\n' +
         '    deploy:\n      platform: cloudrun\n      project: p\n' +

--- a/src/deployments/deploy.test.ts
+++ b/src/deployments/deploy.test.ts
@@ -165,7 +165,7 @@ describe('what a deploy sends up', () => {
  */
 describe('what a deploy repairs before sending it', () => {
   /** An old profile: a real connection, its grant, and no setup surface. */
-  const OLD = (name: string) => `contract: 4
+  const OLD = (name: string) => `contract: 5
 instance:
   profile: ${name}
   port: 7337
@@ -175,7 +175,7 @@ members: []
 `;
 
   /** The workspace it lives in, with the account and no owner-layer row. */
-  const OLD_CONNECTIONS = `contract: 4
+  const OLD_CONNECTIONS = `contract: 5
 connections:
   - { id: a, provider: example, account: someone@example.test }
 oauth_apps: {}
@@ -321,7 +321,7 @@ oauth_apps: {}
 describe('which credentials a deploy asks provision to bind', () => {
   // The rows are the workspace's now, so a "profile" in these fixtures is the
   // set of connections it grants and the file that grants them (ADR-057).
-  const PROFILE = (name: string, connections: string) => `contract: 4
+  const PROFILE = (name: string, connections: string) => `contract: 5
 instance:
   profile: ${name}
 grants:
@@ -350,7 +350,7 @@ members: []
 
     await writeFile(
       join(root, CONNECTIONS_FILE),
-      `contract: 4\nconnections:\n${rows.join('\n')}\noauth_apps: {}\n`,
+      `contract: 5\nconnections:\n${rows.join('\n')}\noauth_apps: {}\n`,
     );
     return root;
   }
@@ -468,7 +468,7 @@ members: []
  */
 describe('publishing a config edit', () => {
   const targets = (extra: string): string => `
-contract: 4
+contract: 5
 instance:
   profile: personal
   port: 7337
@@ -543,13 +543,13 @@ describe('the allowlist against a real workspace listing', () => {
     roots.push(source, destination);
 
     const profile = (name: string): string =>
-      `contract: 4\ninstance:\n  profile: ${name}\ngrants: []\nmembers: []\n`;
+      `contract: 5\ninstance:\n  profile: ${name}\ngrants: []\nmembers: []\n`;
 
     const files: Record<string, string> = {
       'workspaces.yaml': workspaceYaml(['local', 'cloud'], { defaultProfile: 'personal' }),
       'profiles/personal/profile.yaml': profile('personal'),
       'profiles/work/profile.yaml': profile('work'),
-      'connections.yaml': `contract: 4\nconnections: []\noauth_apps: {}\n`,
+      'connections.yaml': `contract: 5\nconnections: []\noauth_apps: {}\n`,
       [`${layout.skills('personal', 'main')}/review-diff/SKILL.md`]: '---\ndescription: d\n---\nb\n',
       [`${layout.skills('work', 'main')}/triage.md`]: '---\ndescription: d\n---\nb\n',
       ['providers.d/acme.yaml']: 'id: acme\n',

--- a/src/deployments/deploy.test.ts
+++ b/src/deployments/deploy.test.ts
@@ -5,6 +5,7 @@ import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { readableRefs, rotatableRefs } from './prepare.ts';
+import { registerLine } from './report.ts';
 import {
   deployedWorkspace,
   isWorkspaceConfig,
@@ -623,3 +624,23 @@ describe('the allowlist against a real workspace listing', () => {
  * a deploy that reports success followed by a service that will not start, and
  * nothing in either points at the profile that caused it.
  */
+
+/**
+ * What a deploy tells an operator whose clients are already registered.
+ *
+ * ADR-032 covers the first deploy: register before the accounts exist and the
+ * client holds a two-tool surface. The case it left unsaid is every deploy after
+ * that one, and 0.9.0 is what made it expensive — renaming the owner layer's
+ * provider ids renamed their tools, so a registered client went on calling
+ * `setup_overview` against an endpoint serving `lanes_setup_overview` and read as
+ * a broken endpoint rather than a stale list. `sayContract4` says it when the
+ * migration runs; a deploy is when it reaches anybody.
+ */
+describe('the deploy report names the re-add', () => {
+  test('an already-registered client is told, and given the command', () => {
+    const line = registerLine('personal', 'cloud');
+
+    expect(line).toContain('registered before this deploy');
+    expect(line).toContain('lanes link mcp add');
+  });
+});

--- a/src/deployments/prepare.ts
+++ b/src/deployments/prepare.ts
@@ -4,7 +4,7 @@ import {
   readConnections, listProfiles, loadProfileConfig, vaultRef, type Config, type TargetConfig } from '#profile';
 import { VAULT_DOCUMENT_REF, VAULT_KEY_REF, generateVaultKey, type SecretStore } from '#secrets';
 import { ok, print, style, warn } from '#cli/output.ts';
-import { buildRegistryWithWorkspace, ensureProfileToken } from '#cli/runtime.ts';
+import { buildRegistryWithWorkspace } from '#cli/runtime.ts';
 
 /**
  * Getting the target's credential store to the state a revision can boot from.
@@ -198,7 +198,6 @@ export async function readableRefs(
       continue;
     }
 
-    refs.add(config.auth.token_ref);
     if (declared?.vault?.adapter === 'secret') refs.add(vaultRef(declared, config));
     // The OIDC audience check reads this on every verify (`server/endpoint.ts`).
     if (config.auth.authorization?.mode === 'oidc') {
@@ -209,6 +208,13 @@ export async function readableRefs(
 
   // Once, for the reason `rotatableRefs` gives.
   const connectionsFile = await readConnections(root);
+
+  // The endpoint's own tokens, which are the workspace's rather than any
+  // profile's since ADR-068. Pushed so a deployed revision can authenticate a
+  // headless caller; the *rows* travel with `connections.yaml`, so a ref here
+  // without its value is a row that matches nothing and reads to the client
+  // exactly like a wrong token.
+  for (const issued of connectionsFile.tokens) refs.add(issued.ref);
   const registry = await buildRegistryWithWorkspace(root);
 
   for (const connection of connectionsFile.connections) {
@@ -227,7 +233,6 @@ export async function prepareSecrets(input: PrepareInput): Promise<PrepareResult
   const blocking: string[] = [];
   const warnings: string[] = [];
 
-  await seedProfileToken({ config, credentials, readOnly, blocking });
   await seedVaultKey({ declared: input.declared, credentials, readOnly });
 
   // Connection credentials are written by `connect`, against a real account, in
@@ -280,34 +285,4 @@ async function seedVaultKey(input: {
   print(ok(`minted the vault key at "${VAULT_KEY_REF}" — the revision reads it from there`));
 }
 
-/**
- * The endpoint's own bearer token.
- *
- * Minted rather than demanded, and not even asked about: it is a random string
- * this process generates correctly and the operator cannot usefully choose, so a
- * prompt would be a question with one answer. `ensureProfileToken` is the same
- * call `outputs` makes for a local target, which is what keeps "the token" one
- * thing rather than a per-command notion.
- *
- * The deployed container deliberately will *not* do this — a token invented
- * inside something that scales to zero is a token nobody can read back, and the
- * endpoint would come up healthy while rejecting every agent.
- */
-async function seedProfileToken(input: {
-  config: Config;
-  credentials: SecretStore;
-  readOnly: boolean;
-  blocking: string[];
-}): Promise<void> {
-  const ref = input.config.auth.token_ref;
-  if (await input.credentials.has(ref)) return;
-
-  if (input.readOnly) {
-    input.blocking.push(`the endpoint bearer token — nothing at "${ref}"`);
-    return;
-  }
-
-  const { created } = await ensureProfileToken(input.credentials, ref);
-  if (created) print(ok(`minted an endpoint token at "${ref}" — read it with lanes link token show`));
-}
 

--- a/src/deployments/record.test.ts
+++ b/src/deployments/record.test.ts
@@ -33,7 +33,7 @@ afterAll(async () => {
 async function workspace(): Promise<string> {
   const root = await mkdtemp(join(tmpdir(), 'lanes-link-record-'));
   roots.push(root);
-  await writeFile(join(root, 'workspaces.yaml'), 'contract: 4\n');
+  await writeFile(join(root, 'workspaces.yaml'), 'contract: 5\n');
   return root;
 }
 

--- a/src/deployments/report.ts
+++ b/src/deployments/report.ts
@@ -22,14 +22,14 @@ import { heading, ok, print, style, warn } from '#cli/output.ts';
  * `tools/list` when it connects and keeps it: this endpoint is stateless, so
  * there is no stream on which to send `notifications/tools/list_changed`, and
  * `buildMcpServer` no longer pretends otherwise. A first deploy necessarily
- * publishes a profile whose only connection is `setup.main` — the accounts come
+ * publishes a profile whose only connection is `lanes_setup.lan1` — the accounts come
  * after — so a connector registered in that window captures a two-tool surface
  * and holds it. The endpoint is right, every reload lands, and the client shows
  * two tools until someone removes and re-adds it.
  *
  * Unconditional, and that is the correction that matters. This was gated on
  * `prepared.warnings.length`, which is zero in precisely the case it describes:
- * a fresh profile declares only `setup.main`, `setup` is a local provider with
+ * a fresh profile declares only `lanes_setup.lan1`, and it is a local provider with
  * no credential, so `prepareSecrets` has nothing to warn about. The advice
  * appeared only on a later re-deploy, by which point the connector is usually
  * registered and the ordering is no longer available to get right.
@@ -39,7 +39,10 @@ export function registerLine(profile: string, target: string): string {
     `  Connect your accounts first, then register with:\n` +
       `    lanes link outputs --profile ${profile} --workspace ${target}\n` +
       '  A client keeps the tool list it fetched when it connected, so one registered\n' +
-      '  before the accounts holds a surface without them until it is re-added.',
+      '  before the accounts holds a surface without them until it is re-added.\n' +
+      '  One registered before this deploy holds the list from before it, so a version\n' +
+      '  that renamed a provider or an id leaves it calling names that are gone:\n' +
+      '    lanes link mcp add',
   );
 }
 

--- a/src/dispatch/context.ts
+++ b/src/dispatch/context.ts
@@ -131,6 +131,8 @@ export interface BuildContextOptions {
   readonly authorize?: ((request: Request) => Promise<Request>) | undefined;
   /** `oauth_apps` entries this profile declares. See `resolveSecretRefs`. */
   readonly ownClients?: readonly string[] | undefined;
+  /** Every profile the caller may reach. See `ProviderContext.profiles`. */
+  readonly profiles: readonly string[];
 }
 
 export function buildProviderContext(options: BuildContextOptions): ProviderContext {
@@ -146,6 +148,7 @@ export function buildProviderContext(options: BuildContextOptions): ProviderCont
 
   return {
     connection: info,
+    profiles: options.profiles,
     state: createScopedStore(options.state, namespace),
     storage: scopeBlobStore(options.storage, namespace),
     credentials: scopeSecrets(

--- a/src/dispatch/control-plane.test.ts
+++ b/src/dispatch/control-plane.test.ts
@@ -197,6 +197,7 @@ describe('the provider context exposes no control-plane handle', () => {
       manifest: exampleProvider.manifest,
       definition: exampleProvider,
       connection: { id: 'a', provider: 'example', account: 'A' },
+      profiles: ['personal'],
       state: createMemoryState(),
       credentials: createMemoryCredentials({ 'gmail/main': 'refresh-token' }),
       storage: createMemoryBlobStore(),
@@ -214,10 +215,26 @@ describe('the provider context exposes no control-plane handle', () => {
       'connection',
       'credentials',
       'log',
+      // The caller's reachable profile names (ADR-068). A design decision, and
+      // the argument for it is that it is not a handle: it is the same routing
+      // fact the client already holds in every tool's `profile` enum, and a
+      // provider still acts in exactly one profile per dispatch. It is here so
+      // a surface describing what a caller can reach is given the caller's
+      // answer rather than the workspace's.
+      'profiles',
       'signal',
       'state',
       'storage',
     ]);
+  });
+
+  test('the profile names it carries are strings, not a way into any of them', () => {
+    // The thing that would make this a control-plane handle is a runtime, a
+    // store, or a dispatcher per profile. It is a list of names.
+    const surface = contextFor() as unknown as Record<string, unknown>;
+
+    expect(Array.isArray(surface['profiles'])).toBe(true);
+    expect((surface['profiles'] as unknown[]).every((n) => typeof n === 'string')).toBe(true);
   });
 
   test('carries no unscoped store, config, policy, or registry', () => {
@@ -323,6 +340,7 @@ describe('vault will not be able to reach the credential store', () => {
       manifest: exampleProvider.manifest,
       definition: exampleProvider,
       connection: { id: 'a', provider: 'example', account: 'A' },
+      profiles: ['personal'],
       state: createMemoryState(),
       credentials: createMemoryCredentials(),
       storage: createMemoryBlobStore(),

--- a/src/dispatch/dispatch.test.ts
+++ b/src/dispatch/dispatch.test.ts
@@ -104,7 +104,7 @@ const testProvider = defineLocalProvider({
 });
 
 const CONFIG = parseConfig(`
-contract: 4
+contract: 5
 instance:
   profile: personal
 limits:

--- a/src/dispatch/dispatch.ts
+++ b/src/dispatch/dispatch.ts
@@ -271,6 +271,11 @@ export class Dispatcher {
         // provider that could be brokered but is not reads its client from the
         // store, so it has to be able to.
         ownClients: this.#deps.oauthApps,
+        // The *caller's* set, not the workspace's. `undefined` means
+        // unrestricted — the stdio pipe — and the profile in play is the only
+        // honest answer a dispatcher can give for it without knowing what the
+        // endpoint is serving.
+        profiles: request.principal.profiles ?? [request.principal.profile],
         ...(entry.manifest.connector.kind === 'local' ? {} : { authorize }),
       });
 

--- a/src/dispatch/strategy.test.ts
+++ b/src/dispatch/strategy.test.ts
@@ -65,7 +65,7 @@ afterAll(async () => {
 });
 
 const CONFIG = parseConfig(`
-contract: 4
+contract: 5
 instance:
   profile: personal
 limits:

--- a/src/profile/connections.test.ts
+++ b/src/profile/connections.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, test } from 'bun:test';
+import { defaultConnectionLabel } from './connections.ts';
+
+/**
+ * What a connection is called when nobody has named it.
+ *
+ * One rule, read by four surfaces: the label `connect` offers, the label it
+ * declines to write because it offered it, the name `connection list` prints,
+ * and the name the dashboard shows. They agreed on the account before this
+ * existed, which is why an unlabelled row read as its address in one place and
+ * as `con8` in another.
+ */
+describe('defaultConnectionLabel', () => {
+  test('is the provider and the account, so two mailboxes are two names', () => {
+    expect(defaultConnectionLabel('Gmail', 'ada@example.com')).toBe('Gmail (ada)');
+    expect(defaultConnectionLabel('Gmail', 'rin@example.com')).toBe('Gmail (rin)');
+  });
+
+  test('takes the local part, because the domain repeats on every address at one', () => {
+    expect(defaultConnectionLabel('iCloud Mail', 'ada@example.test')).toBe('iCloud Mail (ada)');
+  });
+
+  test('keeps an account that is not an address whole', () => {
+    // `Lanes HQ` cut at the space is `Lanes`, which is a different workspace's
+    // name as often as not. There is no first part to guess at here.
+    expect(defaultConnectionLabel('Notion', 'Acme HQ')).toBe('Notion (Acme HQ)');
+    expect(defaultConnectionLabel('GitHub', 'acme-sh')).toBe('GitHub (acme-sh)');
+  });
+
+  test('is the provider alone where there is no account behind it', () => {
+    // The owner layer. Its rows carry the proper noun in `account` already, so
+    // composing the two would read `Memory (Memory)`.
+    expect(defaultConnectionLabel('Memory', 'Memory')).toBe('Memory');
+    expect(defaultConnectionLabel('Vault', null)).toBe('Vault');
+    expect(defaultConnectionLabel('Setup', undefined)).toBe('Setup');
+  });
+
+  test('an empty account is no account', () => {
+    expect(defaultConnectionLabel('Gmail', '')).toBe('Gmail');
+    // And an address with nothing before the `@` falls back to the whole of it
+    // rather than to `Gmail ()`.
+    expect(defaultConnectionLabel('Gmail', '@example.com')).toBe('Gmail (@example.com)');
+  });
+});

--- a/src/profile/connections.ts
+++ b/src/profile/connections.ts
@@ -21,6 +21,38 @@ export function connectionRefOf(connection: ConnectionConfig): string {
 }
 
 /**
+ * What to call a connection nobody has named.
+ *
+ * `label` is the operator's own word for a row and is usually unset: `connect`
+ * offers a default and does not write one that only repeats a line above it, so
+ * most rows are an id, a provider and an account and nothing else. Every reader
+ * then has to decide what to show, and each of them picked the id — which is the
+ * one field that says nothing. It is opaque on purpose (`nextConnectionId`), so
+ * `con8` tells a reader strictly less about a row than any other line of it.
+ *
+ * The provider is what somebody is asking about, and the account is what tells
+ * two rows of the same provider apart, so the name is both: `Gmail (ada)`. The
+ * local part only — every address a person holds at one domain repeats it, and
+ * the account itself is on the line beside this everywhere this is shown.
+ *
+ * A connection with no account behind it is its provider and nothing else. That
+ * is the owner layer, whose rows carry the proper noun in `account` already, so
+ * composing the two would read `Memory (Memory)`.
+ */
+export function defaultConnectionLabel(
+  providerName: string,
+  account: string | null | undefined,
+): string {
+  if (!account || account === providerName) return providerName;
+
+  // Split on `@` and nothing else. A handle, an IBAN or a workspace name has no
+  // "first part" that is safe to guess at: `Lanes HQ` cut at the space is
+  // `Lanes`, which is a different workspace's name as often as not.
+  const local = account.split('@')[0];
+  return `${providerName} (${local || account})`;
+}
+
+/**
  * One account this profile reaches, with the rules that govern it.
  *
  * The grant travels with the connection deliberately. Every caller that has a

--- a/src/profile/deployments.test.ts
+++ b/src/profile/deployments.test.ts
@@ -34,7 +34,7 @@ afterAll(async () => {
 
 describe('recording where a target lives', () => {
   test('a workspace with no registry reports none, rather than failing', async () => {
-    const root = await workspace('contract: 4\n');
+    const root = await workspace('contract: 5\n');
     expect(await readRegistry(root)).toEqual({});
   });
 
@@ -73,7 +73,7 @@ describe('recording where a target lives', () => {
     // `deploy` writes the bucket's own registry after the upload. Merging there
     // left this machine's `at:` on the entry — and a bucket pointing at
     // itself is a loop `openTarget` refuses, on the target just deployed.
-    const root = await workspace('contract: 4\n');
+    const root = await workspace('contract: 5\n');
     await recordTarget(root, 'cloud', { at: 'gs://your-bucket', primary: 'personal' });
     await recordTarget(root, 'cloud', {
       credentials: { adapter: 'gcp-secret-manager', project: 'p' },
@@ -109,7 +109,7 @@ describe('recording where a target lives', () => {
   });
 
   test('two targets are two entries', async () => {
-    const root = await workspace('contract: 4\n');
+    const root = await workspace('contract: 5\n');
     await recordTarget(root, 'cloud', { at: 'gs://one-bucket' });
     await recordTarget(root, 'staging', { at: 'gs://two-bucket' });
 
@@ -124,7 +124,7 @@ describe('recording where a target lives', () => {
   });
 
   test('the operator’s comments survive being written to', async () => {
-    const root = await workspace('# why this workspace exists\ncontract: 4\n');
+    const root = await workspace('# why this workspace exists\ncontract: 5\n');
     await recordTarget(root, 'cloud', { at: 'gs://your-bucket' });
 
     expect(await readFile(join(root, 'workspaces.yaml'), 'utf8')).toContain(

--- a/src/profile/identity.test.ts
+++ b/src/profile/identity.test.ts
@@ -14,7 +14,7 @@ import { parseConfig } from './load.ts';
  * directions: prose passes, and a credential pasted into a value does not.
  */
 
-const PROFILE = `contract: 4
+const PROFILE = `contract: 5
 instance:
   profile: personal
 grants: []

--- a/src/profile/index.ts
+++ b/src/profile/index.ts
@@ -123,6 +123,14 @@ export {
 } from './registry.ts';
 export { recordTarget, removeTarget } from './deployments.ts';
 export {
+  anyIssuedToken,
+  membersResolver,
+  nextTokenId,
+  readEndpointTokens,
+  tokenRef,
+  type EndpointToken,
+} from './tokens.ts';
+export {
   isRemoteWorkspace,
   readWorkspaceFile,
   workspaceFiles,

--- a/src/profile/index.ts
+++ b/src/profile/index.ts
@@ -46,6 +46,7 @@ export {
   assertGrantsResolve,
   assertNoRenamedProviders,
   connectionRefOf,
+  defaultConnectionLabel,
   selectConnections,
   soleGrantFor,
   vaultRef,

--- a/src/profile/load.test.ts
+++ b/src/profile/load.test.ts
@@ -7,7 +7,7 @@ import { assertNoRenamedProviders } from './connections.ts';
 
 /** A minimal valid config; each test overrides the part it is about. */
 const VALID = `
-contract: 4
+contract: 5
 instance:
   profile: personal
 grants:
@@ -23,7 +23,6 @@ describe('a valid config', () => {
     expect(config.instance.profile).toBe('personal');
     expect(config.instance.port).toBe(7337);
     expect(config.instance.host).toBe('127.0.0.1');
-    expect(config.auth.token_ref).toBe('profile/token');
     expect(config.limits.requests_per_minute).toBe(120);
     expect(connectionKeys).toEqual(['example.a']);
   });
@@ -37,13 +36,13 @@ describe('a valid config', () => {
 
 describe('contract major fails closed', () => {
   test('rejects a newer major outright', () => {
-    expect(() => parseConfig(VALID.replace('contract: 4', 'contract: 5'))).toThrow(
-      /contract 5 is newer than.*Upgrade lanes-link/s,
+    expect(() => parseConfig(VALID.replace('contract: 5', 'contract: 6'))).toThrow(
+      /contract 6 is newer than.*Upgrade lanes-link/s,
     );
   });
 
   test('rejects an older major outright', () => {
-    expect(() => parseConfig(VALID.replace('contract: 4', 'contract: 0'))).toThrow(/older than/);
+    expect(() => parseConfig(VALID.replace('contract: 5', 'contract: 0'))).toThrow(/older than/);
   });
 
   // Contract 1 is the shape this release replaced, and it is refused here rather
@@ -51,14 +50,14 @@ describe('contract major fails closed', () => {
   // that, so a profile still carrying `targets:` fails at the boundary with a
   // sentence naming the migration (ADR-052).
   test('rejects contract 2, which the migration handles instead', () => {
-    expect(() => parseConfig(VALID.replace('contract: 4', 'contract: 2'))).toThrow(
+    expect(() => parseConfig(VALID.replace('contract: 5', 'contract: 2'))).toThrow(
       /contract 2 is older than/,
     );
   });
 
   test('rejects a missing or non-integer contract', () => {
-    expect(() => parseConfig(VALID.replace('contract: 4\n', ''))).toThrow(/"contract" is required/);
-    expect(() => parseConfig(VALID.replace('contract: 4', 'contract: "2"'))).toThrow(
+    expect(() => parseConfig(VALID.replace('contract: 5\n', ''))).toThrow(/"contract" is required/);
+    expect(() => parseConfig(VALID.replace('contract: 5', 'contract: "2"'))).toThrow(
       /must be an integer/,
     );
   });
@@ -66,7 +65,7 @@ describe('contract major fails closed', () => {
   test('the contract check runs before anything else', () => {
     // A config that is wrong in several ways must report the contract, because
     // under an unknown major we cannot claim to know what the rest means.
-    const broken = VALID.replace('contract: 4', 'contract: 99').replace(
+    const broken = VALID.replace('contract: 5', 'contract: 99').replace(
       'profile: personal',
       'profile: "not an identifier"',
     );
@@ -333,7 +332,7 @@ describe('where a target deploys', () => {
   const withTarget = (block: string) =>
     workspaceSchema.parse(
       parseYaml(
-        'contract: 4\nworkspaces:\n  cloud:\n' +
+        'contract: 5\nworkspaces:\n  cloud:\n' +
           '    credentials: { adapter: gcp-secret-manager, project: my-project }\n' +
           '    storage: { adapter: s3, bucket: link-blobs }\n' +
           block,
@@ -471,7 +470,7 @@ describe('malformed input', () => {
   });
 
   test('reports unparseable YAML as such', () => {
-    expect(() => parseConfig('contract: 4\n  bad: [indent')).toThrow(/could not parse YAML/);
+    expect(() => parseConfig('contract: 5\n  bad: [indent')).toThrow(/could not parse YAML/);
   });
 
   test('rejects an out-of-range port', () => {

--- a/src/profile/schema.ts
+++ b/src/profile/schema.ts
@@ -59,11 +59,22 @@ import { knowledgeTargetSchema } from './knowledge.ts';
  * declaration moved inside it. No file's *shape* changed: `grants:`,
  * `members:` and `connections.yaml` are untouched, and only the paths moved.
  *
+ * **5 made the endpoint token a person's rather than a profile's** (ADR-068).
+ * `auth.token_ref` defaulted to the constant `profile/token` for every profile
+ * out of a credential store that is one per workspace, so the "profile's token"
+ * was the workspace's wearing a per-profile name — which is why removing one
+ * profile once deleted the token its siblings were served by. It moves to
+ * `tokens:` in `connections.yaml`, one row per issued token, each naming the
+ * Lanes subject it was issued to. What that buys is the thing a bearer token
+ * could not do: it resolves through `members:` like an OAuth token does, so a
+ * credential says who you are and the profiles follow from that rather than
+ * from which profile happened to mint it.
+ *
  * A hard cut each time, and only the newest is read here. `./legacy.ts`
  * understands the older shapes and only the migration uses it — a runtime that
  * loaded either would be the two-sources-of-truth problem again, one level up.
  */
-export const SUPPORTED_CONTRACT = 4;
+export const SUPPORTED_CONTRACT = 5;
 
 /**
  * There is no `database:` block any more.
@@ -447,6 +458,29 @@ export const oauthAppSchema = z.object({
   client_secret_ref: credentialRef,
 });
 
+/**
+ * One static endpoint token, and the person it was issued to.
+ *
+ * **`subject` is the whole point** (ADR-068). A bearer token used to resolve to
+ * the primary profile's owner and reach every profile in the workspace, which
+ * made it the one credential here that answered "what may I open" without ever
+ * answering "who are you". It names a Lanes subject now, and the profiles it
+ * reaches are the ones whose `members:` list that subject — the same resolution
+ * an OAuth token has gone through since ADR-060.
+ *
+ * The value is never here. `ref` points into the workspace's credential store,
+ * which is what keeps `findSecrets` from having anything to find in this file.
+ */
+export const endpointTokenSchema = z.object({
+  id: identifier,
+  subject: subjectRef,
+  ref: credentialRef,
+  /** What it is for, in a word — `ci`, `runner`. Free text, shown in listings. */
+  label: z.string().min(1).optional(),
+  /** ISO 8601, written when the row is created. Reported, never compared. */
+  issued_at: z.string().min(1).optional(),
+});
+
 
 /**
  * One profile: who it is, what it reaches, and what it may do.
@@ -473,7 +507,6 @@ export const configSchema = z.object({
   auth: z
     .object({
       mode: z.literal('bearer').default('bearer'),
-      token_ref: credentialRef.default('profile/token'),
       /**
        * Additive. `mode` above still describes what the endpoint accepts on the
        * wire — a bearer token — and this describes where a *remote* client can
@@ -490,7 +523,7 @@ export const configSchema = z.object({
        */
       allowed_origins: z.array(browserOrigin).optional(),
     })
-    .default({ mode: 'bearer', token_ref: 'profile/token' }),
+    .default({ mode: 'bearer' }),
 
   limits: z
     .object({
@@ -575,12 +608,23 @@ export const connectionsFileSchema = z.object({
   contract: z.number().int().positive(),
   connections: z.array(connectionSchema).default([]),
   oauth_apps: z.record(identifier, oauthAppSchema).default({}),
+  /**
+   * The static tokens this workspace has issued (ADR-068).
+   *
+   * Here rather than in a file of their own because this is already where the
+   * workspace keeps what is not a profile's and not an account's — `oauth_apps`
+   * is the precedent, and it is credential-referencing in the same way. A
+   * workspace that has issued none has no key, which is what lets an untouched
+   * file parse.
+   */
+  tokens: z.array(endpointTokenSchema).default([]),
 });
 
 export type ConnectionsFile = z.infer<typeof connectionsFileSchema>;
 
 export type Config = z.infer<typeof configSchema>;
 export type ConnectionConfig = z.infer<typeof connectionSchema>;
+export type EndpointToken = z.infer<typeof endpointTokenSchema>;
 export type GrantConfig = z.infer<typeof grantSchema>;
 export type MemberConfig = z.infer<typeof memberSchema>;
 export type PolicyRuleConfig = z.infer<typeof policyRuleSchema>;

--- a/src/profile/tokens.ts
+++ b/src/profile/tokens.ts
@@ -1,0 +1,137 @@
+import { loadWorkspaceProfiles, readConnections } from './workspace.ts';
+import type { EndpointToken } from './schema.ts';
+
+/**
+ * The endpoint's static tokens, which belong to the workspace (ADR-068).
+ *
+ * **Why this is not a field on a profile any more.** `auth.token_ref` defaulted
+ * to the constant `profile/token` for every profile, out of a credential store
+ * that has been one per workspace since ADR-057 — so naming a profile to find
+ * the endpoint's token asked a question with one answer, and every command whose
+ * subject is the endpoint had to ask it. `profile/removal.ts` records the
+ * sharper consequence: removing one profile deleted the token its siblings were
+ * being served by, and the deployed revision then refused every request.
+ *
+ * **A row names a person.** That is the part that changes behaviour rather than
+ * merely moving a file. A bearer token used to resolve to `ownerPrincipal` of
+ * whichever profile was primary, with `profiles: undefined` — "all of them" —
+ * so it was the one credential on this endpoint that answered *what may I open*
+ * without ever answering *who are you*. A row carries a Lanes subject, so the
+ * token resolves through the profile's `members:` exactly as an OAuth token has
+ * since ADR-060, and `mayReach` needs no special case for it.
+ *
+ * The value is never in the file. A row holds a `ref` into the workspace's
+ * credential store, which is what keeps `findSecrets` with nothing to find.
+ */
+
+/** Where a row's value lives in the workspace credential store. */
+export function tokenRef(id: string): string {
+  return `tokens/${id}`;
+}
+
+/**
+ * The next free row id, `tok1` upward.
+ *
+ * Same shape as `nextConnectionId` and opaque for the same reason: the id ends
+ * up in a listing and in a credential path, and an id derived from the label or
+ * the subject would either collide or leak. `label` is the field for saying what
+ * a token is for.
+ */
+export function nextTokenId(taken: readonly string[]): string {
+  let highest = 0;
+  for (const id of taken) {
+    const match = /^tok([0-9]+)$/.exec(id);
+    if (match) highest = Math.max(highest, Number(match[1]));
+  }
+  return `tok${highest + 1}`;
+}
+
+/**
+ * Every token this workspace has issued.
+ *
+ * Read through `readConnections` rather than the filesystem, so a deployed
+ * revision whose root is a bucket URL loads them (ADR-049). A workspace that has
+ * issued none returns empty, which is not an error: it is what a fresh install
+ * looks like, and what a workspace looks like after `token revoke` removes the
+ * last row.
+ */
+export async function readEndpointTokens(
+  workspaceRoot: string,
+): Promise<readonly EndpointToken[]> {
+  return (await readConnections(workspaceRoot)).tokens;
+}
+
+export type { EndpointToken };
+
+/**
+ * Which profiles in this workspace list a subject as a member.
+ *
+ * The rule is ADR-060's and is stated once: a caller reaches a profile if that
+ * profile's `members:` names them. `server/endpoint.ts` answers the same
+ * question from its live runtime map when an OAuth code is minted; this answers
+ * it from disk, which is what a static token needs because it has no mint to be
+ * resolved at. Both are bounded by what the endpoint is actually serving —
+ * `visibility.ts` iterates the served profiles, so a name returned here that is
+ * not being served is filtered out rather than reachable.
+ *
+ * **Cached for the same window the token values are.** Without it a deployed
+ * revision read every profile's YAML out of a bucket on every request. The
+ * window is why `profile members remove` takes effect in seconds rather than on
+ * the next rotation, which is the property worth keeping.
+ */
+export function membersResolver(
+  workspaceRoot: string,
+  options: { readonly ttlMs?: number; readonly now?: () => number } = {},
+): (subject: string) => Promise<readonly string[]> {
+  const ttl = options.ttlMs ?? 5_000;
+  const now = options.now ?? Date.now;
+
+  let cached: ReadonlyMap<string, readonly string[]> | null = null;
+  let readAt = 0;
+
+  return async (subject) => {
+    if (cached === null || now() - readAt >= ttl) {
+      const { loaded } = await loadWorkspaceProfiles(workspaceRoot);
+      const bySubject = new Map<string, string[]>();
+      for (const entry of loaded) {
+        for (const member of entry.config.members) {
+          const known = bySubject.get(member.subject) ?? [];
+          known.push(entry.profile);
+          bySubject.set(member.subject, known);
+        }
+      }
+      cached = bySubject;
+      readAt = now();
+    }
+
+    return cached.get(subject) ?? [];
+  };
+}
+
+/**
+ * Any token this workspace holds, for talking to its own endpoint.
+ *
+ * `outputs`, `tools`, `doctor` and the reload notification all need *a* valid
+ * credential to ask the endpoint something, and none of them cares whose: they
+ * are the operator's own commands run against the operator's own workspace.
+ * Which row answers is therefore not a choice worth making visible — unlike
+ * `token show`, where it is the whole subject of the command and `--id` is
+ * required once there is more than one.
+ *
+ * **Null is an ordinary answer, not a failure.** A workspace that has issued
+ * none is the common case after ADR-062: a person's client registers against
+ * the bare URL and signs in, so nothing needs a static token until something
+ * headless does. Every caller degrades — reporting what it could not ask rather
+ * than minting a credential nobody asked for, which is what the old
+ * `ensureProfileToken` did on six different commands.
+ */
+export async function anyIssuedToken(
+  workspaceRoot: string,
+  credentials: { get(ref: string): Promise<string | null> },
+): Promise<{ readonly id: string; readonly value: string } | null> {
+  for (const row of await readEndpointTokens(workspaceRoot)) {
+    const value = await credentials.get(row.ref);
+    if (value) return { id: row.id, value };
+  }
+  return null;
+}

--- a/src/profile/workspace.test.ts
+++ b/src/profile/workspace.test.ts
@@ -178,7 +178,7 @@ describe('reading every profile at once', () => {
    * look vanished from inside one profile.
    */
   const declaring = (profile: string): string =>
-    `contract: 4\ninstance: { profile: ${profile} }\n`;
+    `contract: 5\ninstance: { profile: ${profile} }\n`;
 
   test('loads each profile with its config', async () => {
     const root = await withTargets({
@@ -198,7 +198,7 @@ describe('reading every profile at once', () => {
     // dies on the first bad file stops working exactly when it is needed.
     const root = await withTargets({
       alpha: declaring('alpha'),
-      broken: 'contract: 4\ninstance: {}\n',
+      broken: 'contract: 5\ninstance: {}\n',
     });
 
     const workspace = await loadWorkspaceProfiles(root);

--- a/src/profile/workspace.ts
+++ b/src/profile/workspace.ts
@@ -178,7 +178,7 @@ export const CONNECTIONS_FILE = 'connections.yaml';
 export async function readConnections(workspaceRoot: string): Promise<ConnectionsFile> {
   const path = join(workspaceRoot, CONNECTIONS_FILE);
   const text = await readWorkspaceFile(workspaceFiles(workspaceRoot), CONNECTIONS_FILE);
-  if (text === null) return { contract: SUPPORTED_CONTRACT, connections: [], oauth_apps: {} };
+  if (text === null) return { contract: SUPPORTED_CONTRACT, connections: [], oauth_apps: {}, tokens: [] };
 
   const raw = parseYaml(text);
 

--- a/src/providers/example/provider.test.ts
+++ b/src/providers/example/provider.test.ts
@@ -16,6 +16,7 @@ function contextFor(connectionKey: string, state = new Map<string, string>()): P
       displayName: 'Test',
       config: {},
     },
+    profiles: ['personal'],
     state: {
       async get(key) {
         return state.get(key) ?? null;

--- a/src/providers/harness.ts
+++ b/src/providers/harness.ts
@@ -36,6 +36,7 @@ export function harnessFor(
     manifest: definition.manifest,
     definition,
     connection: { id: connectionId, provider: definition.manifest.id, account: 'Owner' },
+    profiles: ['personal'],
     state: createMemoryState(),
     // Seeded deliberately: an owner provider must not be able to read any of
     // this, and the credential-boundary test says so by name.

--- a/src/providers/setup/plan.ts
+++ b/src/providers/setup/plan.ts
@@ -188,3 +188,19 @@ export function planAll(
     .sort((a, b) => a.id.localeCompare(b.id))
     .map((manifest) => planFor(manifest, context));
 }
+
+/**
+ * One connection this profile can reach, as the overview renders it.
+ *
+ * Declared once rather than spelled structurally at both ends: the two literals
+ * had to agree about `providerName`, and the display name went missing on one
+ * side — which is how an owner row came to read "Memory (lanes_memory (Memory))".
+ */
+export interface ReachableConnection {
+  readonly key: string;
+  readonly provider?: string;
+  /** The manifest's display name, which is what a label composes with. */
+  readonly providerName?: string;
+  readonly account: string;
+  readonly label?: string | undefined;
+}

--- a/src/providers/setup/provider.test.ts
+++ b/src/providers/setup/provider.test.ts
@@ -71,13 +71,28 @@ function tool(name: string, options: Parameters<typeof createSetupProvider>[0]):
   return found;
 }
 
-/** Only `connection.key` is read by these handlers. */
-const context = { connection: { key: 'lanes_setup.main', id: 'main', provider: 'lanes_setup' } } as
-  unknown as ProviderContext;
+/**
+ * `connection.key` and `profiles` are the only two these handlers read.
+ *
+ * `profiles` is the *caller's* reachable set (ADR-068), which is what the
+ * overview names — so a test that wants to see the leak this fixed passes a
+ * narrower set than `options.profiles` holds.
+ */
+const contextFor = (profiles: readonly string[] = ['personal']): ProviderContext =>
+  ({
+    connection: { key: 'lanes_setup.main', id: 'main', provider: 'lanes_setup' },
+    profiles,
+  }) as unknown as ProviderContext;
 
-async function textOf(capability: Capability, input: unknown): Promise<string> {
+const context = contextFor();
+
+async function textOf(
+  capability: Capability,
+  input: unknown,
+  ctx: ProviderContext = context,
+): Promise<string> {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const result = (await (capability as any).handler(input, context)) as {
+  const result = (await (capability as any).handler(input, ctx)) as {
     content: { text: string }[];
     isError?: boolean;
   };
@@ -153,16 +168,75 @@ describe('lanes_setup.overview', () => {
     expect(await textOf(capability, {})).toContain('thing.main');
   });
 
-  test('points at sibling profiles by name only', async () => {
-    const text = await textOf(tool('overview', {
-      profile: 'personal',
-      target: 'local',
-      profiles: ['personal', 'work'],
-      catalogue: CATALOGUE,
-    }), {});
+  test("an unnamed row is called what every other surface calls it", async () => {
+    // `defaultConnectionLabel` (#147), given the provider's display *name*. The
+    // bug this covers was found by running the endpoint: handed the provider id
+    // instead, an owner-layer row whose account is already the proper noun read
+    // `Memory (lanes_memory (Memory))`.
+    const text = await textOf(
+      tool('overview', {
+        profile: 'personal',
+        target: 'local',
+        catalogue: CATALOGUE,
+        reachable: () => [
+          {
+            key: 'lanes_memory.lan1',
+            provider: 'lanes_memory',
+            providerName: 'Memory',
+            account: 'Memory',
+          },
+          { key: 'thing.con1', provider: 'thing', providerName: 'Thing', account: 'ada@example.test' },
+        ],
+      }),
+      {},
+    );
 
-    expect(text).toContain('work');
-    expect(text).not.toContain('personal, work');
+    // The provider alone where the account repeats it, which is every owner
+    // surface — composing would read "Memory (Memory)".
+    expect(text).toContain('lanes_memory.lan1  — Memory\n');
+    expect(text).not.toContain('lanes_memory (Memory)');
+    // And the pair where the account is an address.
+    expect(text).toContain('thing.con1  — ada@example.test (Thing (ada))');
+  });
+
+  test('names the sibling profiles this caller can reach', async () => {
+    const text = await textOf(
+      tool('overview', {
+        profile: 'personal',
+        target: 'local',
+        profiles: ['personal', 'work'],
+        catalogue: CATALOGUE,
+      }),
+      {},
+      contextFor(['personal', 'work']),
+    );
+
+    expect(text).toContain('You can reach 2 profile(s)');
+    expect(text).toContain('Also: work');
+    // Nothing to hide from somebody who is a member of both.
+    expect(text).not.toContain('you are not a member of');
+  });
+
+  test('a profile the caller cannot reach is counted, never named', async () => {
+    // The leak this had: `options.profiles` is every profile on disk, and
+    // naming them told a delegated member about profiles `mayReach` keeps out
+    // of the `profile` enum they were shown (ADR-068). A count is not a leak —
+    // and it is what stops an agent concluding the others do not exist.
+    const text = await textOf(
+      tool('overview', {
+        profile: 'personal',
+        target: 'local',
+        profiles: ['personal', 'work', 'shared'],
+        catalogue: CATALOGUE,
+      }),
+      {},
+      contextFor(['personal']),
+    );
+
+    expect(text).not.toContain('work');
+    expect(text).not.toContain('shared,');
+    expect(text).toContain('You can reach 1 profile(s)');
+    expect(text).toContain('2 other profile(s) exist here that you are not a member of');
   });
 
   /**

--- a/src/providers/setup/provider.ts
+++ b/src/providers/setup/provider.ts
@@ -1,6 +1,7 @@
 import { z } from 'zod';
 import { defineLocalProvider, keepKeys, type ProviderDefinition, type ProviderManifest } from '#connectivity';
-import { planAll, planFor, type ProviderPlan } from './plan.ts';
+import { defaultConnectionLabel } from '#profile';
+import { planAll, planFor, type ProviderPlan, type ReachableConnection } from './plan.ts';
 
 /**
  * `setup` — what is connected, and what connecting something else would take.
@@ -54,7 +55,11 @@ export interface SetupProviderOptions {
    * further than the commands this provider emits — nothing here opens a store.
    */
   readonly target: string;
-  /** Sibling profile names on this endpoint. Names only; already at `/health`. */
+  /**
+   * Every profile on disk. **Not what gets rendered:** the caller's own set
+   * arrives at handler time in `ProviderContext.profiles`; this only says how
+   * many are withheld — "one profile" versus "one of four".
+   */
   readonly profiles?: readonly string[];
   /**
    * `oauth_apps` entries this profile declares.
@@ -77,7 +82,7 @@ export interface SetupProviderOptions {
    * enum from. Computing it separately here is how discovery and enforcement
    * drift, and a leak in discovery is still a leak.
    */
-  readonly reachable?: () => ReadonlyArray<{ key: string; provider: string; account: string }>;
+  readonly reachable?: () => ReadonlyArray<ReachableConnection>;
 }
 
 export function createSetupProvider(options: SetupProviderOptions): ProviderDefinition {
@@ -132,7 +137,13 @@ export function createSetupProvider(options: SetupProviderOptions): ProviderDefi
             content: [
               {
                 type: 'text',
-                text: renderOverview(options, connections, plans, handlerContext.connection.key),
+                // The caller's set, not the workspace's (ADR-068): rendering
+                // `options.profiles` named profiles `mayReach` hides from the
+                // same caller's `profile` enum.
+                text: renderOverview(options, connections, plans, handlerContext.connection.key, {
+                  reachable: handlerContext.profiles,
+                  total: options.profiles?.length ?? handlerContext.profiles.length,
+                }),
               },
             ],
           };
@@ -185,9 +196,10 @@ export function createSetupProvider(options: SetupProviderOptions): ProviderDefi
 
 function renderOverview(
   options: SetupProviderOptions,
-  connections: ReadonlyArray<{ key: string; account: string; label?: string | undefined }>,
+  connections: ReadonlyArray<ReachableConnection>,
   plans: readonly ProviderPlan[],
   self: string,
+  caller: { reachable: readonly string[]; total: number },
 ): string {
   const lines: string[] = [`Profile "${options.profile}".`, ''];
 
@@ -199,11 +211,16 @@ function renderOverview(
       // Account first, label in brackets. The other way round for a person
       // reading `status`, and deliberately not here: an agent choosing which
       // connection to call needs the identity, and "Work mail" is not one.
+      //
+      // `defaultConnectionLabel` when the row carries none, so an unnamed row is
+      // called what `connection list` and `/state` call it. The provider's
+      // *name*, never its id: `lanes_memory` with account `Memory` would read
+      // "lanes_memory (Memory)".
+      const provider = connection.providerName ?? connection.key.split('.')[0] ?? connection.key;
+      const named = connection.label ?? defaultConnectionLabel(provider, connection.account);
       lines.push(
         `  ${connection.key}  — ${connection.account}` +
-          (connection.label && connection.label !== connection.account
-            ? ` (${connection.label})`
-            : ''),
+          (named && named !== connection.account ? ` (${named})` : ''),
       );
     }
   }
@@ -241,11 +258,21 @@ function renderOverview(
     );
   }
 
-  const siblings = (options.profiles ?? []).filter((name) => name !== options.profile);
-  if (siblings.length > 0) {
+  // **Which profiles *this caller* can reach** — the question an agent asks
+  // first. `initialize.instructions` names them until its budget is tight, then
+  // collapses to a count; this is the surface it already points at.
+  const others = caller.reachable.filter((name) => name !== options.profile);
+  lines.push('', `You can reach ${caller.reachable.length} profile(s) on this endpoint.`);
+  if (others.length > 0) {
+    lines.push(`  Also: ${others.join(', ')}. Pass one as \`profile\` to see what it reaches.`);
+  }
+
+  // A count, never names: naming them is the leak this used to be. That some
+  // exist is not a secret, and an agent told "one of four" asks the owner.
+  const hidden = caller.total - caller.reachable.length;
+  if (hidden > 0) {
     lines.push(
-      '',
-      `This endpoint also serves: ${siblings.join(', ')}. Pass that profile to see what it reaches.`,
+      `  ${hidden} other profile(s) exist here that you are not a member of. Only the owner can change that.`,
     );
   }
 

--- a/src/server/boot.test.ts
+++ b/src/server/boot.test.ts
@@ -1,0 +1,125 @@
+import { afterAll, describe, expect, test } from 'bun:test';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { profileAdd } from '#cli/commands/profile.ts';
+import { primaryProfile } from '#cli/runtime.ts';
+import { startEndpoint } from './endpoint.ts';
+import { allocatePort } from './harness.ts';
+
+/**
+ * The endpoint boots with no static token issued.
+ *
+ * This is a test for a deletion, which is why it exists at all. `startEndpoint`
+ * used to do one of two things at this point: mint a token when `start` asked
+ * it to, or **refuse to boot** when a deployed revision found none — on the
+ * reasoning that an endpoint whose token nobody holds is no use.
+ *
+ * Since ADR-062 that is backwards, and ADR-068 removed both halves. A client
+ * discovers the protected-resource document from the 401 and signs its owner
+ * in; a static row is what CI uses because it has no browser. So **zero rows is
+ * the ordinary state of a healthy endpoint**, and the deployed case — where
+ * nothing mints anything — is the one that used to throw.
+ *
+ * Asserted against a real workspace and a real socket rather than the harness,
+ * because the harness wires an authenticator directly and would demonstrate
+ * that the harness works.
+ */
+
+const homes: string[] = [];
+
+afterAll(async () => {
+  for (const home of homes) await rm(home, { recursive: true, force: true });
+});
+
+async function workspace(): Promise<string> {
+  const home = await mkdtemp(join(tmpdir(), 'lanes-boot-'));
+  homes.push(home);
+  const previous = process.env['LANES_LINK_HOME'];
+  process.env['LANES_LINK_HOME'] = home;
+  // Swallowed, not because the output is uninteresting but because `profileAdd`
+  // writes its JSON to the same stdout the test reporter uses.
+  const write = process.stdout.write.bind(process.stdout);
+  try {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (process.stdout as any).write = (): boolean => true;
+    await profileAdd('personal', { targets: ['local'], nonInteractive: true, json: true });
+  } finally {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (process.stdout as any).write = write;
+    if (previous === undefined) delete process.env['LANES_LINK_HOME'];
+    else process.env['LANES_LINK_HOME'] = previous;
+  }
+  return home;
+}
+
+describe('a workspace that has issued no token', () => {
+  test('boots, serves, and says how to authorise', async () => {
+    const home = await workspace();
+    const previous = process.env['LANES_LINK_HOME'];
+    process.env['LANES_LINK_HOME'] = home;
+
+    const port = allocatePort();
+    let endpoint: Awaited<ReturnType<typeof startEndpoint>> | null = null;
+
+    try {
+      // No `mintToken`, because there is no such option any more, and nothing
+      // here has written a credential.
+      // The primary, resolved the way `serve.ts` resolves it: `startEndpoint`
+      // opens a runtime and a runtime names a profile. What `--profile` no
+      // longer decides is whose token opens it (ADR-068).
+      const flags = { target: 'local', quiet: true, profile: await primaryProfile({ target: 'local' }) };
+      endpoint = await startEndpoint({ flags, port, host: '127.0.0.1' });
+
+      expect(endpoint.profiles).toEqual(['personal']);
+
+      // Up, and withholding the profile list from an anonymous caller.
+      const health = await fetch(`http://127.0.0.1:${port}/health`);
+      expect(await health.json()).toEqual({ status: 'ok' });
+
+      // And the 401 carries where to go next, which is the whole of ADR-062's
+      // flow: without this a client with no credential has nothing to do.
+      const refused = await fetch(`http://127.0.0.1:${port}/mcp`, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: '{}',
+      });
+      expect(refused.status).toBe(401);
+      expect(refused.headers.get('www-authenticate')).toContain(
+        'oauth-protected-resource',
+      );
+    } finally {
+      await endpoint?.stop();
+      if (previous === undefined) delete process.env['LANES_LINK_HOME'];
+      else process.env['LANES_LINK_HOME'] = previous;
+    }
+  });
+
+  test('and refuses a token that was never issued, distinctly from a wrong one', async () => {
+    const home = await workspace();
+    const previous = process.env['LANES_LINK_HOME'];
+    process.env['LANES_LINK_HOME'] = home;
+
+    const port = allocatePort();
+    let endpoint: Awaited<ReturnType<typeof startEndpoint>> | null = null;
+
+    try {
+      const flags = { target: 'local', quiet: true, profile: await primaryProfile({ target: 'local' }) };
+      endpoint = await startEndpoint({ flags, port, host: '127.0.0.1' });
+
+      const response = await fetch(`http://127.0.0.1:${port}/mcp`, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json', authorization: 'Bearer llk_invented' },
+        body: '{}',
+      });
+
+      // Refused, and not by crashing: the endpoint is serving, it simply holds
+      // no row this could match.
+      expect(response.status).toBe(401);
+    } finally {
+      await endpoint?.stop();
+      if (previous === undefined) delete process.env['LANES_LINK_HOME'];
+      else process.env['LANES_LINK_HOME'] = previous;
+    }
+  });
+});

--- a/src/server/container.ts
+++ b/src/server/container.ts
@@ -72,8 +72,9 @@ try {
     },
     port,
     host,
-    // A deployed instance never mints its own token: see `endpoint.ts`.
-    mintToken: false,
+    // Nothing about tokens here any more (ADR-068): a deployed instance neither
+    // mints one nor needs one to boot. A client discovers the
+    // protected-resource document from the 401 and signs its owner in.
     // Stdout is where Cloud Run collects logs, and a rejected credential on a
     // public URL is the event this exists for.
     log: streamLogger((line) => process.stdout.write(`${line}\n`)),
@@ -84,7 +85,6 @@ try {
         // into an image that will be replaced.
         log(`reconciled ${profile}\n${plan}`);
       },
-      tokenMinted() {},
     },
   });
 

--- a/src/server/cors.test.ts
+++ b/src/server/cors.test.ts
@@ -63,8 +63,9 @@ function deployed(allowedOrigins: readonly string[]): (request: Request) => Prom
     primary: 'personal',
     authenticator: new BearerAuthenticator({
       profile: 'personal',
-      tokenRef: 'profile/token',
+      tokens: async () => [{ id: 'tok1', subject: 'lanes:harness0000', ref: 'tokens/tok1' }],
       credentials,
+      profilesFor: async () => ['personal'],
     }),
     log,
   });

--- a/src/server/endpoint.ts
+++ b/src/server/endpoint.ts
@@ -18,7 +18,7 @@ import {
   planReconcile,
   toPolicyDocument,
 } from '#registry';
-import { ensureProfileToken, openRuntime, type GlobalFlags, type Runtime } from '#cli/runtime.ts';
+import { openRuntime, type GlobalFlags, type Runtime } from '#cli/runtime.ts';
 
 /**
  * Bringing the endpoint up: open a runtime per profile, reconcile, and serve.
@@ -40,8 +40,6 @@ import { ensureProfileToken, openRuntime, type GlobalFlags, type Runtime } from 
 export interface EndpointReporter {
   /** A profile whose runtime state differed from its config, and what was applied. */
   reconciled(input: { profile: string; plan: string; ofMany: boolean }): void;
-  /** No profile token existed and one was minted. */
-  tokenMinted(minted: { target: string }): void;
   /**
    * A sibling profile that could not be opened against this target.
    *
@@ -51,7 +49,7 @@ export interface EndpointReporter {
   skipped?(input: { profile: string; reason: string }): void;
 }
 
-const SILENT: EndpointReporter = { reconciled() {}, tokenMinted() {} };
+const SILENT: EndpointReporter = { reconciled() {} };
 
 /** The first line of an error, which is the part fit to print beside a name. */
 function message(error: unknown): string {
@@ -64,11 +62,6 @@ export interface EndpointOptions {
   readonly host?: string | undefined;
   /** Serve just the resolved profile, rather than every profile in the workspace. */
   readonly only?: boolean | undefined;
-  /**
-   * Mint a profile token when the store has none. True for `lanes link start`,
-   * false in a container — see the note above.
-   */
-  readonly mintToken?: boolean | undefined;
   readonly reporter?: EndpointReporter | undefined;
   /** Operational events. Silent when absent, which is what the tests want. */
   readonly log?: Logger | undefined;
@@ -203,26 +196,21 @@ export async function startEndpoint(options: EndpointOptions): Promise<RunningEn
   const { primary, runtimes } = await openReconciled(options);
 
   try {
-    if (options.mintToken) {
-      const { created } = await ensureProfileToken(
-        primary.credentials,
-        primary.config.auth.token_ref,
-      );
-      if (created) reporter.tokenMinted({ target: primary.target });
-    } else {
-      // Deployed, the token is written by the operator's CLI into the target's
-      // credential store and read back here. Refusing to start beats serving an
-      // endpoint whose token nobody holds.
-      const token = await primary.credentials.get(primary.config.auth.token_ref);
-      if (!token) {
-        throw new Error(
-          `No profile token at "${primary.config.auth.token_ref}" in this target's credential store. ` +
-            'A deployed instance never mints its own — run `lanes link token rotate --workspace <name>` ' +
-            'from your machine, or `lanes link secrets push --from local --to cloud`, then redeploy.',
-        );
-      }
-    }
-
+    // **No token is minted or required here any more** (ADR-068). Both halves of
+    // what used to be at this point are gone, and for the same reason.
+    //
+    // Minting: `start` did it because there was one token per endpoint and it
+    // had to exist for anything to connect. A token names the person it was
+    // issued to now, and `start` does not know who is about to connect — so
+    // inventing one would be binding a credential to a subject nobody chose.
+    //
+    // Refusing: a deployed revision used to fail to boot without one, on the
+    // reasoning that an endpoint whose token nobody holds is no use. Since
+    // ADR-062 that is backwards. A client discovers the protected-resource
+    // document, signs its owner in, and comes back with a token of its own; a
+    // static row is what CI uses because it has no browser. Zero rows is the
+    // ordinary state of a healthy endpoint, and refusing to serve was refusing
+    // the case the endpoint is now built for.
     // Read through a holder rather than closed over `runtimes`, because a
     // reload replaces that map and the gate is deliberately built once
     // (ADR-029). Without the indirection, a member added after start would

--- a/src/server/harness.ts
+++ b/src/server/harness.ts
@@ -53,6 +53,16 @@ function harnessConnections(config: Config): ConnectionConfig[] {
 
 export const TEST_TOKEN = 'llk_test_token_value';
 
+/**
+ * The subject the harness's one token row is issued to.
+ *
+ * A real subject shape rather than a placeholder, because `subjectRef` validates
+ * it wherever a config carries one — and the harness's `profilesFor` returns
+ * every wired profile for it, which is what the static token used to reach by
+ * having no list at all.
+ */
+export const HARNESS_SUBJECT = 'lanes:harness0000';
+
 /** A signed-in person no profile lists. See the federation stub below. */
 export const STRANGER = 'NOBODY_LISTS_THIS_PERSON';
 
@@ -75,7 +85,7 @@ export function configFor(profile: string, port: number, policy: string): Config
     `  - connection: example.${id}\n${rules.replace(/^ {4}(allow|deny):/gm, '    $1:')}`;
 
   return parseConfig(`
-contract: 4
+contract: 5
 instance:
   profile: ${profile}
   port: ${port}
@@ -133,6 +143,15 @@ export interface HarnessOptions {
   config?: Config;
   /** Extra profiles this one endpoint also serves, each with its own policy. */
   alsoServe?: ReadonlyArray<{ profile: string; policy: string }>;
+  /**
+   * The profiles the static token's subject is a member of.
+   *
+   * Absent means every profile wired, which is what a workspace owner's token
+   * reaches. Naming fewer is how a test expresses a delegated member — the
+   * caller ADR-068 exists for, and the one every disclosure surface has to be
+   * checked against.
+   */
+  reaches?: readonly string[];
   /**
    * What the endpoint calls to re-read skills before serving a request.
    *
@@ -192,7 +211,9 @@ export function wireProfiles(options: HarnessOptions): WiredProfiles {
 
   const state = createMemoryState();
   const audit = createBlobAuditStore({ storage: createMemoryBlobStore() });
-  const credentials = createMemoryCredentials({ 'profile/token': token, ...options.credentials });
+  // `tokens/tok1`, matching the row `startHarness` declares below. The old key
+  // was `profile/token`, the constant ADR-068 removed.
+  const credentials = createMemoryCredentials({ 'tokens/tok1': token, ...options.credentials });
   // `allowReserved` for the same reason `buildRegistry` passes it: the owner
   // layer claims `memory`, `skills`, and `vault`, and the guard still refuses
   // them everywhere else.
@@ -267,10 +288,14 @@ export function wireProfiles(options: HarnessOptions): WiredProfiles {
 export function startHarness(options: HarnessOptions): Harness {
   const { profiles, state, audit, dispatcher, credentials, token } = wireProfiles(options);
 
+  // One row, bound to a subject the harness's profiles list, so the static
+  // token resolves the way it does in production (ADR-068) rather than through
+  // a special case that would stop the tests covering the real path.
   const bearer = new BearerAuthenticator({
     profile: options.profile,
-    tokenRef: 'profile/token',
+    tokens: async () => [{ id: 'tok1', subject: HARNESS_SUBJECT, ref: 'tokens/tok1' }],
     credentials,
+    profilesFor: async () => options.reaches ?? [...profiles.keys()],
   });
 
   // The real wiring from `endpoint.ts`, not a stand-in: the flow under test is

--- a/src/server/index.test.ts
+++ b/src/server/index.test.ts
@@ -170,6 +170,58 @@ describe('authentication', () => {
       profiles: ['personal'],
     });
   });
+
+  test('health names only the profiles the caller is a member of', async () => {
+    // The same rule as discovery, in the one place that had its own answer.
+    // This listed every profile served, to anybody holding any credential — so
+    // a delegated member read the names of profiles `mayReach` deliberately
+    // keeps out of the `profile` enum they were shown (ADR-068).
+    const harness = startHarness({
+      profile: 'personal',
+      port: allocatePort(),
+      policy: 'allow: ["example.*"]',
+      alsoServe: [{ profile: 'work', policy: 'allow: ["example.*"]' }],
+      reaches: ['personal'],
+    });
+
+    try {
+      const url = new URL(harness.server.url);
+      const response = await fetch(`${url.origin}/health`, {
+        headers: { authorization: `Bearer ${TEST_TOKEN}` },
+      });
+
+      const body = (await response.json()) as { profiles: string[] };
+      expect(body.profiles).toEqual(['personal']);
+      expect(body.profiles).not.toContain('work');
+    } finally {
+      await harness.stop();
+    }
+  });
+
+  test('and every profile it serves, to a caller who is a member of all of them', async () => {
+    // The contrast is what makes the test above mean something: the filter is
+    // the caller's membership, not a blanket narrowing to the primary.
+    const harness = startHarness({
+      profile: 'personal',
+      port: allocatePort(),
+      policy: 'allow: ["example.*"]',
+      alsoServe: [{ profile: 'work', policy: 'allow: ["example.*"]' }],
+    });
+
+    try {
+      const url = new URL(harness.server.url);
+      const response = await fetch(`${url.origin}/health`, {
+        headers: { authorization: `Bearer ${TEST_TOKEN}` },
+      });
+
+      expect(((await response.json()) as { profiles: string[] }).profiles.sort()).toEqual([
+        'personal',
+        'work',
+      ]);
+    } finally {
+      await harness.stop();
+    }
+  });
 });
 
 describe('discovery is filtered by policy', () => {
@@ -768,7 +820,7 @@ describe('reload', () => {
   /** A config naming exactly these connections, so one can be seen to appear. */
   function configWith(profile: string, port: number, ids: string[], policy: string): Config {
     return parseConfig(`
-contract: 4
+contract: 5
 instance:
   profile: ${profile}
   port: ${port}

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -1,4 +1,4 @@
-import type { Authenticator } from '#auth';
+import { mayReach, type Authenticator } from '#auth';
 import type { Logger } from '#connectivity';
 import { capabilityIdForToolName } from '#server/mcp';
 import { ATTACHMENTS_PATH, handleAttachments } from './attachments.ts';
@@ -186,18 +186,18 @@ export function createRequestHandler(options: ServerOptions): RequestHandler {
       if (url.pathname === HEALTH_PATH) {
         // `status` is unauthenticated because the platform's own probe reads it
         // and a deploy waits on it. The profile *names* are not: on a public URL
-        // that is a list of what this endpoint holds, handed to anyone who asks,
-        // and `outputs` and `mcp add` — which are the reason it was ever
-        // published — both hold the token already.
+        // that is a list of what this endpoint holds, handed to anyone who asks.
+        // And they are the *caller's* since ADR-068: this listed every profile
+        // served to anybody holding a credential, so a delegated member read the
+        // ones `mayReach` keeps out of their own enum.
         const named = await options.authenticator.authenticate(
           request.headers.get('authorization'),
         );
-
+        const who = named.ok ? named.principal : null;
+        const mine = options.generations.current.names().filter((n) => who && mayReach(who, n));
         return Response.json({
           status: 'ok',
-          ...(named.ok
-            ? { profile: options.primary, profiles: options.generations.current.names() }
-            : {}),
+          ...(named.ok ? { profile: options.primary, profiles: mine } : {}),
         });
       }
 

--- a/src/server/mcp/connection-choice.test.ts
+++ b/src/server/mcp/connection-choice.test.ts
@@ -33,7 +33,7 @@ describe('the connection argument says which account it is', () => {
   test('two ids that differ by a digit carry the addresses that differ by a domain', () => {
     const described = describeWithConnections(
       'Read a message.',
-      new Map([['personal', ['ada_lovelace', 'ada_lovelace2']]]),
+      new Map([['personal', ['gmail.ada_lovelace', 'gmail.ada_lovelace2']]]),
       accountsByProfile(
         options([
           connection('ada_lovelace', 'ada.lovelace@example.com'),
@@ -42,18 +42,31 @@ describe('the connection argument says which account it is', () => {
       ),
     );
 
-    expect(described).toContain('ada_lovelace — ada.lovelace@example.com');
-    expect(described).toContain('ada_lovelace2 — ada.lovelace@example.org');
+    expect(described).toContain('gmail.ada_lovelace — ada.lovelace@example.com');
+    expect(described).toContain('gmail.ada_lovelace2 — ada.lovelace@example.org');
+  });
+
+  test('keyed on the grant ref, which is what the enum carries', () => {
+    // The guard on the bug the tests below hid. `connectionsOf` fills the enum
+    // from the grant rows, so `reachable` holds `gmail.ada_lovelace`; a map keyed
+    // on the bare `connection.id` missed every lookup and no served description
+    // ever showed an account, while these tests passed the bare id by hand and
+    // went green. Both sides read `ref` now, so they cannot drift.
+    const accounts = accountsByProfile(
+      options([connection('ada_lovelace', 'ada.lovelace@example.com')]),
+    );
+
+    expect([...accounts.get('personal')!.keys()]).toEqual(['gmail.ada_lovelace']);
   });
 
   test("the operator's label comes too, where they set one", () => {
     const described = describeWithConnections(
       'Read a message.',
-      new Map([['personal', ['ada_lovelace']]]),
+      new Map([['personal', ['gmail.ada_lovelace']]]),
       accountsByProfile(options([connection('ada_lovelace', 'ada.lovelace@example.com', 'Work')])),
     );
 
-    expect(described).toContain('ada_lovelace — ada.lovelace@example.com (Work)');
+    expect(described).toContain('gmail.ada_lovelace — ada.lovelace@example.com (Work)');
   });
 
   test('grouped by profile, because the two arguments are not independent', () => {

--- a/src/server/mcp/visibility.ts
+++ b/src/server/mcp/visibility.ts
@@ -185,7 +185,15 @@ export function visibleToolCount(options: BuildServerOptions): number {
  * entities: ordering is not selection, and a caller that cannot tell two
  * candidates apart must be given what tells them apart.
  *
- * The enum stays bare ids, because the id is what the caller passes.
+ * **The key is the grant ref, not the bare id.** `connectionsOf` fills the enum
+ * from the grant rows (ADR-058), so `reachable` carries `gmail.con1`, and
+ * `accountsByProfile` keys on that same `ref` — one string from one source, so
+ * the two sides cannot drift. Keyed on `connection.id` instead it missed every
+ * lookup, and no served description carried an account at all, while
+ * `connection-choice.test.ts` passed bare ids in by hand and stayed green.
+ * Contract 4 is what turned that from cosmetic into a real loss: the ids used to
+ * carry the account and are `con1`, `con2` now, so the id says nothing about
+ * which mailbox it is and this annotation is the only thing that does.
  */
 export function describeWithConnections(
   description: string,
@@ -215,9 +223,9 @@ export function accountsByProfile(
 
   for (const [name, runtime] of options.profiles) {
     const rows = new Map<string, string>();
-    for (const { connection } of runtime.connections ?? []) {
+    for (const { ref, connection } of runtime.connections ?? []) {
       rows.set(
-        connection.id,
+        ref,
         connection.label === undefined
           ? connection.account
           : `${connection.account} (${connection.label})`,

--- a/src/server/owner.test.ts
+++ b/src/server/owner.test.ts
@@ -85,7 +85,7 @@ function ownerConfig(profile: string, port: number, policy: string) {
     .join('\n');
 
   return parseConfig(`
-contract: 4
+contract: 5
 instance:
   profile: ${profile}
   port: ${port}

--- a/src/server/read/deployed.test.ts
+++ b/src/server/read/deployed.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from 'bun:test';
 import { BearerAuthenticator } from '#auth';
-import { allocatePort, wireProfiles, TEST_TOKEN } from '../harness.ts';
+import { allocatePort, wireProfiles, HARNESS_SUBJECT, TEST_TOKEN } from '../harness.ts';
 import { createRequestHandler, MCP_PATH, serve } from '../index.ts';
 import { ATTACHMENTS_PATH } from '../attachments.ts';
 import { ANY_ORIGIN, corsAware } from '../cors.ts';
@@ -84,8 +84,9 @@ function deployed(read: ReadDeps | undefined): (request: Request) => Promise<Res
     primary: 'personal',
     authenticator: new BearerAuthenticator({
       profile: 'personal',
-      tokenRef: 'profile/token',
+      tokens: async () => [{ id: 'tok1', subject: HARNESS_SUBJECT, ref: 'tokens/tok1' }],
       credentials,
+      profilesFor: async () => ['personal'],
     }),
     log,
     meterUnauthenticated: true,
@@ -240,8 +241,9 @@ describe('a deployment-only grant stays one', () => {
       primary: 'personal',
       authenticator: new BearerAuthenticator({
         profile: 'personal',
-        tokenRef: 'profile/token',
+        tokens: async () => [{ id: 'tok1', subject: 'lanes:harness0000', ref: 'tokens/tok1' }],
         credentials,
+        profilesFor: async () => ['personal'],
       }),
       log,
       host: '127.0.0.1',

--- a/src/server/read/deployed.ts
+++ b/src/server/read/deployed.ts
@@ -40,6 +40,10 @@ export function deployedReadDeps(input: {
     audit: primary.audit,
     connections: async () =>
       (await readConnections(primary.resolution.workspaceRoot)).connections,
+    // The names the dashboard shows for a row nobody has labelled. From the
+    // registry rather than a catalogue, so the owner layer, the vendors and a
+    // workspace's own manifests are all named the same way.
+    providerName: (id) => primary.registry.manifest(id)?.name,
     // Cached, unlike loopback's. `GcpSecretManagerStore` holds nothing between
     // calls, so a dashboard polling `/state` would be one network round trip per
     // poll and a stranger sending a wrong token one per request — which is the

--- a/src/server/read/open.ts
+++ b/src/server/read/open.ts
@@ -62,6 +62,10 @@ export async function openReadListener(
       audit: primary.audit,
       connections: async () =>
         (await readConnections(primary.resolution.workspaceRoot)).connections,
+      // The names the dashboard shows for a row nobody has labelled. From the
+      // registry rather than a catalogue, so the owner layer, the vendors and a
+      // workspace's own manifests are all named the same way.
+      providerName: (id) => primary.registry.manifest(id)?.name,
       // Read on every presentation, so `pair --rotate` takes effect on a
       // running endpoint. Affordable here because the store is a local file;
       // the deployed bind caches for exactly this reason. `refresh()` drops the

--- a/src/server/read/routes.ts
+++ b/src/server/read/routes.ts
@@ -1,7 +1,12 @@
 import type { Logger } from '#connectivity';
 import type { ProfileRuntime } from '../mcp/visibility.ts';
 import type { PairingCredential } from './credential.ts';
-import { readState, type ConnectionRow, type ReadEndpoint } from './state.ts';
+import {
+  readState,
+  type ConnectionRow,
+  type ProviderNames,
+  type ReadEndpoint,
+} from './state.ts';
 
 /**
  * The two routes a browser origin may read, and everything that guards them.
@@ -100,6 +105,14 @@ export interface ReadDeps {
    */
   readonly connections: () => Promise<readonly ConnectionRow[]>;
   readonly credential: PairingCredential;
+  /**
+   * What each provider is called, for the row nobody has labelled.
+   *
+   * Optional so a harness can omit it: absent, an unlabelled row reports a null
+   * label and its reader falls back to the id, which is what every reader did
+   * before. Both real binds pass their runtime's registry.
+   */
+  readonly providerName?: ProviderNames | undefined;
   /** What this endpoint says about itself. Fixed for the life of the bind. */
   readonly endpoint: ReadEndpoint;
   readonly allowedOrigins?: readonly string[] | undefined;
@@ -166,7 +179,7 @@ export async function readRoutes(request: Request, deps: ReadDeps): Promise<Resp
   if (url.pathname === STATE_PATH) {
     const rows = await deps.connections().catch(() => []);
     return json(
-      readState(deps.workspace, deps.profiles(), rows, deps.endpoint),
+      readState(deps.workspace, deps.profiles(), rows, deps.endpoint, deps.providerName),
       200,
       cors(origin, allowed),
     );

--- a/src/server/read/state.test.ts
+++ b/src/server/read/state.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, test } from 'bun:test';
-import { readState, type ConnectionRow, type ReadEndpoint } from './state.ts';
+import {
+  readState,
+  type ConnectionRow,
+  type ProviderNames,
+  type ReadEndpoint,
+} from './state.ts';
 import type { ProfileRuntime } from '../mcp/visibility.ts';
 
 /**
@@ -18,6 +23,16 @@ const ROWS: ConnectionRow[] = [
   { provider: 'gmail', id: 'ada', account: 'ada@example.com', label: 'Work mail' },
   { provider: 'gmail', id: 'rin', account: 'rin@example.com' },
 ];
+
+/**
+ * What the two providers in `ROWS` are called, as a registry would say.
+ *
+ * A closure rather than the real registry: `readState` takes the lookup because
+ * the read surface may not import the catalogue, and a test supplying two names
+ * exercises the same path a bind does.
+ */
+const NAMES: ProviderNames = (provider) =>
+  ({ gmail: 'Gmail', lanes_memory: 'Memory' })[provider];
 
 /** What the bind says about itself. Fixed for a test about which rows exist. */
 const ENDPOINT: ReadEndpoint = {
@@ -63,17 +78,36 @@ describe('which connections exist', () => {
   });
 
   test('carries the label and the account, which are what a reader is shown', () => {
-    const state = readState('local', new Map(), ROWS, ENDPOINT);
+    const state = readState('local', new Map(), ROWS, ENDPOINT, NAMES);
     const ada = state.connections.find((one) => one.ref === 'gmail.ada');
 
     expect(ada?.label).toBe('Work mail');
     expect(ada?.account).toBe('ada@example.com');
   });
 
-  test('a row with no label says null rather than inventing one', () => {
-    const state = readState('local', new Map(), ROWS, ENDPOINT);
+  test('a row with no label is named after its provider and its account', () => {
+    // `con8` is what this showed before, which is the one field on a row that
+    // says nothing: the id is opaque on purpose. Every reader fell back to it,
+    // so a dashboard's whole Label column read as keys.
+    const state = readState('local', new Map(), ROWS, ENDPOINT, NAMES);
 
-    expect(state.connections.find((one) => one.ref === 'gmail.rin')?.label).toBeNull();
+    expect(state.connections.find((one) => one.ref === 'gmail.rin')?.label).toBe('Gmail (rin)');
+  });
+
+  test('a built-in is its proper noun, not its noun twice', () => {
+    // The owner layer carries the name in `account` already, so composing the
+    // two would read `Memory (Memory)`.
+    const state = readState('local', new Map(), ROWS, ENDPOINT, NAMES);
+
+    expect(state.connections.find((one) => one.ref === 'lanes_memory.main')?.label).toBe('Memory');
+  });
+
+  test('a provider nothing can name says null rather than guessing', () => {
+    // A grant pointing at a connection the workspace no longer holds, and the
+    // one row left with nothing to derive a name from.
+    const state = readState('local', new Map([['personal', profile(['ghost.one'])]]), ROWS, ENDPOINT, NAMES);
+
+    expect(state.connections.find((one) => one.ref === 'ghost.one')?.label).toBeNull();
   });
 
   test('with no profiles at all, the workspace still lists what it holds', () => {

--- a/src/server/read/state.ts
+++ b/src/server/read/state.ts
@@ -1,4 +1,5 @@
 import { allowedConnections } from '#policy';
+import { defaultConnectionLabel } from '#profile';
 import type { ProfileRuntime } from '../mcp/visibility.ts';
 
 /**
@@ -19,11 +20,20 @@ export interface ReadConnection {
   readonly provider: string;
   readonly id: string;
   /**
-   * The operator's own word for it, and what a reader should be shown.
+   * What a reader should be shown: the operator's own word for it, or the name
+   * derived from the provider and the account when they never gave one.
    *
    * `gmail.ada_lovelace` is an address, not a name. A dashboard listing refs is
    * asking somebody to read identifiers when they gave the thing a label
    * precisely so they would not have to.
+   *
+   * **Filled rather than left null**, which reverses what this said. Null meant
+   * "they never gave one" and every consumer answered it the same way, by
+   * showing the id — so a dashboard's whole Label column read `con8`, `lan7`,
+   * `con5`. `connect` writes no label that only repeats the lines above it
+   * (`declareConnection`), so an unlabelled row is the ordinary case and not an
+   * omission worth reporting. `null` survives for the row nothing can name: a
+   * grant pointing at a connection the workspace no longer holds.
    */
   readonly label: string | null;
   /** The identity the provider reported at connect time. */
@@ -31,6 +41,20 @@ export interface ReadConnection {
   /** Which profiles grant this connection at all. */
   readonly profiles: readonly string[];
 }
+
+/**
+ * What a provider is called, asked of whoever built the registry.
+ *
+ * A function rather than a catalogue, because `server` may not import
+ * `#providers` — the read surface has no business knowing the vendor list, and
+ * the rule that says so is `architecture.test.ts`. Both binds already hold a
+ * `Runtime`, whose registry names the owner layer, the catalogue and a
+ * workspace's own manifests alike, so the caller passes a closure over that.
+ *
+ * Defaulted to naming nothing. A caller that supplies none gets `label: null`
+ * on an unlabelled row, which is what every reader saw before this existed.
+ */
+export type ProviderNames = (provider: string) => string | undefined;
 
 /** The connection rows as `connections.yaml` holds them. */
 export interface ConnectionRow {
@@ -97,6 +121,7 @@ export function readState(
   profiles: ReadonlyMap<string, ProfileRuntime>,
   rows: readonly ConnectionRow[],
   endpoint: ReadEndpoint,
+  providerName: ProviderNames = () => undefined,
 ): ReadState {
   // The workspace's own list is the source of truth for *which connections
   // exist*. Deriving it from the grants instead made an account that no profile
@@ -138,11 +163,14 @@ export function readState(
 
   const connections: ReadConnection[] = rows.map((row) => {
     const ref = `${row.provider}.${row.id}`;
+    const named = providerName(row.provider);
     return {
       ref,
       provider: row.provider,
       id: row.id,
-      label: row.label ?? null,
+      // The same rule `connect` offers and `connection list` prints, so one
+      // connection is called one thing wherever somebody reads it.
+      label: row.label ?? (named ? defaultConnectionLabel(named, row.account) : null),
       account: row.account ?? null,
       profiles: grantedBy.get(ref) ?? [],
     };

--- a/src/server/setup-surface.test.ts
+++ b/src/server/setup-surface.test.ts
@@ -80,7 +80,7 @@ function grantsFrom(policy: string, connections: readonly string[]): string {
 
 function config(profile: string, port: number, policy: string) {
   return parseConfig(`
-contract: 4
+contract: 5
 instance:
   profile: ${profile}
   port: ${port}
@@ -148,7 +148,7 @@ const never = startHarness({
   token: 'llk_never_token_value',
   providers: providersFor('never', []),
   config: parseConfig(`
-contract: 4
+contract: 5
 instance:
   profile: never
   port: ${neverPort}

--- a/src/server/skills-authoring.test.ts
+++ b/src/server/skills-authoring.test.ts
@@ -69,7 +69,7 @@ function skillsFixture(): { store: BlobStore; refresh: (registry: ProviderRegist
 
 function config(profile: string, port: number, policy: string) {
   return parseConfig(`
-contract: 4
+contract: 5
 instance:
   profile: ${profile}
   port: ${port}


### PR DESCRIPTION
Publishes 0.9.3 to npm. **Merge with `--merge`, never `--squash`** — a squash writes a new commit onto `main`, `develop`'s tip stops being an ancestor, and the fast-forward afterwards is rejected as non-fast-forward even though the trees are identical.

## What ships

- **#148 — a credential names a person, and the profiles follow from that.** Contract 5. The endpoint token moves from `auth.token_ref` on every profile to `tokens:` on the workspace, one row per token naming the Lanes subject it was issued to; a static token resolves through `members:` exactly as an OAuth one has since ADR-060. `mcp add`, `mcp stdio`, `outputs` and the `token` family stop naming a profile. Also fixes two live disclosure bugs — `lanes_setup.overview` and `/health` both listed every profile on the endpoint to any authenticated caller, including profiles `mayReach` keeps out of that caller's own `profile` enum.
- **#147** — an unnamed connection is called after its provider, not its id.
- **#146** — a deploy tells an already-registered client to re-add.
- **#144** — the contract-4 rename: what it cost a registered client, and the annotation it broke.

## Upgrade

`doctor --fix`, `update` and `deploy` all migrate contract 4 → 5. The token's credential ref is **not** re-keyed, so the value an endpoint is already serving with survives the migration and a deployed revision keeps reading the same secret.

One thing to know: a token now reaches only the profiles whose `members:` lists its subject. A workspace whose profiles list nobody gets a row bound to the migrating operator and a warning naming `profile members add --me` — the token would otherwise look issued and reach nothing.

No client needs re-adding. This renames no provider id, tool or connection.

## Verification

`bun test` 3115 pass, 0 fail. `bun run typecheck` clean. CI green on #148 and #149.

Deployed to a live Cloud Run target ahead of this release and verified from a real MCP client: the migration ran against the bucket, the revision rolled, the pre-migration token still opens the endpoint, and the caller-scoped profile listing and corrected connection labels are what the new code renders. The existing connector kept working across the redeploy.