### PR TITLE
A contributor's own handle is a real identifier, and nothing was checking

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -80,3 +80,6 @@ coverage/
 .vscode/
 !.vscode/extensions.json
 .worktrees/
+
+# Handles a contributor must never commit — see the identifier check in src/architecture.test.ts
+.private-identifiers

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -89,7 +89,7 @@ paths `release.yml` takes, and the verification that a release shipped. What an 
 - **Never tag or `npm publish` by hand.** The workflow owns both, in that order, for a reason a
   manual run reverses.
 
-## Never write a real address, project, or bucket into this repository
+## Never write a real address, name, project, or bucket into this repository
 
 This repository is public. The shortest path to a passing test or a convincing doc example is
 to paste the account you are actually working with, and that account is the operator's — a
@@ -106,8 +106,24 @@ example, use a name that reads as a placeholder: `my-project`, `your-bucket`, `<
 Prose about a domain is fine (`a personal @gmail.com cannot enrol`) — it is an address *at* one
 that is not.
 
-`src/architecture.test.ts` fails the build on both. It reads every `.ts`, `.md`, `.json`, and
+**A person's name or handle is the same rule, and it is the one that gets missed.** Not just
+an address — a bare handle, a username, a slug derived from either. It reaches the repository
+through *prose about what actually happened*: a comment narrating a real rehearsal, an ADR
+recounting a real incident, a test fixture copied from a real workspace. A credential ref built
+from the operator's own mailbox sat in two comments here for months precisely because it was not
+an address, so nothing flagged it and nobody reading the sentence was looking for it.
+
+Write the rehearsal, not the person. `ada.lovelace@example.com` and `ada_lovelace` are the
+house example; use them. If a sentence only makes sense with the real handle in it, the sentence
+is wrong, not the rule.
+
+`src/architecture.test.ts` fails the build on all of it. It reads every `.ts`, `.md`, `.json`, and
 `.yaml` file in the repository, so there is nowhere to put one where the check does not look.
+Handles are checked against the committer's git identity — including the `<id>+<handle>@…`
+form a forge commits under — and against `.private-identifiers`, a gitignored file of one token
+per line. Keep your own handles there: git only knows the address you commit under, and the one
+that leaked here came from a personal mailbox git had never seen. A denylist inside the repository
+cannot work, because writing the name into it is the thing being prevented.
 
 ## Where things are
 

--- a/src/architecture.test.ts
+++ b/src/architecture.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from 'bun:test';
+import { execFileSync } from 'node:child_process';
 import { readdir, readFile } from 'node:fs/promises';
 import { join, relative } from 'node:path';
 
@@ -486,6 +487,90 @@ describe('no real identifiers', () => {
           const domain = address.slice(address.indexOf('@') + 1);
           if (RESERVED_DOMAIN.test(domain) || MACHINE_DOMAIN.test(domain)) continue;
           violations.push(`${shown}:${index + 1} — ${address} is at a registrable domain`);
+        }
+      }
+    }
+
+    expect(violations).toEqual([]);
+  });
+
+  /**
+   * The one the address rule could not express: a contributor's own handle.
+   *
+   * A credential ref built from a real person's mailbox sat in two comments
+   * here for months. It is not an address, so the check above had nothing to
+   * say about it; it is not a bucket or a project, so neither did the one
+   * below. It was a real handle in a public repository, written while
+   * narrating a real rehearsal — which is exactly how the forty-five
+   * occurrences scrubbed before the first push got there. Prose about what
+   * actually happened is where this always comes from, and it is the one place
+   * nobody thinks to look. (Naming it here would repeat it, which is the joke
+   * this check played on its own first draft.)
+   *
+   * **A denylist in the repository cannot work**, because writing the name into
+   * a checked-in list is the thing being prevented. Two sources that are not:
+   *
+   * - **git.** `user.email` on a forge commit is
+   *   `<id>+<handle>@users.noreply.github.com`, so the handle *is* there and
+   *   discarding the address for being a noreply throws away the one name a
+   *   commit reliably carries. That was this check's first draft and it caught
+   *   nothing.
+   * - **`.private-identifiers`**, gitignored, one token per line. git only ever
+   *   knows the address someone commits under, and the handle that leaked here
+   *   came from a personal mailbox git has never seen. Nothing can infer that,
+   *   so there is a file to say it, and it stays out of the tree by definition.
+   *
+   * Tokens shorter than five characters are ignored, and a `user.name` with a
+   * space in it is skipped entirely: splitting a display name into words would
+   * fail the build for anyone called Mark the moment a comment mentioned a mark.
+   */
+  test('a contributor has not written their own handle into the tree', async () => {
+    const config = (key: string): string => {
+      try {
+        return execFileSync('git', ['config', '--get', key], { encoding: 'utf8' }).trim();
+      } catch {
+        return '';
+      }
+    };
+
+    // `<id>+<handle>@users.noreply.github.com` → `handle`, and a plain address
+    // → its local part. One expression covers both.
+    const local = (config('user.email').split('@')[0] ?? '').split('+').pop() ?? '';
+    const name = config('user.name');
+
+    let declared: string[] = [];
+    try {
+      declared = (await readFile(join(SRC, '..', '.private-identifiers'), 'utf8'))
+        .split('\n')
+        .map((line) => line.trim())
+        .filter((line) => line.length > 0 && !line.startsWith('#'));
+    } catch {
+      // Absent is the ordinary case. The rule is in CLAUDE.md either way.
+    }
+
+    const handles = new Set<string>();
+    for (const candidate of [local, /\s/.test(name) ? '' : name, ...declared]) {
+      if (candidate.length < 5) continue;
+      // A handle also appears slugified, which is how one reached a credential
+      // ref: `ada.lovelace` became `ada_lovelace`.
+      handles.add(candidate.toLowerCase());
+      handles.add(candidate.replace(/[.\-]/g, '_').toLowerCase());
+      handles.add(candidate.replace(/[._\-]/g, '').toLowerCase());
+    }
+
+    if (handles.size === 0) return;
+
+    const violations: string[] = [];
+
+    for (const path of await publishedFiles()) {
+      const shown = relative(SRC, path);
+      if (shown.includes(NOT_OURS)) continue;
+
+      for (const [index, line] of (await readFile(path, 'utf8')).split('\n').entries()) {
+        const haystack = line.toLowerCase();
+        for (const handle of handles) {
+          if (!haystack.includes(handle)) continue;
+          violations.push(`${shown}:${index + 1} — names a contributor (${handle})`);
         }
       }
     }

--- a/src/cli/contract4.test.ts
+++ b/src/cli/contract4.test.ts
@@ -402,7 +402,7 @@ describe('the credentials, which the rename would otherwise orphan', () => {
     // It warned and carried on once. The rehearsal that found it showed why
     // that is the wrong shape: the warning was printed, the rows were renamed
     // anyway, and the workspace came out naming `gmail.con1` with the secret
-    // still at `gmail/wjj_andrews`. A rerun cannot repair that — the rows are
+    // still at `gmail/ada_lovelace`. A rerun cannot repair that — the rows are
     // renamed, so the second pass computes no rename and the old ref is
     // orphaned with nothing left that knows what it belonged to.
     //

--- a/src/cli/contract4.ts
+++ b/src/cli/contract4.ts
@@ -210,7 +210,7 @@ export async function migrateToContract4(
  * warned once, and the rehearsal that found it showed why it must not: the
  * warning was printed, `renameConnections` ran anyway, and the workspace came
  * out with rows naming `gmail.con1` while the secret sat at
- * `gmail/wjj_andrews`. A rerun cannot repair that — the rows are renamed, so
+ * `gmail/ada_lovelace`. A rerun cannot repair that — the rows are renamed, so
  * the second run computes no rename for them and the old ref is orphaned with
  * nothing left that knows what it belonged to.
  *


### PR DESCRIPTION
A credential ref built from the operator's personal mailbox sat in two comments in
`src/cli/contract4.ts` and `src/cli/contract4.test.ts`. This repository is public.

It is not an address, so the address rule had nothing to say about it. It is not a bucket or a
project, so neither did the deployment rule. It got in the way this always happens — prose
narrating a real rehearsal, which is the one place nobody is looking.

Both now read `gmail/ada_lovelace`, the house example the same test file already used a hundred
lines earlier.

## The check

A denylist in the repository cannot work — writing the name into a checked-in list is the thing
being prevented. Two sources that are not:

- **git.** `user.email` on a forge commit is `<id>+<handle>@users.noreply.github.com`, so the
  handle *is* there. The first draft discarded the whole address for being a noreply and therefore
  caught nothing; that was found by reintroducing the leak and watching the test stay green.
- **`.private-identifiers`**, gitignored, one token per line. git only knows the address you commit
  under, and the handle that leaked came from a personal mailbox git has never seen. Nothing can
  infer that, so there is a file to say it, and it stays out of the tree by definition.

Each handle is matched literally, underscored, and stripped, because a handle reaches a credential
ref slugified. Tokens under five characters are ignored, and a `user.name` containing a space is
skipped — splitting a display name into words would fail the build for anyone called Mark the
moment a comment mentioned a mark.

The check's own doc comment named the handle it was written for, and the check caught it. That is
the argument for having it, so the comment now makes the point without repeating the name.

`CLAUDE.md` carries the rule, since the parts a test cannot infer still have to be written down.

## Verification

Proven in both directions rather than assumed:

- Reintroduce the forge handle in a scratch file → fails, `names a contributor (sqave)`.
- Declare a personal handle in `.private-identifiers` and reintroduce its slug → fails,
  `names a contributor (…)`.
- Clean tree with the declaration in place → passes.

`bun test` 3146 pass, `bun run typecheck` clean. The 2 failures are the pre-existing `token`
output timeouts on `develop`, unrelated and present at baseline.

## After merging

Add a `.private-identifiers` to your own checkout — it is gitignored, one token per line. Without
it the check still covers your forge handle, but not a personal address git never sees.
