### PR TITLE
The writing example stops modelling a command that does nothing

### DIFF
--- a/.claude/skills/lanes-writing/SKILL.md
+++ b/.claude/skills/lanes-writing/SKILL.md
@@ -160,7 +160,6 @@ Needs Bun 1.3.11+.
 $ bun install -g @lanes-sh/link
 $ lanes auth login
 $ lanes link profile add personal
-$ lanes link profile members add --me --profile personal
 $ lanes link start
 ok  serving http://127.0.0.1:7337/mcp
 


### PR DESCRIPTION
Missed from #175, which took this line out of the README that this worked example quotes.

The example's "after" block is meant to mirror the README, so leaving it here had a style guide
teaching the one command #175 established is a no-op. The "before" block is a snapshot of what
that page used to say and is unchanged.

One line. `web` has the same fix in its canonical copy (`lanes-sh/web#67`); `core` holds a third
copy that is out of scope for both.