### PR TITLE
One footer line on every surface

### DIFF
--- a/src/cli/brand.ts
+++ b/src/cli/brand.ts
@@ -61,9 +61,10 @@ export const FONTS =
   '<link href="https://fonts.googleapis.com/css2?family=Geist+Mono:wght@400;500' +
   '&amp;family=Geist:wght@400;500&amp;family=Lora:wght@400;500&amp;display=swap" rel="stylesheet">';
 
-/** The one-row footer, identical to the one the Lanes API's own pages carry. */
+/** The one-row footer, identical to the one every other Lanes surface carries:
+ * the API's pages and emails, and the desktop app's OAuth success page. */
 export const FOOTER =
-  '<div class="footer"><p>Run many agents at once. Connect them to your tools once - ' +
+  '<div class="footer"><p>Power up your agentic fleet with ' +
   '<a href="https://lanes.sh/">lanes.sh</a></p></div>';
 
 /**


### PR DESCRIPTION
Every CLI-served page ends on the `FOOTER` constant in `src/cli/brand.ts`, so
this is a one-string change that reaches the provider-connect landing page, the
sign-in success and failure cards, the "Not authorised" notice and the Google
loopback page.

> Power up your agentic fleet with **lanes.sh**

It replaces a sentence that was hand-copied across five repos and had drifted:
the API's emails carried a Lora wordmark above it that no page had, and the
Slack OAuth closing page carried no footer at all. Both are fixed in the
companion PRs.

## Verified

- `bun run typecheck` clean
- `bun test` 3145 pass, 2 fail. Both failures are 5s timeouts in the token-command
  tests and reproduce identically on a clean tree; nothing here touches them.
- Rendered `completionPage()` and diffed the footer

Companions: lanes-sh/api, lanes-sh/core, lanes-sh/web, lanes-sh/gtm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MQWuVmvgWue3ZCXHg1HmgM