### PR TITLE
chore: 0.10.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lanes-sh/link",
-  "version": "0.10.0",
+  "version": "0.10.1",
   "description": "A self-hostable MCP gateway for all your connections, memory, tasks, files, and secrets",
   "license": "Apache-2.0",
   "homepage": "https://lanes.sh/link",


### PR DESCRIPTION
Patch release for #170: connecting one account twice now lands on the row it already has, instead of appending a second one beside it.

Version only — no source change. Merging this to `develop` and then `develop` to `main` publishes 0.10.1 to npm.