### PR TITLE
chore: 0.10.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lanes-sh/link",
-  "version": "0.10.2",
+  "version": "0.10.3",
   "description": "A self-hostable MCP gateway for all your connections, memory, tasks, files, and secrets",
   "license": "Apache-2.0",
   "homepage": "https://lanes.sh/link",


### PR DESCRIPTION
Version on `develop` before the release pull request. Contents: #183, verified against a real deployment from the branch before this bump, per the workflow it adds to CLAUDE.md.