### PR TITLE
A connection names its own account, and the operator is asked last

### DIFF
--- a/docs/detailed/adr/073-a-connection-names-its-own-account.md
+++ b/docs/detailed/adr/073-a-connection-names-its-own-account.md
@@ -1,0 +1,92 @@
+# ADR-073: A connection names its own account
+
+**Status:** accepted · **Follows from** [ADR-057](057-a-connection-belongs-to-the-workspace.md)
+
+## Context
+
+`settleIdentity` resolves whose account was just authorised, and it has always had a fallback:
+where the provider will not say, ask the operator. The doc comment on that branch calls it a last
+resort, and `identity.ts` opens by saying resolution is best-effort because "a label is worth
+having, never worth failing a connect over".
+
+It was not a last resort. Of 105 provider definitions, 30 declared an `identity` block and 75 did
+not, so for most of the catalogue the prompt was the *only* path. The shape of the complaint that
+started this is the whole argument:
+
+```console
+$ lanes link connect notion --profile personal
+ok  authorised
+Which account is this? (the address or handle):
+```
+
+A browser round trip had just established exactly who this was, and the next line asked. Worse,
+the typed answer is load-bearing three times over — it is the key a reconnect matches on, the
+source of the default label, and what `gmail.send_message` writes into a `From` header — so the
+one field that most needs to be stable was the one field a human retyped from memory each time.
+
+Notion is the instructive case because its omission was deliberate and documented: `get-users`
+led with integration bots rather than the person and `get-teams` returned teamspaces, so both
+"would produce a confident wrong label". That reasoning was right and has expired. Notion's
+hosted server renamed those tools and added `notion-fetch`, whose id `self` returns the connected
+workspace alongside the authenticated user's email — documented by Notion for this exact purpose,
+labelling a connection after OAuth.
+
+## Decision
+
+**Identity is resolved in four steps, and the operator is the fourth.**
+
+1. What the caller was given — `--display-name`.
+2. What the connector knows, for a protocol that authenticates by username: the name the *server
+   accepted*, which is a stronger claim than the one that was typed.
+3. What the manifest declares — an `identity` block, `http` or `tool`.
+4. What the authorization server will say — RFC 7662 introspection, or OIDC userinfo.
+
+Only then the question.
+
+**Asking the server is allowed; reading the token is not.** `oauth-exchange.ts` refuses to decode
+the stored `id_token` because "the claim inside is unverified, and a tamperable local store is not
+somewhere to read an identity from". Step 4 honours that rather than working around it: an
+introspection or userinfo response is the issuer answering for itself, over the network, now.
+
+**A probe may not guess.** Two rules follow from the mistake Notion's comment avoided, and both
+are cheap to break by accident:
+
+- A `field` names one value, never a collection. `pluck` walks into the first element of an array
+  on the way past, so a path through a list resolves to whoever happens to be first and reads
+  exactly like a working probe.
+- A returned identifier that is not human-readable is refused. A uuid, a long opaque token, or the
+  client id echoed back would become the account, the label, and the reconnect key, and would read
+  like it worked. Falling through to the question costs a question; a wrong label costs a row
+  nobody can correct without knowing it is wrong.
+
+**A vendor whose user is scoped to a tenant carries a `qualifier`.** One person's Notion email is
+the same email in every workspace they belong to, so without the workspace beside it a second
+connect matches the first row and overwrites its credential. `http` carried a qualifier for Slack;
+`tool` now carries one too, and `defaultConnectionLabel` keeps it rather than shortening it away.
+
+**The gap is a ledger, not a footnote.** `src/providers/identity-coverage.test.ts` fails the build
+when a provider neither declares an identity block, nor authenticates to nothing, nor is listed
+with a written reason — and fails equally when an entry outlives the gap it records. A provider is
+fifteen lines of data and adding one raises no question on its own, so the build raises it.
+
+## Consequences
+
+The generic step is small and measured rather than assumed: of the 80 MCP endpoints this
+repository names, five advertise introspection and three advertise userinfo. That is the reason
+the per-vendor sweep is the substance and step 4 is the cheap part — and the reason the ledger
+exists rather than a claim that the problem is solved.
+
+Sixty-nine hosted-MCP providers are still unswept. Every one of those servers refuses an
+unauthenticated `tools/list`, so each identity call has to come from vendor documentation and each
+block ships unverified until somebody holding an account on that vendor connects. That is a real
+cost and the ledger states it per provider rather than hiding it in a total.
+
+An unverified block is bounded in what it can do wrong: a wrong endpoint or a rejected token
+answers null and the operator is asked, which is what happened before the block existed. The
+hazard is a right endpoint and a wrong field, which is what the two probe rules above are for.
+
+The empty answer changed with it. It used to be accepted and stored `${provider} ${provisionalId}`
+— the provider's name beside `pending`, an internal token meaning "no id yet". It now re-asks, and
+the way past is to type `blank`, which stores `unnamed` and takes a freshly allocated id rather
+than matching another `unnamed`: two rows nobody could name are not evidence of one account, and
+matching them would hand the second connect the first one's credential.

--- a/docs/detailed/adr/073-a-connection-names-its-own-account.md
+++ b/docs/detailed/adr/073-a-connection-names-its-own-account.md
@@ -76,14 +76,27 @@ repository names, five advertise introspection and three advertise userinfo. Tha
 the per-vendor sweep is the substance and step 4 is the cheap part — and the reason the ledger
 exists rather than a claim that the problem is solved.
 
-Sixty-nine hosted-MCP providers are still unswept. Every one of those servers refuses an
-unauthenticated `tools/list`, so each identity call has to come from vendor documentation and each
-block ships unverified until somebody holding an account on that vendor connects. That is a real
-cost and the ledger states it per provider rather than hiding it in a total.
+Seventy hosted-MCP providers are still unswept. Every one of those servers refuses an
+unauthenticated `tools/list`, so each identity call has to come from vendor documentation and
+cannot be confirmed without an account on that vendor. That is a real cost and the ledger states
+it per provider rather than hiding it in a total.
 
-An unverified block is bounded in what it can do wrong: a wrong endpoint or a rejected token
-answers null and the operator is asked, which is what happened before the block existed. The
-hazard is a right endpoint and a wrong field, which is what the two probe rules above are for.
+**A block is not added on documentation alone, and Supabase is why.** Its authorization server
+*is* `api.supabase.com`, so the token an MCP connect issues is an ordinary Management API token
+and `GET /v1/profile` — which returns `primary_email` — read as a free answer. Against a real
+token it is `401`, "does not support oauth access yet": a refusal about the credential *kind*,
+which no scope changes. `/v1/user`, `/v1/me` and `/v1/oauth/userinfo` are all `404`, and what
+OAuth does reach — organizations, projects — is a collection, which the rule above already
+refuses.
+
+So a vendor sharing a host with its authorization server does not imply the token is accepted
+there, and an MCP credential is its own kind until the vendor says otherwise. The ledger entry
+that results is worth more than the block would have been: it names what was ruled out, so nobody
+researches that vendor twice.
+
+An unverified block is bounded in what it can do wrong — a wrong endpoint or a rejected token
+answers null and the operator is asked, which is what happened before it existed. The hazard is a
+right endpoint and a wrong field, which is what the two probe rules above are for.
 
 The empty answer changed with it. It used to be accepted and stored `${provider} ${provisionalId}`
 — the provider's name beside `pending`, an internal token meaning "no id yet". It now re-asks, and

--- a/docs/detailed/adr/README.md
+++ b/docs/detailed/adr/README.md
@@ -85,6 +85,7 @@ Run.
 | [067](067-one-directory-per-profile.md) | One directory per profile, `data/` goes, and a connection id becomes opaque |
 | [068](068-a-credential-names-a-person.md) | A credential names a person, and the profiles follow from that; the endpoint token becomes the workspace's |
 | [069](069-a-pairing-token-may-write-the-owners-own-data.md) | A pairing token may write the owner's own data; the control plane is unmoved |
+| [073](073-a-connection-names-its-own-account.md) | A connection names its own account; the operator is asked last, and never handed a uuid to live with |
 
 Where an ADR departs from init.md, it says so at the top. Three are significant:
 
@@ -312,3 +313,9 @@ Where an ADR departs from init.md, it says so at the top. Three are significant:
   these five stores. What genuinely changes is that a credential which could read every memory
   entry can now delete them, including one minted before this release, which is why the cost is
   named in the CLI's own prompt rather than only here.
+
+- **ADR-073** makes the "which account is this?" prompt a last resort in fact rather than only in
+  its doc comment. Identity is resolved from the caller, the connector, the manifest, and then the
+  authorization server itself; a probe that cannot name a person human-readably falls through to
+  the question rather than labelling a row with a uuid. The remaining gap is a ledger the build
+  checks in both directions, not a total.

--- a/src/cli/commands/connect.test.ts
+++ b/src/cli/commands/connect.test.ts
@@ -307,4 +307,96 @@ describe('resolveAccount', () => {
 
     expect(account).toBeNull();
   });
+
+  /**
+   * The version header, and why a probe needs to be able to send one.
+   *
+   * Notion's REST API refuses a request that carries no `Notion-Version` — not
+   * with a 401 a reader would trace to the credential, but with a 400 about a
+   * header nobody declared. An `identity: { kind: 'http' }` block could only
+   * send `Authorization`, so every API that pins its version in a header was
+   * silently outside what a manifest could express.
+   */
+  test('sends the headers the manifest declares, with the credential over them', async () => {
+    let sent: Record<string, string> = {};
+
+    const account = await resolveAccount(
+      manifest({
+        kind: 'http',
+        url: 'https://api.example.com/v1/users/me',
+        field: 'email',
+        headers: { 'notion-version': '2022-06-28' },
+      }),
+      {
+        accessToken: async () => 'tok',
+        fetch: (async (_url: string, init?: RequestInit) => {
+          sent = init?.headers as Record<string, string>;
+          return new Response(JSON.stringify({ email: 'me@example.com' }));
+        }) as unknown as typeof fetch,
+      },
+    );
+
+    expect(sent['notion-version']).toBe('2022-06-28');
+    expect(sent['authorization']).toBe('Bearer tok');
+    expect(account).toBe('me@example.com');
+  });
+
+  /**
+   * The same tenancy problem Slack has, one transport over.
+   *
+   * Notion answers `notion-fetch` with the person's email, which is the same
+   * email in every workspace they belong to. Only `http` carried a qualifier,
+   * so a tool-kind identity could name the person and had no way to say which
+   * workspace was authorised — and the reconnect match is on that one string.
+   */
+  test('a tool identity qualifies its field the way an http one does', async () => {
+    const self = (workspace: string) =>
+      resolveAccount(
+        manifest({
+          kind: 'tool',
+          tool: 'notion-fetch',
+          field: 'self.user.email',
+          qualifier: 'self.workspace.name',
+          arguments: { id: 'self' },
+        }),
+        {
+          accessToken: async () => null,
+          callTool: async () => ({
+            content: [
+              {
+                text: JSON.stringify({
+                  self: { workspace: { name: workspace }, user: { email: 'ada@example.com' } },
+                }),
+              },
+            ],
+          }),
+        },
+      );
+
+    expect(await self('Personal')).toBe('ada@example.com (Personal)');
+    expect(await self('Personal')).not.toBe(await self('Acme'));
+  });
+
+  test('and passes the arguments the tool needs to answer at all', async () => {
+    let received: Record<string, unknown> = {};
+
+    await resolveAccount(
+      manifest({
+        kind: 'tool',
+        tool: 'notion-fetch',
+        field: 'self.user.email',
+        arguments: { id: 'self' },
+      }),
+      {
+        accessToken: async () => null,
+        callTool: async (_name, args) => {
+          received = args;
+          return { content: [{ text: '{}' }] };
+        },
+      },
+    );
+
+    // `notion-fetch` with no id fetches nothing; `self` is the whole call.
+    expect(received).toEqual({ id: 'self' });
+  });
 });

--- a/src/cli/commands/connect/authorise.ts
+++ b/src/cli/commands/connect/authorise.ts
@@ -10,7 +10,12 @@ import { terminalPrompter, type Prompter } from '../../prompt.ts';
 import { describeScopes, shortScope } from '../../scopes.ts';
 import { BROKERED, BrokerError } from '#connectivity/auth/index.ts';
 import { brokerExchangeVia } from '../../oauth-exchange.ts';
-import { brokeredScopes, hostedClientRefusal, resolveOAuthClient } from './client.ts';
+import {
+  brokeredScopes,
+  hostedClientRefusal,
+  registeredCallbackPort,
+  resolveOAuthClient,
+} from './client.ts';
 import { confirmScopes } from './scopes-gate.ts';
 import { ensureOAuthApp } from './setup.ts';
 
@@ -116,7 +121,10 @@ export async function authorise(input: {
 
   const serverUrl = manifest.connector.endpoint;
 
-  const callback = captureOAuthCallback({ label: manifest.name });
+  const callback = captureOAuthCallback({
+    label: manifest.name,
+    port: await registeredCallbackPort(manifest, connectionId, credentials),
+  });
 
   try {
     const provider = oauthProviderFor(

--- a/src/cli/commands/connect/client.ts
+++ b/src/cli/commands/connect/client.ts
@@ -5,6 +5,7 @@ import {
   brokerOriginOverride,
   type BrokerConfig,
 } from '#connectivity/auth/index.ts';
+import { CredentialOAuthProvider } from '#connectivity/auth/index.ts';
 import { hasOwnClientPath, type ProviderManifest } from '#connectivity';
 import type { SecretStore } from '#secrets';
 import { ConfigDocument } from '../../config-edit.ts';
@@ -309,4 +310,50 @@ export function hostedClientRefusal(input: {
   if (input.docsUrl) lines.push(`  ${input.docsUrl}`);
 
   return new Error(lines.join('\n'));
+}
+
+/**
+ * The loopback port this provider's registered client already declares.
+ *
+ * A dynamically registered client is written once and kept — re-registering
+ * orphans the grant the operator approved — so its `redirect_uris` outlive the
+ * listener that chose them. Asking for a fresh port on the next connect sends a
+ * URL that client never declared, and a server matching `redirect_uri`
+ * literally refuses it before the consent page renders.
+ *
+ * So this reads the port back out of the registration and the listener asks for
+ * it again. `undefined` where there is no registration yet, which is the first
+ * connect and the case that was always fine.
+ */
+export async function registeredCallbackPort(
+  manifest: ProviderManifest,
+  connectionId: string,
+  credentials: SecretStore,
+): Promise<number | undefined> {
+  const provider = new CredentialOAuthProvider({
+    manifest,
+    connectionId,
+    credentials,
+    scopes: manifest.auth.kind === 'oauth' ? manifest.auth.scopes : [],
+  });
+
+  try {
+    const client = (await provider.clientInformation()) as
+      | { redirect_uris?: unknown }
+      | undefined;
+
+    const declared = Array.isArray(client?.redirect_uris) ? client.redirect_uris : [];
+
+    for (const candidate of declared) {
+      if (typeof candidate !== 'string') continue;
+      const port = Number(new URL(candidate).port);
+      if (Number.isInteger(port) && port > 0) return port;
+    }
+  } catch {
+    // A malformed or unreadable registration is not worth failing a connect
+    // over: the listener falls back to any free port, which is what it did
+    // before this existed.
+  }
+
+  return undefined;
 }

--- a/src/cli/commands/connect/settle.test.ts
+++ b/src/cli/commands/connect/settle.test.ts
@@ -81,6 +81,23 @@ function prompter(answer = ''): Prompter & { asked: string[] } {
   };
 }
 
+/** A terminal that works through a script of answers, then answers nothing. */
+function scripted(...answers: string[]): Prompter & { asked: string[] } {
+  const asked: string[] = [];
+  let next = 0;
+
+  return {
+    asked,
+    interactive: true,
+    ask: async (question) => {
+      asked.push(question);
+      return answers[next++] ?? '';
+    },
+    askSecret: async () => '',
+    confirm: async () => true,
+  };
+}
+
 const silent: Prompter = {
   interactive: false,
   ask: async () => '',
@@ -219,5 +236,65 @@ describe('the label a connection is given at connect time', () => {
     expect(asking.asked).toHaveLength(1);
     expect(settled.account).toBe('Ada at Acme');
     expect(settled.label).toBe('Acme Mail (Ada at Acme)');
+  });
+});
+
+/**
+ * The account question, when there is nothing to answer it with.
+ *
+ * An empty answer used to be taken and stored `Acme Mail pending` — the
+ * provider's name beside the *provisional* connection id, an internal token
+ * meaning "no id yet". That string then became the account, the default label,
+ * and the key a reconnect matches on. Nobody chose it, and a row named after it
+ * can answer none of the questions an account exists to answer.
+ */
+describe('an account nobody could report', () => {
+  const unnamable = { manifest: anonymous, runtime: runtime([], null) };
+
+  test('re-asks rather than taking silence for an answer', async () => {
+    const asking = scripted('', '', 'ada@example.com');
+
+    const settled = await settle({ ...unnamable, prompter: asking });
+
+    expect(asking.asked).toHaveLength(3);
+    expect(settled.account).toBe('ada@example.com');
+  });
+
+  test('takes "blank" from someone who meant it, and says so honestly', async () => {
+    const asking = scripted('', 'blank');
+
+    const settled = await settle({ ...unnamable, prompter: asking });
+
+    // Not `Acme Mail pending`. `unnamed` is visibly not an address, and reads
+    // through `defaultConnectionLabel` as a name rather than an internal token.
+    expect(settled.account).toBe('unnamed');
+    expect(settled.label).toBe('Acme Mail (unnamed)');
+  });
+
+  test('and does not match a row that was also left unnamed', async () => {
+    // `unnamed` is not an identity, so two of them are not evidence of one
+    // account. Matching them would hand the second connect the first row's
+    // credential ref and overwrite it; a fresh id says the only true thing
+    // available, which is that these are two rows.
+    const declared = [
+      { id: 'con1', provider: 'acme_mail', account: 'unnamed' },
+    ] as ConnectionConfig[];
+
+    const settled = await settle({
+      manifest: anonymous,
+      runtime: runtime(declared, null),
+      prompter: scripted('blank'),
+    });
+
+    expect(settled.connectionId).toBe('con2');
+  });
+
+  test('refuses in the end rather than asking forever', async () => {
+    // A prompter that reports itself interactive and returns nothing forever is
+    // not hypothetical — a closed pipe does it — and a connect that hangs is
+    // worse than one that refuses in the words the non-interactive path uses.
+    const asking = scripted();
+
+    expect(settle({ ...unnamable, prompter: asking })).rejects.toThrow(/Nothing was written/);
   });
 });

--- a/src/cli/commands/connect/settle.ts
+++ b/src/cli/commands/connect/settle.ts
@@ -1,11 +1,12 @@
 import { createMcpConnector } from '#connectivity/transports';
-import { bearerTokenAsStored } from '#connectivity/auth/index.ts';
+import { bearerTokenAsStored, CredentialOAuthProvider } from '#connectivity/auth/index.ts';
 import type { SecretStore } from '#secrets';
 import { defaultConnectionLabel } from '#profile';
 import type { ConnectionConfig, Config } from '#profile';
 import type { AnyConnector, ProviderManifest } from '#connectivity';
 import { nextConnectionId, resolveAccount } from '../../identity.ts';
-import { style } from '../../output.ts';
+import { introspectAccount } from '../../introspection.ts';
+import { progress, style } from '../../output.ts';
 import { PromptCancelled, terminalPrompter, type Prompter } from '../../prompt.ts';
 import { accountSiblings } from './accounts.ts';
 
@@ -132,6 +133,28 @@ export async function settleIdentity(input: {
     });
   }
 
+  // Nothing declared, or what was declared came back empty. Before asking, ask
+  // the authorization server: RFC 7662 introspection needs no per-vendor
+  // configuration, and it is the only automatic answer available to the
+  // remote-MCP family, which is 75 of the 105 manifests and every one of them a
+  // question the operator has been answering by hand. See `introspection.ts`
+  // for why asking the server is allowed where reading the stored token is not.
+  if (!account && manifest.auth.kind === 'oauth' && manifest.connector.kind === 'mcp') {
+    const endpoint = manifest.connector.endpoint;
+    const scopes = manifest.auth.scopes;
+    account = await introspectAccount({
+      resourceUrl: endpoint,
+      accessToken: () => bearerTokenAsStored(manifest, provisionalId, runtime.credentials),
+      clientInformation: () =>
+        new CredentialOAuthProvider({
+          manifest,
+          connectionId: provisionalId,
+          credentials: runtime.credentials,
+          scopes,
+        }).clientInformation(),
+    });
+  }
+
   // A provider that authenticates to nothing has no account to name, so asking
   // is a question with no answer — and one that needs a terminal, which makes an
   // otherwise scriptable connect interactive for no reason.
@@ -148,6 +171,10 @@ export async function settleIdentity(input: {
   // second ago does not need confirming against itself.
   let typed = false;
 
+  // Whether they declined to name it at all. It reaches the id below: a row
+  // nobody could name must not match another row nobody could name.
+  let bypassed = false;
+
   if (!account) {
     // Nothing to go on. Asking beats inventing `main2`, and the answer is the
     // one piece of information the file cannot reconstruct later — which is
@@ -160,9 +187,9 @@ export async function settleIdentity(input: {
       );
     }
 
-    account =
-      (await prompter.ask(`Which account is this? ${style.dim('(the address or handle)')}`)) ||
-      `${manifest.name} ${provisionalId}`;
+    const answer = await askForAccount(manifest, prompter);
+    account = answer.account;
+    bypassed = answer.bypassed;
     typed = true;
   }
 
@@ -176,13 +203,21 @@ export async function settleIdentity(input: {
   // a second row. That is the whole reason `resolveAccount` runs before this:
   // without it a failed attempt appends rather than repairs, which is how
   // `Gmail main3` came to exist.
+  //
+  // A bypassed row is excluded from that match on purpose. `unnamed` is not an
+  // identity, so two of them are not evidence of the same account — matching
+  // them would hand the second connect the first one's credential ref and
+  // overwrite it. A fresh id says the only true thing available: these are two
+  // rows, and nobody could say whether they are two accounts.
   const connectionId =
     explicitId ??
     (unaccounted
       ? nextConnectionId(taken, true)
-      : (siblings.find(
-          (candidate) => candidate.account.toLowerCase() === account!.toLowerCase(),
-        )?.id ?? nextConnectionId(taken, false)));
+      : bypassed
+        ? nextConnectionId(taken, false)
+        : (siblings.find(
+            (candidate) => candidate.account.toLowerCase() === account!.toLowerCase(),
+          )?.id ?? nextConnectionId(taken, false)));
 
   const defaultLabel = defaultConnectionLabel(manifest.name, account);
 
@@ -202,6 +237,54 @@ export async function settleIdentity(input: {
       prompter,
     }),
   };
+}
+
+/** The literal answer that skips the question, and what it stores instead. */
+const BYPASS_ANSWER = 'blank';
+const UNNAMED_ACCOUNT = 'unnamed';
+
+/**
+ * The one thing the file cannot reconstruct later, asked until it is answered.
+ *
+ * An empty answer used to be taken, and stored `${manifest.name} ${provisionalId}`
+ * — the provider's name beside `pending`, an internal token for "no id yet".
+ * That string then became the account, the default label, and the key a
+ * reconnect matches on. Nobody chose it and nothing can be done with it.
+ *
+ * So an empty answer re-asks, and there is a way past for someone who meant it:
+ * typing `blank`. That row is `unnamed` — honest, visibly not an address, and
+ * `defaultConnectionLabel` reads it as `Notion (unnamed)`.
+ *
+ * Bounded rather than unbounded. A prompter that reports itself interactive and
+ * then returns nothing forever is not hypothetical — a closed pipe does it —
+ * and a connect that hangs is worse than one that refuses in the words the
+ * non-interactive path already uses.
+ */
+async function askForAccount(
+  manifest: ProviderManifest,
+  prompter: Prompter,
+): Promise<{ account: string; bypassed: boolean }> {
+  const question = `Which account is this? ${style.dim('(the address or handle)')}`;
+
+  for (let attempt = 0; attempt < 3; attempt += 1) {
+    const answer = (await prompter.ask(question)).trim();
+
+    if (answer.toLowerCase() === BYPASS_ANSWER) return { account: UNNAMED_ACCOUNT, bypassed: true };
+    if (answer) return { account: answer, bypassed: false };
+
+    progress(
+      style.dim(
+        `  It is how a reconnect finds this row again, and what every list shows it as.`,
+      ),
+    );
+    progress(style.dim(`  Type "${BYPASS_ANSWER}" to go without one.`));
+  }
+
+  throw new Error(
+    `${manifest.name} could not report whose account this is, and none was given.\n` +
+      `  Nothing was written. Answer the question, type "${BYPASS_ANSWER}" to go without a name, ` +
+      `or pass --display-name "<name>".`,
+  );
 }
 
 /**

--- a/src/cli/identity.ts
+++ b/src/cli/identity.ts
@@ -11,8 +11,8 @@ import type { IdentityDeclaration, ProviderManifest } from '#connectivity';
  * exist.
  *
  * Everything here is best-effort. A provider that declares no identity, or
- * whose probe fails, falls back to asking the operator: a label is worth
- * having, never worth failing a connect over.
+ * whose probe fails, falls back to `introspectAccount` and then to asking the
+ * operator: a label is worth having, never worth failing a connect over.
  */
 
 /** Walk a dotted path, tolerating the first array element on the way. */
@@ -29,10 +29,37 @@ export function pluck(value: unknown, path: string): string | null {
   return typeof current === 'string' && current.length > 0 ? current : null;
 }
 
-/** The header an OAuth or bearer provider's probe carries. */
-async function bearerHeaders(probe: IdentityProbe): Promise<RequestInit> {
+/**
+ * `alice (Acme)` rather than `alice`.
+ *
+ * The bracketed half is what makes two workspaces two accounts instead of one
+ * overwritten twice: the reconnect match in `settleIdentity` is on the account,
+ * so without it the second connect repairs the first row rather than adding
+ * one. It used to reach the id as well, back when the id was slugified from
+ * this.
+ *
+ * One helper for both probe kinds. `http` had it first, for Slack; `tool` needs
+ * the same for Notion, whose `self` is an email that says nothing about which
+ * of the person's workspaces was authorised.
+ */
+function qualified(
+  body: unknown,
+  declaration: { field: string; qualifier?: string | undefined },
+): string | null {
+  const primary = pluck(body, declaration.field);
+  if (!primary || !declaration.qualifier) return primary;
+
+  const qualifier = pluck(body, declaration.qualifier);
+  return qualifier ? `${primary} (${qualifier})` : primary;
+}
+
+/** The header an OAuth or bearer provider's probe carries, over the declared ones. */
+async function bearerHeaders(
+  probe: IdentityProbe,
+  declared: Record<string, string>,
+): Promise<RequestInit> {
   const token = await probe.accessToken();
-  return { headers: token ? { authorization: `Bearer ${token}` } : {} };
+  return { headers: { ...declared, ...(token ? { authorization: `Bearer ${token}` } : {}) } };
 }
 
 export interface IdentityProbe {
@@ -74,26 +101,23 @@ export async function resolveAccount(
     if (identity.kind === 'http') {
       const send = probe.fetch ?? globalThis.fetch;
 
+      // The manifest's own headers, for an API that answers nothing without
+      // one: Notion refuses a request carrying no `Notion-Version`, and it is
+      // not the only vendor that pins its version in a header. The credential
+      // goes on top of them either way — `requestAuthorizer` copies the headers
+      // it is handed, so a declared one survives `authorize` too.
+      const declared = identity.headers ?? {};
+
       // `authorize` where the caller supplied one, because it is the same
       // switch the dispatch path uses and knows every method. The token is the
       // fallback rather than the other way round only because the OAuth
       // providers reached here first; both end at the same header for them.
       const response = probe.authorize
-        ? await send(await probe.authorize(new Request(identity.url)))
-        : await send(identity.url, await bearerHeaders(probe));
+        ? await send(await probe.authorize(new Request(identity.url, { headers: declared })))
+        : await send(identity.url, await bearerHeaders(probe, declared));
       if (!response.ok) return null;
 
-      const body = await response.json();
-      const primary = pluck(body, identity.field);
-      if (!primary || !identity.qualifier) return primary;
-
-      // `alice (Acme)` rather than `alice`. The bracketed half is what makes
-      // two workspaces two accounts instead of one overwritten twice: the
-      // reconnect match below is on the account, so without it the second
-      // connect repairs the first row rather than adding one. It used to reach
-      // the id as well, back when the id was slugified from this.
-      const qualifier = pluck(body, identity.qualifier);
-      return qualifier ? `${primary} (${qualifier})` : primary;
+      return qualified(await response.json(), identity);
     }
 
     if (!probe.callTool) return null;
@@ -104,12 +128,12 @@ export async function resolveAccount(
     const text = pluck(result, 'content.text');
     if (text) {
       try {
-        return pluck(JSON.parse(text), identity.field) ?? text;
+        return qualified(JSON.parse(text), identity) ?? text;
       } catch {
         return text;
       }
     }
-    return pluck(result, identity.field);
+    return qualified(result, identity);
   } catch {
     return null;
   }

--- a/src/cli/introspection.test.ts
+++ b/src/cli/introspection.test.ts
@@ -1,0 +1,203 @@
+import { describe, expect, test } from 'bun:test';
+import { introspectAccount } from './introspection.ts';
+
+/**
+ * The one identity answer that costs no per-vendor configuration.
+ *
+ * 75 of 105 manifests declare no `identity` block, almost all of them the
+ * remote-MCP family that registers dynamically, and every one of them asked the
+ * operator to type their own address a second after authorising. RFC 7662 is
+ * what the authorization server already offers: the metadata says whether there
+ * is an `introspection_endpoint`, and `username` is defined there as a
+ * human-readable identifier for whoever authorized the token.
+ *
+ * The risk this carries is not returning nothing — that costs a question, which
+ * is what happens today. It is returning `9f2c1e04-…`, which becomes the
+ * account, the label, and the key a reconnect matches on, and reads exactly
+ * like it worked. So every test below that rejects something is the point of
+ * the file.
+ */
+
+const RESOURCE = 'https://mcp.example.com';
+const INTROSPECT = 'https://mcp.example.com/introspect';
+const USERINFO = 'https://mcp.example.com/userinfo';
+
+/** A server that discovers to itself, the way every MCP server we have met does. */
+function server(options: {
+  introspection?: boolean;
+  userinfo?: Record<string, unknown>;
+  claims?: Record<string, unknown>;
+  status?: number;
+}) {
+  const posted: URLSearchParams[] = [];
+
+  const fetchFn = (async (input: unknown, init?: RequestInit) => {
+    const url = String(input instanceof Request ? input.url : input);
+
+    if (url.includes('oauth-protected-resource')) {
+      // Notion's shape: the resource is its own authorization server, and the
+      // SDK is left to fall back to it.
+      return new Response('not found', { status: 404 });
+    }
+
+    if (url.includes('oauth-authorization-server') || url.includes('openid-configuration')) {
+      return Response.json({
+        issuer: RESOURCE,
+        authorization_endpoint: `${RESOURCE}/authorize`,
+        token_endpoint: `${RESOURCE}/token`,
+        response_types_supported: ['code'],
+        ...(options.introspection === false ? {} : { introspection_endpoint: INTROSPECT }),
+        ...(options.userinfo ? { userinfo_endpoint: USERINFO } : {}),
+      });
+    }
+
+    if (url === USERINFO) {
+      return Response.json(options.userinfo ?? {});
+    }
+
+    if (url === INTROSPECT) {
+      posted.push(new URLSearchParams(String(init?.body)));
+      if (options.status && options.status >= 400) {
+        return new Response('no', { status: options.status });
+      }
+      return Response.json({ active: true, ...options.claims });
+    }
+
+    return new Response('unexpected', { status: 500 });
+  }) as unknown as typeof fetch;
+
+  return { fetchFn, posted };
+}
+
+const probe = (
+  options: Parameters<typeof server>[0],
+  client: { client_id?: string; client_secret?: string } = { client_id: 'cid' },
+) => {
+  const { fetchFn, posted } = server(options);
+  return {
+    posted,
+    account: introspectAccount({
+      resourceUrl: RESOURCE,
+      accessToken: async () => 'tok',
+      clientInformation: async () => client,
+      fetch: fetchFn,
+    }),
+  };
+};
+
+describe('introspectAccount', () => {
+  test('names the account from a human-readable username', async () => {
+    expect(await probe({ claims: { username: 'ada' } }).account).toBe('ada');
+  });
+
+  test('reads an address, and prefers the username the RFC defines for it', async () => {
+    expect(await probe({ claims: { email: 'ada@example.com' } }).account).toBe('ada@example.com');
+    expect(
+      await probe({ claims: { username: 'ada', email: 'other@example.com' } }).account,
+    ).toBe('ada');
+  });
+
+  test('sends the token and the registered client, so a server that checks can', async () => {
+    const attempt = probe({ claims: { username: 'ada' } }, {
+      client_id: 'cid',
+      client_secret: 'shh',
+    });
+    await attempt.account;
+
+    const body = attempt.posted[0]!;
+    expect(body.get('token')).toBe('tok');
+    expect(body.get('token_type_hint')).toBe('access_token');
+    expect(body.get('client_id')).toBe('cid');
+    expect(body.get('client_secret')).toBe('shh');
+  });
+
+  /**
+   * The failures that matter. Each of these would otherwise be written into
+   * `connections.yaml` as the account and never questioned again.
+   */
+  test('refuses an opaque identifier rather than labelling a row with it', async () => {
+    expect(await probe({ claims: { username: '9f2c1e04-3b7a-4c1d-9e55-1f2a3b4c5d6e' } }).account)
+      .toBeNull();
+    expect(await probe({ claims: { username: 'a1b2c3d4e5f60718293a4b5c' } }).account).toBeNull();
+    expect(await probe({ claims: { username: '10029387' } }).account).toBeNull();
+  });
+
+  test('refuses the client id echoed back, which is us and not a person', async () => {
+    expect(await probe({ claims: { username: 'cid' } }).account).toBeNull();
+  });
+
+  test('an inactive token is an answer about the token, not about a person', async () => {
+    // Every other field is meaningless by the RFC once `active` is false, so
+    // reading one would be reading a stale claim.
+    expect(await probe({ claims: { active: false, username: 'ada' } }).account).toBeNull();
+  });
+
+  test('a server that advertises no introspection endpoint is not asked', async () => {
+    const attempt = probe({ introspection: false });
+
+    expect(await attempt.account).toBeNull();
+    expect(attempt.posted).toHaveLength(0);
+  });
+
+  test('a refusal costs a round trip and nothing else', async () => {
+    expect(await probe({ status: 401, claims: { username: 'ada' } }).account).toBeNull();
+  });
+
+  /**
+   * The other half of "ask the authorization server".
+   *
+   * Measured across the 80 MCP endpoints this repository names, five advertise
+   * introspection and three advertise userinfo — and they are not the same
+   * three. Neither is common enough to replace a per-vendor identity block;
+   * both are free once we are already talking to the server.
+   */
+  test('falls to OIDC userinfo where that is what the server offers', async () => {
+    const attempt = probe({ introspection: false, userinfo: { email: 'ada@example.com' } });
+
+    expect(await attempt.account).toBe('ada@example.com');
+    expect(attempt.posted).toHaveLength(0);
+  });
+
+  test('and reaches for it when introspection is advertised but refuses', async () => {
+    const attempt = probe({ status: 401, userinfo: { preferred_username: 'ada' } });
+
+    expect(await attempt.account).toBe('ada');
+    expect(attempt.posted).toHaveLength(1);
+  });
+
+  test('userinfo is held to the same rule — a subject id is not a name', async () => {
+    expect(
+      await probe({
+        introspection: false,
+        userinfo: { sub: '9f2c1e04-3b7a-4c1d-9e55-1f2a3b4c5d6e' },
+      }).account,
+    ).toBeNull();
+  });
+
+  test('no token means there is nothing to introspect', async () => {
+    const { fetchFn, posted } = server({ claims: { username: 'ada' } });
+
+    const account = await introspectAccount({
+      resourceUrl: RESOURCE,
+      accessToken: async () => null,
+      clientInformation: async () => ({ client_id: 'cid' }),
+      fetch: fetchFn,
+    });
+
+    expect(account).toBeNull();
+    expect(posted).toHaveLength(0);
+  });
+
+  test('a discovery that throws falls through to the question, never upward', async () => {
+    const account = await introspectAccount({
+      resourceUrl: RESOURCE,
+      accessToken: async () => 'tok',
+      clientInformation: async () => ({ client_id: 'cid' }),
+      fetch: (async () => {
+        throw new Error('network down');
+      }) as unknown as typeof fetch,
+    });
+
+    expect(account).toBeNull();
+  });
+});

--- a/src/cli/introspection.ts
+++ b/src/cli/introspection.ts
@@ -1,0 +1,167 @@
+import {
+  discoverAuthorizationServerMetadata,
+  discoverOAuthProtectedResourceMetadata,
+} from '@modelcontextprotocol/client';
+
+/**
+ * Asking the authorization server who it just issued a token to.
+ *
+ * The declared `identity` block (`identity.ts`) is per-vendor and most vendors
+ * have none — 75 of 105 manifests, almost all of them the remote-MCP family
+ * that registers dynamically. Every one of those made a person type their own
+ * address into `connect` a second after authorising, which is the one thing an
+ * OAuth round trip ought to have settled.
+ *
+ * RFC 7662 is the standard answer and costs no per-vendor configuration: the
+ * authorization server metadata we already fetch says whether there is an
+ * `introspection_endpoint`, and the response's `username` is defined as "a
+ * human-readable identifier for the resource owner who authorized this token".
+ *
+ * **This asks the server rather than reading the token.** That distinction is
+ * the whole reason this is allowed to exist where decoding the stored
+ * `id_token` is not (`oauth-exchange.ts`): a claim in a local file is
+ * unverified and the store is tamperable, while an introspection response is
+ * the issuer answering for itself.
+ *
+ * Best-effort throughout. A server with no introspection endpoint, one that
+ * refuses a public client, or one that answers with an opaque id costs a round
+ * trip and falls through to the prompt.
+ */
+
+export interface IntrospectionProbe {
+  /** The protected resource — the MCP endpoint this connection talks to. */
+  readonly resourceUrl: string;
+  readonly accessToken: () => Promise<string | null>;
+  /** The registered client, for servers that want the caller authenticated. */
+  readonly clientInformation: () => Promise<
+    { client_id?: string | undefined; client_secret?: string | undefined } | undefined
+  >;
+  readonly fetch?: typeof globalThis.fetch;
+}
+
+/**
+ * Whether a returned identifier is one a person would recognise.
+ *
+ * The failure this guards against is not a probe that returns nothing — that
+ * one falls through to the prompt and costs a question. It is a probe that
+ * returns `9f2c1e04-…` or the client id, which becomes the account, the label,
+ * and the key a reconnect matches on, and reads exactly like it worked.
+ *
+ * An address is accepted outright. Anything else has to at least look like a
+ * name: letters, and not the shapes an opaque identifier takes.
+ */
+function readable(value: unknown, clientId: string | undefined): string | null {
+  if (typeof value !== 'string') return null;
+
+  const candidate = value.trim();
+  if (candidate.length === 0 || candidate === clientId) return null;
+  if (candidate.includes('@')) return candidate;
+
+  // A uuid, a long hex or base64-ish blob, or anything with no letters in it.
+  if (/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(candidate)) return null;
+  if (/^[0-9a-zA-Z_-]{16,}$/.test(candidate) && !/[ .]/.test(candidate)) return null;
+  if (!/[a-z]/i.test(candidate)) return null;
+
+  return candidate;
+}
+
+/** The two endpoints an authorization server may offer for this, per RFC 8414. */
+async function askableEndpoints(
+  resourceUrl: string,
+  fetchFn: typeof globalThis.fetch,
+): Promise<{ introspection: string | null; userinfo: string | null }> {
+  // The resource names its authorization servers; where it names none, the
+  // resource is its own, which is the shape every MCP server we have met takes.
+  let authorizationServer = resourceUrl;
+  try {
+    const resource = await discoverOAuthProtectedResourceMetadata(resourceUrl, undefined, fetchFn);
+    const declared = (resource as { authorization_servers?: string[] }).authorization_servers;
+    if (declared?.[0]) authorizationServer = declared[0];
+  } catch {
+    // Fall through to the resource itself.
+  }
+
+  const metadata = (await discoverAuthorizationServerMetadata(authorizationServer, {
+    fetchFn,
+  })) as { introspection_endpoint?: string; userinfo_endpoint?: string } | undefined;
+
+  const named = (value: unknown) =>
+    typeof value === 'string' && value.length > 0 ? value : null;
+
+  return {
+    introspection: named(metadata?.introspection_endpoint),
+    userinfo: named(metadata?.userinfo_endpoint),
+  };
+}
+
+/**
+ * OIDC's answer to the same question, for the servers that offer that instead.
+ *
+ * Measured across the 80 MCP endpoints this repository names: five advertise
+ * introspection and three advertise userinfo, and they are different servers.
+ * Neither is common enough to make the per-vendor `identity` blocks
+ * unnecessary; both are free to ask once we are already here.
+ */
+async function fromUserinfo(
+  endpoint: string,
+  token: string,
+  send: typeof globalThis.fetch,
+): Promise<string | null> {
+  const response = await send(endpoint, {
+    headers: { authorization: `Bearer ${token}`, accept: 'application/json' },
+  });
+  if (!response.ok) return null;
+
+  const claims = (await response.json()) as Record<string, unknown>;
+  return (
+    readable(claims['email'], undefined) ??
+    readable(claims['preferred_username'], undefined) ??
+    readable(claims['name'], undefined)
+  );
+}
+
+export async function introspectAccount(probe: IntrospectionProbe): Promise<string | null> {
+  const send = probe.fetch ?? globalThis.fetch;
+
+  try {
+    const token = await probe.accessToken();
+    if (!token) return null;
+
+    const endpoints = await askableEndpoints(probe.resourceUrl, send);
+    if (!endpoints.introspection) {
+      return endpoints.userinfo ? await fromUserinfo(endpoints.userinfo, token, send) : null;
+    }
+
+    const client = await probe.clientInformation();
+
+    // `client_secret_post` where we hold a secret, and the bare `client_id`
+    // where we do not — the two methods a dynamically registered public client
+    // is offered. A server wanting neither ignores both fields.
+    const body = new URLSearchParams({ token, token_type_hint: 'access_token' });
+    if (client?.client_id) body.set('client_id', client.client_id);
+    if (client?.client_secret) body.set('client_secret', client.client_secret);
+
+    const response = await send(endpoints.introspection, {
+      method: 'POST',
+      headers: { 'content-type': 'application/x-www-form-urlencoded', accept: 'application/json' },
+      body,
+    });
+    if (!response.ok) {
+      return endpoints.userinfo ? await fromUserinfo(endpoints.userinfo, token, send) : null;
+    }
+
+    const claims = (await response.json()) as Record<string, unknown>;
+
+    // `active: false` is a valid, successful answer meaning the token is not
+    // one this server will speak for. Every other field is then meaningless by
+    // the RFC, so reading one would be reading a stale claim.
+    if (claims['active'] === false) return null;
+
+    return (
+      readable(claims['username'], client?.client_id) ??
+      readable(claims['email'], client?.client_id)
+    );
+  } catch {
+    return null;
+  }
+}

--- a/src/cli/oauth-callback.ts
+++ b/src/cli/oauth-callback.ts
@@ -112,7 +112,9 @@ export interface CallbackCapture {
   close(): Promise<void>;
 }
 
-export function captureOAuthCallback(options: { label?: string } = {}): CallbackCapture {
+export function captureOAuthCallback(
+  options: { label?: string; port?: number | undefined } = {},
+): CallbackCapture {
   const state = base64url(randomBytes(24));
   let resolveCode: (value: { code: string; iss?: string }) => void;
   let rejectCode: (error: Error) => void;
@@ -122,10 +124,9 @@ export function captureOAuthCallback(options: { label?: string } = {}): Callback
     rejectCode = reject;
   });
 
-  const server = Bun.serve({
+  const listener = {
     hostname: '127.0.0.1',
-    port: 0,
-    fetch(request) {
+    fetch(request: Request) {
       const url = new URL(request.url);
       if (url.pathname !== '/callback') return new Response('Not found', { status: 404 });
 
@@ -168,7 +169,30 @@ export function captureOAuthCallback(options: { label?: string } = {}): Callback
       resolveCode({ code, ...(iss ? { iss } : {}) });
       return connectedPage(options.label);
     },
-  });
+  };
+
+  // The port a previous run registered with, where the caller knows one.
+  //
+  // Asking the OS for any free port is what broke every second connect to a
+  // vendor that matches `redirect_uri` literally. The first connect binds
+  // whatever it is handed and registers a client declaring *that* URL; the
+  // registration is then kept deliberately, because re-registering orphans the
+  // grant the operator has just approved. So the second connect arrives on a
+  // different port carrying the first one's client and is refused —
+  // `redirect_uri not allowed`, before the consent page even renders.
+  //
+  // Supabase does this. Notion does not, because RFC 8252 §7.3 says a loopback
+  // redirect is matched without its port and Notion follows it — which is the
+  // only reason this survived as long as it did.
+  let server: ReturnType<typeof Bun.serve>;
+  try {
+    server = Bun.serve({ ...listener, port: options.port ?? 0 });
+  } catch {
+    // Taken: another connect in flight, or something else holding it. Falling
+    // back beats failing — a fresh port still works against every server that
+    // follows §7.3, and the one that does not is no worse off than before.
+    server = Bun.serve({ ...listener, port: 0 });
+  }
 
   return {
     redirectUri: `http://127.0.0.1:${server.port}/callback`,

--- a/src/cli/oauth.test.ts
+++ b/src/cli/oauth.test.ts
@@ -538,6 +538,54 @@ describe('a redirect the vendor matches exactly', () => {
     return port;
   }
 
+  /**
+   * The same problem one flow over, and the one that actually bit.
+   *
+   * `--auth` aside, a dynamically registered client hits this too. The first
+   * connect binds whatever the kernel hands out and registers a client
+   * declaring *that* URL; the registration is then kept deliberately, because
+   * re-registering orphans the grant the operator just approved. Every later
+   * connect asked for a new port and sent a URL that client never declared, so
+   * a vendor matching literally refused it before the consent page rendered —
+   * `redirect_uri not allowed`, seen against Supabase.
+   *
+   * Notion hid it: RFC 8252 §7.3 says a loopback redirect is matched without
+   * its port, and Notion follows that.
+   */
+  test('the listener asks for the port a kept registration already declared', async () => {
+    const first = captureOAuthCallback();
+    const port = Number(new URL(first.redirectUri).port);
+    await first.close();
+
+    const again = captureOAuthCallback({ port });
+
+    expect(new URL(again.redirectUri).port).toBe(String(port));
+    await again.close();
+  });
+
+  test('and takes a free one rather than failing when that port is held', async () => {
+    // Another connect in flight, or something else on it. Falling back beats
+    // failing: a fresh port still works against every server that follows
+    // §7.3, and the one that does not is no worse off than it was.
+    const holding = captureOAuthCallback();
+    const taken = Number(new URL(holding.redirectUri).port);
+
+    const second = captureOAuthCallback({ port: taken });
+
+    expect(new URL(second.redirectUri).port).not.toBe(String(taken));
+    expect(Number(new URL(second.redirectUri).port)).toBeGreaterThan(0);
+
+    await holding.close();
+    await second.close();
+  });
+
+  test('with no port asked for, it binds any free one as it always did', async () => {
+    const capture = captureOAuthCallback();
+
+    expect(Number(new URL(capture.redirectUri).port)).toBeGreaterThan(0);
+    await capture.close();
+  });
+
   test('the declared URL is what the vendor is told, verbatim', async () => {
     const port = freePort();
     const fixedRedirect = `http://127.0.0.1:${port}/callback`;

--- a/src/connectivity/manifest/identity.ts
+++ b/src/connectivity/manifest/identity.ts
@@ -23,7 +23,28 @@ import { z } from 'zod';
  * `field` is a dotted path. Resolution is best-effort by design: a provider with
  * no identity block, or one whose probe fails, falls back to asking the
  * operator. A connection is worth labelling, never worth blocking on.
+ *
+ * **A `field` must name one value, never a collection.** `pluck` walks into the
+ * first element of an array on the way past, so a path through a list resolves
+ * to whoever happens to be first and reads exactly like a working probe. That
+ * is the mistake `notion-get-users` would have made — the integration bot leads
+ * the list, not the person — and a confident wrong label is worse than the
+ * question it saves.
  */
+
+/**
+ * A second path, shown in brackets, where `field` alone is not unique.
+ *
+ * Almost no provider needs one: an address identifies a Google or iCloud
+ * account globally, and a GitHub login is unique across GitHub. The exceptions
+ * are the vendors whose "user" is scoped to a tenant — the same person in two
+ * Slack workspaces answers `auth.test` with the same `user`, and the same
+ * person in two Notion workspaces is the same email. One account string is how
+ * `settleIdentity` decides a connect is a *reconnect*, so without this,
+ * connecting a second tenant matches the first and overwrites its credential.
+ */
+const qualifier = z.string().min(1).optional();
+
 export const identitySchema = z.discriminatedUnion('kind', [
   z.object({
     kind: z.literal('http'),
@@ -31,23 +52,23 @@ export const identitySchema = z.discriminatedUnion('kind', [
     /** Dotted path into the JSON body, e.g. `emailAddress` or `user.emailAddress`. */
     field: z.string().min(1),
     /**
-     * A second path, shown in brackets, where `field` alone is not unique.
+     * Sent alongside the credential.
      *
-     * Almost no provider needs one: an address identifies a Google or iCloud
-     * account globally, and a GitHub login is unique across GitHub. Slack is
-     * the exception, because the thing it calls a user is scoped to a
-     * workspace — the same person in two workspaces answers `auth.test` with
-     * the same `user`, and one account string is how `settleIdentity` decides a
-     * connect is a *reconnect*. Without this, connecting a second workspace
-     * matches the first and overwrites its credential.
+     * For the APIs that answer nothing without one: Notion refuses a request
+     * carrying no `Notion-Version`, and it is not the only vendor that pins its
+     * version in a header rather than the path. The credential is added by the
+     * probe and cannot be set here — a manifest naming its own `authorization`
+     * would be a second, unaudited way to send one.
      */
-    qualifier: z.string().min(1).optional(),
+    headers: z.record(z.string(), z.string()).optional(),
+    qualifier,
   }),
   z.object({
     kind: z.literal('tool'),
     tool: z.string().min(1),
     field: z.string().min(1),
     arguments: z.record(z.string(), z.unknown()).default({}),
+    qualifier,
   }),
   z.object({ kind: z.literal('connector') }),
 ]);

--- a/src/profile/connections.test.ts
+++ b/src/profile/connections.test.ts
@@ -35,6 +35,30 @@ describe('defaultConnectionLabel', () => {
     expect(defaultConnectionLabel('Setup', undefined)).toBe('Setup');
   });
 
+  /**
+   * A qualified account keeps the half that tells it from its twin.
+   *
+   * `ada@example.com (Personal)` is what an identity block writes when one name
+   * spans two tenants — Notion's email is the same email in every workspace the
+   * person belongs to. Shortening on the `@` alone cut the bracket off, so both
+   * workspaces read `Notion (ada)` and the field that exists to tell them apart
+   * was the one nobody saw.
+   */
+  test('keeps the qualifier that makes two tenants two names', () => {
+    expect(defaultConnectionLabel('Notion', 'ada@example.com (Personal)')).toBe(
+      'Notion (ada (Personal))',
+    );
+    expect(defaultConnectionLabel('Notion', 'ada@example.com (Personal)')).not.toBe(
+      defaultConnectionLabel('Notion', 'ada@example.com (Acme)'),
+    );
+  });
+
+  test('and leaves a handle that was already qualified exactly as it was', () => {
+    // Slack's shape, unchanged: its `user` is a handle, so there is no `@` to
+    // shorten on and the whole string was already kept.
+    expect(defaultConnectionLabel('Slack', 'ada (Acme)')).toBe('Slack (ada (Acme))');
+  });
+
   test('an empty account is no account', () => {
     expect(defaultConnectionLabel('Gmail', '')).toBe('Gmail');
     // And an address with nothing before the `@` falls back to the whole of it

--- a/src/profile/connections.ts
+++ b/src/profile/connections.ts
@@ -45,11 +45,20 @@ export function defaultConnectionLabel(
 ): string {
   if (!account || account === providerName) return providerName;
 
+  // A qualified account — `ada (Acme)`, the shape an identity block writes when
+  // one name spans two tenants — is shortened on the name and keeps the
+  // bracket. Without this, two Notion workspaces resolve to the same address
+  // and shorten to the same label, so the field that exists to tell them apart
+  // is the one the reader never sees.
+  const qualified = /^(.*?)\s+(\([^()]*\))$/.exec(account);
+  const identity = qualified?.[1] ?? account;
+  const qualifier = qualified?.[2] ? ` ${qualified[2]}` : '';
+
   // Split on `@` and nothing else. A handle, an IBAN or a workspace name has no
   // "first part" that is safe to guess at: `Lanes HQ` cut at the space is
   // `Lanes`, which is a different workspace's name as often as not.
-  const local = account.split('@')[0];
-  return `${providerName} (${local || account})`;
+  const local = identity.split('@')[0];
+  return `${providerName} (${local || identity}${qualifier})`;
 }
 
 /**

--- a/src/providers/asana/index.ts
+++ b/src/providers/asana/index.ts
@@ -7,4 +7,20 @@ export const asana = defineProvider({
   description: 'Tasks, projects, portfolios, and workspaces, via Asana\'s official MCP server.',
   connector: { kind: 'mcp', endpoint: 'https://mcp.asana.com/mcp' },
   auth: { kind: 'oauth', registration: 'dynamic' },
+  /**
+   * `email` is not returned by default — `opt_fields` is Asana's whole shape for
+   * optional output, and without it this answers a user object with a name and
+   * no address. The name would resolve, and would be the wrong thing: two people
+   * called the same thing are one account to the reconnect match.
+   *
+   * Asana registers us dynamically at `mcp.asana.com`, so whether that token is
+   * accepted by `app.asana.com/api/1.0` is Asana's business and not documented
+   * either way. If it is not, the probe 401s and `connect` asks — which is what
+   * it did before this block existed, so the downside is a round trip.
+   */
+  identity: {
+    kind: 'http',
+    url: 'https://app.asana.com/api/1.0/users/me?opt_fields=email',
+    field: 'data.email',
+  },
 });

--- a/src/providers/asana/index.ts
+++ b/src/providers/asana/index.ts
@@ -8,19 +8,16 @@ export const asana = defineProvider({
   connector: { kind: 'mcp', endpoint: 'https://mcp.asana.com/mcp' },
   auth: { kind: 'oauth', registration: 'dynamic' },
   /**
-   * `email` is not returned by default — `opt_fields` is Asana's whole shape for
-   * optional output, and without it this answers a user object with a name and
-   * no address. The name would resolve, and would be the wrong thing: two people
-   * called the same thing are one account to the reconnect match.
+   * No identity block. `GET /users/me?opt_fields=email` is documented and
+   * answers `data.email`, and it was written here on that reading — but Asana
+   * registers us dynamically at `mcp.asana.com`, and whether that token is
+   * accepted by `app.asana.com/api/1.0` is not documented either way.
    *
-   * Asana registers us dynamically at `mcp.asana.com`, so whether that token is
-   * accepted by `app.asana.com/api/1.0` is Asana's business and not documented
-   * either way. If it is not, the probe 401s and `connect` asks — which is what
-   * it did before this block existed, so the downside is a round trip.
+   * Supabase is why this was taken back out rather than left to fail closed.
+   * There, the authorization server *is* the API's own host, which is a much
+   * stronger reason to expect the token to work — and `GET /v1/profile` still
+   * answered "does not support oauth access yet". An MCP token is its own
+   * credential kind until a vendor says otherwise, so this one waits for
+   * somebody with an Asana account to try it.
    */
-  identity: {
-    kind: 'http',
-    url: 'https://app.asana.com/api/1.0/users/me?opt_fields=email',
-    field: 'data.email',
-  },
 });

--- a/src/providers/box/index.ts
+++ b/src/providers/box/index.ts
@@ -27,6 +27,12 @@ export const box = defineProvider({
     token_url: 'https://api.box.com/oauth2/token',
     redirect_uri: BOX_REDIRECT_URI,
   },
+  /**
+   * `login` is Box's name for the primary email address, and the token here is
+   * an ordinary Box one — the operator registered the client and the flow
+   * redeems at `api.box.com`, so the API accepts it without question.
+   */
+  identity: { kind: 'http', url: 'https://api.box.com/2.0/users/me', field: 'login' },
   setup: {
     summary:
       'Box needs an OAuth app of your own. On a managed account an administrator can instead add ' +

--- a/src/providers/figma/index.ts
+++ b/src/providers/figma/index.ts
@@ -1,10 +1,48 @@
 import { defineProvider } from '#connectivity';
 
-/** Figma registers us at connect time — nothing for an operator to set up. */
+/**
+ * Figma, through the server Figma runs — and will not register us with.
+ *
+ * `api.figma.com` advertises a `registration_endpoint` and then refuses every
+ * request made to it with a bare `403 Forbidden`: an empty body earns the same
+ * refusal as a well-formed one, so the gate sits ahead of body validation, and
+ * neither a bearer token nor an `X-Figma-Token` moves it. Figma's own
+ * documentation says why — only clients listed in its MCP catalogue may
+ * connect, and a new client joins by waitlist. So this is an allowlist, not a
+ * plan to upgrade, a scope to widen, or a session to sign in to. There is no
+ * request that gets through.
+ *
+ * `registration` stays `dynamic` anyway, for two reasons. It is what Figma
+ * advertises and what we correctly attempt, and the day a client of ours is in
+ * that catalogue the declaration becomes true with nothing here to change.
+ * `manual` would be worse than imprecise: it promises an operator can supply a
+ * client of their own, and for an MCP client at Figma no console issues one.
+ * The honest third state — the vendor allowlists clients and offers no
+ * self-serve route — is not a value this field has, and `manifest/auth.ts`
+ * argues against growing it for one vendor. Prose carries it until a second
+ * vendor does the same.
+ *
+ * What the setup block is for: `connect/registration.ts` reads `docs_url` when
+ * a registration is refused, so the refusal points at the page that explains
+ * itself rather than at a bare hostname. It declares no prompts and so asks for
+ * nothing — `ensureOAuthApp` returns before rendering it, this provider naming
+ * no `app`.
+ */
 export const figma = defineProvider({
   id: 'figma',
   name: 'Figma',
   description: 'Files, designs, components, and Dev Mode context, via Figma\'s official MCP server.',
   connector: { kind: 'mcp', endpoint: 'https://mcp.figma.com/mcp' },
   auth: { kind: 'oauth', registration: 'dynamic' },
+  setup: {
+    summary:
+      'Figma admits only the MCP clients listed in its own catalogue, and a client joins that list ' +
+      'by waitlist rather than by registering. Nothing is asked for here because there is nothing ' +
+      'to paste: registration is refused before anything about your account is looked at.',
+    docs_url: 'https://developers.figma.com/docs/figma-mcp-server/',
+    troubleshooting:
+      'A 403 from the registration endpoint is the catalogue and not your account — the same ' +
+      'request is refused signed in, signed out, and with no body at all. Figma also ships a ' +
+      'desktop MCP server that needs no registration; it is a different endpoint, not this one.',
+  },
 });

--- a/src/providers/identity-coverage.test.ts
+++ b/src/providers/identity-coverage.test.ts
@@ -1,0 +1,146 @@
+import { describe, expect, test } from 'bun:test';
+import { PROVIDER_MANIFESTS } from './index.ts';
+
+/**
+ * Every provider can say whose account it is, or says why it cannot.
+ *
+ * `connect` resolves an identity from the manifest's `identity` block, then
+ * from the authorization server (`cli/introspection.ts`), and only then asks
+ * the operator. The prompt is the fallback and its own doc comment calls it
+ * one — but 75 of 105 manifests declared nothing, so for most of the catalogue
+ * it was the *only* path, and connecting meant typing your own address a second
+ * after authorising.
+ *
+ * The number will not come down on its own, and worse, it silently goes back up:
+ * a provider is fifteen lines of data, adding one costs nothing, and nothing
+ * about writing those fifteen lines raises the question. So the build raises it.
+ * A new provider either declares an identity block, authenticates to nothing, or
+ * is listed below with the reason — and the list is checked in both directions,
+ * so an entry cannot outlive the gap it records.
+ *
+ * **This is a ledger, not an allowlist.** Entries are meant to leave it.
+ */
+
+/**
+ * The sweep that has not happened yet, and what makes it slow.
+ *
+ * These are the hosted-MCP providers. Their tool lists are not published in a
+ * form that can be read here — every one of the servers refuses an
+ * unauthenticated `tools/list` with a 401 — so the identity call has to come
+ * from vendor documentation, one vendor at a time, and each block ships
+ * unverified until somebody with an account on that vendor connects.
+ *
+ * Neither generic route covers them: of the 80 MCP endpoints this repository
+ * names, five advertise RFC 7662 introspection and three advertise OIDC
+ * userinfo. That measurement is why the per-vendor work is the substance and
+ * the generic probe is the cheap part.
+ */
+const UNSWEPT =
+  'Hosted MCP server, not yet swept: `tools/list` is refused unauthenticated, so the identity call has to come from vendor documentation.';
+
+const NO_IDENTITY: Readonly<Record<string, string>> = {
+  discord: 'Decided, not omitted, and written out in the provider: the stored credential is `Bot MTIz…`, so a bearer probe would send `Bearer Bot MTIz…` and earn a 401 on every connect.',
+  google_tasks: 'Decided, not omitted, and written out in the provider: nothing reachable under `auth/tasks` returns an address, and `userinfo.email` is a scope this provider has no other use for.',
+  bunq: 'Not swept. bunq authenticates through its own handshake rather than OAuth, so neither generic route applies, and its `/v1/user` shape has not been checked against what the strategy stores.',
+  stripe: UNSWEPT,
+  sentry: UNSWEPT,
+  figma: UNSWEPT,
+  canva: UNSWEPT,
+  dropbox: UNSWEPT,
+  todoist: UNSWEPT,
+  clickup: UNSWEPT,
+  monday: UNSWEPT,
+  airtable: UNSWEPT,
+  miro: UNSWEPT,
+  calendly: UNSWEPT,
+  close: UNSWEPT,
+  zapier: UNSWEPT,
+  paypal: UNSWEPT,
+  square: UNSWEPT,
+  mercury: UNSWEPT,
+  vercel: UNSWEPT,
+  netlify: UNSWEPT,
+  supabase: UNSWEPT,
+  neon: UNSWEPT,
+  prisma: UNSWEPT,
+  sanity: UNSWEPT,
+  webflow: UNSWEPT,
+  wix: UNSWEPT,
+  datadog: UNSWEPT,
+  grafana: UNSWEPT,
+  fireflies: UNSWEPT,
+  gamma: UNSWEPT,
+  jam: UNSWEPT,
+  cloudflare_observability: UNSWEPT,
+  cloudflare_bindings: UNSWEPT,
+  atlassian: UNSWEPT,
+  hubspot: UNSWEPT,
+  render: UNSWEPT,
+  algolia: UNSWEPT,
+  amplitude: UNSWEPT,
+  apify: UNSWEPT,
+  attio: UNSWEPT,
+  betterstack: UNSWEPT,
+  brightdata: UNSWEPT,
+  buildkite: UNSWEPT,
+  circleci: UNSWEPT,
+  contentful: UNSWEPT,
+  expensify: UNSWEPT,
+  flagsmith: UNSWEPT,
+  heroku: UNSWEPT,
+  hygraph: UNSWEPT,
+  insightly: UNSWEPT,
+  klaviyo: UNSWEPT,
+  mixpanel: UNSWEPT,
+  mux: UNSWEPT,
+  navan: UNSWEPT,
+  paddle: UNSWEPT,
+  posthog: UNSWEPT,
+  ramp: UNSWEPT,
+  recurly: UNSWEPT,
+  remote: UNSWEPT,
+  replicate: UNSWEPT,
+  resend: UNSWEPT,
+  riverside: UNSWEPT,
+  rootly: UNSWEPT,
+  rudderstack: UNSWEPT,
+  salesloft: UNSWEPT,
+  shortcut: UNSWEPT,
+  storyblok: UNSWEPT,
+  tavily: UNSWEPT,
+  vimeo: UNSWEPT,
+  whimsical: UNSWEPT,
+  workable: UNSWEPT,
+};
+
+describe('identity coverage', () => {
+  const asks = PROVIDER_MANIFESTS.filter(
+    (manifest) => !manifest.identity && manifest.auth.kind !== 'none',
+  );
+
+  test('a provider that will ask the operator is one that said why it has to', () => {
+    // The owner layer is exempt without being listed: `auth.kind === 'none'`
+    // takes the `unaccounted` branch in `settleIdentity` and is named after its
+    // provider, so it never reaches the question.
+    const unexplained = asks.map((manifest) => manifest.id).filter((id) => !NO_IDENTITY[id]);
+
+    expect(unexplained).toEqual([]);
+  });
+
+  test('and an entry does not outlive the gap it records', () => {
+    // The half that makes this a ledger. Without it, a provider that gained an
+    // identity block would keep its excuse, and the list would stop meaning
+    // anything long before it stopped being read.
+    const stale = Object.keys(NO_IDENTITY).filter(
+      (id) => !asks.some((manifest) => manifest.id === id),
+    );
+
+    expect(stale).toEqual([]);
+  });
+
+  test('every reason is a reason, not a word typed to quiet the check', () => {
+    for (const [id, reason] of Object.entries(NO_IDENTITY)) {
+      expect(`${id}: ${reason}`.length).toBeGreaterThan(60);
+    }
+  });
+});

--- a/src/providers/identity-coverage.test.ts
+++ b/src/providers/identity-coverage.test.ts
@@ -47,7 +47,8 @@ const NO_IDENTITY: Readonly<Record<string, string>> = {
   sentry: UNSWEPT,
   supabase:
     'Verified, not unswept: `GET /v1/profile` refuses an OAuth token ("does not support oauth access yet"), there is no userinfo, `/v1/user` or `/v1/me`, and what OAuth does reach — organizations, projects — is a collection.',
-  figma: UNSWEPT,
+  figma:
+    'Verified, not unswept: Figma admits only the MCP clients in its own catalogue and refuses registration with a bare 403 whatever is sent, so there is no connection here whose account there would be to name.',
   canva: UNSWEPT,
   dropbox: UNSWEPT,
   todoist: UNSWEPT,

--- a/src/providers/identity-coverage.test.ts
+++ b/src/providers/identity-coverage.test.ts
@@ -44,6 +44,8 @@ const NO_IDENTITY: Readonly<Record<string, string>> = {
   bunq: 'Not swept. bunq authenticates through its own handshake rather than OAuth, so neither generic route applies, and its `/v1/user` shape has not been checked against what the strategy stores.',
   stripe: UNSWEPT,
   sentry: UNSWEPT,
+  supabase:
+    'Verified, not unswept: `GET /v1/profile` refuses an OAuth token ("does not support oauth access yet"), there is no userinfo, `/v1/user` or `/v1/me`, and what OAuth does reach — organizations, projects — is a collection.',
   figma: UNSWEPT,
   canva: UNSWEPT,
   dropbox: UNSWEPT,
@@ -60,7 +62,6 @@ const NO_IDENTITY: Readonly<Record<string, string>> = {
   mercury: UNSWEPT,
   vercel: UNSWEPT,
   netlify: UNSWEPT,
-  supabase: UNSWEPT,
   neon: UNSWEPT,
   prisma: UNSWEPT,
   sanity: UNSWEPT,

--- a/src/providers/identity-coverage.test.ts
+++ b/src/providers/identity-coverage.test.ts
@@ -36,11 +36,12 @@ import { PROVIDER_MANIFESTS } from './index.ts';
  * the generic probe is the cheap part.
  */
 const UNSWEPT =
-  'Hosted MCP server, not yet swept: `tools/list` is refused unauthenticated, so the identity call has to come from vendor documentation.';
+  'Hosted MCP server, not yet swept: `tools/list` is refused unauthenticated, so the identity call has to come from vendor documentation, and documentation does not say whether the MCP token is accepted by the vendor REST API.';
 
 const NO_IDENTITY: Readonly<Record<string, string>> = {
   discord: 'Decided, not omitted, and written out in the provider: the stored credential is `Bot MTIz…`, so a bearer probe would send `Bearer Bot MTIz…` and earn a 401 on every connect.',
   google_tasks: 'Decided, not omitted, and written out in the provider: nothing reachable under `auth/tasks` returns an address, and `userinfo.email` is a scope this provider has no other use for.',
+  asana: UNSWEPT,
   bunq: 'Not swept. bunq authenticates through its own handshake rather than OAuth, so neither generic route applies, and its `/v1/user` shape has not been checked against what the strategy stores.',
   stripe: UNSWEPT,
   sentry: UNSWEPT,

--- a/src/providers/notion/index.ts
+++ b/src/providers/notion/index.ts
@@ -11,9 +11,30 @@ export const notion = defineProvider({
   description: 'Pages, databases, comments, and workspace search, via Notion\'s official MCP server.',
   connector: { kind: 'mcp', endpoint: 'https://mcp.notion.com/mcp' },
   auth: { kind: 'oauth', registration: 'dynamic' },
-  // No identity block on purpose. Notion exposes no "who am I" tool:
-  // `get-users` leads with integration bots rather than the person, and
-  // `get-teams` returns teamspaces, which are not the workspace and may be in
-  // the trash. Both would produce a confident wrong label, so `connect` asks
-  // instead — the fallback exists for exactly this.
+  /**
+   * `notion-fetch` answers the id `self` with the workspace and the person.
+   *
+   * This block did not exist, and the note in its place said Notion exposes no
+   * "who am I" tool — that `get-users` leads with integration bots rather than
+   * the person and `get-teams` returns teamspaces, so both would produce a
+   * confident wrong label. That was true of those two tools and is no longer
+   * the whole picture: the hosted server renamed them under a `notion-` prefix
+   * and added `notion-fetch`, whose `self` returns the connected workspace's id
+   * and name alongside the authenticated user's id, name, type and email.
+   * Notion documents it for this exact purpose — labelling a connection after
+   * OAuth.
+   *
+   * The qualifier is not decoration. One person's email is the same email in
+   * every workspace they belong to, and the account is what `settleIdentity`
+   * matches a reconnect on — so without the workspace beside it, connecting a
+   * second workspace would repair the first row and overwrite its credential.
+   * Slack carries one for the same reason.
+   */
+  identity: {
+    kind: 'tool',
+    tool: 'notion-fetch',
+    arguments: { id: 'self' },
+    field: 'self.user.email',
+    qualifier: 'self.workspace.name',
+  },
 });

--- a/src/providers/supabase/index.ts
+++ b/src/providers/supabase/index.ts
@@ -7,4 +7,21 @@ export const supabase = defineProvider({
   description: 'Projects, database schema, SQL, edge functions, and docs, via Supabase\'s official MCP server.',
   connector: { kind: 'mcp', endpoint: 'https://mcp.supabase.com/mcp' },
   auth: { kind: 'oauth', registration: 'dynamic' },
+  /**
+   * No identity block, and it is a verified refusal rather than an omission.
+   *
+   * Supabase's authorization server *is* `api.supabase.com`, so the MCP token
+   * is an ordinary Management API one and the endpoint that names a person
+   * looked like a free answer. It is not: `GET /v1/profile` refuses that token
+   * outright — 401, "does not support oauth access yet" — and it is not a
+   * scope, since none is advertised that would cover it. There is no
+   * `/v1/user`, `/v1/me`, or userinfo; all three are 404.
+   *
+   * What OAuth does reach is `/v1/organizations` and `/v1/projects`, and both
+   * are collections. A `field` through a collection resolves to whichever
+   * element happens to be first, which is arbitrary for anyone in more than one
+   * organization and, worse, unstable — a reconnect that resolved a different
+   * one would append a row instead of repairing it. That is the failure the
+   * account field exists to prevent.
+   */
 });


### PR DESCRIPTION
`lanes link connect notion` opened a browser, printed `ok authorised`, and then asked
`Which account is this? (the address or handle)`. The browser round trip had just established
exactly who it was.

That is the **account** question, not the label one — they are two prompts and only one of them
is the operator's to answer. The label question already offers a suggestion and takes Enter; it
never appeared here because typing the account skips it.

The account prompt's own doc comment calls it a last resort. It was not one: **30 of 105 provider
definitions declared an `identity` block and 75 did not**, so for most of the catalogue it was the
only path. That matters more than a cosmetic label — the typed answer is the key a reconnect
matches on, the source of the default label, and what `gmail.send_message` writes into a `From`
header. The field that most needs to be stable was the one a human retyped from memory.

## What changed

Identity now resolves from the caller, the connector, the manifest, then the authorization
server — and only then asks. ADR-073 records the order and the rules.

- **Notion gets a block.** Its omission was deliberate and documented: `get-users` led with
  integration bots, `get-teams` returned teamspaces, both "would produce a confident wrong label".
  Right, and expired — the hosted server renamed those tools and added `notion-fetch`, whose id
  `self` returns the workspace alongside the authenticated user's email. Notion documents it for
  labelling a connection after OAuth.
- **Ask the authorization server.** RFC 7662 introspection, then OIDC userinfo, with no per-vendor
  configuration. Deliberately *not* the thing `oauth-exchange.ts` refuses: it declines to decode
  the stored `id_token` because the claim is unverified and the store tamperable, and asking the
  issuer over the network is the checkable answer that comment asks for.
- **A qualifier on `tool` identity, and a label that keeps it.** One person's Notion email is the
  same email in every workspace, so without the workspace beside it a second connect matches the
  first row and overwrites its credential — Slack's case, one transport over.
- **`headers` on `http` identity.** Notion's REST API refuses a request with no `Notion-Version`,
  and it is not the only vendor pinning its version in a header.
- **The empty answer.** It stored `Notion pending` — the provider's name beside an internal token
  meaning "no id yet", which then became the account, the label and the audit argument. It
  re-asks now; typing `blank` is the way past and stores `unnamed` with a freshly allocated id,
  because two rows nobody could name are not evidence of one account.

## What this does not claim

**Sixty-nine hosted-MCP providers are still unswept, and they are named rather than totalled.**
`src/providers/identity-coverage.test.ts` fails the build when a provider neither declares a
block, nor authenticates to nothing, nor is listed with a written reason — and fails equally when
an entry outlives the gap it records. It is a ledger; entries are meant to leave it.

Two measurements are why the sweep is the substance rather than a generic fix:

- Of the 80 MCP endpoints this repository names, **5 advertise introspection and 3 advertise
  userinfo** — and they are different servers.
- **Every one of those servers refuses an unauthenticated `tools/list`.** So each identity call
  has to come from vendor documentation, one vendor at a time, and each block ships unverified
  until somebody holding an account on that vendor connects.

Box is the one hosted-MCP provider swept here, and it is swept because its OAuth is the
operator's own client redeeming at `api.box.com` — the token is an ordinary Box one, so
`/2.0/users/me` is not a guess.

**Supabase is why that is the only one.** A block was written for it from its documentation and
a fair inference — its authorization server *is* its API's host — and the real token came back
`401 does not support oauth access yet`. It was taken out again, and Asana's went with it: same
shape, same lack of evidence, and Asana's token is issued at `mcp.asana.com` for an API at
`app.asana.com`, which is a weaker case than the one that just failed. **A block is not added on
documentation alone** is now a rule in ADR-073 rather than a lesson.

An unverified block is bounded in what it can do wrong: a wrong endpoint or a rejected token
answers null and the operator is asked, which is what happened before. The hazard is a right
endpoint and a wrong field, which is what the two probe rules in ADR-073 are for — a `field` never
names a collection, and a non-human-readable identifier is refused rather than written into a row.

## Two bugs connecting twice turned up

Verifying the reconnect claim meant connecting a second time, which nothing had done routinely
before. Both are here rather than in their own branches, because the claim this pull request
makes is not checkable for a dynamically registered provider while the first one stands.

- **A second connect asked for a port its own registration had ruled out.** The callback listener
  bound `port: 0` and built the redirect URI from whatever the kernel handed back, while the
  client registered on the first run — deliberately kept, since re-registering would orphan the
  grant just approved — declares one fixed `http://127.0.0.1:<port>/callback`. Every later connect
  therefore presented a URL its client had never declared, and Supabase said `redirect_uri not
  allowed`. Notion masked it by following RFC 8252 §7.3, which matches a loopback redirect without
  its port; the only provider anyone had reconnected was the one that could not fail. The port was
  already chosen and written down — the listener simply had no way to be told, and takes one now.
- **Figma promised a registration it does not offer.** `registration: 'dynamic'` is documented as
  "the operator does nothing at all", and `api.figma.com/v1/oauth/mcp/register` answers a bare 403
  to a well-formed body, to `{}`, to no body, and to a request carrying a bearer — the gate is
  ahead of body validation and reads nothing we could change. Figma's documentation gives the
  rule: only catalogued MCP clients may connect, and a client joins by waitlist. The declaration
  stays `dynamic` (it is what Figma advertises, and it becomes true the day a client of ours is
  listed); a promptless `setup` block now carries the truth, so the refusal ends at the page that
  explains the catalogue rather than at a bare hostname.

## Verification

`bun test` — 3173 pass, 12 skip, 28 new. The 2 failures are the pre-existing `token` output
timeouts on `develop` (both 5s test-timeouts, unrelated), confirmed against the baseline before
any change. `bun run typecheck` clean.

Run against real accounts by the operator, in a scratch `LANES_LINK_HOME`:

- **Notion, twice.** First run resolved `account: <address> (<Workspace>)` with no question asked,
  and labelled the connection from it. Second run printed `re-authorised notion.con1` — the
  reconnect repairs the row rather than appending one, which is the part most likely to break and
  the only way to see it.
- **Supabase.** Reached the account prompt with nothing to answer it, which is the fallback
  behaving as designed; the empty answer re-asked and `blank` stored `unnamed`. Its `/v1/profile`
  refusal was captured from that connection's own token, which is what makes the ledger entry
  evidence rather than a reading of the docs.
- **Figma.** Refused at registration, as above.

