### PR TITLE
0.10.3

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -66,6 +66,39 @@ talking to their server.
 writes credentials. Running it changes something outside the repository that a `git checkout`
 cannot undo. Get to a green `bun test` unattended, then stop and ask.
 
+## Prove a fix against a real deployment before releasing it
+
+A release publishes to npm, and npm does not take a version back. So a fix whose whole point is
+how a *deployed* endpoint behaves gets tested on one first, from the branch, and is released only
+once that worked.
+
+It works because `installRoot` walks up from the running module to the nearest `package.json`,
+so running the CLI out of a worktree makes the worktree the thing `gcloud builds submit` tarballs:
+
+```console
+$ cd .worktrees/<name>
+$ bun run ./src/cli/lanes.ts link deploy --workspace <target>
+```
+
+That builds an image from the branch and rolls a revision on a real target. Three things about it:
+
+- **`LANES_LINK_HOME` stays unset for this, deliberately** — the opposite of the rule above,
+  because the point is to reach a real deployment. So the target is the operator's, the deploy is
+  theirs to authorise, and a broken revision is theirs to live with until the next one. Ask.
+- **A previous revision is still there.** Cloud Run keeps them and traffic can be moved back, which
+  is what makes this recoverable and a bad npm publish not.
+- **Verify against the endpoint, not the command's exit code.** `POST /reload` returns the
+  generation it now serves — `{reloaded, epoch, profiles, tools}` — which is the only surface that
+  answers "what is this instance actually holding" without a pairing token. `/health` answers the
+  same question filtered to the caller's own member profiles, so a profile missing from it may be a
+  membership problem rather than a serving one. Check both before believing either.
+
+A profile is the case that keeps proving this. `deploy` binds one secret per profile into the
+revision, so a profile created *since* the last deploy cannot be opened by the running one however
+many times it re-reads its config — and `openReconciled` skips a profile it cannot open rather
+than failing the endpoint for its siblings. Adding a profile to a deployed target is therefore two
+steps, and the second one is a deploy.
+
 ## A release publishes, and npm does not give a version back
 
 [The development lifecycle](https://lanes.sh/docs/link/releasing) is the lifecycle end to end — the two

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lanes-sh/link",
-  "version": "0.10.2",
+  "version": "0.10.3",
   "description": "A self-hostable MCP gateway for all your connections, memory, tasks, files, and secrets",
   "license": "Apache-2.0",
   "homepage": "https://lanes.sh/link",

--- a/src/cli/commands/connect/client.test.ts
+++ b/src/cli/commands/connect/client.test.ts
@@ -1,4 +1,4 @@
-import { newProfileTemplate } from '../../config-templates.ts';
+import { newProfileTemplate, TEMPLATE_SURFACES } from '../../config-templates.ts';
 import { afterAll, describe, expect, test } from 'bun:test';
 import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
@@ -77,7 +77,7 @@ async function document(body?: string): Promise<ConfigDocument> {
   const root = await mkdtemp(join(tmpdir(), 'lanes-link-client-'));
   roots.push(root);
   await mkdir(join(root, 'profiles', 'personal'), { recursive: true });
-  await writeFile(join(root, 'profiles', 'personal', 'profile.yaml'), body ?? newProfileTemplate('personal', 7337));
+  await writeFile(join(root, 'profiles', 'personal', 'profile.yaml'), body ?? newProfileTemplate('personal', 7337, TEMPLATE_SURFACES));
   return await ConfigDocument.open(root, 'personal');
 }
 

--- a/src/cli/commands/operate/serve.ts
+++ b/src/cli/commands/operate/serve.ts
@@ -71,6 +71,12 @@ export async function start(
         print(plan);
         print(ok(`reconciled ${ofMany ? profile : ''}`.trim()));
       },
+      // The same silence the container's reporter carried. `serving` prints the
+      // profiles that opened, so a workspace holding four and serving three
+      // said so only by the length of a list nobody counts.
+      skipped({ profile, reason }) {
+        print(warn(`not serving ${style.bold(profile)}: ${reason}`));
+      },
     },
   });
 

--- a/src/cli/commands/profile.test.ts
+++ b/src/cli/commands/profile.test.ts
@@ -1,5 +1,6 @@
 import { afterAll, describe, expect, test } from 'bun:test';
 import { workspaceYaml } from '#profile/testing.ts';
+import { assertGrantsResolve, loadProfileConfig, readConnections } from '#profile';
 import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
 import { existsSync } from 'node:fs';
 import { tmpdir } from 'node:os';
@@ -316,5 +317,97 @@ describe('a created profile is published to the endpoint that serves it', () => 
     expect(parsed.name).toBe('personal');
     expect(parsed.published).toBeUndefined();
     expect(existsSync(join(root, 'profiles', 'personal', 'profile.yaml'))).toBe(true);
+  });
+});
+
+/**
+ * A new profile grants the connections this workspace holds.
+ *
+ * The template used to pair each owner-layer surface with a fixed id, which is
+ * true only of a workspace the same template seeded. `connections.yaml` numbers
+ * its rows in creation order, so a workspace whose owner layer arrived in a
+ * different order holds `lanes_memory` somewhere other than `lan1` — and a
+ * profile added to it named seven connections that were not there.
+ *
+ * What made that expensive to find is what happens next. `assertGrantsResolve`
+ * refuses the profile at load, and `openReconciled` skips a profile it cannot
+ * open rather than failing the endpoint for its siblings. So the profile was
+ * written, refused and skipped: it listed under `profile list`, which reads the
+ * directory, and appeared in nothing that reads config. On a deployed workspace
+ * the only trace was one line in the endpoint's log.
+ */
+describe('the owner layer is granted by id, not by assumption', () => {
+  /** A workspace whose owner layer is numbered in a different order. */
+  async function shuffled(): Promise<string> {
+    const root = await workspace();
+    await writeFile(
+      join(root, 'connections.yaml'),
+      [
+        'contract: 5',
+        '',
+        'connections:',
+        '  - { id: lan1, provider: lanes_setup, account: Setup }',
+        '  - { id: lan2, provider: lanes_memory, account: Memory }',
+        '  - { id: lan3, provider: lanes_skills, account: Skills }',
+        '  - { id: lan4, provider: lanes_tasks, account: Tasks }',
+        '  - { id: lan5, provider: lanes_assets, account: Assets }',
+        '  - { id: lan6, provider: lanes_vault, account: Vault }',
+        '  - { id: lan7, provider: lanes_entities, account: Entities }',
+        '',
+        'oauth_apps: {}',
+        'tokens: []',
+        '',
+      ].join('\n'),
+    );
+    return root;
+  }
+
+  test('every grant names a connection the workspace actually holds', async () => {
+    const root = await shuffled();
+    await createProfile('projects', { targets: ['local'] });
+
+    const written = await readFile(join(root, 'profiles', 'projects', 'profile.yaml'), 'utf8');
+
+    // The shuffled ids, not the template's. `lanes_memory` is lan2 here.
+    expect(written).toContain('connection: lanes_memory.lan2');
+    expect(written).toContain('connection: lanes_setup.lan1');
+    expect(written).not.toContain('connection: lanes_memory.lan1');
+  });
+
+  test('the profile it writes actually loads', async () => {
+    // The assertion that matters, because the grants resolving is only the
+    // mechanism. `resolveSelection` plus a load is what the endpoint does, and
+    // what silently skipped this profile before.
+    const root = await shuffled();
+    await createProfile('projects', { targets: ['local'] });
+
+    const { config } = await loadProfileConfig(root, 'projects');
+    const held = await readConnections(root);
+
+    expect(config.grants.map((grant) => grant.connection)).toContain('lanes_memory.lan2');
+    expect(() => assertGrantsResolve(config, held.connections)).not.toThrow();
+  });
+
+  test('a surface the workspace does not hold is left ungranted, not invented', async () => {
+    // Inventing a ref produces a profile that never loads. Leaving it out
+    // produces one that loads and is missing a surface, which `ensureOwnerLayer`
+    // repairs on the next `start` by writing both halves.
+    const root = await workspace();
+    await writeFile(
+      join(root, 'connections.yaml'),
+      ['contract: 5', '', 'connections:', '  - { id: lan1, provider: lanes_memory, account: Memory }', '', 'oauth_apps: {}', 'tokens: []', ''].join('\n'),
+    );
+
+    await createProfile('sparse', { targets: ['local'] });
+
+    // The parsed grants, not the file's text: the template's own header explains
+    // the surfaces by name, so a substring search finds `lanes_vault.` in a
+    // comment and says the grant is there.
+    const { config } = await loadProfileConfig(root, 'sparse');
+    const held = await readConnections(root);
+    const granted = config.grants.map((grant) => grant.connection);
+
+    expect(granted).toEqual(['lanes_memory.lan1']);
+    expect(() => assertGrantsResolve(config, held.connections)).not.toThrow();
   });
 });

--- a/src/cli/commands/profile.ts
+++ b/src/cli/commands/profile.ts
@@ -1,9 +1,11 @@
 import { newConnectionsTemplate, newProfileTemplate, newWorkspaceTemplate } from '../config-templates.ts';
+import { DEFAULT_SURFACES } from '../config-repair.ts';
 import { mkdir, writeFile } from 'node:fs/promises';
 import { existsSync } from 'node:fs';
 import { join } from 'node:path';
 import {
   CONNECTIONS_FILE,
+  readConnections,
   ConfigError,
   WORKSPACE_FILE,
   LEGACY_WORKSPACE_FILE,
@@ -85,6 +87,41 @@ export interface ProfileListing {
  * until the revision restarted. `profileAdd` notifies for the same reason every
  * other config edit does; see below.
  */
+/**
+ * Which connection each owner-layer surface sits under, in this workspace.
+ *
+ * Read from `connections.yaml` rather than assumed, because the ids in that
+ * file are assigned in creation order and a workspace whose owner layer arrived
+ * in a different order holds them under different ones. A profile written
+ * against the wrong ids is refused by `assertGrantsResolve` and then *skipped*
+ * by `openReconciled`, so it exists, is never served, and says so only in the
+ * endpoint's log.
+ *
+ * **The first row per provider**, which is the rule `ensureReservedConnection`
+ * already applies and states: any instance will do, and taking the first means
+ * an operator who renamed theirs does not get a second one bolted on beside it.
+ *
+ * A surface with no row at all is absent from the map and therefore ungranted.
+ * That is the honest outcome: `ensureOwnerLayer` writes both halves on the next
+ * `start`, where inventing a ref here would produce a profile that never loads.
+ */
+async function ownedSurfaces(workspaceRoot: string): Promise<Map<string, string>> {
+  const owned = new Map<string, string>();
+
+  // Absent or unreadable is not a failure. `createProfile` seeds the file just
+  // above this when the workspace has none, and a workspace holding one that
+  // cannot be parsed is a problem for `doctor` rather than a reason to refuse a
+  // profile.
+  const held = await readConnections(workspaceRoot).catch(() => null);
+
+  for (const surface of DEFAULT_SURFACES) {
+    const row = held?.connections.find((one) => one.provider === surface);
+    if (row) owned.set(surface, `${surface}.${row.id}`);
+  }
+
+  return owned;
+}
+
 export async function createProfile(
   name: string,
   options: { targets: readonly string[]; nonInteractive?: boolean },
@@ -171,7 +208,7 @@ export async function createProfile(
   await writeWorkspaceFile(
     workspaceFiles(root),
     layout.profileConfig(name),
-    newProfileTemplate(name, port, session?.subject),
+    newProfileTemplate(name, port, await ownedSurfaces(root), session?.subject),
   );
 
   return { name, path, port, targets: options.targets, copiedFrom: {} };

--- a/src/cli/config-edit.test.ts
+++ b/src/cli/config-edit.test.ts
@@ -1,4 +1,4 @@
-import { newConnectionsTemplate, newProfileTemplate } from './config-templates.ts';
+import { newConnectionsTemplate, newProfileTemplate, TEMPLATE_SURFACES } from './config-templates.ts';
 import { afterAll, describe, expect, test } from 'bun:test';
 import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
 import { readdir } from 'node:fs/promises';
@@ -31,7 +31,7 @@ async function profileFile(contents?: string): Promise<{ root: string; path: str
   roots.push(root);
   await mkdir(join(root, 'profiles', 'personal'), { recursive: true });
   const path = join(root, 'profiles', 'personal', 'profile.yaml');
-  await writeFile(path, contents ?? newProfileTemplate('personal', 7337));
+  await writeFile(path, contents ?? newProfileTemplate('personal', 7337, TEMPLATE_SURFACES));
   return { root, path };
 }
 
@@ -490,7 +490,7 @@ oauth_apps: {}
   test('a fresh profile and workspace need no repair at all', async () => {
     // The check that keeps the template and the repair in one spelling. Two
     // spellings of one row is how they drift apart, and this is what notices.
-    const p = await pair(newProfileTemplate('personal', 7337), newConnectionsTemplate());
+    const p = await pair(newProfileTemplate('personal', 7337, TEMPLATE_SURFACES), newConnectionsTemplate());
 
     expect(repairLines(ensureOwnerLayer(p.connections, p.profile))).toEqual([]);
   });

--- a/src/cli/config-templates.ts
+++ b/src/cli/config-templates.ts
@@ -14,7 +14,78 @@ import { SUPPORTED_CONTRACT } from '#profile';
  * that catches it (ADR-050).
  */
 
-export function newProfileTemplate(profile: string, port: number, subject?: string): string {
+/**
+ * The owner layer a fresh workspace is seeded with, in one place.
+ *
+ * Both halves are generated from this: the rows `newConnectionsTemplate` writes
+ * into `connections.yaml`, and the refs `TEMPLATE_SURFACES` below hands a fresh
+ * profile. They were two literal lists, and `config-edit.test.ts` asserts a
+ * fresh profile needs no repair precisely because two spellings of one row is
+ * how they drift — so the assertion stays and the second spelling goes.
+ */
+const SEEDED_OWNER_LAYER: readonly { id: string; provider: string; account: string }[] = [
+  { id: 'lan1', provider: 'lanes_memory', account: 'Memory' },
+  { id: 'lan2', provider: 'lanes_tasks', account: 'Tasks' },
+  { id: 'lan3', provider: 'lanes_assets', account: 'Assets' },
+  { id: 'lan4', provider: 'lanes_skills', account: 'Skills' },
+  { id: 'lan5', provider: 'lanes_vault', account: 'Vault' },
+  { id: 'lan6', provider: 'lanes_setup', account: 'Setup' },
+  { id: 'lan7', provider: 'lanes_entities', account: 'Entities' },
+];
+
+/**
+ * What a workspace this template just seeded holds each surface under.
+ *
+ * For a caller creating the workspace and the profile in one go, and for the
+ * tests that pair the two templates. A caller adding a profile to a workspace
+ * that already exists must read that workspace instead: see `ownedSurfaces` in
+ * `commands/profile.ts`.
+ */
+export const TEMPLATE_SURFACES: OwnedSurfaces = new Map(
+  SEEDED_OWNER_LAYER.map(({ provider, id }) => [provider, `${provider}.${id}`]),
+);
+
+/**
+ * The owner-layer grants, against the ids this workspace actually holds.
+ *
+ * These used to be seven literal lines pairing each surface with a fixed id —
+ * `lanes_memory.lan1`, `lanes_tasks.lan2`, and so on — which is true only of a
+ * workspace this same template seeded. `connections.yaml` numbers its rows in
+ * the order they were created, so a workspace whose owner layer arrived in a
+ * different order holds `lanes_memory` under a different id, and a profile
+ * added to it named seven connections that were not there.
+ *
+ * `assertGrantsResolve` then refuses the profile at load, and `openReconciled`
+ * skips a profile it cannot open rather than failing the endpoint for its
+ * siblings — so the profile was written, refused, and skipped, and the only
+ * trace was a line in the endpoint's log. It listed under `profile list`,
+ * because that reads the directory, and appeared nowhere that reads config.
+ *
+ * So the caller resolves each surface against the target workspace and passes
+ * what it found. A surface with no row is left ungranted rather than guessed
+ * at: `ensureOwnerLayer` adds the row *and* the grant on the next `start`,
+ * which is a repair that works, where an unresolvable ref is a profile that
+ * never loads.
+ */
+export type OwnedSurfaces = ReadonlyMap<string, string>;
+
+function ownerGrantLines(owned: OwnedSurfaces): string {
+  const lines = [...owned].map(
+    ([provider, ref]) => `  - { connection: ${ref}, allow: [${provider}.*], deny: [] }`,
+  );
+
+  // `[]` rather than an absent key. The schema wants the field, and a profile
+  // with no owner layer is a real state on a workspace that has no
+  // `connections.yaml` rows yet.
+  return lines.length > 0 ? lines.join('\n') : '  []';
+}
+
+export function newProfileTemplate(
+  profile: string,
+  port: number,
+  owned: OwnedSurfaces,
+  subject?: string,
+): string {
   return `# Lanes Link profile: ${profile}
 #
 # A profile is a *selection*: which of the workspace's accounts this agent may
@@ -95,13 +166,7 @@ limits:
 #   deny: [lanes_skills.manage.*]  invoke procedures, do not write them
 #   deny: [lanes_vault.put, lanes_vault.remove]
 grants:
-  - { connection: lanes_memory.lan1, allow: [lanes_memory.*], deny: [] }
-  - { connection: lanes_tasks.lan2, allow: [lanes_tasks.*], deny: [] }
-  - { connection: lanes_assets.lan3, allow: [lanes_assets.*], deny: [] }
-  - { connection: lanes_skills.lan4, allow: [lanes_skills.*], deny: [] }
-  - { connection: lanes_vault.lan5, allow: [lanes_vault.*], deny: [] }
-  - { connection: lanes_setup.lan6, allow: [lanes_setup.*], deny: [] }
-  - { connection: lanes_entities.lan7, allow: [lanes_entities.*], deny: [] }
+${ownerGrantLines(owned)}
 
 # Who may consume this profile (ADR-060).
 #
@@ -186,13 +251,7 @@ export function newConnectionsTemplate(): string {
 contract: 5
 
 connections:
-  - { id: lan1, provider: lanes_memory, account: Memory }
-  - { id: lan2, provider: lanes_tasks, account: Tasks }
-  - { id: lan3, provider: lanes_assets, account: Assets }
-  - { id: lan4, provider: lanes_skills, account: Skills }
-  - { id: lan5, provider: lanes_vault, account: Vault }
-  - { id: lan6, provider: lanes_setup, account: Setup }
-  - { id: lan7, provider: lanes_entities, account: Entities }
+${SEEDED_OWNER_LAYER.map((row) => `  - { id: ${row.id}, provider: ${row.provider}, account: ${row.account} }`).join('\n')}
 
 # App registrations, shared by every connection of that vendor.
 oauth_apps: {}

--- a/src/server/container.ts
+++ b/src/server/container.ts
@@ -85,6 +85,21 @@ try {
         // into an image that will be replaced.
         log(`reconciled ${profile}\n${plan}`);
       },
+      // **A skipped profile was silent here, and that is what cost the time.**
+      // `openReconciled` skips a sibling it cannot open rather than failing the
+      // endpoint for the rest, which is right — but this reporter declared only
+      // `reconciled`, so the optional hook was a no-op and a deployed endpoint
+      // served a set smaller than its workspace with nothing anywhere saying
+      // which profile was missing or why.
+      //
+      // Two ways in, both real. A profile whose grants name a connection this
+      // workspace does not hold is refused at load. And a profile created since
+      // the last deploy has no per-profile secret bound into this revision, so
+      // opening its runtime fails until a deploy binds one — which reads,
+      // from outside, exactly like a profile that does not exist.
+      skipped({ profile, reason }) {
+        log(`not serving ${profile}: ${reason}`);
+      },
     },
   });
 


### PR DESCRIPTION
Release. Version is already on `develop` (#184), so this takes the publish path directly.

- **#183** — A new profile grants the connections its workspace holds, not the ones the template
  assumed. The template paired each owner-layer surface with a fixed id, true only of a workspace
  it seeded itself; a profile added elsewhere named connections that were not there, was refused at
  load, and was then skipped by the endpoint in silence. A skipped profile now says which one and
  why, on both binds.

Verified against a real deployment from the branch before this release, per the workflow #183 adds
to `CLAUDE.md`.

**Merge with `--merge`, not `--squash`** — a squash breaks the fast-forward afterwards.