### PR TITLE
0.9.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lanes-sh/link",
-  "version": "0.9.3",
+  "version": "0.9.4",
   "description": "A self-hostable MCP gateway for all your connections, memory, tasks, files, and secrets",
   "license": "Apache-2.0",
   "homepage": "https://lanes.sh/link",


### PR DESCRIPTION
The version for the change that just landed, set on `develop` before the release pull request so `develop` and `main` end on the same tree.

`0.9.3` is tagged, so merging `develop` into `main` without this would run the *propose* path: the bump would land on a side branch that merges into `main` only, leaving `develop` a version commit behind and needing a fast-forward to finish. Setting it here publishes directly instead.

This commit's message is the release note.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VzFzJJKcNJJ4ehoWVVVZRH