### PR TITLE
chore: 0.10.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lanes-sh/link",
-  "version": "0.10.3",
+  "version": "0.10.4",
   "description": "A self-hostable MCP gateway for all your connections, memory, tasks, files, and secrets",
   "license": "Apache-2.0",
   "homepage": "https://lanes.sh/link",


### PR DESCRIPTION
Version bump on `develop`, before the release pull request to `main`, so the merge to `main` runs the *publish* path rather than the *propose* path and both branches end on the same tree.

Contents: #182.

`bun test` 3356 pass / 12 skip / 2 fail (the known `emitted.test.ts` timeout flakes, which fail identically on `develop`), `bun run typecheck` clean.