### PR TITLE
0.9.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lanes-sh/link",
-  "version": "0.9.4",
+  "version": "0.9.5",
   "description": "A self-hostable MCP gateway for all your connections, memory, tasks, files, and secrets",
   "license": "Apache-2.0",
   "homepage": "https://lanes.sh/link",

--- a/src/providers/assets/provider.test.ts
+++ b/src/providers/assets/provider.test.ts
@@ -4,8 +4,9 @@ import { join } from 'node:path';
 import { afterAll, describe, expect, test } from 'bun:test';
 import { isResourceListResult, isResourceResult, isToolResult } from '#connectivity';
 import { assetsProvider } from './provider.ts';
-import { isTextual } from './store.ts';
+import { assetStorage, isTextual } from './store.ts';
 import { harnessFor, linksOf, textOf } from '../harness.ts';
+import { createMemoryBlobStore } from '#stores/blobs/testing.ts';
 
 /**
  * Assets.
@@ -233,5 +234,46 @@ describe('reading and writing are different capabilities', () => {
 
     expect(write?.default).toBeFalsy();
     expect(write?.capabilities.sort()).toEqual(['remove', 'store']);
+  });
+});
+
+describe('a store that does not know the type', () => {
+  test('an octet-stream from the store is re-read from the extension', async () => {
+    // What a bucket hands back for a file uploaded without a content type, and
+    // the reason a markdown asset on a deployed workspace was described instead
+    // of returned. `??` never fired, because the store did give a value: it
+    // just was not a claim about the bytes.
+    const storage = createMemoryBlobStore();
+    await storage.put('notes.md', new TextEncoder().encode('# Notes\n'), {
+      contentType: 'application/octet-stream',
+    });
+
+    const asset = await assetStorage.find(storage, 'notes.md');
+    expect(asset?.contentType).toBe('text/markdown');
+    expect(assetStorage.isTextual(asset!.contentType, new TextEncoder().encode('# Notes\n'))).toBe(
+      true,
+    );
+  });
+
+  test('a real declaration is still believed over the extension', async () => {
+    const storage = createMemoryBlobStore();
+    await storage.put('report.md', new Uint8Array([0x25, 0x50, 0x44, 0x46]), {
+      contentType: 'application/pdf',
+    });
+
+    // The store knows something the name does not, and it wins.
+    expect((await assetStorage.find(storage, 'report.md'))?.contentType).toBe('application/pdf');
+  });
+
+  test('an extension nobody recognises lands where it started', async () => {
+    const storage = createMemoryBlobStore();
+    await storage.put('thing.qqq', new Uint8Array([1, 2, 3]), {
+      contentType: 'application/octet-stream',
+    });
+
+    // Re-guessing is free here: `guessContentType` falls back to the same value.
+    expect((await assetStorage.find(storage, 'thing.qqq'))?.contentType).toBe(
+      'application/octet-stream',
+    );
   });
 });

--- a/src/providers/assets/store.ts
+++ b/src/providers/assets/store.ts
@@ -102,12 +102,35 @@ export async function allAssets(storage: BlobStore): Promise<Asset[]> {
             {
               name,
               bytes: blob.size,
-              contentType: blob.contentType ?? guessContentType(name),
+              contentType: declaredType(blob.contentType) ?? guessContentType(name),
               modifiedAt: blob.modifiedAt.toISOString(),
             },
           ];
     })
     .sort((a, b) => b.modifiedAt.localeCompare(a.modifiedAt) || a.name.localeCompare(b.name));
+}
+
+/**
+ * The store's content type, unless the store is telling us it does not know.
+ *
+ * `application/octet-stream` is not a claim about the bytes, it is the absence
+ * of one, and adapters differ in how they say so. The filesystem adapter omits
+ * the field, so `?? guessContentType(name)` reached the extension. A bucket
+ * stores whatever was set at upload time and hands back `application/octet-stream`
+ * when that was nothing — which is a value, so the `??` never fired and every
+ * asset on a deployed workspace read as binary. A markdown file was then
+ * described rather than returned by `assets.get`, and could not be edited from
+ * a browser, on exactly the workspaces whose files nobody can reach with a text
+ * editor instead.
+ *
+ * Re-guessing costs nothing where it is genuinely unknown: `guessContentType`
+ * falls back to the same value, so an extension nobody recognises lands where it
+ * started.
+ */
+const UNKNOWN_TYPE = 'application/octet-stream';
+
+function declaredType(contentType: string | undefined): string | undefined {
+  return contentType === undefined || contentType === UNKNOWN_TYPE ? undefined : contentType;
 }
 
 export async function findAsset(storage: BlobStore, name: string): Promise<Asset | null> {


### PR DESCRIPTION
Publishes `0.9.5`. `package.json` carries the version with no tag behind it, so merging this publishes and cuts `v0.9.5` directly.

**An octet-stream from a store is the absence of a claim, not a claim.**

Found by deploying 0.9.4 and looking at it. Every asset on a deployed workspace read as binary, so a markdown file was described rather than returned by `assets.get` and could not be edited from the dashboard, on exactly the workspaces whose files nobody can reach with a text editor instead.

`allAssets` resolved the type as `blob.contentType ?? guessContentType(name)`. That `??` was doing all the work on a filesystem, which omits the field for an extension it does not recognise. A bucket hands back `application/octet-stream` when nothing was set at upload time, which is a value, so the fallback never fired.

Fixed at the shared source, so `assets.get`, `assets.list`, the resource and the Data tab all get one answer. A real declaration still beats the name; only the value that means "no answer" is re-guessed.

**`--merge`, not squash**, so `develop` stays an ancestor and the fast-forward that ends the release is not rejected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VzFzJJKcNJJ4ehoWVVVZRH