### PR TITLE
docs: the README leads with the quickstart, and the reasoning moves to Notes

### DIFF
--- a/.claude/skills/lanes-writing/SKILL.md
+++ b/.claude/skills/lanes-writing/SKILL.md
@@ -1,0 +1,158 @@
+---
+name: lanes-writing
+description: Use when writing or editing any Lanes documentation, README, marketing copy, doc page, use case, comparison, or release post. Sets the register per page type, the test a sentence has to pass to stay, and the standing house rules.
+---
+
+# Writing for Lanes
+
+Canonical copy lives in `lanes-sh/web` at `.claude/skills/lanes-writing/SKILL.md`.
+The copies in `lanes-sh/link` and `lanes-sh/core` follow it; edit the canonical one.
+
+## The reader
+
+One person, in a hurry, who wants the thing running. They did not come to admire the
+architecture. Every sentence between them and a working setup is a cost, and the only
+justification for that cost is that the sentence saves them more than it spends.
+
+## Step 1: pick the register
+
+Three registers. Which one a page gets depends on what success means for its reader.
+
+| Register | Reader's success | Shape |
+|---|---|---|
+| **Quickstart** | "It is running." | Prerequisite line, numbered commands, one line of result, one link out. Reasoning goes in a `Notes` block at the foot |
+| **Layered** | "I understand this well enough to decide." | What it is, what you do about it, then why it works this way. In that order, never interleaved |
+| **Site voice** | "I know whether this is for me." | A claim, then the proof. Benefit-first subheads, second person, short paragraphs |
+
+Look the page up rather than deciding by feel:
+
+| Page type | Register |
+|---|---|
+| Quickstart, install, connect, deploy, "add it to your agent" | Quickstart |
+| Per-feature how-to (worktrees, loops, gateway, sessions, issue board) | Quickstart, plus one sentence on a step with a real gotcha |
+| Concept and explainer (architecture, security, scopes, identity, capabilities) | Layered |
+| Reference (commands, settings, shortcuts, providers, errors, API) | Tables only. One row per thing, no prose between rows |
+| README, first screen | Site voice |
+| README, everything below install | Quickstart |
+| Index and overview (`/docs`, `/docs/mcp`, `src/content/pages/*.md`) | Site voice |
+| Use case, comparison | Site voice |
+| Blog | Leave the voice alone. Correct facts only |
+| Terms, privacy, GDPR, cookies | Plain legal English. Accuracy beats brevity. No register change |
+
+## Step 2: apply the sentence test
+
+Read every sentence and ask what it does for the reader. It stays only if it does one of:
+
+1. Tells them what to type or click.
+2. Changes what they would type or click: a prerequisite, a default, a gotcha.
+3. Tells them whether the page is for them.
+4. Prevents a specific mistake that costs real time.
+
+Everything else moves to `Notes`, moves behind a link, or goes. **The default answer is: it
+goes.** A sentence that is true, well written and interesting still goes if it does none of
+the four.
+
+The legal documents get a fifth reason: it is a commitment or a disclosure the document has
+to make. Nothing else does.
+
+### What the test catches
+
+| Cut | Why |
+|---|---|
+| The history of a rename | Nobody typing the new name needs the old one |
+| A flag that is already the default | `--workspace local` when local is the default |
+| An edge case affecting few readers | Move it to `Notes`; do not put it mid-procedure |
+| Restating what the UI labels | If the dialog says "Working directory", the doc does not list the fields |
+| A second link to the same place | One "next" per page |
+| The mechanism behind a result | "Your agents can reach it" beats "the endpoint reconciles its manifest" |
+
+## Step 3: the standing rules
+
+- **No em dashes.** Anywhere. Use a comma, a full stop, a colon, or a hyphen.
+- **Sentence case headings.** "Connect an account", not "Connect An Account".
+- **Second person.** "You", never "the user".
+- **Imperative headings on procedures.** "Install it", not "Installation".
+- **One idea per sentence.** A semicolon joining two clauses is two sentences, or it is one.
+- **Drop default flags from examples.** Show the shortest command that works.
+- **One "next" per page.** A menu of five is a page that has not decided.
+- **Counts that rot become ranges.** "Over a hundred providers", never "105", and never a list
+  of five in a document that has to stay true.
+- **Name the result, not the mechanism.**
+- **Numbered sections are numbered once.** Check the sequence before you commit.
+- **Every claim is checkable.** If you cannot point at the code, the doc does not say it.
+
+## The `Notes` block
+
+The escape hatch that makes cutting safe. Reasoning, edge cases and history that would
+otherwise interrupt a procedure go under a `## Notes` heading at the foot of the page, one
+bolded lead-in per note:
+
+```markdown
+## Notes
+
+**Why the sign-in.** A profile declares who may use it, and the endpoint cannot check that
+against anything if it does not know who is asking. The network is needed to sign in and to
+refresh, not per call.
+
+**If `lanes` is not on your PATH.** Several commands read your token with
+`$(lanes link token show --raw)`, which substitutes to an empty string. The symptom is a 401
+that looks like a bad token.
+```
+
+Nothing is lost. It is just no longer standing between the reader and step 4.
+
+## Worked example
+
+The Lanes Link README quickstart. Before, 230 words plus two "Why" paragraphs, every command
+carrying a flag that is already the default:
+
+```markdown
+## Quickstart
+
+Needs [Bun](https://bun.com) 1.3.11+, and a Lanes sign-in.
+
+$ bun install -g @lanes-sh/link                # puts `lanes` on your PATH
+$ lanes auth login                             # opens a browser once
+$ lanes link profile add personal --workspace local
+$ lanes link profile members add --me --profile personal --workspace local
+$ lanes link start --workspace local
+
+**Why the sign-in.** A profile declares who may consume it, and there is nothing to check
+that against if the endpoint has no idea who is asking. That is a real dependency for a
+self-hostable tool and worth stating plainly; what it is not is a dependency per request...
+
+**Why `mcp add` names no profile.** One endpoint serves every profile in the workspace...
+```
+
+After, 62 words, with both "Why" paragraphs moved to `Notes`:
+
+```markdown
+## Quickstart
+
+Needs Bun 1.3.11+.
+
+$ bun install -g @lanes-sh/link
+$ lanes auth login
+$ lanes link profile add personal
+$ lanes link profile members add --me --profile personal
+$ lanes link start
+ok  serving http://127.0.0.1:7337/mcp
+
+In a second shell, point every installed agent at it:
+
+$ lanes link mcp add
+
+Your memory, tasks, files and skills work now. Mail and calendar are next:
+`lanes link connect gmail`.
+
+**[Full quickstart](https://lanes.sh/docs/link/quickstart)**
+```
+
+## Before you call it done
+
+- Every heading is sentence case, and numbered sequences are numbered once.
+- No em dashes.
+- Every command is the shortest form that works.
+- Every sentence passes the test in step 2.
+- One "next" at the foot.
+- Every internal link resolves to a page that exists.

--- a/.claude/skills/lanes-writing/SKILL.md
+++ b/.claude/skills/lanes-writing/SKILL.md
@@ -39,7 +39,33 @@ Look the page up rather than deciding by feel:
 | Blog | Leave the voice alone. Correct facts only |
 | Terms, privacy, GDPR, cookies | Plain legal English. Accuracy beats brevity. No register change |
 
-## Step 2: apply the sentence test
+## Step 2: make every heading name an outcome
+
+**A heading says what the reader achieves, or what the section explains.** Not the noun the
+feature is filed under. This is the single most common way a page reads as robotic: the writer
+labels the machinery, and the reader has to read the section to find out whether it was for them.
+
+| Instead of | Write |
+|---|---|
+| Permissions | Decide what an agent may do |
+| Selection | Choose which profile a command acts on |
+| Inspection | See what is connected, and what your agents did |
+| Gate order | Catch a problem in the cheapest place |
+| Governance | Why you cannot remove the last admin |
+| The envelope | What an error looks like |
+| Tips | Settings worth changing first |
+
+**"Tips" is never a heading.** It is a bin for whatever had no home, and a reader cannot tell
+whether it is worth reading. Name what the advice is about, or move each item to the section it
+belongs to.
+
+The same applies to the page. A reader landing on it should know, from the title and the first
+sentence, what they will be able to do when they leave.
+
+**A section never opens straight into a code block.** One sentence first, saying what the code
+achieves. The reader decides whether to run it from that sentence, not by parsing the snippet.
+
+## Step 3: apply the sentence test
 
 Read every sentence and ask what it does for the reader. It stays only if it does one of:
 
@@ -66,7 +92,7 @@ to make. Nothing else does.
 | A second link to the same place | One "next" per page |
 | The mechanism behind a result | "Your agents can reach it" beats "the endpoint reconciles its manifest" |
 
-## Step 3: the standing rules
+## Step 4: the standing rules
 
 - **No em dashes.** Anywhere. Use a comma, a full stop, a colon, or a hyphen.
 - **Sentence case headings.** "Connect an account", not "Connect An Account".
@@ -150,6 +176,8 @@ Your memory, tasks, files and skills work now. Mail and calendar are next:
 
 ## Before you call it done
 
+- Every heading names an outcome, not the machinery. No section called "Tips".
+- No section opens straight into a code block.
 - Every heading is sentence case, and numbered sequences are numbered once.
 - No em dashes.
 - Every command is the shortest form that works.

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ ok    registered lanes-link with Claude Code (user scope)
 ok    registered lanes-link with Codex
 ```
 
-Your memory, tasks, files and skills work now, with nothing to authorise. Mail and calendar are
+Your memory, tasks, files, skills, entities and vault work now, with nothing to authorise. Mail and calendar are
 the next step: `lanes link connect gmail`.
 
 **[Full quickstart](https://lanes.sh/docs/link/quickstart)**
@@ -76,7 +76,8 @@ comes.
 | **Tasks** | what you have to do, each with a status | `lanes link tasks` |
 | **Assets** | files you want kept, by name | `lanes link assets` |
 | **Skills** | your own procedures, handed to an agent as instructions | `lanes link skills` |
-| **Identity** | who you are, and the people and companies that recur in your work | `lanes link identity` |
+| **Identity** | who you are, so an agent signs off as you | `lanes link identity` |
+| **Entities** | the people and companies you deal with, so an agent looks an address up rather than recalling one | `lanes link entities` |
 | **Vault** | passwords and API keys, released only where you allow it | `lanes link vault` |
 
 Everything except connections arrives switched on, because it holds your own material rather

--- a/README.md
+++ b/README.md
@@ -6,92 +6,72 @@
 
 **One endpoint you own, holding everything your agents need to know you: connections, memory, tasks, files, contacts, and secrets.**
 
-You own it and you run it. Connect your mail, calendar, files, and notes once, and add the memory,
-tasks, and procedures that only you have. Every agent you use — Claude, ChatGPT, and anything else
-that speaks MCP — reaches all of it through that one endpoint. Change your AI and you keep your
-context, because none of it ever lived in the agent. Open source, self-hostable, no vendor in the
-middle of your data.
+Connect your mail, calendar, files and notes once. Every agent you use, Claude, ChatGPT, and
+anything else that speaks MCP, reaches all of it through that one endpoint. Change your AI and
+you keep your context, because none of it ever lived in the agent.
 
 ![Left: every agent wired directly to every account, each line crossing the others. Right: the same three agents reaching one Lanes Link endpoint, which fans out to Gmail, GitHub, Slack, memory, skills, and a task list through an Access Profile named engineering.](docs/images/lanes-link-hero.png)
+
+## Quickstart
+
+Needs [Bun](https://bun.com) 1.3.11+ and a Lanes sign-in.
+
+```console
+$ bun install -g @lanes-sh/link
+$ lanes auth login
+$ lanes link profile add personal
+$ lanes link profile members add --me --profile personal
+$ lanes link start
+ok    serving http://127.0.0.1:7337/mcp
+      profiles: personal
+```
+
+Leave that running. In a second shell, point every agent you have installed at it:
+
+```console
+$ lanes link mcp add
+ok    registered lanes-link with Claude Code (user scope)
+ok    registered lanes-link with Codex
+```
+
+Your memory, tasks, files and skills work now, with nothing to authorise. Mail and calendar are
+the next step: `lanes link connect gmail`.
+
+**[Full quickstart](https://lanes.sh/docs/link/quickstart)**
 
 ## Why
 
 - **Connect once, use everywhere.** No per-agent integrations, no re-authorising every new tool.
 - **You decide what agents can touch.** Permissions default to deny, and the runtime enforces
-  them — it does not ask the model to behave.
+  them rather than asking the model to behave.
 - **Work and personal never mix.** Separate profiles, separate credentials, separate stores.
 - **Every call is recorded.** An append-only log of what was reached, and what was refused.
-- **It is yours to move.** What you store is plain files on your own disk — readable in an editor,
-  backed up like anything else, and portable to a private Git repository or to another machine
-  whenever you want. There is no export to ask for.
+- **It is yours to move.** Plain files on your own disk, readable in an editor and portable to
+  another machine. There is no export to ask for.
 
 ## What people use it for
 
 - **A personal assistant on your phone.** A deployment is a URL, so the claude.ai or ChatGPT app
-  reaches your mail, calendar, and files from anywhere — "what's on tomorrow", "reply to Ana's
-  thread", "find the invoice from March". This is the case that needs [your own
-  cloud](#run-it-anywhere); everything below works on your machine.
-- **Inbox triage you sign off on.** An agent searches, reads, labels, and composes — and saves a
-  draft for you to send rather than sending it, until you decide otherwise.
+  reaches your mail, calendar and files from anywhere. This is the one case that needs [your own
+  cloud](#run-it-anywhere); everything else here works on your machine.
+- **Inbox triage you sign off on.** An agent searches, reads, labels and composes, and saves a
+  draft for you to send rather than sending it.
 - **Coding agents that start from your context.** Claude Code and Codex reach the same Linear
-  issues, Notion pages, and notes you do, so a session begins from what you already know instead
-  of an empty prompt.
-- **One set of notes behind every agent.** What you have Claude Code write down, claude.ai reads
-  back later — your accumulated context follows you between tools instead of being trapped in
-  whichever one recorded it.
+  issues and Notion pages you do, so a session begins from what you already know.
+- **One set of notes behind every agent.** What Claude Code writes down, claude.ai reads back.
 - **A to-do list your agents share.** "Remind me to chase the invoice" lands somewhere with a
-  status, so whichever agent you are talking to next knows it is still open — and knows when it
-  is done.
+  status, so whichever agent you talk to next knows it is still open.
 - **Your own procedures, followed rather than guessed.** How a standup update reads, where an
-  invoice gets filed, who gets cc'd on a contract — written down once, and every agent you use
-  follows the same one.
-
-## Quickstart
-
-Needs [Bun](https://bun.com) 1.3.11+, and a Lanes sign-in.
-
-```console
-$ bun install -g @lanes-sh/link                # puts `lanes` on your PATH
-$ lanes auth login                             # opens a browser once
-$ lanes link profile add personal --workspace local
-$ lanes link profile members add --me --profile personal --workspace local
-$ lanes link start --workspace local
-ok    serving http://127.0.0.1:7337/mcp
-      profiles: personal
-```
-
-Then, in another shell:
-
-```console
-$ lanes link mcp add --workspace local     # every agent installed; or name one: claude, codex
-ok    registered lanes-link with Claude Code (user scope)
-ok    registered lanes-link with Codex
-```
-
-Your agents can now use it. Memory, tasks, files, skills, and the vault hold your own material
-rather than an account, so they are already there — nothing to connect, no credentials, no browser.
-Mail and calendar are the next step. **[Full quickstart →](https://lanes.sh/docs/link/quickstart)**
-
-**Why the sign-in.** A profile declares who may consume it, and there is nothing to check that
-against if the endpoint has no idea who is asking. That is a real dependency for a self-hostable
-tool and worth stating plainly; what it is not is a dependency per request. The network is needed
-to sign in and to refresh, and a machine offline for a day keeps serving.
-
-**Why `mcp add` names no profile.** One endpoint serves every profile in the workspace, and each
-call names one in its `profile` argument — so registering is about the endpoint, not a profile.
-Which profiles a client actually reaches is decided when its owner signs in: every profile whose
-`members:` lists them, and no others. A credential is an identity here, not a selection. For a
-runner with no browser, `lanes link token issue --me` mints a static token that reaches exactly
-what its subject is a member of.
+  invoice gets filed, who gets cc'd. Written once, and every agent follows the same one.
 
 ## What you keep in it
 
-Not "what your agent gets" — the distinction is the whole point. These are yours. An agent is a
-visitor to them, and you decide per profile how far in it comes.
+Not "what your agent gets". These are yours, and you decide per profile how far in a visitor
+comes.
 
 | | | Manage it with |
 |---|---|---|
-| **Connections** | your external accounts — mail, calendar, files, issues | `lanes link connect` |
+| **Connections** | your external accounts: mail, calendar, files, issues | `lanes link connect` |
 | **Memory** | what you want remembered between sessions | `lanes link memory` |
 | **Tasks** | what you have to do, each with a status | `lanes link tasks` |
 | **Assets** | files you want kept, by name | `lanes link assets` |
@@ -99,35 +79,29 @@ visitor to them, and you decide per profile how far in it comes.
 | **Identity** | who you are, and the people and companies that recur in your work | `lanes link identity` |
 | **Vault** | passwords and API keys, released only where you allow it | `lanes link vault` |
 
-Every one of these except connections arrives switched on: they hold your own material rather than
-an account, so there was never anything to authorise. Memory, tasks, and skills are plain Markdown
-files and an asset is stored under its own filename, so a text editor and an agent reach the same
-bytes. Every one of them belongs to a single profile: what you add under `work` is invisible under
-`personal`.
+Everything except connections arrives switched on, because it holds your own material rather
+than an account. Memory, tasks and skills are plain Markdown, and an asset keeps its own
+filename, so a text editor and an agent reach the same bytes. Each belongs to one profile: what
+you add under `work` is invisible under `personal`.
 
-Identity is the one that is read-only by construction. An agent able to rewrite whose name it signs
-with would be rewriting the one fact that stops it signing as the wrong person, so you declare it in
-a terminal and the endpoint only reads it back.
+**Memory is what is true, tasks is what is to be done, assets is a file.** "Remember to chase
+the invoice" is a task. Filed as memory it becomes a note nothing can ever close. Your agents
+are told this too.
 
-Which store a thing goes in is the one thing worth knowing. **Memory is what is true, tasks is what
-is to be done, assets is a file.** "Remember to chase the invoice" is a task — filed as memory it
-becomes a note nothing can ever close. Your agents are told this too.
-
-Keep those two in a private GitHub repository instead of on this machine, and get history, diffs,
-and the same notes from anywhere you run this:
+Keep memory and skills in a private GitHub repository instead, and get history, diffs, and the
+same notes from anywhere you run this:
 
 ```console
 $ lanes link knowledge use github --repo <owner/name> --migrate
 ```
 
-It moves what you have already stored, in one commit, and `lanes link knowledge use local
---migrate` brings it back. Nothing else moves — your credentials and your vault stay where they
-are, and there is no setting that would put them in a repository.
+Credentials and the vault stay where they are. There is no setting that would put them in a
+repository.
 
 ## Connect an account
 
-**Over a hundred accounts and services, one command each.** Run it again to add a second mailbox, a
-second calendar, a second anything.
+**Over a hundred accounts and services, one command each.** Run it again to add a second
+mailbox, a second calendar, a second anything.
 
 | | |
 |---|---|
@@ -138,76 +112,76 @@ second calendar, a second anything.
 | **Content and data** | Contentful · Storyblok · Hygraph · Sanity · Webflow · Wix · Algolia · PostHog · Mixpanel · Amplitude · RudderStack |
 | **Everything else** | Reddit · Discord · Dropbox · Box · Airtable · Zapier · Attio · Klaviyo · Salesloft · Vimeo · Mux · Replicate · Apify · Tavily · Bright Data |
 
-**[The full list, with the command for each →](https://lanes.sh/docs/link/connect)**
+Most need nothing set up: `connect` opens a browser, you approve, and it is live. The rest ask
+for an app password, a token you paste, or an OAuth client of your own, and the guide says which
+is which.
 
-Most of them need nothing set up. Seventy of them run their own MCP server and offer dynamic client
-registration, so `connect` registers us on the spot: browser, approve, done. The rest are one of
-three shapes — an app password you issue yourself (iCloud, Fastmail, Gmail over IMAP), a token you
-paste (GitHub, Discord), or an OAuth client of your own (Reddit, Microsoft). A few also ask *where*
-they are, because the address belongs to the account rather than the vendor — a Nextcloud you run,
-or any IMAP server.
+**[Connect your accounts](https://lanes.sh/docs/link/connect)** covers every provider, what each
+one gives your agent, and how to add one that is not on the list.
 
-**Most of them are also untested**, and the tables say which. A provider marked † validates, generates
-tools inside the budget, and answers a probe — but nobody has connected it to a real account yet, and
-that is the part only a real account proves. See
-[`src/providers/README.md`](src/providers/README.md) for what that means and how the list is kept.
-
-Three things worth knowing up front. `lanes link connect icloud` sets up Mail, Calendar, and
-Contacts together, because one app-specific password covers all three — and `lanes link connect
-fastmail` does the same for Fastmail's three. Reddit is the one that does
-need an app of your own — it rate-limits per client id, so a shared client would mean strangers
-spending your budget. Google and Slack need no
-OAuth client of your own: both authorise against the one Lanes operates, so there is no console to
-visit — for Google, add `--own-client` if you would rather register your own, or take a service
-account key or an app password over IMAP where you would rather nothing expired. And GitHub takes a
-token you paste rather than a browser sign-in, because it will not register a client for us. And
-bunq — which wants a key from inside its app rather than a console at all — is the one that can move
-money, and it says so: its payment tool executes immediately and is not reversible. Set a spending
-limit on the API key while you are in there, and read
-[Connecting bunq](https://lanes.sh/docs/link/bunq) before connecting it.
-
-Full guide — what each one gives your agent, what it needs, and adding your own:
-**[Connect your accounts](https://lanes.sh/docs/link/connect)**. How the provider layer works, and
-the whole inventory by connector and credential type:
-**[src/providers/README.md](src/providers/README.md)**.
+Two worth knowing before you connect them. **bunq** can move money: its payment tool executes
+immediately and is not reversible, so set a spending limit on the API key and read [Connecting
+bunq](https://lanes.sh/docs/link/bunq) first. **Most providers are untested** against a real
+account, and the tables mark which with a †. See [`src/providers/README.md`](src/providers/README.md)
+for what that means.
 
 ## Run it anywhere
 
-The same code, the same config, in all three. Only the storage adapters change.
+The same code and the same config in all three. Only the storage adapters change.
 
 | | **Local** | **Self-Hosted** | **Lanes Cloud** |
 |---|---|---|---|
 | Runs on | your machine | your GCP project, on Cloud Run | managed for you |
-| Needs | Bun, nothing else | a Google Cloud billing account | — |
+| Needs | Bun, nothing else | a Google Cloud billing account | nothing |
 | Set up with | `lanes link start` | `lanes link deploy` | [join the waitlist](https://lanes.sh/forms/f/a46d8b45-4759-485b-841c-d117a823b645) |
 | Reachable from | that machine | anywhere, including your phone | anywhere |
 | Status | ready | ready | **coming soon** |
 
-**Local** is the fastest way to start, and where most people stay. **Self-Hosted** is what you
-want if you need to reach it from claude.ai, ChatGPT, or a phone — `lanes link deploy` creates the
-project, the bucket, the service account, and the revision on its first run. **Lanes Cloud** is the
-managed version; because it is the same data model, a workspace you build today moves across rather
-than being rebuilt.
-[Join the waitlist](https://lanes.sh/forms/f/a46d8b45-4759-485b-841c-d117a823b645) to hear when it opens.
+Start local; most people stay there. Go self-hosted when you need to reach it from claude.ai,
+ChatGPT or a phone: `lanes link deploy` creates the project, the bucket, the service account and
+the revision on its first run.
 
 ## Docs
 
-- **[Quickstart](https://lanes.sh/docs/link/quickstart)** — from nothing to a working endpoint
-- **[In the Lanes desktop app](https://lanes.sh/docs/desktop/lanes-link)** — the page that drives it
-- **[Connect your accounts](https://lanes.sh/docs/link/connect)** — every provider, and what each one needs
-- **[Add it to your agent](https://lanes.sh/docs/link/clients)** — Claude Code, Codex, Claude Desktop, claude.ai, ChatGPT
-- **[Deploy to your own cloud](https://lanes.sh/docs/link/deploy)** — five commands to a URL
-- **[Every command](https://lanes.sh/docs/link/commands)** — arguments and flags, one entry each
-- **[Full reference](https://lanes.sh/docs/link)** — architecture, configuration, the CLI, the
-  security model, and writing a provider
-- **[Decision records](docs/detailed/adr/)** — why each choice was made, kept here with the source
+| | |
+|---|---|
+| **[Quickstart](https://lanes.sh/docs/link/quickstart)** | From nothing to a working endpoint |
+| **[Connect your accounts](https://lanes.sh/docs/link/connect)** | Every provider, and what each needs |
+| **[Add it to your agent](https://lanes.sh/docs/link/clients)** | Claude Code, Codex, Claude Desktop, claude.ai, ChatGPT |
+| **[Deploy to your own cloud](https://lanes.sh/docs/link/deploy)** | Five commands to a URL |
+| **[Every command](https://lanes.sh/docs/link/commands)** | Arguments and flags, one entry each |
+| **[In the Lanes desktop app](https://lanes.sh/docs/desktop/lanes-link)** | The page that drives it |
+| **[Full reference](https://lanes.sh/docs/link)** | Architecture, configuration, security, writing a provider |
 
 ## Security
 
-Lanes Link holds live credentials to your email and documents. The
-[security model](https://lanes.sh/docs/link/security) states its limits plainly rather than implying
-guarantees the code does not deliver — read it before you trust it with an account. To report a
-vulnerability, see [`SECURITY.md`](SECURITY.md); please do not open a public issue.
+Lanes Link holds live credentials to your email and documents. The [security
+model](https://lanes.sh/docs/link/security) states its limits plainly rather than implying
+guarantees the code does not deliver. Read it before you trust it with an account.
+
+To report a vulnerability, see [`SECURITY.md`](SECURITY.md). Please do not open a public issue.
+
+## Notes
+
+**Why the sign-in.** A profile declares who may use it, and the endpoint cannot check that
+against anything if it does not know who is asking. The network is needed to sign in and to
+refresh, not per call, so a machine offline for a day keeps serving.
+
+**Why members is not optional.** An empty members list means nobody, not everybody. The profile
+you just created reaches no caller until you are on it.
+
+**Why `mcp add` names no profile.** One endpoint serves every profile in the workspace, and each
+call names one in its `profile` argument, so registering is about the endpoint. Which profiles a
+client actually reaches is decided when its owner signs in: every profile whose `members:` lists
+them, and no others. For a runner with no browser, `lanes link token issue --me` mints a static
+token that reaches exactly what its subject is a member of.
+
+**Why no `--workspace` flag.** `local` is the default in a fresh config. Commands that publish or
+destroy (`deploy`, `sync`, `secrets push`, `profile remove`, `disconnect`, `token rotate`) refuse
+the default and make you type the name.
+
+**Where the decision records live.** [`docs/detailed/adr/`](docs/detailed/adr/), kept with the
+source as engineering history rather than documentation.
 
 ## License
 


### PR DESCRIPTION
Part of a documentation sweep across the Lanes repos. The style itself is agreed in [lanes-sh/web#53](https://github.com/lanes-sh/web/pull/53), and this repo carries a copy of the skill.

## README

Someone arriving here wants the endpoint running. The argument for why it should exist was sitting between them and the commands, so the quickstart moves above it. The two "Why" blocks, the connector-shapes paragraph and the bunq warning move to a `Notes` section at the foot. Nothing is lost, it is just no longer in the way. 2,186 words to 1,648.

`--workspace local` comes off every command. It is redundant: `default_workspace: local` ships in the generated config template, and every command in the quickstart path resolves against it. The commands that refuse the default (`deploy`, `sync`, `secrets push`, `profile remove`, `disconnect`, `token rotate`) are named in `Notes` instead.

The per-provider specifics that were in the connect paragraph (iCloud bundling three services from one app password, Reddit needing a client of its own, GitHub taking a pasted token) already live on their own provider pages, which is where a reader meets them anyway. Verified before removing.

## The skill

`.claude/skills/lanes-writing/SKILL.md`, canonical in `lanes-sh/web`. It sets a register per page type and gives a four-part test a sentence has to pass to stay.

## Worth knowing

The web PR fixes something that affects this repo's tests: all 8 `contract:` declarations in the published Link docs said 4, while `SUPPORTED_CONTRACT` here is 5. `src/profile/docs.test.ts` was failing on `configuration.mdx` and `deployment-cloudrun.mdx` and now passes, run as:

```console
$ LANES_DOCS_DIR=/path/to/web/src/content/docs/link bun test
```

58 pass, 0 fail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013yYxJggwWkaTLipRYYBoL1