### PR TITLE
The primitives a Lanes-hosted runtime needs

### DIFF
--- a/docs/detailed/adr/070-one-process-serves-many-workspaces.md
+++ b/docs/detailed/adr/070-one-process-serves-many-workspaces.md
@@ -1,0 +1,113 @@
+# ADR-070: One process serves many workspaces, and the boundary becomes a code path
+
+**Status:** accepted · **Amends** [ADR-009](009-one-endpoint-per-workspace.md) ·
+**Follows from** [ADR-023](023-the-workspace-is-not-in-the-image.md),
+[ADR-029](029-connecting-is-not-deploying.md) ·
+**Requires** [ADR-071](071-a-managed-workspace-is-a-workspace.md)
+
+## Context
+
+`docs/detailed/init.md` says it plainly: *"Deployments are single-tenant. Run one instance per
+profile, so personal and work never share a database or credential store."* ADR-009 widened that
+to one instance per *workspace* and left the rest standing. `src/server/container.ts` reads
+`LANES_LINK_HOME` once at boot and serves that workspace for the life of the process.
+
+That is right for a self-hosted deploy and it is the thing a Lanes-hosted one cannot do. A managed
+workspace is not rare: once Lanes Forms becomes an owner-layer provider, every Lanes workspace has
+one. A Cloud Run service per tenant is a service, a service account, a set of secrets and a cold
+start per tenant, against a per-project service cap, for a discriminator a string already provides.
+
+So one process serves many. **The honest way to state that is not "we added multi-tenancy" but
+"the boundary that used to be a process is now a code path"**, and this record exists to say what
+holds it up rather than to imply nothing changed.
+
+## Decision
+
+**A workspace router above the generations, and two stores scoped beneath them.**
+
+```
+                    request
+                       |
+         router   (workspace <- Host)         src/server/router.ts
+                       |
+      Generations  (one per workspace)        src/server/generations.ts
+                       |
+        Generation  (one boot's runtimes)     src/server/generation.ts
+```
+
+The layering is the point. `Generations` already held a workspace's runtimes and swapped them on
+reload (ADR-029); the router is that map one level up, holding a whole `RequestHandler` per
+workspace. A reload inside one workspace cannot disturb another, because a generation belongs to a
+handler and a handler belongs to one workspace.
+
+`container.ts`'s single-workspace mode is untouched. A self-hosted deploy runs the code it ran
+before.
+
+## What the router does that is not obvious from its shape
+
+**An `open` promise is stored before it resolves.** Two requests arriving together for a cold
+workspace share one open rather than building two handlers and leaking whichever loses.
+
+**A failed open is not cached.** A bucket that was briefly unreadable must not become a workspace
+that stays broken until the process restarts.
+
+**An evicted resident is retired, not closed.** `inFlight` is incremented before the fetch and the
+close waits for zero, so a handler pushed out of the cache under load is not closed underneath a
+request already committed to it. That is the same reason ADR-029's generations are retired rather
+than closed when a reload replaces them, applied one level up.
+
+**A request naming no workspace and one that will not open get the same 404.** Answers that
+differed would let a caller enumerate tenants by watching which hostnames fail which way. ADR-007
+makes this argument about capabilities — an unknown capability is refused identically to a denied
+one — and it holds here for the same reason. The real cause goes to the log.
+
+## The two stores that would otherwise still be shared
+
+A router that only routed would leave two things process-global, and both were.
+
+**A credential reference was unique only because a project had one workspace.** `encodeRef` maps
+`tokens/tok1` to the secret id `tokens__tok1`, flat within a Secret Manager project. Two workspaces
+in one project both write it, so the second `set` adds a version to the first workspace's secret
+and both then read one refresh token. `GcpSecretManagerStore` takes a `namespace`, prepended to the
+reference *before* encoding — so the separator collision `encodeRef` already refuses per reference
+is refused once for the namespace too, rather than reintroduced by a second encoding. The reference
+is validated before the namespace is prepended, or the malformed `nonamespace` becomes the
+well-formed `<workspace>/nonamespace` and a namespaced store accepts what an unnamespaced one
+refuses.
+
+**A vault key came from the process environment.** `LANES_LINK_VAULT_KEY` reached both deployed
+vault adapters, so one key would open every tenant's vault and rotating one workspace's key was not
+expressible at all. Both adapters take a `keySource`. The existing `encryptionKey` was the wrong
+shape: it is eager, so a host would fetch every workspace's key to build stores that may never
+touch the vault — a network round trip per request, and a failure mode for requests that had
+nothing to do with the vault. A `KeySource` resolves on first use and is cached by the store.
+
+The blob root needs nothing: it is per workspace already, because the router resolves it.
+
+## What this costs, stated plainly
+
+**Isolation is now a property of code rather than of the operating system.** A self-hosted
+deployment gets its boundary from the fact that another tenant's bytes are not in the process. Here
+they can be, and what stands between them is: a handler built from the workspace it was resolved
+for and from nothing a request body can influence, a credential namespace, and a vault key source.
+Three things that can have bugs, where there used to be one thing that could not.
+
+**A bug in the router is a cross-tenant data leak**, which is a different severity from the bugs
+this repository has had before. That is the reason the two scoping changes landed first and with
+tests that fail the *old* way — the credential test asserts that workspace A's `get` does not
+return workspace B's token, and it did before the fix.
+
+**Memory is bounded by a cap rather than by the platform.** One workspace per process meant Cloud
+Run decided how much memory a workspace could have. An LRU with an idle eviction decides now, and a
+cap set too high is an OOM that takes every resident workspace down rather than one.
+
+**A noisy workspace is now somebody else's problem.** Per-profile rate limits still apply, but a
+workspace doing enormous work occupies a process other workspaces are served from.
+
+## What this does not do
+
+It does not change what a request may reach. `mayReach`, the policy evaluation and the member
+lists are untouched, and a caller still reaches exactly the profiles their subject is a member of.
+It does not give the endpoint a control plane — ADR-007 is unmoved, and
+`src/dispatch/control-plane.test.ts` passes unchanged. And it does not apply to a self-hosted
+deployment, which resolves one root at boot exactly as it did.

--- a/docs/detailed/adr/071-a-managed-workspace-is-a-workspace.md
+++ b/docs/detailed/adr/071-a-managed-workspace-is-a-workspace.md
@@ -1,0 +1,94 @@
+# ADR-071: A managed workspace is a workspace, reached over the API
+
+**Status:** accepted · **Extends** [ADR-023](023-the-workspace-is-not-in-the-image.md),
+[ADR-049](049-manifests-are-read-through-the-workspace-store.md) ·
+**Completes** [ADR-061](061-a-workspace-is-the-only-word.md) ·
+**Required by** [ADR-070](070-one-process-serves-many-workspaces.md)
+
+## Context
+
+ADR-023 made `LANES_LINK_HOME` accept `gs://bucket/prefix` as well as a directory, and ADR-049
+made every read of configuration go through that store. Between them, a workspace stopped being a
+place on a filesystem and became a `BlobStore` with a root — which is what lets one image serve any
+workspace.
+
+Lanes Cloud needs a third root, and `gs://` cannot be it.
+
+A bucket root is opened with the caller's own Google credentials. That is exactly right for a
+bucket in the operator's project: they own it, they granted the service account, and the adapter
+authenticates as whatever identity is already present. It is impossible for a bucket in ours.
+Handing a laptop credentials that reach Lanes' storage would reach every tenant's bytes, and
+narrowing that per workspace means an IAM condition per tenant on a bucket nobody outside Lanes
+should be able to name.
+
+There is a second reason, and it is the better one. The question "may this person read this
+workspace" already has an answer, in one place, on the API: it is workspace membership, the same
+list a profile's `members:` selects from (ADR-060). Asking it again in a storage adapter would be a
+second place to decide the same thing.
+
+## Decision
+
+**`LANES_LINK_HOME` accepts `lanes://<workspace-id>`, served by an adapter over the Lanes API.**
+
+```
+~/.lanes-link                 a directory        createFilesystemBlobStore
+gs://your-bucket/prefix       a bucket           createGcsBlobStore
+lanes://<workspace-id>        Lanes hosts it     createLanesBlobStore
+```
+
+It is a `BlobStore` like the other two and it passes the same conformance suite, so the CLI, the
+control plane and the runtime administer a managed workspace with the code that administers a local
+one. `lanes link profile add work --workspace managed` is not a new command path; it is the command,
+against a different root.
+
+`isRemoteWorkspace` covers it, and that is the quiet half of the decision. Every caller of that
+predicate is asking whether it may treat the root as a filesystem path, and a managed root
+answering "yes" produces a directory literally named `lanes:` beside the process's working
+directory — config that reads as *absent* rather than as unreachable, which is the failure ADR-049
+was written about.
+
+## The credential is registered, not passed
+
+`workspaceFiles(root)` takes a root and nothing else, at thirty-five call sites, and that is not an
+oversight to correct. A credential is a property of the process's identity rather than of any one
+call, which is precisely why a `gs://` root needs none either: Google's client resolves Application
+Default Credentials from the environment and nobody threads them through.
+
+This adapter cannot do the same thing the same way. Reading the signed-in session means importing
+`auth`, and `deployments` may not — the rule that keeps a storage backend from growing an opinion
+about who is calling. So the layer that *may* read a session registers one, and the adapter asks
+for it at call time rather than at construction, so registration order does not matter. A process
+that registered nothing gets a sentence naming `lanes auth login`, not a 401 from three components
+away.
+
+A mutable module-level slot is the kind of thing this repository refuses by default, and the
+alternative here is threading a credential through thirty-five call sites of a function whose whole
+job is "give me this workspace's files".
+
+## Listings are sorted here rather than trusted
+
+The contract every other adapter satisfies says a listing is sorted. A store that is sorted only
+when the server felt like it is not the same interface, and the callers that walk a profile's files
+would then differ by backend — which is the whole thing `describeBlobStoreContract` exists to
+prevent.
+
+## What this costs, stated plainly
+
+**Lanes is in the path of a managed workspace's configuration.** Not its agent traffic — that goes
+to the endpoint — but every read and write of a profile, a grant or a connection row crosses a
+Lanes server, and an outage there is an outage of administering the workspace. A local or
+self-hosted workspace has no such dependency, and this is a real difference between the three
+options rather than a detail.
+
+**A credential written from a laptop cannot be read back over HTTP.** The `lanes` secret store
+supports `set`, `has`, `list` and `delete`; `get` is refused for a CLI caller and the runtime reads
+values internally. That is deliberate and it is a genuine loss of symmetry: `lanes link secrets`
+cannot show you a value in a managed workspace the way it can in a local one.
+
+## What this does not do
+
+It does not make the API a control plane for the endpoint — this is storage, and ADR-007's wall is
+where it was. It does not change the layout: a managed workspace's bytes are the same tree in the
+same shape (`layout.ts`), because a fourth layout for one structure is what that file exists to
+prevent. And it does not move a self-hosted workspace anywhere; `gs://` is unchanged and remains
+what `lanes link deploy` writes.

--- a/docs/detailed/adr/072-an-environment-is-derived-not-assembled.md
+++ b/docs/detailed/adr/072-an-environment-is-derived-not-assembled.md
@@ -1,0 +1,64 @@
+# ADR-072: A deployment derives its environment, and a mismatch refuses to boot
+
+**Status:** accepted · **Follows from** [ADR-070](070-one-process-serves-many-workspaces.md),
+[ADR-071](071-a-managed-workspace-is-a-workspace.md)
+
+## Context
+
+A Lanes-hosted runtime has two deployments, staging and production, sharing a code path, a
+container image and a cloud project. The Lanes API already has that shape, and the way it derives
+staging is the thing this record exists to not copy.
+
+Its stage trigger overrides **each secret substitution individually** to a `_STAGING` twin. A
+secret added to `cloudbuild.yaml` without a matching override therefore leaves staging reading the
+production secret. Nothing warns. Two are already in that state, and have been for months.
+
+For a form endpoint that misroutes a submission, which is bad. Here the secrets are OAuth refresh
+tokens for customers' mailboxes, and a staging revision reading production storage is not a
+misrouted record — it is an unauthorised read of somebody's mail by a deployment nobody thought was
+pointed there. The mechanism has to fail the other way.
+
+## Decision
+
+**One environment name, everything derived from it, and a mismatch is a boot failure.**
+
+`_ENV_NAME` is the only substitution a stage trigger overrides. The storage root, the secret
+prefix, the API URL and the endpoint domain are computed from it. One thing to get wrong instead of
+fifteen.
+
+`environmentFrom` has **no default**. An unset or misspelled variable resolving to `prod` is
+exactly how a staging revision comes to hold production's root, so an unrecognised value is a boot
+failure rather than an assumption. `staging` is refused beside nonsense for the same reason: one
+spelling, or the check below has two things to agree with.
+
+`assertEnvironmentMatches` is called once per derived location and **throws**. Refusing to start is
+the part worth arguing with, so it is stated rather than implied: a mismatch that logs a warning
+and serves anyway is the silent fallback with an extra step, and what it would be protecting is the
+one asset in this system that cannot be un-leaked.
+
+## Why one substring rather than a rule per location
+
+A bucket, a hostname and a secret prefix are spelled differently enough that any single pattern
+fitting all three would be loose — and a loose rule here is worse than no rule, because it passes
+the case it exists to catch while looking like protection.
+
+So the check is one marker. A production name that happens to contain it fails closed and is
+renamed, which is the right way round: the cost of the false positive is a rename before anything
+ships, and the cost of the false negative is a mailbox.
+
+## What this costs, stated plainly
+
+**A deployment can refuse to start over a naming mistake**, and a container that will not boot is a
+worse *symptom* than one that boots wrong. It is a much better *outcome*, and the message names the
+location, the value and both sides so the fix is visible in a log with no command line to inspect.
+
+**Neither environment can be reached from the other, including deliberately.** Copying a production
+workspace into staging to reproduce something is not a thing this permits, and that is intended
+rather than incidental — it is the same act as the accident it prevents.
+
+## What this does not do
+
+It does not apply to a self-hosted deploy, which has one environment and needs none of this. It
+does not make the two deployments independent by itself: separate storage, separate secrets and
+separate signing keys are what does that, and this only refuses to run when they have been wired
+together by mistake.

--- a/docs/detailed/adr/README.md
+++ b/docs/detailed/adr/README.md
@@ -85,6 +85,9 @@ Run.
 | [067](067-one-directory-per-profile.md) | One directory per profile, `data/` goes, and a connection id becomes opaque |
 | [068](068-a-credential-names-a-person.md) | A credential names a person, and the profiles follow from that; the endpoint token becomes the workspace's |
 | [069](069-a-pairing-token-may-write-the-owners-own-data.md) | A pairing token may write the owner's own data; the control plane is unmoved |
+| [070](070-one-process-serves-many-workspaces.md) | One process serves many workspaces, and the boundary becomes a code path |
+| [071](071-a-managed-workspace-is-a-workspace.md) | A managed workspace is a workspace, reached over the API |
+| [072](072-an-environment-is-derived-not-assembled.md) | A deployment derives its environment, and a mismatch refuses to boot |
 
 Where an ADR departs from init.md, it says so at the top. Three are significant:
 
@@ -312,3 +315,24 @@ Where an ADR departs from init.md, it says so at the top. Three are significant:
   these five stores. What genuinely changes is that a credential which could read every memory
   entry can now delete them, including one minted before this release, which is why the cost is
   named in the CLI's own prompt rather than only here.
+
+- **ADR-070** is the one to read before the other two. Everything Lanes Cloud is rests on one
+  process serving many workspaces, and the honest way to state that is not "multi-tenancy was
+  added" but "the boundary that used to be a process is now a code path". The record says what
+  holds it up — a router above the generations, a credential namespace, a vault key source — and
+  says plainly that a bug in any of the three is a cross-tenant leak, which is a severity this
+  repository has not had to reason about before. `container.ts` is untouched: a self-hosted deploy
+  runs what it ran.
+
+- **ADR-071** is why a third root exists at all. A `gs://` root is opened with the caller's own
+  Google credentials, which is right for a bucket the operator owns and impossible for one of
+  ours. The better reason is the second one: "may this person read this workspace" already has an
+  answer, on the API, and asking it again inside a storage adapter would be a second place to
+  decide one thing. The cost named in it is real — Lanes is now in the path of a managed
+  workspace's configuration, and a credential written from a laptop cannot be read back.
+
+- **ADR-072** exists because the API's own staging mechanism is a trap, and this is the record of
+  choosing not to copy it. Overriding each secret individually means a forgotten one leaves staging
+  reading production, silently; two already are. Deriving everything from one name and refusing to
+  boot on a mismatch trades a container that will not start for a staging revision that reads
+  somebody's mail, which is not a close call.

--- a/src/deployments/adapters/gcp-secret-manager.test.ts
+++ b/src/deployments/adapters/gcp-secret-manager.test.ts
@@ -553,3 +553,90 @@ describe('application default credentials', () => {
     }
   });
 });
+
+/**
+ * One project, many workspaces.
+ *
+ * A self-hosted deploy gets a project per workspace, so a reference is unique
+ * by construction and nothing here was needed. A Lanes-hosted runtime serves
+ * many workspaces from one project, and every one of them stores
+ * `tokens/tok1`. Without a namespace the second `set` adds a version to the
+ * first workspace's secret and both then read the same refresh token, which is
+ * the one failure in this adapter whose wrong answer is somebody else's
+ * mailbox.
+ *
+ * The fake is shared between the two stores on purpose: the question is not
+ * whether each store works on its own, it is whether either can reach the
+ * other's secrets.
+ */
+function sharedProject(seed: Record<string, string> = {}) {
+  const api = fakeSecretManager(seed);
+  const tokens = {
+    async token() {
+      return 'test-access-token';
+    },
+  };
+  return {
+    api,
+    workspace: (namespace: string) =>
+      new GcpSecretManagerStore({ project: PROJECT, namespace, fetch: api.fetch, tokens }),
+  };
+}
+
+describe('workspace namespace', () => {
+  test('two workspaces in one project do not share a reference', async () => {
+    const project = sharedProject();
+    const first = project.workspace('ws-aaa');
+    const second = project.workspace('ws-bbb');
+
+    await first.set('tokens/tok1', 'first-workspace-token');
+    await second.set('tokens/tok1', 'second-workspace-token');
+
+    expect(await first.get('tokens/tok1')).toBe('first-workspace-token');
+    expect(await second.get('tokens/tok1')).toBe('second-workspace-token');
+  });
+
+  test('listing returns this workspace only, with its own references', async () => {
+    const project = sharedProject();
+    const first = project.workspace('ws-aaa');
+    const second = project.workspace('ws-bbb');
+
+    await first.set('gmail/main', 'a');
+    await second.set('gmail/main', 'b');
+    await second.set('gmail/side', 'c');
+
+    // The namespace is an encoding detail: a caller writes and reads the same
+    // reference it would against an unnamespaced store.
+    expect(await first.list()).toEqual(['gmail/main']);
+    expect(await second.list()).toEqual(['gmail/main', 'gmail/side']);
+  });
+
+  test('one workspace cannot see another through has or delete', async () => {
+    const project = sharedProject();
+    const first = project.workspace('ws-aaa');
+    const second = project.workspace('ws-bbb');
+
+    await first.set('gmail/main', 'a');
+
+    expect(await second.has('gmail/main')).toBe(false);
+    // Deleting a reference this workspace does not hold must not reach across.
+    await second.delete('gmail/main');
+    expect(await first.get('gmail/main')).toBe('a');
+  });
+
+  test('a namespaced store does not read an unnamespaced secret', async () => {
+    // The migration hazard: a workspace deployed before namespacing has its
+    // secrets at the bare id. A namespaced store must miss them rather than
+    // silently adopt whatever is at the old name.
+    const project = sharedProject({ gmail__main: 'pre-existing' });
+    expect(await project.workspace('ws-aaa').get('gmail/main')).toBeNull();
+  });
+
+  test('refuses a namespace that would collide with a reference segment', async () => {
+    // `__` separates segments, so a namespace carrying one would let
+    // `a__b` + `c/d` and `a` + `b__c/d` land on the same secret id.
+    expect(() => sharedProject().workspace('ws__aaa')).toThrow(/namespace/i);
+    expect(() => sharedProject().workspace('ws_')).toThrow(/namespace/i);
+    expect(() => sharedProject().workspace('')).toThrow(/namespace/i);
+  });
+});

--- a/src/deployments/adapters/gcp-secret-manager.ts
+++ b/src/deployments/adapters/gcp-secret-manager.ts
@@ -84,6 +84,31 @@ export function encodeRef(ref: SecretRef): string {
   return id;
 }
 
+/**
+ * A workspace namespace, checked once at construction rather than per call.
+ *
+ * `SEPARATOR` separates segments in an encoded id, so a namespace containing
+ * one — or ending in `_`, which produces one as soon as the separator is
+ * appended — would let two different (namespace, reference) pairs encode to the
+ * same secret id. That is the collision `encodeRef` already refuses per
+ * reference, applied to the segment prepended to every one of them.
+ */
+export function assertValidNamespace(namespace: string): void {
+  const refuse = (why: string): never => {
+    throw new Error(
+      `Secret Manager namespace ${JSON.stringify(namespace)} ${why}. A namespace is one ` +
+        `segment of [A-Za-z0-9_-] that neither contains "${SEPARATOR}" nor ends in "_", ` +
+        'because it is prepended to every reference and shares their encoding.',
+    );
+  };
+
+  if (namespace.length === 0) refuse('is empty');
+  if (!/^[A-Za-z0-9_-]+$/.test(namespace)) refuse('is not a single Secret Manager id segment');
+  if (namespace.includes(SEPARATOR) || namespace.endsWith('_')) {
+    refuse('would collide with the segment separator');
+  }
+}
+
 export function decodeRef(secretId: string): string {
   return secretId.split(SEPARATOR).join('/');
 }
@@ -97,6 +122,16 @@ export interface GcpSecretManagerOptions {
   /** The Google Cloud project holding the secrets. */
   readonly project: string;
   /**
+   * Which workspace's secrets these are, when the project holds more than one.
+   *
+   * Omitted for a self-hosted deploy: it owns its project, so a reference is
+   * unique by construction. A Lanes-hosted runtime serves many workspaces from
+   * one project and every one of them stores `tokens/tok1`, so without this the
+   * second write adds a version to the first workspace's secret and both then
+   * read one refresh token.
+   */
+  readonly namespace?: string;
+  /**
    * Where the token comes from. Defaults to Application Default Credentials:
    * `GOOGLE_ACCESS_TOKEN`, then `GOOGLE_APPLICATION_CREDENTIALS`, then the
    * gcloud well-known file, then the metadata server.
@@ -108,6 +143,7 @@ export interface GcpSecretManagerOptions {
 
 export class GcpSecretManagerStore implements SecretStore {
   readonly #project: string;
+  readonly #namespace: string | undefined;
   readonly #tokens: AccessTokenSource;
   readonly #fetch: typeof globalThis.fetch;
 
@@ -118,7 +154,9 @@ export class GcpSecretManagerStore implements SecretStore {
           'Set `credentials.project` on the target.',
       );
     }
+    if (options.namespace !== undefined) assertValidNamespace(options.namespace);
     this.#project = options.project;
+    this.#namespace = options.namespace;
     this.#fetch = options.fetch ?? globalThis.fetch;
     this.#tokens =
       options.tokens ??
@@ -128,10 +166,40 @@ export class GcpSecretManagerStore implements SecretStore {
       });
   }
 
+  /**
+   * The secret id one reference maps to in this store.
+   *
+   * A namespaced store prepends its workspace before encoding, so `tokens/tok1`
+   * in workspace `ws-aaa` is `ws-aaa__tokens__tok1` and the same reference in
+   * another workspace is a different secret. Unnamespaced this is `encodeRef`
+   * unchanged, which is what keeps every existing deployment reading the ids it
+   * already wrote.
+   *
+   * The reference is validated before the namespace is prepended, not after:
+   * `nonamespace` is malformed and must say so, and composing first would make
+   * it `ws-aaa/nonamespace`, which is well-formed and would be accepted.
+   */
+  #id(ref: SecretRef): string {
+    assertValidSecretRef(ref);
+    return encodeRef(this.#namespace === undefined ? ref : `${this.#namespace}/${ref}`);
+  }
+
+  /**
+   * The reference a stored id represents here, or null when it is not ours.
+   *
+   * Only `list` needs this. Every other method addresses one secret by name and
+   * simply misses when it belongs to another workspace.
+   */
+  #owned(stored: SecretRef): SecretRef | null {
+    if (this.#namespace === undefined) return stored;
+    const scope = `${this.#namespace}/`;
+    return stored.startsWith(scope) ? stored.slice(scope.length) : null;
+  }
+
   async get(ref: SecretRef): Promise<string | null> {
     const response = await this.#call(
       'GET',
-      `/projects/${this.#project}/secrets/${encodeRef(ref)}/versions/latest:access`,
+      `/projects/${this.#project}/secrets/${this.#id(ref)}/versions/latest:access`,
     );
 
     // A ref with no secret, and a ref whose secret has no live version, are the
@@ -185,7 +253,7 @@ export class GcpSecretManagerStore implements SecretStore {
    * both 404, both create, the loser gets `ALREADY_EXISTS`, and both add.
    */
   async set(ref: SecretRef, value: string): Promise<void> {
-    const id = encodeRef(ref);
+    const id = this.#id(ref);
     const version = `/projects/${this.#project}/secrets/${id}:addVersion`;
     const payload = { payload: { data: Buffer.from(value, 'utf8').toString('base64') } };
 
@@ -212,7 +280,7 @@ export class GcpSecretManagerStore implements SecretStore {
     // leave `list` reporting a ref that `get` cannot read.
     const response = await this.#call(
       'DELETE',
-      `/projects/${this.#project}/secrets/${encodeRef(ref)}`,
+      `/projects/${this.#project}/secrets/${this.#id(ref)}`,
     );
     if (response.status === 404) return; // Deleting what is not there is a no-op.
     await this.#json(response, `delete ${ref}`);
@@ -236,11 +304,13 @@ export class GcpSecretManagerStore implements SecretStore {
         const id = secret.name?.split('/').pop();
         if (!id) continue;
 
-        const ref = decodeRef(id);
+        const ref = this.#owned(decodeRef(id));
         // A project may hold secrets this system did not write — a Cloud Build
-        // key, another app's token. Anything that does not decode to a valid
-        // reference is not ours, and is skipped rather than reported.
-        if (!isValidSecretRef(ref)) continue;
+        // key, another app's token — and, where it serves more than one
+        // workspace, secrets belonging to a different one. Anything that is not
+        // a valid reference inside this store's own namespace is skipped rather
+        // than reported.
+        if (ref === null || !isValidSecretRef(ref)) continue;
         if (prefix && !ref.startsWith(prefix)) continue;
         refs.push(ref);
       }

--- a/src/deployments/adapters/lanes.test.ts
+++ b/src/deployments/adapters/lanes.test.ts
@@ -1,0 +1,199 @@
+import { describe, expect, test } from 'bun:test';
+import { describeBlobStoreContract } from '#stores/blobs/conformance.ts';
+import { createLanesBlobStore } from './lanes.ts';
+
+/**
+ * A workspace Lanes hosts, reached over the API rather than a bucket.
+ *
+ * `gs://` needs the operator's own Google credentials, which is right for a
+ * workspace in their project and impossible for one in ours: handing a laptop
+ * bucket credentials to Lanes' storage would give it every tenant's bytes. So
+ * the managed scheme addresses a workspace through the API, which already knows
+ * who is calling and which workspaces they are a member of.
+ *
+ * The point of running the shared contract against it is that the CLI, the
+ * control plane and the runtime all read config through `BlobStore`. An adapter
+ * that satisfied most of the contract would fail somewhere none of them think
+ * about storage at all.
+ */
+
+const API = 'https://api.example.com';
+
+/** The API's file routes, in memory. */
+function fakeApi() {
+  const files = new Map<string, { data: Uint8Array; contentType?: string; modifiedAt: Date }>();
+  const seen: { authorization: string | null }[] = [];
+
+  const route = (url: URL): { workspace: string; kind: string } | null => {
+    const parts = url.pathname.split('/').filter(Boolean);
+    // v1 / workspaces / <ws> / link / files / <kind>
+    if (parts.length !== 6) return null;
+    if (parts[0] !== 'v1' || parts[1] !== 'workspaces' || parts[3] !== 'link') return null;
+    if (parts[4] !== 'files') return null;
+    return { workspace: parts[2] ?? '', kind: parts[5] ?? '' };
+  };
+
+  const fetch = async (input: string | URL | Request, init: RequestInit = {}): Promise<Response> => {
+    const request = input instanceof Request ? input : new Request(String(input), init);
+    const url = new URL(request.url);
+    seen.push({ authorization: request.headers.get('authorization') });
+
+    const placed = route(url);
+    if (!placed) return new Response('no such route', { status: 404 });
+
+    const scope = `${placed.workspace}::`;
+
+    if (placed.kind === 'list') {
+      const prefix = scope + (url.searchParams.get('prefix') ?? '');
+      return Response.json({
+        files: [...files.entries()]
+          .filter(([key]) => key.startsWith(prefix))
+          .map(([key, held]) => ({
+            key: key.slice(scope.length),
+            size: held.data.byteLength,
+            ...(held.contentType ? { contentType: held.contentType } : {}),
+            modifiedAt: held.modifiedAt.toISOString(),
+          })),
+      });
+    }
+
+    if (placed.kind !== 'object') return new Response('no such route', { status: 404 });
+    const key = scope + (url.searchParams.get('key') ?? '');
+
+    if (request.method === 'PUT') {
+      files.set(key, {
+        data: new Uint8Array(await request.arrayBuffer()),
+        ...(request.headers.get('content-type')
+          ? { contentType: request.headers.get('content-type') as string }
+          : {}),
+        modifiedAt: new Date('2026-01-01T00:00:00.000Z'),
+      });
+      return new Response(null, { status: 204 });
+    }
+
+    if (request.method === 'DELETE') {
+      files.delete(key);
+      return new Response(null, { status: 204 });
+    }
+
+    const held = files.get(key);
+    if (!held) return new Response(null, { status: 404 });
+    if (request.method === 'HEAD') return new Response(null, { status: 200 });
+    return new Response(held.data, {
+      status: 200,
+      headers: { 'content-type': held.contentType ?? 'application/octet-stream' },
+    });
+  };
+
+  return { fetch, files, seen };
+}
+
+const store = (workspace: string, api: ReturnType<typeof fakeApi>) =>
+  createLanesBlobStore({
+    apiUrl: API,
+    workspace,
+    tokens: { async token() { return 'id-token'; } },
+    fetch: api.fetch,
+  });
+
+describeBlobStoreContract('lanes', async () => {
+  const api = fakeApi();
+  return {
+    open: () => store('ws-aaa', api),
+    dispose: async () => {
+      api.files.clear();
+    },
+  };
+});
+
+describe('lanes: the workspace is the scope', () => {
+  test('two workspaces on one API do not see each other', async () => {
+    const api = fakeApi();
+    const first = store('ws-aaa', api);
+    const second = store('ws-bbb', api);
+
+    await first.put('connections.yaml', new TextEncoder().encode('first'));
+    await second.put('connections.yaml', new TextEncoder().encode('second'));
+
+    expect(new TextDecoder().decode(await first.get('connections.yaml') ?? undefined)).toBe('first');
+    expect(await second.list()).toEqual([
+      expect.objectContaining({ key: 'connections.yaml' }),
+    ]);
+  });
+
+  test('presents a credential on every request', async () => {
+    const api = fakeApi();
+    await store('ws-aaa', api).get('connections.yaml');
+
+    expect(api.seen.at(-1)?.authorization).toBe('Bearer id-token');
+  });
+
+  test('says which workspace was refused rather than reporting a bare status', async () => {
+    const api = fakeApi();
+    const refusing = createLanesBlobStore({
+      apiUrl: API,
+      workspace: 'ws-aaa',
+      tokens: { async token() { return 'id-token'; } },
+      fetch: async () => new Response('nope', { status: 403 }),
+    });
+
+    await expect(refusing.get('connections.yaml')).rejects.toThrow(/ws-aaa/);
+  });
+});
+
+describe('lanes: the workspace root', () => {
+  test('a root naming no workspace is refused', async () => {
+    const { lanesWorkspaceFrom } = await import('./lanes.ts');
+    expect(() => lanesWorkspaceFrom('lanes://')).toThrow(/workspace/i);
+    expect(() => lanesWorkspaceFrom('lanes:///')).toThrow(/workspace/i);
+  });
+
+  test('reads the workspace out of the root', async () => {
+    const { lanesWorkspaceFrom } = await import('./lanes.ts');
+    expect(lanesWorkspaceFrom('lanes://ws-aaa')).toBe('ws-aaa');
+    expect(lanesWorkspaceFrom('lanes://ws-aaa/')).toBe('ws-aaa');
+  });
+});
+
+describe('lanes: where the credential comes from', () => {
+  test('a store built without one uses whatever the process registered', async () => {
+    const { useLanesCredentials } = await import('./lanes.ts');
+    const api = fakeApi();
+    useLanesCredentials({ async token() { return 'ambient-token'; } });
+
+    await createLanesBlobStore({ apiUrl: API, workspace: 'ws-aaa', fetch: api.fetch }).get('x.yaml');
+
+    expect(api.seen.at(-1)?.authorization).toBe('Bearer ambient-token');
+    useLanesCredentials(null);
+  });
+
+  test('says what to do when nothing registered one', async () => {
+    const { useLanesCredentials } = await import('./lanes.ts');
+    useLanesCredentials(null);
+    const api = fakeApi();
+
+    // The adapter cannot read the signed-in session itself: `deployments` may
+    // not import `auth`, and that rule is what keeps a storage backend from
+    // growing an opinion about identity. So the process registers one, and a
+    // process that did not gets a sentence rather than a 401.
+    await expect(
+      createLanesBlobStore({ apiUrl: API, workspace: 'ws-aaa', fetch: api.fetch }).get('x.yaml'),
+    ).rejects.toThrow(/lanes auth login|no credential/i);
+  });
+
+  test('an explicitly passed source wins over the registered one', async () => {
+    const { useLanesCredentials } = await import('./lanes.ts');
+    const api = fakeApi();
+    useLanesCredentials({ async token() { return 'ambient-token'; } });
+
+    await createLanesBlobStore({
+      apiUrl: API,
+      workspace: 'ws-aaa',
+      tokens: { async token() { return 'explicit-token'; } },
+      fetch: api.fetch,
+    }).get('x.yaml');
+
+    expect(api.seen.at(-1)?.authorization).toBe('Bearer explicit-token');
+    useLanesCredentials(null);
+  });
+});

--- a/src/deployments/adapters/lanes.ts
+++ b/src/deployments/adapters/lanes.ts
@@ -1,0 +1,223 @@
+import { containedKey, type BlobKey, type BlobMetadata, type BlobStore } from '#stores/blobs';
+
+/**
+ * A workspace Lanes hosts, addressed over the API.
+ *
+ * The other remote adapter is `gcs.ts`, and it cannot serve this. A `gs://`
+ * root is opened with the caller's own Google credentials, which is exactly
+ * right for a bucket in the operator's project and impossible for one in ours:
+ * handing a laptop credentials to Lanes' storage would hand it every tenant's
+ * bytes, and scoping that down per workspace is an IAM condition per tenant on
+ * a bucket nobody outside Lanes should be able to name.
+ *
+ * So the managed scheme goes through the API, which already knows who is
+ * calling and which workspaces they are a member of. The check that a caller
+ * may read this workspace happens there, once, beside every other check of the
+ * same kind — not here, where it would be a client-side rule a client could
+ * simply not apply.
+ *
+ * **This is the seam that makes managed symmetric with the other two.** The
+ * CLI, the control plane and the runtime all read config through `BlobStore`,
+ * so a workspace at `lanes://<id>` is administered by the same commands as one
+ * in `~/.lanes-link` or a bucket. Nothing above this file knows which it has.
+ */
+
+export const LANES_SCHEME = 'lanes://';
+
+/**
+ * A `fetch` this adapter can be handed.
+ *
+ * Narrower than `typeof globalThis.fetch`, which under Bun's types carries a
+ * `preconnect` method no test double has any reason to implement. Spelled the
+ * same way in `gcs.ts` and `github-api.ts` for the same reason.
+ */
+export type FetchLike = (input: string | URL | Request, init?: RequestInit) => Promise<Response>;
+
+/** Objects per listing page. The API pages; this is what it is asked for. */
+const PAGE_SIZE = 1000;
+
+/** How a caller proves who it is. The CLI signs in; the control plane asserts. */
+export interface TokenSource {
+  token(): Promise<string>;
+}
+
+export interface LanesBlobStoreOptions {
+  /** Where the API lives, without a trailing slash. */
+  readonly apiUrl: string;
+  /** Which workspace's files these are. */
+  readonly workspace: string;
+  /** Omitted, the one the process registered. See `useLanesCredentials`. */
+  readonly tokens?: TokenSource;
+  readonly fetch?: FetchLike;
+}
+
+/**
+ * The credential this process presents to the Lanes API, registered once.
+ *
+ * A slot rather than a parameter, and it is worth saying why, because a mutable
+ * module-level value is the kind of thing this repository refuses by default.
+ *
+ * `workspaceFiles(root)` takes a root and nothing else, at thirty-five call
+ * sites, because "give me this workspace's files" genuinely needs nothing else
+ * — a `gs://` root is opened with Application Default Credentials, which Google's
+ * own client resolves from the environment without anybody threading it
+ * through. The credential is a property of the process's identity, not of any
+ * one call.
+ *
+ * This adapter cannot do the same thing the same way: reading the signed-in
+ * session means importing `auth`, and `deployments` may not, which is the rule
+ * that keeps a storage backend from growing an opinion about who is calling.
+ * So the layer that *may* read a session registers one — `src/cli/lanes.ts`
+ * after sign-in, the container from its own identity — and the adapter asks for
+ * it at call time rather than at construction, so registration order does not
+ * matter.
+ */
+let registered: TokenSource | null = null;
+
+/** Register the process's credential, or clear it with `null`. */
+export function useLanesCredentials(tokens: TokenSource | null): void {
+  registered = tokens;
+}
+
+const registeredTokens: TokenSource = {
+  async token() {
+    if (registered === null) {
+      throw new Error(
+        'No credential is registered for a lanes:// workspace, so there is nothing to ' +
+          'present to the Lanes API. Run `lanes auth login` if you are at a terminal; a ' +
+          'service registers one at startup.',
+      );
+    }
+    return registered.token();
+  },
+};
+
+/**
+ * The workspace named by a `lanes://` root.
+ *
+ * Kept beside the adapter rather than in `files.ts` so the scheme is parsed and
+ * served in one place. `files.ts` decides *which* adapter a root gets; what a
+ * root means is this file's.
+ */
+export function lanesWorkspaceFrom(root: string): string {
+  const workspace = root.slice(LANES_SCHEME.length).replace(/\/+$/, '');
+  if (workspace.length === 0 || workspace.includes('/')) {
+    throw new Error(
+      `LANES_LINK_HOME is ${JSON.stringify(root)}, which names no workspace. ` +
+        `Expected ${LANES_SCHEME}<workspace-id>.`,
+    );
+  }
+  return workspace;
+}
+
+export function createLanesBlobStore(options: LanesBlobStoreOptions): BlobStore {
+  const call: FetchLike = options.fetch ?? globalThis.fetch;
+  const tokens = options.tokens ?? registeredTokens;
+  const base = `${options.apiUrl.replace(/\/+$/, '')}/v1/workspaces/${encodeURIComponent(options.workspace)}/link/files`;
+
+  // Containment is applied here as well as on the server. The server's check is
+  // the one that counts — a client rule is one a client can decline to run —
+  // but a key that escapes should fail in the caller's own stack trace rather
+  // than as a 400 from three components away.
+  const objectUrl = (key: BlobKey): string =>
+    `${base}/object?key=${encodeURIComponent(containedKey(key))}`;
+
+  const request = async (url: string, init: RequestInit = {}): Promise<Response> =>
+    call(url, {
+      ...init,
+      headers: { ...init.headers, authorization: `Bearer ${await tokens.token()}` },
+    });
+
+  const failure = async (operation: string, key: string, response: Response): Promise<Error> => {
+    const detail = (await response.text().catch(() => '')).slice(0, 400);
+
+    if (response.status === 401 || response.status === 403) {
+      return new Error(
+        `Lanes refused to ${operation} "${key}" in workspace ${options.workspace} ` +
+          `(${response.status}). Either this credential has expired — \`lanes auth login\` ` +
+          'mints a new one — or its subject is not a member of that workspace. ' +
+          `${detail}`,
+      );
+    }
+    return new Error(
+      `Lanes failed to ${operation} "${key}" in workspace ${options.workspace} ` +
+        `(${response.status}). ${detail}`,
+    );
+  };
+
+  return {
+    async put(key, data, putOptions) {
+      const response = await request(objectUrl(key), {
+        method: 'PUT',
+        body: data,
+        headers: { 'content-type': putOptions?.contentType ?? 'application/octet-stream' },
+      });
+      if (!response.ok) throw await failure('write', key, response);
+    },
+
+    async get(key) {
+      const response = await request(objectUrl(key));
+      // Absence is a value, not an error — every caller is written against null.
+      if (response.status === 404) return null;
+      if (!response.ok) throw await failure('read', key, response);
+      return new Uint8Array(await response.arrayBuffer());
+    },
+
+    async has(key) {
+      const response = await request(objectUrl(key), { method: 'HEAD' });
+      if (response.status === 404) return false;
+      if (!response.ok) throw await failure('stat', key, response);
+      return true;
+    },
+
+    async delete(key) {
+      const response = await request(objectUrl(key), { method: 'DELETE' });
+      // Deleting what is not there is not a failure: callers use this to make
+      // absence true, and a sweep racing another sweep must not throw.
+      if (response.status === 404) return;
+      if (!response.ok) throw await failure('delete', key, response);
+    },
+
+    async list(prefix) {
+      const found: BlobMetadata[] = [];
+      let cursor: string | undefined;
+
+      do {
+        const query = new URLSearchParams({ limit: String(PAGE_SIZE) });
+        if (prefix) query.set('prefix', containedKey(prefix));
+        if (cursor) query.set('cursor', cursor);
+
+        const response = await request(`${base}/list?${query}`);
+        if (!response.ok) throw await failure('list', prefix ?? '', response);
+
+        const page = (await response.json()) as {
+          files?: Array<{
+            key: string;
+            size?: number;
+            contentType?: string;
+            modifiedAt?: string;
+          }>;
+          next?: string;
+        };
+
+        for (const file of page.files ?? []) {
+          found.push({
+            key: file.key,
+            size: file.size ?? 0,
+            ...(file.contentType ? { contentType: file.contentType } : {}),
+            modifiedAt: file.modifiedAt ? new Date(file.modifiedAt) : new Date(0),
+          });
+        }
+
+        cursor = page.next;
+      } while (cursor !== undefined);
+
+      // Sorted here rather than trusted from the API. The contract every other
+      // adapter satisfies says listings are sorted, and a store that is sorted
+      // only when the server felt like it is not the same interface — the
+      // callers that walk a profile's files would differ by backend, which is
+      // exactly what `describeBlobStoreContract` exists to prevent.
+      return found.sort((left, right) => (left.key < right.key ? -1 : left.key > right.key ? 1 : 0));
+    },
+  };
+}

--- a/src/deployments/adapters/lanes.ts
+++ b/src/deployments/adapters/lanes.ts
@@ -24,6 +24,14 @@ import { containedKey, type BlobKey, type BlobMetadata, type BlobStore } from '#
 
 export const LANES_SCHEME = 'lanes://';
 
+/** Where a managed workspace is read from, when nothing overrides it. */
+export const DEFAULT_LANES_API_URL = 'https://api.lanes.sh';
+
+/** The API this process talks to. `LANES_API_URL` is what a stage deployment sets. */
+export function lanesApiUrl(env: Record<string, string | undefined> = process.env): string {
+  return env['LANES_API_URL'] ?? DEFAULT_LANES_API_URL;
+}
+
 /**
  * A `fetch` this adapter can be handed.
  *

--- a/src/deployments/environment.test.ts
+++ b/src/deployments/environment.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, test } from 'bun:test';
+import { assertEnvironmentMatches, environmentFrom } from './environment.ts';
+
+/**
+ * The guard that stops a staging deployment reading production.
+ *
+ * The Lanes API derives its stage configuration by overriding each secret
+ * substitution individually, so a secret added without its override leaves
+ * stage silently reading the prod one. Nothing warns, and two are already in
+ * that state. For a form endpoint that misroutes a submission; for a workspace
+ * holding OAuth refresh tokens it is somebody's mailbox.
+ *
+ * So a managed deployment derives everything from one environment name and
+ * refuses to boot when what it derived disagrees. Refusing is the whole point:
+ * a mismatch that logs a warning and serves anyway is the silent fallback with
+ * an extra step.
+ */
+
+describe('reading the environment', () => {
+  test('accepts the two names a deployment may carry', () => {
+    expect(environmentFrom('prod')).toBe('prod');
+    expect(environmentFrom('stage')).toBe('stage');
+  });
+
+  test('refuses anything else rather than assuming production', () => {
+    // The dangerous default. An unset or misspelled variable resolving to
+    // `prod` is how a staging revision ends up holding production's root.
+    expect(() => environmentFrom(undefined)).toThrow(/environment/i);
+    expect(() => environmentFrom('')).toThrow(/environment/i);
+    expect(() => environmentFrom('production')).toThrow(/environment/i);
+    expect(() => environmentFrom('staging')).toThrow(/environment/i);
+  });
+});
+
+describe('matching a location to its environment', () => {
+  const check = (environment: 'prod' | 'stage', value: string) =>
+    assertEnvironmentMatches({ environment, what: 'LANES_LINK_HOME', value });
+
+  test('a stage deployment accepts a location that names stage', () => {
+    expect(() => check('stage', 'gs://lanes-link-managed-stage/workspaces')).not.toThrow();
+    expect(() => check('stage', 'https://api-stage.example.com')).not.toThrow();
+  });
+
+  test('a stage deployment refuses a location that does not name stage', () => {
+    // The failure this whole file exists for.
+    expect(() => check('stage', 'gs://lanes-link-managed/workspaces')).toThrow(
+      /LANES_LINK_HOME/,
+    );
+    expect(() => check('stage', 'https://api.example.com')).toThrow(/stage/i);
+  });
+
+  test('a prod deployment refuses a location that names stage', () => {
+    // The mirror, and worth having: a production revision pointed at staging
+    // storage serves an empty workspace and looks like data loss.
+    expect(() => check('prod', 'gs://lanes-link-managed-stage/workspaces')).toThrow(
+      /LANES_LINK_HOME/,
+    );
+  });
+
+  test('a prod deployment accepts a location that names no environment', () => {
+    expect(() => check('prod', 'gs://lanes-link-managed/workspaces')).not.toThrow();
+    expect(() => check('prod', 'https://api.example.com')).not.toThrow();
+  });
+
+  test('names the location and both sides in the refusal', () => {
+    // A boot failure is read in a log with no command line to inspect, so the
+    // message carries what the operator would otherwise have to go and find.
+    expect(() => check('stage', 'gs://lanes-link-managed/workspaces')).toThrow(
+      /gs:\/\/lanes-link-managed\/workspaces/,
+    );
+  });
+});

--- a/src/deployments/environment.ts
+++ b/src/deployments/environment.ts
@@ -1,0 +1,86 @@
+/**
+ * Which deployment this process is, and the refusal when it does not add up.
+ *
+ * A self-hosted deploy has one environment and no need for any of this. A
+ * Lanes-hosted runtime has two, sharing a code path, a container image and a
+ * cloud project — and the failure that matters is a staging revision reading
+ * production's workspaces, which hold live OAuth refresh tokens.
+ *
+ * The Lanes API derives its stage configuration by overriding each secret
+ * substitution individually, so a secret added to `cloudbuild.yaml` without a
+ * matching override leaves stage reading the production secret. Nothing warns,
+ * and two are already in that state. For a form endpoint that misroutes a
+ * submission. Here it would be somebody's mailbox.
+ *
+ * So a managed deployment derives every location from one environment name and
+ * checks what it derived. **A mismatch refuses to boot**, which is the whole
+ * point: a mismatch that logs and serves anyway is the silent fallback with an
+ * extra step, and the thing it would be protecting is the one asset in this
+ * system that cannot be un-leaked.
+ */
+
+/** The deployments a managed runtime runs as. Not an open set, deliberately. */
+export type Environment = 'prod' | 'stage';
+
+const ENVIRONMENTS: readonly Environment[] = ['prod', 'stage'];
+
+/**
+ * The marker a non-production location has to carry.
+ *
+ * One substring rather than a pattern per location. A bucket, a hostname and a
+ * secret prefix are spelled differently enough that any rule fitting all three
+ * would be loose, and a loose rule here is worse than none — it would pass the
+ * case it exists to catch.
+ */
+const STAGE_MARKER = 'stage';
+
+/**
+ * The environment named by a variable, or a refusal.
+ *
+ * There is no default, and that is the decision. An unset or misspelled
+ * variable resolving to `prod` is precisely how a staging revision comes to
+ * hold production's root, so an unrecognised value is a boot failure rather
+ * than an assumption. `staging` is rejected alongside nonsense for the same
+ * reason: one spelling, or the marker check below has two things to agree with.
+ */
+export function environmentFrom(value: string | undefined): Environment {
+  const found = ENVIRONMENTS.find((environment) => environment === value);
+  if (found) return found;
+
+  throw new Error(
+    `The deployment environment is ${JSON.stringify(value)}, which is not one of ` +
+      `${ENVIRONMENTS.join(', ')}. Set it explicitly — there is no default, because a ` +
+      'misspelled value defaulting to "prod" is how a staging revision comes to hold ' +
+      "production's workspaces.",
+  );
+}
+
+/**
+ * Refuse a location that belongs to a different environment than this one.
+ *
+ * Called once per derived location at boot — the workspace root, the API URL,
+ * the endpoint domain — rather than once over a bundle, so the refusal names
+ * which one disagreed. A boot failure is read in a log with no command line to
+ * inspect, so the message carries what the operator would otherwise go and find.
+ */
+export function assertEnvironmentMatches(input: {
+  readonly environment: Environment;
+  /** What is being checked, named in the refusal. */
+  readonly what: string;
+  readonly value: string;
+}): void {
+  const names = input.value.toLowerCase().includes(STAGE_MARKER);
+  const shouldName = input.environment === 'stage';
+  if (names === shouldName) return;
+
+  throw new Error(
+    `${input.what} is ${JSON.stringify(input.value)}, which ` +
+      (shouldName
+        ? `does not name "${STAGE_MARKER}" while this deployment is "stage". A stage ` +
+          'deployment reading production storage is the failure this check exists for, ' +
+          'so it refuses to start rather than serve.'
+        : `names "${STAGE_MARKER}" while this deployment is "prod". A production ` +
+          'revision pointed at staging storage serves an empty workspace, which reads ' +
+          'as data loss.'),
+  );
+}

--- a/src/deployments/target-managed.test.ts
+++ b/src/deployments/target-managed.test.ts
@@ -1,0 +1,111 @@
+import { afterEach, describe, expect, test } from 'bun:test';
+import { configSchema } from '#profile';
+import { targetSchema } from '#profile/schema.ts';
+import { useLanesCredentials } from './adapters/lanes.ts';
+import { openSecrets, openStorage } from './target.ts';
+import type { SecretStore } from '#secrets';
+
+/**
+ * Declaring a workspace Lanes hosts.
+ *
+ * The adapter and the credential namespace exist; this is what makes them
+ * reachable from a `workspaces.yaml`, which is the only way anything the
+ * operator writes can select them. An adapter no config can name is an adapter
+ * nothing exercises.
+ */
+
+const config = configSchema.parse({
+  contract: 5,
+  instance: { profile: 'personal' },
+  grants: [],
+  members: [],
+});
+
+const declared = (storage: Record<string, unknown>, credentials?: Record<string, unknown>) =>
+  targetSchema.parse({
+    credentials: credentials ?? { adapter: 'gcp-secret-manager', project: 'my-project' },
+    storage,
+  });
+
+afterEach(() => {
+  useLanesCredentials(null);
+});
+
+describe('a managed storage target', () => {
+  test('addresses the API for the workspace it declares', async () => {
+    const seen: string[] = [];
+    useLanesCredentials({ async token() { return 'id-token'; } });
+
+    const storage = await openStorage(
+      {
+        declared: declared({ adapter: 'lanes', workspace: 'ws-aaa' }),
+        config,
+        root: 'lanes://ws-aaa',
+        target: 'managed',
+      },
+      {} as SecretStore,
+    );
+
+    const real = globalThis.fetch;
+    globalThis.fetch = (async (url: string | URL | Request) => {
+      seen.push(String(url instanceof Request ? url.url : url));
+      return new Response(null, { status: 204 });
+    }) as typeof globalThis.fetch;
+
+    try {
+      await storage().put('memory/main/one.md', new Uint8Array([1]));
+    } finally {
+      globalThis.fetch = real;
+    }
+
+    expect(seen[0]).toContain('/v1/workspaces/ws-aaa/link/files/object');
+    // The profile's own area, exactly as the bucket adapters scope it.
+    expect(decodeURIComponent(seen[0] ?? '')).toContain('profiles/personal/memory/main/one.md');
+  });
+
+  test('refuses to open without a workspace, naming the field', async () => {
+    await expect(
+      openStorage(
+        {
+          declared: declared({ adapter: 'lanes' }),
+          config,
+          root: 'lanes://ws-aaa',
+          target: 'managed',
+        },
+        {} as SecretStore,
+      ),
+    ).rejects.toThrow(/workspaces\.managed\.storage\.workspace/);
+  });
+});
+
+describe('a managed credential target', () => {
+  test('scopes references to the namespace it declares', async () => {
+    const seen: string[] = [];
+    const real = globalThis.fetch;
+    globalThis.fetch = (async (url: string | URL | Request) => {
+      seen.push(String(url instanceof Request ? url.url : url));
+      return new Response(null, { status: 404 });
+    }) as typeof globalThis.fetch;
+    process.env['GOOGLE_ACCESS_TOKEN'] = 'test-token';
+
+    try {
+      const secrets = await openSecrets({
+        declared: declared(
+          { adapter: 'lanes', workspace: 'ws-aaa' },
+          { adapter: 'gcp-secret-manager', project: 'my-project', namespace: 'ws-aaa' },
+        ),
+        root: 'lanes://ws-aaa',
+        target: 'managed',
+      });
+
+      await secrets.get('tokens/tok1');
+    } finally {
+      globalThis.fetch = real;
+      delete process.env['GOOGLE_ACCESS_TOKEN'];
+    }
+
+    // Without the namespace this is `tokens__tok1`, which every other workspace
+    // in the project also writes.
+    expect(seen[0]).toContain('/secrets/ws-aaa__tokens__tok1/');
+  });
+});

--- a/src/deployments/target.ts
+++ b/src/deployments/target.ts
@@ -2,7 +2,7 @@ import type { AuditReader, AuditSink, AuditStore } from '#audit';
 import { ConfigError, layout, workspacePath, type Config, type TargetConfig } from '#profile';
 import type { SecretStore } from '#secrets';
 import { createFileSecretStore } from '#secrets';
-import type { BlobStore } from '#stores/blobs';
+import { scopeBlobStore, type BlobStore } from '#stores/blobs';
 import { createRuntimeState, type RuntimeState } from '#stores/state';
 import { createBlobAuditStore } from './adapters/audit-blob.ts';
 
@@ -93,7 +93,15 @@ export async function openSecrets(input: {
         );
       }
       const { GcpSecretManagerStore } = await import('./adapters/gcp-secret-manager.ts');
-      return new GcpSecretManagerStore({ project: declared.credentials.project });
+      return new GcpSecretManagerStore({
+        project: declared.credentials.project,
+        // Absent for a self-hosted deploy, which owns its project. Present for
+        // a Lanes-hosted one, where every workspace stores `tokens/tok1` into
+        // the same namespace and the collision is somebody else's token.
+        ...(declared.credentials.namespace !== undefined
+          ? { namespace: declared.credentials.namespace }
+          : {}),
+      });
     }
   }
 }
@@ -247,6 +255,32 @@ export async function openStorage(
           bucket,
           prefix: `${base}${area ?? root}/`,
         });
+    }
+
+    case 'lanes': {
+      // No bucket and no key pair: a managed workspace names itself, and the
+      // API resolves where its bytes live and refuses a caller who is not a
+      // member. The credential is the process's, registered rather than
+      // declared, for the reason `adapters/lanes.ts` gives.
+      const { workspace } = declared.storage;
+      if (!workspace) {
+        throw new ConfigError(
+          `workspaces.${target}.storage.workspace is required for the lanes adapter.`,
+        );
+      }
+
+      const { createLanesBlobStore, lanesApiUrl } = await import('./adapters/lanes.ts');
+      const apiUrl = lanesApiUrl();
+      const base = layout.blobs(config.instance.profile);
+
+      // Scoped exactly as the bucket adapters scope: the profile's own area by
+      // default, or whichever area the caller asked for. A managed workspace
+      // that laid its bytes out differently would be a fourth layout for the
+      // same tree.
+      return (area) => {
+        const store = createLanesBlobStore({ apiUrl, workspace });
+        return scopeBlobStore(store, area ?? base);
+      };
     }
 
     case 's3': {

--- a/src/profile/files.test.ts
+++ b/src/profile/files.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, test } from 'bun:test';
+import { isRemoteWorkspace, workspaceFiles } from './files.ts';
+
+/**
+ * Which backing a workspace root names.
+ *
+ * Three schemes now, and the third is the one this file exists to pin. A
+ * `lanes://` root has to be *remote* — every caller that asks
+ * `isRemoteWorkspace` is asking "can I treat this as a filesystem path", and
+ * the answer for a managed workspace is no. Getting that wrong does not fail
+ * loudly: it produces a directory literally named `lanes:` beside whatever the
+ * process's working directory happens to be.
+ */
+
+describe('a workspace root', () => {
+  test('a directory is not remote', () => {
+    expect(isRemoteWorkspace('/Users/someone/.lanes-link')).toBe(false);
+    expect(isRemoteWorkspace('./relative')).toBe(false);
+  });
+
+  test('a bucket is remote', () => {
+    expect(isRemoteWorkspace('gs://your-bucket')).toBe(true);
+    expect(isRemoteWorkspace('gs://your-bucket/prefix')).toBe(true);
+  });
+
+  test('a managed workspace is remote', () => {
+    expect(isRemoteWorkspace('lanes://ws-aaa')).toBe(true);
+  });
+});
+
+describe('opening a workspace root', () => {
+  test('a managed root is served by the API rather than the filesystem', async () => {
+    // Nothing registered a credential here, so the lanes adapter refuses. That
+    // refusal is the proof: a filesystem store would have happily reported
+    // absence from a directory named `lanes:`.
+    await expect(workspaceFiles('lanes://ws-aaa').get('connections.yaml')).rejects.toThrow(
+      /credential is registered/i,
+    );
+  });
+
+  test('a managed root naming no workspace is refused', () => {
+    expect(() => workspaceFiles('lanes://')).toThrow(/workspace/i);
+  });
+});

--- a/src/profile/files.ts
+++ b/src/profile/files.ts
@@ -1,5 +1,10 @@
 import { createFilesystemBlobStore } from '#deployments/adapters/filesystem.ts';
 import { createGcsBlobStore } from '#deployments/adapters/gcs.ts';
+import {
+  LANES_SCHEME,
+  createLanesBlobStore,
+  lanesWorkspaceFrom,
+} from '#deployments/adapters/lanes.ts';
 import type { BlobStore } from '#stores/blobs';
 
 /**
@@ -31,9 +36,26 @@ import type { BlobStore } from '#stores/blobs';
 
 const GCS_SCHEME = 'gs://';
 
-/** Whether a workspace root names a bucket rather than a directory. */
+/**
+ * Where a managed workspace is read from, when nothing overrides it.
+ *
+ * Spelled here rather than imported from `#auth/lanes/login.ts`, which holds
+ * the same default: `profile` may not import `auth`. The override is the same
+ * variable both sides read, so a stage deployment points both at one place.
+ */
+const DEFAULT_API_URL = 'https://api.lanes.sh';
+
+/**
+ * Whether a workspace root is somewhere other than this filesystem.
+ *
+ * Every caller is really asking "may I treat this as a path". Two schemes
+ * answer no: a bucket the operator owns, and a workspace Lanes hosts. Getting a
+ * managed root wrong here does not fail loudly — `join` would produce a
+ * directory named `lanes:` beside the process's working directory, and the
+ * config would read as absent rather than as unreachable.
+ */
 export function isRemoteWorkspace(root: string): boolean {
-  return root.startsWith(GCS_SCHEME);
+  return root.startsWith(GCS_SCHEME) || root.startsWith(LANES_SCHEME);
 }
 
 /**
@@ -44,6 +66,18 @@ export function isRemoteWorkspace(root: string): boolean {
  */
 export function workspaceFiles(root: string): BlobStore {
   if (!isRemoteWorkspace(root)) return createFilesystemBlobStore({ root });
+
+  // A managed workspace is addressed through the API, which already knows who
+  // is calling and which workspaces they belong to. It takes no credential
+  // here: the process registers one (ADR: a managed workspace is a workspace),
+  // exactly as a `gs://` root takes none and resolves Application Default
+  // Credentials from the environment.
+  if (root.startsWith(LANES_SCHEME)) {
+    return createLanesBlobStore({
+      apiUrl: process.env['LANES_API_URL'] ?? DEFAULT_API_URL,
+      workspace: lanesWorkspaceFrom(root),
+    });
+  }
 
   const withoutScheme = root.slice(GCS_SCHEME.length);
   const slash = withoutScheme.indexOf('/');

--- a/src/profile/files.ts
+++ b/src/profile/files.ts
@@ -3,6 +3,7 @@ import { createGcsBlobStore } from '#deployments/adapters/gcs.ts';
 import {
   LANES_SCHEME,
   createLanesBlobStore,
+  lanesApiUrl,
   lanesWorkspaceFrom,
 } from '#deployments/adapters/lanes.ts';
 import type { BlobStore } from '#stores/blobs';
@@ -36,14 +37,6 @@ import type { BlobStore } from '#stores/blobs';
 
 const GCS_SCHEME = 'gs://';
 
-/**
- * Where a managed workspace is read from, when nothing overrides it.
- *
- * Spelled here rather than imported from `#auth/lanes/login.ts`, which holds
- * the same default: `profile` may not import `auth`. The override is the same
- * variable both sides read, so a stage deployment points both at one place.
- */
-const DEFAULT_API_URL = 'https://api.lanes.sh';
 
 /**
  * Whether a workspace root is somewhere other than this filesystem.
@@ -74,7 +67,7 @@ export function workspaceFiles(root: string): BlobStore {
   // Credentials from the environment.
   if (root.startsWith(LANES_SCHEME)) {
     return createLanesBlobStore({
-      apiUrl: process.env['LANES_API_URL'] ?? DEFAULT_API_URL,
+      apiUrl: lanesApiUrl(),
       workspace: lanesWorkspaceFrom(root),
     });
   }

--- a/src/profile/schema.ts
+++ b/src/profile/schema.ts
@@ -91,12 +91,32 @@ export const credentialsTargetSchema = z.object({
   adapter: z.enum(['file', 'gcp-secret-manager']),
   path: z.string().optional(),
   project: z.string().optional(),
+  /**
+   * Which workspace's secrets these are, when the project holds more than one.
+   *
+   * A self-hosted deploy gets a project per workspace, so a reference is unique
+   * by construction and this is absent. A Lanes-hosted runtime serves many
+   * workspaces from one project and every one of them stores `tokens/tok1`, so
+   * without this the second write adds a version to the first workspace's
+   * secret and both read one refresh token.
+   */
+  namespace: z.string().optional(),
 });
 
 export const storageTargetSchema = z.object({
-  adapter: z.enum(['filesystem', 'gcs', 's3']),
+  adapter: z.enum(['filesystem', 'gcs', 's3', 'lanes']),
   path: z.string().optional(),
   bucket: z.string().optional(),
+  /**
+   * Which workspace, for the `lanes` adapter.
+   *
+   * The bucket adapters name a bucket and a prefix; a managed workspace names
+   * itself, because the API resolves where its bytes are and refuses a caller
+   * who is not a member. Declared rather than derived from the root so a
+   * pointer and a declaration cannot disagree about which workspace is being
+   * opened.
+   */
+  workspace: z.string().optional(),
   /**
    * The S3-compatible service endpoint. Named for the protocol rather than a
    * vendor (ADR-013) — Supabase Storage, R2, MinIO, and AWS differ only in this

--- a/src/secrets/vault-key-source.test.ts
+++ b/src/secrets/vault-key-source.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, test } from 'bun:test';
+import { createMemoryBlobStore } from '#stores/blobs/testing.ts';
+import { createMemoryCredentials } from '#stores/state/testing.ts';
+import { createBlobVaultStore, createSecretVaultStore } from './vault.ts';
+
+/**
+ * Where a deployed vault's key comes from, when one process serves more than
+ * one workspace.
+ *
+ * `LANES_LINK_VAULT_KEY` is process-global, which is exactly right for a
+ * self-hosted deploy: one process, one workspace, one key, delivered by
+ * `--set-secrets`. A Lanes-hosted runtime serves many workspaces from one
+ * process, and a process-global key there means one key opens every tenant's
+ * vault — so a single leak is total, and rotating one workspace's key is not
+ * expressible at all.
+ *
+ * `encryptionKey` already accepts a resolved key, and is the wrong shape for
+ * this: a host would have to fetch every workspace's key before building a
+ * store that may never touch the vault, turning an unused surface into a
+ * Secret Manager round trip on every request and a failure mode for requests
+ * that had nothing to do with the vault. A `KeySource` is resolved on first use
+ * and cached, which is what these first two tests pin.
+ */
+
+const keyOf = (fill: number): Uint8Array => new Uint8Array(32).fill(fill);
+
+const counting = (fill: number) => {
+  let calls = 0;
+  return {
+    calls: () => calls,
+    source: async (): Promise<Uint8Array> => {
+      calls += 1;
+      return keyOf(fill);
+    },
+  };
+};
+
+describe('a vault key source', () => {
+  test('is not consulted until the vault is actually touched', async () => {
+    const key = counting(1);
+
+    createBlobVaultStore({
+      store: createMemoryBlobStore(),
+      env: {},
+      keySource: key.source,
+    });
+
+    expect(key.calls()).toBe(0);
+  });
+
+  test('is resolved once, however many operations follow', async () => {
+    const key = counting(1);
+    const vault = createBlobVaultStore({
+      store: createMemoryBlobStore(),
+      env: {},
+      keySource: key.source,
+    });
+
+    await vault.put('main', { id: 'stripe', value: 'sk_test_x' });
+    await vault.get('main', 'stripe');
+    await vault.ids();
+
+    expect(key.calls()).toBe(1);
+  });
+
+  test('one workspace does not open another workspace vault', async () => {
+    // One backend on purpose. Separate roots already keep two workspaces apart;
+    // this is the property that still holds when something else has failed and
+    // one tenant is looking at another tenant's bytes.
+    const blobs = createMemoryBlobStore();
+
+    const first = createBlobVaultStore({ store: blobs, env: {}, keySource: async () => keyOf(1) });
+    await first.put('main', { id: 'stripe', value: 'sk_live_first' });
+
+    const second = createBlobVaultStore({ store: blobs, env: {}, keySource: async () => keyOf(2) });
+    await expect(second.get('main', 'stripe')).rejects.toThrow();
+  });
+
+  test('is preferred over the environment, which a host must not depend on', async () => {
+    // A multi-tenant host sets no LANES_LINK_VAULT_KEY. If one were present —
+    // left over, or set for something else — a store given its own source must
+    // still use that source, or one workspace silently seals under a key
+    // another workspace can open.
+    const env = { LANES_LINK_VAULT_KEY: Buffer.from(keyOf(9)).toString('base64') };
+    const blobs = createMemoryBlobStore();
+
+    const scoped = createBlobVaultStore({ store: blobs, env, keySource: async () => keyOf(1) });
+    await scoped.put('main', { id: 'stripe', value: 'sk_live_x' });
+
+    const ambient = createBlobVaultStore({ store: blobs, env });
+    await expect(ambient.get('main', 'stripe')).rejects.toThrow();
+  });
+
+  test('reaches the secret-backed adapter too', async () => {
+    // `secret` is the adapter a deployment actually uses, so a key source that
+    // only reached `blob` would leave the deployed path process-global.
+    const credentials = createMemoryCredentials();
+
+    const first = createSecretVaultStore({
+      store: credentials,
+      env: {},
+      keySource: async () => keyOf(1),
+    });
+    await first.put('main', { id: 'stripe', value: 'sk_live_first' });
+
+    const second = createSecretVaultStore({
+      store: credentials,
+      env: {},
+      keySource: async () => keyOf(2),
+    });
+    await expect(second.get('main', 'stripe')).rejects.toThrow();
+  });
+});

--- a/src/secrets/vault.ts
+++ b/src/secrets/vault.ts
@@ -117,6 +117,17 @@ export interface BlobVaultStoreOptions {
   readonly key?: string;
   /** 32-byte key. When omitted, `LANES_LINK_VAULT_KEY` — and nothing else. */
   readonly encryptionKey?: Uint8Array;
+  /**
+   * Where this store's key comes from, when the environment is not the answer.
+   *
+   * Set by a host serving more than one workspace from one process: a
+   * process-global `LANES_LINK_VAULT_KEY` there is one key over every tenant's
+   * vault, so a single leak is total and rotating one workspace's key cannot be
+   * expressed. Resolved on first use and cached, unlike `encryptionKey`, which
+   * would make a host fetch a key for every store it builds including the ones
+   * that never touch the vault.
+   */
+  readonly keySource?: KeySource;
   readonly env?: Record<string, string | undefined>;
 }
 
@@ -133,13 +144,14 @@ export function createBlobVaultStore(options: BlobVaultStoreOptions): VaultStore
 
   return new DocumentVaultStore(
     blobDocumentIO(options.store, key),
-    envOnlyKeySource({
-      envVar: KEY_ENV,
-      env,
-      explicit: options.encryptionKey,
-      label: key,
-      remedy: 'lanes link vault key generate',
-    }),
+    options.keySource ??
+      envOnlyKeySource({
+        envVar: KEY_ENV,
+        env,
+        explicit: options.encryptionKey,
+        label: key,
+        remedy: 'lanes link vault key generate',
+      }),
   );
 }
 
@@ -153,6 +165,17 @@ export interface SecretVaultStoreOptions {
   readonly ref?: string;
   /** 32-byte key. When omitted, `LANES_LINK_VAULT_KEY` — and nothing else. */
   readonly encryptionKey?: Uint8Array;
+  /**
+   * Where this store's key comes from, when the environment is not the answer.
+   *
+   * Set by a host serving more than one workspace from one process: a
+   * process-global `LANES_LINK_VAULT_KEY` there is one key over every tenant's
+   * vault, so a single leak is total and rotating one workspace's key cannot be
+   * expressed. Resolved on first use and cached, unlike `encryptionKey`, which
+   * would make a host fetch a key for every store it builds including the ones
+   * that never touch the vault.
+   */
+  readonly keySource?: KeySource;
   readonly env?: Record<string, string | undefined>;
 }
 
@@ -189,13 +212,14 @@ export function createSecretVaultStore(options: SecretVaultStoreOptions): VaultS
 
   return new DocumentVaultStore(
     secretDocumentIO(options.store, ref),
-    envOnlyKeySource({
-      envVar: KEY_ENV,
-      env,
-      explicit: options.encryptionKey,
-      label: ref,
-      remedy: 'lanes link vault key generate',
-    }),
+    options.keySource ??
+      envOnlyKeySource({
+        envVar: KEY_ENV,
+        env,
+        explicit: options.encryptionKey,
+        label: ref,
+        remedy: 'lanes link vault key generate',
+      }),
   );
 }
 

--- a/src/server/router.test.ts
+++ b/src/server/router.test.ts
@@ -1,0 +1,181 @@
+import { describe, expect, test } from 'bun:test';
+import { createWorkspaceRouter } from './router.ts';
+import type { RequestHandler } from './index.ts';
+
+/**
+ * One process, many workspaces.
+ *
+ * A self-hosted deploy resolves `LANES_LINK_HOME` once at boot and serves one
+ * workspace for the life of the process. A Lanes-hosted runtime serves many, so
+ * something has to decide which one a request is for, build that workspace's
+ * handler at most once, and let it go again when it has been idle.
+ *
+ * The unit under test is deliberately thin: `RequestHandler` is `{fetch,
+ * close}`, so none of the endpoint's machinery is needed to pin what routing
+ * must do. What it must never do — hand one workspace another's handler — is
+ * the first test, and it is the whole reason this file exists.
+ */
+
+const silent = {
+  debug() {},
+  info() {},
+  warn() {},
+  error() {},
+};
+
+/** A handler that says which workspace it is, and records its own lifecycle. */
+function fake(workspace: string) {
+  const state = { closed: 0, served: 0, release: null as (() => void) | null };
+  const handler: RequestHandler = {
+    async fetch() {
+      state.served += 1;
+      if (state.release) {
+        await new Promise<void>((resolve) => {
+          state.release = resolve;
+        });
+      }
+      return new Response(workspace);
+    },
+    async close() {
+      state.closed += 1;
+    },
+  };
+  return { handler, state };
+}
+
+function router(options: { limit?: number } = {}) {
+  const built = new Map<string, ReturnType<typeof fake>>();
+  const opens: string[] = [];
+
+  const handler = createWorkspaceRouter({
+    // A workspace is the first label, and a bare domain names none — so
+    // `example.com` is unplaceable rather than the workspace `example`.
+    resolve: (request) => {
+      const labels = new URL(request.url).hostname.split('.');
+      return labels.length >= 3 ? (labels[0] ?? null) : null;
+    },
+    open: async (workspace) => {
+      if (workspace === 'missing') throw new Error('no such workspace');
+      opens.push(workspace);
+      const made = fake(workspace);
+      built.set(workspace, made);
+      return made.handler;
+    },
+    log: silent,
+    ...options,
+  });
+
+  return {
+    handler,
+    opens,
+    built,
+    get: (workspace: string) => handler.fetch(new Request(`https://${workspace}.example.com/mcp`)),
+  };
+}
+
+describe('the workspace router', () => {
+  test('serves each workspace from its own handler', async () => {
+    const under = router();
+
+    expect(await (await under.get('ws-aaa')).text()).toBe('ws-aaa');
+    expect(await (await under.get('ws-bbb')).text()).toBe('ws-bbb');
+  });
+
+  test('builds a workspace handler once, however many requests arrive', async () => {
+    const under = router();
+
+    await under.get('ws-aaa');
+    await under.get('ws-aaa');
+    await under.get('ws-aaa');
+
+    expect(under.opens).toEqual(['ws-aaa']);
+  });
+
+  test('refuses a request naming no workspace without building anything', async () => {
+    const under = createWorkspaceRouter({
+      resolve: () => null,
+      open: async () => {
+        throw new Error('open must not be called');
+      },
+      log: silent,
+    });
+
+    const response = await under.fetch(new Request('https://example.com/mcp'));
+    expect(response.status).toBe(404);
+  });
+
+  test('refuses an unopenable workspace exactly as it refuses an unnamed one', async () => {
+    // Probing must not be an oracle: a workspace that does not exist and one
+    // whose bucket is briefly unreadable answer a caller identically, and the
+    // difference goes to the log. ADR-007 makes this point about capabilities;
+    // it is the same point one level up.
+    const under = router();
+    const unnamed = await under.handler.fetch(new Request('https://example.com/mcp'));
+    const unopenable = await under.get('missing');
+
+    expect(unopenable.status).toBe(unnamed.status);
+    expect(await unopenable.text()).toBe(await unnamed.text());
+  });
+
+  test('does not cache a workspace that failed to open', async () => {
+    const under = router();
+
+    await under.get('missing');
+    await under.get('missing');
+
+    // Nothing was cached, so the second request tried again rather than
+    // serving a rejection remembered from the first.
+    expect(under.opens).toEqual([]);
+  });
+
+  test('evicts the least recently used workspace over the limit, and closes it', async () => {
+    const under = router({ limit: 2 });
+
+    await under.get('ws-aaa');
+    await under.get('ws-bbb');
+    await under.get('ws-aaa'); // ws-bbb is now the least recently used.
+    await under.get('ws-ccc');
+
+    expect(under.built.get('ws-bbb')?.state.closed).toBe(1);
+    expect(under.built.get('ws-aaa')?.state.closed).toBe(0);
+
+    // Evicted means gone, not forgotten-but-alive: reaching it again rebuilds.
+    await under.get('ws-bbb');
+    expect(under.opens).toEqual(['ws-aaa', 'ws-bbb', 'ws-ccc', 'ws-bbb']);
+  });
+
+  test('does not close a handler while a request is still in flight against it', async () => {
+    const under = router({ limit: 1 });
+
+    await under.get('ws-aaa');
+    const first = under.built.get('ws-aaa');
+    if (!first) throw new Error('ws-aaa was not built');
+
+    // Hold one request open inside ws-aaa, then push it out of the cache.
+    first.state.release = () => {};
+    const held = under.get('ws-aaa');
+    // Wait until the request is genuinely inside the handler rather than
+    // relying on microtask ordering to have put it there.
+    while (first.state.served === 0) await Bun.sleep(0);
+    await under.get('ws-bbb');
+
+    expect(first.state.closed).toBe(0);
+    first.state.release?.();
+    await held;
+
+    // Closed once the last request drained, not before.
+    await Bun.sleep(1);
+    expect(first.state.closed).toBe(1);
+  });
+
+  test('closing the router closes every resident workspace', async () => {
+    const under = router();
+
+    await under.get('ws-aaa');
+    await under.get('ws-bbb');
+    await under.handler.close();
+
+    expect(under.built.get('ws-aaa')?.state.closed).toBe(1);
+    expect(under.built.get('ws-bbb')?.state.closed).toBe(1);
+  });
+});

--- a/src/server/router.ts
+++ b/src/server/router.ts
@@ -1,0 +1,163 @@
+import type { Logger } from '#connectivity';
+import type { RequestHandler } from './index.ts';
+
+/**
+ * Which workspace a request is for, and the handler that serves it.
+ *
+ * A self-hosted deploy resolves `LANES_LINK_HOME` once at boot and serves one
+ * workspace for the life of the process — `container.ts` does exactly that, and
+ * nothing here changes it. A Lanes-hosted runtime serves many, so the map from
+ * request to workspace has to exist somewhere, and this is the only file that
+ * knows there is more than one.
+ *
+ * It sits *above* `Generations`, which is the equivalent map one level down:
+ * that one holds a workspace's runtimes and swaps them on reload, this one
+ * holds a workspace's whole handler and lets it go when it has been idle. The
+ * layering is deliberate — a reload inside one workspace must not disturb
+ * another, and it cannot, because a generation belongs to a handler and a
+ * handler belongs to one workspace.
+ *
+ * **Isolation here is a code path where a self-hosted deploy has a process.**
+ * That is the cost of one process serving many workspaces and it is worth
+ * naming rather than implying. What holds it up: a handler is built from the
+ * workspace it was resolved for and from nothing a request body can influence,
+ * a workspace is never handed another's handler, and the two stores that could
+ * otherwise be shared are scoped per workspace by their own adapters — the
+ * credential namespace in `#deployments/adapters/gcp-secret-manager.ts` and the
+ * vault's `keySource` in `#secrets`.
+ */
+
+/** How many workspaces stay resident when the caller names no limit. */
+const DEFAULT_LIMIT = 64;
+
+export interface WorkspaceRouterOptions {
+  /**
+   * Which workspace this request is for, or null when it names none.
+   *
+   * A function rather than a scheme, because how a workspace is named is a
+   * deployment's business: a hostname per workspace is what the managed
+   * runtime uses, and a test says so in one line instead of constructing one.
+   */
+  readonly resolve: (request: Request) => string | null;
+  /** Build the handler that serves one workspace. Called at most once per resident. */
+  readonly open: (workspace: string) => Promise<RequestHandler>;
+  /** How many workspaces stay resident. The least recently used is evicted past it. */
+  readonly limit?: number;
+  readonly log: Logger;
+}
+
+interface Resident {
+  readonly ready: Promise<RequestHandler>;
+  /** Requests currently inside this handler. An evicted resident closes at zero. */
+  inFlight: number;
+  evicted: boolean;
+}
+
+/**
+ * The refusal for a request this router cannot place.
+ *
+ * One answer for two causes — a request naming no workspace, and a workspace
+ * that would not open — because the alternative is an oracle. A caller that can
+ * tell "no such workspace" from "that one exists but is unreadable right now"
+ * can enumerate tenants by watching which hostnames answer differently. ADR-007
+ * makes this argument about capabilities; it is the same argument one level up,
+ * and the real reason goes to the log rather than to the caller.
+ */
+function unplaceable(): Response {
+  return Response.json({ error: 'not_found' }, { status: 404 });
+}
+
+export function createWorkspaceRouter(options: WorkspaceRouterOptions): RequestHandler {
+  const limit = options.limit ?? DEFAULT_LIMIT;
+  // Insertion-ordered, so the least recently used is simply the first key and
+  // touching a resident is a delete followed by a set. A separate recency list
+  // would be a second structure to keep in step with this one.
+  const residents = new Map<string, Resident>();
+
+  const retire = (resident: Resident): void => {
+    resident.evicted = true;
+    // A request that started against this handler is still using it, so the
+    // close waits for the last one to drain — the same reason a `Generation` is
+    // retired rather than closed when a reload replaces it.
+    if (resident.inFlight === 0) void closeQuietly(resident);
+  };
+
+  const closeQuietly = async (resident: Resident): Promise<void> => {
+    try {
+      (await resident.ready).close();
+    } catch (error) {
+      options.log.warn('could not close a workspace', { message: describe(error) });
+    }
+  };
+
+  const evictOverLimit = (): void => {
+    while (residents.size > limit) {
+      const oldest = residents.keys().next();
+      if (oldest.done) return;
+      const resident = residents.get(oldest.value);
+      residents.delete(oldest.value);
+      if (resident) retire(resident);
+    }
+  };
+
+  /**
+   * The resident for one workspace, opening it if this is the first request.
+   *
+   * The promise is stored before it resolves, so two requests arriving together
+   * for a cold workspace share one `open` rather than building two handlers and
+   * leaking whichever loses. A failed open is removed rather than remembered:
+   * a bucket that was briefly unreadable must not turn into a workspace that
+   * stays broken until the process restarts.
+   */
+  const acquire = async (workspace: string): Promise<Resident | null> => {
+    const existing = residents.get(workspace);
+    const resident = existing ?? { ready: options.open(workspace), inFlight: 0, evicted: false };
+
+    // Touch for recency whether it was resident or not; for a new one this is
+    // the insert.
+    residents.delete(workspace);
+    residents.set(workspace, resident);
+
+    try {
+      await resident.ready;
+    } catch (error) {
+      if (residents.get(workspace) === resident) residents.delete(workspace);
+      options.log.warn('could not open a workspace', { workspace, message: describe(error) });
+      return null;
+    }
+
+    // Counted before returning, and before any other request can run: a
+    // resident evicted between here and the fetch below must not be closed
+    // underneath a request that is already committed to it.
+    resident.inFlight += 1;
+    evictOverLimit();
+    return resident;
+  };
+
+  return {
+    async fetch(request) {
+      const workspace = options.resolve(request);
+      if (workspace === null || workspace.length === 0) return unplaceable();
+
+      const resident = await acquire(workspace);
+      if (resident === null) return unplaceable();
+
+      try {
+        return await (await resident.ready).fetch(request);
+      } finally {
+        resident.inFlight -= 1;
+        if (resident.evicted && resident.inFlight === 0) void closeQuietly(resident);
+      }
+    },
+
+    async close() {
+      const open = [...residents.values()];
+      residents.clear();
+      await Promise.all(open.map((resident) => closeQuietly(resident)));
+    },
+  };
+}
+
+function describe(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}


### PR DESCRIPTION
Groundwork for Lanes Cloud — the third column of the README's hosting table. Nothing here changes what a local or self-hosted deploy does; every addition is inert unless a workspace declares it.

Six commits, each independently reviewable.

## Isolation

One process serving many workspaces replaces a process boundary with a code path, so the two stores that would otherwise be shared are scoped first.

**A credential reference is scoped to its workspace.** `GcpSecretManagerStore` addressed a secret by `encodeRef(ref)` alone, unique only because a self-hosted deploy owns its project. Many workspaces in one project all store `tokens/tok1`, so the second `set` added a version to the first workspace's secret and both read one refresh token. The test fails that way before the fix: workspace A's `get` returns workspace B's token. An optional `namespace` is prepended before encoding, so the separator collision `encodeRef` already refuses per reference is refused once for the namespace too rather than reintroduced.

**A vault key belongs to a workspace, not a process.** Both deployed vault adapters resolved `LANES_LINK_VAULT_KEY` from the process environment, so one key would open every tenant's vault and rotating one workspace's key was not expressible. `keySource` is preferred when given, on `blob` and `secret` both — reaching only `blob` would have left the deployed path process-global while looking fixed. The existing `encryptionKey` is the wrong shape because it is eager: a host would fetch every workspace's key to build stores that may never touch the vault.

## The runtime

**One process may serve many workspaces.** A router above `Generations`, holding a handler per workspace with an LRU and idle eviction. An `open` promise is stored before it resolves so two cold requests share one open; a failed open is not cached, so a briefly unreadable bucket does not become a workspace that stays broken until restart; an evicted resident is retired rather than closed, so a handler pushed out under load is not closed underneath a request already committed to it. A request naming no workspace and one that will not open get the same 404 — distinguishable answers would let a caller enumerate tenants.

**A deployment that cannot place itself refuses to boot.** Everything derives from one environment name and a mismatch throws. This deliberately does not copy the API's per-secret stage overrides, where a secret added without its override leaves stage reading the production one; two are already in that state there. For a form endpoint that misroutes a submission, for a workspace holding refresh tokens it is somebody's mailbox.

## The scheme

**A managed workspace is a workspace.** `LANES_LINK_HOME` accepts `lanes://<workspace-id>`, read through `BlobStore` like the other two, so the CLI administers a managed workspace with the same commands. `gs://` could not serve this: laptop credentials against Lanes' storage would reach every tenant's bytes. The credential is registered by the process rather than passed in — `workspaceFiles(root)` takes a root at thirty-five call sites, and a credential is a property of the process's identity, which is why a `gs://` root needs none either. The adapter cannot read the session itself because `deployments` may not import `auth`, and that rule is what keeps a storage backend from growing an opinion about identity.

**A `workspaces.yaml` can name a managed target**, or none of the above is selectable from config.

## Verification

`bun test` — 3205 pass, 12 skip, 0 fail (baseline 3147/0; the delta is the 58 tests added here).
`bun run typecheck` — clean.

`src/dispatch/control-plane.test.ts` passes unchanged, which is the one that matters: nothing here puts a control-plane capability on the endpoint's MCP surface.

The new `lanes` adapter runs the shared `describeBlobStoreContract`, so it satisfies the same contract as `filesystem`, `gcs`, `s3` and `github` rather than most of it.

## The reasoning

Three records, in `docs/detailed/adr/`:

- **[ADR-070](docs/detailed/adr/070-one-process-serves-many-workspaces.md)** covers the router *and* both scoping changes, because they are not separate decisions: they are what makes the router safe, and splitting them would let someone read the router's record and think the map was the boundary.
- **[ADR-071](docs/detailed/adr/071-a-managed-workspace-is-a-workspace.md)** on why `gs://` could not be the third root.
- **[ADR-072](docs/detailed/adr/072-an-environment-is-derived-not-assembled.md)** on deliberately not copying the API's staging mechanism.

## Not here

The endpoint is not yet wired to the router. That wants the control-plane service to exist first, so it lands with it.
