### PR TITLE
0.9.4

### DIFF
--- a/docs/detailed/adr/069-a-pairing-token-may-write-the-owners-own-data.md
+++ b/docs/detailed/adr/069-a-pairing-token-may-write-the-owners-own-data.md
@@ -1,0 +1,121 @@
+# ADR-069: A pairing token may write the owner's own data
+
+**Status:** accepted · **Narrows** [ADR-063](063-one-origin-may-read-a-loopback-endpoint.md),
+[ADR-064](064-a-deployed-endpoint-is-read-over-its-own-url.md) ·
+**Follows from** [ADR-007](007-control-plane-exclusions.md),
+[ADR-050](050-the-owner-layer-is-granted-by-default.md)
+
+## Context
+
+ADR-063 opened one origin onto a loopback endpoint and ADR-064 finished the sentence for a
+deployed one. Both list the same five constraints, and the fourth is stated without qualification:
+
+> **Reads only, ever.** Editing a connection or a profile from a browser would put control-plane
+> mutation behind a CORS grant, and ADR-007 is not moving for a convenience.
+
+`src/server/read/routes.ts` enforces it by answering `404` to every method that is not `GET`, and
+the dashboard's Connections and Profiles tabs render their Save, Rename and Disconnect controls
+disabled, which is the honest state rather than an unfinished one.
+
+The sentence is right about what it names. It is broader than what it argues. Read the clause
+again: *editing a connection or a profile*. Both are configuration, both authorise future agent
+behaviour, and ADR-007 excludes them for that reason. Neither is what the endpoint mostly holds.
+
+**What it mostly holds is the owner's own material.** Memory entries, tasks, assets, skills and
+entities: five stores that carry no account, no credential and no grant, that arrive granted to
+every new profile precisely because there is nothing behind them to protect (ADR-050), and that
+any agent the owner has connected already writes over MCP through `lanes_memory.write`,
+`lanes_tasks.add`, `lanes_assets.store`, `lanes_skills.manage.write` and `lanes_entities.write`.
+
+There has been nowhere for a person to look at any of it. `lanes link memory list` is the whole
+surface, and the audience ADR-063 moved to the web dashboard for is the audience least likely to
+be at a terminal. Worse, the one operation a person actually needs on accumulated memory is the
+one an agent should be slowest to perform: reading what has piled up and deleting what is wrong.
+
+## Decision
+
+**The pairing token reads and writes the owner's own data. It still cannot touch the control
+plane.**
+
+A `/data` prefix joins `/state` and `/audit` behind the same pairing credential, the same single
+named origin, and the same non-ambient header:
+
+```
+GET    /data/:store?profile=&query=&limit=
+GET    /data/:store/:id?profile=
+POST   /data/:store?profile=
+PUT    /data/:store/:id?profile=
+DELETE /data/:store/:id?profile=
+GET    /data/assets/:name/content?profile=
+```
+
+`:store` is a closed list: `memory`, `tasks`, `assets`, `skills`, `entities`, `vault`.
+
+**Five stores are writable. The vault is names only, in both directions.** ADR-007 makes reading a
+raw credential value CLI-only, and that does not move for a browser any more than it moved for an
+agent. A vault listing carries the item ids and their descriptions and no value under any key; a
+write to `vault` is refused with the same `404` this surface gives every unroutable path, because
+a distinguishable refusal would confirm the shape of what is here.
+
+**`identity` and `setup` are not on the list.** Identity is configuration and changed in the CLI
+(ADR-007), and it is the one fact that stops an agent signing as the wrong person. Setup describes
+the others rather than holding anything.
+
+**Policy does not gate this, and the grants still scope it.** `lanes link memory write` does not
+consult the profile's write bundle today, because the CLI is the owner rather than an agent, and a
+pairing token is the same kind of credential: it is minted by a person at a terminal who already
+holds the workspace. What the grants decide is which connection *exists* to address, since
+`ownerConnection` derives its candidates from them. A profile granting no memory connection has
+nothing to write to and says so.
+
+**Every write is audited, in the same log and the same vocabulary as an agent's.** The capability
+recorded is the one that would have done it over MCP, so a dashboard delete and an agent delete
+are one search rather than two. Identifiers are kept and content is withheld, which is the rule
+the write path already follows everywhere else.
+
+**The profile is named on every request and never defaulted.** Owner data has been per-profile
+since ADR-066, and a default would let a page write to a profile the person was not looking at.
+
+## What this costs, plainly
+
+**A pairing token stops being read-only.** ADR-063 already said "read only is not harmless" about
+a credential that returns every connection, every profile and the whole audit log. It is now a
+credential that can also destroy the owner's memory. It rotates with one command, it is refused
+the moment it does, and `--print` is still the way to look at the link without minting one.
+
+**An existing pairing token gains this silently.** The token carries no version; the endpoint
+decides what it may do. Somebody who paired before this release has a credential sitting in a
+browser's `localStorage` that becomes write-capable the first time they run a newer endpoint, with
+nothing on either side announcing it. That cannot be fixed by the token, so it is handled by
+saying it: in the release note, in the prompt `lanes link pair` asks before minting one, and in
+`lanes link status`, which reports the pairing and should report what it can now do.
+
+Requiring a re-pair to unlock writes was considered and rejected. It would mean a second token
+kind, a second thing to rotate, and a version marker inside a credential whose entire security
+story is that it is opaque and compared in constant time. The honest disclosure is cheaper and
+does not leave two credentials able to do each other's job, which is the failure ADR-063's second
+constraint exists to prevent.
+
+**The blast radius is one workspace's owner data.** Not a credential, because the vault is closed
+in both directions and `credentials.not-agent-reachable` is unaffected. Not another origin,
+because the named echo, the `Vary: Origin`, and the deliberate absence of
+`access-control-allow-credentials` are untouched. Not the endpoint, because `/mcp` gains no CORS,
+no route, and no change to the rebinding guard.
+
+## What this does not do
+
+It does not move ADR-007. Policy, tokens, credential writing, connection creation, configuration
+mutation and audit mutation are exactly as unreachable as they were, from a browser and from an
+agent, and `src/dispatch/control-plane.test.ts` still holds them up.
+
+It does not make the disabled controls on Connections and Profiles work. They stay disabled, and
+they stay disabled for the reason ADR-063 gave.
+
+It does not add an upload. `lanes link assets add` resolves a source, records where it came from
+and annotates the audit event with a digest of what arrived; reproducing that over HTTP is its own
+decision and has not been made here. Assets are listed, previewed and deleted.
+
+It does not put the store inside `server`. The dependency direction in
+`src/architecture.test.ts` gives `server` no reach into `#providers` or `#audit`, and this does
+not widen that table: `src/server/read/data.ts` declares the narrow interface it needs and
+`src/cli/data/` satisfies it, which is the same split `readRoutes` already makes for `AuditTail`.

--- a/docs/detailed/adr/README.md
+++ b/docs/detailed/adr/README.md
@@ -84,6 +84,7 @@ Run.
 | [066](066-a-profile-owns-its-data-again.md) | A profile owns its data again: the bytes go back in front of the connection, and two profiles granting one instance share nothing |
 | [067](067-one-directory-per-profile.md) | One directory per profile, `data/` goes, and a connection id becomes opaque |
 | [068](068-a-credential-names-a-person.md) | A credential names a person, and the profiles follow from that; the endpoint token becomes the workspace's |
+| [069](069-a-pairing-token-may-write-the-owners-own-data.md) | A pairing token may write the owner's own data; the control plane is unmoved |
 
 Where an ADR departs from init.md, it says so at the top. Three are significant:
 
@@ -299,3 +300,15 @@ Where an ADR departs from init.md, it says so at the top. Three are significant:
   ref defaulted to the constant `profile/token`, so finding it meant resolving one. The same
   constant is why removing a profile once deleted the token its siblings were served by, and the
   fix is not the survivor check that was added then: the token was never a profile's to declare.
+
+- **ADR-069** narrows ADR-063 rather than reversing it. The pairing token reads and writes the
+  owner's own data — memory, tasks, assets, skills and entities — and still cannot reach a
+  connection, a profile, a grant, a token, the configuration, the audit log, or a vault value.
+
+  The part to read is the sentence being narrowed. ADR-063 said "reads only, ever" and argued it
+  from *editing a connection or a profile*, which is configuration and which ADR-007 excludes
+  because it authorises future agent behaviour. Writing a memory entry authorises nothing, the
+  owner layer arrives granted for that reason (ADR-050), and every connected agent already writes
+  these five stores. What genuinely changes is that a credential which could read every memory
+  entry can now delete them, including one minted before this release, which is why the cost is
+  named in the CLI's own prompt rather than only here.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lanes-sh/link",
-  "version": "0.9.3",
+  "version": "0.9.4",
   "description": "A self-hostable MCP gateway for all your connections, memory, tasks, files, and secrets",
   "license": "Apache-2.0",
   "homepage": "https://lanes.sh/link",

--- a/src/cli/audit-change.ts
+++ b/src/cli/audit-change.ts
@@ -122,6 +122,114 @@ export async function recordConfigChange(
   }
 }
 
+
+/**
+ * The vocabulary a data change is recorded under.
+ *
+ * Not a `config.*` name, and not a new one either: these are the capabilities
+ * an agent would have called to make the same change over MCP. A memory entry
+ * edited from the dashboard and one written by a connected client are the same
+ * event about the same bytes, so they carry the same capability and one filter
+ * over the log finds both (ADR-069).
+ *
+ * Closed, for the reason `CONFIG_CAPABILITIES` is closed: the log's value is
+ * that its vocabulary is small enough to know.
+ */
+export const DATA_CAPABILITIES = [
+  'memory.write',
+  'memory.forget',
+  'tasks.add',
+  'tasks.remove',
+  'assets.store',
+  'assets.remove',
+  'skills.manage.write',
+  'skills.manage.remove',
+  'entities.write',
+  'entities.forget',
+] as const;
+
+export type DataCapability = (typeof DATA_CAPABILITIES)[number];
+
+export interface DataChange {
+  readonly capability: DataCapability;
+  /** The owner-layer provider whose store changed, e.g. `lanes_memory`. */
+  readonly provider: string;
+  /** `<provider>.<id>`, so a row can be traced to the store it touched. */
+  readonly connection: string;
+  /**
+   * Identifiers and shape, never the document.
+   *
+   * A write log that recorded the content would be a second copy of the thing
+   * it describes, kept somewhere with different retention. What belongs here is
+   * what changed and how much of it: the id, the store, the byte length,
+   * whether something was replaced.
+   */
+  readonly arguments: Readonly<Record<string, unknown>>;
+}
+
+/**
+ * What the paired browser did to the owner's own data.
+ *
+ * The same sink and the same event shape as a config change, and for the same
+ * reason: a change and the calls around it are one story and belong in one
+ * chain. What differs is the provider and the principal. `provider` is the
+ * owner-layer provider that owns the bytes rather than the `config`
+ * pseudo-provider, because unlike a policy edit this really is an operation on
+ * a store an agent can also reach.
+ *
+ * `principal` is the caller's to supply and is not the CLI session: a pairing
+ * token authenticates the owner at a browser, and attributing its writes to
+ * whoever last signed in at this terminal would be a guess presented as a fact.
+ *
+ * **Failing to log never fails the write**, which is `recordConfigChange`'s
+ * rule and is right for the same reason: the bytes are already on the store by
+ * the time this is called, and reporting failure for something that succeeded
+ * leaves the operator to work out which half happened.
+ */
+export async function recordDataChange(
+  runtime: {
+    readonly config: Config;
+    readonly resolution: { readonly workspaceRoot: string };
+    readonly target: string;
+  },
+  principal: string,
+  change: DataChange,
+  warn?: (message: string) => void,
+): Promise<void> {
+  const root = runtime.resolution.workspaceRoot;
+
+  try {
+    const resolved = await openTarget(root, runtime.target);
+    const input = {
+      declared: resolved.declared,
+      config: runtime.config,
+      root: resolved.workspaceRoot,
+      target: runtime.target,
+    };
+    const audit = openAudit(await openStorage(input, await openSecrets(input)));
+
+    try {
+      await audit.append({
+        profile: runtime.config.instance.profile,
+        principal,
+        provider: change.provider,
+        connection: change.connection,
+        capability: change.capability,
+        arguments: change.arguments,
+        // Written after the bytes are on the store, so there is no denied case
+        // to record and no duration worth measuring.
+        authorization: 'allowed',
+        status: 'ok',
+        durationMs: 0,
+      });
+    } finally {
+      await audit.close();
+    }
+  } catch (error) {
+    warn?.(`the change was made but not recorded in the audit log: ${message(error)}`);
+  }
+}
+
 /**
  * Who made the change.
  *

--- a/src/cli/commands/operate/pair.ts
+++ b/src/cli/commands/operate/pair.ts
@@ -21,9 +21,18 @@ import { openSecretStoreFor, type GlobalFlags } from '../../runtime.ts';
  * `lanes link pair` — let the Lanes dashboard read this machine (ADR-063).
  *
  * Three things, and each is the operator's to decline. It installs a locally
- * trusted certificate, mints a credential that reads the whole workspace, and
- * hands the browser a link carrying it. None of that happens without being
- * asked for, and none of it is implied by `start`.
+ * trusted certificate, mints a credential that reads the whole workspace and
+ * writes the owner's own data in it, and hands the browser a link carrying it.
+ * None of that happens without being asked for, and none of it is implied by
+ * `start`.
+ *
+ * **The credential is not read-only, since ADR-069.** It edits and deletes
+ * memory, tasks, assets, skills and entities, in every profile the workspace
+ * holds, and it still reaches no connection, token, policy rule, configuration
+ * or vault value. That is a widening of something a year of notes calls a read,
+ * so the paragraph this command prints says it before the operator answers —
+ * and a token minted before that release gains it silently, which is the reason
+ * saying it here is not decoration.
  *
  * **The certificate is the largest side effect any command in this CLI has.**
  * It is a persistent change to the machine's trust store, made by a CLI, and
@@ -193,7 +202,10 @@ export async function pair(flags: PairFlags, deps: PairDeps = {}): Promise<void>
       '      Open that in a browser on this machine. The token is in the URL fragment,\n' +
         '      so it never reaches a Lanes server.\n' +
         '      It reads every connection, profile and audit entry in this workspace, and\n' +
-        '      can change nothing. Take it back with: lanes link pair --rotate\n' +
+        '      can edit and delete your memory, tasks, files, skills and entities in every\n' +
+        '      profile here. It changes no connection, token, policy rule or configuration,\n' +
+        '      and never reads a vault value.\n' +
+        '      Take it back with: lanes link pair --rotate\n' +
         '\n' +
         `      The endpoint has to be running: lanes link start --workspace ${target}`,
     ),
@@ -282,7 +294,10 @@ async function pairDeployed(input: {
       '      Open that in any browser, on any machine. The token is in the URL fragment,\n' +
         '      so it never reaches a Lanes server.\n' +
         '      It reads every connection, profile and audit entry in this workspace, and\n' +
-        '      can change nothing. Take it back with:\n' +
+        '      can edit and delete your memory, tasks, files, skills and entities in every\n' +
+        '      profile here. It changes no connection, token, policy rule or configuration,\n' +
+        '      and never reads a vault value.\n' +
+        '      Take it back with:\n' +
         `        lanes link pair --workspace ${target} --rotate\n` +
         '\n' +
         '      A rotation takes up to five seconds to be refused, because the endpoint\n' +

--- a/src/cli/owner-data/browse.ts
+++ b/src/cli/owner-data/browse.ts
@@ -1,0 +1,363 @@
+import { loadProfileSkills, readSkill } from '#providers/skills/store.ts';
+import { assetStorage, entityStorage, memoryStorage, taskStorage } from '#providers/owner.ts';
+import type { BlobStore } from '#stores/blobs';
+import type { Runtime } from '../runtime.ts';
+import { storeFor } from './stores.ts';
+import {
+  answered,
+  refused,
+  type Answer,
+  type DataContent,
+  type DataDetail,
+  type DataItem,
+  type DataStoreName,
+} from './surface.ts';
+
+/**
+ * Reading the six stores, through the modules that own their formats.
+ *
+ * Nothing here parses a document itself. `memoryStorage`, `taskStorage`,
+ * `assetStorage` and `entityStorage` are the same objects the providers and the
+ * CLI read through, and `loadProfileSkills` is the same loader the registry
+ * builds from — so a listing here cannot come to disagree with the listing an
+ * agent sees, which is the whole reason those namespace objects are exported.
+ *
+ * **A detail carries the document raw.** Frontmatter included, exactly as it
+ * sits on the store. The alternative was projecting each format into fields and
+ * reassembling them on the way back, which is a second copy of five schemas and
+ * a lossy round trip for anything the projection did not know about.
+ */
+
+/** What a listing returns at most, whatever was asked for. */
+const LIMIT_CEILING = 500;
+const LIMIT_DEFAULT = 200;
+
+/**
+ * The largest asset served as an editable document.
+ *
+ * The provider's own ceiling for handing text to a model, reused here because
+ * the question is close enough: past this a text box is not a sensible way to
+ * look at a file, and the content route serves the bytes instead.
+ */
+const MAX_TEXT_BYTES = 256 * 1024;
+
+function bounded(limit: number | undefined): number {
+  return Math.min(limit && limit > 0 ? limit : LIMIT_DEFAULT, LIMIT_CEILING);
+}
+
+/** Case-insensitive substring, which is the match every one of these stores makes. */
+function matches(query: string | undefined, ...fields: readonly string[]): boolean {
+  if (!query) return true;
+  const needle = query.toLowerCase();
+  return fields.some((field) => field.toLowerCase().includes(needle));
+}
+
+function decode(bytes: Uint8Array): string {
+  return new TextDecoder().decode(bytes);
+}
+
+/**
+ * Most recently touched first, which is the question a browser is opened with.
+ *
+ * One rule over all six stores rather than each store's own, and applied here
+ * rather than in the page, because the listing is capped: ordering after the
+ * cap would sort whichever items happened to survive it, and the newest thing
+ * in a store of four hundred would be missing from a list claiming to show what
+ * changed last.
+ *
+ * **This deliberately overrides the task order.** `compareTasks` ranks by
+ * status, then due date, and its docstring is right about why: a task list is
+ * read to decide what to do next, and the most recently edited task is rarely
+ * that. A data browser is not a task list. It answers "what changed", the
+ * status is on the row either way, and a table that ordered one of six stores
+ * by a different rule would be the surface disagreeing with itself.
+ *
+ * An item with no timestamp sorts last rather than first. Skills carry no
+ * `updated_at` and the vault reports none, so absent means unknown here, and
+ * unknown is not new. Those two fall back to their name, which is stable and is
+ * what their columns show.
+ */
+function byRecency(items: DataItem[]): DataItem[] {
+  return [...items].sort((a, b) => {
+    const left = instantOf(a.updatedAt);
+    const right = instantOf(b.updatedAt);
+
+    if (left !== null && right !== null) {
+      return right - left || a.title.localeCompare(b.title);
+    }
+    if (left !== null) return -1;
+    if (right !== null) return 1;
+    return a.title.localeCompare(b.title);
+  });
+}
+
+/**
+ * A timestamp as an instant, or `null` where it is not one.
+ *
+ * Compared as a time rather than as a string. A string compare is correct for
+ * ISO-8601 in UTC and only for that, and nothing guarantees it: these files are
+ * in a directory the owner edits, `parseEntry` and `parseTask` take `updated_at`
+ * verbatim rather than normalising it, and the same store can hold
+ * `2026-09-01T11:05:00.000Z` written by the endpoint beside a date-only
+ * `2026-09-01` or an offset `2026-09-01T13:05:00+02:00` written by hand. Two of
+ * those three sort wrong as text, and the third sorts wrong against the first.
+ *
+ * Unparseable is `null` rather than zero, so a value nobody can read as a time
+ * joins the items that have none instead of claiming to be the oldest thing in
+ * the store.
+ */
+function instantOf(value: string | null): number | null {
+  if (value === null) return null;
+  const at = Date.parse(value);
+  return Number.isNaN(at) ? null : at;
+}
+
+export async function listItems(
+  runtime: Runtime,
+  store: DataStoreName,
+  options: { query?: string | undefined; limit?: number | undefined },
+): Promise<Answer<DataItem[]>> {
+  const limit = bounded(options.limit);
+
+  if (store === 'vault') return listVault(runtime, options.query, limit);
+
+  const scoped = storeFor(runtime, store);
+  if (!scoped.ok) return scoped;
+
+  const rows = await collect(scoped.value.store, store, options.query);
+  return answered(byRecency(rows).slice(0, limit));
+}
+
+async function collect(
+  blobs: BlobStore,
+  store: DataStoreName,
+  query: string | undefined,
+): Promise<DataItem[]> {
+  switch (store) {
+    case 'memory': {
+      const entries = await memoryStorage.all(blobs);
+      return entries
+        .filter((entry) => matches(query, entry.id, entry.title, entry.tags.join(' '), entry.body))
+        .map((entry) => ({
+          id: entry.id,
+          title: entry.title,
+          summary: null,
+          updatedAt: entry.updatedAt,
+          tags: entry.tags,
+        }));
+    }
+    case 'tasks': {
+      const tasks = await taskStorage.all(blobs);
+      return tasks
+        .filter((task) => matches(query, task.id, task.title, task.tags.join(' '), task.body))
+        .map((task) => ({
+          id: task.id,
+          title: task.title,
+          // Status first, because it is what a task list is scanned for, and
+          // the due date beside it because the two are read together.
+          summary: task.due ? `${task.status} · due ${task.due}` : task.status,
+          updatedAt: task.updatedAt,
+          tags: task.tags,
+        }));
+    }
+    case 'assets': {
+      const assets = await assetStorage.all(blobs);
+      return assets
+        .filter((asset) => matches(query, asset.name, asset.contentType))
+        .map((asset) => ({
+          id: asset.name,
+          title: asset.name,
+          summary: `${asset.contentType} · ${assetStorage.humanBytes(asset.bytes)}`,
+          updatedAt: asset.modifiedAt,
+          tags: [],
+        }));
+    }
+    case 'skills': {
+      const skills = await loadProfileSkills(blobs);
+      return skills
+        .filter((skill) => matches(query, skill.name, skill.title ?? '', skill.description))
+        .map((skill) => ({
+          id: skill.name,
+          title: skill.title ?? skill.name,
+          summary: skill.description,
+          // A skill's document carries no timestamp: its frontmatter is what
+          // the owner wrote, and inventing one from the blob's mtime would
+          // report a re-sync as an edit.
+          updatedAt: null,
+          tags: [],
+        }));
+    }
+    case 'entities': {
+      const entities = await entityStorage.all(blobs);
+      return entities
+        .filter((entity) =>
+          matches(query, entity.id, entity.name, entity.aliases.join(' '), entity.tags.join(' ')),
+        )
+        .map((entity) => ({
+          id: entity.id,
+          title: entity.name,
+          summary:
+            entity.aliases.length > 0 ? `${entity.type} · ${entity.aliases.join(', ')}` : entity.type,
+          updatedAt: entity.updatedAt,
+          tags: entity.tags,
+        }));
+    }
+    default:
+      return [];
+  }
+}
+
+/**
+ * The vault, by name.
+ *
+ * Ids and descriptions, and no value under any key. `VaultStore` has no
+ * operation that would enumerate one, so this is enforced by what is reachable
+ * rather than by remembering not to ask (ADR-007, ADR-069).
+ */
+async function listVault(
+  runtime: Runtime,
+  query: string | undefined,
+  limit: number,
+): Promise<Answer<DataItem[]>> {
+  const items = await runtime.vault.ids();
+
+  return answered(
+    byRecency(
+      items
+        .filter((item) => matches(query, item.id, item.description ?? ''))
+        .map((item) => ({
+          id: item.id,
+          title: item.id,
+          summary: item.description ?? null,
+          updatedAt: null,
+          tags: [],
+        })),
+    ).slice(0, limit),
+  );
+}
+
+export async function readItem(
+  runtime: Runtime,
+  store: DataStoreName,
+  id: string,
+): Promise<Answer<DataDetail>> {
+  if (store === 'vault') return readVaultItem(runtime, id);
+
+  const scoped = storeFor(runtime, store);
+  if (!scoped.ok) return scoped;
+
+  const blobs = scoped.value.store;
+
+  if (store === 'assets') return readAsset(blobs, id);
+
+  const key =
+    store === 'memory'
+      ? memoryStorage.key(id)
+      : store === 'tasks'
+        ? taskStorage.key(id)
+        : entityStorage.key(id);
+
+  if (store === 'skills') {
+    const skill = await readSkill(blobs, id).catch(() => null);
+    if (!skill) return missing(store, id);
+
+    // The stored document, frontmatter and all — the same bytes
+    // `skills.manage.get` returns, and the same bytes a write puts back.
+    const bytes = await blobs.get(skill.path);
+    return answered({
+      id: skill.name,
+      title: skill.title ?? skill.name,
+      summary: skill.description,
+      updatedAt: null,
+      tags: [],
+      body: bytes === null ? '' : decode(bytes),
+      readOnly: null,
+      contentType: 'text/markdown',
+      bytes: bytes?.byteLength ?? 0,
+    });
+  }
+
+  const bytes = await blobs.get(key);
+  if (bytes === null) return missing(store, id);
+
+  const rows = await collect(blobs, store, undefined);
+  const row = rows.find((one) => one.id === id);
+
+  return answered({
+    id,
+    title: row?.title ?? id,
+    summary: row?.summary ?? null,
+    updatedAt: row?.updatedAt ?? null,
+    tags: row?.tags ?? [],
+    body: decode(bytes),
+    readOnly: null,
+    contentType: 'text/markdown',
+    bytes: bytes.byteLength,
+  });
+}
+
+async function readAsset(blobs: BlobStore, name: string): Promise<Answer<DataDetail>> {
+  const asset = await assetStorage.find(blobs, name);
+  if (!asset) return missing('assets', name);
+
+  const bytes = await blobs.get(name);
+  const textual =
+    bytes !== null && asset.bytes <= MAX_TEXT_BYTES && assetStorage.isTextual(asset.contentType, bytes);
+
+  return answered({
+    id: asset.name,
+    title: asset.name,
+    summary: `${asset.contentType} · ${assetStorage.humanBytes(asset.bytes)}`,
+    updatedAt: asset.modifiedAt,
+    tags: [],
+    body: textual && bytes !== null ? decode(bytes) : null,
+    readOnly: textual
+      ? null
+      : `${assetStorage.describe(asset)} — not text, so it is shown rather than edited.`,
+    contentType: asset.contentType,
+    bytes: asset.bytes,
+  });
+}
+
+/**
+ * One vault item, which is its name and nothing else.
+ *
+ * It opens rather than refusing, because a row a person can see and cannot open
+ * reads as a fault. What it says is the answer: the value is not readable from
+ * here and there is a command that reads it.
+ */
+async function readVaultItem(runtime: Runtime, id: string): Promise<Answer<DataDetail>> {
+  const item = (await runtime.vault.ids()).find((one) => one.id === id);
+  if (!item) return missing('vault', id);
+
+  return answered({
+    id: item.id,
+    title: item.id,
+    summary: item.description ?? null,
+    updatedAt: null,
+    tags: [],
+    body: null,
+    readOnly:
+      'A vault value is never returned to a browser. Read it with "lanes link vault get" at a terminal.',
+    contentType: null,
+    bytes: null,
+  });
+}
+
+/** An asset's bytes. The one route where content crosses, and only for assets. */
+export async function readContent(runtime: Runtime, name: string): Promise<Answer<DataContent>> {
+  const scoped = storeFor(runtime, 'assets');
+  if (!scoped.ok) return scoped;
+
+  const asset = await assetStorage.find(scoped.value.store, name);
+  if (!asset) return missing('assets', name);
+
+  const bytes = await scoped.value.store.get(name);
+  if (bytes === null) return missing('assets', name);
+
+  return answered({ bytes, contentType: asset.contentType });
+}
+
+function missing<T>(store: string, id: string): Answer<T> {
+  return refused(404, 'not_found', `No ${store} item ${JSON.stringify(id)} in this profile.`);
+}

--- a/src/cli/owner-data/edit.ts
+++ b/src/cli/owner-data/edit.ts
@@ -1,0 +1,281 @@
+import { ConfigError } from '#profile';
+import { openCatalogue } from '#providers/entities/catalogue.ts';
+import { forgetEntity, persistEntity } from '#providers/entities/writes.ts';
+import { readSkill, removeSkill, writeSkill } from '#providers/skills/store.ts';
+import { assetStorage, entityStorage, memoryStorage, taskStorage } from '#providers/owner.ts';
+import type { BlobStore } from '#stores/blobs';
+import type { Runtime } from '../runtime.ts';
+import { recordDataChange, type DataCapability } from '../audit-change.ts';
+import { readItem } from './browse.ts';
+import { storeFor } from './stores.ts';
+import {
+  answered,
+  DASHBOARD_PRINCIPAL,
+  refused,
+  type Answer,
+  type DataDetail,
+  type DataStoreName,
+} from './surface.ts';
+
+/**
+ * Writing the five stores a pairing token may write (ADR-069).
+ *
+ * **A write is the document, parsed by the module that owns the format and
+ * written back through it.** Not a passthrough `put`: an entity written without
+ * maintaining `_index.json` leaves every later read rebuilding it, and a skill
+ * whose frontmatter does not parse is a capability that disappears from the
+ * registry at the next reload. Both of those fail silently, which is why the
+ * parse happens here rather than being trusted to the caller.
+ *
+ * **An id is derived, never invented by the caller.** Every Markdown store
+ * slugifies from the title, and skills refuse a name needing a slug rather than
+ * renaming one silently — a renamed skill is a policy rule that stops matching.
+ * So `create` reads the id out of the document it was handed and answers with
+ * what it actually wrote.
+ *
+ * **Every write is recorded before it is answered.** `recordDataChange` writes
+ * the capability an agent would have used, so one search over the log finds
+ * both. Identifiers are kept, the document is not.
+ */
+
+const now = (): string => new Date().toISOString();
+
+function decode(bytes: Uint8Array): string {
+  return new TextDecoder().decode(bytes);
+}
+
+function encode(text: string): Uint8Array {
+  return new TextEncoder().encode(text);
+}
+
+/**
+ * The capability a store's write and removal are recorded under.
+ *
+ * The names an agent's call carries, so a row written from a browser and a row
+ * written over MCP sort together rather than needing two vocabularies.
+ */
+const WROTE: Record<Exclude<DataStoreName, 'vault'>, DataCapability> = {
+  memory: 'memory.write',
+  tasks: 'tasks.add',
+  assets: 'assets.store',
+  skills: 'skills.manage.write',
+  entities: 'entities.write',
+};
+
+const REMOVED: Record<Exclude<DataStoreName, 'vault'>, DataCapability> = {
+  memory: 'memory.forget',
+  tasks: 'tasks.remove',
+  assets: 'assets.remove',
+  skills: 'skills.manage.remove',
+  entities: 'entities.forget',
+};
+
+/**
+ * The id a document is about to be stored under.
+ *
+ * Read out of the document by the store's own parser, so a title becomes the
+ * same id it would have become through the CLI or over MCP. `null` where the
+ * document carries nothing to derive one from, which is a `400` rather than a
+ * generated name nobody asked for.
+ */
+function idFromDocument(store: DataStoreName, body: string): string | null {
+  const { frontmatter } = splitTitle(body);
+  const title = frontmatter ?? '';
+  if (title.trim().length === 0) return null;
+
+  const slug =
+    store === 'tasks'
+      ? taskStorage.slugify(title)
+      : store === 'entities'
+        ? entityStorage.slugify(title)
+        : memoryStorage.slugify(title);
+
+  return slug.length > 0 ? slug : null;
+}
+
+/**
+ * The `title:` or `name:` line, without parsing the whole document.
+ *
+ * A create has to know the id before it can validate the document against the
+ * store, and every store's parser wants an id to parse *with* — so this reads
+ * the one line it needs. Deliberately shallow: the real parse happens below and
+ * is what decides whether the write is accepted.
+ */
+function splitTitle(body: string): { frontmatter: string | null } {
+  const match = /^---\r?\n([\s\S]*?)\r?\n---/.exec(body);
+  if (!match) return { frontmatter: null };
+
+  const line = /^(?:title|name):\s*(.+)$/m.exec(match[1] ?? '');
+  const value = line?.[1]?.trim() ?? '';
+  return { frontmatter: value.replace(/^["']|["']$/g, '') };
+}
+
+export async function writeItem(
+  runtime: Runtime,
+  store: DataStoreName,
+  id: string,
+  body: string,
+): Promise<Answer<DataDetail>> {
+  if (store === 'vault') return notWritable();
+
+  const scoped = storeFor(runtime, store);
+  if (!scoped.ok) return scoped;
+
+  const existed = await exists(scoped.value.store, store, id);
+  const accepted = await persist(scoped.value.store, store, id, body);
+  if (!accepted.ok) return accepted;
+
+  await recordDataChange(runtime, DASHBOARD_PRINCIPAL, {
+    capability: WROTE[store],
+    connection: scoped.value.connection,
+    provider: scoped.value.provider,
+    // Identifiers and shape, never the document. The house rule for a write
+    // log: it must record that something changed and what, without becoming a
+    // second copy of the thing that changed.
+    arguments: { id, store, bytes: encode(body).byteLength, replaced: existed },
+  });
+
+  return readItem(runtime, store, id);
+}
+
+export async function createItem(
+  runtime: Runtime,
+  store: DataStoreName,
+  body: string,
+): Promise<Answer<DataDetail>> {
+  if (store === 'vault') return notWritable();
+
+  const id = idFromDocument(store, body);
+  if (id === null) {
+    return refused(
+      400,
+      'no_title',
+      'A new item needs frontmatter carrying a title, which is what its id is derived from.',
+    );
+  }
+
+  return writeItem(runtime, store, id, body);
+}
+
+export async function removeItem(
+  runtime: Runtime,
+  store: DataStoreName,
+  id: string,
+): Promise<Answer<void>> {
+  if (store === 'vault') return notWritable();
+
+  const scoped = storeFor(runtime, store);
+  if (!scoped.ok) return scoped;
+
+  const blobs = scoped.value.store;
+
+  if (store === 'entities') {
+    const catalogue = await openCatalogue(blobs);
+    if (!catalogue.entities.some((one) => one.id === id)) return missing(store, id);
+    await forgetEntity(blobs, catalogue, id, now());
+  } else if (store === 'skills') {
+    if (!(await removeSkill(blobs, id))) return missing(store, id);
+  } else {
+    const key = keyFor(store, id);
+    if (!(await blobs.has(key))) return missing(store, id);
+    await blobs.delete(key);
+  }
+
+  await recordDataChange(runtime, DASHBOARD_PRINCIPAL, {
+    capability: REMOVED[store],
+    connection: scoped.value.connection,
+    provider: scoped.value.provider,
+    arguments: { id, store },
+  });
+
+  return answered(undefined);
+}
+
+/**
+ * Put one document on the store, through whatever owns its format.
+ *
+ * Each branch validates by parsing and refuses with the message the parser
+ * wrote. A `400` here is the one refusal on this surface a reader is shown
+ * verbatim: "not paired" for a skill with a bad `description:` would send
+ * somebody to re-run a pairing command that was never the problem.
+ */
+async function persist(
+  blobs: BlobStore,
+  store: DataStoreName,
+  id: string,
+  body: string,
+): Promise<Answer<void>> {
+  try {
+    switch (store) {
+      case 'memory': {
+        // Parsed to prove it reads back as the entry a listing will show, then
+        // stored as written. Frontmatter is optional here by design, so a
+        // document without any is an entry titled after its id, not an error.
+        memoryStorage.parse(id, body, now());
+        await blobs.put(memoryStorage.key(id), encode(body), { contentType: 'text/markdown' });
+        return answered(undefined);
+      }
+      case 'tasks': {
+        taskStorage.parse(id, body, now());
+        await blobs.put(taskStorage.key(id), encode(body), { contentType: 'text/markdown' });
+        return answered(undefined);
+      }
+      case 'entities': {
+        const entity = entityStorage.parse(id, body, now());
+        // Through `persistEntity`, never `writeEntity`: it is what keeps
+        // `_index.json` describing the store it sits in.
+        await persistEntity(blobs, entity);
+        return answered(undefined);
+      }
+      case 'skills': {
+        // `writeSkill` parses before it persists and rewrites an existing skill
+        // in whatever layout it already has, so nothing here decides between
+        // `<name>.md` and `<name>/SKILL.md`.
+        await writeSkill(blobs, id, body);
+        return answered(undefined);
+      }
+      case 'assets': {
+        assetStorage.assertName(id);
+        await blobs.put(id, encode(body), { contentType: 'text/plain; charset=utf-8' });
+        return answered(undefined);
+      }
+      default:
+        return notWritable();
+    }
+  } catch (error) {
+    return refused(400, 'rejected', message(error));
+  }
+}
+
+function keyFor(store: DataStoreName, id: string): string {
+  switch (store) {
+    case 'memory':
+      return memoryStorage.key(id);
+    case 'tasks':
+      return taskStorage.key(id);
+    case 'entities':
+      return entityStorage.key(id);
+    default:
+      return id;
+  }
+}
+
+async function exists(blobs: BlobStore, store: DataStoreName, id: string): Promise<boolean> {
+  if (store === 'skills') return (await readSkill(blobs, id).catch(() => null)) !== null;
+  return blobs.has(keyFor(store, id));
+}
+
+function notWritable<T>(): Answer<T> {
+  // The same answer an unroutable path gets. A distinguishable refusal would
+  // confirm the shape of what is here to a page that is not the dashboard.
+  return refused(404, 'not_found', 'Not found.');
+}
+
+function missing<T>(store: string, id: string): Answer<T> {
+  return refused(404, 'not_found', `No ${store} item ${JSON.stringify(id)} in this profile.`);
+}
+
+function message(error: unknown): string {
+  if (error instanceof ConfigError) return error.message;
+  return error instanceof Error ? error.message : String(error);
+}

--- a/src/cli/owner-data/index.ts
+++ b/src/cli/owner-data/index.ts
@@ -1,0 +1,89 @@
+import type { Runtime } from '../runtime.ts';
+import { listItems, readContent, readItem } from './browse.ts';
+import { createItem, removeItem, writeItem } from './edit.ts';
+import { refused, type Answer, type DataSurface } from './surface.ts';
+
+export {
+  DATA_STORES,
+  DASHBOARD_PRINCIPAL,
+  isDataStore,
+  isWritableStore,
+  type Answer,
+  type DataContent,
+  type DataDetail,
+  type DataItem,
+  type DataRefusal,
+  type DataScope,
+  type DataStoreName,
+  type DataSurface,
+  type ListOptions,
+} from './surface.ts';
+
+/**
+ * The owner's data, as one object the read surface can hold.
+ *
+ * Built over the *generation's* runtimes rather than over the primary one.
+ * `ProfileRuntime` carries a registry, a dispatcher and a policy and no store
+ * at all, so the map the MCP surface reads cannot answer this — and reading the
+ * primary runtime would make every profile but one unreachable on an endpoint
+ * whose whole shape is that it serves them all (ADR-009).
+ *
+ * A thunk, for the reason `ReadDeps.profiles` is one: a reload replaces the
+ * runtimes, and a surface closed over the set it was built with would keep
+ * serving the generation that has been closed.
+ */
+export function dataSurface(runtimes: () => ReadonlyMap<string, Runtime>): DataSurface {
+  /**
+   * The runtime for a named profile, or the refusal for one this endpoint does
+   * not serve.
+   *
+   * `404`, not a default. Defaulting would let a page write to a profile the
+   * person at it was not looking at, and naming the profiles that do exist
+   * would answer a question the caller has already been answered by `/state`
+   * if they are entitled to it.
+   */
+  function open(profile: string): Answer<Runtime> {
+    const runtime = runtimes().get(profile);
+    return runtime
+      ? { ok: true, value: runtime }
+      : refused(404, 'not_found', 'Not found.');
+  }
+
+  return {
+    async list(options) {
+      const runtime = open(options.profile);
+      if (!runtime.ok) return runtime;
+      return listItems(runtime.value, options.store, options);
+    },
+
+    async read(options) {
+      const runtime = open(options.profile);
+      if (!runtime.ok) return runtime;
+      return readItem(runtime.value, options.store, options.id);
+    },
+
+    async content(options) {
+      const runtime = open(options.profile);
+      if (!runtime.ok) return runtime;
+      return readContent(runtime.value, options.name);
+    },
+
+    async create(options) {
+      const runtime = open(options.profile);
+      if (!runtime.ok) return runtime;
+      return createItem(runtime.value, options.store, options.body);
+    },
+
+    async write(options) {
+      const runtime = open(options.profile);
+      if (!runtime.ok) return runtime;
+      return writeItem(runtime.value, options.store, options.id, options.body);
+    },
+
+    async remove(options) {
+      const runtime = open(options.profile);
+      if (!runtime.ok) return runtime;
+      return removeItem(runtime.value, options.store, options.id);
+    },
+  };
+}

--- a/src/cli/owner-data/owner-data.test.ts
+++ b/src/cli/owner-data/owner-data.test.ts
@@ -1,0 +1,374 @@
+import { afterAll, beforeAll, describe, expect, test } from 'bun:test';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { profileAdd } from '../commands/profile.ts';
+import { openRuntime, type Runtime } from '../runtime.ts';
+import { dataSurface } from './index.ts';
+import { listItems, readItem } from './browse.ts';
+import { createItem, removeItem, writeItem } from './edit.ts';
+
+/**
+ * The data surface, against a real workspace on disk.
+ *
+ * Plain function calls over a temp `LANES_LINK_HOME`, not the HTTP surface:
+ * what is being asserted here is that a write lands where the *provider* reads,
+ * which is the failure a route test cannot see. `src/server/read/data.test.ts`
+ * covers the transport.
+ *
+ * A profile created by `profileAdd` arrives with the whole owner layer granted
+ * (ADR-050), which is what makes `storeFor` resolve without any further setup.
+ */
+
+let home: string;
+let runtime: Runtime;
+
+const MEMORY = ['---', 'title: A first note', 'tags:', '  - inbox', '---', '', 'The body.'].join('\n');
+
+beforeAll(async () => {
+  home = await mkdtemp(join(tmpdir(), 'lanes-data-'));
+  process.env['LANES_LINK_HOME'] = home;
+
+  // `profileAdd` writes its JSON to the stdout the reporter uses.
+  const write = process.stdout.write.bind(process.stdout);
+  try {
+    (process.stdout as unknown as { write: () => boolean }).write = (): boolean => true;
+    await profileAdd('personal', { targets: ['local'], nonInteractive: true, json: true });
+  } finally {
+    (process.stdout as unknown as { write: typeof write }).write = write;
+  }
+
+  runtime = await openRuntime({ profile: 'personal', target: 'local' });
+});
+
+afterAll(async () => {
+  await runtime?.close();
+  delete process.env['LANES_LINK_HOME'];
+  await rm(home, { recursive: true, force: true });
+});
+
+describe('memory', () => {
+  test('a write round-trips through the store the provider reads', async () => {
+    const written = await writeItem(runtime, 'memory', 'a-first-note', MEMORY);
+    expect(written.ok).toBe(true);
+
+    // Read back through `readItem`, which goes via `memoryStorage` — the same
+    // object `lanes_memory.get` and `lanes link memory get` read through.
+    const read = await readItem(runtime, 'memory', 'a-first-note');
+    if (!read.ok) throw new Error(read.refusal.message);
+
+    expect(read.value.title).toBe('A first note');
+    expect(read.value.tags).toEqual(['inbox']);
+    expect(read.value.body).toBe(MEMORY);
+  });
+
+  test('a listing shows it, and a query that misses does not', async () => {
+    await writeItem(runtime, 'memory', 'a-first-note', MEMORY);
+
+    const all = await listItems(runtime, 'memory', {});
+    if (!all.ok) throw new Error(all.refusal.message);
+    expect(all.value.map((one) => one.id)).toContain('a-first-note');
+
+    const miss = await listItems(runtime, 'memory', { query: 'nothing-matches-this' });
+    if (!miss.ok) throw new Error(miss.refusal.message);
+    expect(miss.value).toEqual([]);
+  });
+
+  test('a removal takes it out, and removing it twice is not found', async () => {
+    await writeItem(runtime, 'memory', 'to-forget', MEMORY);
+    expect((await removeItem(runtime, 'memory', 'to-forget')).ok).toBe(true);
+
+    const again = await removeItem(runtime, 'memory', 'to-forget');
+    expect(again.ok).toBe(false);
+    if (!again.ok) expect(again.refusal.status).toBe(404);
+  });
+});
+
+describe('entities', () => {
+  const ENTITY = ['---', 'type: person', 'name: Ada', 'aliases:', '  - ada', '---', '', 'Notes.'].join(
+    '\n',
+  );
+
+  test('a write leaves the derived index describing the store', async () => {
+    const written = await writeItem(runtime, 'entities', 'ada', ENTITY);
+    expect(written.ok).toBe(true);
+
+    // `persistEntity` rather than a bare put is the whole point: the index is
+    // a cache stamped with a fingerprint of the entity files, and a write that
+    // skipped it would leave every later read rebuilding.
+    const { indexState } = await import('#providers/entities/catalogue.ts');
+    const { storeFor } = await import('./stores.ts');
+    const scoped = storeFor(runtime, 'entities');
+    if (!scoped.ok) throw new Error(scoped.refusal.message);
+
+    expect((await indexState(scoped.value.store)).current).toBe(true);
+  });
+
+  test('a removal leaves the index current too', async () => {
+    await writeItem(runtime, 'entities', 'to-drop', ENTITY);
+    expect((await removeItem(runtime, 'entities', 'to-drop')).ok).toBe(true);
+
+    const { indexState } = await import('#providers/entities/catalogue.ts');
+    const { storeFor } = await import('./stores.ts');
+    const scoped = storeFor(runtime, 'entities');
+    if (!scoped.ok) throw new Error(scoped.refusal.message);
+
+    expect((await indexState(scoped.value.store)).current).toBe(true);
+  });
+});
+
+describe('skills', () => {
+  test('a document with no description is refused, and nothing is written', async () => {
+    const refusal = await writeItem(runtime, 'skills', 'broken', '---\ntitle: no description\n---\n\nBody.');
+
+    expect(refusal.ok).toBe(false);
+    // A `400` carrying the parser's own message, not the surface's one error.
+    // "not paired" for a bad `description:` would send somebody to re-run a
+    // pairing command that was never the problem.
+    if (!refusal.ok) expect(refusal.refusal.status).toBe(400);
+
+    expect((await readItem(runtime, 'skills', 'broken')).ok).toBe(false);
+  });
+
+  test('a valid skill round-trips whole, frontmatter included', async () => {
+    const document = ['---', 'description: Review a diff.', '---', '', 'Read the diff.'].join('\n');
+    expect((await writeItem(runtime, 'skills', 'review-diff', document)).ok).toBe(true);
+
+    const read = await readItem(runtime, 'skills', 'review-diff');
+    if (!read.ok) throw new Error(read.refusal.message);
+    expect(read.value.body).toContain('description: Review a diff.');
+    expect(read.value.summary).toBe('Review a diff.');
+  });
+});
+
+describe('the vault', () => {
+  test('lists by name and never carries a value', async () => {
+    await runtime.vault.put('lan1', { id: 'api_key', value: 'secret-value', description: 'A key' });
+
+    const listed = await listItems(runtime, 'vault', {});
+    if (!listed.ok) throw new Error(listed.refusal.message);
+
+    const row = listed.value.find((one) => one.id === 'api_key');
+    expect(row?.summary).toBe('A key');
+    expect(JSON.stringify(listed.value)).not.toContain('secret-value');
+  });
+
+  test('opens, says why the value is not here, and refuses every write', async () => {
+    await runtime.vault.put('lan1', { id: 'api_key', value: 'secret-value' });
+
+    const read = await readItem(runtime, 'vault', 'api_key');
+    if (!read.ok) throw new Error(read.refusal.message);
+    expect(read.value.body).toBeNull();
+    expect(read.value.readOnly).toContain('never returned to a browser');
+    expect(JSON.stringify(read.value)).not.toContain('secret-value');
+
+    // Not `405`, and not a message naming the vault: the same answer an
+    // unroutable path gets, so nothing is confirmed to a page that is not the
+    // dashboard (ADR-069).
+    for (const attempt of [
+      await writeItem(runtime, 'vault', 'api_key', 'anything'),
+      await removeItem(runtime, 'vault', 'api_key'),
+      await createItem(runtime, 'vault', '---\ntitle: x\n---\n'),
+    ]) {
+      expect(attempt.ok).toBe(false);
+      if (!attempt.ok) expect(attempt.refusal.status).toBe(404);
+    }
+  });
+});
+
+describe('creating', () => {
+  test('derives the id from the document rather than taking one', async () => {
+    const created = await createItem(
+      runtime,
+      'memory',
+      '---\ntitle: Derived From Title\n---\n\nBody.',
+    );
+    if (!created.ok) throw new Error(created.refusal.message);
+
+    expect(created.value.id).toBe('derived-from-title');
+  });
+
+  test('refuses a document with no title to derive one from', async () => {
+    const refusal = await createItem(runtime, 'memory', 'No frontmatter at all.');
+    expect(refusal.ok).toBe(false);
+    if (!refusal.ok) expect(refusal.refusal.status).toBe(400);
+  });
+});
+
+describe('the surface a route holds', () => {
+  test('a profile this endpoint does not serve is not found', async () => {
+    const surface = dataSurface(() => new Map([['personal', runtime]]));
+
+    const answer = await surface.list({ profile: 'work', store: 'memory' });
+    expect(answer.ok).toBe(false);
+    // Not "no such profile". A caller who may not read `/state` learns nothing
+    // about which profiles exist.
+    if (!answer.ok) expect(answer.refusal).toEqual({
+      status: 404,
+      error: 'not_found',
+      message: 'Not found.',
+    });
+  });
+
+  test('reads through the generation it is asked at, not the one it was built with', async () => {
+    let current = new Map<string, Runtime>();
+    const surface = dataSurface(() => current);
+
+    expect((await surface.list({ profile: 'personal', store: 'memory' })).ok).toBe(false);
+
+    current = new Map([['personal', runtime]]);
+    expect((await surface.list({ profile: 'personal', store: 'memory' })).ok).toBe(true);
+  });
+});
+
+describe('the audit log', () => {
+  test('records a write with the identifiers and without the document', async () => {
+    const body = '---\ntitle: Logged\n---\n\nA sentence that must not be in the log.';
+    await writeItem(runtime, 'memory', 'logged', body);
+
+    const events = await runtime.audit.tail({ limit: 50 });
+    const written = events.filter((event) => event.capability === 'memory.write');
+    expect(written.length).toBeGreaterThan(0);
+
+    const last = written[written.length - 1]!;
+    expect(last.provider).toBe('lanes_memory');
+    expect(last.principal).toBe('lanes:dashboard');
+    expect(last.arguments).toMatchObject({ id: 'logged', store: 'memory' });
+    expect(JSON.stringify(last.arguments)).not.toContain('must not be in the log');
+  });
+
+  test('records a removal under the capability an agent would have called', async () => {
+    await writeItem(runtime, 'memory', 'logged-removal', MEMORY);
+    await removeItem(runtime, 'memory', 'logged-removal');
+
+    const events = await runtime.audit.tail({ limit: 50 });
+    expect(events.some((event) => event.capability === 'memory.forget')).toBe(true);
+  });
+});
+
+describe('ordering', () => {
+  test('every store answers most recently touched first', async () => {
+    // Written oldest first, so passing this cannot be an accident of insertion
+    // order or of the store's own listing. The marker in each title is what the
+    // query narrows on, so entries written by the blocks above cannot join in.
+    for (const [id, when] of [
+      ['ordercheck-older', '2026-01-01T00:00:00.000Z'],
+      ['ordercheck-newest', '2026-06-01T00:00:00.000Z'],
+      ['ordercheck-middle', '2026-03-01T00:00:00.000Z'],
+    ] as const) {
+      await writeItem(
+        runtime,
+        'memory',
+        id,
+        `---\ntitle: ${id}\nupdated_at: ${when}\n---\n\nBody.`,
+      );
+    }
+
+    const listed = await listItems(runtime, 'memory', { query: 'ordercheck-' });
+    if (!listed.ok) throw new Error(listed.refusal.message);
+
+    expect(listed.value.map((one) => one.id)).toEqual([
+      'ordercheck-newest',
+      'ordercheck-middle',
+      'ordercheck-older',
+    ]);
+  });
+
+  test('a task list here is ordered by recency, not by what to do next', async () => {
+    // `compareTasks` ranks by status and would put the done task last. That rule
+    // is right for `lanes link tasks list` and wrong for a browser, which is
+    // asked "what changed" rather than "what next" — and the status is on the
+    // row either way.
+    await writeItem(
+      runtime,
+      'tasks',
+      'ordercheck-done',
+      '---\ntitle: ordercheck done recently\nstatus: done\nupdated_at: 2026-06-01T00:00:00.000Z\n---\n\nx',
+    );
+    await writeItem(
+      runtime,
+      'tasks',
+      'ordercheck-open',
+      '---\ntitle: ordercheck open long ago\nstatus: open\nupdated_at: 2026-01-01T00:00:00.000Z\n---\n\nx',
+    );
+
+    const listed = await listItems(runtime, 'tasks', { query: 'ordercheck' });
+    if (!listed.ok) throw new Error(listed.refusal.message);
+
+    expect(listed.value.map((one) => one.id)).toEqual(['ordercheck-done', 'ordercheck-open']);
+  });
+
+  test('an item with no timestamp sorts last, and by name', async () => {
+    // Skills carry no `updated_at`. Absent is unknown rather than new, so they
+    // fall back to the name their column actually shows.
+    for (const name of ['zeta-ordercheck', 'alpha-ordercheck']) {
+      await writeItem(runtime, 'skills', name, `---\ndescription: ${name}.\n---\n\nBody.`);
+    }
+
+    const listed = await listItems(runtime, 'skills', { query: 'ordercheck' });
+    if (!listed.ok) throw new Error(listed.refusal.message);
+
+    expect(listed.value.map((one) => one.id)).toEqual(['alpha-ordercheck', 'zeta-ordercheck']);
+  });
+});
+
+describe('a timestamp is compared as a time, not as text', () => {
+  test('mixed spellings of the same instant still order correctly', async () => {
+    // All three are what a store actually holds: the endpoint writes the first,
+    // and the owner edits these files by hand. As strings, "2026-05-02" sorts
+    // above "2026-05-01T23:00:00.000Z" and an offset sorts by its literal hour.
+    await writeItem(
+      runtime,
+      'memory',
+      'stamp-utc',
+      '---\ntitle: stamp utc\nupdated_at: 2026-05-01T23:00:00.000Z\n---\n\nx',
+    );
+    await writeItem(
+      runtime,
+      'memory',
+      'stamp-dateonly',
+      '---\ntitle: stamp dateonly\nupdated_at: 2026-05-02\n---\n\nx',
+    );
+    await writeItem(
+      runtime,
+      'memory',
+      'stamp-offset',
+      '---\ntitle: stamp offset\nupdated_at: 2026-05-03T01:00:00+02:00\n---\n\nx',
+    );
+
+    const listed = await listItems(runtime, 'memory', { query: 'stamp-' });
+    if (!listed.ok) throw new Error(listed.refusal.message);
+
+    // 2026-05-02T23:00Z, then 2026-05-02T00:00Z, then 2026-05-01T23:00Z.
+    expect(listed.value.map((one) => one.id)).toEqual([
+      'stamp-offset',
+      'stamp-dateonly',
+      'stamp-utc',
+    ]);
+  });
+
+  test('a timestamp nobody can read joins the items that have none', async () => {
+    await writeItem(
+      runtime,
+      'memory',
+      'stampbad-unreadable',
+      '---\ntitle: stampbad unreadable\nupdated_at: last Tuesday\n---\n\nx',
+    );
+    await writeItem(
+      runtime,
+      'memory',
+      'stampbad-dated',
+      '---\ntitle: stampbad dated\nupdated_at: 2020-01-01T00:00:00.000Z\n---\n\nx',
+    );
+
+    const listed = await listItems(runtime, 'memory', { query: 'stampbad-' });
+    if (!listed.ok) throw new Error(listed.refusal.message);
+
+    // Unknown sorts last rather than claiming to be the oldest thing here,
+    // which is what treating it as zero would have done.
+    expect(listed.value.map((one) => one.id)).toEqual([
+      'stampbad-dated',
+      'stampbad-unreadable',
+    ]);
+  });
+});

--- a/src/cli/owner-data/stores.ts
+++ b/src/cli/owner-data/stores.ts
@@ -1,0 +1,101 @@
+import { scopeNamespace } from '#dispatch';
+import { scopeBlobStore, type BlobStore } from '#stores/blobs';
+import type { Config } from '#profile';
+import type { Runtime } from '../runtime.ts';
+import { answered, refused, type Answer, type DataStoreName } from './surface.ts';
+
+/**
+ * Which bytes a store name means, for one profile.
+ *
+ * Built from `scopeNamespace` and `scopeBlobStore` — the two functions
+ * `buildProviderContext` uses — rather than from a path spelled out again, for
+ * the reason `memoryStore` in `commands/owner/memory.ts` gives: a second
+ * spelling is a second directory the day one of them changes.
+ *
+ * Skills are the exception and are not scoped here at all. They live at
+ * `skills.d/<connection>/` rather than under a provider's blob root, so the
+ * runtime hands the store over whole — and hands over `undefined` when the
+ * profile grants no skills connection, which is a real state rather than an
+ * empty one (ADR-050: a surface that is missing was denied on purpose).
+ */
+
+/** The provider id each browsable store belongs to. */
+const PROVIDER: Record<Exclude<DataStoreName, 'vault'>, string> = {
+  memory: 'lanes_memory',
+  tasks: 'lanes_tasks',
+  assets: 'lanes_assets',
+  skills: 'lanes_skills',
+  entities: 'lanes_entities',
+};
+
+/**
+ * The connection this profile grants for a provider, or nothing.
+ *
+ * Derived from the grants rather than from the workspace's connections, which
+ * is the same question `ownerConnection` asks and the same reason: a workspace
+ * holding a store this profile does not grant is not a candidate, and offering
+ * it would let the dashboard write somewhere the endpoint would refuse to read.
+ *
+ * Unlike `ownerConnection` this does not refuse an ambiguous profile by
+ * throwing. Two connections is a legitimate shape and the caller may name one;
+ * absent a name the first grant wins, in declaration order, because a browser
+ * has no terminal to be asked at and a listing that fails is worse than one
+ * that shows the store the profile lists first.
+ */
+function connectionFor(config: Config, provider: string): string | null {
+  const prefix = `${provider}.`;
+  const grant = config.grants.find((one) => one.connection.startsWith(prefix));
+  return grant ? grant.connection.slice(prefix.length) : null;
+}
+
+export interface ScopedStore {
+  readonly store: BlobStore;
+  /** `<provider>.<connection>`, for the audit row. */
+  readonly connection: string;
+  readonly provider: string;
+}
+
+/**
+ * The store behind one profile's copy of a browsable name.
+ *
+ * `409` rather than `404` when the profile grants nothing: the store exists and
+ * the person asking owns it, so telling them the grant is missing is useful and
+ * reveals nothing they did not already have. A missing *profile* is the other
+ * answer and is decided before this is called.
+ */
+export function storeFor(runtime: Runtime, store: DataStoreName): Answer<ScopedStore> {
+  if (store === 'vault') {
+    return refused(409, 'not_a_blob_store', 'The vault is not read through a blob store.');
+  }
+
+  const provider = PROVIDER[store];
+  const connection = connectionFor(runtime.config, provider);
+
+  if (connection === null) {
+    return refused(
+      409,
+      'not_granted',
+      `This profile grants no ${provider} connection, so there is nothing here to read.`,
+    );
+  }
+
+  if (store === 'skills') {
+    // Handed over whole rather than scoped, because it is not under the
+    // provider blob root. `undefined` and "granted but empty" are different
+    // facts and only the first one gets here.
+    if (!runtime.skills) {
+      return refused(
+        409,
+        'not_granted',
+        'This profile grants no skills connection, so there is nothing here to read.',
+      );
+    }
+    return answered({ store: runtime.skills, connection: `${provider}.${connection}`, provider });
+  }
+
+  return answered({
+    store: scopeBlobStore(runtime.storage, scopeNamespace(provider, connection)),
+    connection: `${provider}.${connection}`,
+    provider,
+  });
+}

--- a/src/cli/owner-data/surface.ts
+++ b/src/cli/owner-data/surface.ts
@@ -1,0 +1,136 @@
+/**
+ * What the dashboard may do to the owner's own data, as one narrow interface.
+ *
+ * ADR-069 is the decision this expresses: a pairing token reads and writes
+ * memory, tasks, assets, skills and entities, lists the vault by name, and
+ * cannot reach a connection, a profile, a grant, a token, the configuration or
+ * the log. The shape of that permission is the shape of this file — there is no
+ * method here for anything the ADR refuses, which is a stronger guarantee than
+ * a check inside one.
+ *
+ * **It lives under `cli` because only `cli` may reach both a store and the
+ * log.** `src/architecture.test.ts` gives `dispatch` no path to `#providers`
+ * and `server` no path to either, so the alternative was widening the table for
+ * one surface. `server/read/data.ts` imports these *types* and nothing else,
+ * which is the same seam `readRoutes` already keeps with `AuditTail`.
+ *
+ * **Nothing here throws for a refusal.** A missing profile, a store the profile
+ * cannot reach and a document that will not parse are all answers rather than
+ * failures, and a route that had to tell an exception it expected from one it
+ * did not would get it wrong on the day it mattered. `Answer<T>` carries both.
+ */
+
+/**
+ * The stores a person may browse.
+ *
+ * A closed tuple, not a string: it is the whole of what ADR-069 opened, and the
+ * route validates against it rather than against whatever a caller sends.
+ * `identity` and `setup` are absent deliberately — both are configuration, and
+ * configuration is the CLI's (ADR-007).
+ */
+export const DATA_STORES = ['memory', 'tasks', 'assets', 'skills', 'entities', 'vault'] as const;
+
+export type DataStoreName = (typeof DATA_STORES)[number];
+
+export function isDataStore(value: string): value is DataStoreName {
+  return (DATA_STORES as readonly string[]).includes(value);
+}
+
+/** The stores a write may name. The vault is readable by name and never writable. */
+export function isWritableStore(store: DataStoreName): boolean {
+  return store !== 'vault';
+}
+
+/** One row in a listing. Enough to scan; never enough to be the document. */
+export interface DataItem {
+  readonly id: string;
+  readonly title: string;
+  /** The one line under the title: a task's status, an asset's type and size. */
+  readonly summary: string | null;
+  readonly updatedAt: string | null;
+  readonly tags: readonly string[];
+}
+
+export interface DataDetail extends DataItem {
+  /**
+   * The document exactly as it is stored, frontmatter included.
+   *
+   * Raw rather than a parsed object, because the panel that edits this would
+   * otherwise need a field per frontmatter key and a second copy of every
+   * store's schema. `null` where there is no text form: a binary asset, a vault
+   * item.
+   */
+  readonly body: string | null;
+  /** Why this cannot be edited here, or `null` when it can. Shown verbatim. */
+  readonly readOnly: string | null;
+  /** Assets only. Lets a reader choose between rendering, showing and describing. */
+  readonly contentType: string | null;
+  readonly bytes: number | null;
+}
+
+/** An asset's bytes, for the one route that serves them. */
+export interface DataContent {
+  readonly bytes: Uint8Array;
+  readonly contentType: string;
+}
+
+/**
+ * A refusal, with the status the surface should answer.
+ *
+ * `404` for anything whose existence is not this caller's to learn, `409` for a
+ * profile that grants no connection to the store asked for, and `400` for a
+ * document the store will not accept. Only the last carries a message worth
+ * showing: the other two are the same answer an unknown path gets, on purpose.
+ */
+export interface DataRefusal {
+  readonly status: 400 | 404 | 409;
+  readonly error: string;
+  readonly message: string;
+}
+
+export type Answer<T> =
+  | { readonly ok: true; readonly value: T }
+  | { readonly ok: false; readonly refusal: DataRefusal };
+
+export function answered<T>(value: T): Answer<T> {
+  return { ok: true, value };
+}
+
+export function refused<T>(
+  status: DataRefusal['status'],
+  error: string,
+  message: string,
+): Answer<T> {
+  return { ok: false, refusal: { status, error, message } };
+}
+
+/** Every read and write names the profile whose data it means. Never defaulted. */
+export interface DataScope {
+  readonly profile: string;
+  readonly store: DataStoreName;
+}
+
+export interface ListOptions extends DataScope {
+  readonly query?: string | undefined;
+  readonly limit?: number | undefined;
+}
+
+/**
+ * Who is asking, for the log.
+ *
+ * A pairing token authenticates the workspace's owner at a browser rather than
+ * an agent, and the log should be able to say so: a row written from here and a
+ * row written by a connected client are the same kind of event and must not
+ * look like the same actor.
+ */
+export const DASHBOARD_PRINCIPAL = 'lanes:dashboard';
+
+export interface DataSurface {
+  list(options: ListOptions): Promise<Answer<DataItem[]>>;
+  read(options: DataScope & { id: string }): Promise<Answer<DataDetail>>;
+  /** An asset's bytes. Refused for every other store. */
+  content(options: { profile: string; name: string }): Promise<Answer<DataContent>>;
+  create(options: DataScope & { body: string }): Promise<Answer<DataDetail>>;
+  write(options: DataScope & { id: string; body: string }): Promise<Answer<DataDetail>>;
+  remove(options: DataScope & { id: string }): Promise<Answer<void>>;
+}

--- a/src/server/edge.ts
+++ b/src/server/edge.ts
@@ -151,7 +151,7 @@ export function unauthenticatedRefusal(input: {
   readonly isAuthorizationPath: (pathname: string) => boolean;
   readonly authorizationEnabled: boolean;
   /** Passed rather than imported, for the reason `isAuthorizationPath` is. */
-  readonly isReadPath: (pathname: string) => boolean;
+  readonly isPairedPath: (pathname: string) => boolean;
   readonly readEnabled: boolean;
 }): Response | undefined {
   // A `/health` carrying no credential reads nothing and is deliberately free —
@@ -161,7 +161,7 @@ export function unauthenticatedRefusal(input: {
   const costly =
     input.pathname === input.healthPath
       ? input.request.headers.get('authorization') !== null
-      : (input.readEnabled && input.isReadPath(input.pathname)) ||
+      : (input.readEnabled && input.isPairedPath(input.pathname)) ||
         (input.authorizationEnabled && input.isAuthorizationPath(input.pathname));
 
   if (!costly) return undefined;

--- a/src/server/endpoint.ts
+++ b/src/server/endpoint.ts
@@ -19,6 +19,7 @@ import {
   toPolicyDocument,
 } from '#registry';
 import { openRuntime, type GlobalFlags, type Runtime } from '#cli/runtime.ts';
+import { dataSurface, type DataSurface } from '#cli/owner-data/index.ts';
 
 /**
  * Bringing the endpoint up: open a runtime per profile, reconcile, and serve.
@@ -218,6 +219,13 @@ export async function startEndpoint(options: EndpointOptions): Promise<RunningEn
     // thing `profile members add` tells the operator has taken effect.
     let serving: ReadonlyMap<string, Runtime> = runtimes;
 
+    // The owner's data, over the same holder for the same reason: a reload
+    // replaces the runtimes, and a surface closed over the set it was built
+    // with would keep reading a generation that has been closed. Built once and
+    // handed to both binds, so loopback and a deployed port cannot come to
+    // disagree about what a pairing token may do (ADR-069).
+    const data = dataSurface(() => serving);
+
     const gate = await openAuthorization(primary, log, async (subject) =>
       [...serving]
         .filter(([, runtime]) =>
@@ -278,6 +286,7 @@ export async function startEndpoint(options: EndpointOptions): Promise<RunningEn
         profiles: () => generations.current.profiles,
         log,
         version: runningVersion,
+        data,
       }),
     });
 
@@ -295,6 +304,7 @@ export async function startEndpoint(options: EndpointOptions): Promise<RunningEn
       () => generations.current.profiles,
       log,
       runningVersion,
+      data,
     );
 
     return {

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -4,7 +4,7 @@ import { capabilityIdForToolName } from '#server/mcp';
 import { ATTACHMENTS_PATH, handleAttachments } from './attachments.ts';
 import { allowedHostnamesFor, rebindingRefusal } from './rebinding.ts';
 import { ANY_ORIGIN, corsAware, type CorsPolicy } from './cors.ts';
-import { isReadPath, readRoutes, type ReadDeps } from './read/routes.ts';
+import { isPairedPath, readRoutes, type ReadDeps } from './read/routes.ts';
 import type { Generation } from './generation.ts';
 import type { Generations } from './generations.ts';
 import {
@@ -166,7 +166,7 @@ export function createRequestHandler(options: ServerOptions): RequestHandler {
           healthPath: HEALTH_PATH,
           isAuthorizationPath,
           authorizationEnabled: options.authorization !== undefined,
-          isReadPath,
+          isPairedPath,
           readEnabled: options.read !== undefined,
         });
         if (refusal) {
@@ -206,9 +206,9 @@ export function createRequestHandler(options: ServerOptions): RequestHandler {
       // different credential for a different surface, and one shared check
       // would make each able to do the other's job (ADR-063). Below the meter,
       // because verifying one costs a credential-store read. Only what
-      // `isReadPath` matched is handed over — `readRoutes` answers everything
+      // `isPairedPath` matched is handed over — `readRoutes` answers everything
       // it is given, so a wider hand-off would swallow `/mcp`.
-      if (options.read && isReadPath(url.pathname)) {
+      if (options.read && isPairedPath(url.pathname)) {
         return await readRoutes(request, options.read);
       }
 

--- a/src/server/read/data.test.ts
+++ b/src/server/read/data.test.ts
@@ -1,0 +1,470 @@
+import { afterAll, beforeAll, describe, expect, test } from 'bun:test';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { BearerAuthenticator } from '#auth';
+import { dataSurface, type Answer, type DataSurface } from '#cli/owner-data/index.ts';
+import { openRuntime, type Runtime } from '#cli/runtime.ts';
+import { profileAdd } from '#cli/commands/profile.ts';
+import { allocatePort, wireProfiles, HARNESS_SUBJECT, TEST_TOKEN } from '../harness.ts';
+import { createRequestHandler, MCP_PATH, serve } from '../index.ts';
+import { ATTACHMENTS_PATH } from '../attachments.ts';
+import { ANY_ORIGIN, corsAware } from '../cors.ts';
+import { Generations } from '../generations.ts';
+import { silentLogger } from '../logging.ts';
+import { directPairingCredential } from './credential.ts';
+import type { AuditTail, ReadDeps } from './routes.ts';
+
+/**
+ * `/data`, the surface a pairing token may write (ADR-069).
+ *
+ * Two halves, because two different things can break. The composed handler
+ * covers the transport — methods, CORS, the credential, and the mapping from a
+ * refusal to a status — with a stubbed surface, in `deployed.test.ts`'s shape
+ * and for the reason it gives: driving `dataRoutes` alone would pass while
+ * `corsAware` quietly overwrote its headers. The second half runs the same
+ * composition over a real workspace on disk, because "the write landed where
+ * the provider reads" is the failure a stubbed surface cannot see.
+ *
+ * Neither half binds TLS. `listener.test.ts` owns that, and it owns it over the
+ * same `readRoutes` these go through.
+ */
+
+const ORIGIN = 'https://lanes.sh';
+const HOSTILE = 'https://evil.example';
+const PAIR_TOKEN = 'llp_a-data-pairing-token';
+
+const AUDIT: AuditTail = { tail: async () => [] };
+
+/** Every call recorded, so a test can assert what did and did not reach it. */
+interface Spy extends DataSurface {
+  readonly calls: string[];
+}
+
+function stub(overrides: Partial<DataSurface> = {}): Spy {
+  const calls: string[] = [];
+  const seen = <T>(name: string, value: T) => {
+    calls.push(name);
+    return Promise.resolve({ ok: true, value } as Answer<T>);
+  };
+
+  return {
+    calls,
+    list: (options) => seen('list', [{ id: 'a', title: 'A', summary: null, updatedAt: null, tags: [options.store] }]),
+    read: () => seen('read', detail()),
+    content: () => seen('content', { bytes: new TextEncoder().encode('hi'), contentType: 'text/plain' }),
+    create: () => seen('create', detail()),
+    write: () => seen('write', detail()),
+    remove: () => seen('remove', undefined),
+    ...overrides,
+  } as Spy;
+}
+
+function detail() {
+  return {
+    id: 'a',
+    title: 'A',
+    summary: null,
+    updatedAt: null,
+    tags: [],
+    body: 'the document',
+    readOnly: null,
+    contentType: 'text/markdown',
+    bytes: 12,
+  };
+}
+
+function readDeps(overrides: Partial<ReadDeps> = {}): ReadDeps {
+  return {
+    workspace: 'cloud',
+    profiles: () => new Map(),
+    audit: AUDIT,
+    connections: async () => [],
+    credential: directPairingCredential({ read: async () => PAIR_TOKEN }),
+    endpoint: { kind: 'deployed', version: '0.0.0-test', certificateExpiresAt: null },
+    ...overrides,
+  };
+}
+
+function deployed(read: ReadDeps): (request: Request) => Promise<Response> {
+  const { profiles, credentials } = wireProfiles({
+    profile: 'personal',
+    port: allocatePort(),
+    policy: `  allow:\n    - "example.*"`,
+  });
+
+  const nothing = () => Promise.resolve();
+  const log = silentLogger();
+
+  const handler = createRequestHandler({
+    generations: new Generations(
+      { profiles, close: nothing },
+      async () => ({ profiles, close: nothing }),
+      { primary: 'personal', log },
+    ),
+    primary: 'personal',
+    authenticator: new BearerAuthenticator({
+      profile: 'personal',
+      tokens: async () => [{ id: 'tok1', subject: HARNESS_SUBJECT, ref: 'tokens/tok1' }],
+      credentials,
+      profilesFor: async () => ['personal'],
+    }),
+    log,
+    meterUnauthenticated: true,
+    read,
+  });
+
+  return corsAware((request) => handler.fetch(request), [MCP_PATH, ATTACHMENTS_PATH], {
+    allowedOrigins: [ANY_ORIGIN],
+  });
+}
+
+function send(
+  path: string,
+  init: { method?: string; body?: unknown; origin?: string; token?: string | null } = {},
+): Request {
+  const headers: Record<string, string> = { origin: init.origin ?? ORIGIN };
+  const token = init.token === undefined ? PAIR_TOKEN : init.token;
+  if (token !== null) headers['authorization'] = `Bearer ${token}`;
+  if (init.body !== undefined) headers['content-type'] = 'application/json';
+
+  return new Request(`https://endpoint.example${path}`, {
+    method: init.method ?? 'GET',
+    headers,
+    ...(init.body !== undefined ? { body: JSON.stringify(init.body) } : {}),
+  });
+}
+
+describe('the credential', () => {
+  test('an unpaired write is refused, and the surface is never asked', async () => {
+    const surface = stub();
+    const response = await deployed(readDeps({ data: surface }))(
+      send('/data/memory/a?profile=personal', { method: 'PUT', body: { body: 'x' }, token: null }),
+    );
+
+    expect(response.status).toBe(401);
+    expect(await response.json()).toMatchObject({ error: 'unpaired', run: 'lanes link pair' });
+    // The gate is above the store, so a stranger costs nothing.
+    expect(surface.calls).toEqual([]);
+  });
+
+  test('the MCP bearer does not write the data surface', async () => {
+    const surface = stub();
+    const response = await deployed(readDeps({ data: surface }))(
+      send('/data/memory/a?profile=personal', { method: 'PUT', body: { body: 'x' }, token: TEST_TOKEN }),
+    );
+
+    expect(response.status).toBe(401);
+    expect(surface.calls).toEqual([]);
+  });
+
+  test('a hostile origin is refused before the credential is looked at', async () => {
+    const surface = stub();
+    const response = await deployed(readDeps({ data: surface }))(
+      send('/data/memory?profile=personal', { origin: HOSTILE }),
+    );
+
+    expect(response.status).toBe(403);
+    expect(response.headers.get('vary')).toBe('Origin');
+    expect(surface.calls).toEqual([]);
+  });
+});
+
+describe('the methods, and where they stop', () => {
+  test('a preflight for a write names the methods and the header a body needs', async () => {
+    const response = await deployed(readDeps({ data: stub() }))(
+      new Request('https://endpoint.example/data/memory/a', {
+        method: 'OPTIONS',
+        headers: { origin: ORIGIN },
+      }),
+    );
+
+    expect(response.status).toBe(204);
+    expect(response.headers.get('access-control-allow-methods')).toContain('PUT');
+    expect(response.headers.get('access-control-allow-methods')).toContain('DELETE');
+    expect(response.headers.get('access-control-allow-headers')).toContain('content-type');
+    // Still never ambient. The whole safety of this surface rests on it.
+    expect(response.headers.get('access-control-allow-credentials')).toBeNull();
+  });
+
+  test('/state did not widen with it', async () => {
+    const allow = await deployed(readDeps({ data: stub() }))(
+      new Request('https://endpoint.example/state', {
+        method: 'OPTIONS',
+        headers: { origin: ORIGIN },
+      }),
+    );
+
+    expect(allow.headers.get('access-control-allow-methods')).toBe('GET, OPTIONS');
+
+    const written = await deployed(readDeps({ data: stub() }))(
+      send('/state', { method: 'PUT', body: { body: 'x' } }),
+    );
+
+    // Not 405, and not written: `/state` and `/audit` are reads only, still.
+    expect(written.status).toBe(404);
+  });
+
+  test('an endpoint with no data surface answers /data as an unknown path', async () => {
+    const response = await deployed(readDeps())(send('/data/memory?profile=personal'));
+
+    expect(response.status).toBe(404);
+  });
+});
+
+describe('what a path may name', () => {
+  test('a store that is not on the list is not found', async () => {
+    const surface = stub();
+    const response = await deployed(readDeps({ data: surface }))(
+      send('/data/credentials?profile=personal'),
+    );
+
+    expect(response.status).toBe(404);
+    expect(surface.calls).toEqual([]);
+  });
+
+  test('a missing profile is not found rather than defaulted', async () => {
+    const surface = stub();
+    const response = await deployed(readDeps({ data: surface }))(send('/data/memory'));
+
+    expect(response.status).toBe(404);
+    // Never a default: it would write into whichever profile happened to be first.
+    expect(surface.calls).toEqual([]);
+  });
+
+  test('a create names no id, and a write names one', async () => {
+    const surface = stub();
+    const deps = readDeps({ data: surface });
+
+    // The route decides these, not the surface: an id is derived from the
+    // document, so `POST` to one would be the caller inventing a name.
+    expect((await deployed(deps)(send('/data/memory/a?profile=personal', { method: 'POST', body: { body: 'x' } }))).status).toBe(404);
+    expect((await deployed(deps)(send('/data/memory?profile=personal', { method: 'PUT', body: { body: 'x' } }))).status).toBe(404);
+    expect((await deployed(deps)(send('/data/memory?profile=personal', { method: 'DELETE' }))).status).toBe(404);
+  });
+
+  test('a write with no document is a bad request, and never reaches the store', async () => {
+    const surface = stub();
+    const response = await deployed(readDeps({ data: surface }))(
+      send('/data/memory/a?profile=personal', { method: 'PUT', body: { nothing: true } }),
+    );
+
+    expect(response.status).toBe(400);
+    expect(surface.calls).toEqual([]);
+  });
+
+  test('the content route belongs to assets alone', async () => {
+    const surface = stub();
+    const deps = readDeps({ data: surface });
+
+    expect((await deployed(deps)(send('/data/assets/a.txt/content?profile=personal'))).status).toBe(200);
+    expect((await deployed(deps)(send('/data/memory/a/content?profile=personal'))).status).toBe(404);
+  });
+});
+
+describe('a refusal reaches the reader only when it is theirs to act on', () => {
+  test('a rejected document carries the message, because no command fixes it', async () => {
+    const surface = stub({
+      write: async () =>
+        ({ ok: false, refusal: { status: 400, error: 'rejected', message: 'skill: description is required' } }),
+    });
+
+    const response = await deployed(readDeps({ data: surface }))(
+      send('/data/skills/a?profile=personal', { method: 'PUT', body: { body: 'x' } }),
+    );
+
+    expect(response.status).toBe(400);
+    // "not paired" here would send somebody to re-run a pairing command that
+    // was never the problem.
+    expect(await response.json()).toMatchObject({ message: 'skill: description is required' });
+  });
+
+  test('a not-found carries no message at all', async () => {
+    const surface = stub({
+      read: async () => ({ ok: false, refusal: { status: 404, error: 'not_found', message: 'No memory item "a".' } }),
+    });
+
+    const response = await deployed(readDeps({ data: surface }))(send('/data/memory/a?profile=personal'));
+
+    expect(response.status).toBe(404);
+    expect(await response.json()).toEqual({ error: 'not_found' });
+  });
+});
+
+describe('an asset is served as a file, never as this origin', () => {
+  test('the bytes come back with the stored type, as an attachment, nosniff', async () => {
+    const surface = stub({
+      content: async () => ({
+        ok: true,
+        value: { bytes: new TextEncoder().encode('<script>alert(1)</script>'), contentType: 'text/html' },
+      }),
+    });
+
+    const response = await deployed(readDeps({ data: surface }))(
+      send('/data/assets/page.html/content?profile=personal'),
+    );
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get('content-type')).toBe('text/html');
+    // On a deployed bind this origin also serves `/mcp`, `/authorize` and the
+    // discovery documents. Inline would run that script in the endpoint's own
+    // origin, so both headers are unconditional.
+    expect(response.headers.get('content-disposition')).toBe('attachment');
+    expect(response.headers.get('x-content-type-options')).toBe('nosniff');
+  });
+});
+
+describe('a deployment-only grant stays one', () => {
+  test('a loopback bind does not serve /data on the MCP port', async () => {
+    const { profiles, credentials } = wireProfiles({
+      profile: 'personal',
+      port: allocatePort(),
+      policy: `  allow:\n    - "example.*"`,
+    });
+
+    const nothing = () => Promise.resolve();
+    const log = silentLogger();
+
+    const server = serve({
+      generations: new Generations(
+        { profiles, close: nothing },
+        async () => ({ profiles, close: nothing }),
+        { primary: 'personal', log },
+      ),
+      primary: 'personal',
+      authenticator: new BearerAuthenticator({
+        profile: 'personal',
+        tokens: async () => [{ id: 'tok1', subject: HARNESS_SUBJECT, ref: 'tokens/tok1' }],
+        credentials,
+        profilesFor: async () => ['personal'],
+      }),
+      log,
+      host: '127.0.0.1',
+      port: allocatePort(),
+      read: readDeps({ data: stub() }),
+    });
+
+    try {
+      const response = await fetch(
+        `${server.url.replace(MCP_PATH, '')}/data/memory?profile=personal`,
+        { method: 'PUT', headers: { authorization: `Bearer ${PAIR_TOKEN}` } },
+      );
+
+      // `serve()` discards `read` on loopback, so the write surface is not on
+      // the MCP port either. This is what keeps ADR-039's refusal intact.
+      expect(response.status).toBe(404);
+    } finally {
+      await server.stop();
+    }
+  });
+});
+
+describe('over the real composition, against a real workspace', () => {
+  let home: string;
+  let runtime: Runtime;
+  let handler: (request: Request) => Promise<Response>;
+
+  beforeAll(async () => {
+    home = await mkdtemp(join(tmpdir(), 'lanes-data-http-'));
+    process.env['LANES_LINK_HOME'] = home;
+
+    const write = process.stdout.write.bind(process.stdout);
+    try {
+      (process.stdout as unknown as { write: () => boolean }).write = (): boolean => true;
+      await profileAdd('personal', { targets: ['local'], nonInteractive: true, json: true });
+    } finally {
+      (process.stdout as unknown as { write: typeof write }).write = write;
+    }
+
+    runtime = await openRuntime({ profile: 'personal', target: 'local' });
+    handler = deployed(
+      readDeps({ data: dataSurface(() => new Map([['personal', runtime]])) }),
+    );
+  });
+
+  afterAll(async () => {
+    await runtime?.close();
+    delete process.env['LANES_LINK_HOME'];
+    await rm(home, { recursive: true, force: true });
+  });
+
+  test('a write over the route lands where the provider reads it', async () => {
+    const document = '---\ntitle: Over the wire\n---\n\nThe body.';
+
+    const written = await handler(
+      send('/data/memory/over-the-wire?profile=personal', { method: 'PUT', body: { body: document } }),
+    );
+    expect(written.status).toBe(200);
+
+    // Read back through the store the provider reads, not through the route
+    // that wrote it, so this cannot pass on a surface talking to itself.
+    const { memoryStorage } = await import('#providers/owner.ts');
+    const { storeFor } = await import('#cli/owner-data/stores.ts');
+    const scoped = storeFor(runtime, 'memory');
+    if (!scoped.ok) throw new Error(scoped.refusal.message);
+
+    const entry = await memoryStorage.read(scoped.value.store, 'over-the-wire');
+    expect(entry?.title).toBe('Over the wire');
+  });
+
+  test('the write it made is in the audit log, without the document', async () => {
+    await handler(
+      send('/data/memory/logged-over-http?profile=personal', {
+        method: 'PUT',
+        body: { body: '---\ntitle: Logged\n---\n\nSecret sentence.' },
+      }),
+    );
+
+    const events = await runtime.audit.tail({ limit: 50 });
+    const row = events.find(
+      (event) => event.capability === 'memory.write' && event.arguments['id'] === 'logged-over-http',
+    );
+
+    expect(row?.principal).toBe('lanes:dashboard');
+    expect(JSON.stringify(row?.arguments)).not.toContain('Secret sentence');
+  });
+
+  test('a listing and a delete round-trip', async () => {
+    await handler(
+      send('/data/tasks/a-task?profile=personal', {
+        method: 'PUT',
+        body: { body: '---\ntitle: A task\nstatus: open\n---\n\nDo it.' },
+      }),
+    );
+
+    const listed = await handler(send('/data/tasks?profile=personal'));
+    expect(listed.status).toBe(200);
+    expect(
+      ((await listed.json()) as { items: { id: string }[] }).items.map((one) => one.id),
+    ).toContain('a-task');
+
+    expect((await handler(send('/data/tasks/a-task?profile=personal', { method: 'DELETE' }))).status).toBe(200);
+    expect((await handler(send('/data/tasks/a-task?profile=personal'))).status).toBe(404);
+  });
+
+  test('a profile this endpoint does not serve is not found', async () => {
+    expect((await handler(send('/data/memory?profile=work'))).status).toBe(404);
+  });
+
+  test('every write to the vault is refused, and told nothing', async () => {
+    for (const attempt of [
+      send('/data/vault/api_key?profile=personal', { method: 'PUT', body: { body: 'x' } }),
+      send('/data/vault/api_key?profile=personal', { method: 'DELETE' }),
+      send('/data/vault?profile=personal', { method: 'POST', body: { body: 'x' } }),
+    ]) {
+      const response = await handler(attempt);
+      // The same body an unknown path gets. A distinguishable refusal would
+      // confirm the shape of what is here to a page that is not the dashboard.
+      expect(response.status).toBe(404);
+      expect(await response.json()).toEqual({ error: 'not_found' });
+    }
+  });
+
+  test('a vault listing carries no value under any key', async () => {
+    await runtime.vault.put('lan1', { id: 'api_key', value: 'a-secret-value', description: 'A key' });
+
+    const response = await handler(send('/data/vault?profile=personal'));
+    expect(response.status).toBe(200);
+    expect(await response.text()).not.toContain('a-secret-value');
+  });
+});

--- a/src/server/read/data.ts
+++ b/src/server/read/data.ts
@@ -1,0 +1,208 @@
+import { isDataStore, type Answer, type DataStoreName, type DataSurface } from '#cli/owner-data/surface.ts';
+import { json } from './http.ts';
+
+/**
+ * The owner's own data, over the pairing credential (ADR-069).
+ *
+ * A sibling of `./routes.ts` rather than a branch inside it, and it shares that
+ * file's gate rather than repeating it: `readRoutes` checks the origin and the
+ * credential once and hands over what `isDataPath` matched. So there is exactly
+ * one place a pairing token is verified, which is what stops the two surfaces
+ * disagreeing about who may reach them.
+ *
+ * **This knows no store's shape.** Every answer below is a projection of what
+ * `DataSurface` returned, and that interface is satisfied under `cli`, which is
+ * the only component allowed to reach both a store and the log. `server` may
+ * import neither, and this file widens nothing to get around that — the same
+ * arrangement `readRoutes` already keeps with `AuditTail`.
+ *
+ * **Methods are the whole of what changed.** `/state` and `/audit` still answer
+ * `404` to anything that is not a `GET`, and they still do it here.
+ */
+
+const DATA_PREFIX = '/data';
+
+/** The methods this surface answers. Everything else is a `404`, as elsewhere. */
+export const DATA_METHODS = 'GET, POST, PUT, DELETE, OPTIONS';
+
+/**
+ * `content-type` joins the allowed headers, because a body-carrying request is
+ * no longer simple and preflights on it. Named rather than reflected.
+ */
+export const DATA_HEADERS = 'authorization, content-type';
+
+export function isDataPath(pathname: string): boolean {
+  return pathname === DATA_PREFIX || pathname.startsWith(`${DATA_PREFIX}/`);
+}
+
+/** The most a listing returns, whatever was asked for. `/audit`'s ceiling. */
+const LIMIT_CEILING = 500;
+
+interface Route {
+  readonly store: DataStoreName;
+  readonly id: string | null;
+  /** `/data/assets/<name>/content`, the one route that answers bytes. */
+  readonly content: boolean;
+}
+
+/**
+ * The path, or `null` for anything that is not one of the five shapes.
+ *
+ * Rejected rather than repaired: a segment that is not a store on the closed
+ * list, an empty id, or a trailing segment other than `content` is not a path
+ * this surface has, and answering one would be inventing a route.
+ */
+function parse(pathname: string): Route | null {
+  const parts = pathname.slice(DATA_PREFIX.length).split('/').filter((one) => one.length > 0);
+  const [store, id, tail, ...rest] = parts;
+
+  if (store === undefined || !isDataStore(store) || rest.length > 0) return null;
+  if (id === undefined) return { store, id: null, content: false };
+
+  const name = safeDecode(id);
+  if (name === null || name.length === 0) return null;
+
+  if (tail === undefined) return { store, id: name, content: false };
+  if (tail === 'content' && store === 'assets') return { store, id: name, content: true };
+  return null;
+}
+
+/** A percent-encoded segment, or `null` where it will not decode. */
+function safeDecode(value: string): string | null {
+  try {
+    return decodeURIComponent(value);
+  } catch {
+    return null;
+  }
+}
+
+export async function dataRoutes(
+  request: Request,
+  url: URL,
+  surface: DataSurface,
+  headers: Record<string, string>,
+): Promise<Response> {
+  const route = parse(url.pathname);
+  const profile = url.searchParams.get('profile');
+
+  // Not found rather than a message naming what was wrong. An unknown store, a
+  // malformed path and a profile this endpoint does not serve are one answer,
+  // so none of them tells a page that is not the dashboard what does exist.
+  if (route === null || profile === null || profile === '') {
+    return json({ error: 'not_found' }, 404, headers);
+  }
+
+  if (route.content && route.id !== null) {
+    if (request.method !== 'GET') return json({ error: 'not_found' }, 404, headers);
+    return content(await surface.content({ profile, name: route.id }), headers);
+  }
+
+  const scope = { profile, store: route.store };
+
+  switch (request.method) {
+    case 'GET':
+      return route.id === null
+        ? answer(
+            await surface.list({
+              ...scope,
+              query: url.searchParams.get('query') ?? undefined,
+              limit: limitOf(url),
+            }),
+            headers,
+            (items) => ({ store: route.store, profile, items }),
+          )
+        : answer(await surface.read({ ...scope, id: route.id }), headers, (item) => item);
+
+    case 'POST': {
+      if (route.id !== null) return json({ error: 'not_found' }, 404, headers);
+      const body = await documentOf(request);
+      if (body === null) return json({ error: 'bad_request' }, 400, headers);
+      return answer(await surface.create({ ...scope, body }), headers, (item) => item);
+    }
+
+    case 'PUT': {
+      if (route.id === null) return json({ error: 'not_found' }, 404, headers);
+      const body = await documentOf(request);
+      if (body === null) return json({ error: 'bad_request' }, 400, headers);
+      return answer(await surface.write({ ...scope, id: route.id, body }), headers, (item) => item);
+    }
+
+    case 'DELETE': {
+      if (route.id === null) return json({ error: 'not_found' }, 404, headers);
+      return answer(await surface.remove({ ...scope, id: route.id }), headers, () => ({
+        id: route.id,
+        deleted: true,
+      }));
+    }
+
+    default:
+      return json({ error: 'not_found' }, 404, headers);
+  }
+}
+
+function limitOf(url: URL): number | undefined {
+  const raw = Number(url.searchParams.get('limit'));
+  if (!Number.isFinite(raw) || raw <= 0) return undefined;
+  return Math.min(raw, LIMIT_CEILING);
+}
+
+/** The `body` out of a JSON request, or `null` for anything that is not one. */
+async function documentOf(request: Request): Promise<string | null> {
+  try {
+    const parsed: unknown = await request.json();
+    if (typeof parsed !== 'object' || parsed === null) return null;
+    const body = (parsed as { body?: unknown }).body;
+    return typeof body === 'string' ? body : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * One answer, or the refusal the surface decided on.
+ *
+ * The status comes from the surface rather than being inferred here, because
+ * only it knows the difference between an item that is absent, a store this
+ * profile does not grant, and a document the store would not accept. The
+ * message travels for `400` alone: the others are the same body an unknown
+ * path gets, deliberately.
+ */
+function answer<T>(
+  result: Answer<T>,
+  headers: Record<string, string>,
+  shape: (value: T) => unknown,
+): Response {
+  if (result.ok) return json(shape(result.value), 200, headers);
+
+  const { status, error, message } = result.refusal;
+  return json(status === 400 ? { error, message } : { error }, status, headers);
+}
+
+/**
+ * An asset's bytes, with the type they were stored under.
+ *
+ * `attachment` and `nosniff`, always. On a deployed bind this origin also
+ * serves `/mcp`, `/authorize` and the discovery documents, so a stored
+ * `text/html` asset served inline would run script in the endpoint's own
+ * origin. A page fetches this and makes an object URL, which `attachment` does
+ * not obstruct.
+ */
+function content(result: Answer<{ bytes: Uint8Array; contentType: string }>, headers: Record<string, string>): Response {
+  if (!result.ok) return json({ error: result.refusal.error }, result.refusal.status, headers);
+
+  // Copied into a fresh view before it is handed to `Response`, so the body is
+  // a buffer of its own rather than a window onto whatever the adapter returned.
+  const bytes = new Uint8Array(result.value.bytes);
+
+  return new Response(bytes.buffer as ArrayBuffer, {
+    status: 200,
+    headers: {
+      ...headers,
+      'content-type': result.value.contentType,
+      'content-length': String(bytes.byteLength),
+      'content-disposition': 'attachment',
+      'x-content-type-options': 'nosniff',
+      'cache-control': 'no-store',
+    },
+  });
+}

--- a/src/server/read/deployed.test.ts
+++ b/src/server/read/deployed.test.ts
@@ -197,7 +197,12 @@ describe('never ambient', () => {
   });
 });
 
-describe('reads only, ever', () => {
+describe('the control plane is still unreachable', () => {
+  // The block was `reads only, ever` until ADR-069 gave a pairing token the
+  // owner's own data. What it asserted about *these* paths did not change and
+  // must not: `/state` and `/audit` are reads, and everything the control plane
+  // owns is unreachable from here in either direction. `read/data.test.ts`
+  // holds the other half.
   test('a write to a read path is not found rather than not allowed', async () => {
     const response = await deployed(readDeps())(
       new Request('https://endpoint.example/state', {
@@ -211,10 +216,13 @@ describe('reads only, ever', () => {
     expect(response.status).toBe(404);
   });
 
-  test('the surface is exactly two paths', async () => {
-    const response = await deployed(readDeps())(paired('/connections'));
-
-    expect(response.status).toBe(404);
+  test('nothing the control plane owns is a path here', async () => {
+    // Each of these is a thing ADR-007 keeps in the CLI. None of them gained a
+    // route when `/data` did, and a pairing token reaches none of them.
+    for (const path of ['/connections', '/profiles', '/policy', '/tokens', '/config']) {
+      const response = await deployed(readDeps())(paired(path));
+      expect(response.status).toBe(404);
+    }
   });
 });
 

--- a/src/server/read/deployed.ts
+++ b/src/server/read/deployed.ts
@@ -4,6 +4,7 @@ import type { Logger } from '#connectivity';
 import type { ProfileRuntime } from '../mcp/visibility.ts';
 import { cachedPairingCredential } from './credential.ts';
 import type { ReadDeps } from './routes.ts';
+import type { DataSurface } from '#cli/owner-data/surface.ts';
 
 /**
  * The same read surface, on a deployed endpoint's own port (ADR-064).
@@ -31,6 +32,8 @@ export function deployedReadDeps(input: {
   readonly profiles: () => ReadonlyMap<string, ProfileRuntime>;
   readonly log: Logger;
   readonly version: string;
+  /** The owner's data, when the endpoint wired it. Absent means `/data` is a 404. */
+  readonly data?: DataSurface | undefined;
 }): ReadDeps {
   const { primary, log } = input;
 
@@ -55,6 +58,7 @@ export function deployedReadDeps(input: {
       onError: (reason) => log.warn('could not read the pairing credential', { reason }),
     }),
     endpoint: { kind: 'deployed', version: input.version, certificateExpiresAt: null },
+    ...(input.data ? { data: input.data } : {}),
     log,
   };
 }

--- a/src/server/read/http.ts
+++ b/src/server/read/http.ts
@@ -1,0 +1,59 @@
+/**
+ * The three answers `/state`, `/audit` and `/data` all have to give the same way.
+ *
+ * Extracted when the data surface arrived, because that surface allows methods
+ * the other two refuse and the CORS headers had to become an argument. Two
+ * copies of `cors` would be two answers to what a pairing token's origin may
+ * do, and the one that drifted would be the one nobody was reading.
+ *
+ * Everything ADR-063 fixes about these headers is fixed here: one named origin
+ * echoed rather than wildcarded, `Vary: Origin` unconditionally including on a
+ * refusal, a fixed header list rather than a reflected one, and no
+ * `access-control-allow-credentials` at all.
+ */
+
+export function bearer(request: Request): string | null {
+  const header = request.headers.get('authorization') ?? '';
+  if (!header.toLowerCase().startsWith('bearer ')) return null;
+
+  const presented = header.slice(7).trim();
+  return presented === '' ? null : presented;
+}
+
+/**
+ * The CORS headers for one surface.
+ *
+ * `methods` and `headers` are named by the caller rather than reflected from
+ * the request. Echoing `Access-Control-Request-Headers` would grant whatever
+ * was asked for, which is ADR-039's rule and the reason the read surface has
+ * never done it — and it matters more now that one of these lists contains
+ * `PUT` and `DELETE`.
+ */
+export function cors(
+  origin: string | null,
+  allowed: boolean,
+  methods: string,
+  headers = 'authorization',
+): Record<string, string> {
+  // `Vary: Origin` unconditionally, including on a refusal. Without it a cache
+  // between here and the page can serve one origin's answer to another, which
+  // is the whole grant leaking through an intermediary.
+  const out: Record<string, string> = { vary: 'Origin' };
+  if (!allowed || origin === null) return out;
+
+  out['access-control-allow-origin'] = origin;
+  out['access-control-allow-headers'] = headers;
+  out['access-control-allow-methods'] = methods;
+  out['access-control-max-age'] = '600';
+  // Deliberately absent: `access-control-allow-credentials`. The token is sent
+  // explicitly by the page, so allowing cookies would add an ambient credential
+  // to a surface whose safety rests on there not being one.
+  return out;
+}
+
+export function json(body: unknown, status: number, headers: Record<string, string>): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { ...headers, 'content-type': 'application/json', 'cache-control': 'no-store' },
+  });
+}

--- a/src/server/read/open.ts
+++ b/src/server/read/open.ts
@@ -4,6 +4,7 @@ import type { Runtime } from '#cli/runtime.ts';
 import type { Logger } from '#connectivity';
 import type { RunningServer } from '../index.ts';
 import type { ProfileRuntime } from '../mcp/visibility.ts';
+import type { DataSurface } from '#cli/owner-data/surface.ts';
 import { directPairingCredential } from './credential.ts';
 import { serveRead, type RunningReadListener } from './listener.ts';
 
@@ -27,6 +28,7 @@ export async function openReadListener(
   profiles: () => ReadonlyMap<string, ProfileRuntime>,
   log: Logger,
   version: string,
+  data?: DataSurface | undefined,
 ): Promise<RunningReadListener | null> {
   // Loopback only, and checked before a single credential is read.
   //
@@ -77,6 +79,7 @@ export async function openReadListener(
         onError: (reason) => log.warn('could not read the pairing credential', { reason }),
       }),
       endpoint: { kind: 'local', version, certificateExpiresAt: expiryOf(cert) },
+      ...(data ? { data } : {}),
       tls: { cert, key },
     });
   } catch (error) {

--- a/src/server/read/routes.ts
+++ b/src/server/read/routes.ts
@@ -1,6 +1,9 @@
 import type { Logger } from '#connectivity';
 import type { ProfileRuntime } from '../mcp/visibility.ts';
 import type { PairingCredential } from './credential.ts';
+import { bearer, cors, json } from './http.ts';
+import { dataRoutes, isDataPath, DATA_HEADERS, DATA_METHODS } from './data.ts';
+import type { DataSurface } from '#cli/owner-data/surface.ts';
 import {
   readState,
   type ConnectionRow,
@@ -56,6 +59,18 @@ export const AUDIT_PATH = '/audit';
  */
 export function isReadPath(pathname: string): boolean {
   return pathname === STATE_PATH || pathname === AUDIT_PATH;
+}
+
+/**
+ * Everything a pairing token may reach, which is what the router hands over.
+ *
+ * A second predicate rather than widening `isReadPath`, because that one still
+ * has a job: it names the two paths that are reads and nothing else, and a
+ * predicate called "read" gating a `DELETE` would be the kind of quiet
+ * disagreement between a name and a behaviour this file exists to prevent.
+ */
+export function isPairedPath(pathname: string): boolean {
+  return isReadPath(pathname) || isDataPath(pathname);
 }
 
 /** The most entries `/audit` will return, however many are asked for. */
@@ -115,6 +130,17 @@ export interface ReadDeps {
   readonly providerName?: ProviderNames | undefined;
   /** What this endpoint says about itself. Fixed for the life of the bind. */
   readonly endpoint: ReadEndpoint;
+  /**
+   * The owner's own data, when this endpoint opened runtimes that can reach it.
+   *
+   * Narrow on purpose, and satisfied under `cli` — the only component allowed
+   * to touch both a store and the log. `server` may import neither, so this is
+   * the same seam `AuditTail` above keeps, for the same reason (ADR-069).
+   *
+   * Optional because a harness may omit it. Absent, `/data` is a `404` and
+   * every other path behaves exactly as it did before this surface existed.
+   */
+  readonly data?: DataSurface | undefined;
   readonly allowedOrigins?: readonly string[] | undefined;
   readonly log?: Logger | undefined;
 }
@@ -131,24 +157,39 @@ export async function readRoutes(request: Request, deps: ReadDeps): Promise<Resp
   const origins = deps.allowedOrigins ?? READ_ORIGINS;
   const origin = request.headers.get('origin');
   const allowed = origin !== null && origins.includes(origin);
+  const url = new URL(request.url);
+
+  // Whether this request is for the surface that may write (ADR-069), decided
+  // once. `deps.data` absent means no data surface at all — an endpoint whose
+  // runtimes were never wired answers these paths exactly as it answers an
+  // unknown one, which is the same shape as an unpaired workspace and needs no
+  // second code path.
+  const writable = deps.data !== undefined && isDataPath(url.pathname);
+  const methods = writable ? DATA_METHODS : 'GET, OPTIONS';
+  const permitted = (headers = 'authorization'): Record<string, string> =>
+    cors(origin, allowed, methods, headers);
 
   // Answered before the credential is checked, because a preflight carries no
   // credential — that is what it is for. It carries no data either, so
   // answering one reveals only that something is listening, which the TCP
   // connection already revealed.
   if (request.method === 'OPTIONS') {
-    return new Response(null, { status: allowed ? 204 : 403, headers: cors(origin, allowed) });
+    return new Response(null, {
+      status: allowed ? 204 : 403,
+      headers: permitted(writable ? DATA_HEADERS : undefined),
+    });
   }
 
   // Not `405`. A surface that answered "method not allowed" would be confirming
   // to any page that a Lanes read surface is here; a page that is not the
-  // dashboard learns nothing it did not send.
-  if (request.method !== 'GET') {
-    return json({ error: 'not_found' }, 404, cors(origin, allowed));
+  // dashboard learns nothing it did not send. `/state` and `/audit` are still
+  // reads only: the widening below is scoped to the paths `isDataPath` matched.
+  if (request.method !== 'GET' && !(writable && DATA_METHODS.includes(request.method))) {
+    return json({ error: 'not_found' }, 404, permitted());
   }
 
   if (origin !== null && !allowed) {
-    return json({ error: 'origin_not_allowed' }, 403, cors(origin, false));
+    return json({ error: 'origin_not_allowed' }, 403, cors(origin, false, methods));
   }
 
   // The header is parsed before the store is asked anything. A request carrying
@@ -170,18 +211,22 @@ export async function readRoutes(request: Request, deps: ReadDeps): Promise<Resp
         run: 'lanes link pair',
       },
       401,
-      cors(origin, allowed),
+      permitted(),
     );
   }
 
-  const url = new URL(request.url);
+  // Below the credential check, so one place verifies a pairing token and the
+  // two surfaces cannot come to disagree about who may reach them.
+  if (writable && deps.data) {
+    return dataRoutes(request, url, deps.data, permitted(DATA_HEADERS));
+  }
 
   if (url.pathname === STATE_PATH) {
     const rows = await deps.connections().catch(() => []);
     return json(
       readState(deps.workspace, deps.profiles(), rows, deps.endpoint, deps.providerName),
       200,
-      cors(origin, allowed),
+      permitted(),
     );
   }
 
@@ -220,41 +265,9 @@ export async function readRoutes(request: Request, deps: ReadDeps): Promise<Resp
         })),
       },
       200,
-      cors(origin, allowed),
+      permitted(),
     );
   }
 
-  return json({ error: 'not_found' }, 404, cors(origin, allowed));
-}
-
-function bearer(request: Request): string | null {
-  const header = request.headers.get('authorization') ?? '';
-  if (!header.toLowerCase().startsWith('bearer ')) return null;
-
-  const presented = header.slice(7).trim();
-  return presented === '' ? null : presented;
-}
-
-function cors(origin: string | null, allowed: boolean): Record<string, string> {
-  // `Vary: Origin` unconditionally, including on a refusal. Without it a cache
-  // between here and the page can serve one origin's answer to another, which
-  // is the whole grant leaking through an intermediary.
-  const headers: Record<string, string> = { vary: 'Origin' };
-  if (!allowed || origin === null) return headers;
-
-  headers['access-control-allow-origin'] = origin;
-  headers['access-control-allow-headers'] = 'authorization';
-  headers['access-control-allow-methods'] = 'GET, OPTIONS';
-  headers['access-control-max-age'] = '600';
-  // Deliberately absent: `access-control-allow-credentials`. The token is sent
-  // explicitly by the page, so allowing cookies would add an ambient credential
-  // to a surface whose safety rests on there not being one.
-  return headers;
-}
-
-function json(body: unknown, status: number, headers: Record<string, string>): Response {
-  return new Response(JSON.stringify(body), {
-    status,
-    headers: { ...headers, 'content-type': 'application/json', 'cache-control': 'no-store' },
-  });
+  return json({ error: 'not_found' }, 404, permitted());
 }


### PR DESCRIPTION
Publishes `0.9.4`.

`package.json` already carries the version and no tag stands behind it, so merging this runs the *publish* half of `release.yml`: it publishes to npm over OIDC and cuts `v0.9.4`. There is no propose step to follow, and `develop` and `main` end on the same tree.

## What ships

**A paired browser can read and write the owner's own data.** `/data` joins `/state` and `/audit` on the pairing-token surface: memory, tasks, assets, skills and entities are listed, previewed, edited and deleted, and the vault is listed by name and never by value.

ADR-069 narrows ADR-063's "reads only, ever" to the control plane rather than reversing it. That sentence was argued from *editing a connection or a profile*, which is configuration and which ADR-007 excludes because it authorises future agent behaviour. Writing a memory entry authorises nothing, the owner layer arrives granted for exactly that reason (ADR-050), and every connected agent already writes these five stores.

## The one thing to read before merging

**A pairing token minted before this version can now write.** The token carries no version and the endpoint decides what it may do, so an existing token sitting in a browser's `localStorage` gains this the moment its endpoint updates, with nothing on either side announcing it.

It still reaches no connection, profile, grant, token, configuration or audit entry, and no vault value in either direction. `lanes link pair --rotate` is how one is taken back, and `pair` now states what the credential can edit and delete before the operator answers the prompt. The security model table in `lanes-sh/web` gains a `pairing.data-plane-only` row in the matching pull request.

## Merge method

**`--merge`, not squash.** A squash writes a new commit onto `main`, `develop`'s tip stops being an ancestor, and the fast-forward that ends a release is then rejected as non-fast-forward even though the trees are identical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VzFzJJKcNJJ4ehoWVVVZRH