### PR TITLE
0.10.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lanes-sh/link",
-  "version": "0.9.6",
+  "version": "0.10.0",
   "description": "A self-hostable MCP gateway for all your connections, memory, tasks, files, and secrets",
   "license": "Apache-2.0",
   "homepage": "https://lanes.sh/link",

--- a/src/cli/argv.test.ts
+++ b/src/cli/argv.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from 'bun:test';
 import { globalFlags, normaliseWorkspace, ownerFlags, parseArgv, text } from './argv.ts';
-import { PROGRAM, USAGE } from './usage.ts';
+import { PROGRAM, usage } from './usage.ts';
 
 /**
  * The parser had no tests because it could not have any: it lived inside the
@@ -71,7 +71,11 @@ describe('the program name', () => {
   test('every command line in the usage text is spelled with it', () => {
     // The guard against a rename that edits the constant and leaves the help
     // text behind — or vice versa.
-    const commands = USAGE.split('\n').filter((line) => /^ {2}\w/.test(line));
+    // Pinned to eighty rather than the terminal's width: `usage` is rendered
+    // now, and an inherited COLUMNS would otherwise decide what this parses.
+    const commands = usage(80)
+      .split('\n')
+      .filter((line: string) => /^ {2}\w/.test(line));
     expect(commands.length).toBeGreaterThan(20);
     for (const line of commands) expect(line.trimStart().startsWith(PROGRAM)).toBe(true);
   });
@@ -80,8 +84,8 @@ describe('the program name', () => {
     // Assembled rather than written out, so the tree-wide grep that proves the
     // old name is gone does not trip over the test that forbids it.
     const runTogether = ['lanes', 'link'].join('');
-    expect(USAGE.toLowerCase()).not.toContain(runTogether);
-    expect(USAGE).not.toContain('lanes-link');
+    expect(usage(80).toLowerCase()).not.toContain(runTogether);
+    expect(usage(80)).not.toContain('lanes-link');
   });
 });
 

--- a/src/cli/commands/auth.ts
+++ b/src/cli/commands/auth.ts
@@ -1,7 +1,7 @@
 import { clearSession, isFresh, readSession } from '#auth/lanes/session.ts';
 import { DEFAULT_API_URL, currentIdToken, login } from '#auth/lanes/login.ts';
 import { completionPage } from '../callback-page.ts';
-import { print, ok, style, warn } from '../output.ts';
+import { print, ok, prose, style, warn } from '../output.ts';
 
 /**
  * `lanes auth` — who this machine is signed in as.
@@ -62,12 +62,10 @@ export async function authLogin(flags: AuthFlags = {}): Promise<void> {
   print(ok(`signed in as ${style.bold(session.email ?? session.subject)}`));
   print(style.dim(`      subject  ${session.subject}`));
   print('');
-  print(
-    style.dim(
-      '      A profile reaches you only where its members list that subject:\n' +
-        '        lanes link profile members add <subject> --profile <name>',
-    ),
-  );
+  prose('      A profile reaches you only where its members list that subject:', {
+    paint: style.dim,
+  });
+  print(style.dim('        lanes link profile members add <subject> --profile <name>'));
   void opened;
 }
 
@@ -89,12 +87,11 @@ export async function authLogout(flags: AuthFlags = {}): Promise<void> {
   // Said out loud, because it is the surprising half. Signing out removes the
   // identity this machine presents; it does not touch a profile's members list,
   // and it does not revoke a token an agent already holds.
-  print(
-    style.dim(
-      '      Profiles still list you, and a client holding a token still holds it.\n' +
-        '      To take a token back: lanes link token rotate --workspace <name>',
-    ),
-  );
+  prose('      Profiles still list you, and a client holding a token still holds it.', {
+    paint: style.dim,
+  });
+  prose('      To take a token back:', { paint: style.dim });
+  print(style.dim('        lanes link token rotate --workspace <name>'));
 }
 
 export async function authStatus(flags: AuthFlags = {}): Promise<void> {
@@ -204,11 +201,9 @@ export async function authWorkspaces(flags: AuthFlags = {}): Promise<void> {
   }
 
   print('');
-  print(
-    style.dim(
-      'A remote lanes link workspace binds to one of these with `lanes_workspace:`\n' +
-        'in lanes-link.yaml, which is whose members a profile may delegate to.',
-    ),
+  prose(
+    'A remote lanes link workspace binds to one of these with `lanes_workspace:` in lanes-link.yaml, which is whose members a profile may delegate to.',
+    { paint: style.dim },
   );
 }
 

--- a/src/cli/commands/connect/assertion.ts
+++ b/src/cli/commands/connect/assertion.ts
@@ -172,7 +172,7 @@ async function askForSubject(
 
   progress();
   const answer = await prompter.ask(
-    `  ${assertion.subject_label}${optional ? style.dim(' [none]') : ''}`,
+    `${assertion.subject_label}${optional ? style.dim(' [none]') : ''}`,
   );
 
   if (answer.length > 0) return answer;

--- a/src/cli/commands/connect/client.ts
+++ b/src/cli/commands/connect/client.ts
@@ -9,7 +9,7 @@ import { CredentialOAuthProvider } from '#connectivity/auth/index.ts';
 import { hasOwnClientPath, type ProviderManifest } from '#connectivity';
 import type { SecretStore } from '#secrets';
 import { ConfigDocument } from '../../config-edit.ts';
-import { progress, style, warn } from '../../output.ts';
+import { progress, prose, style, warn } from '../../output.ts';
 import type { Prompter } from '../../prompt.ts';
 import { shortScope } from '../../scopes.ts';
 import { declareOwnClient, ensureOAuthApp } from './setup.ts';
@@ -76,12 +76,11 @@ export async function resolveOAuthClient(input: ClientChoice): Promise<OAuthClie
   const insteadOfOwn = input.client === 'hosted' && broker !== undefined && hasOwnClient;
 
   if (insteadOfOwn) {
-    progress(
-      style.dim(
-        `This profile has an OAuth client of its own, and this connection is being authorised ` +
-          `against ${broker.operator}'s instead. Existing connections are unaffected — they keep ` +
-          `refreshing against the client that issued them.`,
-      ),
+    prose(
+      `This profile has an OAuth client of its own, and this connection is being authorised ` +
+        `against ${broker.operator}'s instead. Existing connections are unaffected — they keep ` +
+        `refreshing against the client that issued them.`,
+      { paint: style.dim, to: progress },
     );
   }
 
@@ -126,11 +125,10 @@ export async function resolveOAuthClient(input: ClientChoice): Promise<OAuthClie
   // authorization code somewhere other than where the operator believes.
   const overridden = brokerOriginOverride();
   if (overridden) {
-    progress(
-      warn(
-        `${BROKER_ORIGIN_ENV} is set — the authorization code will be exchanged at ${overridden}, ` +
-          `not by ${broker.operator}.`,
-      ),
+    prose(
+      `${BROKER_ORIGIN_ENV} is set — the authorization code will be exchanged at ${overridden}, ` +
+        `not by ${broker.operator}.`,
+      { prefix: warn(''), to: progress },
     );
   }
 
@@ -185,19 +183,17 @@ export async function resolveOAuthClient(input: ClientChoice): Promise<OAuthClie
     if (left <= 10) {
       // `warn` formats; `progress` is what puts it on the stream. Called bare it
       // builds the sentence and drops it, which is how this one went unsaid.
-      progress(
-        warn(
-          `The ${broker.operator} client is near capacity (${config.capacity.accounts} of ${config.capacity.cap} accounts).`,
-        ),
+      prose(
+        `The ${broker.operator} client is near capacity (${config.capacity.accounts} of ${config.capacity.cap} accounts).`,
+        { prefix: warn(''), to: progress },
       );
     }
   }
 
-  progress(
-    style.dim(
-      `Authorising against the OAuth client ${broker.operator} operates — nothing to register.`,
-    ),
-  );
+  prose(`Authorising against the OAuth client ${broker.operator} operates — nothing to register.`, {
+    paint: style.dim,
+    to: progress,
+  });
 
   return { kind: 'brokered', url: broker.url, config };
 }

--- a/src/cli/commands/connect/custom/ask.test.ts
+++ b/src/cli/commands/connect/custom/ask.test.ts
@@ -60,9 +60,9 @@ describe('what the flags did not say is asked for', () => {
     expect('missing' in result).toBe(false);
     // Counted from the lists rather than written down: a member landing in
     // either union is not a reason for this test to fail.
-    expect(prompter.asked[0]).toBe(`Choose 1-${CONNECTOR_KINDS.length}:`);
-    expect(prompter.asked[1]).toBe(`Choose 1-${AUTH_METHODS.length}:`);
-    expect(prompter.asked.slice(2, 4)).toEqual(['Base URL:', 'OpenAPI document:']);
+    expect(prompter.asked[0]).toBe(`Choose 1-${CONNECTOR_KINDS.length}`);
+    expect(prompter.asked[1]).toBe(`Choose 1-${AUTH_METHODS.length}`);
+    expect(prompter.asked.slice(2, 4)).toEqual(['Base URL', 'OpenAPI document']);
   });
 
   test('a member can be typed by name instead of counted', async () => {
@@ -85,7 +85,7 @@ describe('what the flags did not say is asked for', () => {
     const prompter = answering('https://mcp.example.com/mcp', '');
     await gather({ connector: 'mcp', auth: 'none' }, prompter);
 
-    expect(prompter.asked).toEqual(['MCP endpoint:', 'Display name [Thing]:']);
+    expect(prompter.asked).toEqual(['MCP endpoint', 'Display name [Thing]']);
   });
 
   test('the display name defaults to the id, read as words', async () => {

--- a/src/cli/commands/connect/custom/ask.ts
+++ b/src/cli/commands/connect/custom/ask.ts
@@ -1,4 +1,4 @@
-import { style } from '../../../output.ts';
+import { progress, style } from '../../../output.ts';
 import type { Prompter } from '../../../prompt.ts';
 import { parseAuthMethod, parseConnectorKind, refuseIllegalPair } from './derive.ts';
 import {
@@ -123,13 +123,13 @@ const EXTRA: readonly FieldSpec[] = [
 ];
 
 async function askFor(prompter: Prompter, field: FieldSpec): Promise<string> {
-  if (field.hint) print(style.dim(`  ${field.hint}`));
-  return (await prompter.ask(`${field.label}: `)).trim();
+  if (field.hint) progress(style.dim(`  ${field.hint}`));
+  return (await prompter.ask(field.label)).trim();
 }
 
 async function askName(prompter: Prompter, id: string): Promise<string> {
   const suggested = titleCase(id);
-  const answer = (await prompter.ask(`Display name [${suggested}]: `)).trim();
+  const answer = (await prompter.ask(`Display name [${suggested}]`)).trim();
   return answer.length > 0 ? answer : suggested;
 }
 
@@ -146,11 +146,11 @@ async function choose(
   question: string,
   options: readonly string[],
 ): Promise<string> {
-  print('');
-  print(question);
-  options.forEach((option, index) => print(`  ${index + 1}. ${option}`));
+  progress();
+  progress(question);
+  options.forEach((option, index) => progress(`  ${index + 1}. ${option}`));
 
-  const answer = (await prompter.ask(`Choose 1-${options.length}: `)).trim();
+  const answer = (await prompter.ask(`Choose 1-${options.length}`)).trim();
   const index = Number(answer);
 
   // A name is accepted too. Somebody who already knows it should not have to
@@ -159,9 +159,4 @@ async function choose(
   if (Number.isInteger(index) && index >= 1 && index <= options.length) return options[index - 1]!;
 
   throw new Error(`"${answer}" is not one of: ${options.join(', ')}.`);
-}
-
-/** Prompts and their hints go to stderr, so `--json` leaves stdout clean. */
-function print(line: string): void {
-  process.stderr.write(`${line}\n`);
 }

--- a/src/cli/commands/connect/method.ts
+++ b/src/cli/commands/connect/method.ts
@@ -219,7 +219,7 @@ async function ask(
   );
   progress();
 
-  const answer = await prompter.ask(`  Which ${style.dim(`[${preferred}]`)}`);
+  const answer = await prompter.ask(`Which ${style.dim(`[${preferred}]`)}`);
   const picked = answer.length === 0 ? preferred : answer;
 
   const byNumber = available[Number(picked) - 1];

--- a/src/cli/commands/connect/outcome.ts
+++ b/src/cli/commands/connect/outcome.ts
@@ -1,5 +1,5 @@
 import type { SetupRequirement } from '#connectivity';
-import { fail, ok, print, progress, style } from '../../output.ts';
+import { fail, ok, print, progress, prose, style } from '../../output.ts';
 import type { Blocked } from './requirements.ts';
 
 /**
@@ -124,8 +124,9 @@ export function renderOutcome(outcome: ConnectOutcome): void {
 
     if ((outcome.writable ?? 0) > 0) {
       const provider = outcome.key?.split('.')[0] ?? '';
-      print(
-        `      ${style.dim(`${outcome.writable} of them write — lanes link policy deny ${provider}.<capability> to withhold one`)}`,
+      prose(
+        `      ${outcome.writable} of them write — lanes link policy deny ${provider}.<capability> to withhold one`,
+        { paint: style.dim },
       );
     }
   }

--- a/src/cli/commands/connect/scopes-gate.ts
+++ b/src/cli/commands/connect/scopes-gate.ts
@@ -1,6 +1,6 @@
 import { discoverOAuthProtectedResourceMetadata } from '@modelcontextprotocol/client';
 import type { ProviderManifest } from '#connectivity';
-import { progress, style, warn } from '../../output.ts';
+import { progress, prose, style, warn } from '../../output.ts';
 import type { Prompter } from '../../prompt.ts';
 import { describeScopes, shortScope } from '../../scopes.ts';
 
@@ -46,22 +46,23 @@ async function reportScopeDrift(pinned: readonly string[], serverUrl: string): P
 
   if (missing.length > 0) {
     progress('');
-    progress(
-      style.dim(
-        `${new URL(serverUrl).host} advertises ${missing.length} scope(s) not requested: ` +
-          `${missing.map(shortScope).join(', ')}.`,
-      ),
+    prose(
+      `${new URL(serverUrl).host} advertises ${missing.length} scope(s) not requested: ` +
+        `${missing.map(shortScope).join(', ')}.`,
+      { paint: style.dim, to: progress },
     );
-    progress(
-      style.dim(
-        '  Deliberate — an advertised scope is not necessarily a required one, and these are broader than the docs ask for. Worth revisiting only if calls fail on permission.',
-      ),
+    prose(
+      '  Deliberate — an advertised scope is not necessarily a required one, and these are broader than the docs ask for. Worth revisiting only if calls fail on permission.',
+      { paint: style.dim, to: progress },
     );
   }
 
   if (extra.length > 0) {
     progress('');
-    progress(style.dim(`Note: ${extra.map(shortScope).join(', ')} is no longer declared by the server.`));
+    prose(`Note: ${extra.map(shortScope).join(', ')} is no longer declared by the server.`, {
+      paint: style.dim,
+      to: progress,
+    });
   }
 }
 
@@ -108,16 +109,14 @@ export async function confirmScopes(
   // Why the broad ones cannot simply be dropped — otherwise the obvious next
   // question is why we ask instead of asking for less.
   progress('');
-  progress(
-    warn(
-      'The marked scopes are broader than this provider needs. Grant them only if you ' +
-        'mean to — policy can restrict what an agent calls, but it cannot un-grant a token.',
-    ),
+  prose(
+    'The marked scopes are broader than this provider needs. Grant them only if you ' +
+      'mean to — policy can restrict what an agent calls, but it cannot un-grant a token.',
+    { prefix: warn(''), to: progress },
   );
-  progress(
-    style.dim(
-      '  Policy still applies: only capabilities you allow are reachable, and every call is audited.',
-    ),
+  prose(
+    '  Policy still applies: only capabilities you allow are reachable, and every call is audited.',
+    { paint: style.dim, to: progress },
   );
   progress('');
 

--- a/src/cli/commands/connect/setup.ts
+++ b/src/cli/commands/connect/setup.ts
@@ -2,7 +2,7 @@ import type { SecretStore } from '#secrets';
 import type { ProviderManifest, SetupDeclaration, SetupPrompt } from '#connectivity';
 import { credentialRefForConnection } from '#connectivity';
 import { ConfigDocument } from '../../config-edit.ts';
-import { ok, progress, style } from '../../output.ts';
+import { divider, heading, ok, paint, progress, prose, steps, style } from '../../output.ts';
 import { terminalPrompter, type Prompter } from '../../prompt.ts';
 
 /**
@@ -41,15 +41,26 @@ export function printSetup(
   const setup = declaration;
   if (!setup) return;
 
+  // Every line of this goes to stderr, which is why each block is handed
+  // `progress`. The instructions are narration; stdout belongs to whatever the
+  // command returns, and a `--json` connect must still be parseable.
+  heading(`Setting up ${manifest.name}`, progress);
   progress();
-  progress(style.bold(`Setting up ${manifest.name}`));
-  if (setup.summary) progress(setup.summary);
-  if (setup.docs_url) progress(style.dim(setup.docs_url));
+
+  if (setup.summary) prose(setup.summary, { paint: paint.muted, to: progress });
+  if (setup.docs_url) progress(paint.link(setup.docs_url));
+
+  if (setup.steps.length > 0) {
+    progress();
+    steps(setup.steps, progress);
+  }
+
   progress();
-  setup.steps.forEach((step, index) => progress(`  ${index + 1}. ${step}`));
-  progress();
-  progress(style.dim(note));
-  progress();
+  prose(note, { paint: paint.muted, to: progress });
+
+  // Closed rather than left open, because what follows is a prompt. Without a
+  // rule the question reads as an eighth step.
+  divider(progress);
 }
 
 /**
@@ -79,8 +90,8 @@ export async function askForSetup(
   const answers = new Map<string, string>();
   for (const prompt of prompts) {
     const value = prompt.secret
-      ? await prompter.askSecret(`  ${prompt.label}`)
-      : await prompter.ask(`  ${prompt.label}`);
+      ? await prompter.askSecret(prompt.label)
+      : await prompter.ask(prompt.label);
     if (!value) throw new Error(`${prompt.label} is required.`);
     answers.set(prompt.key, value);
   }

--- a/src/cli/commands/knowledge/setup.ts
+++ b/src/cli/commands/knowledge/setup.ts
@@ -2,7 +2,7 @@ import { ConfigError, type KnowledgeConfig } from '#profile';
 import type { SecretStore } from '#secrets';
 import { GithubRepository, type RepositoryFacts } from '#deployments/adapters/github-repo.ts';
 import type { FetchLike } from '#deployments/knowledge.ts';
-import { heading, print, style } from '../../output.ts';
+import { heading, print, prose, steps, style } from '../../output.ts';
 import { askSecret, isInteractive } from '../../prompt.ts';
 
 /**
@@ -36,11 +36,13 @@ const STEPS = [
 
 export function printSetupSteps(repo: string): void {
   heading('A token for this repository');
-  print(style.dim(`  Storing memory and skills in ${repo} needs a token that may write to it.`));
+  prose(`  Storing memory and skills in ${repo} needs a token that may write to it.`, {
+    paint: style.dim,
+  });
   print('');
-  for (const [index, step] of STEPS.entries()) {
-    print(`  ${style.dim(`${index + 1}.`)} ${step.replace(/\*\*(.+?)\*\*/g, (_, inner: string) => style.bold(inner))}`);
-  }
+  // The emphasis is resolved before `steps` sees it, because the markers are
+  // this file's convention rather than something the layout should know about.
+  steps(STEPS.map((step) => step.replace(/\*\*(.+?)\*\*/g, (_, inner: string) => style.bold(inner))));
   print('');
 }
 
@@ -82,7 +84,7 @@ export async function resolveToken(
   }
 
   printSetupSteps(repo);
-  const token = await askSecret('  GitHub personal access token');
+  const token = await askSecret('GitHub personal access token');
   if (!token) throw new ConfigError('No token given, so nothing was changed.');
   return token;
 }

--- a/src/cli/commands/operate/outputs.ts
+++ b/src/cli/commands/operate/outputs.ts
@@ -1,7 +1,7 @@
 import { anyIssuedToken, listProfiles } from '#profile';
 import { fileURLToPath } from 'node:url';
 import { deployedUrl, endpointHealth, localUrl } from '../../endpoint-url.ts';
-import { announceWorkspace, heading, print, style, warn } from '../../output.ts';
+import { announceWorkspace, heading, print, prose, style, warn } from '../../output.ts';
 import { openWorkspaceRuntime, type GlobalFlags } from '../../runtime.ts';
 
 export interface OutputsFlags extends GlobalFlags {
@@ -80,17 +80,16 @@ export async function outputs(flags: OutputsFlags): Promise<void> {
       // The URL is the platform's, not the configured host and port: those
       // govern where `lanes link start` listens locally and mean nothing to a
       // deployed revision, which listens on whatever $PORT it was given.
-      print(style.dim(`  ${declared.platform} service "${declared.service}" for target "${runtime.target}".`));
+      prose(`  ${declared.platform} service "${declared.service}" for target "${runtime.target}".`, {
+        paint: style.dim,
+      });
     }
 
     heading(`Profiles served by it (${profiles.length})`);
     for (const profile of profiles) print(`  ${profile}`);
-    print(
-      style.dim(
-        '  Each call names one, in its `profile` argument. Which of these a client\n' +
-          '  actually reaches is decided by who signs in — every profile whose members\n' +
-          '  list them, and no others.',
-      ),
+    prose(
+      '  Each call names one, in its `profile` argument. Which of these a client actually reaches is decided by who signs in — every profile whose members list them, and no others.',
+      { paint: style.dim },
     );
 
     if (flags.show && token !== undefined) {
@@ -99,11 +98,9 @@ export async function outputs(flags: OutputsFlags): Promise<void> {
     }
 
     heading('Register with your agent');
-    print(
-      style.dim(
-        '  Not run for you: which config file an agent reads is its business, not ours.',
-      ),
-    );
+    prose('  Not run for you: which config file an agent reads is its business, not ours.', {
+      paint: style.dim,
+    });
     print('');
 
     // **The bare URL, and no header** (ADR-062). This printed the
@@ -115,24 +112,18 @@ export async function outputs(flags: OutputsFlags): Promise<void> {
     // in instead.
     print(`  claude mcp add --transport http lanes-link ${url}`);
     print('');
-    print(
-      style.dim(
-        '  No credential goes into that command. The client reads this endpoint\'s\n' +
-          '  protected-resource document, sends its owner to sign in, and comes back\n' +
-          '  holding a token of its own — so a config file synced to a dotfiles repo\n' +
-          '  is not a leak, and rotating a static token does not invalidate it.',
-      ),
+    prose(
+      "  No credential goes into that command. The client reads this endpoint's protected-resource document, sends its owner to sign in, and comes back holding a token of its own — so a config file synced to a dotfiles repo is not a leak, and rotating a static token does not invalidate it.",
+      { paint: style.dim },
     );
 
     heading('For a machine with no browser');
     if (token === undefined) {
       print(style.dim('  No static token is issued in this workspace.'));
-      print(
-        style.dim(
-          `      lanes link token issue --me --workspace ${runtime.target}\n` +
-            '  It reaches the profiles that list your subject as a member, and nothing else.',
-        ),
-      );
+      print(style.dim(`      lanes link token issue --me --workspace ${runtime.target}`));
+      prose('  It reaches the profiles that list your subject as a member, and nothing else.', {
+        paint: style.dim,
+      });
     } else {
       const invocation = await tokenInvocation(runtime.resolution.target);
       print(
@@ -146,17 +137,15 @@ export async function outputs(flags: OutputsFlags): Promise<void> {
         // the only symptom is a 401 that looks like a bad token rather than a
         // missing binary.
         print(warn('lanes is not on your PATH, so the short form would substitute to nothing.'));
-        print(style.dim('  The command above uses this checkout instead. To shorten it permanently:'));
+        prose('  The command above uses this checkout instead. To shorten it permanently:', {
+          paint: style.dim,
+        });
         print(`      cd ${process.cwd()} && bun link`);
         print('');
       }
-      print(
-        style.dim(
-          '  CI only, and it is narrower than it looks: the token reaches the profiles\n' +
-            '  its subject is a member of. The $(…) keeps it out of your agent\'s context\n' +
-            '  and out of the transcript, but it resolves once and is stored as a literal —\n' +
-            '  so a rotate means registering again.',
-        ),
+      prose(
+        "  CI only, and it is narrower than it looks: the token reaches the profiles its subject is a member of. The $(…) keeps it out of your agent's context and out of the transcript, but it resolves once and is stored as a literal — so a rotate means registering again.",
+        { paint: style.dim },
       );
     }
   } finally {

--- a/src/cli/commands/operate/status.ts
+++ b/src/cli/commands/operate/status.ts
@@ -11,7 +11,7 @@ import {
 } from '#profile';
 import { oneProfile, visibleCapabilities } from '#server/mcp';
 import { toPolicyDocument } from '#registry';
-import { announce, emit, heading, print, style, table } from '../../output.ts';
+import { announce, emit, heading, print, prose, style, table } from '../../output.ts';
 import { grantedConnections, openRuntime, ownerPrincipal, type GlobalFlags } from '../../runtime.ts';
 import { deploymentIdentity } from '../../endpoint-url.ts';
 
@@ -140,12 +140,8 @@ export async function status(flags: StatusFlags): Promise<void> {
         } else {
           const { platform, service, region } = deployment;
           print(`  ${platform} service ${style.bold(service)} in ${region}`);
-          print(
-            style.dim(
-              '  the address is the platform\'s to assign — run: ' +
-                `lanes link outputs --workspace ${runtime.target}`,
-            ),
-          );
+          prose("  the address is the platform's to assign — run:", { paint: style.dim });
+          print(style.dim(`    lanes link outputs --workspace ${runtime.target}`));
         }
       },
     );
@@ -262,10 +258,10 @@ async function workspaceStatus(flags: StatusFlags): Promise<void> {
       }
 
       print(`  ${deployment.platform} service ${style.bold(deployment.service)} in ${deployment.region}`);
+      prose("  the address is the platform's to assign — run:", { paint: style.dim });
       print(
         style.dim(
-          "  the address is the platform's to assign — run: " +
-            `lanes link outputs --workspace ${target} --profile ${profiles[0]?.name ?? '<name>'}`,
+          `    lanes link outputs --workspace ${target} --profile ${profiles[0]?.name ?? '<name>'}`,
         ),
       );
     },

--- a/src/cli/commands/profile/disposition.ts
+++ b/src/cli/commands/profile/disposition.ts
@@ -78,14 +78,14 @@ export async function settleDisposition(
   const answer = (
     await prompter.ask(
       `What becomes of ${profile}'s memory, tasks, assets and skills?\n` +
-        `  [d] delete them   [m] move them into another profile   [anything else] stop: `,
+        `  [d] delete them   [m] move them into another profile   [anything else] stop`,
     )
   ).trim().toLowerCase();
 
   if (answer === 'd') return { kind: 'delete' };
   if (answer !== 'm') return null;
 
-  const into = (await prompter.ask('  Move them into which profile? ')).trim();
+  const into = (await prompter.ask('Move them into which profile?')).trim();
   return into.length === 0 ? null : { kind: 'migrate', into };
 }
 

--- a/src/cli/commands/profile/remove.ts
+++ b/src/cli/commands/profile/remove.ts
@@ -261,7 +261,7 @@ export async function confirmedByName(
     );
   }
 
-  const typed = (await prompter.ask(`Type ${profile} to remove it, or anything else to stop: `))
+  const typed = (await prompter.ask(`Type ${profile} to remove it, or anything else to stop`))
     .trim();
 
   if (typed !== profile) {

--- a/src/cli/commands/setup.ts
+++ b/src/cli/commands/setup.ts
@@ -1,5 +1,5 @@
 import { planAll, planFor, type ProviderPlan } from '#providers/setup/plan.ts';
-import { announce, emit, heading, print, style, table } from '../output.ts';
+import { announce, emit, heading, paint, print, prose, steps, style, table } from '../output.ts';
 import { missingRequirements } from './connect/requirements.ts';
 import { openRuntime, type GlobalFlags } from '../runtime.ts';
 
@@ -95,9 +95,9 @@ export async function setupPlan(provider: string | undefined, flags: SetupFlags)
 
 function renderOne(plan: ProviderPlan, missing: ReadonlySet<string>): void {
   heading(plan.name);
-  print(`  ${plan.description}`);
-  if (plan.summary) print(`  ${plan.summary}`);
-  if (plan.docsUrl) print(`  ${style.dim(plan.docsUrl)}`);
+  prose(`  ${plan.description}`);
+  if (plan.summary) prose(`  ${plan.summary}`, { paint: paint.muted });
+  if (plan.docsUrl) print(`  ${paint.link(plan.docsUrl)}`);
 
   if (plan.connected.length > 0) {
     print();
@@ -106,13 +106,14 @@ function renderOne(plan: ProviderPlan, missing: ReadonlySet<string>): void {
 
   if (plan.steps.length > 0 && !plan.brokered) {
     heading('First, in the vendor’s console');
-    plan.steps.forEach((step, index) => print(`  ${index + 1}. ${step}`));
+    steps(plan.steps);
   }
 
   if (plan.brokered) {
     heading('Values it needs');
-    print(
-      `  ${style.dim(`none — the OAuth client is operated by ${plan.clientOperator}, and its secret never reaches this machine.`)}`,
+    prose(
+      `  none — the OAuth client is operated by ${plan.clientOperator}, and its secret never reaches this machine.`,
+      { paint: paint.muted },
     );
   }
 
@@ -136,7 +137,7 @@ function renderOne(plan: ProviderPlan, missing: ReadonlySet<string>): void {
     heading('Where it is');
     for (const variable of plan.variables) {
       print(`  ${style.bold(variable.label)}  ${style.dim(`e.g. ${variable.example}`)}`);
-      print(`    ${style.dim(variable.description)}`);
+      prose(`    ${variable.description}`, { paint: paint.muted });
     }
   }
 
@@ -152,7 +153,7 @@ function renderOne(plan: ProviderPlan, missing: ReadonlySet<string>): void {
     print(`  ${plan.ownClientCommand}`);
     if (plan.steps.length > 0) {
       print();
-      plan.steps.forEach((step, index) => print(`  ${index + 1}. ${step}`));
+      steps(plan.steps);
     }
   }
 
@@ -161,18 +162,17 @@ function renderOne(plan: ProviderPlan, missing: ReadonlySet<string>): void {
   if (plan.tokenCommand && plan.pastedCredential) {
     heading('Or paste a token you already hold');
     print(`  ${plan.tokenCommand}`);
-    print(`  ${style.dim(`Asks for the ${plan.pastedCredential}.`)}`);
+    prose(`  Asks for the ${plan.pastedCredential}.`, { paint: paint.muted });
     if (plan.steps.length > 0 && !plan.ownClientCommand) {
       print();
-      plan.steps.forEach((step, index) => print(`  ${index + 1}. ${step}`));
+      steps(plan.steps);
     }
   }
   if (plan.browser) {
     print();
-    print(
-      style.dim(
-        '  This one authorises in a browser, so it has to be run by whoever owns the account.',
-      ),
+    prose(
+      '  This one authorises in a browser, so it has to be run by whoever owns the account.',
+      { paint: paint.muted },
     );
   }
 }

--- a/src/cli/commands/sync.ts
+++ b/src/cli/commands/sync.ts
@@ -103,7 +103,7 @@ async function locateRemote(
     );
   }
 
-  if (!(await confirm(`  Point "${target}" at ${first.workspace}?`))) {
+  if (!(await confirm(`Point "${target}" at ${first.workspace}?`))) {
     throw new ConfigError('Nothing was read or written.');
   }
 

--- a/src/cli/instructions.test.ts
+++ b/src/cli/instructions.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, test } from 'bun:test';
 import type { Flags } from './argv.ts';
 import { ASSETS, readAsset } from './commands/mcp/assets.ts';
 import { assertKnownFlags, requirementFor, selectionKey } from './selection.ts';
-import { PROGRAM, USAGE } from './usage.ts';
+import { PROGRAM, usage } from './usage.ts';
 import { RESERVED_PROVIDER_IDS } from '#connectivity/manifest/provider.ts';
 
 /**
@@ -28,7 +28,8 @@ function commandsNamedIn(text: string): string[] {
 
 /** The command paths `USAGE` documents, as `"mcp add"` and `"start"`. */
 const documented = new Set(
-  USAGE.split('\n')
+  usage(80)
+    .split('\n')
     .map((line) => line.trim())
     // The title line spells PROGRAM in bold, so it carries ANSI codes and does
     // not match — which is right: it is a heading, not a command.

--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -53,7 +53,7 @@ import type { GlobalFlags } from './runtime.ts';
 import type { OwnerFlags } from './commands/owner/shared.ts';
 import { assertKnownFlags } from './selection.ts';
 import { requireSelection } from './selection-require.ts';
-import { PROGRAM, USAGE } from './usage.ts';
+import { PROGRAM, usage } from './usage.ts';
 import { version } from './version.ts';
 import { print } from './output.ts';
 
@@ -87,7 +87,7 @@ export async function run(argv: readonly string[]): Promise<void> {
   const json = flags['json'] === true;
 
   if (!first || first === 'help' || flags['help'] === true) {
-    print(USAGE);
+    print(usage());
     return;
   }
 
@@ -245,18 +245,21 @@ export async function run(argv: readonly string[]): Promise<void> {
       // Both subcommands take the same two positionals, so the usage line is
       // built once rather than written twice with one of them going stale.
       const [kind, value] = rest;
-      const usage = (form: string): string =>
+      // Named `identityUsage` rather than `usage`, which is now the imported
+      // help renderer: a local shadowing it would hand a later edit in this
+      // block the wrong function, or a TDZ error if it were placed above.
+      const identityUsage = (form: string): string =>
         `Usage: ${PROGRAM} identity ${form}\n  e.g. ${PROGRAM} identity add name "Your Name" --note "for open-source work"`;
 
       switch (second) {
         case 'add':
-          if (!kind || !value) throw new Error(usage('add <kind> <value> [--note text]'));
+          if (!kind || !value) throw new Error(identityUsage('add <kind> <value> [--note text]'));
           return identityAdd(kind, value, { ...global, note: text(flags, 'note'), json });
         case 'list':
         case undefined:
           return identityList({ ...global, json });
         case 'remove':
-          if (!kind || !value) throw new Error(usage('remove <kind> <value>'));
+          if (!kind || !value) throw new Error(identityUsage('remove <kind> <value>'));
           return identityRemove(kind, value, { ...global, json });
         default:
           throw new Error(`Unknown: ${PROGRAM} identity ${second}`);

--- a/src/cli/output.test.ts
+++ b/src/cli/output.test.ts
@@ -1,5 +1,6 @@
-import { describe, expect, test } from 'bun:test';
-import { waiting } from './output.ts';
+import { afterEach, describe, expect, test } from 'bun:test';
+import { divider, heading, prose, steps, waiting } from './output.ts';
+import { stripAnsi, visibleWidth } from './typeset.ts';
 
 /**
  * The wait indicator, minus the part you have to look at.
@@ -31,5 +32,74 @@ describe('waiting', () => {
     await waiting('checking', async () => Bun.sleep(30));
 
     expect(Date.now() - before).toBeGreaterThanOrEqual(25);
+  });
+});
+
+
+/**
+ * The block renderers, asserted on structure rather than on wording.
+ *
+ * A snapshot of a heading and seven steps would be rewritten by every copy edit
+ * to a provider manifest, and would then be re-approved without being read —
+ * which is a test that costs maintenance and catches nothing. What is worth
+ * holding is that a line fits, that a rule reaches the edge, and that a
+ * continuation lands under the text.
+ */
+describe('blocks', () => {
+  const COLUMNS = process.env['COLUMNS'];
+
+  afterEach(() => {
+    if (COLUMNS === undefined) delete process.env['COLUMNS'];
+    else process.env['COLUMNS'] = COLUMNS;
+  });
+
+  /** What a renderer wrote, with the colour taken back off. */
+  function captured(render: (to: (line?: string) => void) => void): string[] {
+    const lines: string[] = [];
+    render((line = '') => lines.push(stripAnsi(line)));
+    return lines;
+  }
+
+  test('a heading is a blank line, the title, and a rule out to the width', () => {
+    process.env['COLUMNS'] = '41';
+    const [blank, titled] = captured((to) => heading('Endpoint', to));
+
+    expect(blank).toBe('');
+    expect(titled).toStartWith('Endpoint ─');
+    expect(visibleWidth(titled!)).toBe(40);
+  });
+
+  test('a heading with no room for a rule is still a heading', () => {
+    process.env['COLUMNS'] = '41';
+    const [, titled] = captured((to) => heading('x'.repeat(60), to));
+
+    expect(titled).toBe('x'.repeat(60));
+  });
+
+  test('a divider reaches the width and nothing more', () => {
+    process.env['COLUMNS'] = '51';
+    const [line] = captured((to) => divider(to));
+
+    expect(visibleWidth(line!)).toBe(50);
+  });
+
+  test('prose wraps to the terminal; print would not have', () => {
+    process.env['COLUMNS'] = '41';
+    const long = 'There is no OAuth app to register, and one of your own would need a fixed port.';
+    const lines = captured((to) => prose(long, { to }));
+
+    expect(lines.length).toBeGreaterThan(1);
+    for (const line of lines) expect(visibleWidth(line)).toBeLessThanOrEqual(40);
+    expect(lines.join(' ')).toBe(long);
+  });
+
+  test('steps put continuations under the text, not under the number', () => {
+    process.env['COLUMNS'] = '41';
+    const lines = captured((to) =>
+      steps(['short', 'a step long enough that it has to be broken across two lines'], to),
+    );
+
+    expect(lines[0]).toStartWith('  1  ');
+    expect(lines.at(-1)).toStartWith('     ');
   });
 });

--- a/src/cli/output.ts
+++ b/src/cli/output.ts
@@ -1,4 +1,6 @@
 import { wasDefaulted } from './selection-require.ts';
+import { columns, style, width } from './terminal.ts';
+import { numbered, rule, truncate, visibleWidth, wrap } from './typeset.ts';
 import type { Resolution } from '#profile';
 
 /**
@@ -9,18 +11,23 @@ import type { Resolution } from '#profile';
  * pipe into other tools, and a log line interleaved into a token corrupts it.
  */
 
-const isTTY = process.stdout.isTTY === true && !process.env['NO_COLOR'];
+/**
+ * Re-exported rather than moved away, because `style` is imported by sixty-five
+ * files and moving it would put every one of them in a diff about colour. It now
+ * resolves per call instead of at module load: see `terminal.ts`.
+ */
+export { paint, style } from './terminal.ts';
 
-const paint = (code: string) => (text: string) => (isTTY ? `[${code}m${text}[0m` : text);
-
-export const style = {
-  bold: paint('1'),
-  dim: paint('2'),
-  green: paint('32'),
-  yellow: paint('33'),
-  red: paint('31'),
-  cyan: paint('36'),
-};
+/**
+ * Whether the spinner below may redraw in place.
+ *
+ * Deliberately the predicate `isTTY` was before this file grew a colour ladder,
+ * rather than `level() > 0`. The two agree today, but they answer different
+ * questions — one is "can I erase a line", the other "may I paint it" — and a
+ * `FORCE_COLOR` that animated a spinner into a log file would be the ladder
+ * answering the wrong one.
+ */
+const animated = (): boolean => process.stdout.isTTY === true && !process.env['NO_COLOR'];
 
 export function print(line = ''): void {
   process.stdout.write(`${line}\n`);
@@ -69,7 +76,7 @@ const SPINNER = ['\u280b', '\u2819', '\u2839', '\u2838', '\u283c', '\u2834', '\u
 const CLEAR = '\r\u001b[2K';
 
 export async function waiting<T>(label: string, work: () => Promise<T>): Promise<T> {
-  if (!isTTY) {
+  if (!animated()) {
     progress(style.dim(`  ${label}\u2026`));
     return work();
   }
@@ -84,7 +91,14 @@ export async function waiting<T>(label: string, work: () => Promise<T>): Promise
     const elapsed = seconds >= 3 ? ` (${seconds}s)` : '';
     const mark = SPINNER[frame % SPINNER.length];
 
-    process.stderr.write(`${CLEAR}${style.dim(`  ${mark} ${label}\u2026${elapsed}`)}`);
+    // `\u001b[2K` erases one *physical* row. A label that outruns the terminal
+    // wraps onto a second, and the erase then leaves the first on screen for the
+    // rest of the run with nothing to explain it.
+    const text = `  ${mark} ${label}\u2026${elapsed}`;
+    const room = Math.max(columns() - 1, 1);
+    const shown = visibleWidth(text) > room ? `${truncate(text, room - 1)}\u2026` : text;
+
+    process.stderr.write(`${CLEAR}${style.dim(shown)}`);
     frame += 1;
   };
 
@@ -194,9 +208,88 @@ export function emit(
   return render();
 }
 
-export function heading(text: string): void {
-  print();
-  print(style.bold(text));
+/**
+ * Where a block writes to.
+ *
+ * A parameter rather than two copies of every renderer, because the same shapes
+ * go to different streams: `setup plan` prints its walkthrough as the command's
+ * output, and `connect` narrates the identical walkthrough on stderr while
+ * stdout is reserved for a `--json` document. Defaulting to `print` is what
+ * keeps the fifty-five existing `heading` calls out of this diff.
+ */
+type Sink = (line?: string) => void;
+
+/**
+ * A section title, and a rule running out to the width of the terminal.
+ *
+ * The rule is the whole reason this is a function rather than `print(bold(x))`.
+ * A bold line alone stops separating anything once the block under it is more
+ * than a couple of lines — which is what a provider's seven-step walkthrough
+ * is — and a heading nobody sees as a heading is a blank line with extra steps.
+ *
+ * Measured with `visibleWidth` rather than `.length` because a heading may
+ * already carry colour: `mcp list` builds one as `Registered as ${bold(name)}`,
+ * and counting its escape codes as characters would shorten the rule by nine.
+ */
+export function heading(text: string, to: Sink = print): void {
+  const room = width() - visibleWidth(text) - 1;
+
+  to();
+  to(room > 0 ? `${style.bold(text)} ${style.dim(rule(room))}` : style.bold(text));
+}
+
+/** The rule that closes a block, where something follows it that is not a heading. */
+export function divider(to: Sink = print): void {
+  to(style.dim(rule(width())));
+}
+
+export interface ProseOptions {
+  /** Tint the whole paragraph — a summary, or a note under a block. */
+  readonly paint?: ((text: string) => string) | undefined;
+  readonly to?: Sink;
+  /**
+   * Put on the first line, with continuations aligned past it.
+   *
+   * For the `ok` / `warn` / `fail` markers, which are a six-column gutter and
+   * not part of the sentence: `prose(why, { prefix: warn('') })`. Calling the
+   * marker with an empty string is what yields the gutter alone, and it has to
+   * be called rather than stored — colour resolves per call now, so a marker
+   * captured at module load would be the colourless one forever.
+   */
+  readonly prefix?: string;
+}
+
+/**
+ * A sentence, wrapped to the terminal.
+ *
+ * The counterpart to `print`, which stays raw and is still correct for
+ * everything that is not prose: a value, a path, a credential ref, a pasteable
+ * command, a table row, a JSON document. Wrapping those would corrupt them, so
+ * the choice is the call site's and the function name is how it is made.
+ *
+ * URLs, `lanes link …` invocations and quoted literals are picked out inside
+ * the sentence — the three things a reader is meant to act on. Anything the
+ * paragraph tint claims is painted; the rest keeps the terminal's foreground.
+ */
+export function prose(text: string, options: ProseOptions = {}): void {
+  const { paint: tint, to = print, prefix = '' } = options;
+  const gutter = visibleWidth(prefix);
+  const lines = wrap(text, width() - gutter, { highlight: true, paint: tint });
+
+  lines.forEach((line, index) => to(index === 0 ? prefix + line : ' '.repeat(gutter) + line));
+}
+
+/**
+ * A numbered walkthrough whose continuations align under the text.
+ *
+ * This replaces `steps.forEach((step, i) => print(`  ${i + 1}. ${step}`))`,
+ * written out four times across `connect`, `setup plan` and `deploy`. That
+ * rendering had no continuation at all: a step ran to the edge of the terminal
+ * and carried on at column zero, which is what turned a seven-step walkthrough
+ * into one paragraph.
+ */
+export function steps(items: readonly string[], to: Sink = print): void {
+  for (const line of numbered(items, width())) to(line);
 }
 
 export function table(rows: ReadonlyArray<readonly string[]>): void {
@@ -205,7 +298,7 @@ export function table(rows: ReadonlyArray<readonly string[]>): void {
   const widths: number[] = [];
   for (const row of rows) {
     row.forEach((cell, index) => {
-      widths[index] = Math.max(widths[index] ?? 0, stripAnsi(cell).length);
+      widths[index] = Math.max(widths[index] ?? 0, visibleWidth(cell));
     });
   }
 
@@ -215,7 +308,7 @@ export function table(rows: ReadonlyArray<readonly string[]>): void {
         .map((cell, index) =>
           index === row.length - 1
             ? cell
-            : cell + ' '.repeat((widths[index] ?? 0) - stripAnsi(cell).length),
+            : cell + ' '.repeat((widths[index] ?? 0) - visibleWidth(cell)),
         )
         .join('  ')
         .trimEnd(),
@@ -223,10 +316,6 @@ export function table(rows: ReadonlyArray<readonly string[]>): void {
   }
 }
 
-function stripAnsi(text: string): string {
-  // eslint-disable-next-line no-control-regex
-  return text.replace(/\[[0-9;]*m/g, '');
-}
 
 export const ok = (text: string) => `${style.green('ok')}    ${text}`;
 export const warn = (text: string) => `${style.yellow('warn')}  ${text}`;

--- a/src/cli/prompt.test.ts
+++ b/src/cli/prompt.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from 'bun:test';
-import { nonInteractivePrompter, terminalPrompter } from './prompt.ts';
+import { chrome, nonInteractivePrompter, terminalPrompter } from './prompt.ts';
+import { stripAnsi } from './typeset.ts';
 
 /**
  * Where a command collects an answer from.
@@ -51,5 +52,38 @@ describe('terminalPrompter', () => {
     expect(terminalPrompter.askSecret('  App password')).rejects.toThrow(
       /write the credentials to the store first and re-run/,
     );
+  });
+});
+
+describe('the chrome around a question', () => {
+  test('carries a marker and a caret, so a prompt is not read as another step', () => {
+    // The block above a prompt ends in seven numbered steps. Without a marker
+    // the question was an eighth.
+    const { prompt } = chrome('GitHub personal access token');
+
+    expect(stripAnsi(prompt)).toBe('? GitHub personal access token › ');
+  });
+
+  test('does not double the punctuation five call sites used to append', () => {
+    // `ask` added `: ` and so did the call site, so this came out as
+    // `Display name [foo]: : `. It shipped, which is the argument for the
+    // punctuation living here rather than at every question.
+    expect(stripAnsi(chrome('Display name [foo]').prompt)).not.toContain(':');
+  });
+
+  test('an indent a call site no longer needs is absorbed rather than shown', () => {
+    // The thirteen sites that indented their own questions are swept in this
+    // change; trimming here is what stops a missed one rendering as `?   Foo`.
+    expect(stripAnsi(chrome('  Region').prompt)).toBe('? Region › ');
+  });
+
+  test('everything before the last line is narration, not part of the question', () => {
+    // A variable's description is a sentence nobody can guess, and `ask` takes
+    // one string. Decorating the whole thing would put the caret two lines
+    // above the cursor.
+    const { lead, prompt } = chrome('Where the server lives.\nHostname [example.com]');
+
+    expect(lead).toEqual(['Where the server lives.']);
+    expect(stripAnsi(prompt)).toBe('? Hostname [example.com] › ');
   });
 });

--- a/src/cli/prompt.ts
+++ b/src/cli/prompt.ts
@@ -1,5 +1,5 @@
 import { createInterface } from 'node:readline';
-import { style } from './output.ts';
+import { paint, style } from './terminal.ts';
 
 /**
  * Interactive input.
@@ -37,13 +37,58 @@ function assertInteractive(): void {
   }
 }
 
+/**
+ * The chrome around every question, in one place so the three cannot drift.
+ *
+ * A marker, the question, and a caret. The marker is what separates a question
+ * from the block above it — a prompt with no chrome at the end of a seven-step
+ * walkthrough reads as an eighth step, which is what it looked like before.
+ *
+ * The trailing `: ` this replaces was appended here *and* by five call sites,
+ * so `Display name [foo]: ` came out as `Display name [foo]: : `. That the
+ * double colon survived is the argument for the punctuation living in one
+ * place rather than at every question.
+ *
+ * A question may carry lines before its last one — a variable's description is
+ * a sentence nobody can guess, and `Prompter.ask` takes one string. Those go
+ * out as narration and only the final line is decorated, so the caret stays
+ * where the cursor is.
+ */
+export function chrome(question: string): { readonly lead: readonly string[]; readonly prompt: string } {
+  const lines = question.trim().split('\n');
+  const last = lines.pop() ?? '';
+
+  return {
+    lead: lines.map((line) => line.trim()),
+    prompt: `${paint.accent('?')} ${last.trim()} ${paint.muted('\u203a')} `,
+  };
+}
+
 export async function ask(question: string): Promise<string> {
   assertInteractive();
 
-  const rl = createInterface({ input: process.stdin, output: process.stdout });
+  const { lead, prompt } = chrome(question);
+  for (const line of lead) process.stderr.write(`${line}\n`);
+
+  // stderr, not stdout. `--json` is universal (`selection.ts`), nothing stops an
+  // interactive `connect --json`, and readline wrote its question into the
+  // middle of the document. `connect/custom/ask.ts` had already reached this
+  // conclusion and applied it to its own prompts only.
+  //
+  // `terminal` keys off the stream readline *echoes to*, not off stdin. With
+  // `terminal: true` readline puts stdin in raw mode and does the echo itself —
+  // so keying it off stdin meant `connect 2>connect.log` sent every keystroke
+  // to the file and the operator typed a token blind. Keyed off stderr, a
+  // redirect degrades to canonical mode and the tty does the echo, which is the
+  // behaviour this had before the stream moved.
+  const rl = createInterface({
+    input: process.stdin,
+    output: process.stderr,
+    terminal: process.stderr.isTTY === true,
+  });
   try {
     const answer = await new Promise<string>((resolve, reject) => {
-      rl.question(`${question}: `, resolve);
+      rl.question(prompt, resolve);
       rl.once('SIGINT', () => reject(new PromptCancelled()));
     });
     return answer.trim();
@@ -68,7 +113,9 @@ export async function ask(question: string): Promise<string> {
 export async function askSecret(question: string): Promise<string> {
   assertInteractive();
 
-  process.stdout.write(`${question}: `);
+  const { lead, prompt } = chrome(question);
+  for (const line of lead) process.stderr.write(`${line}\n`);
+  process.stderr.write(prompt);
 
   const stdin = process.stdin;
   const wasRaw = stdin.isRaw === true;
@@ -83,7 +130,7 @@ export async function askSecret(question: string): Promise<string> {
       stdin.removeListener('data', onData);
       stdin.setRawMode(wasRaw);
       stdin.pause();
-      process.stdout.write('\n');
+      process.stderr.write('\n');
     };
 
     const onData = (chunk: string): void => {

--- a/src/cli/terminal.test.ts
+++ b/src/cli/terminal.test.ts
@@ -1,0 +1,146 @@
+import { afterEach, describe, expect, test } from 'bun:test';
+import { columns, level, paint, style, width } from './terminal.ts';
+
+/**
+ * The environment is the injection point, so the tests set it.
+ *
+ * Every one of these restores what it touched. `bun test` runs a file in one
+ * process, so a leaked `NO_COLOR` does not fail here — it fails somewhere else
+ * entirely, which is the worst kind of failure to find.
+ */
+const TOUCHED = ['COLUMNS', 'NO_COLOR', 'FORCE_COLOR', 'TERM', 'COLORTERM', 'COLORFGBG'] as const;
+const before = new Map(TOUCHED.map((key) => [key, process.env[key]] as const));
+
+afterEach(() => {
+  for (const [key, value] of before) {
+    if (value === undefined) delete process.env[key];
+    else process.env[key] = value;
+  }
+});
+
+/** Colour at all, so a role emits something to assert on. */
+function forceColour(rung: '1' | '2' | '3' | 'true'): void {
+  delete process.env['NO_COLOR'];
+  process.env['FORCE_COLOR'] = rung;
+  process.env['TERM'] = 'xterm';
+  delete process.env['COLORTERM'];
+}
+
+describe('how wide', () => {
+  test('COLUMNS wins, because it is the only knob a test or a CI job has', () => {
+    process.env['COLUMNS'] = '64';
+    expect(columns()).toBe(64);
+    expect(width()).toBe(63);
+  });
+
+  test('a terminal wider than the measure is clamped, so prose stays readable', () => {
+    process.env['COLUMNS'] = '200';
+    expect(width()).toBe(90);
+  });
+
+  test('a terminal narrower than the floor is clamped, so the arithmetic holds', () => {
+    // Below this the rule length goes negative and `repeat` throws. Overflowing
+    // into the emulator's own wrap is ugly; crashing is worse.
+    process.env['COLUMNS'] = '20';
+    expect(width()).toBe(40);
+  });
+
+  test('a nonsense COLUMNS is ignored rather than believed', () => {
+    process.env['COLUMNS'] = 'wide';
+    expect(columns()).toBe(80);
+  });
+});
+
+describe('how much colour', () => {
+  test('NO_COLOR silences every rung', () => {
+    process.env['NO_COLOR'] = '1';
+    process.env['COLORTERM'] = 'truecolor';
+    expect(level()).toBe(0);
+    expect(style.bold('x')).toBe('x');
+    expect(paint.accent('x')).toBe('x');
+  });
+
+  test('every falsy spelling of FORCE_COLOR turns colour off, not on', () => {
+    // Only the digit was checked, so `FORCE_COLOR=false` skipped both this and
+    // the non-TTY gate — the one variable somebody reaches for to turn colour
+    // off turned it on in a pipe.
+    delete process.env['NO_COLOR'];
+    process.env['COLORTERM'] = 'truecolor';
+
+    for (const spelling of ['0', 'false', '']) {
+      process.env['FORCE_COLOR'] = spelling;
+      expect(level()).toBe(0);
+    }
+  });
+
+  test('a dumb terminal is not argued with', () => {
+    process.env['FORCE_COLOR'] = '3';
+    process.env['TERM'] = 'dumb';
+    expect(level()).toBe(0);
+  });
+
+  test('truecolor is claimed by COLORTERM', () => {
+    // `FORCE_COLOR=true` says there is colour without saying how much, which is
+    // what leaves the rung to be inferred.
+    forceColour('true');
+    process.env['COLORTERM'] = 'truecolor';
+    expect(level()).toBe(3);
+  });
+
+  test('an explicit FORCE_COLOR outranks a terminal that claims more', () => {
+    // The precedence a probe caught: a shell exporting COLORTERM=truecolor made
+    // FORCE_COLOR=2 mean 3, which is the variable being ignored in the one
+    // situation somebody sets it.
+    delete process.env['NO_COLOR'];
+    process.env['COLORTERM'] = 'truecolor';
+    process.env['FORCE_COLOR'] = '2';
+    expect(level()).toBe(2);
+
+    process.env['FORCE_COLOR'] = '1';
+    expect(level()).toBe(1);
+  });
+
+  test('256 is claimed by TERM', () => {
+    forceColour('true');
+    process.env['TERM'] = 'xterm-256color';
+    expect(level()).toBe(2);
+  });
+
+  test('a plain terminal gets the sixteen it has always had', () => {
+    forceColour('true');
+    expect(level()).toBe(1);
+    expect(paint.accent('x')).toContain('[32m');
+  });
+});
+
+describe('the accent down the ladder', () => {
+  test('truecolor spells the brand emerald out', () => {
+    forceColour('3');
+    delete process.env['COLORFGBG'];
+    expect(paint.accent('x')).toContain('[38;2;16;185;129m');
+  });
+
+  test('256 falls to the nearest cube entry, not to a number chosen by eye', () => {
+    forceColour('2');
+    expect(paint.accent('x')).toContain('[38;5;36m');
+    expect(paint.link('x')).toContain('[38;5;31m');
+  });
+
+  test('a terminal that declares a light background gets the light emerald', () => {
+    forceColour('3');
+    process.env['COLORFGBG'] = '0;15';
+    expect(paint.accent('x')).toContain('[38;2;5;150;105m');
+  });
+
+  test('a terminal that declares a dark background gets the dark one', () => {
+    forceColour('3');
+    process.env['COLORFGBG'] = '15;0';
+    expect(paint.accent('x')).toContain('[38;2;52;211;153m');
+  });
+
+  test('weight is not hue, so muted and strong survive a colourless terminal', () => {
+    forceColour('1');
+    expect(paint.muted('x')).toBe(style.dim('x'));
+    expect(paint.strong('x')).toBe(style.bold('x'));
+  });
+});

--- a/src/cli/terminal.ts
+++ b/src/cli/terminal.ts
@@ -1,0 +1,206 @@
+/**
+ * What this terminal can do, and what Lanes looks like on it.
+ *
+ * Two questions with one answer each — how wide, and how much colour — and both
+ * are read on every call rather than captured once. That is not a style
+ * preference: `style` used to close over a module-load constant, which made
+ * colour impossible to test without a pty, and a width captured at startup
+ * cannot follow a terminal that is resized under a long-running `start`.
+ *
+ * The seam to cut on if this file outgrows the budget is palette versus
+ * capability: `level()` and `columns()` describe the terminal, `paint` describes
+ * Lanes. They are together here because the palette is *defined* as a fallback
+ * ladder over the capability, and splitting them would put the ladder's two
+ * halves in two files.
+ */
+
+/** No terminal said how wide it is — what every other tool assumes. */
+const FALLBACK_COLUMNS = 80;
+
+/**
+ * The widest a paragraph is allowed to get, and the narrowest it may be asked
+ * to fit.
+ *
+ * Ninety because readable measure runs out somewhere under a hundred: the GitHub
+ * summary is 274 characters, which is three lines at 90 and an indistinct block
+ * at 140. Forty because the arithmetic below it goes negative — a heading's rule
+ * is `width - heading - 1`, and `'─'.repeat(-3)` throws. Clamping means a
+ * 30-column pane overflows into the emulator's own wrap, which is ugly, rather
+ * than crashing, which is worse.
+ */
+const MAX_MEASURE = 90;
+const MIN_MEASURE = 40;
+
+/**
+ * How wide the terminal says it is.
+ *
+ * `COLUMNS` first because it is the conventional override — `git` reads it the
+ * same way — and because it is the only knob a test, a CI job, or `script` has.
+ * The cost is worth stating rather than discovering: a shell that *exports*
+ * COLUMNS pins the width for the life of the child, so a resize under a
+ * long-running `start` is not followed. Most shells set it without exporting it,
+ * which is why the override is worth more than the case it costs.
+ *
+ * `process.stdout.columns` is only ever set on a TTY, and stderr is consulted
+ * after it because the setup block narrates there — a run with stdout piped and
+ * stderr on the terminal still knows the width of the thing a person reads.
+ */
+export function columns(): number {
+  const declared = Number(process.env['COLUMNS']);
+  if (Number.isInteger(declared) && declared > 0) return declared;
+
+  const out = process.stdout.columns;
+  if (typeof out === 'number' && out > 0) return out;
+
+  const err = process.stderr.columns;
+  if (typeof err === 'number' && err > 0) return err;
+
+  return FALLBACK_COLUMNS;
+}
+
+/**
+ * The measure to lay text out in.
+ *
+ * One column short of the terminal, deliberately. A line that exactly fills the
+ * width makes many emulators emit a phantom wrap, which puts a blank line
+ * between every rule and the text under it — and reads as a bug in the spacing
+ * rather than in the arithmetic.
+ */
+export function width(): number {
+  return Math.min(Math.max(columns() - 1, MIN_MEASURE), MAX_MEASURE);
+}
+
+/** How much colour this terminal renders: none, 16, 256, or 16 million. */
+export type Level = 0 | 1 | 2 | 3;
+
+/**
+ * Which rung of the ladder to paint on.
+ *
+ * The TTY gate is stdout's, which is the rule this CLI has always used and is
+ * kept rather than improved: deciding per stream would mean `style.bold` had to
+ * know where its result was going, and 468 call sites say it does not.
+ *
+ * `FORCE_COLOR` was not honoured before. It is here because it is the only way
+ * to exercise rungs 2 and 3 from a test or a CI job, and a ladder nothing can
+ * climb on purpose is a ladder nobody checks. It follows the spelling everyone
+ * else uses: `0` off, `1`/`2`/`3` a rung, and anything else — `true`, or the
+ * bare variable — meaning *on*, with the rung still inferred.
+ */
+export function level(): Level {
+  const force = process.env['FORCE_COLOR'];
+  const noColor = process.env['NO_COLOR'];
+
+  if (noColor !== undefined && noColor !== '') return 0;
+  // Every falsy spelling, not just the digit. `FORCE_COLOR=false` and an empty
+  // `FORCE_COLOR=` both used to skip this *and* the TTY gate below, so the one
+  // variable somebody reaches for to turn colour off turned it on in a pipe.
+  if (force === '0' || force === 'false' || force === '') return 0;
+  if (process.env['TERM'] === 'dumb') return 0;
+  if (force === undefined && process.stdout.isTTY !== true) return 0;
+
+  // Said before inferred. `FORCE_COLOR=2` on a terminal that also exports
+  // `COLORTERM=truecolor` has to mean 256 — it is somebody overriding the
+  // guess, and a guess that outranked them would make the variable useless for
+  // the one thing it is for.
+  if (force === '3') return 3;
+  if (force === '2') return 2;
+  if (force === '1') return 1;
+
+  if (/truecolor|24bit/i.test(process.env['COLORTERM'] ?? '')) return 3;
+  if (/-256(color)?$/.test(process.env['TERM'] ?? '')) return 2;
+
+  return 1;
+}
+
+const sgr = (code: string) => (text: string) => `[${code}m${text}[0m`;
+
+/**
+ * The six codes this CLI has always had, now resolved per call.
+ *
+ * Kept exactly as they were — and re-exported from `output.ts` — so that moving
+ * them here is not a change to any of the sixty-five files that use them.
+ */
+const basic = (code: string) => (text: string) => (level() === 0 ? text : sgr(code)(text));
+
+export const style = {
+  bold: basic('1'),
+  dim: basic('2'),
+  green: basic('32'),
+  yellow: basic('33'),
+  red: basic('31'),
+  cyan: basic('36'),
+};
+
+/**
+ * One brand colour, not two, and the reason is that a terminal cannot be asked.
+ *
+ * `brand.ts` carries an emerald per colour scheme — `#059669` on light,
+ * `#34D399` on dark — because a browser reports `prefers-color-scheme`. A
+ * terminal reports nothing, so a fixed choice of either is wrong half the time.
+ * `#10B981` sits between them and stays legible on both a near-black and a
+ * near-white background, which is the only property that matters when the
+ * background is unknown.
+ *
+ * `COLORFGBG` is the exception: where a terminal does declare its background
+ * (`fg;bg`, with 0-6 dark and 7-15 light) the exact brand pair is used instead.
+ * Most terminals do not set it, which is why it refines the answer rather than
+ * deciding it.
+ */
+const ACCENT_MID = [16, 185, 129] as const;
+const ACCENT_ON_DARK = [52, 211, 153] as const;
+const ACCENT_ON_LIGHT = [5, 150, 105] as const;
+
+type Rgb = readonly [number, number, number];
+
+function accentRgb(): Rgb {
+  const background = Number(process.env['COLORFGBG']?.split(';').at(-1));
+  if (!Number.isInteger(background)) return ACCENT_MID;
+  return background >= 7 ? ACCENT_ON_LIGHT : ACCENT_ON_DARK;
+}
+
+/**
+ * A role, resolved down the ladder.
+ *
+ * The 256-colour indices are computed from the 6x6x6 cube rather than chosen by
+ * eye: `16 + 36r + 6g + b` over the [0, 95, 135, 175, 215, 255] steps, taking
+ * the nearest step per channel. They are the closest the palette holds to each
+ * hex above it, and writing that down is what stops the next person "correcting"
+ * one to a number that looks better in isolation.
+ */
+function role(rgb: () => Rgb, cube: number, ansi: string): (text: string) => string {
+  return (text: string) => {
+    switch (level()) {
+      case 0:
+        return text;
+      case 3: {
+        const [r, g, b] = rgb();
+        return sgr(`38;2;${r};${g};${b}`)(text);
+      }
+      case 2:
+        return sgr(`38;5;${cube}`)(text);
+      default:
+        return sgr(ansi)(text);
+    }
+  };
+}
+
+/**
+ * What each colour means, so that a call site names a role and never a colour.
+ *
+ * `muted` and `strong` are dim and bold at every rung: they are weight rather
+ * than hue, and a terminal that renders no colour still renders both.
+ */
+export const paint = {
+  /** The Lanes accent. Prompts, and the literals a step tells you to type. */
+  accent: role(accentRgb, 36, '32'),
+  /** A URL or a command — something to click, copy, or run. */
+  link: role(() => [8, 145, 178], 31, '36'),
+  /** Something survivable that the reader should still see. */
+  warn: role(() => [180, 83, 9], 130, '33'),
+  /** Something that failed. */
+  danger: role(() => [160, 96, 96], 131, '31'),
+  /** Secondary prose, rules, and step numbers. */
+  muted: style.dim,
+  /** A heading. */
+  strong: style.bold,
+};

--- a/src/cli/typeset.test.ts
+++ b/src/cli/typeset.test.ts
@@ -1,0 +1,276 @@
+import { afterEach, describe, expect, test } from 'bun:test';
+import { numbered, rule, stripAnsi, truncate, visibleWidth, wrap } from './typeset.ts';
+import { PROVIDER_MANIFESTS } from '#providers/index.ts';
+
+const before = new Map(
+  (['NO_COLOR', 'FORCE_COLOR'] as const).map((key) => [key, process.env[key]] as const),
+);
+
+afterEach(() => {
+  for (const [key, value] of before) {
+    if (value === undefined) delete process.env[key];
+    else process.env[key] = value;
+  }
+});
+
+const indentOf = (line: string): number => line.match(/^ */)![0].length;
+
+/** Where a numbered line's text starts, past its gutter and its own lead. */
+function textColumn(head: string): number {
+  const gutter = head.match(/^\s*\d+\s\s/)![0];
+  const lead = head.slice(gutter.length).match(/^ */)![0];
+
+  return gutter.length + lead.length;
+}
+
+/** The words of a laid-out block, in order, with the colour taken back off. */
+const wordsOf = (lines: readonly string[]): string[] =>
+  lines
+    .flatMap((line) => stripAnsi(line).split(/\s+/))
+    .filter((word) => word.length > 0);
+
+describe('measuring', () => {
+  test('colour costs nothing, because it occupies nothing', () => {
+    expect(visibleWidth('[2mabc[0m')).toBe(3);
+  });
+
+  test('a wide character costs two, which String.length gets wrong', () => {
+    // `table()` measured with `.length` before this existed, so a CJK label
+    // pushed every column after it one place left.
+    expect('日本'.length).toBe(2);
+    expect(visibleWidth('日本')).toBe(4);
+  });
+
+  test('a combining mark costs nothing, because it hangs off its neighbour', () => {
+    expect(visibleWidth('é')).toBe(1);
+  });
+
+  test('a rule with no room is empty rather than a thrown RangeError', () => {
+    expect(rule(0)).toBe('');
+    expect(rule(-5)).toBe('');
+    expect(rule(3)).toBe('───');
+  });
+});
+
+describe('wrapping', () => {
+  const paragraph =
+    'GitHub issues a fine-grained personal access token for this. There is no ' +
+    'OAuth app to register, and an app of your own would need a fixed callback port.';
+
+  test('no line is wider than it was told to be', () => {
+    for (const width of [40, 60, 80]) {
+      for (const line of wrap(paragraph, width)) {
+        expect(visibleWidth(line)).toBeLessThanOrEqual(width);
+      }
+    }
+  });
+
+  test('nothing is lost and nothing is invented', () => {
+    // The property that catches most wrapper bugs on its own.
+    expect(wordsOf(wrap(paragraph, 37)).join(' ')).toBe(paragraph);
+  });
+
+  test('an embedded newline is a hard break, not a space', () => {
+    const lines = wrap('one\ntwo', 80);
+    expect(lines).toEqual(['one', 'two']);
+  });
+
+  test("a line's own indent carries onto its continuations", () => {
+    // Google's steps indent their sub-headings by two. A continuation that
+    // returned to column zero would read as a new bullet.
+    const lines = wrap('  BRANDING must be filled in before anything else is offered', 30);
+    expect(lines.length).toBeGreaterThan(1);
+    for (const line of lines) expect(line.startsWith('  ')).toBe(true);
+  });
+
+  test('a hanging indent is added on top of that', () => {
+    const lines = wrap('alpha beta gamma delta epsilon', 20, { hanging: '>>' });
+    expect(lines[0]!.startsWith('>>')).toBe(false);
+    for (const line of lines.slice(1)) expect(line.startsWith('>>')).toBe(true);
+  });
+
+  test('a word longer than the width is never broken', () => {
+    // A broken URL cannot be clicked, and terminals linkify by contiguity.
+    const url = 'https://github.com/settings/personal-access-tokens';
+    const lines = wrap(`Open ${url} and choose a name`, 20);
+    expect(lines.some((line) => stripAnsi(line).includes(url))).toBe(true);
+  });
+
+  test('degenerate widths do not throw or loop', () => {
+    expect(wrap('', 40)).toEqual(['']);
+    expect(() => wrap('a b c', 1)).not.toThrow();
+    expect(() => wrap('a b c', 0)).not.toThrow();
+    expect(() => wrap('a b c', -10)).not.toThrow();
+  });
+});
+
+describe('picking things out of prose', () => {
+  test('a quoted phrase split across two lines is painted on both halves', () => {
+    // The reason colour is decided per word. Wrapping a string that already
+    // carries escape codes is how a sequence gets split and leaks onward.
+    process.env['NO_COLOR'] = '1';
+    const plain = wrap('Choose "Generate a brand new token" now', 24, { highlight: true });
+    expect(wordsOf(plain).join(' ')).toBe('Choose "Generate a brand new token" now');
+  });
+
+  test('highlighting never changes the words, only their colour', () => {
+    const text = 'Run lanes link connect github --replace and open https://example.com now';
+    process.env['NO_COLOR'] = '1';
+    expect(wrap(text, 30, { highlight: true }).map(stripAnsi).join(' ').split(/\s+/)).toEqual(
+      text.split(' '),
+    );
+  });
+
+  test('a span is painted once, not once per word', () => {
+    // Per-word escapes render identically and treble the bytes. A reset
+    // between every word is also what makes a piped log unreadable.
+    delete process.env['NO_COLOR'];
+    process.env['FORCE_COLOR'] = '1';
+
+    const [line] = wrap('Choose "Generate a new token" now', 80, { highlight: true });
+    expect([...line!.matchAll(/\u001b\[0m/g)]).toHaveLength(1);
+  });
+
+  test('the program name used as a noun is not painted as a command', () => {
+    // The tail is greedy over lowercase words, because a command is mostly
+    // lowercase words. `A remote lanes link workspace binds to one of these…`
+    // came out with seven words of English in link cyan, so position decides:
+    // a command is given at the start of a line or after a colon.
+    process.env['FORCE_COLOR'] = '1';
+    delete process.env['NO_COLOR'];
+
+    const [prose] = wrap('A remote lanes link workspace binds to one of these', 90, {
+      highlight: true,
+    });
+
+    expect(prose).not.toContain('\u001b');
+  });
+
+  test('the same words after a colon, or at the start of a line, are painted', () => {
+    process.env['FORCE_COLOR'] = '1';
+    delete process.env['NO_COLOR'];
+
+    expect(wrap('run: lanes link connect github --replace', 90, { highlight: true })[0]).toContain(
+      '\u001b',
+    );
+    expect(wrap('  lanes link token issue --me', 90, { highlight: true })[0]).toContain('\u001b');
+  });
+
+  test('a span that starts inside a word still paints it', () => {
+    // `(https://example.com)` is one word whose first character carries no
+    // mark, and keying on index zero left the URL in it unpainted.
+    process.env['FORCE_COLOR'] = '1';
+    delete process.env['NO_COLOR'];
+
+    expect(wrap('See (https://example.com) now', 90, { highlight: true })[0]).toContain('\u001b');
+  });
+
+  test('a value is not prose, so nothing in it is picked out', () => {
+    process.env['NO_COLOR'] = '1';
+    const [line] = wrap('github/pending', 40);
+    expect(line).toBe('github/pending');
+  });
+});
+
+describe('a numbered walkthrough', () => {
+  const steps = [
+    'Open the console and choose Generate.',
+    'Name it, and set an expiry you are willing to renew, because the name is how ' +
+      'you revoke this one later without touching your other tokens.',
+  ];
+
+  test('continuations align under the text rather than under the number', () => {
+    const lines = numbered(steps, 50).map(stripAnsi);
+    const wrapped = lines.filter((line) => !/^\s*\d/.test(line));
+
+    expect(wrapped.length).toBeGreaterThan(0);
+    for (const line of wrapped) expect(line.startsWith('     ')).toBe(true);
+  });
+
+  test('the gutter grows with the largest number, so a list lines up with itself', () => {
+    const many = Array.from({ length: 12 }, (_, index) => `step ${index + 1}`);
+    const lines = numbered(many, 60).map(stripAnsi);
+
+    expect(lines[0]).toStartWith('   1  ');
+    expect(lines[11]).toStartWith('  12  ');
+  });
+
+  test("an embedded line is re-indented under its step, not under column zero", () => {
+    // Google's steps indent continuations by seven spaces, a depth chosen for
+    // the old fixed four-character gutter. Added to a computed gutter it landed
+    // thirteen columns in and read as unrelated to the step above it.
+    const [head, ...tail] = numbered(['Enable the APIs:\n       gcloud services enable x'], 60).map(
+      stripAnsi,
+    );
+
+    // Two columns in from where the step's own text begins, whatever the
+    // gutter happens to be — asserting the relationship rather than a column
+    // keeps this honest when a list grows past nine entries.
+    expect(indentOf(tail[0]!)).toBe(textColumn(head!) + 2);
+  });
+
+  test('a sub-item nests below its own lead, not level with its continuations', () => {
+    // `  AUDIENCE — …` already sits one level in. Flattening its embedded lines
+    // to a fixed two columns would put them level with its wrapped text, which
+    // is the difference between a nested paragraph and a wrapped one.
+    const [head, ...tail] = numbered(
+      ['  AUDIENCE — pick a type\n    INTERNAL, if it is a Workspace'],
+      60,
+    ).map(stripAnsi);
+
+    expect(tail.at(-1)).toStartWith(' '.repeat(textColumn(head!) + 2) + 'INTERNAL');
+  });
+
+  test('no line overflows the width it was given', () => {
+    for (const line of numbered(steps, 44)) {
+      expect(visibleWidth(line)).toBeLessThanOrEqual(44);
+    }
+  });
+});
+
+/**
+ * The strongest check here, and the cheapest.
+ *
+ * Every setup step this repository ships, at every width the renderer can be
+ * asked for. It fails the moment somebody adds a provider whose steps the
+ * layout cannot handle, which no fixture can promise — and it needs no fixture
+ * of its own, because the data is already in the tree.
+ */
+describe('every step of every provider fits', () => {
+  const withSteps = PROVIDER_MANIFESTS.filter((manifest) => (manifest.setup?.steps ?? []).length > 0);
+
+  test('there are some, or the sweep below passed on an empty list', () => {
+    expect(withSteps.length).toBeGreaterThan(5);
+  });
+
+  test.each([40, 60, 80, 90])('at width %i', (width) => {
+    const overflowing: string[] = [];
+
+    for (const manifest of withSteps) {
+      for (const line of numbered(manifest.setup!.steps, width)) {
+        // A single unbreakable token — a URL, a scope, a service account
+        // address — is allowed past the edge. Anything else is a layout bug.
+        const words = stripAnsi(line).trim().split(/\s+/);
+        if (visibleWidth(line) > width && words.length > 1) {
+          overflowing.push(`${manifest.id}: ${stripAnsi(line)}`);
+        }
+      }
+    }
+
+    expect(overflowing).toEqual([]);
+  });
+});
+
+describe('cutting to a width', () => {
+  test('counts columns, not UTF-16 units', () => {
+    // `slice` cut a CJK label at the wrong column and could split a surrogate
+    // pair, handing the terminal half a character.
+    expect(truncate('日本語です', 4)).toBe('日本');
+    expect(visibleWidth(truncate('日本語です', 5))).toBeLessThanOrEqual(5);
+  });
+
+  test('leaves a string that already fits, and copes with no room', () => {
+    expect(truncate('short', 40)).toBe('short');
+    expect(truncate('short', 0)).toBe('');
+  });
+});

--- a/src/cli/typeset.ts
+++ b/src/cli/typeset.ts
@@ -1,0 +1,332 @@
+import { paint } from './terminal.ts';
+
+/**
+ * Turning text into lines that fit.
+ *
+ * Pure: nothing here reads the environment, holds state, or writes to a stream.
+ * Every function is handed the width it must work to, which is what makes the
+ * hard part — wrapping — testable without a terminal.
+ *
+ * Not named `layout.ts`. That word is taken twice in this tree already
+ * (`profile/layout.ts` is the filesystem layout, `cli/contract3-layout.ts` is
+ * where contract 3 put things) and both mean something else.
+ */
+
+// eslint-disable-next-line no-control-regex
+const ANSI = /\[[0-9;]*m/g;
+
+/** The text without its colour, which is the only form worth measuring. */
+export function stripAnsi(text: string): string {
+  return text.replace(ANSI, '');
+}
+
+/**
+ * How many columns a string occupies, as opposed to how long it is.
+ *
+ * `String.length` counts UTF-16 units, which is wrong three ways and was wrong
+ * in `table()` before this existed: an emoji counts two and occupies two, so it
+ * was accidentally right; a CJK ideograph counts one and occupies two; a
+ * combining accent counts one and occupies nothing. Connection labels and
+ * entity names are operator-supplied, so none of these are hypothetical.
+ *
+ * An approximation of `wcwidth`, not a conformant implementation — it does not
+ * resolve ZWJ sequences or regional indicator pairs, and a flag emoji will
+ * measure wide twice. Naming that here is cheaper than a bug report about it.
+ */
+export function visibleWidth(text: string): number {
+  let total = 0;
+
+  for (const character of stripAnsi(text)) {
+    const code = character.codePointAt(0)!;
+
+    // Combining marks hang off the character before them.
+    if (code >= 0x0300 && code <= 0x036f) continue;
+
+    total += isWide(code) ? 2 : 1;
+  }
+
+  return total;
+}
+
+function isWide(code: number): boolean {
+  return (
+    (code >= 0x1100 && code <= 0x115f) ||
+    (code >= 0x2e80 && code <= 0xa4cf) ||
+    (code >= 0xac00 && code <= 0xd7a3) ||
+    (code >= 0xf900 && code <= 0xfaff) ||
+    (code >= 0xfe30 && code <= 0xfe6f) ||
+    (code >= 0xff00 && code <= 0xff60) ||
+    (code >= 0xffe0 && code <= 0xffe6) ||
+    (code >= 0x1f300 && code <= 0x1f9ff) ||
+    (code >= 0x20000 && code <= 0x3fffd)
+  );
+}
+
+/**
+ * Cut to a number of columns, counting what a terminal counts.
+ *
+ * `slice` counts UTF-16 units, so a label carrying a CJK name or an emoji was
+ * cut at the wrong column — and a cut landing between a surrogate pair hands
+ * the terminal half a character.
+ */
+export function truncate(text: string, columns: number): string {
+  if (columns <= 0) return '';
+  if (visibleWidth(text) <= columns) return text;
+
+  let out = '';
+  let used = 0;
+
+  for (const character of text) {
+    const size = visibleWidth(character);
+    if (used + size > columns) break;
+    out += character;
+    used += size;
+  }
+
+  return out;
+}
+
+/** A run of horizontal rule, or nothing at all where there is no room. */
+export function rule(count: number): string {
+  return count > 0 ? '─'.repeat(count) : '';
+}
+
+/**
+ * A word, and what it is.
+ *
+ * Colour is decided per word rather than per span, which is what lets a wrapped
+ * line be styled correctly: a quoted phrase broken across two lines is three
+ * words that each know they are quoted, so both halves come out painted. The
+ * alternative — wrapping a string that already carries escape codes — is the
+ * classic way to split a sequence and leak it down the rest of the output.
+ */
+interface Word {
+  readonly text: string;
+  readonly paint?: Painter | undefined;
+}
+
+type Painter = (text: string) => string;
+
+/**
+ * What a step is allowed to pick out of its own prose.
+ *
+ * Deliberately three patterns and no more. Every one of them is something the
+ * reader is meant to *act on* — open it, run it, or type it — which is the only
+ * justification for colour inside a sentence. A fourth pattern for emphasis
+ * would make the first three mean less.
+ */
+const SPANS: ReadonlyArray<{ pattern: RegExp; paint: Painter; group?: number }> = [
+  // A URL, minus the punctuation that ends the sentence it sits in.
+  { pattern: /https?:\/\/[^\s]+?(?=[.,;:)]*(?:\s|$))/g, paint: paint.link },
+  /**
+   * An invocation of this CLI — but only where one is being *given*, not where
+   * the name is used as a noun.
+   *
+   * The tail is greedy over lowercase words, because a command is mostly
+   * lowercase words, and nothing in a regular expression can tell `connect
+   * github` from `workspace binds to one of these`. So position decides
+   * instead: a command appears at the start of its line or after a colon, and
+   * `A remote lanes link workspace binds to…` — which this painted as a
+   * runnable command, seven words of English in link cyan — appears in neither.
+   */
+  {
+    pattern: /(^\s*|:\s+)(lanes link(?:\s+(?:--?[\w-]+|<[^>\s]+>|[a-z][\w.-]*))*)/g,
+    paint: paint.link,
+    group: 2,
+  },
+  // Something the vendor's console calls a thing, which is what to click.
+  { pattern: /"[^"]+"/g, paint: paint.accent },
+];
+
+/** Which character offsets carry which colour, first pattern winning. */
+function spansOf(line: string): Array<Painter | undefined> {
+  const marks: Array<Painter | undefined> = new Array(line.length).fill(undefined);
+
+  for (const { pattern, paint: role, group } of SPANS) {
+    // `matchAll` clones its argument and never touches `lastIndex`, so the
+    // pattern is used directly rather than rebuilt for every line of every
+    // paragraph — `usage()` alone wraps some three hundred of them.
+    for (const match of line.matchAll(pattern)) {
+      // A pattern may match more than it paints: the invocation above matches
+      // the colon that introduces a command so that it can require one, and
+      // colouring that colon would be colouring the sentence.
+      const painted = group === undefined ? match[0] : match[group]!;
+      const from = match.index! + match[0].indexOf(painted);
+
+      for (let at = from; at < from + painted.length; at += 1) marks[at] ??= role;
+    }
+  }
+
+  return marks;
+}
+
+/**
+ * One line of prose, split into words that each know their own colour.
+ *
+ * `highlight: false` is how a caller says "this is a value, not a sentence" —
+ * a credential ref, a path, or a pasted command has nothing to pick out and
+ * would only be tinted by accident.
+ */
+function wordsOf(line: string, highlight: boolean): Word[] {
+  const marks = highlight ? spansOf(line) : [];
+  const words: Word[] = [];
+
+  for (const match of line.matchAll(/\S+/g)) {
+    const at = match.index!;
+    // The first *marked* character in the word, rather than the word's first
+    // character. A span may begin inside one: `(https://example.com)` is a
+    // single word whose opening bracket carries no mark, and keying on index
+    // zero left the URL in it unpainted.
+    let role: Painter | undefined;
+    for (let index = at; index < at + match[0].length && role === undefined; index += 1) {
+      role = marks[index];
+    }
+
+    words.push({ text: match[0], paint: role });
+  }
+
+  return words;
+}
+
+export interface WrapOptions {
+  /** Pick out URLs, commands and quoted literals. Off for anything not prose. */
+  readonly highlight?: boolean;
+  /** Applied to every word that no span claimed — a whole-paragraph tint. */
+  readonly paint?: Painter | undefined;
+  /** Prefixed to every line after the first, on top of the line's own indent. */
+  readonly hanging?: string;
+}
+
+/**
+ * Break text into lines no wider than `width`.
+ *
+ * Three things it preserves, each because something in this repository depends
+ * on it:
+ *
+ * - **An embedded newline is a hard break.** Google's setup steps are single
+ *   strings containing real newlines, and reflowing across one would run its
+ *   sub-headings into the paragraph above.
+ * - **A line's own leading whitespace becomes its hanging indent.** The same
+ *   steps indent `  BRANDING — …` by two, and a continuation that returned to
+ *   column zero would read as a new bullet.
+ * - **A word longer than the width is never broken.** The GitHub token URL is
+ *   forty-nine characters and has to survive a forty-column terminal intact: a
+ *   broken URL cannot be clicked, and a terminal linkifies by contiguity. It
+ *   goes on its own line and is allowed to overflow.
+ */
+export function wrap(text: string, width: number, options: WrapOptions = {}): string[] {
+  const { highlight = false, paint: base, hanging = '' } = options;
+  const out: string[] = [];
+
+  for (const source of text.split('\n')) {
+    const lead = source.match(/^\s*/)![0];
+    const words = wordsOf(source, highlight);
+
+    if (words.length === 0) {
+      out.push('');
+      continue;
+    }
+
+    const first = lead;
+    const rest = hanging + lead;
+    // Never below one, or a narrow pane divides by a room that does not exist
+    // and every word lands on a line of its own forever.
+    const room = (indent: string) => Math.max(width - visibleWidth(indent), 1);
+
+    let line: Word[] = [];
+    let used = 0;
+    let indent = first;
+
+    // Adjacent words sharing a colour are painted once, not each. Per-word
+    // escapes render identically and cost nothing to look at, but they treble
+    // the bytes on the wire and turn a piped log into noise — and a reset
+    // between every word is the thing that makes `less -R` output unreadable.
+    const flush = (): void => {
+      const parts: string[] = [];
+      let run: Word[] = [];
+
+      const painterOf = (word: Word): Painter => word.paint ?? base ?? identity;
+      const close = (): void => {
+        if (run.length === 0) return;
+        parts.push(painterOf(run[0]!)(run.map((word) => word.text).join(' ')));
+        run = [];
+      };
+
+      for (const word of line) {
+        if (run.length > 0 && painterOf(run[0]!) !== painterOf(word)) close();
+        run.push(word);
+      }
+      close();
+
+      out.push(indent + parts.join(' '));
+      line = [];
+      used = 0;
+      indent = rest;
+    };
+
+    for (const word of words) {
+      const size = visibleWidth(word.text);
+      const needs = line.length === 0 ? size : used + 1 + size;
+
+      if (line.length > 0 && needs > room(indent)) flush();
+
+      line.push(word);
+      used = line.length === 1 ? size : used + 1 + size;
+    }
+
+    if (line.length > 0) flush();
+  }
+
+  return out;
+}
+
+const identity: Painter = (text) => text;
+
+/**
+ * A numbered list whose continuations align under the text, not the number.
+ *
+ * The gutter is sized from the largest number rather than fixed, so a
+ * nine-step provider and a twelve-step one both line up with themselves. The
+ * previous rendering was `\`  ${index + 1}. ${step}\`` and had no continuation
+ * at all — a step ran to the edge of the terminal and carried on at column
+ * zero, which is what made a seven-step walkthrough read as one paragraph.
+ *
+ * A step's *embedded* indentation is normalised to one level before wrapping,
+ * which `relative` above does. Google's steps indent their continuations by
+ * seven spaces, a depth chosen to sit under the old fixed four-character
+ * gutter; added on top of a gutter that is now computed it came out thirteen
+ * columns in, far enough from the step text to read as unrelated. Hard-coded
+ * alignment cannot survive a gutter that varies, so the layer that owns the
+ * gutter owns this too. It is presentation, not data — the manifest strings are
+ * untouched, and `lanes_setup_provider` still serves them verbatim (ADR-019).
+ */
+function relative(item: string): string {
+  const [first, ...rest] = item.split('\n');
+  // One level in from the step's *own* lead, not from column zero. A sub-item
+  // like `  AUDIENCE — …` already sits two in, and flattening its embedded
+  // lines to a fixed two would put them level with its own continuations —
+  // which is the difference between a nested paragraph and a wrapped one.
+  const under = `${(first ?? '').match(/^[ \t]*/)![0]}  `;
+
+  return [first, ...rest.map((line) => line.replace(/^[ \t]+/, under))].join('\n');
+}
+
+export function numbered(items: readonly string[], width: number): string[] {
+  const gutter = String(items.length).length;
+  const out: string[] = [];
+
+  items.forEach((item, index) => {
+    const marker = String(index + 1).padStart(gutter);
+    const hanging = ' '.repeat(gutter + 4);
+
+    const [head, ...tail] = wrap(relative(item), width - gutter - 4, {
+      highlight: true,
+      hanging: '',
+    });
+
+    out.push(`  ${paint.muted(marker)}  ${head ?? ''}`);
+    for (const line of tail) out.push(hanging + line);
+  });
+
+  return out;
+}

--- a/src/cli/usage-data.ts
+++ b/src/cli/usage-data.ts
@@ -1,0 +1,388 @@
+/**
+ * Every command and flag this CLI documents, as data.
+ *
+ * Split from `usage.ts` on the seam the file-size budget pointed at, and it is a
+ * real one rather than an arithmetic one: this file changes when a command is
+ * added, and the renderer beside it changes when the layout does. Neither has
+ * ever been a reason to open the other.
+ *
+ * It is also the file `src/cli/contract3-data.ts` and `contract4-data.ts` are
+ * named after — a data literal whose length is a count of what this tool does,
+ * not a count of what it is responsible for.
+ */
+
+export interface Entry {
+  /** Spelled without `PROGRAM`, which the renderer puts back. */
+  readonly command: string;
+  readonly description?: string;
+  /** A bare flag rather than a command, so `PROGRAM` is not prefixed. */
+  readonly flag?: boolean;
+  /**
+   * Start a new group, with a blank line before it.
+   *
+   * `Your own context` is seven surfaces — memory, tasks, assets, skills,
+   * entities, knowledge, vault — and the template literal separated them with
+   * blank lines it could spell and this shape could not. Forty entries in one
+   * run is a list nobody reads to the end of.
+   */
+  readonly gap?: boolean;
+}
+
+export interface Section {
+  readonly title: string;
+  readonly entries: readonly Entry[];
+}
+
+export const SECTIONS: readonly Section[] = [
+  {
+    title: 'Everyday',
+    entries: [
+      {
+        command: 'setup plan [--json]',
+        description: 'what each provider needs, and which are connected',
+      },
+      {
+        command: 'setup plan <provider>',
+        description: 'the console steps, the values, and the command',
+      },
+      {
+        command: 'connect <provider>',
+        description: 'authorise an account into this workspace (once per account, not once per profile)',
+      },
+      { command: 'connect <provider>.<id>', description: 're-authorise one existing account' },
+      {
+        command: 'connect <...> --replace',
+        description: 'ask for the stored password or key again',
+      },
+      {
+        command: 'connect <...> --auth <method>',
+        description: 'pick how, where there is a choice',
+      },
+      {
+        command: 'connect <...> --non-interactive [--json]',
+        description: 'answer nothing from a terminal: take every value from the credential store, or say what is missing',
+      },
+      {
+        command: 'disconnect <provider>.<id>',
+        description: 'remove an account, and delete its credential',
+      },
+      {
+        command: 'disconnect <...> --keep-credential',
+        description: 'leave the credential in the store',
+      },
+      {
+        command: 'relabel <provider>.<id> <name>',
+        description: 'rename what an account is called',
+      },
+      {
+        command: 'connect custom <id> --connector <kind> --auth <method>',
+        description: 'declare a service that is not built in, and connect it. kinds: mcp, http, imap, dav, fs. Omit a value and it is asked for; the manifest it writes is yours to edit',
+      },
+      {
+        command: 'connection list [--json]',
+        description: 'every account in this workspace, and who grants it',
+      },
+      {
+        command: 'grant add <provider>.<id>',
+        description: 'let a profile reach one, with nothing allowed yet',
+      },
+      { command: 'grant remove <provider>.<id>' },
+      {
+        command: 'start [--only]',
+        description: 'reconcile and serve every profile on one endpoint',
+      },
+      { command: 'outputs [--show] [--json]', description: 'the endpoint an agent needs' },
+      {
+        command: 'desktop [--print] [--yes]',
+        description: 'open the Lanes app on its Lanes Link page, installing it first if it is not there',
+      },
+      { command: 'dashboard', description: 'the older spelling of the line above' },
+      {
+        command: 'mcp add [claude|codex]',
+        description: 'register this endpoint, and install the agent skill',
+      },
+      {
+        command: 'mcp add --no-skill',
+        description: "register only, leaving the agent's own files alone",
+      },
+      {
+        command: 'mcp list',
+        description: 'where it is registered, and whether the skill is current',
+      },
+      { command: 'mcp stdio', description: 'serve on stdin/stdout, for a client that spawns it' },
+      {
+        command: 'mcp skill [--print]',
+        description: 'the bundled skill — its path, or the document itself',
+      },
+      {
+        command: 'mcp install-instructions [--client claude|chatgpt|codex|cursor]',
+        description: 'a block to paste where a client keeps its own standing instructions, so it knows to look here',
+      },
+      {
+        command: 'pair [--print] [--rotate]',
+        description: 'let the Lanes dashboard read this machine',
+      },
+      { command: 'status [--json]', description: 'connections, reachable capabilities, endpoint' },
+    ],
+  },
+  {
+    title: 'Profiles',
+    entries: [
+      {
+        command: 'profile add <name> --workspace <name> [--workspace <name>] [--json]',
+        description: 'a target per place it runs; local is derived, the rest are copied from a sibling profile',
+      },
+      { command: 'profile list [--json]' },
+      {
+        command: 'profile remove <name> [--workspace <name>] [--dry-run] [--yes] [--json] [--delete-data | --migrate-to <profile>]',
+        description: 'Say which of --delete-data or --migrate-to for its memory, tasks, assets and skills — there is no default. Accounts outlive it; disconnect removes those, and token revoke the tokens.',
+      },
+    ],
+  },
+  {
+    title: 'Workspaces',
+    entries: [
+      { command: 'workspace list [--urls]', description: 'every workspace this one knows' },
+      {
+        command: 'workspace show <name>',
+        description: "one workspace's adapters, and its address",
+      },
+      {
+        command: 'sync workspaces --workspace <name> [--from gs://bucket] [--discover] [--prefer local|remote] [--dry-run]',
+        description: 'reconcile this workspace with the copy the deployment reads; recovers one a profile has lost',
+      },
+    ],
+  },
+  {
+    title: 'Who you are',
+    entries: [
+      {
+        command: 'identity add <kind> <value> [--note text] [--json]',
+        description: 'e.g. name, email, github — any kind you like',
+      },
+      { command: 'identity list [--json]' },
+      { command: 'identity remove <kind> <value> [--json]' },
+    ],
+  },
+  {
+    title: 'Permissions',
+    entries: [
+      { command: 'policy list' },
+      {
+        command: 'policy allow <capability> --connection <provider>.<id>',
+        description: 'e.g. gmail.* or gmail.send_message. A rule lands in one grant, so two accounts can differ',
+      },
+      { command: 'policy deny  <capability> --connection <provider>.<id>' },
+      {
+        command: 'profile members list',
+        description: 'who may consume this profile, and who could',
+      },
+      { command: 'profile members add <subject>|--me [--role owner|member]' },
+      { command: 'profile members remove <subject>' },
+      { command: 'token list [--json]', description: 'static tokens, and what each one reaches' },
+      {
+        command: 'token issue --me|--subject <id> [--label <t>]',
+        description: 'CI only: a token for one person. It reaches every profile whose members list them',
+      },
+      {
+        command: 'token show [--id t] [--show|--raw]',
+        description: '--raw prints only it, for $(…)',
+      },
+      { command: 'token rotate [--id t] [--show]' },
+      { command: 'token revoke --id <t>' },
+    ],
+  },
+  {
+    title: 'Your own context',
+    entries: [
+      { command: 'memory list [--tag t]', description: 'what you have stored' },
+      { command: 'memory get <id>' },
+      { command: 'memory write <id> --title <t> [--tag t]', description: 'body on stdin' },
+      { command: 'memory forget <id>' },
+      {
+        gap: true,
+        command: 'tasks list [--status s]',
+        description: 'what is outstanding; --status all for everything',
+      },
+      { command: 'tasks get <id>' },
+      {
+        command: 'tasks add <title> [--status s] [--due d] [--tag t]',
+        description: 'notes on stdin',
+      },
+      {
+        command: 'tasks update <id> --status <s>',
+        description: 'closing one is an update, not a remove',
+      },
+      {
+        command: 'tasks remove <id>',
+        description: 'statuses: in_progress open blocked muted done dropped',
+      },
+      { gap: true, command: 'assets list', description: 'files kept in this profile' },
+      { command: 'assets get <name>', description: 'the bytes, to stdout — redirect them' },
+      { command: 'assets add <file> [--name n] [--content-type t]' },
+      { command: 'assets remove <name>' },
+      { gap: true, command: 'skills list', description: 'the procedures agents can invoke' },
+      { command: 'skills show <name>' },
+      { command: 'skills add <name> [--file f]', description: 'document on stdin' },
+      { command: 'skills remove <name>' },
+      { gap: true, command: 'entities', description: 'who and what everyone else is' },
+      {
+        command: 'entities find [query] [--type t] [--tag t] [--attr kind[=value]] [--related predicate=id]',
+        description: 'every match, never a choice',
+      },
+      { command: 'entities get <id>', description: 'with its relationships, both ways' },
+      {
+        command: 'entities write <name> [--type t] [--name id] [--alias a] [--attr kind=value] [--related predicate=id]',
+        description: 'notes on stdin; a flag you omit keeps what is stored',
+      },
+      {
+        command: 'entities link <from> <predicate>=<to>',
+        description: 'one edge, written on <from> only',
+      },
+      { command: 'entities forget <id>' },
+      { command: 'entities reindex', description: 'rebuild the lookup index from the files' },
+      { gap: true, command: 'knowledge show', description: 'where memory and skills are kept, and how many' },
+      {
+        command: 'knowledge use github --repo <owner/name> [--branch b] [--path p]',
+        description: 'keep both in a private repository, over the GitHub API [--migrate] moves what is already stored, in one commit [--no-migrate] switches and leaves it where it is [--keep] moves it, and leaves the local copies unread',
+      },
+      {
+        command: 'knowledge use local [--migrate]',
+        description: 'bring them back onto this target',
+      },
+      { gap: true, command: 'vault list', description: 'names only, never values' },
+      { command: 'vault get <id> [--show|--raw]' },
+      { command: 'vault set <id> [--description d]', description: 'value on stdin' },
+      { command: 'vault remove <id>' },
+      { command: 'vault key generate', description: 'a fresh LANES_LINK_VAULT_KEY, printed once' },
+    ],
+  },
+  {
+    title: 'Deploying',
+    entries: [
+      {
+        command: 'deploy --workspace <name> [--dry-run]',
+        description: 'set up, build, and roll one revision serving every profile that declares the target',
+      },
+      {
+        command: 'deploy --workspace <name> --profile a --profile b',
+        description: 'only these; the first is the primary',
+      },
+      { command: 'deploy --non-interactive', description: 'take the stored answers, never prompt' },
+      {
+        command: 'deploy --access iam|public',
+        description: "who gets past the platform's own door",
+      },
+      { command: 'secrets list', description: 'credential references in this target' },
+      { command: 'secrets set <ref>', description: 'store one value, read from stdin' },
+      { command: 'secrets push --from local --to cloud' },
+    ],
+  },
+  {
+    title: 'Inspection',
+    entries: [
+      { command: 'check', description: 'static validation, no external calls' },
+      { command: 'doctor [--json]', description: 'credentials resolve, stores reachable' },
+      {
+        command: 'doctor --fix',
+        description: 'apply a repair it can make itself, such as a provider this project renamed under you',
+      },
+      { command: 'auth [--json]', description: 'whether each connection can still sign in' },
+      { command: 'auth --connection <key>', description: 'just this one' },
+      { command: 'tools [--json]', description: 'what the endpoint advertises to a client' },
+      { command: 'plan', description: 'what reconcile would change' },
+      { command: 'audit tail [--limit N] [--denied-only] [--format md]' },
+      { command: 'audit verify', description: 'has anything in the log been altered or removed' },
+      { command: 'config show' },
+      { command: 'version', description: 'which release this is — same as lanes --version' },
+      {
+        command: 'update [--check] [--json]',
+        description: 'install the newer release, or say what is available',
+      },
+    ],
+  },
+  {
+    title: 'Attachments',
+    entries: [
+      {
+        command: 'attach <file> --connection <provider>.<account>',
+        description: 'stage a file, print a handle to send it by',
+      },
+    ],
+  },
+  {
+    title: 'Naming what a command acts on',
+    entries: [
+      {
+        command: '--profile <name>',
+        description: 'required by every command that reads or writes a profile',
+        flag: true,
+      },
+      {
+        command: '--workspace <name>',
+        description: "required by every command that opens a workspace's stores. \"lanes set-workspace <name>\" writes a default; every command that uses it prints the name it resolved, and deploy, sync, secrets push, profile remove, disconnect and token rotate refuse it and want the flag.",
+        flag: true,
+      },
+      {
+        command: '--target <name>',
+        description: 'the old spelling of --workspace. Accepted for one minor, and it warns.',
+        flag: true,
+      },
+    ],
+  },
+  {
+    title: 'Other flags',
+    entries: [
+      {
+        command: '--connection <id>',
+        description: 'which memory/tasks/assets/skills/vault/entities connection, where a profile has several of one kind',
+        flag: true,
+      },
+      {
+        command: '--yes',
+        description: 'skip the confirmation a destructive command would ask for',
+        flag: true,
+      },
+      {
+        command: '--json',
+        description: 'machine-readable output, where a command offers it',
+        flag: true,
+      },
+      {
+        command: '--non-interactive',
+        description: 'never prompt: connect refuses with what to store, deploy takes the answers its config already holds',
+        flag: true,
+      },
+      {
+        command: '--label <text>',
+        description: 'what to call a connection, instead of being asked at the end of connect. A display name only: nothing addresses a connection by it. Use relabel to change one later',
+        flag: true,
+      },
+      {
+        command: '--accept-broad-scopes',
+        description: 'agree in advance to scopes broader than a provider needs',
+        flag: true,
+      },
+      {
+        command: '--own-client',
+        description: 'register your own OAuth client instead of using the one this project operates (connect only)',
+        flag: true,
+      },
+      {
+        command: '--auth <method>',
+        description: 'which way in, where a provider offers two (connect only). "oauth" is the browser; the other is named in the choice connect prints. On connect custom it names the credential type instead: none, bearer, api-key, header, basic, oauth, strategy',
+        flag: true,
+      },
+      {
+        command: '--replace-manifest',
+        description: 'rewrite a declaration that already exists and differs (connect custom only — --replace is about the credential)',
+        flag: true,
+      },
+      {
+        command: '--port <n>',
+        description: 'override the configured port (start only)',
+        flag: true,
+      },
+    ],
+  },
+];

--- a/src/cli/usage.test.ts
+++ b/src/cli/usage.test.ts
@@ -1,0 +1,143 @@
+import { describe, expect, test } from 'bun:test';
+import { visibleWidth } from './typeset.ts';
+import { PROGRAM, usage } from './usage.ts';
+import { SECTIONS } from './usage-data.ts';
+
+/**
+ * The help text, now that it is rendered rather than typed.
+ *
+ * What is worth asserting changed with it. Nothing here checks wording — that
+ * is what the data file is for, and a test repeating it would be a second copy
+ * to keep in step. What these hold is that the layout survives a terminal of any
+ * width, and that a description cannot come adrift from its command again.
+ */
+
+describe('the help fits the terminal it is asked on', () => {
+  test.each([40, 60, 80, 100, 120])('at width %i', (measure) => {
+    const overflowing = usage(measure)
+      .split('\n')
+      // A single unbreakable token is allowed past the edge, the same exception
+      // the wrapper makes: `memory/tasks/assets/skills/vault/entities` is
+      // forty-one characters and breaking it would invent a word.
+      .filter((line) => visibleWidth(line) > measure && line.trim().split(/\s+/).length > 1);
+
+    expect(overflowing).toEqual([]);
+  });
+
+  test('a wider terminal is actually used', () => {
+    // The old text was one fixed string, so eighty columns of a hundred-and-
+    // twenty-column terminal went to waste and a seventy-column one shredded it.
+    const narrow = usage(60).split('\n').length;
+    const wide = usage(120).split('\n').length;
+
+    expect(wide).toBeLessThan(narrow);
+  });
+});
+
+describe('what the two parsing tests depend on', () => {
+  // `argv.test.ts` and `instructions.test.ts` read this string to find every
+  // command the CLI documents. Both rules are now the renderer's to keep rather
+  // than something a person maintains by counting spaces, so they are asserted
+  // here as well as relied on there.
+  const lines = usage(80).split('\n');
+
+  test('a command sits at exactly two spaces, and nothing else does', () => {
+    const entries = lines.filter((line) => /^ {2}\w/.test(line));
+
+    expect(entries.length).toBeGreaterThan(20);
+    for (const line of entries) expect(line.trimStart()).toStartWith(PROGRAM);
+  });
+
+  test('no description line can be mistaken for a command', () => {
+    for (const line of lines) {
+      if (line.trim() === '') continue;
+      const indent = line.length - line.trimStart().length;
+
+      // Three shapes, and only three: a section title at column zero, an entry
+      // at two, or anything belonging to an entry indented past it. Two is the
+      // load-bearing one — an entry there is either a command, which must be
+      // spelled with PROGRAM, or a flag, which begins with a dash and is
+      // therefore not matched by the `^ {2}\w` both parsing tests use.
+      if (indent === 0 || indent >= 4) continue;
+
+      expect(indent).toBe(2);
+      expect(line.trimStart().startsWith(PROGRAM) || line.trimStart().startsWith('-')).toBe(true);
+    }
+  });
+});
+
+describe('a description stays with its command', () => {
+  test('--non-interactive describes itself, not the entry four rows below it', () => {
+    // The defect the restructure exists to make impossible. These two lines were
+    // indented to column 40 and sat under `connect custom`, because that entry
+    // was inserted between them and the flag they belong to. They read as part
+    // of its description for as long as the text was hand-aligned.
+    const entry = SECTIONS.flatMap((section) => section.entries).find((candidate) =>
+      candidate.command.includes('--non-interactive'),
+    );
+
+    expect(entry?.description).toContain('answer nothing from a terminal');
+
+    const custom = SECTIONS.flatMap((section) => section.entries).find((candidate) =>
+      candidate.command.startsWith('connect custom'),
+    );
+
+    expect(custom?.description).not.toContain('answer nothing from a terminal');
+  });
+
+  test('every entry carries its own command, and none is empty', () => {
+    for (const section of SECTIONS) {
+      expect(section.entries.length).toBeGreaterThan(0);
+      for (const entry of section.entries) expect(entry.command.trim()).not.toBe('');
+    }
+  });
+});
+
+describe('the layout the review found', () => {
+  test('a description is never set against a wrapped command\'s last fragment', () => {
+    // `  lanes link deploy --workspace <name>` / `    [--dry-run]  set up, build…`
+    // read as the description of `[--dry-run]` rather than of the entry.
+    for (const measure of [40, 60, 80, 90]) {
+      const lines = usage(measure).split('\n');
+
+      for (const [index, line] of lines.entries()) {
+        // A continuation of a wrapped command: indented past an entry, and
+        // still part of the invocation rather than prose.
+        if (!/^ {4}[[<-]/.test(line)) continue;
+        const previous = lines[index - 1] ?? '';
+        if (!previous.startsWith('  lanes link')) continue;
+
+        // No run of two or more spaces inside the content: that gap is what a
+        // description set beside it would look like.
+        const body = line.trimEnd().replace(/^ +/, '');
+        expect(body).toBe(body.split(/ {2,}/)[0] ?? '');
+      }
+    }
+  });
+
+  test('a narrow terminal stacks instead of wasting half of itself', () => {
+    // At sixty the column landed at thirty and left thirty for the text, so
+    // most entries printed a paragraph in a half-width gutter.
+    const narrow = usage(60).split('\n').filter((line) => line.startsWith('    '));
+
+    expect(narrow.length).toBeGreaterThan(20);
+    for (const line of narrow) expect(line.startsWith('     ')).toBe(false);
+  });
+
+  test('the owner surfaces are grouped, not one run of forty', () => {
+    const lines = usage(80).split('\n');
+    const at = lines.findIndex((line) => line.startsWith('  lanes link tasks list'));
+
+    expect(at).toBeGreaterThan(0);
+    expect(lines[at - 1]).toBe('');
+  });
+
+  test('deploy --access carries a description rather than swallowing it', () => {
+    const entry = SECTIONS.flatMap((section) => section.entries).find((candidate) =>
+      candidate.command.startsWith('deploy --access'),
+    );
+
+    expect(entry?.command).toBe('deploy --access iam|public');
+    expect(entry?.description).toContain('who gets past');
+  });
+});

--- a/src/cli/usage.ts
+++ b/src/cli/usage.ts
@@ -1,213 +1,139 @@
 import { style } from './output.ts';
+import { width } from './terminal.ts';
+import { visibleWidth, wrap } from './typeset.ts';
+import { SECTIONS, type Entry } from './usage-data.ts';
 
 /**
  * The help text, and the name the CLI calls itself.
  *
  * `PROGRAM` is a constant rather than 59 string literals because it had been 59
- * string literals: the rename that produced `lanes link` meant editing the
- * usage text, every `Usage:` line, and every `Unknown:` line by hand, with no
- * way to tell from a green test suite whether one had been missed. The next
- * rename touches this line, and `argv.test.ts` holds the two to each other.
+ * string literals: the rename that produced `lanes link` meant editing the usage
+ * text, every `Usage:` line, and every `Unknown:` line by hand, with no way to
+ * tell from a green test suite whether one had been missed. The next rename
+ * touches this line, and `argv.test.ts` holds the two to each other.
  *
- * The text lives here rather than in `main.ts` because it is 65 lines of prose
- * that changes for entirely different reasons from the dispatch below it.
+ * **The text is data now, and the columns are computed.** It used to be one
+ * template literal with the descriptions hand-aligned, which failed in the way
+ * hand-alignment always does: descriptions started at column 40 in most of the
+ * file, 33 in the `connect custom` block, and 41, 49 and 50 elsewhere. Worse,
+ * `--non-interactive`'s description had come adrift from its command — two
+ * lines indented to column 40, sitting four entries below the flag they
+ * describe because `connect custom` was inserted between them, reading as part
+ * of *its* description instead. Nothing could catch that, because nothing knew
+ * the two belonged together. Now they are one object, and the pairing is not
+ * something a person maintains by counting spaces.
+ *
+ * Rendered rather than stored, so `--help` fits the terminal it is asked on.
+ * The longest line was 100 characters and 72 of 195 lines exceeded 80, so an
+ * eighty-column terminal shredded a third of the help.
  */
 
 /** How this CLI is invoked — the `link` area of the `lanes` command. */
 export const PROGRAM = 'lanes link';
 
-export const USAGE = `${style.bold(PROGRAM)} — a self-hostable MCP gateway for all your connections, memory, tasks, files, and secrets
+const BANNER =
+  '— a self-hostable MCP gateway for all your connections, memory, tasks, files, and secrets';
 
-${style.bold('Everyday')}
-  ${PROGRAM} setup plan [--json]        what each provider needs, and which are connected
-  ${PROGRAM} setup plan <provider>      the console steps, the values, and the command
-  ${PROGRAM} connect <provider>         authorise an account into this workspace
-                                        (once per account, not once per profile)
-  ${PROGRAM} connect <provider>.<id>    re-authorise one existing account
-  ${PROGRAM} connect <...> --replace    ask for the stored password or key again
-  ${PROGRAM} connect <...> --auth <method>  pick how, where there is a choice
-  ${PROGRAM} connect <...> --non-interactive [--json]
-  ${PROGRAM} disconnect <provider>.<id>  remove an account, and delete its credential
-  ${PROGRAM} disconnect <...> --keep-credential   leave the credential in the store
-  ${PROGRAM} relabel <provider>.<id> <name>      rename what an account is called
-  ${PROGRAM} connect custom <id> --connector <kind> --auth <method>
-                                 declare a service that is not built in, and connect it.
-                                 kinds: mcp, http, imap, dav, fs. Omit a value and it is
-                                 asked for; the manifest it writes is yours to edit
-                                        answer nothing from a terminal: take every value
-                                        from the credential store, or say what is missing
-  ${PROGRAM} connection list [--json]   every account in this workspace, and who grants it
-  ${PROGRAM} grant add <provider>.<id>   let a profile reach one, with nothing allowed yet
-  ${PROGRAM} grant remove <provider>.<id>
-  ${PROGRAM} start [--only]             reconcile and serve every profile on one endpoint
-  ${PROGRAM} outputs [--show] [--json]  the endpoint an agent needs
-  ${PROGRAM} desktop [--print] [--yes]  open the Lanes app on its Lanes Link page,
-                                        installing it first if it is not there
-  ${PROGRAM} dashboard                  the older spelling of the line above
-  ${PROGRAM} mcp add [claude|codex]     register this endpoint, and install the agent skill
-  ${PROGRAM} mcp add --no-skill         register only, leaving the agent's own files alone
-  ${PROGRAM} mcp list                   where it is registered, and whether the skill is current
-  ${PROGRAM} mcp stdio                  serve on stdin/stdout, for a client that spawns it
-  ${PROGRAM} mcp skill [--print]        the bundled skill — its path, or the document itself
-  ${PROGRAM} mcp install-instructions [--client claude|chatgpt|codex|cursor]
-                                 a block to paste where a client keeps its own
-                                 standing instructions, so it knows to look here
-  ${PROGRAM} pair [--print] [--rotate]  let the Lanes dashboard read this machine
-  ${PROGRAM} status [--json]            connections, reachable capabilities, endpoint
+const FOOTER = 'Every command prints the profile and target it is acting on, before it acts.';
 
-${style.bold('Profiles')}
-  ${PROGRAM} profile add <name> --workspace <name> [--workspace <name>] [--json]
-                                 a target per place it runs; local is derived, the
-                                 rest are copied from a sibling profile
-  ${PROGRAM} profile list [--json]
-  ${PROGRAM} profile remove <name> [--workspace <name>] [--dry-run] [--yes] [--json]
-                                 [--delete-data | --migrate-to <profile>]
-                                 Say which of --delete-data or --migrate-to for
-                                 its memory, tasks, assets and skills — there is
-                                 no default. Accounts outlive it; disconnect
-                                 removes those, and token revoke the tokens.
+/**
+ * Where a description starts.
+ *
+ * The natural column is the longest command plus a gap, capped at a share of
+ * the terminal — otherwise one seventy-character command in `profile remove`
+ * would push every description in the file off the right-hand edge. A command
+ * past the cap keeps its own line and its description begins on the next one,
+ * which is what the cap is for rather than a failure of it.
+ */
+function describeAt(rendered: readonly string[], measure: number): number {
+  const longest = Math.max(...rendered.map(visibleWidth), 0);
 
-${style.bold('Workspaces')}
-  ${PROGRAM} workspace list [--urls]   every workspace this one knows
-  ${PROGRAM} workspace show <name>     one workspace's adapters, and its address
-  ${PROGRAM} sync workspaces --workspace <name> [--from gs://bucket] [--discover]
-                                 [--prefer local|remote] [--dry-run]
-                                 reconcile this workspace with the copy the
-                                 deployment reads; recovers one a profile has lost
+  // Half, not the more usual third, because `  lanes link ` spends thirteen
+  // columns before a command has said anything. A third of eighty leaves
+  // twenty-six for the command itself, which is narrower than most of them and
+  // would push nearly every description onto a line of its own.
+  //
+  // The cap is what decides this in practice: the longest entry spells to 128
+  // columns and `width()` is clamped to 90, so `longest` only ever wins on a
+  // hypothetical narrow set. It is still computed rather than assumed, because
+  // a future help text with no long commands should not indent to half the
+  // screen for nothing.
+  return Math.max(Math.min(longest + 2, Math.floor(measure * 0.5)), 18);
+}
 
-${style.bold('Who you are')}
-  ${PROGRAM} identity add <kind> <value> [--note text] [--json]
-                                 e.g. name, email, github — any kind you like
-  ${PROGRAM} identity list [--json]
-  ${PROGRAM} identity remove <kind> <value> [--json]
+/**
+ * Below this, two columns stop being worth it.
+ *
+ * At sixty columns the description column lands at thirty and leaves thirty for
+ * the text — so three quarters of the entries print a wrapped paragraph in a
+ * half-width gutter with the left half blank. Stacking them under their command
+ * gives the description the whole width back, which is the thing a narrow pane
+ * has least of.
+ */
+const TWO_COLUMN_FROM = 72;
 
-${style.bold('Permissions')}
-  ${PROGRAM} policy list
-  ${PROGRAM} policy allow <capability> --connection <provider>.<id>
-                                 e.g. gmail.* or gmail.send_message. A rule lands
-                                 in one grant, so two accounts can differ
-  ${PROGRAM} policy deny  <capability> --connection <provider>.<id>
-  ${PROGRAM} profile members list       who may consume this profile, and who could
-  ${PROGRAM} profile members add <subject>|--me [--role owner|member]
-  ${PROGRAM} profile members remove <subject>
-  ${PROGRAM} token list [--json]        static tokens, and what each one reaches
-  ${PROGRAM} token issue --me|--subject <id> [--label <t>]
-                                 CI only: a token for one person. It reaches
-                                 every profile whose members list them
-  ${PROGRAM} token show [--id t] [--show|--raw]   --raw prints only it, for $(…)
-  ${PROGRAM} token rotate [--id t] [--show]
-  ${PROGRAM} token revoke --id <t>
+/** One entry's line, as it is measured and as it is shown. */
+function spell(entry: Entry): string {
+  return `  ${entry.flag === true ? entry.command : `${PROGRAM} ${entry.command}`}`;
+}
 
-${style.bold('Your own context')}
-  ${PROGRAM} memory list [--tag t]      what you have stored
-  ${PROGRAM} memory get <id>
-  ${PROGRAM} memory write <id> --title <t> [--tag t]   body on stdin
-  ${PROGRAM} memory forget <id>
+/**
+ * The whole help text, laid out for one width.
+ *
+ * Two shapes are load-bearing and asserted on by `argv.test.ts` and
+ * `instructions.test.ts`, which read this string to find every command the CLI
+ * documents. A command is emitted at exactly two spaces, so `/^ {2}\w/` selects
+ * the entries and nothing else; a flag begins with `-`, which is not `\w`, so
+ * flags are excluded exactly as they were; and every description line is
+ * indented at least four, so none can be mistaken for a command.
+ */
+export function usage(measure: number = width()): string {
+  const lines: string[] = wrap(`${PROGRAM} ${BANNER}`, measure).map((line, index) =>
+    index === 0 ? line.replace(PROGRAM, style.bold(PROGRAM)) : line,
+  );
+  const column = describeAt(SECTIONS.flatMap((s) => s.entries).map(spell), measure);
+  const stacked = measure < TWO_COLUMN_FROM;
 
-  ${PROGRAM} tasks list [--status s]     what is outstanding; --status all for everything
-  ${PROGRAM} tasks get <id>
-  ${PROGRAM} tasks add <title> [--status s] [--due d] [--tag t]   notes on stdin
-  ${PROGRAM} tasks update <id> --status <s>   closing one is an update, not a remove
-  ${PROGRAM} tasks remove <id>
-                                 statuses: in_progress open blocked muted done dropped
+  for (const section of SECTIONS) {
+    lines.push('', style.bold(section.title));
 
-  ${PROGRAM} assets list                files kept in this profile
-  ${PROGRAM} assets get <name>          the bytes, to stdout — redirect them
-  ${PROGRAM} assets add <file> [--name n] [--content-type t]
-  ${PROGRAM} assets remove <name>
+    for (const entry of section.entries) {
+      // A command may be too long for any terminal — `profile remove` with
+      // every flag spelled out is 125 characters. It wraps to a four-column
+      // hanging indent, which is deep enough that a continuation can never be
+      // mistaken for an entry by the two tests that read this string.
+      if (entry.gap === true) lines.push('');
 
-  ${PROGRAM} skills list                the procedures agents can invoke
-  ${PROGRAM} skills show <name>
-  ${PROGRAM} skills add <name> [--file f]             document on stdin
-  ${PROGRAM} skills remove <name>
+      const spelled = wrap(spell(entry), measure, { hanging: '  ' });
+      const last = spelled.at(-1)!;
+      for (const line of spelled.slice(0, -1)) lines.push(line);
 
-  ${PROGRAM} entities                 who and what everyone else is
-  ${PROGRAM} entities find [query] [--type t] [--tag t] [--attr kind[=value]]
-                                 [--related predicate=id]   every match, never a choice
-  ${PROGRAM} entities get <id>                   with its relationships, both ways
-  ${PROGRAM} entities write <name> [--type t] [--name id] [--alias a]
-                                 [--attr kind=value] [--related predicate=id]
-                                 notes on stdin; a flag you omit keeps what is stored
-  ${PROGRAM} entities link <from> <predicate>=<to>       one edge, written on <from> only
-  ${PROGRAM} entities forget <id>
-  ${PROGRAM} entities reindex                    rebuild the lookup index from the files
+      if (entry.description === undefined) {
+        lines.push(last);
+        continue;
+      }
 
-  ${PROGRAM} knowledge show            where memory and skills are kept, and how many
-  ${PROGRAM} knowledge use github --repo <owner/name> [--branch b] [--path p]
-                                 keep both in a private repository, over the GitHub API
-                                 [--migrate] moves what is already stored, in one commit
-                                 [--no-migrate] switches and leaves it where it is
-                                 [--keep] moves it, and leaves the local copies unread
-  ${PROGRAM} knowledge use local [--migrate]        bring them back onto this target
+      const gutter = stacked ? 4 : column;
+      const wrapped = wrap(entry.description, Math.max(measure - gutter, 20));
 
-  ${PROGRAM} vault list                 names only, never values
-  ${PROGRAM} vault get <id> [--show|--raw]
-  ${PROGRAM} vault set <id> [--description d]         value on stdin
-  ${PROGRAM} vault remove <id>
-  ${PROGRAM} vault key generate         a fresh LANES_LINK_VAULT_KEY, printed once
+      // Beside the command only when it is one line and there is room for it.
+      // A wrapped command's last line is a fragment — `[--dry-run]` — and a
+      // description set against that reads as belonging to the fragment rather
+      // than to the entry.
+      const beside = !stacked && spelled.length === 1 && visibleWidth(last) + 1 <= gutter;
 
-${style.bold('Deploying')}
-  ${PROGRAM} deploy --workspace <name> [--dry-run]
-                                 set up, build, and roll one revision serving
-                                 every profile that declares the target
-  ${PROGRAM} deploy --workspace <name> --profile a --profile b
-                                 only these; the first is the primary
-  ${PROGRAM} deploy --non-interactive   take the stored answers, never prompt
-  ${PROGRAM} deploy --access iam|public who gets past the platform's own door
-  ${PROGRAM} secrets list               credential references in this target
-  ${PROGRAM} secrets set <ref>          store one value, read from stdin
-  ${PROGRAM} secrets push --from local --to cloud
+      if (beside) {
+        lines.push(last + ' '.repeat(gutter - visibleWidth(last)) + style.dim(wrapped[0] ?? ''));
+      } else {
+        lines.push(last);
+        if (wrapped[0] !== undefined) lines.push(' '.repeat(gutter) + style.dim(wrapped[0]));
+      }
 
-${style.bold('Inspection')}
-  ${PROGRAM} check                      static validation, no external calls
-  ${PROGRAM} doctor [--json]            credentials resolve, stores reachable
-  ${PROGRAM} doctor --fix               apply a repair it can make itself, such as
-                                        a provider this project renamed under you
-  ${PROGRAM} auth [--json]              whether each connection can still sign in
-  ${PROGRAM} auth --connection <key>    just this one
-  ${PROGRAM} tools [--json]             what the endpoint advertises to a client
-  ${PROGRAM} plan                       what reconcile would change
-  ${PROGRAM} audit tail [--limit N] [--denied-only] [--format md]
-  ${PROGRAM} audit verify           has anything in the log been altered or removed
-  ${PROGRAM} config show
-  ${PROGRAM} version                    which release this is — same as lanes --version
-  ${PROGRAM} update [--check] [--json]  install the newer release, or say what is available
+      for (const line of wrapped.slice(1)) lines.push(' '.repeat(gutter) + style.dim(line));
+    }
+  }
 
-${style.bold('Attachments')}
-  ${PROGRAM} attach <file> --connection <provider>.<account>
-                                        stage a file, print a handle to send it by
+  lines.push('', ...wrap(FOOTER, measure));
 
-${style.bold('Naming what a command acts on')}
-  --profile <name>               required by every command that reads or writes a profile
-  --workspace <name>             required by every command that opens a workspace's
-                                 stores. "lanes set-workspace <name>" writes a default;
-                                 every command that uses it prints the name it resolved,
-                                 and deploy, sync, secrets push, profile remove,
-                                 disconnect and token rotate refuse it and want the flag.
-  --target <name>                the old spelling of --workspace. Accepted for one
-                                 minor, and it warns.
-
-${style.bold('Other flags')}
-  --connection <id>              which memory/tasks/assets/skills/vault/entities
-                                 connection, where a profile has several of one kind
-  --yes                          skip the confirmation a destructive command would ask for
-  --json                         machine-readable output, where a command offers it
-  --non-interactive              never prompt: connect refuses with what to store,
-                                 deploy takes the answers its config already holds
-  --label <text>                 what to call a connection, instead of being asked at the
-                                 end of connect. A display name only: nothing addresses
-                                 a connection by it. Use relabel to change one later
-  --accept-broad-scopes          agree in advance to scopes broader than a provider needs
-  --own-client                   register your own OAuth client instead of using the
-                                 one this project operates (connect only)
-  --auth <method>                which way in, where a provider offers two (connect
-                                 only). "oauth" is the browser; the other is named
-                                 in the choice connect prints. On connect custom it
-                                 names the credential type instead: none, bearer,
-                                 api-key, header, basic, oauth, strategy
-  --replace-manifest             rewrite a declaration that already exists and differs
-                                 (connect custom only — --replace is about the credential)
-  --port <n>                     override the configured port (start only)
-
-Every command prints the profile and target it is acting on, before it acts.
-`;
+  return lines.join('\n');
+}

--- a/src/deployments/deploy.ts
+++ b/src/deployments/deploy.ts
@@ -223,7 +223,7 @@ export async function deploy(flags: DeployFlags): Promise<void> {
     // the same run already took its setup answers from the config rather than
     // asking. `--yes` remains the way to skip it with a terminal attached.
     const assumed = flags.yes === true || flags.nonInteractive === true || !isInteractive();
-    if (!assumed && !(await confirm('  Create these now?'))) {
+    if (!assumed && !(await confirm('Create these now?'))) {
       throw new ConfigError('Stopped before creating anything. Nothing was changed.');
     }
     await runSteps(driver, provision);

--- a/src/deployments/gcp/survey.ts
+++ b/src/deployments/gcp/survey.ts
@@ -1,5 +1,5 @@
 import { ConfigError, DEPLOY_DEFAULTS, type DeployConfig, type TargetConfig } from '#profile';
-import { heading, print, style, waiting } from '#cli/output.ts';
+import { heading, progress, prose, style, waiting } from '#cli/output.ts';
 import { ask, confirm } from '#cli/prompt.ts';
 import type { SurveyInput, SurveyResult } from '../driver.ts';
 import { activeProject, openBillingAccounts, projectExists } from './gcloud.ts';
@@ -104,15 +104,15 @@ export function accountId(service: string): string {
 export async function surveyCloudRun(input: SurveyInput): Promise<SurveyResult> {
   const { current, profile, gated, adapters } = input;
 
-  heading('Where should this deploy?');
-  print(style.dim('  Answers are written into your profile, so this is asked once.'));
-  print('');
+  heading('Where should this deploy?', progress);
+  progress(style.dim('  Answers are written into your profile, so this is asked once.'));
+  progress('');
 
   const project = await askProject(current.project);
   const billing = await askBilling(project, current.billing_account);
-  const region = await askWithDefault('  Region', current.region ?? DEFAULT_REGION);
+  const region = await askWithDefault('Region', current.region ?? DEFAULT_REGION);
   const service = await askWithDefault(
-    '  Cloud Run service name',
+    'Cloud Run service name',
     current.service ?? defaultServiceName(profile),
   );
 
@@ -185,15 +185,14 @@ export async function surveyCloudRun(input: SurveyInput): Promise<SurveyResult> 
 async function askProject(current: string | undefined): Promise<string> {
   const active = await waiting('reading your gcloud configuration', activeProject);
 
-  print('  A project of its own is the cleanest home for this — it holds the bucket,');
-  print(
-    style.dim(
-      '  the credential store, and nothing else. A new id is proposed; type the name\n' +
-        `  of an existing project to deploy into that instead${active ? ` (yours is ${active})` : ''}.`,
-    ),
+  progress('  A project of its own is the cleanest home for this — it holds the bucket,');
+  prose(
+    '  the credential store, and nothing else. A new id is proposed; type the name ' +
+      `of an existing project to deploy into that instead${active ? ` (yours is ${active})` : ''}.`,
+    { paint: style.dim, to: progress },
   );
 
-  return askWithDefault('  Google Cloud project', current ?? proposedName());
+  return askWithDefault('Google Cloud project', current ?? proposedName());
 }
 
 /**
@@ -215,9 +214,9 @@ async function askBilling(project: string, current: string | undefined): Promise
   }
 
   const accounts = await waiting('listing your billing accounts', openBillingAccounts);
-  print('');
-  print(`  ${style.bold(project)} does not exist yet, so this deploy will create it.`);
-  print(style.dim('    A new project needs a billing account before any API can be enabled.'));
+  progress('');
+  progress(`  ${style.bold(project)} does not exist yet, so this deploy will create it.`);
+  progress(style.dim('    A new project needs a billing account before any API can be enabled.'));
 
   if (accounts.length === 0) {
     throw new ConfigError(
@@ -227,8 +226,8 @@ async function askBilling(project: string, current: string | undefined): Promise
     );
   }
 
-  for (const account of accounts) print(style.dim(`    ${account.id}  ${account.name}`));
-  return askWithDefault('  Billing account', accounts[0]!.id);
+  for (const account of accounts) progress(style.dim(`    ${account.id}  ${account.name}`));
+  return askWithDefault('Billing account', accounts[0]!.id);
 }
 
 /**
@@ -239,16 +238,15 @@ async function askBilling(project: string, current: string | undefined): Promise
  * not a failure worth a stack trace three steps later.
  */
 async function askBucket(project: string): Promise<string> {
-  print('');
-  print('  A bucket holds everything this endpoint remembers:');
-  print(
-    style.dim(
-      '    its config, its connection state, the audit log, memory, skills and\n' +
-        '    attachments. Named after the project by default; bucket names are\n' +
-        '    globally unique, so this one may be taken even when the project was not.',
-    ),
+  progress('');
+  progress('  A bucket holds everything this endpoint remembers:');
+  prose(
+    '    its config, its connection state, the audit log, memory, skills and ' +
+      'attachments. Named after the project by default; bucket names are globally ' +
+      'unique, so this one may be taken even when the project was not.',
+    { paint: style.dim, to: progress },
   );
-  return askWithDefault('  Bucket', project);
+  return askWithDefault('Bucket', project);
 }
 
 /**
@@ -264,18 +262,17 @@ async function askBucket(project: string): Promise<string> {
  * message anywhere said why.
  */
 async function askRemoteClients(): Promise<boolean> {
-  print('');
-  print('  Will you add this to Claude or ChatGPT, including on a phone?');
-  print(
-    style.dim(
-      '    yes  this endpoint issues its own tokens — the client registers itself,\n' +
-        '         a browser opens on its approval page, you paste the token once.\n' +
-        '         Nothing to set up: no OAuth client, no console, no redirect URI.\n' +
-        '    no   the bearer token is the only way in, which is all a local\n' +
-        '         registration needs. Add it later under auth.authorization.',
-    ),
+  progress('');
+  progress('  Will you add this to Claude or ChatGPT, including on a phone?');
+  prose(
+    '    yes  this endpoint issues its own tokens — the client registers itself, a ' +
+      'browser opens on its approval page, you paste the token once. Nothing to set ' +
+      'up: no OAuth client, no console, no redirect URI.\n' +
+      '    no   the bearer token is the only way in, which is all a local ' +
+      'registration needs. Add it later under auth.authorization.',
+    { paint: style.dim, to: progress },
   );
-  return confirm('  Issue tokens for remote clients?');
+  return confirm('Issue tokens for remote clients?');
 }
 
 /**
@@ -293,25 +290,23 @@ async function askAccess(
 ): Promise<DeployConfig['access']> {
   const proposed = current ?? (gated ? 'public' : 'iam');
 
-  print('');
-  print('  Who may reach the service?');
-  print(
-    style.dim(
-      '    iam     the platform checks a Google identity token first. Nothing that\n' +
-        '            cannot mint one gets through — which includes every agent harness.\n' +
-        '    public  the platform lets the request in and this endpoint authenticates it.',
-    ),
+  progress('');
+  progress('  Who may reach the service?');
+  prose(
+    '    iam     the platform checks a Google identity token first. Nothing that ' +
+      'cannot mint one gets through — which includes every agent harness.\n' +
+      '    public  the platform lets the request in and this endpoint authenticates it.',
+    { paint: style.dim, to: progress },
   );
   if (gated) {
-    print(
-      style.dim(
-        '    This profile authenticates requests itself, so "public" is the working\n' +
-          '    choice — "iam" in front of it would lock out the clients it exists for.',
-      ),
+    prose(
+      '    This profile authenticates requests itself, so "public" is the working ' +
+        'choice — "iam" in front of it would lock out the clients it exists for.',
+      { paint: style.dim, to: progress },
     );
   }
 
-  const answer = (await askWithDefault('  Access', proposed)).toLowerCase();
+  const answer = (await askWithDefault('Access', proposed)).toLowerCase();
   return answer === 'public' ? 'public' : 'iam';
 }
 
@@ -328,6 +323,6 @@ async function askWithDefault(question: string, fallback: string | null | undefi
     const answer = (await ask(shown)).trim();
     if (answer) return answer;
     if (fallback) return fallback;
-    print(style.dim('    Required.'));
+    progress(style.dim('    Required.'));
   }
 }

--- a/src/deployments/report.ts
+++ b/src/deployments/report.ts
@@ -1,5 +1,5 @@
 import type { DeployConfig } from '#profile';
-import { heading, ok, print, style, warn } from '#cli/output.ts';
+import { heading, ok, print, prose, style, warn } from '#cli/output.ts';
 
 /**
  * What a deploy tells the operator, as against what it does.
@@ -64,15 +64,19 @@ export function reportUnauthorised(warnings: readonly string[], profile: string,
   if (warnings.length === 0) return;
 
   heading('Not authorised yet');
-  for (const problem of warnings) print(warn(problem));
+  for (const problem of warnings) prose(problem, { prefix: warn('') });
   print('');
+  prose('  A browser consent per account is the one step this cannot take for you:', {
+    paint: style.dim,
+  });
+  // Printed rather than wrapped, alone among these lines: it is meant to be
+  // pasted, and a break inserted into it is a break in what somebody copies.
   print(
-    style.dim(
-      '  A browser consent per account is the one step this cannot take for you:\n' +
-        `    lanes link connect <provider> --profile ${profile} --workspace ${target}\n` +
-        '  Each is served as soon as it is authorised. There is no second deploy —\n' +
-        '  deploying is how code gets here, and authorising an account changes none.',
-    ),
+    `    ${style.dim(`lanes link connect <provider> --profile ${profile} --workspace ${target}`)}`,
+  );
+  prose(
+    '  Each is served as soon as it is authorised. There is no second deploy — deploying is how code gets here, and authorising an account changes none.',
+    { paint: style.dim },
   );
 }
 


### PR DESCRIPTION
Terminal output has a width, a structure, and a palette.

`lanes link connect github` printed its seven setup steps as one paragraph, broken mid-word wherever the terminal ran out. Nothing in `src/` read `process.stdout.columns`, so nothing could have done otherwise.

Prose now wraps to the terminal it is on, headings carry a rule, numbered steps align their continuations under the text, prompts are asked with a marker and a caret, and `--help` is laid out for the width it is asked on rather than the one it was typed for. Colour is the brand emerald from `brand.ts`, resolved down a capability ladder from truecolor to none.

**A minor rather than a patch.** Nothing about what the CLI does changed, and every `--json` payload is byte-identical — the desktop app reads `update --check --json` at launch (ADR-065) and sees exactly what it saw before. But every command's human output looks different, and a patch would be the wrong thing to tell somebody reading it in a screenshot.

Five defects fixed along the way, each pre-existing:

- an interactive `connect --json` wrote its prompt into the JSON document
- `--help` had a description sitting four rows from the command it described
- `table()` measured with `.length`, so a CJK connection label shifted every column after it
- the wait spinner could outrun the terminal and leave a row on screen for the rest of the run
- five call sites appended a colon on top of the one `ask` already added

Provider manifest strings are untouched, so the `lanes_setup_provider` MCP surface is unchanged (ADR-019).