### PR TITLE
chore: 0.10.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lanes-sh/link",
-  "version": "0.10.1",
+  "version": "0.10.2",
   "description": "A self-hostable MCP gateway for all your connections, memory, tasks, files, and secrets",
   "license": "Apache-2.0",
   "homepage": "https://lanes.sh/link",


### PR DESCRIPTION
Version on `develop` before the release pull request, so the merge to `main` publishes directly rather than taking the propose path and leaving `develop` a commit behind.

Contents: #175, #176, #178.