### PR TITLE
0.9.6

### DIFF
--- a/.claude/skills/lanes-writing/SKILL.md
+++ b/.claude/skills/lanes-writing/SKILL.md
@@ -1,0 +1,158 @@
+---
+name: lanes-writing
+description: Use when writing or editing any Lanes documentation, README, marketing copy, doc page, use case, comparison, or release post. Sets the register per page type, the test a sentence has to pass to stay, and the standing house rules.
+---
+
+# Writing for Lanes
+
+Canonical copy lives in `lanes-sh/web` at `.claude/skills/lanes-writing/SKILL.md`.
+The copies in `lanes-sh/link` and `lanes-sh/core` follow it; edit the canonical one.
+
+## The reader
+
+One person, in a hurry, who wants the thing running. They did not come to admire the
+architecture. Every sentence between them and a working setup is a cost, and the only
+justification for that cost is that the sentence saves them more than it spends.
+
+## Step 1: pick the register
+
+Three registers. Which one a page gets depends on what success means for its reader.
+
+| Register | Reader's success | Shape |
+|---|---|---|
+| **Quickstart** | "It is running." | Prerequisite line, numbered commands, one line of result, one link out. Reasoning goes in a `Notes` block at the foot |
+| **Layered** | "I understand this well enough to decide." | What it is, what you do about it, then why it works this way. In that order, never interleaved |
+| **Site voice** | "I know whether this is for me." | A claim, then the proof. Benefit-first subheads, second person, short paragraphs |
+
+Look the page up rather than deciding by feel:
+
+| Page type | Register |
+|---|---|
+| Quickstart, install, connect, deploy, "add it to your agent" | Quickstart |
+| Per-feature how-to (worktrees, loops, gateway, sessions, issue board) | Quickstart, plus one sentence on a step with a real gotcha |
+| Concept and explainer (architecture, security, scopes, identity, capabilities) | Layered |
+| Reference (commands, settings, shortcuts, providers, errors, API) | Tables only. One row per thing, no prose between rows |
+| README, first screen | Site voice |
+| README, everything below install | Quickstart |
+| Index and overview (`/docs`, `/docs/mcp`, `src/content/pages/*.md`) | Site voice |
+| Use case, comparison | Site voice |
+| Blog | Leave the voice alone. Correct facts only |
+| Terms, privacy, GDPR, cookies | Plain legal English. Accuracy beats brevity. No register change |
+
+## Step 2: apply the sentence test
+
+Read every sentence and ask what it does for the reader. It stays only if it does one of:
+
+1. Tells them what to type or click.
+2. Changes what they would type or click: a prerequisite, a default, a gotcha.
+3. Tells them whether the page is for them.
+4. Prevents a specific mistake that costs real time.
+
+Everything else moves to `Notes`, moves behind a link, or goes. **The default answer is: it
+goes.** A sentence that is true, well written and interesting still goes if it does none of
+the four.
+
+The legal documents get a fifth reason: it is a commitment or a disclosure the document has
+to make. Nothing else does.
+
+### What the test catches
+
+| Cut | Why |
+|---|---|
+| The history of a rename | Nobody typing the new name needs the old one |
+| A flag that is already the default | `--workspace local` when local is the default |
+| An edge case affecting few readers | Move it to `Notes`; do not put it mid-procedure |
+| Restating what the UI labels | If the dialog says "Working directory", the doc does not list the fields |
+| A second link to the same place | One "next" per page |
+| The mechanism behind a result | "Your agents can reach it" beats "the endpoint reconciles its manifest" |
+
+## Step 3: the standing rules
+
+- **No em dashes.** Anywhere. Use a comma, a full stop, a colon, or a hyphen.
+- **Sentence case headings.** "Connect an account", not "Connect An Account".
+- **Second person.** "You", never "the user".
+- **Imperative headings on procedures.** "Install it", not "Installation".
+- **One idea per sentence.** A semicolon joining two clauses is two sentences, or it is one.
+- **Drop default flags from examples.** Show the shortest command that works.
+- **One "next" per page.** A menu of five is a page that has not decided.
+- **Counts that rot become ranges.** "Over a hundred providers", never "105", and never a list
+  of five in a document that has to stay true.
+- **Name the result, not the mechanism.**
+- **Numbered sections are numbered once.** Check the sequence before you commit.
+- **Every claim is checkable.** If you cannot point at the code, the doc does not say it.
+
+## The `Notes` block
+
+The escape hatch that makes cutting safe. Reasoning, edge cases and history that would
+otherwise interrupt a procedure go under a `## Notes` heading at the foot of the page, one
+bolded lead-in per note:
+
+```markdown
+## Notes
+
+**Why the sign-in.** A profile declares who may use it, and the endpoint cannot check that
+against anything if it does not know who is asking. The network is needed to sign in and to
+refresh, not per call.
+
+**If `lanes` is not on your PATH.** Several commands read your token with
+`$(lanes link token show --raw)`, which substitutes to an empty string. The symptom is a 401
+that looks like a bad token.
+```
+
+Nothing is lost. It is just no longer standing between the reader and step 4.
+
+## Worked example
+
+The Lanes Link README quickstart. Before, 230 words plus two "Why" paragraphs, every command
+carrying a flag that is already the default:
+
+```markdown
+## Quickstart
+
+Needs [Bun](https://bun.com) 1.3.11+, and a Lanes sign-in.
+
+$ bun install -g @lanes-sh/link                # puts `lanes` on your PATH
+$ lanes auth login                             # opens a browser once
+$ lanes link profile add personal --workspace local
+$ lanes link profile members add --me --profile personal --workspace local
+$ lanes link start --workspace local
+
+**Why the sign-in.** A profile declares who may consume it, and there is nothing to check
+that against if the endpoint has no idea who is asking. That is a real dependency for a
+self-hostable tool and worth stating plainly; what it is not is a dependency per request...
+
+**Why `mcp add` names no profile.** One endpoint serves every profile in the workspace...
+```
+
+After, 62 words, with both "Why" paragraphs moved to `Notes`:
+
+```markdown
+## Quickstart
+
+Needs Bun 1.3.11+.
+
+$ bun install -g @lanes-sh/link
+$ lanes auth login
+$ lanes link profile add personal
+$ lanes link profile members add --me --profile personal
+$ lanes link start
+ok  serving http://127.0.0.1:7337/mcp
+
+In a second shell, point every installed agent at it:
+
+$ lanes link mcp add
+
+Your memory, tasks, files and skills work now. Mail and calendar are next:
+`lanes link connect gmail`.
+
+**[Full quickstart](https://lanes.sh/docs/link/quickstart)**
+```
+
+## Before you call it done
+
+- Every heading is sentence case, and numbered sequences are numbered once.
+- No em dashes.
+- Every command is the shortest form that works.
+- Every sentence passes the test in step 2.
+- One "next" at the foot.
+- Every internal link resolves to a page that exists.

--- a/.claude/skills/lanes-writing/SKILL.md
+++ b/.claude/skills/lanes-writing/SKILL.md
@@ -39,7 +39,33 @@ Look the page up rather than deciding by feel:
 | Blog | Leave the voice alone. Correct facts only |
 | Terms, privacy, GDPR, cookies | Plain legal English. Accuracy beats brevity. No register change |
 
-## Step 2: apply the sentence test
+## Step 2: make every heading name an outcome
+
+**A heading says what the reader achieves, or what the section explains.** Not the noun the
+feature is filed under. This is the single most common way a page reads as robotic: the writer
+labels the machinery, and the reader has to read the section to find out whether it was for them.
+
+| Instead of | Write |
+|---|---|
+| Permissions | Decide what an agent may do |
+| Selection | Choose which profile a command acts on |
+| Inspection | See what is connected, and what your agents did |
+| Gate order | Catch a problem in the cheapest place |
+| Governance | Why you cannot remove the last admin |
+| The envelope | What an error looks like |
+| Tips | Settings worth changing first |
+
+**"Tips" is never a heading.** It is a bin for whatever had no home, and a reader cannot tell
+whether it is worth reading. Name what the advice is about, or move each item to the section it
+belongs to.
+
+The same applies to the page. A reader landing on it should know, from the title and the first
+sentence, what they will be able to do when they leave.
+
+**A section never opens straight into a code block.** One sentence first, saying what the code
+achieves. The reader decides whether to run it from that sentence, not by parsing the snippet.
+
+## Step 3: apply the sentence test
 
 Read every sentence and ask what it does for the reader. It stays only if it does one of:
 
@@ -66,7 +92,7 @@ to make. Nothing else does.
 | A second link to the same place | One "next" per page |
 | The mechanism behind a result | "Your agents can reach it" beats "the endpoint reconciles its manifest" |
 
-## Step 3: the standing rules
+## Step 4: the standing rules
 
 - **No em dashes.** Anywhere. Use a comma, a full stop, a colon, or a hyphen.
 - **Sentence case headings.** "Connect an account", not "Connect An Account".
@@ -150,6 +176,8 @@ Your memory, tasks, files and skills work now. Mail and calendar are next:
 
 ## Before you call it done
 
+- Every heading names an outcome, not the machinery. No section called "Tips".
+- No section opens straight into a code block.
 - Every heading is sentence case, and numbered sequences are numbered once.
 - No em dashes.
 - Every command is the shortest form that works.

--- a/.gitignore
+++ b/.gitignore
@@ -80,3 +80,6 @@ coverage/
 .vscode/
 !.vscode/extensions.json
 .worktrees/
+
+# Handles a contributor must never commit — see the identifier check in src/architecture.test.ts
+.private-identifiers

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,6 +24,10 @@ Work lands by pull request into `develop`, squashed — `gh pr merge <n> --squas
 Both `develop` and `main` require a passing `ci` and an approval, so a solo merge adds `--admin`.
 The one pull request that is not squashed is the release; see below.
 
+**No Claude session links in pull requests.** Do not append a `https://claude.ai/code/session_…`
+URL, or a "Generated with Claude Code" footer, to a pull request body. This repository is public
+and the link is noise to everyone reading it. The `Co-Authored-By` trailer on commits is fine.
+
 ## Never run `lanes link` from a worktree without `LANES_LINK_HOME`
 
 `resolveWorkspaceRoot` (`src/profile/workspace.ts`) checks `LANES_LINK_HOME`, then

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -89,7 +89,7 @@ paths `release.yml` takes, and the verification that a release shipped. What an 
 - **Never tag or `npm publish` by hand.** The workflow owns both, in that order, for a reason a
   manual run reverses.
 
-## Never write a real address, project, or bucket into this repository
+## Never write a real address, name, project, or bucket into this repository
 
 This repository is public. The shortest path to a passing test or a convincing doc example is
 to paste the account you are actually working with, and that account is the operator's — a
@@ -106,8 +106,24 @@ example, use a name that reads as a placeholder: `my-project`, `your-bucket`, `<
 Prose about a domain is fine (`a personal @gmail.com cannot enrol`) — it is an address *at* one
 that is not.
 
-`src/architecture.test.ts` fails the build on both. It reads every `.ts`, `.md`, `.json`, and
+**A person's name or handle is the same rule, and it is the one that gets missed.** Not just
+an address — a bare handle, a username, a slug derived from either. It reaches the repository
+through *prose about what actually happened*: a comment narrating a real rehearsal, an ADR
+recounting a real incident, a test fixture copied from a real workspace. A credential ref built
+from the operator's own mailbox sat in two comments here for months precisely because it was not
+an address, so nothing flagged it and nobody reading the sentence was looking for it.
+
+Write the rehearsal, not the person. `ada.lovelace@example.com` and `ada_lovelace` are the
+house example; use them. If a sentence only makes sense with the real handle in it, the sentence
+is wrong, not the rule.
+
+`src/architecture.test.ts` fails the build on all of it. It reads every `.ts`, `.md`, `.json`, and
 `.yaml` file in the repository, so there is nowhere to put one where the check does not look.
+Handles are checked against the committer's git identity — including the `<id>+<handle>@…`
+form a forge commits under — and against `.private-identifiers`, a gitignored file of one token
+per line. Keep your own handles there: git only knows the address you commit under, and the one
+that leaked here came from a personal mailbox git had never seen. A denylist inside the repository
+cannot work, because writing the name into it is the thing being prevented.
 
 ## Where things are
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,8 +6,14 @@ it. This file covers only what an agent gets wrong that a human reading that fil
 
 ## Work on a branch, in a worktree
 
-Implementation goes on a new branch in its own worktree. Never on `main` — it is the checkout
-the operator has open, and unreviewed work landing there mixes into the files they are reading.
+Implementation goes on a new branch in its own worktree. Never on `develop` or `main`: those
+are the checkouts the operator has open, and unreviewed work landing there mixes into the files
+they are reading.
+
+Never check `develop` or `main` out *in* a worktree either. Git allows a branch in one place at
+a time, so a worktree holding `develop` locks the primary checkout out of its own integration
+branch, and the operator cannot pull, rebase or start the next branch without first working out
+which worktree took it. A worktree holds a feature branch and nothing else.
 
 ```console
 $ git worktree add .worktrees/<name> -b <name>
@@ -19,6 +25,14 @@ $ bun test          # establish the baseline before changing anything
 `.worktrees/` is already in `.gitignore`. The `bun install` is not optional: a fresh worktree
 has no `node_modules`. Getting a green baseline first is what makes a later failure
 attributable.
+
+A worktree is deleted when its pull request merges, not left for later. Eleven of them across
+four repositories, all merged, cost 11.5 GB and made the branch list unreadable.
+
+```console
+$ git worktree remove .worktrees/<name>
+$ git branch -d <name>
+```
 
 Work lands by pull request into `develop`, squashed — `gh pr merge <n> --squash --delete-branch`.
 Both `develop` and `main` require a passing `ci` and an approval, so a solo merge adds `--admin`.

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ ok    registered lanes-link with Claude Code (user scope)
 ok    registered lanes-link with Codex
 ```
 
-Your memory, tasks, files and skills work now, with nothing to authorise. Mail and calendar are
+Your memory, tasks, files, skills, entities and vault work now, with nothing to authorise. Mail and calendar are
 the next step: `lanes link connect gmail`.
 
 **[Full quickstart](https://lanes.sh/docs/link/quickstart)**
@@ -76,7 +76,8 @@ comes.
 | **Tasks** | what you have to do, each with a status | `lanes link tasks` |
 | **Assets** | files you want kept, by name | `lanes link assets` |
 | **Skills** | your own procedures, handed to an agent as instructions | `lanes link skills` |
-| **Identity** | who you are, and the people and companies that recur in your work | `lanes link identity` |
+| **Identity** | who you are, so an agent signs off as you | `lanes link identity` |
+| **Entities** | the people and companies you deal with, so an agent looks an address up rather than recalling one | `lanes link entities` |
 | **Vault** | passwords and API keys, released only where you allow it | `lanes link vault` |
 
 Everything except connections arrives switched on, because it holds your own material rather

--- a/README.md
+++ b/README.md
@@ -6,92 +6,72 @@
 
 **One endpoint you own, holding everything your agents need to know you: connections, memory, tasks, files, contacts, and secrets.**
 
-You own it and you run it. Connect your mail, calendar, files, and notes once, and add the memory,
-tasks, and procedures that only you have. Every agent you use — Claude, ChatGPT, and anything else
-that speaks MCP — reaches all of it through that one endpoint. Change your AI and you keep your
-context, because none of it ever lived in the agent. Open source, self-hostable, no vendor in the
-middle of your data.
+Connect your mail, calendar, files and notes once. Every agent you use, Claude, ChatGPT, and
+anything else that speaks MCP, reaches all of it through that one endpoint. Change your AI and
+you keep your context, because none of it ever lived in the agent.
 
 ![Left: every agent wired directly to every account, each line crossing the others. Right: the same three agents reaching one Lanes Link endpoint, which fans out to Gmail, GitHub, Slack, memory, skills, and a task list through an Access Profile named engineering.](docs/images/lanes-link-hero.png)
+
+## Quickstart
+
+Needs [Bun](https://bun.com) 1.3.11+ and a Lanes sign-in.
+
+```console
+$ bun install -g @lanes-sh/link
+$ lanes auth login
+$ lanes link profile add personal
+$ lanes link profile members add --me --profile personal
+$ lanes link start
+ok    serving http://127.0.0.1:7337/mcp
+      profiles: personal
+```
+
+Leave that running. In a second shell, point every agent you have installed at it:
+
+```console
+$ lanes link mcp add
+ok    registered lanes-link with Claude Code (user scope)
+ok    registered lanes-link with Codex
+```
+
+Your memory, tasks, files and skills work now, with nothing to authorise. Mail and calendar are
+the next step: `lanes link connect gmail`.
+
+**[Full quickstart](https://lanes.sh/docs/link/quickstart)**
 
 ## Why
 
 - **Connect once, use everywhere.** No per-agent integrations, no re-authorising every new tool.
 - **You decide what agents can touch.** Permissions default to deny, and the runtime enforces
-  them — it does not ask the model to behave.
+  them rather than asking the model to behave.
 - **Work and personal never mix.** Separate profiles, separate credentials, separate stores.
 - **Every call is recorded.** An append-only log of what was reached, and what was refused.
-- **It is yours to move.** What you store is plain files on your own disk — readable in an editor,
-  backed up like anything else, and portable to a private Git repository or to another machine
-  whenever you want. There is no export to ask for.
+- **It is yours to move.** Plain files on your own disk, readable in an editor and portable to
+  another machine. There is no export to ask for.
 
 ## What people use it for
 
 - **A personal assistant on your phone.** A deployment is a URL, so the claude.ai or ChatGPT app
-  reaches your mail, calendar, and files from anywhere — "what's on tomorrow", "reply to Ana's
-  thread", "find the invoice from March". This is the case that needs [your own
-  cloud](#run-it-anywhere); everything below works on your machine.
-- **Inbox triage you sign off on.** An agent searches, reads, labels, and composes — and saves a
-  draft for you to send rather than sending it, until you decide otherwise.
+  reaches your mail, calendar and files from anywhere. This is the one case that needs [your own
+  cloud](#run-it-anywhere); everything else here works on your machine.
+- **Inbox triage you sign off on.** An agent searches, reads, labels and composes, and saves a
+  draft for you to send rather than sending it.
 - **Coding agents that start from your context.** Claude Code and Codex reach the same Linear
-  issues, Notion pages, and notes you do, so a session begins from what you already know instead
-  of an empty prompt.
-- **One set of notes behind every agent.** What you have Claude Code write down, claude.ai reads
-  back later — your accumulated context follows you between tools instead of being trapped in
-  whichever one recorded it.
+  issues and Notion pages you do, so a session begins from what you already know.
+- **One set of notes behind every agent.** What Claude Code writes down, claude.ai reads back.
 - **A to-do list your agents share.** "Remind me to chase the invoice" lands somewhere with a
-  status, so whichever agent you are talking to next knows it is still open — and knows when it
-  is done.
+  status, so whichever agent you talk to next knows it is still open.
 - **Your own procedures, followed rather than guessed.** How a standup update reads, where an
-  invoice gets filed, who gets cc'd on a contract — written down once, and every agent you use
-  follows the same one.
-
-## Quickstart
-
-Needs [Bun](https://bun.com) 1.3.11+, and a Lanes sign-in.
-
-```console
-$ bun install -g @lanes-sh/link                # puts `lanes` on your PATH
-$ lanes auth login                             # opens a browser once
-$ lanes link profile add personal --workspace local
-$ lanes link profile members add --me --profile personal --workspace local
-$ lanes link start --workspace local
-ok    serving http://127.0.0.1:7337/mcp
-      profiles: personal
-```
-
-Then, in another shell:
-
-```console
-$ lanes link mcp add --workspace local     # every agent installed; or name one: claude, codex
-ok    registered lanes-link with Claude Code (user scope)
-ok    registered lanes-link with Codex
-```
-
-Your agents can now use it. Memory, tasks, files, skills, and the vault hold your own material
-rather than an account, so they are already there — nothing to connect, no credentials, no browser.
-Mail and calendar are the next step. **[Full quickstart →](https://lanes.sh/docs/link/quickstart)**
-
-**Why the sign-in.** A profile declares who may consume it, and there is nothing to check that
-against if the endpoint has no idea who is asking. That is a real dependency for a self-hostable
-tool and worth stating plainly; what it is not is a dependency per request. The network is needed
-to sign in and to refresh, and a machine offline for a day keeps serving.
-
-**Why `mcp add` names no profile.** One endpoint serves every profile in the workspace, and each
-call names one in its `profile` argument — so registering is about the endpoint, not a profile.
-Which profiles a client actually reaches is decided when its owner signs in: every profile whose
-`members:` lists them, and no others. A credential is an identity here, not a selection. For a
-runner with no browser, `lanes link token issue --me` mints a static token that reaches exactly
-what its subject is a member of.
+  invoice gets filed, who gets cc'd. Written once, and every agent follows the same one.
 
 ## What you keep in it
 
-Not "what your agent gets" — the distinction is the whole point. These are yours. An agent is a
-visitor to them, and you decide per profile how far in it comes.
+Not "what your agent gets". These are yours, and you decide per profile how far in a visitor
+comes.
 
 | | | Manage it with |
 |---|---|---|
-| **Connections** | your external accounts — mail, calendar, files, issues | `lanes link connect` |
+| **Connections** | your external accounts: mail, calendar, files, issues | `lanes link connect` |
 | **Memory** | what you want remembered between sessions | `lanes link memory` |
 | **Tasks** | what you have to do, each with a status | `lanes link tasks` |
 | **Assets** | files you want kept, by name | `lanes link assets` |
@@ -99,35 +79,29 @@ visitor to them, and you decide per profile how far in it comes.
 | **Identity** | who you are, and the people and companies that recur in your work | `lanes link identity` |
 | **Vault** | passwords and API keys, released only where you allow it | `lanes link vault` |
 
-Every one of these except connections arrives switched on: they hold your own material rather than
-an account, so there was never anything to authorise. Memory, tasks, and skills are plain Markdown
-files and an asset is stored under its own filename, so a text editor and an agent reach the same
-bytes. Every one of them belongs to a single profile: what you add under `work` is invisible under
-`personal`.
+Everything except connections arrives switched on, because it holds your own material rather
+than an account. Memory, tasks and skills are plain Markdown, and an asset keeps its own
+filename, so a text editor and an agent reach the same bytes. Each belongs to one profile: what
+you add under `work` is invisible under `personal`.
 
-Identity is the one that is read-only by construction. An agent able to rewrite whose name it signs
-with would be rewriting the one fact that stops it signing as the wrong person, so you declare it in
-a terminal and the endpoint only reads it back.
+**Memory is what is true, tasks is what is to be done, assets is a file.** "Remember to chase
+the invoice" is a task. Filed as memory it becomes a note nothing can ever close. Your agents
+are told this too.
 
-Which store a thing goes in is the one thing worth knowing. **Memory is what is true, tasks is what
-is to be done, assets is a file.** "Remember to chase the invoice" is a task — filed as memory it
-becomes a note nothing can ever close. Your agents are told this too.
-
-Keep those two in a private GitHub repository instead of on this machine, and get history, diffs,
-and the same notes from anywhere you run this:
+Keep memory and skills in a private GitHub repository instead, and get history, diffs, and the
+same notes from anywhere you run this:
 
 ```console
 $ lanes link knowledge use github --repo <owner/name> --migrate
 ```
 
-It moves what you have already stored, in one commit, and `lanes link knowledge use local
---migrate` brings it back. Nothing else moves — your credentials and your vault stay where they
-are, and there is no setting that would put them in a repository.
+Credentials and the vault stay where they are. There is no setting that would put them in a
+repository.
 
 ## Connect an account
 
-**Over a hundred accounts and services, one command each.** Run it again to add a second mailbox, a
-second calendar, a second anything.
+**Over a hundred accounts and services, one command each.** Run it again to add a second
+mailbox, a second calendar, a second anything.
 
 | | |
 |---|---|
@@ -138,76 +112,76 @@ second calendar, a second anything.
 | **Content and data** | Contentful · Storyblok · Hygraph · Sanity · Webflow · Wix · Algolia · PostHog · Mixpanel · Amplitude · RudderStack |
 | **Everything else** | Reddit · Discord · Dropbox · Box · Airtable · Zapier · Attio · Klaviyo · Salesloft · Vimeo · Mux · Replicate · Apify · Tavily · Bright Data |
 
-**[The full list, with the command for each →](https://lanes.sh/docs/link/connect)**
+Most need nothing set up: `connect` opens a browser, you approve, and it is live. The rest ask
+for an app password, a token you paste, or an OAuth client of your own, and the guide says which
+is which.
 
-Most of them need nothing set up. Seventy of them run their own MCP server and offer dynamic client
-registration, so `connect` registers us on the spot: browser, approve, done. The rest are one of
-three shapes — an app password you issue yourself (iCloud, Fastmail, Gmail over IMAP), a token you
-paste (GitHub, Discord), or an OAuth client of your own (Reddit, Microsoft). A few also ask *where*
-they are, because the address belongs to the account rather than the vendor — a Nextcloud you run,
-or any IMAP server.
+**[Connect your accounts](https://lanes.sh/docs/link/connect)** covers every provider, what each
+one gives your agent, and how to add one that is not on the list.
 
-**Most of them are also untested**, and the tables say which. A provider marked † validates, generates
-tools inside the budget, and answers a probe — but nobody has connected it to a real account yet, and
-that is the part only a real account proves. See
-[`src/providers/README.md`](src/providers/README.md) for what that means and how the list is kept.
-
-Three things worth knowing up front. `lanes link connect icloud` sets up Mail, Calendar, and
-Contacts together, because one app-specific password covers all three — and `lanes link connect
-fastmail` does the same for Fastmail's three. Reddit is the one that does
-need an app of your own — it rate-limits per client id, so a shared client would mean strangers
-spending your budget. Google and Slack need no
-OAuth client of your own: both authorise against the one Lanes operates, so there is no console to
-visit — for Google, add `--own-client` if you would rather register your own, or take a service
-account key or an app password over IMAP where you would rather nothing expired. And GitHub takes a
-token you paste rather than a browser sign-in, because it will not register a client for us. And
-bunq — which wants a key from inside its app rather than a console at all — is the one that can move
-money, and it says so: its payment tool executes immediately and is not reversible. Set a spending
-limit on the API key while you are in there, and read
-[Connecting bunq](https://lanes.sh/docs/link/bunq) before connecting it.
-
-Full guide — what each one gives your agent, what it needs, and adding your own:
-**[Connect your accounts](https://lanes.sh/docs/link/connect)**. How the provider layer works, and
-the whole inventory by connector and credential type:
-**[src/providers/README.md](src/providers/README.md)**.
+Two worth knowing before you connect them. **bunq** can move money: its payment tool executes
+immediately and is not reversible, so set a spending limit on the API key and read [Connecting
+bunq](https://lanes.sh/docs/link/bunq) first. **Most providers are untested** against a real
+account, and the tables mark which with a †. See [`src/providers/README.md`](src/providers/README.md)
+for what that means.
 
 ## Run it anywhere
 
-The same code, the same config, in all three. Only the storage adapters change.
+The same code and the same config in all three. Only the storage adapters change.
 
 | | **Local** | **Self-Hosted** | **Lanes Cloud** |
 |---|---|---|---|
 | Runs on | your machine | your GCP project, on Cloud Run | managed for you |
-| Needs | Bun, nothing else | a Google Cloud billing account | — |
+| Needs | Bun, nothing else | a Google Cloud billing account | nothing |
 | Set up with | `lanes link start` | `lanes link deploy` | [join the waitlist](https://lanes.sh/forms/f/a46d8b45-4759-485b-841c-d117a823b645) |
 | Reachable from | that machine | anywhere, including your phone | anywhere |
 | Status | ready | ready | **coming soon** |
 
-**Local** is the fastest way to start, and where most people stay. **Self-Hosted** is what you
-want if you need to reach it from claude.ai, ChatGPT, or a phone — `lanes link deploy` creates the
-project, the bucket, the service account, and the revision on its first run. **Lanes Cloud** is the
-managed version; because it is the same data model, a workspace you build today moves across rather
-than being rebuilt.
-[Join the waitlist](https://lanes.sh/forms/f/a46d8b45-4759-485b-841c-d117a823b645) to hear when it opens.
+Start local; most people stay there. Go self-hosted when you need to reach it from claude.ai,
+ChatGPT or a phone: `lanes link deploy` creates the project, the bucket, the service account and
+the revision on its first run.
 
 ## Docs
 
-- **[Quickstart](https://lanes.sh/docs/link/quickstart)** — from nothing to a working endpoint
-- **[In the Lanes desktop app](https://lanes.sh/docs/desktop/lanes-link)** — the page that drives it
-- **[Connect your accounts](https://lanes.sh/docs/link/connect)** — every provider, and what each one needs
-- **[Add it to your agent](https://lanes.sh/docs/link/clients)** — Claude Code, Codex, Claude Desktop, claude.ai, ChatGPT
-- **[Deploy to your own cloud](https://lanes.sh/docs/link/deploy)** — five commands to a URL
-- **[Every command](https://lanes.sh/docs/link/commands)** — arguments and flags, one entry each
-- **[Full reference](https://lanes.sh/docs/link)** — architecture, configuration, the CLI, the
-  security model, and writing a provider
-- **[Decision records](docs/detailed/adr/)** — why each choice was made, kept here with the source
+| | |
+|---|---|
+| **[Quickstart](https://lanes.sh/docs/link/quickstart)** | From nothing to a working endpoint |
+| **[Connect your accounts](https://lanes.sh/docs/link/connect)** | Every provider, and what each needs |
+| **[Add it to your agent](https://lanes.sh/docs/link/clients)** | Claude Code, Codex, Claude Desktop, claude.ai, ChatGPT |
+| **[Deploy to your own cloud](https://lanes.sh/docs/link/deploy)** | Five commands to a URL |
+| **[Every command](https://lanes.sh/docs/link/commands)** | Arguments and flags, one entry each |
+| **[In the Lanes desktop app](https://lanes.sh/docs/desktop/lanes-link)** | The page that drives it |
+| **[Full reference](https://lanes.sh/docs/link)** | Architecture, configuration, security, writing a provider |
 
 ## Security
 
-Lanes Link holds live credentials to your email and documents. The
-[security model](https://lanes.sh/docs/link/security) states its limits plainly rather than implying
-guarantees the code does not deliver — read it before you trust it with an account. To report a
-vulnerability, see [`SECURITY.md`](SECURITY.md); please do not open a public issue.
+Lanes Link holds live credentials to your email and documents. The [security
+model](https://lanes.sh/docs/link/security) states its limits plainly rather than implying
+guarantees the code does not deliver. Read it before you trust it with an account.
+
+To report a vulnerability, see [`SECURITY.md`](SECURITY.md). Please do not open a public issue.
+
+## Notes
+
+**Why the sign-in.** A profile declares who may use it, and the endpoint cannot check that
+against anything if it does not know who is asking. The network is needed to sign in and to
+refresh, not per call, so a machine offline for a day keeps serving.
+
+**Why members is not optional.** An empty members list means nobody, not everybody. The profile
+you just created reaches no caller until you are on it.
+
+**Why `mcp add` names no profile.** One endpoint serves every profile in the workspace, and each
+call names one in its `profile` argument, so registering is about the endpoint. Which profiles a
+client actually reaches is decided when its owner signs in: every profile whose `members:` lists
+them, and no others. For a runner with no browser, `lanes link token issue --me` mints a static
+token that reaches exactly what its subject is a member of.
+
+**Why no `--workspace` flag.** `local` is the default in a fresh config. Commands that publish or
+destroy (`deploy`, `sync`, `secrets push`, `profile remove`, `disconnect`, `token rotate`) refuse
+the default and make you type the name.
+
+**Where the decision records live.** [`docs/detailed/adr/`](docs/detailed/adr/), kept with the
+source as engineering history rather than documentation.
 
 ## License
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -19,8 +19,10 @@ Every page is also served as plain Markdown: add `.md` to the path, for example
 |---|---|
 | [`detailed/adr/`](detailed/adr/) | The architecture decision records: why each choice was made, and what it cost |
 | [`detailed/init.md`](detailed/init.md) | The original specification, amended to match what was built |
+| [`detailed/admission.md`](detailed/admission.md) | Where a vendor admits the client rather than the operator: programmes, catalogues, and waitlists |
 
-Those are engineering history rather than documentation, so they stay with the source.
+Those are engineering history and standing constraints rather than documentation, so they stay
+with the source.
 
 ## Editing the docs
 

--- a/docs/detailed/admission.md
+++ b/docs/detailed/admission.md
@@ -1,0 +1,83 @@
+# Admission: the gates that are ours to clear, not the operator's
+
+Most of what stands between an operator and a working connection is theirs to clear, and the
+manifest already says how: Box wants an OAuth app, GitHub wants a token, Apple wants an
+app-specific password. Those are steps, and a `setup` block is a walkthrough of them.
+
+This page is the other kind. Some vendors admit **clients**, not users — they run a programme, a
+catalogue, a preview, or a review, and until Lanes is through it there is nothing an operator can
+type that changes the answer. The distinction matters because the two failures look identical from
+a terminal, and only one of them is worth an operator's afternoon.
+
+Kept here rather than on the docs site because it is a register of where we stand with other
+companies, it goes stale in ways a release does not fix, and its audience is whoever is deciding
+what to work on next.
+
+## The register
+
+| Providers | The gate | Where we stand | What clears it |
+|---|---|---|---|
+| Google REST — `gmail`, `drive`, `sheets`, `docs`, `calendar`, `contacts`, `google_tasks` | Sensitive and restricted scopes on an unverified project. **100 accounts for the lifetime of the project**, not resettable, plus an unverified-app interstitial on every consent screen. | Published "In production" and unverified. The broker's `/config` reports consumption so the CLI can warn before the ceiling, and a `status` it controls can close the tap. | Google verification: annual, project-wide, and for restricted scopes a third-party security assessment measured in months. See [ADR-028](adr/028-a-hosted-oauth-client-is-the-default.md) and [ADR-031](adr/031-sign-in-and-data-access-are-separate-projects.md). |
+| `gmail_mcp` | Google Workspace **Developer Preview** enrolment. | Not enrolled. Demonstrated not to be a scope problem: with all five advertised scopes granted, `tools/list` succeeds and every `tools/call` answers "The caller does not have permission". | Enrolment. Recorded in [`src/providers/google/gmail-mcp/index.ts`](../../src/providers/google/gmail-mcp/index.ts). |
+| `figma` | The **Figma MCP Catalogue**. Only catalogued MCP clients may connect; a client joins by waitlist, not by registering. | Not listed. `connect` fails at registration and cannot get further. | A place in the catalogue. Recorded in [`src/providers/figma/index.ts`](../../src/providers/figma/index.ts). |
+
+**The "where we stand" column is the operator's to keep current.** Nothing in the build checks it,
+because nothing in this repository can see a waitlist.
+
+**`slack` is in the same structural position and is not on the list.** It authorises against a
+client Lanes operates rather than one the operator registered, so a distribution limit there would
+land on this page — but none has been hit, and a row asserting one would be a guess. The eight
+brokered providers are `slack` and the seven Google REST ones above.
+
+## Google is the one with an exit
+
+It belongs on this page because the *default* path runs through a client Lanes operates and a cap
+Lanes owns — but an operator who does not want to wait has `lanes link connect <provider>
+--own-client`, which registers their own and leaves the programme entirely. That is the whole
+point of ADR-028 being a default rather than an architecture.
+
+Figma has no such exit. No Figma console issues an MCP client, so `--own-client` has nothing to
+point at, and this is why its manifest keeps `registration: 'dynamic'` rather than moving to
+`manual` — `manual` would promise a console route that does not exist.
+
+## Advertising a registration endpoint is not evidence of offering one
+
+All **70** of the hosted-MCP providers in this repository advertise a `registration_endpoint` in
+their authorization-server metadata. Figma advertises one too, and refuses every request to it:
+
+| request to `api.figma.com/v1/oauth/mcp/register` | |
+|---|---|
+| a well-formed registration body | `403` |
+| `{}` | `403` |
+| no body at all | `403` |
+| form-encoded | `403` |
+| carrying a bearer token | `403` |
+| carrying an `X-Figma-Token` | `403` |
+
+An empty body earning the same refusal as a valid one puts the gate ahead of body validation, so
+it reads nothing that could be changed. Metadata therefore tells us who *claims* to register
+clients and nothing about who does, which is why this register grows by discovery — somebody tries
+to connect and cannot — rather than by an audit anybody could run.
+
+Probing the other 69 would mean POSTing a registration to 69 companies nobody asked to register
+with, and leaving a client record behind at each one that answered. Not worth knowing that way.
+
+## What is not on this page
+
+A gate that scales with the operator's own app, rather than with ours. Discord's MESSAGE CONTENT
+intent is the example: under 10,000 servers it is a toggle, above it a review — but the app is the
+operator's, the token is theirs, and so is the review. It belongs in the provider's
+`troubleshooting`, where it already is.
+
+The test is who would fill in the form. If the answer is Lanes, it goes here.
+
+## When one is cleared
+
+Three places, and they can disagree:
+
+1. **The manifest.** Its comment and `setup` block are what an operator reads at the moment of
+   failure, and they are the reason the error does not read as their fault.
+2. **The identity ledger**, `src/providers/identity-coverage.test.ts`, if the provider was listed
+   there because it could not be reached rather than because its identity call is unknown. Figma
+   is such an entry.
+3. **This page.**

--- a/docs/detailed/adr/073-a-connection-names-its-own-account.md
+++ b/docs/detailed/adr/073-a-connection-names-its-own-account.md
@@ -1,0 +1,105 @@
+# ADR-073: A connection names its own account
+
+**Status:** accepted · **Follows from** [ADR-057](057-a-connection-belongs-to-the-workspace.md)
+
+## Context
+
+`settleIdentity` resolves whose account was just authorised, and it has always had a fallback:
+where the provider will not say, ask the operator. The doc comment on that branch calls it a last
+resort, and `identity.ts` opens by saying resolution is best-effort because "a label is worth
+having, never worth failing a connect over".
+
+It was not a last resort. Of 105 provider definitions, 30 declared an `identity` block and 75 did
+not, so for most of the catalogue the prompt was the *only* path. The shape of the complaint that
+started this is the whole argument:
+
+```console
+$ lanes link connect notion --profile personal
+ok  authorised
+Which account is this? (the address or handle):
+```
+
+A browser round trip had just established exactly who this was, and the next line asked. Worse,
+the typed answer is load-bearing three times over — it is the key a reconnect matches on, the
+source of the default label, and what `gmail.send_message` writes into a `From` header — so the
+one field that most needs to be stable was the one field a human retyped from memory each time.
+
+Notion is the instructive case because its omission was deliberate and documented: `get-users`
+led with integration bots rather than the person and `get-teams` returned teamspaces, so both
+"would produce a confident wrong label". That reasoning was right and has expired. Notion's
+hosted server renamed those tools and added `notion-fetch`, whose id `self` returns the connected
+workspace alongside the authenticated user's email — documented by Notion for this exact purpose,
+labelling a connection after OAuth.
+
+## Decision
+
+**Identity is resolved in four steps, and the operator is the fourth.**
+
+1. What the caller was given — `--display-name`.
+2. What the connector knows, for a protocol that authenticates by username: the name the *server
+   accepted*, which is a stronger claim than the one that was typed.
+3. What the manifest declares — an `identity` block, `http` or `tool`.
+4. What the authorization server will say — RFC 7662 introspection, or OIDC userinfo.
+
+Only then the question.
+
+**Asking the server is allowed; reading the token is not.** `oauth-exchange.ts` refuses to decode
+the stored `id_token` because "the claim inside is unverified, and a tamperable local store is not
+somewhere to read an identity from". Step 4 honours that rather than working around it: an
+introspection or userinfo response is the issuer answering for itself, over the network, now.
+
+**A probe may not guess.** Two rules follow from the mistake Notion's comment avoided, and both
+are cheap to break by accident:
+
+- A `field` names one value, never a collection. `pluck` walks into the first element of an array
+  on the way past, so a path through a list resolves to whoever happens to be first and reads
+  exactly like a working probe.
+- A returned identifier that is not human-readable is refused. A uuid, a long opaque token, or the
+  client id echoed back would become the account, the label, and the reconnect key, and would read
+  like it worked. Falling through to the question costs a question; a wrong label costs a row
+  nobody can correct without knowing it is wrong.
+
+**A vendor whose user is scoped to a tenant carries a `qualifier`.** One person's Notion email is
+the same email in every workspace they belong to, so without the workspace beside it a second
+connect matches the first row and overwrites its credential. `http` carried a qualifier for Slack;
+`tool` now carries one too, and `defaultConnectionLabel` keeps it rather than shortening it away.
+
+**The gap is a ledger, not a footnote.** `src/providers/identity-coverage.test.ts` fails the build
+when a provider neither declares an identity block, nor authenticates to nothing, nor is listed
+with a written reason — and fails equally when an entry outlives the gap it records. A provider is
+fifteen lines of data and adding one raises no question on its own, so the build raises it.
+
+## Consequences
+
+The generic step is small and measured rather than assumed: of the 80 MCP endpoints this
+repository names, five advertise introspection and three advertise userinfo. That is the reason
+the per-vendor sweep is the substance and step 4 is the cheap part — and the reason the ledger
+exists rather than a claim that the problem is solved.
+
+Seventy hosted-MCP providers are still unswept. Every one of those servers refuses an
+unauthenticated `tools/list`, so each identity call has to come from vendor documentation and
+cannot be confirmed without an account on that vendor. That is a real cost and the ledger states
+it per provider rather than hiding it in a total.
+
+**A block is not added on documentation alone, and Supabase is why.** Its authorization server
+*is* `api.supabase.com`, so the token an MCP connect issues is an ordinary Management API token
+and `GET /v1/profile` — which returns `primary_email` — read as a free answer. Against a real
+token it is `401`, "does not support oauth access yet": a refusal about the credential *kind*,
+which no scope changes. `/v1/user`, `/v1/me` and `/v1/oauth/userinfo` are all `404`, and what
+OAuth does reach — organizations, projects — is a collection, which the rule above already
+refuses.
+
+So a vendor sharing a host with its authorization server does not imply the token is accepted
+there, and an MCP credential is its own kind until the vendor says otherwise. The ledger entry
+that results is worth more than the block would have been: it names what was ruled out, so nobody
+researches that vendor twice.
+
+An unverified block is bounded in what it can do wrong — a wrong endpoint or a rejected token
+answers null and the operator is asked, which is what happened before it existed. The hazard is a
+right endpoint and a wrong field, which is what the two probe rules above are for.
+
+The empty answer changed with it. It used to be accepted and stored `${provider} ${provisionalId}`
+— the provider's name beside `pending`, an internal token meaning "no id yet". It now re-asks, and
+the way past is to type `blank`, which stores `unnamed` and takes a freshly allocated id rather
+than matching another `unnamed`: two rows nobody could name are not evidence of one account, and
+matching them would hand the second connect the first one's credential.

--- a/docs/detailed/adr/README.md
+++ b/docs/detailed/adr/README.md
@@ -85,6 +85,7 @@ Run.
 | [067](067-one-directory-per-profile.md) | One directory per profile, `data/` goes, and a connection id becomes opaque |
 | [068](068-a-credential-names-a-person.md) | A credential names a person, and the profiles follow from that; the endpoint token becomes the workspace's |
 | [069](069-a-pairing-token-may-write-the-owners-own-data.md) | A pairing token may write the owner's own data; the control plane is unmoved |
+| [073](073-a-connection-names-its-own-account.md) | A connection names its own account; the operator is asked last, and never handed a uuid to live with |
 
 Where an ADR departs from init.md, it says so at the top. Three are significant:
 
@@ -312,3 +313,9 @@ Where an ADR departs from init.md, it says so at the top. Three are significant:
   these five stores. What genuinely changes is that a credential which could read every memory
   entry can now delete them, including one minted before this release, which is why the cost is
   named in the CLI's own prompt rather than only here.
+
+- **ADR-073** makes the "which account is this?" prompt a last resort in fact rather than only in
+  its doc comment. Identity is resolved from the caller, the connector, the manifest, and then the
+  authorization server itself; a probe that cannot name a person human-readably falls through to
+  the question rather than labelling a row with a uuid. The remaining gap is a ledger the build
+  checks in both directions, not a total.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lanes-sh/link",
-  "version": "0.9.5",
+  "version": "0.9.6",
   "description": "A self-hostable MCP gateway for all your connections, memory, tasks, files, and secrets",
   "license": "Apache-2.0",
   "homepage": "https://lanes.sh/link",

--- a/src/architecture.test.ts
+++ b/src/architecture.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from 'bun:test';
+import { execFileSync } from 'node:child_process';
 import { readdir, readFile } from 'node:fs/promises';
 import { join, relative } from 'node:path';
 
@@ -486,6 +487,90 @@ describe('no real identifiers', () => {
           const domain = address.slice(address.indexOf('@') + 1);
           if (RESERVED_DOMAIN.test(domain) || MACHINE_DOMAIN.test(domain)) continue;
           violations.push(`${shown}:${index + 1} — ${address} is at a registrable domain`);
+        }
+      }
+    }
+
+    expect(violations).toEqual([]);
+  });
+
+  /**
+   * The one the address rule could not express: a contributor's own handle.
+   *
+   * A credential ref built from a real person's mailbox sat in two comments
+   * here for months. It is not an address, so the check above had nothing to
+   * say about it; it is not a bucket or a project, so neither did the one
+   * below. It was a real handle in a public repository, written while
+   * narrating a real rehearsal — which is exactly how the forty-five
+   * occurrences scrubbed before the first push got there. Prose about what
+   * actually happened is where this always comes from, and it is the one place
+   * nobody thinks to look. (Naming it here would repeat it, which is the joke
+   * this check played on its own first draft.)
+   *
+   * **A denylist in the repository cannot work**, because writing the name into
+   * a checked-in list is the thing being prevented. Two sources that are not:
+   *
+   * - **git.** `user.email` on a forge commit is
+   *   `<id>+<handle>@users.noreply.github.com`, so the handle *is* there and
+   *   discarding the address for being a noreply throws away the one name a
+   *   commit reliably carries. That was this check's first draft and it caught
+   *   nothing.
+   * - **`.private-identifiers`**, gitignored, one token per line. git only ever
+   *   knows the address someone commits under, and the handle that leaked here
+   *   came from a personal mailbox git has never seen. Nothing can infer that,
+   *   so there is a file to say it, and it stays out of the tree by definition.
+   *
+   * Tokens shorter than five characters are ignored, and a `user.name` with a
+   * space in it is skipped entirely: splitting a display name into words would
+   * fail the build for anyone called Mark the moment a comment mentioned a mark.
+   */
+  test('a contributor has not written their own handle into the tree', async () => {
+    const config = (key: string): string => {
+      try {
+        return execFileSync('git', ['config', '--get', key], { encoding: 'utf8' }).trim();
+      } catch {
+        return '';
+      }
+    };
+
+    // `<id>+<handle>@users.noreply.github.com` → `handle`, and a plain address
+    // → its local part. One expression covers both.
+    const local = (config('user.email').split('@')[0] ?? '').split('+').pop() ?? '';
+    const name = config('user.name');
+
+    let declared: string[] = [];
+    try {
+      declared = (await readFile(join(SRC, '..', '.private-identifiers'), 'utf8'))
+        .split('\n')
+        .map((line) => line.trim())
+        .filter((line) => line.length > 0 && !line.startsWith('#'));
+    } catch {
+      // Absent is the ordinary case. The rule is in CLAUDE.md either way.
+    }
+
+    const handles = new Set<string>();
+    for (const candidate of [local, /\s/.test(name) ? '' : name, ...declared]) {
+      if (candidate.length < 5) continue;
+      // A handle also appears slugified, which is how one reached a credential
+      // ref: `ada.lovelace` became `ada_lovelace`.
+      handles.add(candidate.toLowerCase());
+      handles.add(candidate.replace(/[.\-]/g, '_').toLowerCase());
+      handles.add(candidate.replace(/[._\-]/g, '').toLowerCase());
+    }
+
+    if (handles.size === 0) return;
+
+    const violations: string[] = [];
+
+    for (const path of await publishedFiles()) {
+      const shown = relative(SRC, path);
+      if (shown.includes(NOT_OURS)) continue;
+
+      for (const [index, line] of (await readFile(path, 'utf8')).split('\n').entries()) {
+        const haystack = line.toLowerCase();
+        for (const handle of handles) {
+          if (!haystack.includes(handle)) continue;
+          violations.push(`${shown}:${index + 1} — names a contributor (${handle})`);
         }
       }
     }

--- a/src/cli/brand.ts
+++ b/src/cli/brand.ts
@@ -61,9 +61,10 @@ export const FONTS =
   '<link href="https://fonts.googleapis.com/css2?family=Geist+Mono:wght@400;500' +
   '&amp;family=Geist:wght@400;500&amp;family=Lora:wght@400;500&amp;display=swap" rel="stylesheet">';
 
-/** The one-row footer, identical to the one the Lanes API's own pages carry. */
+/** The one-row footer, identical to the one every other Lanes surface carries:
+ * the API's pages and emails, and the desktop app's OAuth success page. */
 export const FOOTER =
-  '<div class="footer"><p>Run many agents at once. Connect them to your tools once - ' +
+  '<div class="footer"><p>Power up your agentic fleet with ' +
   '<a href="https://lanes.sh/">lanes.sh</a></p></div>';
 
 /**

--- a/src/cli/commands/connect.test.ts
+++ b/src/cli/commands/connect.test.ts
@@ -307,4 +307,96 @@ describe('resolveAccount', () => {
 
     expect(account).toBeNull();
   });
+
+  /**
+   * The version header, and why a probe needs to be able to send one.
+   *
+   * Notion's REST API refuses a request that carries no `Notion-Version` — not
+   * with a 401 a reader would trace to the credential, but with a 400 about a
+   * header nobody declared. An `identity: { kind: 'http' }` block could only
+   * send `Authorization`, so every API that pins its version in a header was
+   * silently outside what a manifest could express.
+   */
+  test('sends the headers the manifest declares, with the credential over them', async () => {
+    let sent: Record<string, string> = {};
+
+    const account = await resolveAccount(
+      manifest({
+        kind: 'http',
+        url: 'https://api.example.com/v1/users/me',
+        field: 'email',
+        headers: { 'notion-version': '2022-06-28' },
+      }),
+      {
+        accessToken: async () => 'tok',
+        fetch: (async (_url: string, init?: RequestInit) => {
+          sent = init?.headers as Record<string, string>;
+          return new Response(JSON.stringify({ email: 'me@example.com' }));
+        }) as unknown as typeof fetch,
+      },
+    );
+
+    expect(sent['notion-version']).toBe('2022-06-28');
+    expect(sent['authorization']).toBe('Bearer tok');
+    expect(account).toBe('me@example.com');
+  });
+
+  /**
+   * The same tenancy problem Slack has, one transport over.
+   *
+   * Notion answers `notion-fetch` with the person's email, which is the same
+   * email in every workspace they belong to. Only `http` carried a qualifier,
+   * so a tool-kind identity could name the person and had no way to say which
+   * workspace was authorised — and the reconnect match is on that one string.
+   */
+  test('a tool identity qualifies its field the way an http one does', async () => {
+    const self = (workspace: string) =>
+      resolveAccount(
+        manifest({
+          kind: 'tool',
+          tool: 'notion-fetch',
+          field: 'self.user.email',
+          qualifier: 'self.workspace.name',
+          arguments: { id: 'self' },
+        }),
+        {
+          accessToken: async () => null,
+          callTool: async () => ({
+            content: [
+              {
+                text: JSON.stringify({
+                  self: { workspace: { name: workspace }, user: { email: 'ada@example.com' } },
+                }),
+              },
+            ],
+          }),
+        },
+      );
+
+    expect(await self('Personal')).toBe('ada@example.com (Personal)');
+    expect(await self('Personal')).not.toBe(await self('Acme'));
+  });
+
+  test('and passes the arguments the tool needs to answer at all', async () => {
+    let received: Record<string, unknown> = {};
+
+    await resolveAccount(
+      manifest({
+        kind: 'tool',
+        tool: 'notion-fetch',
+        field: 'self.user.email',
+        arguments: { id: 'self' },
+      }),
+      {
+        accessToken: async () => null,
+        callTool: async (_name, args) => {
+          received = args;
+          return { content: [{ text: '{}' }] };
+        },
+      },
+    );
+
+    // `notion-fetch` with no id fetches nothing; `self` is the whole call.
+    expect(received).toEqual({ id: 'self' });
+  });
 });

--- a/src/cli/commands/connect/authorise.ts
+++ b/src/cli/commands/connect/authorise.ts
@@ -10,7 +10,12 @@ import { terminalPrompter, type Prompter } from '../../prompt.ts';
 import { describeScopes, shortScope } from '../../scopes.ts';
 import { BROKERED, BrokerError } from '#connectivity/auth/index.ts';
 import { brokerExchangeVia } from '../../oauth-exchange.ts';
-import { brokeredScopes, hostedClientRefusal, resolveOAuthClient } from './client.ts';
+import {
+  brokeredScopes,
+  hostedClientRefusal,
+  registeredCallbackPort,
+  resolveOAuthClient,
+} from './client.ts';
 import { confirmScopes } from './scopes-gate.ts';
 import { ensureOAuthApp } from './setup.ts';
 
@@ -116,7 +121,10 @@ export async function authorise(input: {
 
   const serverUrl = manifest.connector.endpoint;
 
-  const callback = captureOAuthCallback({ label: manifest.name });
+  const callback = captureOAuthCallback({
+    label: manifest.name,
+    port: await registeredCallbackPort(manifest, connectionId, credentials),
+  });
 
   try {
     const provider = oauthProviderFor(

--- a/src/cli/commands/connect/client.ts
+++ b/src/cli/commands/connect/client.ts
@@ -5,6 +5,7 @@ import {
   brokerOriginOverride,
   type BrokerConfig,
 } from '#connectivity/auth/index.ts';
+import { CredentialOAuthProvider } from '#connectivity/auth/index.ts';
 import { hasOwnClientPath, type ProviderManifest } from '#connectivity';
 import type { SecretStore } from '#secrets';
 import { ConfigDocument } from '../../config-edit.ts';
@@ -309,4 +310,50 @@ export function hostedClientRefusal(input: {
   if (input.docsUrl) lines.push(`  ${input.docsUrl}`);
 
   return new Error(lines.join('\n'));
+}
+
+/**
+ * The loopback port this provider's registered client already declares.
+ *
+ * A dynamically registered client is written once and kept — re-registering
+ * orphans the grant the operator approved — so its `redirect_uris` outlive the
+ * listener that chose them. Asking for a fresh port on the next connect sends a
+ * URL that client never declared, and a server matching `redirect_uri`
+ * literally refuses it before the consent page renders.
+ *
+ * So this reads the port back out of the registration and the listener asks for
+ * it again. `undefined` where there is no registration yet, which is the first
+ * connect and the case that was always fine.
+ */
+export async function registeredCallbackPort(
+  manifest: ProviderManifest,
+  connectionId: string,
+  credentials: SecretStore,
+): Promise<number | undefined> {
+  const provider = new CredentialOAuthProvider({
+    manifest,
+    connectionId,
+    credentials,
+    scopes: manifest.auth.kind === 'oauth' ? manifest.auth.scopes : [],
+  });
+
+  try {
+    const client = (await provider.clientInformation()) as
+      | { redirect_uris?: unknown }
+      | undefined;
+
+    const declared = Array.isArray(client?.redirect_uris) ? client.redirect_uris : [];
+
+    for (const candidate of declared) {
+      if (typeof candidate !== 'string') continue;
+      const port = Number(new URL(candidate).port);
+      if (Number.isInteger(port) && port > 0) return port;
+    }
+  } catch {
+    // A malformed or unreadable registration is not worth failing a connect
+    // over: the listener falls back to any free port, which is what it did
+    // before this existed.
+  }
+
+  return undefined;
 }

--- a/src/cli/commands/connect/settle.test.ts
+++ b/src/cli/commands/connect/settle.test.ts
@@ -81,6 +81,23 @@ function prompter(answer = ''): Prompter & { asked: string[] } {
   };
 }
 
+/** A terminal that works through a script of answers, then answers nothing. */
+function scripted(...answers: string[]): Prompter & { asked: string[] } {
+  const asked: string[] = [];
+  let next = 0;
+
+  return {
+    asked,
+    interactive: true,
+    ask: async (question) => {
+      asked.push(question);
+      return answers[next++] ?? '';
+    },
+    askSecret: async () => '',
+    confirm: async () => true,
+  };
+}
+
 const silent: Prompter = {
   interactive: false,
   ask: async () => '',
@@ -219,5 +236,65 @@ describe('the label a connection is given at connect time', () => {
     expect(asking.asked).toHaveLength(1);
     expect(settled.account).toBe('Ada at Acme');
     expect(settled.label).toBe('Acme Mail (Ada at Acme)');
+  });
+});
+
+/**
+ * The account question, when there is nothing to answer it with.
+ *
+ * An empty answer used to be taken and stored `Acme Mail pending` — the
+ * provider's name beside the *provisional* connection id, an internal token
+ * meaning "no id yet". That string then became the account, the default label,
+ * and the key a reconnect matches on. Nobody chose it, and a row named after it
+ * can answer none of the questions an account exists to answer.
+ */
+describe('an account nobody could report', () => {
+  const unnamable = { manifest: anonymous, runtime: runtime([], null) };
+
+  test('re-asks rather than taking silence for an answer', async () => {
+    const asking = scripted('', '', 'ada@example.com');
+
+    const settled = await settle({ ...unnamable, prompter: asking });
+
+    expect(asking.asked).toHaveLength(3);
+    expect(settled.account).toBe('ada@example.com');
+  });
+
+  test('takes "blank" from someone who meant it, and says so honestly', async () => {
+    const asking = scripted('', 'blank');
+
+    const settled = await settle({ ...unnamable, prompter: asking });
+
+    // Not `Acme Mail pending`. `unnamed` is visibly not an address, and reads
+    // through `defaultConnectionLabel` as a name rather than an internal token.
+    expect(settled.account).toBe('unnamed');
+    expect(settled.label).toBe('Acme Mail (unnamed)');
+  });
+
+  test('and does not match a row that was also left unnamed', async () => {
+    // `unnamed` is not an identity, so two of them are not evidence of one
+    // account. Matching them would hand the second connect the first row's
+    // credential ref and overwrite it; a fresh id says the only true thing
+    // available, which is that these are two rows.
+    const declared = [
+      { id: 'con1', provider: 'acme_mail', account: 'unnamed' },
+    ] as ConnectionConfig[];
+
+    const settled = await settle({
+      manifest: anonymous,
+      runtime: runtime(declared, null),
+      prompter: scripted('blank'),
+    });
+
+    expect(settled.connectionId).toBe('con2');
+  });
+
+  test('refuses in the end rather than asking forever', async () => {
+    // A prompter that reports itself interactive and returns nothing forever is
+    // not hypothetical — a closed pipe does it — and a connect that hangs is
+    // worse than one that refuses in the words the non-interactive path uses.
+    const asking = scripted();
+
+    expect(settle({ ...unnamable, prompter: asking })).rejects.toThrow(/Nothing was written/);
   });
 });

--- a/src/cli/commands/connect/settle.ts
+++ b/src/cli/commands/connect/settle.ts
@@ -1,11 +1,12 @@
 import { createMcpConnector } from '#connectivity/transports';
-import { bearerTokenAsStored } from '#connectivity/auth/index.ts';
+import { bearerTokenAsStored, CredentialOAuthProvider } from '#connectivity/auth/index.ts';
 import type { SecretStore } from '#secrets';
 import { defaultConnectionLabel } from '#profile';
 import type { ConnectionConfig, Config } from '#profile';
 import type { AnyConnector, ProviderManifest } from '#connectivity';
 import { nextConnectionId, resolveAccount } from '../../identity.ts';
-import { style } from '../../output.ts';
+import { introspectAccount } from '../../introspection.ts';
+import { progress, style } from '../../output.ts';
 import { PromptCancelled, terminalPrompter, type Prompter } from '../../prompt.ts';
 import { accountSiblings } from './accounts.ts';
 
@@ -132,6 +133,28 @@ export async function settleIdentity(input: {
     });
   }
 
+  // Nothing declared, or what was declared came back empty. Before asking, ask
+  // the authorization server: RFC 7662 introspection needs no per-vendor
+  // configuration, and it is the only automatic answer available to the
+  // remote-MCP family, which is 75 of the 105 manifests and every one of them a
+  // question the operator has been answering by hand. See `introspection.ts`
+  // for why asking the server is allowed where reading the stored token is not.
+  if (!account && manifest.auth.kind === 'oauth' && manifest.connector.kind === 'mcp') {
+    const endpoint = manifest.connector.endpoint;
+    const scopes = manifest.auth.scopes;
+    account = await introspectAccount({
+      resourceUrl: endpoint,
+      accessToken: () => bearerTokenAsStored(manifest, provisionalId, runtime.credentials),
+      clientInformation: () =>
+        new CredentialOAuthProvider({
+          manifest,
+          connectionId: provisionalId,
+          credentials: runtime.credentials,
+          scopes,
+        }).clientInformation(),
+    });
+  }
+
   // A provider that authenticates to nothing has no account to name, so asking
   // is a question with no answer — and one that needs a terminal, which makes an
   // otherwise scriptable connect interactive for no reason.
@@ -148,6 +171,10 @@ export async function settleIdentity(input: {
   // second ago does not need confirming against itself.
   let typed = false;
 
+  // Whether they declined to name it at all. It reaches the id below: a row
+  // nobody could name must not match another row nobody could name.
+  let bypassed = false;
+
   if (!account) {
     // Nothing to go on. Asking beats inventing `main2`, and the answer is the
     // one piece of information the file cannot reconstruct later — which is
@@ -160,9 +187,9 @@ export async function settleIdentity(input: {
       );
     }
 
-    account =
-      (await prompter.ask(`Which account is this? ${style.dim('(the address or handle)')}`)) ||
-      `${manifest.name} ${provisionalId}`;
+    const answer = await askForAccount(manifest, prompter);
+    account = answer.account;
+    bypassed = answer.bypassed;
     typed = true;
   }
 
@@ -176,13 +203,21 @@ export async function settleIdentity(input: {
   // a second row. That is the whole reason `resolveAccount` runs before this:
   // without it a failed attempt appends rather than repairs, which is how
   // `Gmail main3` came to exist.
+  //
+  // A bypassed row is excluded from that match on purpose. `unnamed` is not an
+  // identity, so two of them are not evidence of the same account — matching
+  // them would hand the second connect the first one's credential ref and
+  // overwrite it. A fresh id says the only true thing available: these are two
+  // rows, and nobody could say whether they are two accounts.
   const connectionId =
     explicitId ??
     (unaccounted
       ? nextConnectionId(taken, true)
-      : (siblings.find(
-          (candidate) => candidate.account.toLowerCase() === account!.toLowerCase(),
-        )?.id ?? nextConnectionId(taken, false)));
+      : bypassed
+        ? nextConnectionId(taken, false)
+        : (siblings.find(
+            (candidate) => candidate.account.toLowerCase() === account!.toLowerCase(),
+          )?.id ?? nextConnectionId(taken, false)));
 
   const defaultLabel = defaultConnectionLabel(manifest.name, account);
 
@@ -202,6 +237,54 @@ export async function settleIdentity(input: {
       prompter,
     }),
   };
+}
+
+/** The literal answer that skips the question, and what it stores instead. */
+const BYPASS_ANSWER = 'blank';
+const UNNAMED_ACCOUNT = 'unnamed';
+
+/**
+ * The one thing the file cannot reconstruct later, asked until it is answered.
+ *
+ * An empty answer used to be taken, and stored `${manifest.name} ${provisionalId}`
+ * — the provider's name beside `pending`, an internal token for "no id yet".
+ * That string then became the account, the default label, and the key a
+ * reconnect matches on. Nobody chose it and nothing can be done with it.
+ *
+ * So an empty answer re-asks, and there is a way past for someone who meant it:
+ * typing `blank`. That row is `unnamed` — honest, visibly not an address, and
+ * `defaultConnectionLabel` reads it as `Notion (unnamed)`.
+ *
+ * Bounded rather than unbounded. A prompter that reports itself interactive and
+ * then returns nothing forever is not hypothetical — a closed pipe does it —
+ * and a connect that hangs is worse than one that refuses in the words the
+ * non-interactive path already uses.
+ */
+async function askForAccount(
+  manifest: ProviderManifest,
+  prompter: Prompter,
+): Promise<{ account: string; bypassed: boolean }> {
+  const question = `Which account is this? ${style.dim('(the address or handle)')}`;
+
+  for (let attempt = 0; attempt < 3; attempt += 1) {
+    const answer = (await prompter.ask(question)).trim();
+
+    if (answer.toLowerCase() === BYPASS_ANSWER) return { account: UNNAMED_ACCOUNT, bypassed: true };
+    if (answer) return { account: answer, bypassed: false };
+
+    progress(
+      style.dim(
+        `  It is how a reconnect finds this row again, and what every list shows it as.`,
+      ),
+    );
+    progress(style.dim(`  Type "${BYPASS_ANSWER}" to go without one.`));
+  }
+
+  throw new Error(
+    `${manifest.name} could not report whose account this is, and none was given.\n` +
+      `  Nothing was written. Answer the question, type "${BYPASS_ANSWER}" to go without a name, ` +
+      `or pass --display-name "<name>".`,
+  );
 }
 
 /**

--- a/src/cli/contract4.test.ts
+++ b/src/cli/contract4.test.ts
@@ -402,7 +402,7 @@ describe('the credentials, which the rename would otherwise orphan', () => {
     // It warned and carried on once. The rehearsal that found it showed why
     // that is the wrong shape: the warning was printed, the rows were renamed
     // anyway, and the workspace came out naming `gmail.con1` with the secret
-    // still at `gmail/wjj_andrews`. A rerun cannot repair that — the rows are
+    // still at `gmail/ada_lovelace`. A rerun cannot repair that — the rows are
     // renamed, so the second pass computes no rename and the old ref is
     // orphaned with nothing left that knows what it belonged to.
     //

--- a/src/cli/contract4.ts
+++ b/src/cli/contract4.ts
@@ -210,7 +210,7 @@ export async function migrateToContract4(
  * warned once, and the rehearsal that found it showed why it must not: the
  * warning was printed, `renameConnections` ran anyway, and the workspace came
  * out with rows naming `gmail.con1` while the secret sat at
- * `gmail/wjj_andrews`. A rerun cannot repair that — the rows are renamed, so
+ * `gmail/ada_lovelace`. A rerun cannot repair that — the rows are renamed, so
  * the second run computes no rename for them and the old ref is orphaned with
  * nothing left that knows what it belonged to.
  *

--- a/src/cli/identity.ts
+++ b/src/cli/identity.ts
@@ -11,8 +11,8 @@ import type { IdentityDeclaration, ProviderManifest } from '#connectivity';
  * exist.
  *
  * Everything here is best-effort. A provider that declares no identity, or
- * whose probe fails, falls back to asking the operator: a label is worth
- * having, never worth failing a connect over.
+ * whose probe fails, falls back to `introspectAccount` and then to asking the
+ * operator: a label is worth having, never worth failing a connect over.
  */
 
 /** Walk a dotted path, tolerating the first array element on the way. */
@@ -29,10 +29,37 @@ export function pluck(value: unknown, path: string): string | null {
   return typeof current === 'string' && current.length > 0 ? current : null;
 }
 
-/** The header an OAuth or bearer provider's probe carries. */
-async function bearerHeaders(probe: IdentityProbe): Promise<RequestInit> {
+/**
+ * `alice (Acme)` rather than `alice`.
+ *
+ * The bracketed half is what makes two workspaces two accounts instead of one
+ * overwritten twice: the reconnect match in `settleIdentity` is on the account,
+ * so without it the second connect repairs the first row rather than adding
+ * one. It used to reach the id as well, back when the id was slugified from
+ * this.
+ *
+ * One helper for both probe kinds. `http` had it first, for Slack; `tool` needs
+ * the same for Notion, whose `self` is an email that says nothing about which
+ * of the person's workspaces was authorised.
+ */
+function qualified(
+  body: unknown,
+  declaration: { field: string; qualifier?: string | undefined },
+): string | null {
+  const primary = pluck(body, declaration.field);
+  if (!primary || !declaration.qualifier) return primary;
+
+  const qualifier = pluck(body, declaration.qualifier);
+  return qualifier ? `${primary} (${qualifier})` : primary;
+}
+
+/** The header an OAuth or bearer provider's probe carries, over the declared ones. */
+async function bearerHeaders(
+  probe: IdentityProbe,
+  declared: Record<string, string>,
+): Promise<RequestInit> {
   const token = await probe.accessToken();
-  return { headers: token ? { authorization: `Bearer ${token}` } : {} };
+  return { headers: { ...declared, ...(token ? { authorization: `Bearer ${token}` } : {}) } };
 }
 
 export interface IdentityProbe {
@@ -74,26 +101,23 @@ export async function resolveAccount(
     if (identity.kind === 'http') {
       const send = probe.fetch ?? globalThis.fetch;
 
+      // The manifest's own headers, for an API that answers nothing without
+      // one: Notion refuses a request carrying no `Notion-Version`, and it is
+      // not the only vendor that pins its version in a header. The credential
+      // goes on top of them either way — `requestAuthorizer` copies the headers
+      // it is handed, so a declared one survives `authorize` too.
+      const declared = identity.headers ?? {};
+
       // `authorize` where the caller supplied one, because it is the same
       // switch the dispatch path uses and knows every method. The token is the
       // fallback rather than the other way round only because the OAuth
       // providers reached here first; both end at the same header for them.
       const response = probe.authorize
-        ? await send(await probe.authorize(new Request(identity.url)))
-        : await send(identity.url, await bearerHeaders(probe));
+        ? await send(await probe.authorize(new Request(identity.url, { headers: declared })))
+        : await send(identity.url, await bearerHeaders(probe, declared));
       if (!response.ok) return null;
 
-      const body = await response.json();
-      const primary = pluck(body, identity.field);
-      if (!primary || !identity.qualifier) return primary;
-
-      // `alice (Acme)` rather than `alice`. The bracketed half is what makes
-      // two workspaces two accounts instead of one overwritten twice: the
-      // reconnect match below is on the account, so without it the second
-      // connect repairs the first row rather than adding one. It used to reach
-      // the id as well, back when the id was slugified from this.
-      const qualifier = pluck(body, identity.qualifier);
-      return qualifier ? `${primary} (${qualifier})` : primary;
+      return qualified(await response.json(), identity);
     }
 
     if (!probe.callTool) return null;
@@ -104,12 +128,12 @@ export async function resolveAccount(
     const text = pluck(result, 'content.text');
     if (text) {
       try {
-        return pluck(JSON.parse(text), identity.field) ?? text;
+        return qualified(JSON.parse(text), identity) ?? text;
       } catch {
         return text;
       }
     }
-    return pluck(result, identity.field);
+    return qualified(result, identity);
   } catch {
     return null;
   }

--- a/src/cli/introspection.test.ts
+++ b/src/cli/introspection.test.ts
@@ -1,0 +1,203 @@
+import { describe, expect, test } from 'bun:test';
+import { introspectAccount } from './introspection.ts';
+
+/**
+ * The one identity answer that costs no per-vendor configuration.
+ *
+ * 75 of 105 manifests declare no `identity` block, almost all of them the
+ * remote-MCP family that registers dynamically, and every one of them asked the
+ * operator to type their own address a second after authorising. RFC 7662 is
+ * what the authorization server already offers: the metadata says whether there
+ * is an `introspection_endpoint`, and `username` is defined there as a
+ * human-readable identifier for whoever authorized the token.
+ *
+ * The risk this carries is not returning nothing — that costs a question, which
+ * is what happens today. It is returning `9f2c1e04-…`, which becomes the
+ * account, the label, and the key a reconnect matches on, and reads exactly
+ * like it worked. So every test below that rejects something is the point of
+ * the file.
+ */
+
+const RESOURCE = 'https://mcp.example.com';
+const INTROSPECT = 'https://mcp.example.com/introspect';
+const USERINFO = 'https://mcp.example.com/userinfo';
+
+/** A server that discovers to itself, the way every MCP server we have met does. */
+function server(options: {
+  introspection?: boolean;
+  userinfo?: Record<string, unknown>;
+  claims?: Record<string, unknown>;
+  status?: number;
+}) {
+  const posted: URLSearchParams[] = [];
+
+  const fetchFn = (async (input: unknown, init?: RequestInit) => {
+    const url = String(input instanceof Request ? input.url : input);
+
+    if (url.includes('oauth-protected-resource')) {
+      // Notion's shape: the resource is its own authorization server, and the
+      // SDK is left to fall back to it.
+      return new Response('not found', { status: 404 });
+    }
+
+    if (url.includes('oauth-authorization-server') || url.includes('openid-configuration')) {
+      return Response.json({
+        issuer: RESOURCE,
+        authorization_endpoint: `${RESOURCE}/authorize`,
+        token_endpoint: `${RESOURCE}/token`,
+        response_types_supported: ['code'],
+        ...(options.introspection === false ? {} : { introspection_endpoint: INTROSPECT }),
+        ...(options.userinfo ? { userinfo_endpoint: USERINFO } : {}),
+      });
+    }
+
+    if (url === USERINFO) {
+      return Response.json(options.userinfo ?? {});
+    }
+
+    if (url === INTROSPECT) {
+      posted.push(new URLSearchParams(String(init?.body)));
+      if (options.status && options.status >= 400) {
+        return new Response('no', { status: options.status });
+      }
+      return Response.json({ active: true, ...options.claims });
+    }
+
+    return new Response('unexpected', { status: 500 });
+  }) as unknown as typeof fetch;
+
+  return { fetchFn, posted };
+}
+
+const probe = (
+  options: Parameters<typeof server>[0],
+  client: { client_id?: string; client_secret?: string } = { client_id: 'cid' },
+) => {
+  const { fetchFn, posted } = server(options);
+  return {
+    posted,
+    account: introspectAccount({
+      resourceUrl: RESOURCE,
+      accessToken: async () => 'tok',
+      clientInformation: async () => client,
+      fetch: fetchFn,
+    }),
+  };
+};
+
+describe('introspectAccount', () => {
+  test('names the account from a human-readable username', async () => {
+    expect(await probe({ claims: { username: 'ada' } }).account).toBe('ada');
+  });
+
+  test('reads an address, and prefers the username the RFC defines for it', async () => {
+    expect(await probe({ claims: { email: 'ada@example.com' } }).account).toBe('ada@example.com');
+    expect(
+      await probe({ claims: { username: 'ada', email: 'other@example.com' } }).account,
+    ).toBe('ada');
+  });
+
+  test('sends the token and the registered client, so a server that checks can', async () => {
+    const attempt = probe({ claims: { username: 'ada' } }, {
+      client_id: 'cid',
+      client_secret: 'shh',
+    });
+    await attempt.account;
+
+    const body = attempt.posted[0]!;
+    expect(body.get('token')).toBe('tok');
+    expect(body.get('token_type_hint')).toBe('access_token');
+    expect(body.get('client_id')).toBe('cid');
+    expect(body.get('client_secret')).toBe('shh');
+  });
+
+  /**
+   * The failures that matter. Each of these would otherwise be written into
+   * `connections.yaml` as the account and never questioned again.
+   */
+  test('refuses an opaque identifier rather than labelling a row with it', async () => {
+    expect(await probe({ claims: { username: '9f2c1e04-3b7a-4c1d-9e55-1f2a3b4c5d6e' } }).account)
+      .toBeNull();
+    expect(await probe({ claims: { username: 'a1b2c3d4e5f60718293a4b5c' } }).account).toBeNull();
+    expect(await probe({ claims: { username: '10029387' } }).account).toBeNull();
+  });
+
+  test('refuses the client id echoed back, which is us and not a person', async () => {
+    expect(await probe({ claims: { username: 'cid' } }).account).toBeNull();
+  });
+
+  test('an inactive token is an answer about the token, not about a person', async () => {
+    // Every other field is meaningless by the RFC once `active` is false, so
+    // reading one would be reading a stale claim.
+    expect(await probe({ claims: { active: false, username: 'ada' } }).account).toBeNull();
+  });
+
+  test('a server that advertises no introspection endpoint is not asked', async () => {
+    const attempt = probe({ introspection: false });
+
+    expect(await attempt.account).toBeNull();
+    expect(attempt.posted).toHaveLength(0);
+  });
+
+  test('a refusal costs a round trip and nothing else', async () => {
+    expect(await probe({ status: 401, claims: { username: 'ada' } }).account).toBeNull();
+  });
+
+  /**
+   * The other half of "ask the authorization server".
+   *
+   * Measured across the 80 MCP endpoints this repository names, five advertise
+   * introspection and three advertise userinfo — and they are not the same
+   * three. Neither is common enough to replace a per-vendor identity block;
+   * both are free once we are already talking to the server.
+   */
+  test('falls to OIDC userinfo where that is what the server offers', async () => {
+    const attempt = probe({ introspection: false, userinfo: { email: 'ada@example.com' } });
+
+    expect(await attempt.account).toBe('ada@example.com');
+    expect(attempt.posted).toHaveLength(0);
+  });
+
+  test('and reaches for it when introspection is advertised but refuses', async () => {
+    const attempt = probe({ status: 401, userinfo: { preferred_username: 'ada' } });
+
+    expect(await attempt.account).toBe('ada');
+    expect(attempt.posted).toHaveLength(1);
+  });
+
+  test('userinfo is held to the same rule — a subject id is not a name', async () => {
+    expect(
+      await probe({
+        introspection: false,
+        userinfo: { sub: '9f2c1e04-3b7a-4c1d-9e55-1f2a3b4c5d6e' },
+      }).account,
+    ).toBeNull();
+  });
+
+  test('no token means there is nothing to introspect', async () => {
+    const { fetchFn, posted } = server({ claims: { username: 'ada' } });
+
+    const account = await introspectAccount({
+      resourceUrl: RESOURCE,
+      accessToken: async () => null,
+      clientInformation: async () => ({ client_id: 'cid' }),
+      fetch: fetchFn,
+    });
+
+    expect(account).toBeNull();
+    expect(posted).toHaveLength(0);
+  });
+
+  test('a discovery that throws falls through to the question, never upward', async () => {
+    const account = await introspectAccount({
+      resourceUrl: RESOURCE,
+      accessToken: async () => 'tok',
+      clientInformation: async () => ({ client_id: 'cid' }),
+      fetch: (async () => {
+        throw new Error('network down');
+      }) as unknown as typeof fetch,
+    });
+
+    expect(account).toBeNull();
+  });
+});

--- a/src/cli/introspection.ts
+++ b/src/cli/introspection.ts
@@ -1,0 +1,167 @@
+import {
+  discoverAuthorizationServerMetadata,
+  discoverOAuthProtectedResourceMetadata,
+} from '@modelcontextprotocol/client';
+
+/**
+ * Asking the authorization server who it just issued a token to.
+ *
+ * The declared `identity` block (`identity.ts`) is per-vendor and most vendors
+ * have none — 75 of 105 manifests, almost all of them the remote-MCP family
+ * that registers dynamically. Every one of those made a person type their own
+ * address into `connect` a second after authorising, which is the one thing an
+ * OAuth round trip ought to have settled.
+ *
+ * RFC 7662 is the standard answer and costs no per-vendor configuration: the
+ * authorization server metadata we already fetch says whether there is an
+ * `introspection_endpoint`, and the response's `username` is defined as "a
+ * human-readable identifier for the resource owner who authorized this token".
+ *
+ * **This asks the server rather than reading the token.** That distinction is
+ * the whole reason this is allowed to exist where decoding the stored
+ * `id_token` is not (`oauth-exchange.ts`): a claim in a local file is
+ * unverified and the store is tamperable, while an introspection response is
+ * the issuer answering for itself.
+ *
+ * Best-effort throughout. A server with no introspection endpoint, one that
+ * refuses a public client, or one that answers with an opaque id costs a round
+ * trip and falls through to the prompt.
+ */
+
+export interface IntrospectionProbe {
+  /** The protected resource — the MCP endpoint this connection talks to. */
+  readonly resourceUrl: string;
+  readonly accessToken: () => Promise<string | null>;
+  /** The registered client, for servers that want the caller authenticated. */
+  readonly clientInformation: () => Promise<
+    { client_id?: string | undefined; client_secret?: string | undefined } | undefined
+  >;
+  readonly fetch?: typeof globalThis.fetch;
+}
+
+/**
+ * Whether a returned identifier is one a person would recognise.
+ *
+ * The failure this guards against is not a probe that returns nothing — that
+ * one falls through to the prompt and costs a question. It is a probe that
+ * returns `9f2c1e04-…` or the client id, which becomes the account, the label,
+ * and the key a reconnect matches on, and reads exactly like it worked.
+ *
+ * An address is accepted outright. Anything else has to at least look like a
+ * name: letters, and not the shapes an opaque identifier takes.
+ */
+function readable(value: unknown, clientId: string | undefined): string | null {
+  if (typeof value !== 'string') return null;
+
+  const candidate = value.trim();
+  if (candidate.length === 0 || candidate === clientId) return null;
+  if (candidate.includes('@')) return candidate;
+
+  // A uuid, a long hex or base64-ish blob, or anything with no letters in it.
+  if (/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(candidate)) return null;
+  if (/^[0-9a-zA-Z_-]{16,}$/.test(candidate) && !/[ .]/.test(candidate)) return null;
+  if (!/[a-z]/i.test(candidate)) return null;
+
+  return candidate;
+}
+
+/** The two endpoints an authorization server may offer for this, per RFC 8414. */
+async function askableEndpoints(
+  resourceUrl: string,
+  fetchFn: typeof globalThis.fetch,
+): Promise<{ introspection: string | null; userinfo: string | null }> {
+  // The resource names its authorization servers; where it names none, the
+  // resource is its own, which is the shape every MCP server we have met takes.
+  let authorizationServer = resourceUrl;
+  try {
+    const resource = await discoverOAuthProtectedResourceMetadata(resourceUrl, undefined, fetchFn);
+    const declared = (resource as { authorization_servers?: string[] }).authorization_servers;
+    if (declared?.[0]) authorizationServer = declared[0];
+  } catch {
+    // Fall through to the resource itself.
+  }
+
+  const metadata = (await discoverAuthorizationServerMetadata(authorizationServer, {
+    fetchFn,
+  })) as { introspection_endpoint?: string; userinfo_endpoint?: string } | undefined;
+
+  const named = (value: unknown) =>
+    typeof value === 'string' && value.length > 0 ? value : null;
+
+  return {
+    introspection: named(metadata?.introspection_endpoint),
+    userinfo: named(metadata?.userinfo_endpoint),
+  };
+}
+
+/**
+ * OIDC's answer to the same question, for the servers that offer that instead.
+ *
+ * Measured across the 80 MCP endpoints this repository names: five advertise
+ * introspection and three advertise userinfo, and they are different servers.
+ * Neither is common enough to make the per-vendor `identity` blocks
+ * unnecessary; both are free to ask once we are already here.
+ */
+async function fromUserinfo(
+  endpoint: string,
+  token: string,
+  send: typeof globalThis.fetch,
+): Promise<string | null> {
+  const response = await send(endpoint, {
+    headers: { authorization: `Bearer ${token}`, accept: 'application/json' },
+  });
+  if (!response.ok) return null;
+
+  const claims = (await response.json()) as Record<string, unknown>;
+  return (
+    readable(claims['email'], undefined) ??
+    readable(claims['preferred_username'], undefined) ??
+    readable(claims['name'], undefined)
+  );
+}
+
+export async function introspectAccount(probe: IntrospectionProbe): Promise<string | null> {
+  const send = probe.fetch ?? globalThis.fetch;
+
+  try {
+    const token = await probe.accessToken();
+    if (!token) return null;
+
+    const endpoints = await askableEndpoints(probe.resourceUrl, send);
+    if (!endpoints.introspection) {
+      return endpoints.userinfo ? await fromUserinfo(endpoints.userinfo, token, send) : null;
+    }
+
+    const client = await probe.clientInformation();
+
+    // `client_secret_post` where we hold a secret, and the bare `client_id`
+    // where we do not — the two methods a dynamically registered public client
+    // is offered. A server wanting neither ignores both fields.
+    const body = new URLSearchParams({ token, token_type_hint: 'access_token' });
+    if (client?.client_id) body.set('client_id', client.client_id);
+    if (client?.client_secret) body.set('client_secret', client.client_secret);
+
+    const response = await send(endpoints.introspection, {
+      method: 'POST',
+      headers: { 'content-type': 'application/x-www-form-urlencoded', accept: 'application/json' },
+      body,
+    });
+    if (!response.ok) {
+      return endpoints.userinfo ? await fromUserinfo(endpoints.userinfo, token, send) : null;
+    }
+
+    const claims = (await response.json()) as Record<string, unknown>;
+
+    // `active: false` is a valid, successful answer meaning the token is not
+    // one this server will speak for. Every other field is then meaningless by
+    // the RFC, so reading one would be reading a stale claim.
+    if (claims['active'] === false) return null;
+
+    return (
+      readable(claims['username'], client?.client_id) ??
+      readable(claims['email'], client?.client_id)
+    );
+  } catch {
+    return null;
+  }
+}

--- a/src/cli/oauth-callback.ts
+++ b/src/cli/oauth-callback.ts
@@ -112,7 +112,9 @@ export interface CallbackCapture {
   close(): Promise<void>;
 }
 
-export function captureOAuthCallback(options: { label?: string } = {}): CallbackCapture {
+export function captureOAuthCallback(
+  options: { label?: string; port?: number | undefined } = {},
+): CallbackCapture {
   const state = base64url(randomBytes(24));
   let resolveCode: (value: { code: string; iss?: string }) => void;
   let rejectCode: (error: Error) => void;
@@ -122,10 +124,9 @@ export function captureOAuthCallback(options: { label?: string } = {}): Callback
     rejectCode = reject;
   });
 
-  const server = Bun.serve({
+  const listener = {
     hostname: '127.0.0.1',
-    port: 0,
-    fetch(request) {
+    fetch(request: Request) {
       const url = new URL(request.url);
       if (url.pathname !== '/callback') return new Response('Not found', { status: 404 });
 
@@ -168,7 +169,30 @@ export function captureOAuthCallback(options: { label?: string } = {}): Callback
       resolveCode({ code, ...(iss ? { iss } : {}) });
       return connectedPage(options.label);
     },
-  });
+  };
+
+  // The port a previous run registered with, where the caller knows one.
+  //
+  // Asking the OS for any free port is what broke every second connect to a
+  // vendor that matches `redirect_uri` literally. The first connect binds
+  // whatever it is handed and registers a client declaring *that* URL; the
+  // registration is then kept deliberately, because re-registering orphans the
+  // grant the operator has just approved. So the second connect arrives on a
+  // different port carrying the first one's client and is refused —
+  // `redirect_uri not allowed`, before the consent page even renders.
+  //
+  // Supabase does this. Notion does not, because RFC 8252 §7.3 says a loopback
+  // redirect is matched without its port and Notion follows it — which is the
+  // only reason this survived as long as it did.
+  let server: ReturnType<typeof Bun.serve>;
+  try {
+    server = Bun.serve({ ...listener, port: options.port ?? 0 });
+  } catch {
+    // Taken: another connect in flight, or something else holding it. Falling
+    // back beats failing — a fresh port still works against every server that
+    // follows §7.3, and the one that does not is no worse off than before.
+    server = Bun.serve({ ...listener, port: 0 });
+  }
 
   return {
     redirectUri: `http://127.0.0.1:${server.port}/callback`,

--- a/src/cli/oauth.test.ts
+++ b/src/cli/oauth.test.ts
@@ -538,6 +538,54 @@ describe('a redirect the vendor matches exactly', () => {
     return port;
   }
 
+  /**
+   * The same problem one flow over, and the one that actually bit.
+   *
+   * `--auth` aside, a dynamically registered client hits this too. The first
+   * connect binds whatever the kernel hands out and registers a client
+   * declaring *that* URL; the registration is then kept deliberately, because
+   * re-registering orphans the grant the operator just approved. Every later
+   * connect asked for a new port and sent a URL that client never declared, so
+   * a vendor matching literally refused it before the consent page rendered —
+   * `redirect_uri not allowed`, seen against Supabase.
+   *
+   * Notion hid it: RFC 8252 §7.3 says a loopback redirect is matched without
+   * its port, and Notion follows that.
+   */
+  test('the listener asks for the port a kept registration already declared', async () => {
+    const first = captureOAuthCallback();
+    const port = Number(new URL(first.redirectUri).port);
+    await first.close();
+
+    const again = captureOAuthCallback({ port });
+
+    expect(new URL(again.redirectUri).port).toBe(String(port));
+    await again.close();
+  });
+
+  test('and takes a free one rather than failing when that port is held', async () => {
+    // Another connect in flight, or something else on it. Falling back beats
+    // failing: a fresh port still works against every server that follows
+    // §7.3, and the one that does not is no worse off than it was.
+    const holding = captureOAuthCallback();
+    const taken = Number(new URL(holding.redirectUri).port);
+
+    const second = captureOAuthCallback({ port: taken });
+
+    expect(new URL(second.redirectUri).port).not.toBe(String(taken));
+    expect(Number(new URL(second.redirectUri).port)).toBeGreaterThan(0);
+
+    await holding.close();
+    await second.close();
+  });
+
+  test('with no port asked for, it binds any free one as it always did', async () => {
+    const capture = captureOAuthCallback();
+
+    expect(Number(new URL(capture.redirectUri).port)).toBeGreaterThan(0);
+    await capture.close();
+  });
+
   test('the declared URL is what the vendor is told, verbatim', async () => {
     const port = freePort();
     const fixedRedirect = `http://127.0.0.1:${port}/callback`;

--- a/src/connectivity/manifest/identity.ts
+++ b/src/connectivity/manifest/identity.ts
@@ -23,7 +23,28 @@ import { z } from 'zod';
  * `field` is a dotted path. Resolution is best-effort by design: a provider with
  * no identity block, or one whose probe fails, falls back to asking the
  * operator. A connection is worth labelling, never worth blocking on.
+ *
+ * **A `field` must name one value, never a collection.** `pluck` walks into the
+ * first element of an array on the way past, so a path through a list resolves
+ * to whoever happens to be first and reads exactly like a working probe. That
+ * is the mistake `notion-get-users` would have made — the integration bot leads
+ * the list, not the person — and a confident wrong label is worse than the
+ * question it saves.
  */
+
+/**
+ * A second path, shown in brackets, where `field` alone is not unique.
+ *
+ * Almost no provider needs one: an address identifies a Google or iCloud
+ * account globally, and a GitHub login is unique across GitHub. The exceptions
+ * are the vendors whose "user" is scoped to a tenant — the same person in two
+ * Slack workspaces answers `auth.test` with the same `user`, and the same
+ * person in two Notion workspaces is the same email. One account string is how
+ * `settleIdentity` decides a connect is a *reconnect*, so without this,
+ * connecting a second tenant matches the first and overwrites its credential.
+ */
+const qualifier = z.string().min(1).optional();
+
 export const identitySchema = z.discriminatedUnion('kind', [
   z.object({
     kind: z.literal('http'),
@@ -31,23 +52,23 @@ export const identitySchema = z.discriminatedUnion('kind', [
     /** Dotted path into the JSON body, e.g. `emailAddress` or `user.emailAddress`. */
     field: z.string().min(1),
     /**
-     * A second path, shown in brackets, where `field` alone is not unique.
+     * Sent alongside the credential.
      *
-     * Almost no provider needs one: an address identifies a Google or iCloud
-     * account globally, and a GitHub login is unique across GitHub. Slack is
-     * the exception, because the thing it calls a user is scoped to a
-     * workspace — the same person in two workspaces answers `auth.test` with
-     * the same `user`, and one account string is how `settleIdentity` decides a
-     * connect is a *reconnect*. Without this, connecting a second workspace
-     * matches the first and overwrites its credential.
+     * For the APIs that answer nothing without one: Notion refuses a request
+     * carrying no `Notion-Version`, and it is not the only vendor that pins its
+     * version in a header rather than the path. The credential is added by the
+     * probe and cannot be set here — a manifest naming its own `authorization`
+     * would be a second, unaudited way to send one.
      */
-    qualifier: z.string().min(1).optional(),
+    headers: z.record(z.string(), z.string()).optional(),
+    qualifier,
   }),
   z.object({
     kind: z.literal('tool'),
     tool: z.string().min(1),
     field: z.string().min(1),
     arguments: z.record(z.string(), z.unknown()).default({}),
+    qualifier,
   }),
   z.object({ kind: z.literal('connector') }),
 ]);

--- a/src/profile/connections.test.ts
+++ b/src/profile/connections.test.ts
@@ -35,6 +35,30 @@ describe('defaultConnectionLabel', () => {
     expect(defaultConnectionLabel('Setup', undefined)).toBe('Setup');
   });
 
+  /**
+   * A qualified account keeps the half that tells it from its twin.
+   *
+   * `ada@example.com (Personal)` is what an identity block writes when one name
+   * spans two tenants — Notion's email is the same email in every workspace the
+   * person belongs to. Shortening on the `@` alone cut the bracket off, so both
+   * workspaces read `Notion (ada)` and the field that exists to tell them apart
+   * was the one nobody saw.
+   */
+  test('keeps the qualifier that makes two tenants two names', () => {
+    expect(defaultConnectionLabel('Notion', 'ada@example.com (Personal)')).toBe(
+      'Notion (ada (Personal))',
+    );
+    expect(defaultConnectionLabel('Notion', 'ada@example.com (Personal)')).not.toBe(
+      defaultConnectionLabel('Notion', 'ada@example.com (Acme)'),
+    );
+  });
+
+  test('and leaves a handle that was already qualified exactly as it was', () => {
+    // Slack's shape, unchanged: its `user` is a handle, so there is no `@` to
+    // shorten on and the whole string was already kept.
+    expect(defaultConnectionLabel('Slack', 'ada (Acme)')).toBe('Slack (ada (Acme))');
+  });
+
   test('an empty account is no account', () => {
     expect(defaultConnectionLabel('Gmail', '')).toBe('Gmail');
     // And an address with nothing before the `@` falls back to the whole of it

--- a/src/profile/connections.ts
+++ b/src/profile/connections.ts
@@ -45,11 +45,20 @@ export function defaultConnectionLabel(
 ): string {
   if (!account || account === providerName) return providerName;
 
+  // A qualified account — `ada (Acme)`, the shape an identity block writes when
+  // one name spans two tenants — is shortened on the name and keeps the
+  // bracket. Without this, two Notion workspaces resolve to the same address
+  // and shorten to the same label, so the field that exists to tell them apart
+  // is the one the reader never sees.
+  const qualified = /^(.*?)\s+(\([^()]*\))$/.exec(account);
+  const identity = qualified?.[1] ?? account;
+  const qualifier = qualified?.[2] ? ` ${qualified[2]}` : '';
+
   // Split on `@` and nothing else. A handle, an IBAN or a workspace name has no
   // "first part" that is safe to guess at: `Lanes HQ` cut at the space is
   // `Lanes`, which is a different workspace's name as often as not.
-  const local = account.split('@')[0];
-  return `${providerName} (${local || account})`;
+  const local = identity.split('@')[0];
+  return `${providerName} (${local || identity}${qualifier})`;
 }
 
 /**

--- a/src/providers/asana/index.ts
+++ b/src/providers/asana/index.ts
@@ -7,4 +7,17 @@ export const asana = defineProvider({
   description: 'Tasks, projects, portfolios, and workspaces, via Asana\'s official MCP server.',
   connector: { kind: 'mcp', endpoint: 'https://mcp.asana.com/mcp' },
   auth: { kind: 'oauth', registration: 'dynamic' },
+  /**
+   * No identity block. `GET /users/me?opt_fields=email` is documented and
+   * answers `data.email`, and it was written here on that reading — but Asana
+   * registers us dynamically at `mcp.asana.com`, and whether that token is
+   * accepted by `app.asana.com/api/1.0` is not documented either way.
+   *
+   * Supabase is why this was taken back out rather than left to fail closed.
+   * There, the authorization server *is* the API's own host, which is a much
+   * stronger reason to expect the token to work — and `GET /v1/profile` still
+   * answered "does not support oauth access yet". An MCP token is its own
+   * credential kind until a vendor says otherwise, so this one waits for
+   * somebody with an Asana account to try it.
+   */
 });

--- a/src/providers/box/index.ts
+++ b/src/providers/box/index.ts
@@ -27,6 +27,12 @@ export const box = defineProvider({
     token_url: 'https://api.box.com/oauth2/token',
     redirect_uri: BOX_REDIRECT_URI,
   },
+  /**
+   * `login` is Box's name for the primary email address, and the token here is
+   * an ordinary Box one — the operator registered the client and the flow
+   * redeems at `api.box.com`, so the API accepts it without question.
+   */
+  identity: { kind: 'http', url: 'https://api.box.com/2.0/users/me', field: 'login' },
   setup: {
     summary:
       'Box needs an OAuth app of your own. On a managed account an administrator can instead add ' +

--- a/src/providers/figma/index.ts
+++ b/src/providers/figma/index.ts
@@ -1,10 +1,48 @@
 import { defineProvider } from '#connectivity';
 
-/** Figma registers us at connect time — nothing for an operator to set up. */
+/**
+ * Figma, through the server Figma runs — and will not register us with.
+ *
+ * `api.figma.com` advertises a `registration_endpoint` and then refuses every
+ * request made to it with a bare `403 Forbidden`: an empty body earns the same
+ * refusal as a well-formed one, so the gate sits ahead of body validation, and
+ * neither a bearer token nor an `X-Figma-Token` moves it. Figma's own
+ * documentation says why — only clients listed in its MCP catalogue may
+ * connect, and a new client joins by waitlist. So this is an allowlist, not a
+ * plan to upgrade, a scope to widen, or a session to sign in to. There is no
+ * request that gets through.
+ *
+ * `registration` stays `dynamic` anyway, for two reasons. It is what Figma
+ * advertises and what we correctly attempt, and the day a client of ours is in
+ * that catalogue the declaration becomes true with nothing here to change.
+ * `manual` would be worse than imprecise: it promises an operator can supply a
+ * client of their own, and for an MCP client at Figma no console issues one.
+ * The honest third state — the vendor allowlists clients and offers no
+ * self-serve route — is not a value this field has, and `manifest/auth.ts`
+ * argues against growing it for one vendor. Prose carries it until a second
+ * vendor does the same.
+ *
+ * What the setup block is for: `connect/registration.ts` reads `docs_url` when
+ * a registration is refused, so the refusal points at the page that explains
+ * itself rather than at a bare hostname. It declares no prompts and so asks for
+ * nothing — `ensureOAuthApp` returns before rendering it, this provider naming
+ * no `app`.
+ */
 export const figma = defineProvider({
   id: 'figma',
   name: 'Figma',
   description: 'Files, designs, components, and Dev Mode context, via Figma\'s official MCP server.',
   connector: { kind: 'mcp', endpoint: 'https://mcp.figma.com/mcp' },
   auth: { kind: 'oauth', registration: 'dynamic' },
+  setup: {
+    summary:
+      'Figma admits only the MCP clients listed in its own catalogue, and a client joins that list ' +
+      'by waitlist rather than by registering. Nothing is asked for here because there is nothing ' +
+      'to paste: registration is refused before anything about your account is looked at.',
+    docs_url: 'https://developers.figma.com/docs/figma-mcp-server/',
+    troubleshooting:
+      'A 403 from the registration endpoint is the catalogue and not your account — the same ' +
+      'request is refused signed in, signed out, and with no body at all. Figma also ships a ' +
+      'desktop MCP server that needs no registration; it is a different endpoint, not this one.',
+  },
 });

--- a/src/providers/identity-coverage.test.ts
+++ b/src/providers/identity-coverage.test.ts
@@ -1,0 +1,149 @@
+import { describe, expect, test } from 'bun:test';
+import { PROVIDER_MANIFESTS } from './index.ts';
+
+/**
+ * Every provider can say whose account it is, or says why it cannot.
+ *
+ * `connect` resolves an identity from the manifest's `identity` block, then
+ * from the authorization server (`cli/introspection.ts`), and only then asks
+ * the operator. The prompt is the fallback and its own doc comment calls it
+ * one — but 75 of 105 manifests declared nothing, so for most of the catalogue
+ * it was the *only* path, and connecting meant typing your own address a second
+ * after authorising.
+ *
+ * The number will not come down on its own, and worse, it silently goes back up:
+ * a provider is fifteen lines of data, adding one costs nothing, and nothing
+ * about writing those fifteen lines raises the question. So the build raises it.
+ * A new provider either declares an identity block, authenticates to nothing, or
+ * is listed below with the reason — and the list is checked in both directions,
+ * so an entry cannot outlive the gap it records.
+ *
+ * **This is a ledger, not an allowlist.** Entries are meant to leave it.
+ */
+
+/**
+ * The sweep that has not happened yet, and what makes it slow.
+ *
+ * These are the hosted-MCP providers. Their tool lists are not published in a
+ * form that can be read here — every one of the servers refuses an
+ * unauthenticated `tools/list` with a 401 — so the identity call has to come
+ * from vendor documentation, one vendor at a time, and each block ships
+ * unverified until somebody with an account on that vendor connects.
+ *
+ * Neither generic route covers them: of the 80 MCP endpoints this repository
+ * names, five advertise RFC 7662 introspection and three advertise OIDC
+ * userinfo. That measurement is why the per-vendor work is the substance and
+ * the generic probe is the cheap part.
+ */
+const UNSWEPT =
+  'Hosted MCP server, not yet swept: `tools/list` is refused unauthenticated, so the identity call has to come from vendor documentation, and documentation does not say whether the MCP token is accepted by the vendor REST API.';
+
+const NO_IDENTITY: Readonly<Record<string, string>> = {
+  discord: 'Decided, not omitted, and written out in the provider: the stored credential is `Bot MTIz…`, so a bearer probe would send `Bearer Bot MTIz…` and earn a 401 on every connect.',
+  google_tasks: 'Decided, not omitted, and written out in the provider: nothing reachable under `auth/tasks` returns an address, and `userinfo.email` is a scope this provider has no other use for.',
+  asana: UNSWEPT,
+  bunq: 'Not swept. bunq authenticates through its own handshake rather than OAuth, so neither generic route applies, and its `/v1/user` shape has not been checked against what the strategy stores.',
+  stripe: UNSWEPT,
+  sentry: UNSWEPT,
+  supabase:
+    'Verified, not unswept: `GET /v1/profile` refuses an OAuth token ("does not support oauth access yet"), there is no userinfo, `/v1/user` or `/v1/me`, and what OAuth does reach — organizations, projects — is a collection.',
+  figma:
+    'Verified, not unswept: Figma admits only the MCP clients in its own catalogue and refuses registration with a bare 403 whatever is sent, so there is no connection here whose account there would be to name.',
+  canva: UNSWEPT,
+  dropbox: UNSWEPT,
+  todoist: UNSWEPT,
+  clickup: UNSWEPT,
+  monday: UNSWEPT,
+  airtable: UNSWEPT,
+  miro: UNSWEPT,
+  calendly: UNSWEPT,
+  close: UNSWEPT,
+  zapier: UNSWEPT,
+  paypal: UNSWEPT,
+  square: UNSWEPT,
+  mercury: UNSWEPT,
+  vercel: UNSWEPT,
+  netlify: UNSWEPT,
+  neon: UNSWEPT,
+  prisma: UNSWEPT,
+  sanity: UNSWEPT,
+  webflow: UNSWEPT,
+  wix: UNSWEPT,
+  datadog: UNSWEPT,
+  grafana: UNSWEPT,
+  fireflies: UNSWEPT,
+  gamma: UNSWEPT,
+  jam: UNSWEPT,
+  cloudflare_observability: UNSWEPT,
+  cloudflare_bindings: UNSWEPT,
+  atlassian: UNSWEPT,
+  hubspot: UNSWEPT,
+  render: UNSWEPT,
+  algolia: UNSWEPT,
+  amplitude: UNSWEPT,
+  apify: UNSWEPT,
+  attio: UNSWEPT,
+  betterstack: UNSWEPT,
+  brightdata: UNSWEPT,
+  buildkite: UNSWEPT,
+  circleci: UNSWEPT,
+  contentful: UNSWEPT,
+  expensify: UNSWEPT,
+  flagsmith: UNSWEPT,
+  heroku: UNSWEPT,
+  hygraph: UNSWEPT,
+  insightly: UNSWEPT,
+  klaviyo: UNSWEPT,
+  mixpanel: UNSWEPT,
+  mux: UNSWEPT,
+  navan: UNSWEPT,
+  paddle: UNSWEPT,
+  posthog: UNSWEPT,
+  ramp: UNSWEPT,
+  recurly: UNSWEPT,
+  remote: UNSWEPT,
+  replicate: UNSWEPT,
+  resend: UNSWEPT,
+  riverside: UNSWEPT,
+  rootly: UNSWEPT,
+  rudderstack: UNSWEPT,
+  salesloft: UNSWEPT,
+  shortcut: UNSWEPT,
+  storyblok: UNSWEPT,
+  tavily: UNSWEPT,
+  vimeo: UNSWEPT,
+  whimsical: UNSWEPT,
+  workable: UNSWEPT,
+};
+
+describe('identity coverage', () => {
+  const asks = PROVIDER_MANIFESTS.filter(
+    (manifest) => !manifest.identity && manifest.auth.kind !== 'none',
+  );
+
+  test('a provider that will ask the operator is one that said why it has to', () => {
+    // The owner layer is exempt without being listed: `auth.kind === 'none'`
+    // takes the `unaccounted` branch in `settleIdentity` and is named after its
+    // provider, so it never reaches the question.
+    const unexplained = asks.map((manifest) => manifest.id).filter((id) => !NO_IDENTITY[id]);
+
+    expect(unexplained).toEqual([]);
+  });
+
+  test('and an entry does not outlive the gap it records', () => {
+    // The half that makes this a ledger. Without it, a provider that gained an
+    // identity block would keep its excuse, and the list would stop meaning
+    // anything long before it stopped being read.
+    const stale = Object.keys(NO_IDENTITY).filter(
+      (id) => !asks.some((manifest) => manifest.id === id),
+    );
+
+    expect(stale).toEqual([]);
+  });
+
+  test('every reason is a reason, not a word typed to quiet the check', () => {
+    for (const [id, reason] of Object.entries(NO_IDENTITY)) {
+      expect(`${id}: ${reason}`.length).toBeGreaterThan(60);
+    }
+  });
+});

--- a/src/providers/notion/index.ts
+++ b/src/providers/notion/index.ts
@@ -11,9 +11,30 @@ export const notion = defineProvider({
   description: 'Pages, databases, comments, and workspace search, via Notion\'s official MCP server.',
   connector: { kind: 'mcp', endpoint: 'https://mcp.notion.com/mcp' },
   auth: { kind: 'oauth', registration: 'dynamic' },
-  // No identity block on purpose. Notion exposes no "who am I" tool:
-  // `get-users` leads with integration bots rather than the person, and
-  // `get-teams` returns teamspaces, which are not the workspace and may be in
-  // the trash. Both would produce a confident wrong label, so `connect` asks
-  // instead — the fallback exists for exactly this.
+  /**
+   * `notion-fetch` answers the id `self` with the workspace and the person.
+   *
+   * This block did not exist, and the note in its place said Notion exposes no
+   * "who am I" tool — that `get-users` leads with integration bots rather than
+   * the person and `get-teams` returns teamspaces, so both would produce a
+   * confident wrong label. That was true of those two tools and is no longer
+   * the whole picture: the hosted server renamed them under a `notion-` prefix
+   * and added `notion-fetch`, whose `self` returns the connected workspace's id
+   * and name alongside the authenticated user's id, name, type and email.
+   * Notion documents it for this exact purpose — labelling a connection after
+   * OAuth.
+   *
+   * The qualifier is not decoration. One person's email is the same email in
+   * every workspace they belong to, and the account is what `settleIdentity`
+   * matches a reconnect on — so without the workspace beside it, connecting a
+   * second workspace would repair the first row and overwrite its credential.
+   * Slack carries one for the same reason.
+   */
+  identity: {
+    kind: 'tool',
+    tool: 'notion-fetch',
+    arguments: { id: 'self' },
+    field: 'self.user.email',
+    qualifier: 'self.workspace.name',
+  },
 });

--- a/src/providers/supabase/index.ts
+++ b/src/providers/supabase/index.ts
@@ -7,4 +7,21 @@ export const supabase = defineProvider({
   description: 'Projects, database schema, SQL, edge functions, and docs, via Supabase\'s official MCP server.',
   connector: { kind: 'mcp', endpoint: 'https://mcp.supabase.com/mcp' },
   auth: { kind: 'oauth', registration: 'dynamic' },
+  /**
+   * No identity block, and it is a verified refusal rather than an omission.
+   *
+   * Supabase's authorization server *is* `api.supabase.com`, so the MCP token
+   * is an ordinary Management API one and the endpoint that names a person
+   * looked like a free answer. It is not: `GET /v1/profile` refuses that token
+   * outright — 401, "does not support oauth access yet" — and it is not a
+   * scope, since none is advertised that would cover it. There is no
+   * `/v1/user`, `/v1/me`, or userinfo; all three are 404.
+   *
+   * What OAuth does reach is `/v1/organizations` and `/v1/projects`, and both
+   * are collections. A `field` through a collection resolves to whichever
+   * element happens to be first, which is arbitrary for anyone in more than one
+   * organization and, worse, unstable — a reconnect that resolved a different
+   * one would append a row instead of repairing it. That is the failure the
+   * account field exists to prevent.
+   */
 });


### PR DESCRIPTION
The release. `package.json` says `0.9.6` and no `v0.9.6` tag exists, so the merge takes the
*publish* path: `release.yml` cuts the tag and publishes to npm under this repository's OIDC
identity, and `main` and `develop` end up on the same tree.

**Merged, not squashed.** A squash writes a new commit onto `main`, `develop`'s tip stops being an
ancestor, and the fast-forward back is then rejected as non-fast-forward even though the trees are
identical.

## What ships

**A connection names its own account** ([#160](https://github.com/lanes-sh/link/pull/160)).
Identity resolves from the manifest, the connector, then the authorization server — RFC 7662
introspection, then OIDC userinfo — and the operator is asked last. That prompt's own doc comment
called it a last resort; for 75 of 105 provider definitions it was the only path, so authorising
and then typing your own address was the normal experience. The typed answer is also the key a
reconnect matches on, the source of the default label, and what `gmail.send_message` puts in a
`From` header.

Also in it, both found by connecting a *second* time:

- The callback listener bound a fresh port on every run while the client registration kept from
  the first run declares one fixed `http://127.0.0.1:<port>/callback`. Every reconnect therefore
  presented a redirect URI its own client had never declared. Notion masked it by matching loopback
  redirects without the port (RFC 8252 §7.3) — the only provider anyone had reconnected was the one
  that could not fail.
- Figma's manifest promised a dynamic registration Figma does not offer: only clients in its own
  catalogue may connect, and registration is refused before anything about the request is read.

**A contributor's own handle is a real identifier** ([#161](https://github.com/lanes-sh/link/pull/161)).
`architecture.test.ts` derives it from `git config` at run time, so the check protects whoever is
committing rather than one name written into the tree.

**The admission register** ([#164](https://github.com/lanes-sh/link/pull/164)) — where a vendor
admits the client rather than the operator, so a failure nobody can type their way out of is
recognisable as one.

Plus [#163](https://github.com/lanes-sh/link/pull/163) and
[#157](https://github.com/lanes-sh/link/pull/157).

## After the merge

The release is finished when `develop` and `main` are 0/0, not when npm has the version:
`git push origin origin/main:refs/heads/develop`, then `git rev-list --count` in both directions.