### PR TITLE
0.9.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lanes-sh/link",
-  "version": "0.9.5",
+  "version": "0.9.6",
   "description": "A self-hostable MCP gateway for all your connections, memory, tasks, files, and secrets",
   "license": "Apache-2.0",
   "homepage": "https://lanes.sh/link",


### PR DESCRIPTION
The version, set on `develop` before the release pull request, because `v0.9.5` is already
tagged — a merge to `main` carrying a tagged version takes the *propose* path and leaves `develop`
a version commit behind. Untagged publishes as declared and both branches end up on the same tree.

## What ships

- **[#160](https://github.com/lanes-sh/link/pull/160) — a connection names its own account.**
  Identity resolves from the manifest, the connector, then the authorization server (RFC 7662
  introspection, then OIDC userinfo), and the operator is asked last. Notion gets an identity
  block; `tool` identity gains a `qualifier` so one person in two workspaces is two connections
  rather than one silently overwriting the other's credential; `http` identity gains `headers`;
  an empty answer re-asks rather than storing `Notion pending` as the account, the label and the
  audit argument. `identity-coverage.test.ts` makes the remaining gap a ledger the build checks.

  Two bugs found by connecting a *second* time, which nothing had done routinely before:
  the callback listener bound a fresh port each run while the kept client registration declared a
  fixed one, so every reconnect presented a redirect URI its own client had never declared — masked
  only by Notion, which matches loopback redirects without the port; and Figma's manifest promised
  a dynamic registration Figma does not offer outside its catalogue.

- **[#161](https://github.com/lanes-sh/link/pull/161) — a contributor's own handle is a real
  identifier.** `architecture.test.ts` now fails on one, derived from `git config` at run time, so
  the check works for whoever is committing rather than for one name written into the tree.

- **[#163](https://github.com/lanes-sh/link/pull/163)** — one footer line on every surface.
- **[#164](https://github.com/lanes-sh/link/pull/164)**, [#157](https://github.com/lanes-sh/link/pull/157) — the admission register, and the worktree rule.

## Verification

`bun test` — 3174 pass, 12 skip; the 2 failures are the pre-existing `token` output timeouts on
`develop`, both 5s test-timeouts. `bun run typecheck` clean. Each pull request above merged with
`ci` green.