### PR TITLE
0.10.2

### DIFF
--- a/.claude/skills/lanes-writing/SKILL.md
+++ b/.claude/skills/lanes-writing/SKILL.md
@@ -160,7 +160,6 @@ Needs Bun 1.3.11+.
 $ bun install -g @lanes-sh/link
 $ lanes auth login
 $ lanes link profile add personal
-$ lanes link profile members add --me --profile personal
 $ lanes link start
 ok  serving http://127.0.0.1:7337/mcp
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,6 @@ Needs [Bun](https://bun.com) 1.3.11+ and a Lanes sign-in.
 $ bun install -g @lanes-sh/link
 $ lanes auth login
 $ lanes link profile add personal
-$ lanes link profile members add --me --profile personal
 $ lanes link start
 ok    serving http://127.0.0.1:7337/mcp
       profiles: personal
@@ -168,8 +167,10 @@ To report a vulnerability, see [`SECURITY.md`](SECURITY.md). Please do not open 
 against anything if it does not know who is asking. The network is needed to sign in and to
 refresh, not per call, so a machine offline for a day keeps serving.
 
-**Why members is not optional.** An empty members list means nobody, not everybody. The profile
-you just created reaches no caller until you are on it.
+**Who reaches a profile.** An empty members list means nobody, not everybody. `profile add` puts
+you on the profile it creates, so a profile you made while signed in already reaches you. One
+created before you signed in has nobody on it: add yourself with `lanes link profile members add
+--me --profile <name>`.
 
 **Why `mcp add` names no profile.** One endpoint serves every profile in the workspace, and each
 call names one in its `profile` argument, so registering is about the endpoint. Which profiles a

--- a/docs/detailed/adr/074-the-endpoint-records-where-it-bound.md
+++ b/docs/detailed/adr/074-the-endpoint-records-where-it-bound.md
@@ -1,0 +1,99 @@
+# ADR-074: The endpoint records where it bound
+
+**Status:** accepted · **Follows from** [ADR-029](029-connecting-is-not-deploying.md), [ADR-009](009-one-endpoint-per-workspace.md)
+
+## Context
+
+ADR-029 separated a config edit from a deployment: an edit publishes itself and tells the running
+endpoint to re-read, so connecting an account stopped costing a Docker build. Seven commands do
+this — `connect`, `connection`, `grant`, `identity`, `members`, `policy`, `relabel` — and they
+share one helper, `notifyReload`, which works out the address to POST `/reload` at.
+
+It worked out the wrong address for most of them, and the way it was wrong is the reason this is
+an ADR rather than a bug fix.
+
+ADR-009 says one endpoint serves every profile in the workspace from one URL. `lanes link start`
+binds **one** socket, and which port that is comes from the `instance.port` of the profile it was
+started with. But `notifyReload` derived its address from the `instance.port` of the profile being
+*edited*:
+
+```ts
+url = (await endpointUrl(input.config, declared)).replace(/\/mcp$/, '/reload');
+```
+
+For an edit to the profile `start` was run under, those two are the same number and everything
+works. For an edit to any sibling they are different, and the notify goes to a port with nothing
+behind it. For a profile that has just been *created* they cannot agree: its port is fresh, so
+nothing has ever listened there.
+
+The failure mode is the expensive kind. `notifyReload` catches a refused connection and reports
+`no endpoint answered — saved, and the endpoint will serve this when it next starts`, which is the
+true sentence for an endpoint that is **down**. So an operator with a running endpoint read a
+plausible line, believed the edit would land on the next restart, and had a live endpoint serving
+superseded config in the meantime. It is the same shape as ADR-032's stale tool list: the edit
+succeeded, the surface did not change, and nothing said so.
+
+`profile add` made it visible because it made it total. A new profile in a deployed workspace is
+written straight into the bucket and is durable immediately, while the running revision — which
+lists the profiles at boot and at a reload and at no other time — goes on serving the set it
+found when it came up. The profile exists and is invisible at once, which reads exactly like a
+dashboard that has not refreshed. `profile remove` is the same gap pointing the other way, and
+worse: a profile whose credentials and stores have been deleted stayed reachable through the
+endpoint, so "I revoked that" was not true yet.
+
+## Decision
+
+**The process that binds the socket writes down where it bound, and the commands that have to
+reach it read that.**
+
+`lanes link start` writes `endpoint.json` at the workspace root — the URL, the profiles it opened,
+its own pid, and when it started. `notifyReload` now resolves an address in the order of who
+actually knows:
+
+1. **The platform**, for a deployed target. It assigns the hostname, so it is authoritative.
+2. **The record**, for a local one.
+3. **The edited profile's config**, when there is no record — which is the address this used
+   unconditionally, so a workspace whose endpoint predates this is no worse off.
+
+`profile add` and `profile remove` join the seven commands that publish, and a test asserts the
+rule structurally: a command that calls `recordConfigChange` must also reach `publish.ts`, or name
+itself as an exception with an argument. A hand-kept list of the seven would not have caught this,
+because the list would have been written from the code as it stood.
+
+### The record is a hint, and is allowed to be wrong
+
+This is the part that makes it safe to leave a file like this lying around. `notifyReload` still
+has to reach what the record names, and the POST carries this workspace's own bearer token, so
+both ways it can be stale fail closed:
+
+- **The endpoint is gone.** A `kill -9` skips the shutdown that clears the file, so the record
+  outlives the listener. The reader checks the pid with signal `0` and answers null for a dead
+  one, which returns the caller to the config-derived address it used before.
+- **The pid was reused, or another workspace took the port.** A stranger does not accept this
+  workspace's token, so the notify is refused rather than delivered to the wrong endpoint. This is
+  the hazard `endpointHealth` was written to warn about — "two workspaces can assign the same
+  port, so an endpoint answering is not the same as *this* profile's endpoint answering" — and it
+  is why the answer is not simply "trust the file".
+
+### Local roots only
+
+Nothing is written for a `gs://` workspace. A deployment's address comes from the platform, and
+ADR-007 says a revision never writes its own configuration — a record in the bucket would be a
+revision announcing itself into the files it is forbidden to touch. For the same reason the write
+lives in `commands/operate/serve.ts` rather than in `startEndpoint`, which the container
+entrypoint also calls: the control plane records this, exactly as the control plane, not the
+container, performs the owner-layer repair beside it.
+
+## Consequences
+
+A config edit reaches a running local endpoint whichever profile it touched, and `profile add`
+against a live workspace now prints `Serving it now — the endpoint has re-read its config` instead
+of nothing. A workspace gains one small file that is not config and not data, and which a reader
+has to know is a hint — hence this record and the doc comment on `endpoint-record.ts`.
+
+Two things are deliberately not solved here. The record says nothing about an endpoint started by
+something other than `lanes link start`, which falls back to the old behaviour rather than
+failing. And `profile add` reports its outcome only when the endpoint took the edit or the target
+publishes somewhere: a new profile in a workspace that has never served has nothing holding a
+stale view of it, and the no-endpoint line arrived as the first sentence this CLI ever printed,
+describing an endpoint the reader had not set up yet.

--- a/docs/detailed/adr/README.md
+++ b/docs/detailed/adr/README.md
@@ -86,6 +86,7 @@ Run.
 | [068](068-a-credential-names-a-person.md) | A credential names a person, and the profiles follow from that; the endpoint token becomes the workspace's |
 | [069](069-a-pairing-token-may-write-the-owners-own-data.md) | A pairing token may write the owner's own data; the control plane is unmoved |
 | [073](073-a-connection-names-its-own-account.md) | A connection names its own account; the operator is asked last, and never handed a uuid to live with |
+| [074](074-the-endpoint-records-where-it-bound.md) | The endpoint records where it bound, so an edit reaches the one that is running rather than a port derived from the profile it edited |
 
 Where an ADR departs from init.md, it says so at the top. Three are significant:
 

--- a/instructions/skills/lanes-link/SKILL.md
+++ b/instructions/skills/lanes-link/SKILL.md
@@ -402,11 +402,14 @@ refresh, not per call, so a machine offline for a day keeps serving.
 
 `lanes link start` refuses without a session, and names the command.
 
-A profile declares who may consume it, and **empty means nobody**:
+A profile declares who may consume it, and **empty means nobody**. `profile add`
+puts the signed-in subject on the profile it creates, so there is no step to
+suggest after creating one. A profile made before anyone signed in has nobody on
+it, and that is what the first command below is for:
 
 ```
-lanes link profile members add --me --profile assistant --workspace local
 lanes link profile members list --profile assistant --workspace local
+lanes link profile members add --me --profile assistant --workspace local
 ```
 
 That list is a selection from the Lanes workspace rather than a second list

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lanes-sh/link",
-  "version": "0.10.1",
+  "version": "0.10.2",
   "description": "A self-hostable MCP gateway for all your connections, memory, tasks, files, and secrets",
   "license": "Apache-2.0",
   "homepage": "https://lanes.sh/link",

--- a/src/cli/commands/operate/serve.ts
+++ b/src/cli/commands/operate/serve.ts
@@ -1,5 +1,5 @@
 import { readSession } from '#auth/lanes/session.ts';
-import { ConfigError } from '#profile';
+import { clearEndpointRecord, ConfigError, writeEndpointRecord } from '#profile';
 import { startEndpoint } from '#server/endpoint.ts';
 import { streamLogger } from '#server/logging.ts';
 import { repairOwnerLayer } from '../../config-repair-sweep.ts';
@@ -77,6 +77,17 @@ export async function start(
   print(ok(`serving ${style.bold(endpoint.url)}`));
   print(style.dim(`      profiles: ${endpoint.profiles.join(', ')}`));
 
+  // Written here rather than inside `startEndpoint`, for the reason the owner
+  // repair above gives: the container entrypoint calls that too, and a deployed
+  // revision must not write into its own workspace (ADR-007). A deployment's
+  // address comes from the platform anyway. This is the control plane, on a
+  // local root, recording the one fact no other command can work out — see
+  // `endpoint-record.ts` and ADR-074.
+  await writeEndpointRecord(resolution.workspaceRoot, {
+    url: endpoint.url,
+    profiles: endpoint.profiles,
+  });
+
   // Last, not first: the endpoint is what someone ran this for, and a version
   // note in front of it would be the first thing they read and the least useful.
   const stale = await staleNudge();
@@ -85,6 +96,11 @@ export async function start(
   print(style.dim('Ctrl-C to stop.'));
 
   const shutdown = async (): Promise<void> => {
+    // Before the socket closes, so the window in which the record names a live
+    // pid and a dead listener is as small as this can make it. A `kill -9`
+    // leaves it behind regardless, which is what the pid check on the read side
+    // is for.
+    await clearEndpointRecord(resolution.workspaceRoot);
     await endpoint.stop();
     process.exit(0);
   };

--- a/src/cli/commands/profile.test.ts
+++ b/src/cli/commands/profile.test.ts
@@ -5,7 +5,7 @@ import { existsSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { emit } from '../output.ts';
-import { createProfile, profileList, readProfiles } from './profile.ts';
+import { createProfile, profileAdd, profileList, publishedAfterCreate, readProfiles } from './profile.ts';
 
 /**
  * `lanes link profile`, and the `--json` guard every machine-readable command
@@ -244,5 +244,77 @@ describe('profile list --json', () => {
     const written = await captureStdout(() => profileList('local', { json: true }));
 
     expect(JSON.parse(written)).toMatchObject({ profiles: [] });
+  });
+});
+
+/**
+ * A new profile has to reach the endpoint that will serve it.
+ *
+ * `profile add` was the one config-writing command that wrote its file and told
+ * nobody, while `connect`, `grant`, `members`, `policy`, `identity`, `relabel`
+ * and `connection` all end on `publishProfileEdit`. On a deployed workspace
+ * that made a profile durable and invisible: a running endpoint lists the
+ * profiles at boot and at a reload and at no other time, so the bucket held it
+ * and `/state` — and so the dashboard, and every client — did not, until the
+ * revision happened to restart.
+ *
+ * These sit on `profileAdd` rather than `createProfile` deliberately. The split
+ * between the two is what hid the gap in the first place: every existing test
+ * here drives the data function, and the publish belongs to the wrapper.
+ */
+describe('a created profile is published to the endpoint that serves it', () => {
+  test('a served edit says so, and says how a client picks it up', () => {
+    const line = publishedAfterCreate({ served: true, tools: 26 });
+
+    expect(line).toContain('Serving it now');
+    expect(line).toContain('26 tools');
+  });
+
+  test('a deployed target reports even when nothing answered', () => {
+    // The case this whole change exists for. The config is in the bucket, so
+    // the next boot serves it — but the revision running *now* does not, and
+    // silence is precisely what made that a surprise worth debugging.
+    const line = publishedAfterCreate({
+      served: false,
+      published: 'gs://bucket-name',
+      url: 'https://service.example.com/reload',
+      reason: 'no endpoint answered',
+    });
+
+    expect(line).toContain('no endpoint answered');
+    expect(line).toContain('when it next starts');
+  });
+
+  test('a workspace that publishes nowhere and answers nothing says nothing', () => {
+    // `profile add` is the first command anybody runs. Reporting that an
+    // endpoint could not be notified, as the first sentence this CLI prints,
+    // describes an endpoint they have not set up yet — and nothing is holding a
+    // stale view of a profile that did not exist a moment ago.
+    expect(
+      publishedAfterCreate({
+        served: false,
+        url: 'http://127.0.0.1:7337/reload',
+        reason: 'no static token is issued in this workspace, so the endpoint cannot be notified',
+      }),
+    ).toBeUndefined();
+  });
+
+  test('a fresh workspace still creates the profile, and stays quiet about it', async () => {
+    // The regression guard for the wrapping. `profile add` is the command that
+    // may have *just written* the workspace it publishes to, so the credential
+    // store the notify authenticates with can be opened before one exists — and
+    // a creation that succeeded must never report failure.
+    const root = join(await mkdtemp(join(tmpdir(), 'lanes-link-publish-')), 'workspace');
+    roots.push(root);
+    process.env['LANES_LINK_HOME'] = root;
+
+    const printed = await captureStdout(async () => {
+      await profileAdd('personal', { targets: ['local'], nonInteractive: true, json: true });
+    });
+
+    const parsed = JSON.parse(printed) as { name: string; published?: string };
+    expect(parsed.name).toBe('personal');
+    expect(parsed.published).toBeUndefined();
+    expect(existsSync(join(root, 'profiles', 'personal', 'profile.yaml'))).toBe(true);
   });
 });

--- a/src/cli/commands/profile.ts
+++ b/src/cli/commands/profile.ts
@@ -20,6 +20,7 @@ import {
 } from '#profile';
 
 import { recordConfigChange } from '../audit-change.ts';
+import { nextAfterEdit, publishProfileEdit, type PublishOutcome } from '../publish.ts';
 import { resolveProfile } from '../runtime.ts';
 import { emit, ok, print, style, table } from '../output.ts';
 import { readSession } from '#auth/lanes/session.ts';
@@ -48,6 +49,13 @@ export interface ProfileCreated {
   readonly targets: readonly string[];
   /** Which sibling supplied each non-local target's adapters, where one did. */
   readonly copiedFrom: Readonly<Record<string, string>>;
+  /**
+   * What the endpoint did with it, in a form fit to print.
+   *
+   * Absent from `createProfile`, which writes the file and tells nobody. It is
+   * `profileAdd` that publishes, so it is `profileAdd` that fills this in.
+   */
+  readonly published?: string;
 }
 
 export interface ProfileListing {
@@ -66,8 +74,16 @@ export interface ProfileListing {
  *
  * It now decides *where the file goes* rather than what is written in it: a
  * profile lives in one target's workspace and declares nothing about it
- * (ADR-052), so `--workspace cloud` writes into the bucket and the endpoint there
- * serves it on its next reconcile.
+ * (ADR-052), so `--workspace cloud` writes into the bucket the endpoint there
+ * reads from.
+ *
+ * **Writing it is not enough, and this comment is where that was missed.** It
+ * used to say the endpoint "serves it on its next reconcile". There is no next
+ * reconcile: a running endpoint lists the profiles once, at boot or at a
+ * reload (`openReconciled`), so a profile added underneath one stayed durable
+ * and invisible — to `/state`, and so to the dashboard, and to every client —
+ * until the revision restarted. `profileAdd` notifies for the same reason every
+ * other config edit does; see below.
  */
 export async function createProfile(
   name: string,
@@ -188,6 +204,26 @@ export async function readProfiles(target: string): Promise<ProfileListing> {
   };
 }
 
+/**
+ * The line a *creation* ends on, where one is worth printing.
+ *
+ * The one place this differs from the seven commands that publish an edit. They
+ * change a config that is already being served, so "nothing answered" is always
+ * worth saying — a stale endpoint is serving the previous answer to a question
+ * somebody has already asked. A profile is new: nothing is holding a stale view
+ * of it, and on a fresh workspace `profile add` is the first command anybody
+ * runs, so that line arrived as the first sentence this CLI ever printed and
+ * described an endpoint they had not set up yet.
+ *
+ * So: when the endpoint took the edit, and when the target publishes somewhere.
+ * The second is what makes a deployed workspace always say something — that is
+ * the case this whole change exists for, where a notify that did not land is
+ * exactly the surprise being fixed, and silence is what made it a surprise.
+ */
+export function publishedAfterCreate(outcome: PublishOutcome): string | undefined {
+  return outcome.served || outcome.published !== undefined ? nextAfterEdit(outcome) : undefined;
+}
+
 export async function profileAdd(
   name: string,
   options: { targets: readonly string[]; nonInteractive?: boolean; json?: boolean },
@@ -215,7 +251,30 @@ export async function profileAdd(
     arguments: { port: created.port, workspace: primary },
   });
 
-  return emit(options.json, created, () => {
+  // Told to the endpoint that has to serve it, exactly as every other config
+  // edit tells it (ADR-029). This was the one edit that did not, and a profile
+  // created against a live workspace was invisible until the endpoint next
+  // started — see the header.
+  //
+  // **Wrapped, because this must not be able to fail the creation.** `profile
+  // add` is the command that may have *just written* the workspace it is
+  // publishing to, so the credential store the notify authenticates with can be
+  // opened before one exists. `publishAndNotify` already treats a failed
+  // publish as reportable rather than fatal; this extends that to the store it
+  // opens before reaching that guard. The profile is on disk either way, and a
+  // creation that succeeded must not report failure.
+  let outcome: PublishOutcome;
+  try {
+    outcome = await publishProfileEdit({ resolution, config, target: primary });
+  } catch (error) {
+    const reason =
+      error instanceof Error ? (error.message.split('\n')[0] ?? error.message) : String(error);
+    outcome = { served: false, reason };
+  }
+
+  const published = publishedAfterCreate(outcome);
+
+  return emit(options.json, { ...created, ...(published ? { published } : {}) }, () => {
     print(ok(`created profile ${style.bold(created.name)}`));
     print(`      config   ${created.path}`);
     print(`      port     ${created.port}`);
@@ -224,6 +283,8 @@ export async function profileAdd(
     for (const [target, from] of Object.entries(created.copiedFrom)) {
       print(`      ${style.dim(`${target} adapters copied from profile "${from}"`)}`);
     }
+
+    if (published) print(`      ${style.dim(published)}`);
 
     print();
     print(

--- a/src/cli/commands/profile/confirm.ts
+++ b/src/cli/commands/profile/confirm.ts
@@ -1,0 +1,62 @@
+import { ConfigError } from '#profile';
+import { terminalPrompter, type Prompter } from '../../prompt.ts';
+import { print, style } from '../../output.ts';
+
+/**
+ * Asking somebody to mean it.
+ *
+ * Split from `remove.ts` along the seam that file already had: the other three
+ * things in it plan a removal, perform one, and render what happened, and this
+ * one is the interaction in front of all of them. The budget in
+ * `architecture.test.ts` is what pointed at it — `remove.ts` sat six lines under
+ * 400, so the first real change to it went over, which is the case that budget
+ * describes as "not too long, two things".
+ *
+ * Still local to this folder rather than promoted beside `agreed()`. The
+ * argument the original carried holds: the shape differs, there is one caller,
+ * and bending the shared helper for it would leave both worse. If a second
+ * consumer appears, promote it then.
+ */
+
+/**
+ * The confirmation, which asks for the name rather than a keystroke.
+ *
+ * A step up from `agreed()`, deliberately. That helper is `y/N` and is right
+ * for `vault remove`, which drops one item the operator can put back. This
+ * drops every live OAuth refresh token a profile holds, and putting those back
+ * means visiting each vendor again — so the gesture should be one you cannot
+ * make by leaning on the keyboard.
+ *
+ * Local rather than shared for the same reason it is not `agreed()`: the shape
+ * differs, and bending the existing helper for a single caller in another
+ * command folder would leave both worse. If a second consumer appears, promote
+ * it then.
+ */
+export async function confirmedByName(
+  profile: string,
+  options: { yes?: boolean | undefined; prompter?: Prompter | undefined },
+): Promise<boolean> {
+  if (options.yes) return true;
+
+  // A prompter that was passed in is the caller's answer to "is there anyone
+  // to ask" — the console passes one that replays a form. Only the default
+  // needs stdin consulted, and conflating the two makes an injected prompter
+  // untestable and a real terminal the only place this works.
+  const prompter = options.prompter ?? terminalPrompter;
+  const someoneToAsk = options.prompter ? prompter.interactive : process.stdin.isTTY;
+
+  if (!someoneToAsk) {
+    throw new ConfigError(
+      `Removing "${profile}" cannot be undone, and stdin is not a terminal, so there is nobody to ask. Pass --yes to proceed.`,
+    );
+  }
+
+  const typed = (await prompter.ask(`Type ${profile} to remove it, or anything else to stop`))
+    .trim();
+
+  if (typed !== profile) {
+    print(style.dim('  cancelled — nothing was removed'));
+    return false;
+  }
+  return true;
+}

--- a/src/cli/commands/profile/remove.test.ts
+++ b/src/cli/commands/profile/remove.test.ts
@@ -4,12 +4,12 @@ import type { BlobMetadata, BlobStore } from '#stores/blobs';
 import type { Prompter } from '../../prompt.ts';
 import type { RemovalItem, RemovalPlan } from './removal.ts';
 import {
-  confirmedByName,
   executeRemoval,
   renderOutcome,
   type RemovalOutcome,
   type RunDeps,
 } from './remove.ts';
+import { confirmedByName } from './confirm.ts';
 
 /**
  * Performing a removal, and being honest about the parts that did not happen.

--- a/src/cli/commands/profile/remove.ts
+++ b/src/cli/commands/profile/remove.ts
@@ -13,7 +13,9 @@ import {
 import { parseDocument } from 'yaml';
 import { rm } from 'node:fs/promises';
 import { terminalPrompter, type Prompter } from '../../prompt.ts';
+import { confirmedByName } from './confirm.ts';
 import { recordConfigChange } from '../../audit-change.ts';
+import { nextAfterEdit, publishProfileEdit } from '../../publish.ts';
 import { announceProfile, emit, fail, ok, print, style } from '../../output.ts';
 import {
   buildRegistryWithWorkspace,
@@ -228,49 +230,6 @@ export function renderOutcome(outcome: RemovalOutcome): void {
   process.exitCode = 1;
 }
 
-/**
- * The confirmation, which asks for the name rather than a keystroke.
- *
- * A step up from `agreed()`, deliberately. That helper is `y/N` and is right
- * for `vault remove`, which drops one item the operator can put back. This
- * drops every live OAuth refresh token a profile holds, and putting those back
- * means visiting each vendor again — so the gesture should be one you cannot
- * make by leaning on the keyboard.
- *
- * Local rather than shared for the same reason it is not `agreed()`: the shape
- * differs, and bending the existing helper for a single caller in another
- * command folder would leave both worse. If a second consumer appears, promote
- * it then.
- */
-export async function confirmedByName(
-  profile: string,
-  options: { yes?: boolean | undefined; prompter?: Prompter | undefined },
-): Promise<boolean> {
-  if (options.yes) return true;
-
-  // A prompter that was passed in is the caller's answer to "is there anyone
-  // to ask" — the console passes one that replays a form. Only the default
-  // needs stdin consulted, and conflating the two makes an injected prompter
-  // untestable and a real terminal the only place this works.
-  const prompter = options.prompter ?? terminalPrompter;
-  const someoneToAsk = options.prompter ? prompter.interactive : process.stdin.isTTY;
-
-  if (!someoneToAsk) {
-    throw new ConfigError(
-      `Removing "${profile}" cannot be undone, and stdin is not a terminal, so there is nobody to ask. Pass --yes to proceed.`,
-    );
-  }
-
-  const typed = (await prompter.ask(`Type ${profile} to remove it, or anything else to stop`))
-    .trim();
-
-  if (typed !== profile) {
-    print(style.dim('  cancelled — nothing was removed'));
-    return false;
-  }
-  return true;
-}
-
 export interface RemoveFlags extends GlobalFlags {
   readonly dryRun?: boolean | undefined;
   readonly yes?: boolean | undefined;
@@ -362,7 +321,28 @@ export async function removeProfile(name: string, flags: RemoveFlags): Promise<v
     arguments: { connections: config.grants.map((grant) => grant.connection) },
   });
 
-  return emit(flags.json, outcome, () => renderOutcome(outcome));
+  // And the endpoint is told, as it is told about every other config edit
+  // (ADR-074) — but more urgently than any of them. It holds the profiles it
+  // listed at boot, so without this a profile that has been *removed*, with its
+  // credentials and its stores deleted, stayed reachable until the revision
+  // happened to restart: the operator believing they had revoked something they
+  // had not. Wrapped because the removal has already happened and a failure to
+  // announce it cannot undo it; `publishWorkspace` copies what the local store
+  // has, which no longer includes this profile, so nothing here can put the
+  // file back. A throw is reported as nothing — `renderOutcome` owns the exit
+  // code, derived from what survived on the stores.
+  let published: string | undefined;
+  try {
+    const resolution = { workspaceRoot: root, profile: name };
+    published = nextAfterEdit(await publishProfileEdit({ resolution, config, target }));
+  } catch {
+    // See above.
+  }
+
+  return emit(flags.json, { ...outcome, ...(published ? { published } : {}) }, () => {
+    renderOutcome(outcome);
+    if (published) print(style.dim(`  ${published}`));
+  });
 }
 
 /** `profiles/<name>.yaml`, however the path was spelled for display. */

--- a/src/cli/publish.test.ts
+++ b/src/cli/publish.test.ts
@@ -1,4 +1,6 @@
 import { describe, expect, test } from 'bun:test';
+import { readdir, readFile } from 'node:fs/promises';
+import { join } from 'node:path';
 import { nextAfterEdit } from './publish.ts';
 
 /**
@@ -69,5 +71,72 @@ describe('what an edit says it did', () => {
 
     expect(line).toContain('could not publish');
     expect(line).toContain('bucket not found');
+  });
+});
+
+/**
+ * That an edit which records itself also tells the endpoint.
+ *
+ * The bug this exists for is a missing call, not a wrong one. `profile add`
+ * wrote a profile into a deployed workspace's bucket and told nobody, so the
+ * running revision — which lists the profiles at boot and at a reload and at no
+ * other time — kept serving a set the operator had already added to. The
+ * profile was durable and invisible at once, which reads exactly like a
+ * dashboard that has not refreshed.
+ *
+ * The pattern was followed by seven commands and missed by this one, so a
+ * hand-kept list of the seven would not have caught it: the list would have
+ * been written from the code as it stood. `recordConfigChange` is the signal
+ * instead, because it is the other half every config edit already performs —
+ * a command that thinks the change is worth an audit entry thinks it is a
+ * change, and a change the endpoint has not heard about is a stale endpoint.
+ */
+describe('a recorded config edit reaches the endpoint', () => {
+  /**
+   * Commands that record a change and deliberately do not publish one.
+   *
+   * Each needs an argument, not just an entry — an exception nobody has to
+   * justify is how the gap above lasted as long as it did.
+   */
+  const EXCEPTIONS: Readonly<Record<string, string>> = {
+    // The pairing credential is not in the generation. A deployed endpoint
+    // reads it per request behind `cachedPairingCredential` and a loopback bind
+    // reads it per request outright, so there is nothing held for a reload to
+    // replace: `pair` changes a secret, not the config a generation was built
+    // from.
+    'commands/operate/pair.ts': 'the pairing credential is read per request, not held',
+  };
+
+  async function modules(dir: string): Promise<string[]> {
+    const found: string[] = [];
+    for (const entry of await readdir(join(import.meta.dir, dir), { withFileTypes: true })) {
+      const path = `${dir}/${entry.name}`;
+      if (entry.isDirectory()) found.push(...(await modules(path)));
+      else if (entry.name.endsWith('.ts') && !entry.name.endsWith('.test.ts')) found.push(path);
+    }
+    return found;
+  }
+
+  test('every command that records one publishes it, or says why not', async () => {
+    const offenders: string[] = [];
+
+    for (const path of await modules('commands')) {
+      const source = await readFile(join(import.meta.dir, path), 'utf8');
+      if (!source.includes('recordConfigChange(')) continue;
+      if (source.includes("publish.ts'")) continue;
+      if (path in EXCEPTIONS) continue;
+      offenders.push(path);
+    }
+
+    expect(offenders).toEqual([]);
+  });
+
+  test('the exceptions are still commands that record a change', async () => {
+    // An exception for a file that stopped recording is dead, and dead
+    // exceptions are how a list like this stops meaning anything.
+    for (const path of Object.keys(EXCEPTIONS)) {
+      const source = await readFile(join(import.meta.dir, path), 'utf8');
+      expect(source).toContain('recordConfigChange(');
+    }
   });
 });

--- a/src/cli/publish.ts
+++ b/src/cli/publish.ts
@@ -1,8 +1,8 @@
 import type { SecretStore } from '#secrets';
-import { anyIssuedToken, openTarget, type Config } from '#profile';
+import { anyIssuedToken, openTarget, readEndpointRecord, type Config } from '#profile';
 import { publishWorkspace } from '#deployments/upload.ts';
 import { openSecretStoreFor, type Runtime } from './runtime.ts';
-import { endpointUrl } from './endpoint-url.ts';
+import { deployedUrl, localUrl } from './endpoint-url.ts';
 
 /**
  * Getting an edit to the endpoint that has to serve it.
@@ -122,11 +122,29 @@ async function notifyReload(input: {
 }): Promise<PublishOutcome> {
   let url: string;
   try {
-    // Answers for a deployed target as well as a local one — a loopback URL
-    // sent to a deployment reaches a port with nothing behind it, which is the
-    // bug this function's own doc comment records.
+    // Three answers, in the order of who actually knows.
+    //
+    // **The platform**, for a deployed target. A loopback URL sent to a
+    // deployment reaches a port with nothing behind it, which is the bug this
+    // function's own doc comment records.
+    //
+    // **The endpoint itself**, for a local one. `start` serves every profile in
+    // the workspace from one URL, and that URL is the port of the profile it was
+    // started with — so deriving it from the *edited* profile's `instance.port`
+    // was right only when those happened to be the same profile, and could
+    // never be right for a profile that had only just been created. The record
+    // is written by the process that bound the socket; see `endpoint-record.ts`
+    // and ADR-074.
+    //
+    // **The config**, when there is no record — a workspace whose endpoint has
+    // never run under this version, or is not running at all. That is the
+    // address this used unconditionally, so nothing is worse off for falling
+    // back to it.
     const { declared } = await openTarget(input.workspaceRoot, input.target);
-    url = (await endpointUrl(input.config, declared)).replace(/\/mcp$/, '/reload');
+    const deployed = await deployedUrl(declared.deploy);
+    const recorded = deployed ? null : await readEndpointRecord(input.workspaceRoot);
+    const base = deployed ?? recorded?.url ?? localUrl(input.config);
+    url = base.replace(/\/mcp$/, '/reload');
   } catch (error) {
     return { served: false, reason: `could not work out where the endpoint is: ${message(error)}` };
   }

--- a/src/profile/endpoint-record.test.ts
+++ b/src/profile/endpoint-record.test.ts
@@ -1,0 +1,150 @@
+import { afterAll, describe, expect, test } from 'bun:test';
+import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { existsSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import {
+  clearEndpointRecord,
+  readEndpointRecord,
+  writeEndpointRecord,
+} from './endpoint-record.ts';
+
+/**
+ * Where the endpoint is, according to the endpoint.
+ *
+ * The property under test is not that a file round-trips. It is that **a record
+ * nobody cleaned up cannot send a notify to the wrong place.** One endpoint
+ * serves a whole workspace, so this file is the only thing that knows which
+ * port that is — and a command acting on it is about to POST `/reload` at
+ * whatever this says. A crashed endpoint, a reused pid and a half-written file
+ * all have to answer null rather than an address.
+ */
+
+const roots: string[] = [];
+
+async function workspace(): Promise<string> {
+  const root = await mkdtemp(join(tmpdir(), 'lanes-link-endpoint-'));
+  roots.push(root);
+  return root;
+}
+
+afterAll(async () => {
+  await Promise.all(roots.map((root) => rm(root, { recursive: true, force: true })));
+});
+
+describe('a live record', () => {
+  test('round-trips the url and the profiles it covers', async () => {
+    const root = await workspace();
+    await writeEndpointRecord(root, {
+      url: 'http://127.0.0.1:7451/mcp',
+      profiles: ['personal', 'work'],
+    });
+
+    const record = await readEndpointRecord(root);
+    expect(record?.url).toBe('http://127.0.0.1:7451/mcp');
+    expect(record?.profiles).toEqual(['personal', 'work']);
+    // This process wrote it, so this process is what it names.
+    expect(record?.pid).toBe(process.pid);
+  });
+
+  test('is not readable by anybody but its owner', async () => {
+    const root = await workspace();
+    await writeEndpointRecord(root, { url: 'http://127.0.0.1:7337/mcp', profiles: ['personal'] });
+
+    const { mode } = await import('node:fs/promises').then((fs) =>
+      fs.stat(join(root, 'endpoint.json')),
+    );
+    expect(mode & 0o777).toBe(0o600);
+  });
+});
+
+describe('a record that cannot be trusted answers nothing', () => {
+  test('a workspace that has never served answers null', async () => {
+    expect(await readEndpointRecord(await workspace())).toBeNull();
+  });
+
+  test('a dead pid answers null, not an address', async () => {
+    // The case that makes this safe to leave lying around. A `kill -9` skips
+    // the shutdown that clears it, so the file outlives the listener — and the
+    // address it names is one nothing has answered on since. Returning it would
+    // send every notify in the workspace somewhere it cannot be heard, and
+    // report "no endpoint answered" for an endpoint that is not there, which is
+    // exactly the behaviour that existed before the record — except now it
+    // would also be *wrong* about a workspace whose endpoint had moved.
+    const root = await workspace();
+    await writeFile(
+      join(root, 'endpoint.json'),
+      JSON.stringify({
+        url: 'http://127.0.0.1:7451/mcp',
+        // Above the pid ceiling on every platform this runs on, so it cannot be
+        // a process that happens to exist while the test runs.
+        pid: 0x7fffffff,
+        profiles: ['personal'],
+        startedAt: new Date().toISOString(),
+      }),
+    );
+
+    expect(await readEndpointRecord(root)).toBeNull();
+  });
+
+  test('a half-written file answers null rather than throwing', async () => {
+    // Reachable: `start` writes this while other commands are running, and a
+    // reader that threw would fail an edit over a file that exists only to make
+    // one land faster.
+    const root = await workspace();
+    await writeFile(join(root, 'endpoint.json'), '{"url": "http://127.0.0.1:74');
+
+    expect(await readEndpointRecord(root)).toBeNull();
+  });
+
+  test('a record missing the one field it is for answers null', async () => {
+    const root = await workspace();
+    await writeFile(join(root, 'endpoint.json'), JSON.stringify({ pid: process.pid }));
+
+    expect(await readEndpointRecord(root)).toBeNull();
+  });
+});
+
+describe('clearing it', () => {
+  test('removes the file, and does not mind being run twice', async () => {
+    const root = await workspace();
+    await writeEndpointRecord(root, { url: 'http://127.0.0.1:7337/mcp', profiles: ['personal'] });
+    expect(existsSync(join(root, 'endpoint.json'))).toBe(true);
+
+    await clearEndpointRecord(root);
+    expect(existsSync(join(root, 'endpoint.json'))).toBe(false);
+
+    // A shutdown that races another shutdown, or one that runs after a crash
+    // already took the file with it.
+    await clearEndpointRecord(root);
+    expect(await readEndpointRecord(root)).toBeNull();
+  });
+});
+
+describe('a remote workspace has no record at all', () => {
+  test('nothing is written for a bucket, and nothing is read back', async () => {
+    // A deployed target's address belongs to the platform, which knows it
+    // authoritatively — and ADR-007 says a revision never writes its own
+    // configuration. Writing this into the bucket would be a revision
+    // announcing itself into the files it is forbidden to touch.
+    await writeEndpointRecord('gs://bucket-name', {
+      url: 'https://service.example.com/mcp',
+      profiles: ['personal'],
+    });
+
+    expect(await readEndpointRecord('gs://bucket-name')).toBeNull();
+    await clearEndpointRecord('gs://bucket-name');
+  });
+});
+
+describe('the record is written where the layout says', () => {
+  test('at the workspace root, beside the config it is not part of', async () => {
+    const root = await workspace();
+    await writeEndpointRecord(root, { url: 'http://127.0.0.1:7337/mcp', profiles: ['personal'] });
+
+    const written = JSON.parse(await readFile(join(root, 'endpoint.json'), 'utf8')) as {
+      url: string;
+    };
+    expect(written.url).toBe('http://127.0.0.1:7337/mcp');
+  });
+});

--- a/src/profile/endpoint-record.ts
+++ b/src/profile/endpoint-record.ts
@@ -1,0 +1,152 @@
+import { readFile, unlink, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { layout } from './layout.ts';
+import { isRemoteWorkspace } from './files.ts';
+
+/**
+ * Where this workspace's endpoint is actually listening.
+ *
+ * The gap this closes is one every config edit fell into. `lanes link start`
+ * serves **every profile in the workspace from one URL** (ADR-009), and that
+ * URL is the port of the profile it was started with — but a command that edits
+ * a profile derived the address to notify from *that profile's* own
+ * `instance.port`. For an edit to the profile `start` was run under the two
+ * agree by luck. For any other they do not, and for a profile that has only
+ * just been created they cannot: its port is fresh, so nothing has ever
+ * listened there.
+ *
+ * The failure was silent in the way that costs the most time. The endpoint was
+ * running and serving the profile; the notify went to a port with nothing
+ * behind it; the command reported "saved, and the endpoint will serve this when
+ * it next starts", which is the sentence for an endpoint that is *down*. So the
+ * operator read a true-sounding line, and their live endpoint went on serving
+ * config that had been superseded.
+ *
+ * ## Why a record and not a search
+ *
+ * The alternative was to probe every profile's port and notify whichever
+ * answered. That works, and it makes every command pay for a wrong assumption
+ * by parsing every config in the workspace on the failure path. A record is one
+ * read of one small file, and it is written by the only process that actually
+ * knows the answer.
+ *
+ * ## Why it is safe to be stale
+ *
+ * It is a hint, never a fact. `notifyReload` still has to reach what it names,
+ * and the POST is authenticated by this workspace's own token — so the two ways
+ * this can be wrong both fail closed:
+ *
+ *  - **The endpoint is gone.** The pid check below rejects the record, and the
+ *    caller falls back to exactly the address it used before this existed.
+ *  - **The pid was reused, or another workspace took the port.** The stranger
+ *    does not accept this workspace's bearer, so the notify is refused rather
+ *    than delivered to the wrong endpoint — which is the hazard `endpointHealth`
+ *    was written to warn about, and the reason this is not merely "trust the
+ *    file".
+ *
+ * Local roots only. A deployed target's address comes from the platform, which
+ * knows it authoritatively, and a revision must not write its own configuration
+ * (ADR-007) — so nothing here ever reaches a bucket.
+ */
+export interface EndpointRecord {
+  /** The MCP URL, exactly as `start` printed it. */
+  readonly url: string;
+  /** The process serving it, so a reader can tell a live record from a leftover. */
+  readonly pid: number;
+  /** Every profile it opened, for a caller that needs to know what it covers. */
+  readonly profiles: readonly string[];
+  readonly startedAt: string;
+}
+
+function recordPath(workspaceRoot: string): string {
+  return join(workspaceRoot, layout.endpointRecord());
+}
+
+/**
+ * Note where this process bound, best effort.
+ *
+ * Never throws. A workspace on a read-only mount, or one the endpoint does not
+ * own, is not a reason to fail a `start` that has already bound its socket —
+ * the record is an optimisation for other commands, and its absence returns
+ * them to the behaviour they had.
+ */
+export async function writeEndpointRecord(
+  workspaceRoot: string,
+  record: Omit<EndpointRecord, 'pid' | 'startedAt'>,
+): Promise<void> {
+  if (isRemoteWorkspace(workspaceRoot)) return;
+
+  const full: EndpointRecord = {
+    ...record,
+    pid: process.pid,
+    startedAt: new Date().toISOString(),
+  };
+
+  try {
+    await writeFile(recordPath(workspaceRoot), `${JSON.stringify(full, null, 2)}\n`, {
+      mode: 0o600,
+    });
+  } catch {
+    // See above.
+  }
+}
+
+/** Forget it. Best effort, and absence is the desired end state either way. */
+export async function clearEndpointRecord(workspaceRoot: string): Promise<void> {
+  if (isRemoteWorkspace(workspaceRoot)) return;
+
+  try {
+    await unlink(recordPath(workspaceRoot));
+  } catch {
+    // Already gone, or never written.
+  }
+}
+
+/**
+ * The record, if one is there and the process it names is alive.
+ *
+ * A dead pid answers null rather than a URL, because a leftover from a crashed
+ * endpoint is worse than nothing: it would send every notify to an address that
+ * stopped being right at some point nobody observed, and the fallback it
+ * displaced is at least derived from config that is current.
+ */
+export async function readEndpointRecord(workspaceRoot: string): Promise<EndpointRecord | null> {
+  if (isRemoteWorkspace(workspaceRoot)) return null;
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(await readFile(recordPath(workspaceRoot), 'utf8'));
+  } catch {
+    // Absent, unreadable, or half-written by a `start` that is still going.
+    return null;
+  }
+
+  if (typeof parsed !== 'object' || parsed === null) return null;
+  const record = parsed as Partial<EndpointRecord>;
+  if (typeof record.url !== 'string' || typeof record.pid !== 'number') return null;
+  if (!isAlive(record.pid)) return null;
+
+  return {
+    url: record.url,
+    pid: record.pid,
+    profiles: Array.isArray(record.profiles) ? record.profiles : [],
+    startedAt: typeof record.startedAt === 'string' ? record.startedAt : '',
+  };
+}
+
+/**
+ * Whether a pid is still there, without signalling it.
+ *
+ * Signal `0` performs the permission and existence checks and delivers nothing.
+ * `EPERM` means the process exists and belongs to somebody else, which for this
+ * question is still "alive" — the notify that follows is authenticated, so a
+ * process we cannot signal is not a process we have to rule out here.
+ */
+function isAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (error) {
+    return (error as NodeJS.ErrnoException).code === 'EPERM';
+  }
+}

--- a/src/profile/index.ts
+++ b/src/profile/index.ts
@@ -154,3 +154,10 @@ export {
   legacyProfileConfig,
   layout,
 } from './layout.ts';
+
+export {
+  clearEndpointRecord,
+  readEndpointRecord,
+  writeEndpointRecord,
+  type EndpointRecord,
+} from './endpoint-record.ts';

--- a/src/profile/layout.ts
+++ b/src/profile/layout.ts
@@ -121,6 +121,16 @@ export const layout = {
    * and there is one endpoint.
    */
   state: (): string => 'state.kv',
+  /**
+   * Where `lanes link start` bound, written by the control plane only.
+   *
+   * Not config and not data: a fact about a process that is running right now,
+   * which is why it is JSON beside the YAML rather than a key inside it. One
+   * endpoint serves the whole workspace (ADR-009), so there is one of these per
+   * workspace and it belongs at the root. `endpoint-record.ts` is the whole of
+   * what it means, and ADR-074 is why it exists.
+   */
+  endpointRecord: (): string => 'endpoint.json',
 
   /** Every profile's directory sits under here. */
   profilesRoot: (): string => PROFILES_DIR,

--- a/src/server/read/connections.test.ts
+++ b/src/server/read/connections.test.ts
@@ -1,0 +1,117 @@
+import { afterAll, describe, expect, test } from 'bun:test';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { CONNECTIONS_FILE } from '#profile';
+import type { Runtime } from '#cli/runtime.ts';
+import { createProfile } from '#cli/commands/profile.ts';
+import { connectionRows } from './connections.ts';
+
+/**
+ * The join between what the workspace holds and what the endpoint remembers.
+ *
+ * One property carries this file: **`connections.yaml` decides which rows
+ * exist, and the state store only decorates them.** The store is rebuilt from
+ * the file by reconcile and its own header says it can be deleted and rebuilt
+ * at any time, so every way it can come back short has to cost a reader the
+ * dates and never the row. A listing that empties itself because a disposable
+ * cache would not open is the failure this is here to prevent.
+ */
+
+const CONNECTIONS = `
+  - { id: main, provider: gmail, account: first@example.com }
+  - { id: side, provider: gmail, account: second@example.com }
+`;
+
+const roots: string[] = [];
+const previousHome = process.env['LANES_LINK_HOME'];
+
+async function workspace(): Promise<string> {
+  const root = await mkdtemp(join(tmpdir(), 'lanes-link-read-connections-'));
+  roots.push(root);
+  process.env['LANES_LINK_HOME'] = root;
+  await createProfile('personal', { targets: ['local'] });
+
+  const path = join(root, CONNECTIONS_FILE);
+  const held = await Bun.file(path).text();
+  await Bun.write(path, held.replace('connections:', `connections:${CONNECTIONS}`));
+  return root;
+}
+
+afterAll(async () => {
+  if (previousHome === undefined) delete process.env['LANES_LINK_HOME'];
+  else process.env['LANES_LINK_HOME'] = previousHome;
+  await Promise.all(roots.map((root) => rm(root, { recursive: true, force: true })));
+});
+
+/** A runtime with only the two things `connectionRows` reads. */
+function runtime(root: string, list: () => Promise<unknown[]>): Runtime {
+  return {
+    resolution: { workspaceRoot: root },
+    state: { connections: { list } },
+  } as unknown as Runtime;
+}
+
+const record = (provider: string, id: string, created: string, updated: string) => ({
+  provider,
+  id,
+  createdAt: new Date(created),
+  updatedAt: new Date(updated),
+});
+
+describe('connectionRows', () => {
+  test('a row the store knows carries its dates, as ISO 8601', async () => {
+    const root = await workspace();
+    const rows = await connectionRows(
+      runtime(root, async () => [
+        record('gmail', 'main', '2026-01-02T03:04:05.000Z', '2026-03-04T05:06:07.000Z'),
+      ]),
+    );
+
+    const main = rows.find((row) => row.id === 'main');
+    expect(main?.createdAt).toBe('2026-01-02T03:04:05.000Z');
+    expect(main?.updatedAt).toBe('2026-03-04T05:06:07.000Z');
+  });
+
+  test('a row the store has not caught up with keeps its place', async () => {
+    const root = await workspace();
+    const rows = await connectionRows(
+      runtime(root, async () => [
+        record('gmail', 'main', '2026-01-02T03:04:05.000Z', '2026-01-02T03:04:05.000Z'),
+      ]),
+    );
+
+    const side = rows.find((row) => row.id === 'side');
+    expect(side).toBeDefined();
+    expect(side?.account).toBe('second@example.com');
+    expect(side?.createdAt).toBeUndefined();
+  });
+
+  test('a store that will not open costs the dates, not the listing', async () => {
+    // The one that matters. `state.kv` is disposable, and on a deployed
+    // endpoint it is a bucket read that can fail on its own.
+    const root = await workspace();
+    const rows = await connectionRows(
+      runtime(root, async () => {
+        throw new Error('the bucket said no');
+      }),
+    );
+
+    expect(rows.map((row) => `${row.provider}.${row.id}`)).toContain('gmail.main');
+    expect(rows.map((row) => `${row.provider}.${row.id}`)).toContain('gmail.side');
+    expect(rows.every((row) => row.createdAt === undefined)).toBe(true);
+  });
+
+  test('a record for a connection the file no longer declares adds no row', async () => {
+    // Reconcile removes these, but it runs on a reload and this runs on every
+    // request, so the file has to be the one that decides.
+    const root = await workspace();
+    const rows = await connectionRows(
+      runtime(root, async () => [
+        record('slack', 'gone', '2026-01-02T03:04:05.000Z', '2026-01-02T03:04:05.000Z'),
+      ]),
+    );
+
+    expect(rows.map((row) => `${row.provider}.${row.id}`)).not.toContain('slack.gone');
+  });
+});

--- a/src/server/read/connections.ts
+++ b/src/server/read/connections.ts
@@ -1,0 +1,38 @@
+import { readConnections } from '#profile';
+import type { Runtime } from '#cli/runtime.ts';
+import type { ConnectionRow } from './state.ts';
+
+/**
+ * The workspace's connections, with the endpoint's own memory of them attached.
+ *
+ * Two sources with different jobs. `connections.yaml` is the authority for
+ * *which* connections exist: it is what the operator wrote and what `connect`
+ * appends to. The state store is the authority for *when*, because the file has
+ * never carried a timestamp and a whole-file mtime cannot speak about one row.
+ *
+ * **The file wins on membership, always.** The state store is rebuilt from the
+ * file by reconcile and its own header says it can be deleted at any time, so a
+ * row it has not caught up with, or a store that will not open at all, must
+ * leave the listing intact and the dates absent. That is what the `catch` is
+ * for; it is not defensive habit.
+ *
+ * Both binds call this rather than each holding a copy of the join. Reaching
+ * `primary.state` here is allowed where importing `#stores` would not be:
+ * `architecture.test.ts` forbids the specifier, and the type arrives through
+ * `Runtime`, which this surface already depends on.
+ */
+export async function connectionRows(primary: Runtime): Promise<readonly ConnectionRow[]> {
+  const { connections } = await readConnections(primary.resolution.workspaceRoot);
+  const records = await primary.state.connections.list().catch(() => []);
+  const seen = new Map(records.map((record) => [`${record.provider}.${record.id}`, record]));
+
+  return connections.map((row) => {
+    const record = seen.get(`${row.provider}.${row.id}`);
+    if (!record) return row;
+    return {
+      ...row,
+      createdAt: record.createdAt.toISOString(),
+      updatedAt: record.updatedAt.toISOString(),
+    };
+  });
+}

--- a/src/server/read/deployed.ts
+++ b/src/server/read/deployed.ts
@@ -1,7 +1,8 @@
-import { PAIR_TOKEN_REF, readConnections } from '#profile';
+import { PAIR_TOKEN_REF } from '#profile';
 import type { Runtime } from '#cli/runtime.ts';
 import type { Logger } from '#connectivity';
 import type { ProfileRuntime } from '../mcp/visibility.ts';
+import { connectionRows } from './connections.ts';
 import { cachedPairingCredential } from './credential.ts';
 import type { ReadDeps } from './routes.ts';
 import type { DataSurface } from '#cli/owner-data/surface.ts';
@@ -41,8 +42,7 @@ export function deployedReadDeps(input: {
     workspace: primary.target,
     profiles: input.profiles,
     audit: primary.audit,
-    connections: async () =>
-      (await readConnections(primary.resolution.workspaceRoot)).connections,
+    connections: () => connectionRows(primary),
     // The names the dashboard shows for a row nobody has labelled. From the
     // registry rather than a catalogue, so the owner layer, the vendors and a
     // workspace's own manifests are all named the same way.

--- a/src/server/read/open.ts
+++ b/src/server/read/open.ts
@@ -1,10 +1,11 @@
 import { X509Certificate } from 'node:crypto';
-import { PAIR_CERT_REF, PAIR_KEY_REF, PAIR_TOKEN_REF, readConnections } from '#profile';
+import { PAIR_CERT_REF, PAIR_KEY_REF, PAIR_TOKEN_REF } from '#profile';
 import type { Runtime } from '#cli/runtime.ts';
 import type { Logger } from '#connectivity';
 import type { RunningServer } from '../index.ts';
 import type { ProfileRuntime } from '../mcp/visibility.ts';
 import type { DataSurface } from '#cli/owner-data/surface.ts';
+import { connectionRows } from './connections.ts';
 import { directPairingCredential } from './credential.ts';
 import { serveRead, type RunningReadListener } from './listener.ts';
 
@@ -62,8 +63,7 @@ export async function openReadListener(
       workspace: primary.target,
       profiles,
       audit: primary.audit,
-      connections: async () =>
-        (await readConnections(primary.resolution.workspaceRoot)).connections,
+      connections: () => connectionRows(primary),
       // The names the dashboard shows for a row nobody has labelled. From the
       // registry rather than a catalogue, so the owner layer, the vendors and a
       // workspace's own manifests are all named the same way.

--- a/src/server/read/state.test.ts
+++ b/src/server/read/state.test.ts
@@ -20,7 +20,16 @@ import type { ProfileRuntime } from '../mcp/visibility.ts';
 
 const ROWS: ConnectionRow[] = [
   { provider: 'lanes_memory', id: 'main', account: 'Memory' },
-  { provider: 'gmail', id: 'ada', account: 'ada@example.com', label: 'Work mail' },
+  {
+    provider: 'gmail',
+    id: 'ada',
+    account: 'ada@example.com',
+    label: 'Work mail',
+    createdAt: '2026-01-02T03:04:05.000Z',
+    updatedAt: '2026-03-04T05:06:07.000Z',
+  },
+  // No dates: a row the state store has not caught up with, which is the
+  // ordinary case for a connection added since the last reconcile pass.
   { provider: 'gmail', id: 'rin', account: 'rin@example.com' },
 ];
 
@@ -147,5 +156,44 @@ describe('who can reach one', () => {
     expect(state.connections.find((one) => one.ref === 'ghost.one')?.profiles).toEqual([
       'personal',
     ]);
+  });
+});
+
+/**
+ * When a connection arrived, and when it last moved.
+ *
+ * `connections.yaml` has never carried a date, so these come from the state
+ * store and `connectionRows` attaches them. Two things matter here: a row the
+ * store has no record of still appears, and the row nothing holds but a grant
+ * says null rather than borrowing a date from somewhere else.
+ */
+describe('when a connection arrived', () => {
+  test('the dates the store had are passed through', () => {
+    const state = readState('acme', new Map(), ROWS, ENDPOINT, NAMES);
+    const ada = state.connections.find((one) => one.ref === 'gmail.ada');
+
+    expect(ada?.createdAt).toBe('2026-01-02T03:04:05.000Z');
+    expect(ada?.updatedAt).toBe('2026-03-04T05:06:07.000Z');
+  });
+
+  test('a row the store has no record of is still listed, and says so', () => {
+    // The state store is rebuilt from the file and can be deleted at any time.
+    // Missing dates must cost a reader the dates, never the row.
+    const state = readState('acme', new Map(), ROWS, ENDPOINT, NAMES);
+    const rin = state.connections.find((one) => one.ref === 'gmail.rin');
+
+    expect(rin).toBeDefined();
+    expect(rin?.createdAt).toBeNull();
+    expect(rin?.updatedAt).toBeNull();
+  });
+
+  test('a grant naming a connection the workspace no longer holds has no dates', () => {
+    const profiles = new Map([['personal', profile(['slack.vanished'])]]);
+    const state = readState('acme', profiles, ROWS, ENDPOINT, NAMES);
+    const orphan = state.connections.find((one) => one.ref === 'slack.vanished');
+
+    expect(orphan).toBeDefined();
+    expect(orphan?.createdAt).toBeNull();
+    expect(orphan?.updatedAt).toBeNull();
   });
 });

--- a/src/server/read/state.ts
+++ b/src/server/read/state.ts
@@ -40,6 +40,25 @@ export interface ReadConnection {
   readonly account: string | null;
   /** Which profiles grant this connection at all. */
   readonly profiles: readonly string[];
+  /**
+   * When this endpoint first saw the connection, ISO 8601.
+   *
+   * Null when the state store has no record of it: a row reconcile has not
+   * caught up with, or a store that has been cleared. `connections.yaml` has
+   * never carried a timestamp, so this is the endpoint's own memory rather than
+   * anything the operator wrote, and a reader is told nothing rather than told
+   * a guess.
+   */
+  readonly createdAt: string | null;
+  /**
+   * When the account or the credential status last changed, ISO 8601.
+   *
+   * **Not "last used", and not a token refresh.** Reconcile moves this only
+   * when the account string it resolves differs from the stored one, or when
+   * the status flips, so on an untouched connection it equals `createdAt` for
+   * the life of the workspace. Anything that wants activity wants `/audit`.
+   */
+  readonly updatedAt: string | null;
 }
 
 /**
@@ -56,12 +75,20 @@ export interface ReadConnection {
  */
 export type ProviderNames = (provider: string) => string | undefined;
 
-/** The connection rows as `connections.yaml` holds them. */
+/**
+ * The connection rows as `connections.yaml` holds them.
+ *
+ * The two dates are not in that file and never were; `connectionRows` attaches
+ * them from the state store on the way in. Optional because that store is
+ * disposable by design, so a bind that cannot read it still produces rows.
+ */
 export interface ConnectionRow {
   readonly provider: string;
   readonly id: string;
   readonly account?: string | undefined;
   readonly label?: string | undefined;
+  readonly createdAt?: string | undefined;
+  readonly updatedAt?: string | undefined;
 }
 
 export interface ReadGrant {
@@ -173,6 +200,8 @@ export function readState(
       label: row.label ?? (named ? defaultConnectionLabel(named, row.account) : null),
       account: row.account ?? null,
       profiles: grantedBy.get(ref) ?? [],
+      createdAt: row.createdAt ?? null,
+      updatedAt: row.updatedAt ?? null,
     };
   });
 
@@ -192,6 +221,10 @@ export function readState(
       label: null,
       account: null,
       profiles: grantedBy.get(ref) ?? [],
+      // Nothing holds this row but a grant, so there is no record of it to
+      // date and no file line it came from.
+      createdAt: null,
+      updatedAt: null,
     });
   }
 


### PR DESCRIPTION
Release. Version is already on `develop` (#180), so this takes the publish path directly and both
branches end on the same tree.

- **#175** — A profile edit reaches the endpoint that is running, not a port derived from it.
  `profile add` wrote a profile and told nobody, so one added to a deployed workspace was durable
  and invisible until the revision restarted; `profile remove` left a deleted profile reachable.
  Both publish now, and the address they notify comes from the process that bound the socket
  (ADR-074).
- **#178** — `/state` says when a connection arrived and when it last moved. Additive on a surface
  with no version and no handshake.
- **#176** — the writing example stops modelling a command that does nothing.

Also drops the instruction to add yourself to a profile you just created, which `createProfile`
has done for you since 0.8.0 (#175, #176; `lanes-sh/web#67` for the docs and dashboard).

**Merge with `--merge`, not `--squash`.** A squash writes a new commit onto `main`, `develop`'s tip
stops being an ancestor, and the fast-forward afterwards is rejected as non-fast-forward even
though the trees are identical.