### PR TITLE
/state says when a connection arrived, and when it last moved

### DIFF
--- a/src/server/read/connections.test.ts
+++ b/src/server/read/connections.test.ts
@@ -1,0 +1,117 @@
+import { afterAll, describe, expect, test } from 'bun:test';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { CONNECTIONS_FILE } from '#profile';
+import type { Runtime } from '#cli/runtime.ts';
+import { createProfile } from '#cli/commands/profile.ts';
+import { connectionRows } from './connections.ts';
+
+/**
+ * The join between what the workspace holds and what the endpoint remembers.
+ *
+ * One property carries this file: **`connections.yaml` decides which rows
+ * exist, and the state store only decorates them.** The store is rebuilt from
+ * the file by reconcile and its own header says it can be deleted and rebuilt
+ * at any time, so every way it can come back short has to cost a reader the
+ * dates and never the row. A listing that empties itself because a disposable
+ * cache would not open is the failure this is here to prevent.
+ */
+
+const CONNECTIONS = `
+  - { id: main, provider: gmail, account: first@example.com }
+  - { id: side, provider: gmail, account: second@example.com }
+`;
+
+const roots: string[] = [];
+const previousHome = process.env['LANES_LINK_HOME'];
+
+async function workspace(): Promise<string> {
+  const root = await mkdtemp(join(tmpdir(), 'lanes-link-read-connections-'));
+  roots.push(root);
+  process.env['LANES_LINK_HOME'] = root;
+  await createProfile('personal', { targets: ['local'] });
+
+  const path = join(root, CONNECTIONS_FILE);
+  const held = await Bun.file(path).text();
+  await Bun.write(path, held.replace('connections:', `connections:${CONNECTIONS}`));
+  return root;
+}
+
+afterAll(async () => {
+  if (previousHome === undefined) delete process.env['LANES_LINK_HOME'];
+  else process.env['LANES_LINK_HOME'] = previousHome;
+  await Promise.all(roots.map((root) => rm(root, { recursive: true, force: true })));
+});
+
+/** A runtime with only the two things `connectionRows` reads. */
+function runtime(root: string, list: () => Promise<unknown[]>): Runtime {
+  return {
+    resolution: { workspaceRoot: root },
+    state: { connections: { list } },
+  } as unknown as Runtime;
+}
+
+const record = (provider: string, id: string, created: string, updated: string) => ({
+  provider,
+  id,
+  createdAt: new Date(created),
+  updatedAt: new Date(updated),
+});
+
+describe('connectionRows', () => {
+  test('a row the store knows carries its dates, as ISO 8601', async () => {
+    const root = await workspace();
+    const rows = await connectionRows(
+      runtime(root, async () => [
+        record('gmail', 'main', '2026-01-02T03:04:05.000Z', '2026-03-04T05:06:07.000Z'),
+      ]),
+    );
+
+    const main = rows.find((row) => row.id === 'main');
+    expect(main?.createdAt).toBe('2026-01-02T03:04:05.000Z');
+    expect(main?.updatedAt).toBe('2026-03-04T05:06:07.000Z');
+  });
+
+  test('a row the store has not caught up with keeps its place', async () => {
+    const root = await workspace();
+    const rows = await connectionRows(
+      runtime(root, async () => [
+        record('gmail', 'main', '2026-01-02T03:04:05.000Z', '2026-01-02T03:04:05.000Z'),
+      ]),
+    );
+
+    const side = rows.find((row) => row.id === 'side');
+    expect(side).toBeDefined();
+    expect(side?.account).toBe('second@example.com');
+    expect(side?.createdAt).toBeUndefined();
+  });
+
+  test('a store that will not open costs the dates, not the listing', async () => {
+    // The one that matters. `state.kv` is disposable, and on a deployed
+    // endpoint it is a bucket read that can fail on its own.
+    const root = await workspace();
+    const rows = await connectionRows(
+      runtime(root, async () => {
+        throw new Error('the bucket said no');
+      }),
+    );
+
+    expect(rows.map((row) => `${row.provider}.${row.id}`)).toContain('gmail.main');
+    expect(rows.map((row) => `${row.provider}.${row.id}`)).toContain('gmail.side');
+    expect(rows.every((row) => row.createdAt === undefined)).toBe(true);
+  });
+
+  test('a record for a connection the file no longer declares adds no row', async () => {
+    // Reconcile removes these, but it runs on a reload and this runs on every
+    // request, so the file has to be the one that decides.
+    const root = await workspace();
+    const rows = await connectionRows(
+      runtime(root, async () => [
+        record('slack', 'gone', '2026-01-02T03:04:05.000Z', '2026-01-02T03:04:05.000Z'),
+      ]),
+    );
+
+    expect(rows.map((row) => `${row.provider}.${row.id}`)).not.toContain('slack.gone');
+  });
+});

--- a/src/server/read/connections.ts
+++ b/src/server/read/connections.ts
@@ -1,0 +1,38 @@
+import { readConnections } from '#profile';
+import type { Runtime } from '#cli/runtime.ts';
+import type { ConnectionRow } from './state.ts';
+
+/**
+ * The workspace's connections, with the endpoint's own memory of them attached.
+ *
+ * Two sources with different jobs. `connections.yaml` is the authority for
+ * *which* connections exist: it is what the operator wrote and what `connect`
+ * appends to. The state store is the authority for *when*, because the file has
+ * never carried a timestamp and a whole-file mtime cannot speak about one row.
+ *
+ * **The file wins on membership, always.** The state store is rebuilt from the
+ * file by reconcile and its own header says it can be deleted at any time, so a
+ * row it has not caught up with, or a store that will not open at all, must
+ * leave the listing intact and the dates absent. That is what the `catch` is
+ * for; it is not defensive habit.
+ *
+ * Both binds call this rather than each holding a copy of the join. Reaching
+ * `primary.state` here is allowed where importing `#stores` would not be:
+ * `architecture.test.ts` forbids the specifier, and the type arrives through
+ * `Runtime`, which this surface already depends on.
+ */
+export async function connectionRows(primary: Runtime): Promise<readonly ConnectionRow[]> {
+  const { connections } = await readConnections(primary.resolution.workspaceRoot);
+  const records = await primary.state.connections.list().catch(() => []);
+  const seen = new Map(records.map((record) => [`${record.provider}.${record.id}`, record]));
+
+  return connections.map((row) => {
+    const record = seen.get(`${row.provider}.${row.id}`);
+    if (!record) return row;
+    return {
+      ...row,
+      createdAt: record.createdAt.toISOString(),
+      updatedAt: record.updatedAt.toISOString(),
+    };
+  });
+}

--- a/src/server/read/deployed.ts
+++ b/src/server/read/deployed.ts
@@ -1,7 +1,8 @@
-import { PAIR_TOKEN_REF, readConnections } from '#profile';
+import { PAIR_TOKEN_REF } from '#profile';
 import type { Runtime } from '#cli/runtime.ts';
 import type { Logger } from '#connectivity';
 import type { ProfileRuntime } from '../mcp/visibility.ts';
+import { connectionRows } from './connections.ts';
 import { cachedPairingCredential } from './credential.ts';
 import type { ReadDeps } from './routes.ts';
 import type { DataSurface } from '#cli/owner-data/surface.ts';
@@ -41,8 +42,7 @@ export function deployedReadDeps(input: {
     workspace: primary.target,
     profiles: input.profiles,
     audit: primary.audit,
-    connections: async () =>
-      (await readConnections(primary.resolution.workspaceRoot)).connections,
+    connections: () => connectionRows(primary),
     // The names the dashboard shows for a row nobody has labelled. From the
     // registry rather than a catalogue, so the owner layer, the vendors and a
     // workspace's own manifests are all named the same way.

--- a/src/server/read/open.ts
+++ b/src/server/read/open.ts
@@ -1,10 +1,11 @@
 import { X509Certificate } from 'node:crypto';
-import { PAIR_CERT_REF, PAIR_KEY_REF, PAIR_TOKEN_REF, readConnections } from '#profile';
+import { PAIR_CERT_REF, PAIR_KEY_REF, PAIR_TOKEN_REF } from '#profile';
 import type { Runtime } from '#cli/runtime.ts';
 import type { Logger } from '#connectivity';
 import type { RunningServer } from '../index.ts';
 import type { ProfileRuntime } from '../mcp/visibility.ts';
 import type { DataSurface } from '#cli/owner-data/surface.ts';
+import { connectionRows } from './connections.ts';
 import { directPairingCredential } from './credential.ts';
 import { serveRead, type RunningReadListener } from './listener.ts';
 
@@ -62,8 +63,7 @@ export async function openReadListener(
       workspace: primary.target,
       profiles,
       audit: primary.audit,
-      connections: async () =>
-        (await readConnections(primary.resolution.workspaceRoot)).connections,
+      connections: () => connectionRows(primary),
       // The names the dashboard shows for a row nobody has labelled. From the
       // registry rather than a catalogue, so the owner layer, the vendors and a
       // workspace's own manifests are all named the same way.

--- a/src/server/read/state.test.ts
+++ b/src/server/read/state.test.ts
@@ -20,7 +20,16 @@ import type { ProfileRuntime } from '../mcp/visibility.ts';
 
 const ROWS: ConnectionRow[] = [
   { provider: 'lanes_memory', id: 'main', account: 'Memory' },
-  { provider: 'gmail', id: 'ada', account: 'ada@example.com', label: 'Work mail' },
+  {
+    provider: 'gmail',
+    id: 'ada',
+    account: 'ada@example.com',
+    label: 'Work mail',
+    createdAt: '2026-01-02T03:04:05.000Z',
+    updatedAt: '2026-03-04T05:06:07.000Z',
+  },
+  // No dates: a row the state store has not caught up with, which is the
+  // ordinary case for a connection added since the last reconcile pass.
   { provider: 'gmail', id: 'rin', account: 'rin@example.com' },
 ];
 
@@ -147,5 +156,44 @@ describe('who can reach one', () => {
     expect(state.connections.find((one) => one.ref === 'ghost.one')?.profiles).toEqual([
       'personal',
     ]);
+  });
+});
+
+/**
+ * When a connection arrived, and when it last moved.
+ *
+ * `connections.yaml` has never carried a date, so these come from the state
+ * store and `connectionRows` attaches them. Two things matter here: a row the
+ * store has no record of still appears, and the row nothing holds but a grant
+ * says null rather than borrowing a date from somewhere else.
+ */
+describe('when a connection arrived', () => {
+  test('the dates the store had are passed through', () => {
+    const state = readState('acme', new Map(), ROWS, ENDPOINT, NAMES);
+    const ada = state.connections.find((one) => one.ref === 'gmail.ada');
+
+    expect(ada?.createdAt).toBe('2026-01-02T03:04:05.000Z');
+    expect(ada?.updatedAt).toBe('2026-03-04T05:06:07.000Z');
+  });
+
+  test('a row the store has no record of is still listed, and says so', () => {
+    // The state store is rebuilt from the file and can be deleted at any time.
+    // Missing dates must cost a reader the dates, never the row.
+    const state = readState('acme', new Map(), ROWS, ENDPOINT, NAMES);
+    const rin = state.connections.find((one) => one.ref === 'gmail.rin');
+
+    expect(rin).toBeDefined();
+    expect(rin?.createdAt).toBeNull();
+    expect(rin?.updatedAt).toBeNull();
+  });
+
+  test('a grant naming a connection the workspace no longer holds has no dates', () => {
+    const profiles = new Map([['personal', profile(['slack.vanished'])]]);
+    const state = readState('acme', profiles, ROWS, ENDPOINT, NAMES);
+    const orphan = state.connections.find((one) => one.ref === 'slack.vanished');
+
+    expect(orphan).toBeDefined();
+    expect(orphan?.createdAt).toBeNull();
+    expect(orphan?.updatedAt).toBeNull();
   });
 });

--- a/src/server/read/state.ts
+++ b/src/server/read/state.ts
@@ -40,6 +40,25 @@ export interface ReadConnection {
   readonly account: string | null;
   /** Which profiles grant this connection at all. */
   readonly profiles: readonly string[];
+  /**
+   * When this endpoint first saw the connection, ISO 8601.
+   *
+   * Null when the state store has no record of it: a row reconcile has not
+   * caught up with, or a store that has been cleared. `connections.yaml` has
+   * never carried a timestamp, so this is the endpoint's own memory rather than
+   * anything the operator wrote, and a reader is told nothing rather than told
+   * a guess.
+   */
+  readonly createdAt: string | null;
+  /**
+   * When the account or the credential status last changed, ISO 8601.
+   *
+   * **Not "last used", and not a token refresh.** Reconcile moves this only
+   * when the account string it resolves differs from the stored one, or when
+   * the status flips, so on an untouched connection it equals `createdAt` for
+   * the life of the workspace. Anything that wants activity wants `/audit`.
+   */
+  readonly updatedAt: string | null;
 }
 
 /**
@@ -56,12 +75,20 @@ export interface ReadConnection {
  */
 export type ProviderNames = (provider: string) => string | undefined;
 
-/** The connection rows as `connections.yaml` holds them. */
+/**
+ * The connection rows as `connections.yaml` holds them.
+ *
+ * The two dates are not in that file and never were; `connectionRows` attaches
+ * them from the state store on the way in. Optional because that store is
+ * disposable by design, so a bind that cannot read it still produces rows.
+ */
 export interface ConnectionRow {
   readonly provider: string;
   readonly id: string;
   readonly account?: string | undefined;
   readonly label?: string | undefined;
+  readonly createdAt?: string | undefined;
+  readonly updatedAt?: string | undefined;
 }
 
 export interface ReadGrant {
@@ -173,6 +200,8 @@ export function readState(
       label: row.label ?? (named ? defaultConnectionLabel(named, row.account) : null),
       account: row.account ?? null,
       profiles: grantedBy.get(ref) ?? [],
+      createdAt: row.createdAt ?? null,
+      updatedAt: row.updatedAt ?? null,
     };
   });
 
@@ -192,6 +221,10 @@ export function readState(
       label: null,
       account: null,
       profiles: grantedBy.get(ref) ?? [],
+      // Nothing holds this row but a grant, so there is no record of it to
+      // date and no file line it came from.
+      createdAt: null,
+      updatedAt: null,
     });
   }
 


### PR DESCRIPTION
`ConnectionRecord` has carried `createdAt` and `updatedAt` since contract 4, one JSON object per connection under `state.kv/`, durable across a restart and identical on loopback and in a bucket. Nothing has ever read them. The dashboard lists a workspace's accounts with no way to tell the one authorised this morning from the one authorised in March, and the answer was on disk the whole time.

`connections.yaml` cannot supply it. The schema has no timestamp field and the file is rewritten whole on every connect, relabel and disconnect, so its mtime speaks about the file and never about a row. The state store is the only per-connection record of when, which is why this joins the two rather than widening the config.

## The file decides which rows exist; the store only decorates

Reconcile rebuilds the store from the file, its own header says it can be deleted at any time, and on a deployed endpoint reading it is a bucket call that can fail by itself. So every way it comes back short costs a reader the dates and never the row:

- a connection the store has not caught up with lists without them
- a store that will not open at all lists everything without them
- a record for a connection the file no longer declares adds no row

A listing that empties itself because a disposable cache was unavailable would be the worst outcome available. `connections.test.ts` pins that it does not.

## Where the join lives

One function both binds call rather than a copy in each. `server` may not import `#stores` and does not: the type arrives through `Runtime`, which this surface already depends on, and `architecture.test.ts` still passes.

Auth is checked above `/state` in `routes.ts`, so an unpaired caller never reaches the thunk and the ADR-054 hazard the deployed bind's comment describes does not apply here.

## Named for what the record holds

`createdAt` is the first reconcile pass that saw the connection. `updatedAt` moves only when the account string or the credential status changes, so neither is activity and an untouched connection carries the same instant twice. A reader wanting what happened wants `/audit`. The dashboard labels them Added and Last changed for that reason, and hides the second when it equals the first.

## Additive on a surface with nothing to negotiate

`/state` has no version, no schema and no handshake, and the dashboard casts the response. An older dashboard ignores the two fields; a newer one against an older endpoint sees them absent and says nothing, the way `/data` already answers 404 on an endpoint that predates it.

Consumed by lanes-sh/web#68, which renders the ref alone until this lands.

## Verification

- `bun run typecheck` clean
- `bun test`: 3262 pass, up from 3255. The 2 failures are the pre-existing `outputs` / `--profile` timeouts, unchanged from the baseline on this branch point.
