### PR TITLE
0.10.4

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -208,6 +208,18 @@ question for the owner into a silent pick. Its derived `_index.json` is a cache 
 `key:size` fingerprint of the entity files — not `key:size:mtime`, because the GitHub adapter
 reports the branch tip for every file and the stamp would never match twice.
 
+**`lanes_tools_search` and `lanes_tools_call` are not owner providers, and there is no
+`lanes_tools` id.** They are registered by `src/server/mcp/search.ts` beside `lanes://instructions`,
+outside the loop over what policy decided, so they are advertised to every caller and are absent
+from `mergeCapabilities`. Do not "fix" that by making them a ninth provider: `ProviderContext`
+guarantees "no way to reach another connection", `#providers` may not import `#dispatch` or
+`#policy`, and the merged set and the dispatcher both already live in `#server/mcp`. ADR-075 has the
+argument. What this costs is that every count derived from the merged set has to add
+`SURFACE_TOOL_NAMES` — `visibleToolCount`, which `/reload` returns and the endpoint logs, and
+`Generation.visible()`, which decides whether a `tools/call` is *recorded as a refusal*. A name
+missing from the second one means every successful call to that tool writes an audit row saying the
+agent tried something that was not advertised.
+
 `src/architecture.test.ts` asserts the four rules the layout expresses: dependency
 direction between components, no vendor name in the code a request passes through, a
 file-size budget, and no real identifiers anywhere a reader can see. It replaces what

--- a/docs/detailed/adr/075-the-list-a-client-caches-must-stop-changing.md
+++ b/docs/detailed/adr/075-the-list-a-client-caches-must-stop-changing.md
@@ -1,0 +1,198 @@
+# ADR-075: The list a client caches must stop changing
+
+**Status:** accepted · **Completes** [ADR-032](032-a-stateless-endpoint-does-not-announce-its-tools.md) ·
+**Narrows** [ADR-001](001-connection-routing.md)'s "one tool per capability" to "one tool per
+capability, and one way in that is not a tool"
+
+## Context
+
+Every capability a principal can reach is registered as its own MCP tool, with its full input
+schema, on every `tools/list`. That is ADR-001 and ADR-006 working as designed, and it has two
+costs that have grown past the point where they can be left unrecorded.
+
+**The list is large, and most of it is not ours to shrink.** Measured from the vendored specs, as
+`registerDiscoveredTool` actually registers them — `title`, `description`, `inputSchema`, which is
+what travels and not what the capability object weighs:
+
+| | tools | on the wire |
+|---|---|---|
+| every `http` provider | 144 | 428 KB |
+| gmail, drive, calendar, sheets, google\_tasks, docs, contacts | 65 | 294 KB |
+| drive alone | 9 | 127 KB |
+
+At four bytes to a token that middle row is about 75K tokens, spent before the agent has read the
+request. And it is the *controllable* part: 77 of roughly 105 providers declare
+`connector.kind: 'mcp'`, and their schemas are the upstream server's verbatim — deliberately, since
+`registerDiscoveredTool` spreads rather than rebuilds them because vendors put `$defs` beside
+`properties` and a rebuild leaves a schema that cannot resolve itself. Notion, Linear, Slack, GitHub
+and Atlassian are all in that set. The ceiling on an eager surface is therefore set by other
+people's schema choices, and no amount of care here moves it.
+
+**The list changes, and not every client asks again.** ADR-032 established that a stateless
+endpoint cannot promise `listChanged`, declared it `false` so a client has no reason to trust a
+cache, and said plainly that nothing here can *make* a client re-read. That remains true, and the
+observed consequence is the one recorded in issue #162: connecting a provider a profile had none of
+changes what `tools/list` returns; a client that pinned its list at registration serves the old one;
+in one hosted client the connector has to be deleted and re-added before the new provider is
+reachable at all.
+
+ADR-001 already narrows the window — connection identity is an argument, so a second mailbox, a
+fifth account, a renamed connection all leave the list untouched. The list moves only when a
+provider arrives that the profile had none of. That is a small window and it is the window every
+first use of a new provider falls into.
+
+### What the industry settled while this sat open
+
+Progressive disclosure of tools is real, it works, and it is a **client-side** mechanism. The Claude
+Developer Platform's Tool Search Tool defers definitions above roughly 10K tokens and loads three to
+five on demand: about 72K tokens of definitions becomes about 500 plus 3K, an 85% reduction. The
+number that matters here is not the saving but the accuracy: tool selection *improved*, 79.5% to
+88.1% on one model's MCP evaluations and 49% to 74% on an older one. A discovery step is not a tax on
+selection. It is published guidance to defer above ten tools or 10K tokens, and not to bother below
+that.
+
+Two things follow, and they point in opposite directions.
+
+The first is that our best clients already solve the size problem without us, and better than we
+could. Their index is local, so a search costs no round trip; deferred definitions never enter the
+initial prompt, so prompt caching survives; and the full typed schema is in front of the model at the
+moment it composes arguments. This endpoint cannot match that last property — ADR-002 chose stateless
+streamable HTTP, so a discovery call is a network round trip that rebuilds the whole server. Removing
+the typed tools would make the clients that behave well worse in order to help the clients that do
+not.
+
+The second is that a client-side mechanism is only as good as the client. It does nothing for a
+client that caches a tool list at registration and never asks again, and that client is the one
+issue #162 is about.
+
+### What the protocol added, and what it did not
+
+The 2026-07-28 revision has no tool search, no tool filtering, and no deferred schema. The proposal
+for one — a `searchTools` meta-tool per library — is SEP #1888, a draft opened in November 2025 with
+no sponsor and no pull request. There is nothing to implement against, so anything built here is
+ours alone, and a bespoke discovery surface is one the clients that defer well can no longer defer.
+
+What it did add is cache control, and it is aimed squarely at the staleness half. `tools/list`
+results now carry `ttlMs` and `cacheScope` (SEP-2549), and a server **MUST** include them. `ttlMs: 0`
+means "immediately stale; the client MAY re-fetch every time the result is needed" — which is what
+ADR-032 was saying by declaring `listChanged: false`, now said in a field rather than by implication.
+`@modelcontextprotocol/server` 2.0.0 fills both at its encode seam with the conservative defaults
+`{ ttlMs: 0, cacheScope: 'private' }`, and nothing in `src/` configures `cacheHints`. So the standard
+lever is already in force, already correct, and resting on a third-party default.
+
+The revision also settles a question that would otherwise have been open. The tool set **MUST NOT**
+"vary per-connection or as a side effect of other requests on the connection", but **MAY** "vary by
+the authorization presented on the request". Filtering per principal — `mergeCapabilities` over
+`mayReach` and `allowedConnections` — is exactly the blessed case. Serving a different tool set to a
+different client is exactly the forbidden one.
+
+## Decision
+
+**One typed tool per capability stays, and two tools are added that are always there and never
+change name.**
+
+```
+lanes_tools_search(query, limit?)                              → matches, with their input schemas
+lanes_tools_call(profile, connection, capability, arguments)    → invokes any of them
+```
+
+`search` returns the full `inputSchema` for its strongest matches and name-and-description for the
+tail, because a search that returns only names is the version of this that loses the accuracy the
+published evaluations attribute to it: the gain comes from the model seeing a real schema before it
+composes arguments, not from the list being shorter. The tail exists because a query matching ten
+Drive write tools would otherwise return a quarter of a megabyte in one tool result. An exact
+capability id as the query returns that one capability with its schema.
+
+`call` sits on the path that already exists and is the only path. `Dispatcher.invoke` takes
+`capabilityId` as a string and resolves it through `registry.findCapability`; the per-tool handler is
+a thin closure over one hard-coded id. So this widens nothing: the same principal, the same
+`allowedConnections`, the same policy, the same cross-profile refusal, and the same audit row. And it
+cannot reach the control plane by construction, because control-plane operations are never registered
+and `findCapability` resolves only what is (ADR-007, ADR-051).
+
+**The search says which way in to use.** Issue #162 called this shape "two ways to do one thing on
+one surface — the duplication this codebase refuses elsewhere — and a model seeing both will
+sometimes pick the wrong one". That objection is answered by making the search the authority on
+routing rather than a peer of it: every result names the typed tool to prefer and says
+`lanes_tools_call` is for when the caller's own list does not have it. The model can see its tool
+list and the server cannot — a stateless endpoint has no idea what a client cached — so the decision
+belongs to the party that holds the information. What is on the surface is one way in with a
+fallback, not two ways in.
+
+**Nothing is removed, and no threshold is introduced.** Two small tools cost a client almost nothing,
+so they are unconditional. Whether typed tools should ever *stop* being advertised above some size is
+a different decision, it needs a measurement of this surface against them that no published
+evaluation can supply, and it is not taken here.
+
+## Consequences
+
+**A newly connected provider is reachable without the client asking again.** `lanes_tools_search`
+and `lanes_tools_call` are in every list any client has ever fetched from this endpoint, including
+the first one, which under ADR-032's own worst case held two setup tools and nothing else. So the
+answer to "connect Notion, then use Notion" stops being "start a new session" or "delete the
+connector" and becomes a search.
+
+**ADR-032's trade is unchanged and its reasoning is now carried by a field.** `listChanged: false`
+still says what it said. `ttlMs: 0` says it normatively, and the SDK already sends it. This ADR adds
+the test that pins both that and `cacheScope: 'private'`, because a per-principal tool list is
+deliberately identity-revealing — ADR-060 keeps a profile a member is not on out of the enum so they
+"never learn it exists" — and `cacheScope: 'public'` would let one token's list be served from a
+shared cache to another. That is a correctness property of the surface, not a caching preference, and
+it should not rest on someone else's default.
+
+**The whole advertised payload gets a budget.** `src/cli/tools.test.ts` caps a single tool at 64 KB
+and a single provider's surface at 192 KB. Nothing capped the total a client is handed, which is the
+number that actually decides whether a hosted client accepts the response and whether a client hides
+the tools behind a search of its own. It is seeded at what is measured today, as a ratchet with the
+same headroom the other two carry.
+
+**Tool names and descriptions become the search index, and are written that way.** This follows from
+deferral being client-side: a client that defers ranks on name and description, so those are no
+longer only documentation. `title` was `undefined` on all 144 discovered tools — the field an index
+most wants was empty — and vendor summaries carry no vendor noun, so Gmail's read "Lists the drafts
+in the user's mailbox" and a search for *email* matched nothing in Gmail. `hints` on the manifest is
+the existing mechanism for the sentence a vendor did not write, and it applies to `mcp` providers as
+well as vendored ones.
+
+**A provider can be declared into a profile before it is connected.** The advertised list is built
+from grant rows and never consults credential status, and granted-but-unauthorized is already a
+first-class state that does not block startup and already fails a call with an actionable message.
+What was missing was a way to reach it deliberately. With one, an operator can make the list stable
+*before* a client is registered, and the later `connect` fills in a credential without moving the
+list at all. That is the cheapest available answer to #162 and it is available because of ADR-058:
+the grant row is the grant, and it does not know whether a credential exists.
+
+## What this does not do
+
+**It does not vary the surface by client.** The revision forbids it, and `clientLabel` is
+self-reported and documented in two places as recorded for audit and never consulted to decide what
+a caller may do. A dispatch pair served only to the clients that need it would be both
+non-conformant and an authorization decision made on an unauthenticated string.
+
+**It does not add a per-connection opt-in.** A `lazy: true` on a grant row would be a second surface
+shape with no way for a model to know which one it is looking at, two dispatch paths to keep tested,
+and a client-visible difference whose effect the operator cannot see. It is also the wrong
+granularity: what makes a surface too large is the endpoint's total, which is a property of the
+profile and not of one row in it.
+
+**It does not retire `makeOpaque`.** Making schemas load on demand does not make a large schema
+small. `sheets.spreadsheets.batchUpdate` inlines to 2,469 KB and `spreadsheets.create` to 1,133 KB
+against a 64 KB budget; a deferred load of either is the same number of bytes, and the Anthropic API
+rejects the whole `tools` array over one that will not fit. The per-tool budget is a cap under any
+exposition strategy, and the `opaque` list stays the remedy.
+
+**It does not advertise tools for providers that are not connected.** For the 77 `mcp` providers it
+is not possible: their capabilities are discovered by opening an authenticated connection to the
+upstream server and calling `listTools()`, so with no credential there is no list to advertise. For
+the vendored ones it is possible and worse — the whole 428 KB, for accounts the profile does not
+have. The declared-but-unauthorized state above is the useful part of the idea, and it is scoped to
+what an operator has actually chosen.
+
+**It does not send a notification on the modern leg.** ADR-032 declined this for want of a stream and
+noted that the 2026-07-28 revision has one. It does: `subscriptions/listen`, opted into per
+notification type. The conclusion is unchanged and the reason is better — the protocol has a stream
+and this endpoint does not hold one, because ADR-002 chose stateless streamable HTTP and the server
+instance is discarded once the response is written.
+
+**It does not decide that typed tools have a size limit.** Only that if they ever do, the number
+comes from measuring this surface against them.

--- a/docs/detailed/adr/README.md
+++ b/docs/detailed/adr/README.md
@@ -87,6 +87,7 @@ Run.
 | [069](069-a-pairing-token-may-write-the-owners-own-data.md) | A pairing token may write the owner's own data; the control plane is unmoved |
 | [073](073-a-connection-names-its-own-account.md) | A connection names its own account; the operator is asked last, and never handed a uuid to live with |
 | [074](074-the-endpoint-records-where-it-bound.md) | The endpoint records where it bound, so an edit reaches the one that is running rather than a port derived from the profile it edited |
+| [075](075-the-list-a-client-caches-must-stop-changing.md) | The typed tool list stays and gains a search beside it, so a client that never re-reads can still reach a new connection |
 
 Where an ADR departs from init.md, it says so at the top. Three are significant:
 
@@ -320,3 +321,10 @@ Where an ADR departs from init.md, it says so at the top. Three are significant:
   authorization server itself; a probe that cannot name a person human-readably falls through to
   the question rather than labelling a row with a uuid. The remaining gap is a ledger the build
   checks in both directions, not a total.
+
+- **ADR-075** adds to ADR-032 rather than revisiting it. A stateless endpoint still cannot make a
+  client re-read its tool list, so the surface gains a way in that does not depend on the list being
+  current: the typed tools stay, and `lanes_tools_search` / `lanes_tools_call` sit beside them,
+  present in every list any client has ever fetched. The part worth reading is why this is not the
+  duplication issue #162 rejected — the search names the typed tool to prefer, so the model choosing
+  between the two paths is told which one it is on, by the only party that can see its tool list.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lanes-sh/link",
-  "version": "0.10.3",
+  "version": "0.10.4",
   "description": "A self-hostable MCP gateway for all your connections, memory, tasks, files, and secrets",
   "license": "Apache-2.0",
   "homepage": "https://lanes.sh/link",

--- a/src/cli/accepts.ts
+++ b/src/cli/accepts.ts
@@ -53,6 +53,10 @@ export const ACCEPTS: Record<string, readonly string[]> = {
   doctor: ['fix'],
   // A filter, not a second subject: it narrows the answer to one connection so
   // a caller can re-ask about the row it just repaired. Same shape as `attach`.
+  // Declaring a connection names the account itself, because nothing can be
+  // asked of a provider that is not authorised yet — see `connection-declare.ts`.
+  'connection declare': ['id', 'account', 'label'],
+
   auth: ['connection'],
   relabel: [],
   // A rule lands in a grant row, and a row names one connection (ADR-058), so

--- a/src/cli/commands/connection-declare.test.ts
+++ b/src/cli/commands/connection-declare.test.ts
@@ -1,0 +1,176 @@
+import { afterAll, describe, expect, test } from 'bun:test';
+import { mkdtemp, readFile, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+/**
+ * `lanes link connection declare`, end to end through the real binary.
+ *
+ * Spawned rather than called, because half of what this command is depends on
+ * wiring that a direct call skips: the `connection declare` case in `main.ts`,
+ * the row in `SELECTION`, and the `ACCEPTS` entry that decides whether
+ * `--account` is a flag or an error. A unit test of the exported function would
+ * pass with all three missing.
+ *
+ * What is being asserted is that two files change and a third thing does not:
+ * the workspace gains a connection row, the named profile gains a grant row,
+ * and no credential is stored or asked for. `server/mcp/unauthorized.test.ts`
+ * holds the other half — that a grant in that state is advertised — and the two
+ * together are the whole of why this command exists (ADR-075).
+ */
+
+const BIN = fileURLToPath(new URL('../lanes.ts', import.meta.url));
+
+const homes: string[] = [];
+afterAll(async () => {
+  await Promise.all(homes.map((home) => rm(home, { recursive: true, force: true })));
+});
+
+interface Run {
+  readonly code: number;
+  readonly out: string;
+}
+
+async function workspace(): Promise<{ root: string; run: (args: string[]) => Run }> {
+  const root = await mkdtemp(join(tmpdir(), 'lanes-link-declare-'));
+  homes.push(root);
+  const env = { ...process.env, LANES_LINK_HOME: root };
+
+  const run = (args: string[]): Run => {
+    const result = Bun.spawnSync(['bun', 'run', BIN, 'link', ...args], { env });
+    return {
+      code: result.exitCode,
+      out:
+        new TextDecoder().decode(result.stdout) + new TextDecoder().decode(result.stderr),
+    };
+  };
+
+  expect(run(['profile', 'add', 'assistant', '--workspace', 'local']).code).toBe(0);
+  return { root, run };
+}
+
+describe('declaring an account before authorising it', () => {
+  test('writes the connection row and the profile grant, and no credential', async () => {
+    const { root, run } = await workspace();
+
+    const declared = run([
+      'connection', 'declare', 'gmail',
+      '--account', 'ada.lovelace@example.com',
+      '--profile', 'assistant',
+      '--workspace', 'local',
+    ]);
+
+    expect(declared.code).toBe(0);
+    expect(declared.out).toContain('declared gmail.main');
+
+    const connections = await readFile(join(root, 'connections.yaml'), 'utf8');
+    expect(connections).toContain('provider: gmail');
+    expect(connections).toContain('account: ada.lovelace@example.com');
+
+    const profile = await readFile(join(root, 'profiles', 'assistant', 'profile.yaml'), 'utf8');
+    expect(profile).toContain('connection: gmail.main');
+    expect(profile).toContain('gmail.*');
+
+    // The claim that makes this different from `connect`. `credential_ref`
+    // derives to `<provider>/<id>`, so the absence being asserted is the stored
+    // value, and `doctor` is what reports it as missing.
+    expect(run(['doctor', '--profile', 'assistant', '--workspace', 'local']).out).toContain(
+      'gmail.main has no stored credential',
+    );
+  });
+
+  /**
+   * Without `--profile` nothing is granted, and the output says so rather than
+   * reporting success at the thing the operator ran it for. Declaring is not
+   * granting, the same way connecting is not (ADR-057) — and only the grant row
+   * changes what a client is served.
+   */
+  test('declares into the workspace and grants nothing when no profile is named', async () => {
+    const { root, run } = await workspace();
+
+    const declared = run([
+      'connection', 'declare', 'gmail',
+      '--account', 'ada.lovelace@example.com',
+      '--workspace', 'local',
+    ]);
+
+    expect(declared.code).toBe(0);
+    expect(declared.out).toContain('Granted to nobody');
+
+    expect(await readFile(join(root, 'connections.yaml'), 'utf8')).toContain('provider: gmail');
+    expect(
+      await readFile(join(root, 'profiles', 'assistant', 'profile.yaml'), 'utf8'),
+    ).not.toContain('gmail.main');
+  });
+
+  /**
+   * The account cannot be probed, because probing is what needs the credential
+   * this command is defined by not having (ADR-073). So it is asked for, and the
+   * refusal has to say that rather than name a missing flag — an operator who
+   * has just been told to declare a provider does not know why an address is
+   * suddenly required.
+   */
+  test('refuses without an account, and says why one is needed', async () => {
+    const { run } = await workspace();
+
+    const refused = run([
+      'connection', 'declare', 'gmail', '--profile', 'assistant', '--workspace', 'local',
+    ]);
+
+    expect(refused.code).not.toBe(0);
+    expect(refused.out).toContain('Which account is this Gmail connection?');
+    expect(refused.out).toContain('until it is authorised');
+  });
+
+  /** A second row for the same id is the operator's mistake, not a reconnect. */
+  test('refuses a second declaration of the same connection', async () => {
+    const { run } = await workspace();
+    const args = [
+      'connection', 'declare', 'gmail',
+      '--account', 'ada.lovelace@example.com',
+      '--workspace', 'local',
+    ];
+
+    expect(run(args).code).toBe(0);
+
+    const again = run(args);
+    expect(again.code).not.toBe(0);
+    expect(again.out).toContain('already holds gmail.main');
+    // Both ways forward, because either could be what was meant.
+    expect(again.out).toContain('lanes link connect gmail');
+    expect(again.out).toContain('--id <another>');
+  });
+
+  /**
+   * The owner layer is instances written by `ensureOwnerLayer` (ADR-059), so a
+   * hand-declared row for one would collide with the repair rather than replace
+   * it — and every profile already holds them (ADR-050), so there is nothing to
+   * declare.
+   */
+  test('refuses one of Lanes own surfaces', async () => {
+    const { run } = await workspace();
+
+    const refused = run([
+      'connection', 'declare', 'lanes_memory',
+      '--account', 'ada.lovelace@example.com',
+      '--workspace', 'local',
+    ]);
+
+    expect(refused.code).not.toBe(0);
+    expect(refused.out).toContain("one of Lanes' own surfaces");
+  });
+
+  test('refuses a provider this build does not know', async () => {
+    const { run } = await workspace();
+
+    const refused = run([
+      'connection', 'declare', 'not_a_vendor',
+      '--account', 'someone@example.com',
+      '--workspace', 'local',
+    ]);
+
+    expect(refused.code).not.toBe(0);
+    expect(refused.out).toContain('No provider "not_a_vendor"');
+  });
+});

--- a/src/cli/commands/connection-declare.ts
+++ b/src/cli/commands/connection-declare.ts
@@ -1,0 +1,221 @@
+import { RESERVED_PROVIDER_IDS } from '#connectivity';
+import { PROVIDER_MANIFESTS } from '#providers/index.ts';
+import {
+  CONNECTIONS_FILE,
+  ConfigError,
+  connectionRefOf,
+  defaultConnectionLabel,
+  loadProfileConfig,
+  readConnections,
+  resolveTargetWorkspace,
+  resolveWorkspaceRoot,
+} from '#profile';
+import { ConfigDocument } from '../config-edit.ts';
+import { announce, emit, ok, print, style } from '../output.ts';
+import { nextAfterEdit, publishProfileEdit } from '../publish.ts';
+import { resolveProfile, type GlobalFlags } from '../runtime.ts';
+import { declareConnection } from './connect/declare.ts';
+import { grantConnection } from './connect/grant.ts';
+
+/**
+ * `lanes link connection declare` — name an account before authorising it.
+ *
+ * The command that makes a client's tool list stop moving (ADR-075).
+ *
+ * What a client is served is built from grant rows and never consults whether a
+ * credential exists — `connectionsOf` in `#server/mcp` reads
+ * `config.grants` and nothing else, because the grant row *is* the grant
+ * (ADR-058). And a connection with no valid credential is already a first-class
+ * state rather than a broken one: `reconcile` marks it `unauthorized` from
+ * `credentials.has`, the status is documented as not blocking startup, and a
+ * call against it is refused by the dispatcher with a sentence saying to connect
+ * it.
+ *
+ * So the endpoint could always advertise an account that was not yet authorised.
+ * There was simply no way to ask for one, because the only path to a connection
+ * row went through `connect`, which acquires a credential first — and therefore
+ * the advertised list changed at the moment of authorising, which is the moment
+ * an operator is least able to also go and refresh a client.
+ *
+ * With this, the two events separate. Declare the accounts a profile will hold,
+ * register the client against a list that already names them, then authorise
+ * them whenever — `connect` fills in the credential and the list does not move.
+ * A client that never re-reads its tool list, which is the whole problem issue
+ * #162 is about, sees the right list the first time.
+ *
+ * **The account is asked for, and a later `connect` corrects it.** Identity is
+ * normally resolved from the provider itself (ADR-073), and that needs the
+ * credential this command is defined by not having. So the operator says who it
+ * is, and it is provisional in a way nothing else here is: `declareConnection`'s
+ * reconnect branch rewrites `account` when the provider reports something
+ * different, so the first real `connect` repairs a guess. That is the reason
+ * asking is acceptable rather than a regression against ADR-073 — the answer is
+ * not load-bearing and does not survive being wrong.
+ *
+ * **Declaring is not granting**, the same way connecting is not (ADR-057). Only
+ * `--profile` writes the grant row, and only the grant row changes what a client
+ * sees — so a declare without one has done nothing for the tool list, and says
+ * so rather than reporting success at the thing the operator came for.
+ */
+
+export interface Declared {
+  readonly key: string;
+  readonly provider: string;
+  readonly account: string;
+  readonly label: string;
+  readonly target: string;
+  /** The profile the grant went to, or `null` when none was named. */
+  readonly profile: string | null;
+  readonly allowed: readonly string[];
+  readonly changes: readonly string[];
+  readonly published: string;
+}
+
+export async function connectionDeclare(
+  providerId: string | undefined,
+  flags: GlobalFlags & {
+    json?: boolean;
+    id?: string | undefined;
+    account?: string | undefined;
+    label?: string | undefined;
+  },
+): Promise<void> {
+  if (!providerId) {
+    throw new ConfigError(
+      'Which provider? Run: lanes link setup plan\n' +
+        '  e.g. lanes link connection declare gmail --account ada.lovelace@example.com --profile assistant',
+    );
+  }
+
+  // The owner layer is not connectable and not declarable — its instances are
+  // written by `ensureOwnerLayer`, and a hand-written row for one would collide
+  // with the repair rather than replace it.
+  if (RESERVED_PROVIDER_IDS.includes(providerId)) {
+    throw new ConfigError(
+      `${providerId} is one of Lanes' own surfaces, not an account to declare.\n` +
+        '  Every profile arrives holding it. Run: lanes link check',
+    );
+  }
+
+  const manifest = PROVIDER_MANIFESTS.find((one) => one.id === providerId);
+  if (manifest === undefined) {
+    throw new ConfigError(
+      `No provider "${providerId}".\n` +
+        '  Run "lanes link setup plan" for the ones this build knows.',
+    );
+  }
+
+  if (!flags.account) {
+    throw new ConfigError(
+      `Which account is this ${manifest.name} connection?\n` +
+        '  Nothing can be asked of the provider until it is authorised, so say who it is:\n' +
+        `    lanes link connection declare ${providerId} --account <address>\n` +
+        '  A later `lanes link connect` corrects it if the provider reports something else.',
+    );
+  }
+
+  const local = resolveWorkspaceRoot();
+  const root = await resolveTargetWorkspace(local, flags.target ?? 'local');
+
+  const connectionId = flags.id ?? 'main';
+  const key = `${providerId}.${connectionId}`;
+
+  const held = (await readConnections(root)).connections;
+  if (held.some((one) => connectionRefOf(one) === key)) {
+    throw new ConfigError(
+      `This workspace already holds ${key}.\n` +
+        `  To grant it to a profile:   lanes link grant ${key} --profile <name>\n` +
+        `  To authorise it:            lanes link connect ${providerId} --id ${connectionId}\n` +
+        `  To declare a second account: --id <another>`,
+    );
+  }
+
+  const account = flags.account;
+  const derived = defaultConnectionLabel(manifest.name, account);
+  const label = flags.label ?? derived;
+
+  const connectionsDocument = await ConfigDocument.openKey(root, CONNECTIONS_FILE);
+  const changes = [
+    ...declareConnection({
+      document: connectionsDocument,
+      connections: held,
+      providerId,
+      connectionId,
+      account,
+      label,
+      defaultLabel: derived,
+      method: undefined,
+      config: {},
+    }),
+  ];
+
+  // The grant, and only where a profile was named — see the docstring. Resolved
+  // rather than assumed, so naming a profile that does not exist fails here
+  // instead of writing a connection row and then throwing.
+  const granting = flags.profile !== undefined;
+  let allowed: readonly string[] = [];
+  let profileDocument: ConfigDocument | undefined;
+  let resolved: Awaited<ReturnType<typeof resolveProfile>> | undefined;
+
+  if (granting) {
+    resolved = await resolveProfile(flags);
+    profileDocument = await ConfigDocument.open(root, resolved.resolution.profile);
+    allowed = grantConnection(profileDocument, resolved.config, key);
+  }
+
+  // Connections file first, always. A grant naming a connection the workspace
+  // does not hold is refused at load by `assertGrantsResolve`, so if only one of
+  // the two writes lands it has to be this one — the other order leaves a
+  // workspace that will not open. Same rule, and same reason, as `connect`.
+  await connectionsDocument.save();
+  if (profileDocument) await profileDocument.save();
+
+  const declared: Declared = {
+    key,
+    provider: providerId,
+    account,
+    label,
+    target: flags.target ?? 'local',
+    profile: resolved?.resolution.profile ?? null,
+    allowed,
+    changes,
+    published:
+      resolved === undefined
+        ? ''
+        : nextAfterEdit(
+            await publishProfileEdit({
+              resolution: resolved.resolution,
+              config: (await loadProfileConfig(root, resolved.resolution.profile)).config,
+              target: resolved.target,
+            }),
+          ),
+  };
+
+  return emit(flags.json, declared, () => {
+    if (resolved) announce(resolved.resolution);
+    print(ok(`declared ${style.bold(key)}`));
+    print(`      account     ${style.dim(account)}`);
+    print(`      label       ${style.dim(label)}`);
+
+    if (declared.profile === null) {
+      // Said plainly, because the operator ran this to make a tool list stable
+      // and an ungranted connection changes no tool list at all.
+      print(
+        style.dim(
+          '      Granted to nobody, so no client sees it yet. Grant it with:\n' +
+            `        lanes link grant ${key} --profile <name>`,
+        ),
+      );
+    } else {
+      print(`      granted to  ${style.bold(declared.profile)}`);
+      print(
+        style.dim(
+          `      Its tools are advertised now and refuse calls until it is authorised:\n` +
+            `        lanes link connect ${providerId} --id ${connectionId} --profile ${declared.profile}`,
+        ),
+      );
+    }
+
+    if (declared.published) print(style.dim(`      ${declared.published}`));
+  });
+}

--- a/src/cli/commands/mcp/onboarding.ts
+++ b/src/cli/commands/mcp/onboarding.ts
@@ -79,6 +79,10 @@ and my contacts. It is an MCP endpoint, and it is already connected.
 - Before telling me something cannot be reached or that an account is missing,
   ask the setup surface. It reports what exists and gives the exact command for
   what does not. Run nothing yourself: every change here is mine to make.
+- If the tool you need is not in your list, search for it before concluding it
+  is not there. Your list is a snapshot from when you connected, and an account
+  I added since is reachable through the search and by id even when no tool of
+  its own appears.
 - Read \`lanes://instructions\` before your first call for the full account of
   how routing, profiles and refusals work.
 

--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -2,6 +2,7 @@ import { connect } from './commands/connect/index.ts';
 import { connectCustom } from './commands/connect/custom/index.ts';
 import { disconnect } from './commands/connection.ts';
 import { grantConnectionTo, revokeConnectionFrom } from './commands/grant.ts';
+import { connectionDeclare } from './commands/connection-declare.ts';
 import { connectionList } from './commands/connection-list.ts';
 import { membersAdd, membersList, membersRemove } from './commands/members.ts';
 import { relabel } from './commands/relabel.ts';
@@ -145,6 +146,16 @@ export async function run(argv: readonly string[]): Promise<void> {
     // The command connecting no longer implies. A connection belongs to the
     // workspace (ADR-057), so which profiles may reach it is a separate say.
     case 'connection':
+      if (second === 'declare') {
+        const [provider] = rest;
+        return connectionDeclare(provider, {
+          ...global,
+          json,
+          ...(text(flags, 'id') !== undefined ? { id: text(flags, 'id') } : {}),
+          ...(text(flags, 'account') !== undefined ? { account: text(flags, 'account') } : {}),
+          ...(text(flags, 'label') !== undefined ? { label: text(flags, 'label') } : {}),
+        });
+      }
       if (second !== 'list' && second !== undefined) {
         throw new Error(`Unknown: ${PROGRAM} connection ${second}`);
       }

--- a/src/cli/selection.ts
+++ b/src/cli/selection.ts
@@ -129,6 +129,9 @@ export const SELECTION: Record<string, Requires> = {
   // profile would narrow the column rather than the rows.
   connection: 'workspace',
   'connection list': 'workspace',
+  // Declaring names the workspace the connection lands in; `--profile` is what
+  // *also* grants it there, exactly as on `connect`.
+  'connection declare': 'workspace',
   grant: 'profile+workspace',
   revoke: 'profile+workspace',
   // Both act on a connection, which belongs to the workspace (ADR-057).

--- a/src/cli/tools.test.ts
+++ b/src/cli/tools.test.ts
@@ -162,6 +162,57 @@ describe('vendored specs yield registrable tools', () => {
   );
 
   /**
+   * The size neither budget above measures: every vendored provider at once.
+   *
+   * `BUDGET_KB` is a floor under one runaway schema and `SURFACE_BUDGET_KB` a
+   * floor under one runaway provider. Both are per-something, so both stay green
+   * while the number that actually reaches a client grows one comfortable
+   * provider at a time — which is the only way this has ever grown. Nothing was
+   * watching the sum, and the sum is what decides whether a hosted client
+   * accepts the response and whether a client defers the tools behind a search
+   * of its own (ADR-075).
+   *
+   * Not a per-profile figure, because there is no such thing to assert: what one
+   * endpoint serves depends on which accounts are connected and what policy
+   * allows. This is the ceiling the vendored specs can contribute, which is the
+   * part a change to this repository can move.
+   *
+   * The headroom is deliberate and narrower than the two above. Those are set to
+   * catch an order of magnitude — an un-`opaque`d union, a `$ref` fan-out — and
+   * a single tool going wrong is already caught by them. What this catches is
+   * accumulation, so it is set close enough that adding a provider is noticed
+   * and raised on purpose rather than absorbed. Raising it is the normal
+   * outcome; doing so silently is not.
+   */
+  const ENDPOINT_BUDGET_KB = 512;
+
+  test('every vendored provider together stays inside the endpoint budget', async () => {
+    const measured = await Promise.all(
+      httpProviders.map(async (manifest) => {
+        const connector = manifest.connector as { base_url: string; openapi: string };
+        const capabilities = await createHttpConnector({
+          baseUrl: connector.base_url,
+          openapi: connector.openapi,
+        }).discover({ manifest });
+
+        return capabilities.reduce(
+          (total, { title, description, inputSchema }) =>
+            total + JSON.stringify({ title, description, inputSchema }).length,
+          0,
+        );
+      }),
+    );
+
+    const kb = Math.round(measured.reduce((total, bytes) => total + bytes, 0) / 1024);
+
+    // Reported rather than merely compared: raising this should be an informed
+    // decision, and the number to raise it to is the one the failure is holding.
+    expect(`${kb}KB of ${ENDPOINT_BUDGET_KB}KB`).toBe(
+      `${Math.min(kb, ENDPOINT_BUDGET_KB)}KB of ${ENDPOINT_BUDGET_KB}KB`,
+    );
+  });
+
+  /**
    * A hint that is declared but not delivered.
    *
    * `specs.test.ts` checks that a `hints` key names a real capability. This
@@ -196,6 +247,101 @@ describe('vendored specs yield registrable tools', () => {
       expect(undelivered).toEqual([]);
     },
   );
+
+  /**
+   * Every capability of a provider carries that provider's search vocabulary.
+   *
+   * The same shape as the hint check above and a different failure. A `hints`
+   * entry names one capability, so a missed one costs that capability its
+   * sentence. `keywords` is provider-wide and appended per capability, so a
+   * transport that stopped consulting `manifest.keywords` would take the whole
+   * provider out of the index at once — and, exactly as with hints, would go on
+   * serving descriptions that look correct.
+   */
+  test.each(httpProviders.map((m) => [m.id, m] as const))(
+    '%s delivers its keywords on every capability',
+    async (_id, manifest) => {
+      const declared = manifest.keywords ?? [];
+      if (declared.length === 0) return;
+
+      const connector = manifest.connector as { base_url: string; openapi: string };
+      const capabilities = await createHttpConnector({
+        baseUrl: connector.base_url,
+        openapi: connector.openapi,
+      }).discover({ manifest });
+
+      // Present, not appended: a term the vendor's own wording already uses is
+      // deliberately not repeated, so this asserts the weaker and correct thing.
+      const missing = capabilities
+        .filter((capability) =>
+          declared.some((term) => !capability.description.toLowerCase().includes(term.toLowerCase())),
+        )
+        .map((capability) => capability.name);
+
+      expect(missing).toEqual([]);
+    },
+  );
+
+  /**
+   * The regression the two fields above exist for: the obvious word finds the
+   * provider that answers to it.
+   *
+   * Measured before `title` and `keywords` were added, over the same text a
+   * client's tool search ranks on — the wire name, the title, and the
+   * description. A search for *email* returned two Google Contacts tools and
+   * nothing from either mail provider. *meeting*, *calendar invite*, *todo list*,
+   * *reminder* and *file upload* returned nothing at all, from any provider.
+   *
+   * The cause is that a vendor writes their own document in their own
+   * vocabulary: Gmail's operations say "mail" and "mailbox" and never "email",
+   * Calendar's say "events" and never "meeting", Tasks' say "tasks" and never
+   * "todo". Every one of those tools was in the list the whole time, and an
+   * agent searching for the word a person would use could not reach it.
+   *
+   * Deliberately not a ranking test — there is no ranker here to assert against,
+   * and which of a provider's tools scores highest is the client's business.
+   * This is the weaker claim that was actually false: that the terms appear at
+   * all, on the provider they should.
+   */
+  const FINDABLE: [query: string, provider: string][] = [
+    ['email', 'gmail'],
+    ['send email', 'gmail'],
+    ['email', 'outlook_mail'],
+    ['inbox', 'gmail'],
+    ['meeting', 'calendar'],
+    ['calendar invite', 'calendar'],
+    ['meeting', 'outlook_calendar'],
+    ['todo list', 'google_tasks'],
+    ['reminder', 'google_tasks'],
+    ['reminder', 'microsoft_todo'],
+    ['file upload', 'drive'],
+    ['document', 'drive'],
+    ['spreadsheet formula', 'sheets'],
+    ['address book', 'contacts'],
+  ];
+
+  test.each(FINDABLE)('a search for "%s" reaches %s', async (query, providerId) => {
+    const manifest = httpProviders.find((one) => one.id === providerId);
+    expect(manifest).toBeDefined();
+
+    const connector = manifest!.connector as { base_url: string; openapi: string };
+    const capabilities = await createHttpConnector({
+      baseUrl: connector.base_url,
+      openapi: connector.openapi,
+    }).discover({ manifest: manifest! });
+
+    // The fields a client indexes, and only those. The manifest's own name and
+    // description are not among them — that is the whole reason `title` and
+    // `keywords` had to put the vocabulary onto the tools.
+    const indexed = capabilities.map((capability) =>
+      `${providerId} ${capability.name} ${capability.title ?? ''} ${capability.description}`.toLowerCase(),
+    );
+
+    const terms = query.split(' ');
+    const reachable = indexed.filter((text) => terms.every((term) => text.includes(term)));
+
+    expect(reachable.length).toBeGreaterThan(0);
+  });
 
   /**
    * A redaction key that names no argument keeps nothing, and says nothing.

--- a/src/cli/usage-data.ts
+++ b/src/cli/usage-data.ts
@@ -83,6 +83,10 @@ export const SECTIONS: readonly Section[] = [
         description: 'every account in this workspace, and who grants it',
       },
       {
+        command: 'connection declare <provider> --account <address>',
+        description: 'name an account before authorising it, so its tools are advertised now and a client registered today does not have to be re-added after you connect it',
+      },
+      {
         command: 'grant add <provider>.<id>',
         description: 'let a profile reach one, with nothing allowed yet',
       },

--- a/src/connectivity/manifest/provider.ts
+++ b/src/connectivity/manifest/provider.ts
@@ -64,6 +64,19 @@ export const providerManifestSchema = z.object({
    */
   hints: z.record(z.string(), z.string()).optional(),
   /**
+   * The words a person would search for that the vendor never writes.
+   *
+   * Provider-wide, unlike `hints`, because tool search is client-side and ranks
+   * on names and descriptions — so those are the whole index, and a vendor
+   * documents their product in their own vocabulary: Gmail's operations say
+   * "mail" and never "email". ADR-075 has what that measured, `cli/tools.test.ts`
+   * holds it. Write synonyms and the plain noun for what the provider *is*, not
+   * a restatement of the operations the names already carry — the line is
+   * appended to every one of the provider's descriptions, so it stays short.
+   */
+  keywords: z.array(z.string()).optional(),
+
+  /**
    * What this connection has to say about *where* the service is.
    *
    * Absent for every provider whose address is the same for everybody, which is

--- a/src/connectivity/transports/http/index.ts
+++ b/src/connectivity/transports/http/index.ts
@@ -1,6 +1,6 @@
 import type { McpOpenAPITool, ParameterMapper } from 'mcp-from-openapi';
 import { withLegalKeys } from './keys.ts';
-import { shortenName } from '../mcp/index.ts';
+import { shortenName, titleFor, withKeywords } from '../mcp/index.ts';
 import {
   READ_BUNDLE,
   WRITE_BUNDLE,
@@ -194,7 +194,13 @@ export function createHttpConnector(options: HttpConnectorOptions): Connector {
 
         return {
           name,
-          description: hint ? `${described}\n\n${hint}` : described,
+          // An OpenAPI document has no display name to offer, so this is
+          // synthesised rather than passed through — see `titleFor`.
+          title: titleFor(context.manifest.name, name),
+          description: withKeywords(
+            hint ? `${described}\n\n${hint}` : described,
+            context.manifest.keywords,
+          ),
           inputSchema: legal.schema,
           bundle: bundleForMethod(tool.metadata.method),
           // Everything needed to rebuild the request without re-reading the spec,

--- a/src/connectivity/transports/index.ts
+++ b/src/connectivity/transports/index.ts
@@ -6,7 +6,14 @@
  */
 
 export { createLocalConnector } from './local/index.ts';
-export { createMcpConnector, inferBundle, type McpConnectorOptions } from './mcp/index.ts';
+export {
+  createMcpConnector,
+  inferBundle,
+  shortenName,
+  titleFor,
+  withKeywords,
+  type McpConnectorOptions,
+} from './mcp/index.ts';
 export {
   createHttpConnector,
   bundleForMethod,

--- a/src/connectivity/transports/mcp/index.ts
+++ b/src/connectivity/transports/mcp/index.ts
@@ -83,6 +83,66 @@ export function shortenName(providerId: string, name: string, all: readonly stri
 }
 
 /**
+ * A readable name for a discovered capability, where the vendor supplied none.
+ *
+ * MCP's `title` is optional and almost nobody fills it in: it was `undefined` on
+ * every one of the 144 tools the vendored specs produce, because an OpenAPI
+ * document has a `summary` and an `operationId` and no display name. So a client
+ * listing them had only the wire name to show, and — the reason this exists — a
+ * client that *defers* tool loading had one less field to rank on.
+ *
+ * That second use is what makes this more than cosmetic (ADR-075). Tool search
+ * is client-side and it matches on names and descriptions, so those two fields
+ * are the whole index. The wire name carries the provider id (`gmail_...`) but
+ * the vendor's own noun appears nowhere: `Gmail` is in the manifest, and the
+ * manifest is not what a client is ranking. Putting it in the title puts it in
+ * the index, once per tool, for about twenty-five bytes.
+ *
+ * The operation reads better reversed. An operationId is written
+ * object-then-verb — `users.drafts.list`, `spreadsheets.values.update` — because
+ * it is a path; a person says "list drafts". So the last segment leads, the one
+ * before it follows, and camelCase is split so `copyTo` reads as words. Deeper
+ * segments are dropped rather than joined: `users.` prefixes most of Gmail and
+ * says nothing that distinguishes one tool from another.
+ *
+ * Never overwrites a `title` the vendor did supply. An upstream MCP server that
+ * wrote one knows its own product better than this does.
+ */
+export function titleFor(vendor: string, name: string): string {
+  const words = (segment: string) =>
+    segment.replace(/([a-z0-9])([A-Z])/g, '$1 $2').replace(/[_-]+/g, ' ').toLowerCase();
+
+  const segments = name.split('.').filter((segment) => segment.length > 0);
+  const verb = segments.at(-1);
+  const object = segments.at(-2);
+
+  if (verb === undefined) return vendor;
+  return object === undefined
+    ? `${vendor}: ${words(verb)}`
+    : `${vendor}: ${words(verb)} ${words(object)}`;
+}
+
+/**
+ * The manifest's search vocabulary, on the description that carries it.
+ *
+ * One line, appended to every capability of a provider that declares
+ * `keywords`. Repetitive on purpose: a client's tool search ranks each tool as
+ * its own document, so a word present on the provider and absent from the tool
+ * is a word that does not match the tool. There is nowhere else to put it.
+ *
+ * A term already in the description is dropped rather than repeated, which
+ * keeps the line to the words that are genuinely missing and stops it growing
+ * as vendors improve their own wording.
+ */
+export function withKeywords(description: string, keywords: readonly string[] = []): string {
+  const missing = keywords.filter(
+    (term) => !new RegExp(`\\b${term.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}\\b`, 'i').test(description),
+  );
+
+  return missing.length === 0 ? description : `${description}\n\nAlso: ${missing.join(', ')}.`;
+}
+
+/**
  * Turn an upstream transport error into something readable.
  *
  * The SDK reports a bad HTTP status by appending the whole response body,
@@ -173,8 +233,16 @@ export function createMcpConnector(options: McpConnectorOptions): Connector {
 
         return tools.map((tool) => ({
           name: shortenName(context.manifest.id, tool.name, names),
-          ...(tool.title ? { title: tool.title } : {}),
-          description: tool.description ?? `${context.manifest.name} ${tool.name}`,
+          // The upstream title wins where there is one; `titleFor` fills in
+          // where there is not, so the vendor's noun reaches the field a
+          // deferring client ranks on either way.
+          title:
+            tool.title ??
+            titleFor(context.manifest.name, shortenName(context.manifest.id, tool.name, names)),
+          description: withKeywords(
+            tool.description ?? `${context.manifest.name} ${tool.name}`,
+            context.manifest.keywords,
+          ),
           inputSchema: tool.inputSchema ?? { type: 'object', properties: {} },
           bundle: inferBundle(tool, shortenName(context.manifest.id, tool.name, names)),
           // The upstream name is kept verbatim: ours may differ once it has

--- a/src/connectivity/transports/searchability.test.ts
+++ b/src/connectivity/transports/searchability.test.ts
@@ -1,0 +1,135 @@
+import { describe, expect, test } from 'bun:test';
+import { titleFor, withKeywords } from './index.ts';
+import { gmail } from '#providers/google/gmail/index.ts';
+
+/**
+ * The two fields a client's tool search actually reads.
+ *
+ * Tool search is client-side and ranks on names and descriptions, so those are
+ * the whole index (ADR-075). Neither of the helpers here changes what a tool
+ * *does*, which is why they need tests: a mistake in either is invisible at
+ * runtime and shows up only as a tool nobody picks.
+ */
+
+describe('titleFor', () => {
+  /**
+   * The reversal is the point. An operationId is a path, so it reads
+   * object-then-verb; a person says the verb first.
+   */
+  test('reads the operation as a person would say it', () => {
+    expect(titleFor('Gmail', 'users.drafts.list')).toBe('Gmail: list drafts');
+    expect(titleFor('Google Sheets', 'spreadsheets.values.update')).toBe(
+      'Google Sheets: update values',
+    );
+  });
+
+  test('splits camelCase and separators into words', () => {
+    expect(titleFor('Google Sheets', 'spreadsheets.sheets.copyTo')).toBe(
+      'Google Sheets: copy to sheets',
+    );
+    expect(titleFor('Slack', 'conversations_history')).toBe('Slack: conversations history');
+  });
+
+  /**
+   * Only the last two segments. `users.` prefixes most of Gmail and distinguishes
+   * nothing, so joining every segment would spend bytes to say less.
+   */
+  test('ignores segments above the object', () => {
+    expect(titleFor('Gmail', 'users.messages.attachments.get')).toBe('Gmail: get attachments');
+  });
+
+  test('a single segment is just the verb', () => {
+    expect(titleFor('Tavily', 'search')).toBe('Tavily: search');
+  });
+
+  /**
+   * Degenerate input yields the vendor rather than a title with a dangling
+   * colon. Nothing produces this today; it is here so that nothing has to.
+   */
+  test('an empty name falls back to the vendor', () => {
+    expect(titleFor('Notion', '')).toBe('Notion');
+    expect(titleFor('Notion', '...')).toBe('Notion');
+  });
+});
+
+describe('withKeywords', () => {
+  test('appends the terms a description does not already carry', () => {
+    expect(withKeywords('Lists the drafts in the mailbox.', ['email', 'inbox'])).toBe(
+      'Lists the drafts in the mailbox.\n\nAlso: email, inbox.',
+    );
+  });
+
+  /**
+   * The filter is what keeps the line to what is missing. Without it every
+   * description would restate words already in it, and the line would grow
+   * rather than shrink as vendors improve their own wording.
+   */
+  test('drops a term the description already uses, whatever the case', () => {
+    expect(withKeywords('Send an Email to a recipient.', ['email', 'inbox'])).toBe(
+      'Send an Email to a recipient.\n\nAlso: inbox.',
+    );
+  });
+
+  test('leaves a description alone when nothing is missing', () => {
+    const description = 'Search email in the inbox.';
+    expect(withKeywords(description, ['email', 'inbox'])).toBe(description);
+    expect(withKeywords(description)).toBe(description);
+    expect(withKeywords(description, [])).toBe(description);
+  });
+
+  /**
+   * Whole words only. `mail` must not be considered present because `mailbox`
+   * is — they are different search terms, and treating one as the other is how
+   * a provider ends up with no vocabulary for the thing it is.
+   */
+  test('matches whole words rather than substrings', () => {
+    expect(withKeywords('Lists the mailbox labels.', ['mail'])).toBe(
+      'Lists the mailbox labels.\n\nAlso: mail.',
+    );
+  });
+
+  /** A term is written by an operator in a manifest, so it may contain anything. */
+  test('a term with regex punctuation is matched literally', () => {
+    expect(withKeywords('Reads a file.', ['e-mail', 'c++'])).toBe(
+      'Reads a file.\n\nAlso: e-mail, c++.',
+    );
+  });
+
+  test('a multi-word term is one term', () => {
+    expect(withKeywords('Look up a saved contact.', ['address book'])).toBe(
+      'Look up a saved contact.\n\nAlso: address book.',
+    );
+    expect(withKeywords('Search the address book.', ['address book'])).toBe(
+      'Search the address book.',
+    );
+  });
+});
+
+/**
+ * The helpers being right is half of it. The other half is being *called*, and
+ * the two connectors that call them are not every path a tool arrives by.
+ *
+ * `http` and `mcp` apply both as they build a tool from what they discovered.
+ * An authored capability is never discovered — `createCompositeConnector`
+ * delegates `discover` to the remote and answers only `invoke` — so it reaches
+ * the surface carrying whatever its definition wrote and nothing else. That is
+ * invisible at runtime in the way this file's opening note describes: the tool
+ * works perfectly and merely loses to a neighbour that says "email" when it
+ * does not.
+ *
+ * Which is what happened. `gmail.send_message` is the one authored capability on
+ * a remote provider in the tree, and it was the only tool on a whole profile
+ * with no `title`, so "send an email" ranked `users.drafts.send` above the
+ * capability that exists to send mail.
+ */
+describe('an authored capability is as searchable as a discovered one', () => {
+  test('gmail.send_message carries a title and its provider keywords', () => {
+    const send = gmail.capabilities.find((capability) => capability.name === 'send_message');
+
+    expect(send).toBeDefined();
+    expect(send?.title).toBe('Gmail: send message');
+    // `message` is absent because the description already carries it, which is
+    // `withKeywords` working rather than a term going missing.
+    expect(send?.description).toContain('Also: email, inbox, reply, correspondence.');
+  });
+});

--- a/src/providers/google/calendar/index.ts
+++ b/src/providers/google/calendar/index.ts
@@ -43,6 +43,7 @@ export const calendar = defineProvider({
   name: 'Google Calendar',
   description:
     'Read and write calendar events — list, search, create, reschedule, and cancel — and answer when you are free, via the Calendar REST API.',
+  keywords: ['meeting', 'invite', 'appointment', 'schedule', 'availability'],
   connector: {
     kind: 'http',
     base_url: 'https://www.googleapis.com/calendar/v3',

--- a/src/providers/google/contacts/index.ts
+++ b/src/providers/google/contacts/index.ts
@@ -33,6 +33,7 @@ export const contacts = defineProvider({
   name: 'Google Contacts',
   description:
     'Look up a saved contact by name to find their address or phone number, including the addresses Gmail saved automatically. Read-only, via the People REST API.',
+  keywords: ['address book', 'directory', 'people', 'email address'],
   connector: {
     kind: 'http',
     base_url: 'https://people.googleapis.com',

--- a/src/providers/google/docs/index.ts
+++ b/src/providers/google/docs/index.ts
@@ -22,6 +22,7 @@ export const docs = defineProvider({
   name: 'Google Docs',
   description:
     'Read a document\'s structure and edit its content — insert, replace, and format text — via the Docs REST API.',
+  keywords: ['word processor', 'text', 'writing', 'prose'],
   connector: {
     kind: 'http',
     base_url: 'https://docs.googleapis.com',

--- a/src/providers/google/drive-mcp/index.ts
+++ b/src/providers/google/drive-mcp/index.ts
@@ -14,6 +14,7 @@ export const driveMcp = defineProvider({
   name: 'Google Drive (Google MCP)',
   description:
     'Search, read, and create files via Google\'s official Drive MCP server. Requires Workspace Developer Preview enrolment — use "drive" otherwise.',
+  keywords: ['document', 'upload', 'download', 'attachment', 'storage'],
   connector: { kind: 'mcp', endpoint: 'https://drivemcp.googleapis.com/mcp/v1' },
   auth: { kind: 'oauth', registration: 'manual', app: GOOGLE_APP, scopes: DRIVE_SCOPES },
   identity: DRIVE_IDENTITY,

--- a/src/providers/google/drive/index.ts
+++ b/src/providers/google/drive/index.ts
@@ -16,6 +16,7 @@ export const drive = defineProvider({
   name: 'Google Drive',
   description:
     'Search, read, and export files, and organise the ones this app created — rename, move, trash, copy, and share — via the Drive REST API.',
+  keywords: ['document', 'upload', 'download', 'attachment', 'storage'],
   connector: {
     kind: 'http',
     base_url: 'https://www.googleapis.com/drive/v3',

--- a/src/providers/google/gmail-imap/index.ts
+++ b/src/providers/google/gmail-imap/index.ts
@@ -40,6 +40,7 @@ export const gmailImap = defineProvider({
   name: 'Gmail (IMAP)',
   description:
     'Read, search, and send mail in a personal Gmail mailbox over IMAP and SMTP, with an app password that does not expire.',
+  keywords: ['email', 'message', 'inbox', 'reply', 'correspondence'],
   connector: {
     kind: 'imap',
     host: 'imap.gmail.com',

--- a/src/providers/google/gmail-mcp/index.ts
+++ b/src/providers/google/gmail-mcp/index.ts
@@ -28,6 +28,7 @@ export const gmailMcp = defineProvider({
   name: 'Gmail (Google MCP)',
   description:
     'Read and compose mail via Google\'s official Gmail MCP server. Requires Workspace Developer Preview enrolment — use "gmail" otherwise.',
+  keywords: ['email', 'message', 'inbox', 'reply', 'correspondence'],
   connector: { kind: 'mcp', endpoint: 'https://gmailmcp.googleapis.com/mcp/v1' },
   auth: { kind: 'oauth', registration: 'manual', app: GOOGLE_APP, scopes: GMAIL_MCP_SCOPES },
   identity: GMAIL_IDENTITY,

--- a/src/providers/google/gmail/index.ts
+++ b/src/providers/google/gmail/index.ts
@@ -1,4 +1,5 @@
 import { defineProvider, defineProviderWithCapabilities } from '#connectivity';
+import { titleFor, withKeywords } from '#connectivity/transports';
 import { GMAIL_IDENTITY, GOOGLE_APP, GOOGLE_OAUTH, specPath } from '../shared/oauth.ts';
 import { googleServiceAccount } from '../shared/service-account.ts';
 import { googleSetup } from '../shared/setup.ts';
@@ -73,6 +74,7 @@ const manifest = defineProvider({
   name: 'Gmail',
   description:
     'Read, search, send, draft, and organise mail — labels, read-state, spam, and trash — via the Gmail REST API.',
+  keywords: ['email', 'message', 'inbox', 'reply', 'correspondence'],
   connector: {
     kind: 'http',
     base_url: GMAIL_HOST,
@@ -110,5 +112,19 @@ const manifest = defineProvider({
  */
 export const gmail = defineProviderWithCapabilities({
   manifest,
-  capabilities: [gmailSendMessage],
+  // Searchable on the same two fields as every discovered tool. `titleFor` and
+  // `withKeywords` are applied by the `http` and `mcp` connectors as they build
+  // a tool from what they discovered, and an authored capability never passes
+  // through either — so without this the one capability here is the only tool on
+  // the whole surface with no `title` and none of its provider's keywords. That
+  // is the search's motivating example losing to a neighbour: "send an email"
+  // scored `users.drafts.send` above this, because only the former carried
+  // "email" at all.
+  capabilities: [
+    {
+      ...gmailSendMessage,
+      title: titleFor(manifest.name, gmailSendMessage.name),
+      description: withKeywords(gmailSendMessage.description, manifest.keywords),
+    },
+  ],
 });

--- a/src/providers/google/sheets/index.ts
+++ b/src/providers/google/sheets/index.ts
@@ -50,6 +50,7 @@ export const sheets = defineProvider({
   name: 'Google Sheets',
   description:
     'Read and edit spreadsheet cells — ranges, appends, and structural changes like tabs, formatting, and frozen rows — via the Sheets REST API.',
+  keywords: ['table', 'csv', 'row', 'column', 'formula'],
   connector: {
     kind: 'http',
     base_url: 'https://sheets.googleapis.com',

--- a/src/providers/google/tasks/index.ts
+++ b/src/providers/google/tasks/index.ts
@@ -37,6 +37,7 @@ export const googleTasks = defineProvider({
   name: 'Google Tasks',
   description:
     'Read and write task lists and tasks — create, edit, complete, reorder, and delete — via the Tasks REST API.',
+  keywords: ['todo', 'reminder', 'checklist'],
   connector: {
     kind: 'http',
     base_url: 'https://tasks.googleapis.com',

--- a/src/providers/microsoft/calendar/index.ts
+++ b/src/providers/microsoft/calendar/index.ts
@@ -19,6 +19,7 @@ export const outlookCalendar = defineProvider({
   name: 'Outlook Calendar',
   description:
     'Read and write events in Outlook calendars — list, search, create, reschedule, and cancel — via Microsoft Graph.',
+  keywords: ['meeting', 'invite', 'appointment', 'schedule', 'availability'],
   connector: { kind: 'http', base_url: GRAPH_BASE_URL, openapi: specPath('outlook-calendar.v1.json') },
   auth: {
     kind: 'oauth',

--- a/src/providers/microsoft/contacts/index.ts
+++ b/src/providers/microsoft/contacts/index.ts
@@ -26,6 +26,7 @@ export const outlookContacts = defineProvider({
   id: 'outlook_contacts',
   name: 'Outlook Contacts',
   description: 'Look up an address in Outlook contacts, so "email Bob" resolves. Read-only.',
+  keywords: ['address book', 'directory', 'people', 'email address'],
   connector: { kind: 'http', base_url: GRAPH_BASE_URL, openapi: specPath('outlook-contacts.v1.json') },
   auth: {
     kind: 'oauth',

--- a/src/providers/microsoft/drive/index.ts
+++ b/src/providers/microsoft/drive/index.ts
@@ -32,6 +32,7 @@ export const onedrive = defineProvider({
   id: 'onedrive',
   name: 'OneDrive',
   description: 'Browse, search, read, and organise files in OneDrive, via Microsoft Graph.',
+  keywords: ['document', 'upload', 'download', 'attachment', 'storage'],
   connector: { kind: 'http', base_url: GRAPH_BASE_URL, openapi: specPath('onedrive.v1.json') },
   auth: {
     kind: 'oauth',

--- a/src/providers/microsoft/mail/index.ts
+++ b/src/providers/microsoft/mail/index.ts
@@ -34,6 +34,7 @@ export const outlookMail = defineProvider({
   name: 'Outlook Mail',
   description:
     'Read, search, file, and send mail in an Outlook or Microsoft 365 mailbox, via Microsoft Graph.',
+  keywords: ['email', 'message', 'inbox', 'reply', 'correspondence'],
   connector: {
     kind: 'http',
     // Graph carries its version in the path of the server URL, like Drive and

--- a/src/providers/microsoft/todo/index.ts
+++ b/src/providers/microsoft/todo/index.ts
@@ -25,6 +25,7 @@ export const microsoftTodo = defineProvider({
   id: 'microsoft_todo',
   name: 'Microsoft To Do',
   description: 'Create, edit, complete, and organise tasks and lists in Microsoft To Do.',
+  keywords: ['todo', 'reminder', 'checklist'],
   connector: { kind: 'http', base_url: GRAPH_BASE_URL, openapi: specPath('microsoft-todo.v1.json') },
   auth: {
     kind: 'oauth',

--- a/src/server/caching.test.ts
+++ b/src/server/caching.test.ts
@@ -1,0 +1,99 @@
+import { afterAll, describe, expect, test } from 'bun:test';
+import { allocatePort, rpc, startHarness } from './harness.ts';
+
+/**
+ * What this endpoint tells a client about caching its lists.
+ *
+ * ADR-032 declared `listChanged: false` so that a client has no reason to trust
+ * a cached tool list, and said plainly that nothing here can *make* one
+ * re-read. The 2026-07-28 revision turned the first half of that into a field:
+ * `tools/list` results carry `ttlMs` and `cacheScope` (SEP-2549), a server
+ * **MUST** include them, and `ttlMs: 0` means "immediately stale; the client MAY
+ * re-fetch every time the result is needed". That is ADR-032's sentence, said
+ * normatively instead of by implication.
+ *
+ * Nothing in `src/` sets these. `@modelcontextprotocol/server` fills them at its
+ * encode seam from the conservative defaults `{ ttlMs: 0, cacheScope: 'private'
+ * }`, which happen to be exactly what this endpoint wants — so the behaviour is
+ * correct and is resting entirely on somebody else's default. This is the test
+ * that makes it ours.
+ *
+ * Two ways it could go wrong, and neither would fail anything else:
+ *
+ * **A positive `ttlMs`** would re-create ADR-032's failure with the endpoint's
+ * own cooperation. That ADR exists because a client held two setup tools for as
+ * long as it lived while the endpoint served forty-two; a `ttlMs` of minutes
+ * would tell a *conformant* client to do the same thing on purpose.
+ *
+ * **`cacheScope: 'public'`** would be worse than stale, and is the reason this
+ * asserts a field nobody set. The spec's own security note is that a `public`
+ * response "may be shared outside of the initial request's authorization
+ * context (i.e. different access tokens can leverage the same cache)" — and this
+ * endpoint's tool list is per principal by construction. `mergeCapabilities`
+ * filters on `mayReach` and `allowedConnections`, and ADR-060 keeps a profile a
+ * member is not on out of the `profile` enum specifically so they "never learn
+ * it exists". Serving that list to another token from a shared cache would leak
+ * the set of profiles and accounts a person can reach, which is the one thing
+ * the enum is shaped to withhold.
+ *
+ * So `private` here is a correctness property of the surface rather than a
+ * caching preference, and the spec is explicit that `cacheScope` is not an
+ * access control on its own.
+ */
+
+const listing = startHarness({
+  profile: 'personal',
+  port: allocatePort(),
+  policy: `  allow:
+    - "example.*"`,
+});
+
+afterAll(async () => {
+  await listing.stop();
+});
+
+/** The cacheable-result fields, as they arrive on the wire. */
+async function hints(method: string): Promise<Record<string, unknown>> {
+  const response = await rpc(listing.server.url, method, {});
+  expect(response.status).toBe(200);
+  return (response.body['result'] ?? {}) as Record<string, unknown>;
+}
+
+describe('cacheable list results', () => {
+  /**
+   * `tools/list` is the one that matters. It is the list ADR-032 is about, and
+   * the only one whose staleness has cost a working connector.
+   */
+  test('tools/list is immediately stale and privately scoped', async () => {
+    const result = await hints('tools/list');
+
+    expect(result['ttlMs']).toBe(0);
+    expect(result['cacheScope']).toBe('private');
+  });
+
+  /**
+   * `resources/list` gets the same answer for the same reason, and is asserted
+   * separately because it is reached by a different handler: `lanes://instructions`
+   * is registered unconditionally, so this list is never empty and the
+   * capability is always declared.
+   */
+  test('resources/list is immediately stale and privately scoped', async () => {
+    const result = await hints('resources/list');
+
+    expect(result['ttlMs']).toBe(0);
+    expect(result['cacheScope']).toBe('private');
+  });
+
+  /**
+   * The stamp that says the result is cacheable at all.
+   *
+   * `resultType: 'complete'` is what carries the hints — an interim
+   * `input_required` result under the multi round-trip mechanism is explicitly
+   * not cacheable and carries none. Asserting it here means a future change that
+   * starts answering a list with an interim result cannot quietly drop the two
+   * fields above and still pass.
+   */
+  test('a list result is a complete result', async () => {
+    expect((await hints('tools/list'))['resultType']).toBe('complete');
+  });
+});

--- a/src/server/generation.ts
+++ b/src/server/generation.ts
@@ -3,6 +3,7 @@ import { ownerPrincipal, type Principal } from '#auth';
 import {
   buildMcpServer,
   toolNameFor,
+  SURFACE_TOOL_NAMES,
   visibleCapabilities,
   visibleToolCount,
   type ProfileRuntime,
@@ -81,10 +82,16 @@ export class Generation {
     this.visible = this.#memo(
       () =>
         new Set(
-          visibleCapabilities({
-            profiles: this.profiles,
-            principal: ownerPrincipal(deps.primary),
-          }).map(toolNameFor),
+          [
+            ...visibleCapabilities({
+              profiles: this.profiles,
+              principal: ownerPrincipal(deps.primary),
+            }).map(toolNameFor),
+            // Advertised without being capabilities, so they are absent from
+            // `visibleCapabilities` and have to be added here or every
+            // successful call to one is recorded as a refusal.
+            ...SURFACE_TOOL_NAMES,
+          ],
         ),
     );
 

--- a/src/server/index.test.ts
+++ b/src/server/index.test.ts
@@ -2,6 +2,7 @@ import { afterAll, describe, expect, test } from 'bun:test';
 import type { Icon } from '@modelcontextprotocol/server';
 import { allocatePort, rpc, startHarness, wireProfiles, TEST_TOKEN } from './harness.ts';
 import { isLoopback } from './index.ts';
+import { SURFACE_TOOL_NAMES } from './mcp/index.ts';
 import { parseConfig, type Config } from '#profile';
 import manifest from '../../package.json' with { type: 'json' };
 
@@ -43,6 +44,20 @@ afterAll(async () => {
 interface ToolDefinition {
   name: string;
   inputSchema: { properties?: { connection?: { enum?: string[] }; profile?: { enum?: string[] } } };
+}
+
+/**
+ * The advertised tools that came from a capability.
+ *
+ * `lanes_tools_search` and `lanes_tools_call` are advertised to every caller
+ * regardless of policy, because their value is being present in a list a client
+ * has already cached (ADR-075). Every assertion about *what policy permitted*
+ * therefore has to exclude them — and excluding them by filter rather than by
+ * adding them to the expectation keeps the assertion able to fail when a
+ * capability appears that policy did not permit.
+ */
+function capabilityTools(tools: readonly ToolDefinition[]): string[] {
+  return tools.map((tool) => tool.name).filter((name) => !SURFACE_TOOL_NAMES.includes(name));
 }
 
 async function listTools(url: string, token?: string): Promise<ToolDefinition[]> {
@@ -238,7 +253,14 @@ describe('discovery is filtered by policy', () => {
   test('a narrower profile sees a smaller tool list', async () => {
     const names = (await listTools(work.server.url, 'llk_work_token_value')).map((t) => t.name);
 
-    expect(names.sort()).toEqual(['example_get_note', 'example_list_notes']);
+    // The stable-name pair is advertised to every caller regardless of policy
+    // (ADR-075), so what this test is about is the capabilities beside them.
+    // Filtered rather than added to the expectation, so the assertion still
+    // fails if a capability appears that policy did not permit.
+    expect(names.filter((name) => !SURFACE_TOOL_NAMES.includes(name)).sort()).toEqual([
+      'example_get_note',
+      'example_list_notes',
+    ]);
     // The tool is not merely refused on call — it is not advertised at all.
     expect(names).not.toContain('example_set_note');
     expect(names).not.toContain('example_echo');
@@ -973,7 +995,7 @@ members: []
     );
 
     try {
-      expect((await listTools(harness.server.url)).map((tool) => tool.name)).toEqual([
+      expect(capabilityTools(await listTools(harness.server.url))).toEqual([
         'example_get_note',
       ]);
 
@@ -1011,9 +1033,7 @@ members: []
       expect(body['reloaded']).toBe(false);
       expect(body['reason']).toContain('could not parse YAML');
 
-      expect((await listTools(harness.server.url)).map((tool) => tool.name)).toEqual([
-        'example_get_note',
-      ]);
+      expect(capabilityTools(await listTools(harness.server.url))).toEqual(['example_get_note']);
     } finally {
       await harness.stop();
     }

--- a/src/server/mcp/build.ts
+++ b/src/server/mcp/build.ts
@@ -7,6 +7,7 @@ import { SERVER_NAME } from './naming.ts';
 import { registerPrompt } from './prompts.ts';
 import { registerResource } from './resources.ts';
 import { registerDiscoveredTool, registerLocalTool } from './tools.ts';
+import { registerSearchSurface } from './search.ts';
 import { mergeCapabilities, type BuildServerOptions } from './visibility.ts';
 
 /**
@@ -101,6 +102,12 @@ export function buildMcpServer(options: BuildServerOptions): McpServer {
       contents: [{ uri: uri.href, mimeType: 'text/markdown', text: guideDocument() }],
     }),
   );
+
+  // The two stable-name tools, for the same reason and in the same place as
+  // the resource above: they describe this surface rather than being part of
+  // what policy decided, and their whole value is that a client which fetched
+  // any tool list from this endpoint has them. See `search.ts`.
+  registerSearchSurface(server, options);
 
   for (const [id, entry] of merged) {
     // Discovered first: an upstream MCP server or an OpenAPI document supplies

--- a/src/server/mcp/guide.ts
+++ b/src/server/mcp/guide.ts
@@ -97,6 +97,29 @@ change to what exists here is a command a person runs; nothing on this surface
 adds a connection, edits a profile, or changes who may consume it. That is not an
 omission to work around.
 
+## A tool you cannot see may still be reachable
+
+Your list of tools is a snapshot, taken when your client connected. This endpoint
+cannot tell you when it changes — it is stateless, so there is no stream on which
+to send the notification, and it says so rather than promising one it cannot keep.
+Some clients re-read the list each session; some hold the one they first fetched
+for as long as they are registered.
+
+So a connection authorised since then is reachable here and absent from your list.
+Two tools exist for exactly that, and their names never change, which is what
+makes them present in whatever list you were given:
+
+- **Search** finds any capability this endpoint reaches now, by keyword or by its
+  exact id, and returns the arguments it takes.
+- **Call** invokes one by id, under the same permissions the named tool would
+  have had. It reaches nothing you could not otherwise reach, and a capability
+  the profile does not allow is refused here exactly as it would be there.
+
+Prefer a named tool wherever your list has one — it is the same call, and your
+client can see its schema without asking. Reach for these when you cannot see a
+tool for something the owner has plausibly connected, and before concluding that
+you cannot do it.
+
 ## When a call is refused
 
 A refusal is information, not an obstacle. Three kinds, and they mean different

--- a/src/server/mcp/index.ts
+++ b/src/server/mcp/index.ts
@@ -19,7 +19,7 @@
 
 export { buildMcpServer } from './build.ts';
 export { serverInstructions } from './instructions.ts';
-export { SERVER_NAME, capabilityIdForToolName, toolNameFor } from './naming.ts';
+export { SERVER_NAME, SURFACE_TOOL_NAMES, capabilityIdForToolName, toolNameFor } from './naming.ts';
 export { scopeResourceUri } from './routing.ts';
 export { sanitizeSchema } from './schema.ts';
 export {

--- a/src/server/mcp/instructions.ts
+++ b/src/server/mcp/instructions.ts
@@ -174,6 +174,18 @@ const FILES = `**Files are named, not carried.** Where a tool takes attachments,
 HTTPS URL, or an attachment already on another message; the endpoint reads the
 bytes. Never encode a file into a call — that is the thing this replaces.`;
 
+/**
+ * The paragraph for the client that never re-reads its tool list.
+ *
+ * Unconditional, because the pair it names is (`search.ts`) — and because the
+ * mistake it prevents is available to every caller, not only to one holding some
+ * particular surface.
+ */
+const SEARCH = `**A tool you cannot see may still be reachable.** Your tool list is a snapshot
+from when your client connected, and a connection made since is missing from it. Before
+concluding you cannot do something, call \`lanes_tools_search\` — then \`lanes_tools_call\` to
+invoke what it names, under the permissions the named tool would have had.`;
+
 const REFUSAL = `**A refused call is the permission system working**, not an obstacle to route
 around. Report what was refused and let the owner decide whether to widen it.
 Every call, including a refused one, is recorded.`;
@@ -274,6 +286,28 @@ function habitsFor(reachable: readonly string[]): string[] {
  * no error on an ambiguous result, so between "two candidates" and an agent
  * using the first there is only prose.
  *
+ * Raised a fifth time, to 3300, for `SEARCH` (ADR-075), and the skill question
+ * gets `AVAILABILITY`'s answer rather than a new one. The paragraph exists for a
+ * client that pinned its tool list when it connected and never re-reads — which
+ * is the same client that holds no skills directory, so the skill is not a place
+ * it can go. And the mistake is a refusal: an agent that says it cannot do
+ * something has ended the turn, so there is no later moment at which a skill
+ * loaded when relevant would have helped.
+ *
+ * That raise also corrected the figure below rather than only adding to it. The
+ * measured maximum was **2878**, not the 2800 this recorded — `entities`, tasks
+ * and assets each landed while the arithmetic stayed as it was, so the ceiling
+ * had 22 characters of real headroom while claiming 100. Which is this
+ * docstring's own warning happening to it: the widest case was recertified
+ * whenever the number moved and never when the prose did. The figures below are
+ * now taken from what the test measures rather than composed by hand, so the
+ * next paragraph cannot be certified against a case nothing serves:
+ *
+ *   the paired branch, every owner provider, remote clients   3102
+ *   the unpaired branch, which is the real maximum            3216
+ *
+ * `SEARCH` costs 338 of that — 336 of prose and the two characters `join` adds.
+ *
  * The arithmetic, because the number is a measurement and not a round figure.
  * Twenty profiles, twenty connections each, every owner provider reachable,
  * remote clients:
@@ -300,7 +334,7 @@ function habitsFor(reachable: readonly string[]): string[] {
  * exactly the final length, because `join` adds the same two characters the
  * reduce already counted.
  */
-export const MAX_INSTRUCTIONS = 2900;
+export const MAX_INSTRUCTIONS = 3300;
 
 /** Which of the owner-layer providers this principal can actually reach. */
 function ownerProviders(merged: ReadonlyMap<string, MergedCapability>): string[] {
@@ -369,6 +403,9 @@ export function serverInstructions(
     ROUTING,
     ...habitsFor(owner),
     FILES,
+    // Between "the tool is not there" and "the call was refused", which is the
+    // order a caller meets them in: absent, then present and denied.
+    SEARCH,
     REFUSAL,
     ...(remoteClients ? [AVAILABILITY] : []),
   ];

--- a/src/server/mcp/naming.ts
+++ b/src/server/mcp/naming.ts
@@ -11,6 +11,25 @@
 
 export const SERVER_NAME = 'lanes-link';
 
+/**
+ * The tools this endpoint advertises that are not capabilities.
+ *
+ * Registered by `search.ts` rather than by the loop over what policy decided,
+ * so they are absent from `mergeCapabilities` and every count derived from it.
+ * They live here rather than there because three places need the names and one
+ * of them is `visibility.ts`, which `search.ts` imports — the constant moving
+ * up is what stops that being a cycle.
+ *
+ * Both of the places that add these are load-bearing rather than cosmetic.
+ * `visibleToolCount` is what `/reload` returns and what the endpoint logs, and
+ * ADR-032 exists because an operator compares that number against what their
+ * client shows. And `Generation.visible()` decides whether a `tools/call` is
+ * recorded as a refusal — so a name missing from it means every successful call
+ * to that tool triggers a config re-probe and writes an audit row saying the
+ * agent tried something that was not advertised.
+ */
+export const SURFACE_TOOL_NAMES: readonly string[] = ['lanes_tools_search', 'lanes_tools_call'];
+
 export function toolNameFor(capabilityId: string): string {
   return capabilityId.replace(/\./g, '_');
 }

--- a/src/server/mcp/search-index.test.ts
+++ b/src/server/mcp/search-index.test.ts
@@ -1,0 +1,195 @@
+import { describe, expect, test } from 'bun:test';
+import { searchCapabilities } from './search-index.ts';
+import type { MergedCapability } from './visibility.ts';
+
+/**
+ * What the search says, given a set of capabilities.
+ *
+ * A pure function of the merged map, which is why it is tested here rather than
+ * through an endpoint: what is worth asserting is the ranking and what comes
+ * back with a schema, and neither needs a server to be wrong.
+ */
+
+/** One discovered capability, of the shape an `http` provider yields. */
+function entry(
+  description: string,
+  options: { title?: string; properties?: Record<string, unknown> } = {},
+): MergedCapability {
+  return {
+    reachable: new Map([['personal', ['vendor_mail.main']]]),
+    capability: undefined,
+    discovered: {
+      name: 'ignored',
+      ...(options.title === undefined ? {} : { title: options.title }),
+      description,
+      inputSchema: {
+        type: 'object',
+        properties: options.properties ?? { to: { type: 'string' } },
+      },
+    },
+  } as unknown as MergedCapability;
+}
+
+const surface = new Map<string, MergedCapability>([
+  [
+    'vendor_mail.send_message',
+    entry('Send a message to one or more recipients.', {
+      title: 'Vendor Mail: send message',
+      properties: { to: { type: 'string' }, subject: { type: 'string' } },
+    }),
+  ],
+  ['vendor_mail.messages.list', entry('List the messages in a mailbox.')],
+  ['vendor_sheets.values.update', entry('Set values in a range of a spreadsheet.')],
+  ['vendor_chat.post_message', entry('Post a message to a channel.')],
+]);
+
+describe('searching what a caller can reach', () => {
+  test('a keyword reaches the capability that answers to it', () => {
+    const answer = searchCapabilities('spreadsheet', surface);
+
+    expect(answer).toContain('vendor_sheets_values_update');
+    expect(answer).not.toContain('vendor_chat_post_message');
+  });
+
+  /**
+   * The provider id is in the capability id and nowhere else, and it is what a
+   * query naming a vendor has to match on. Weighted highest for that reason.
+   *
+   * And narrowed to it: `vendor_chat` splits to `vendor` + `chat`, and every
+   * capability here carries `vendor`, so scoring on any term would return the
+   * whole surface with the right one merely on top. Requiring both is what
+   * makes the answer this provider rather than this provider first.
+   */
+  test('a query naming a provider reaches that provider and not its neighbours', () => {
+    const answer = searchCapabilities('vendor_chat', surface);
+
+    expect(answer).toContain('vendor_chat_post_message');
+    expect(answer).not.toContain('vendor_mail_messages_list');
+    expect(answer).not.toContain('vendor_sheets_values_update');
+  });
+
+  /**
+   * The fallback, and why the narrowing above is safe. A caller whose words do
+   * not all appear anywhere is exactly the caller who needs the near misses —
+   * returning nothing there would be worse than returning the loose ranking.
+   */
+  test('falls back to a loose match when no capability has every term', () => {
+    const answer = searchCapabilities('spreadsheet cryptocurrency', surface);
+
+    expect(answer).toContain('vendor_sheets_values_update');
+    expect(answer).not.toContain('Nothing reachable matches');
+  });
+
+  /**
+   * The second call a model makes after a search is "what are the arguments for
+   * this one", and that should not be a search.
+   */
+  test('an exact capability id returns that one, with its schema', () => {
+    const answer = searchCapabilities('vendor_mail.send_message', surface);
+
+    expect(answer).toContain('1 match');
+    expect(answer).toContain('vendor_mail_send_message');
+    expect(answer).toContain('"subject"');
+    expect(answer).not.toContain('vendor_chat');
+  });
+
+  /**
+   * The whole reason the search returns schemas: the accuracy gain that makes
+   * deferred tool loading worth doing is attributed to the model seeing a real
+   * schema before it composes arguments (ADR-075). A search returning only
+   * names would keep the saving and give up the reason.
+   */
+  test('a match carries its input schema, not just its name', () => {
+    const answer = searchCapabilities('send message recipients', surface);
+
+    expect(answer).toContain('JSON Schema');
+    expect(answer).toContain('"to"');
+  });
+
+  /**
+   * Both ways in, and which to prefer. This is the answer to #162's objection
+   * that a model seeing two paths picks the wrong one — it is told which path
+   * it is on, by the only party that can see its tool list.
+   */
+  test('every answer says to prefer the named tool and when not to', () => {
+    const answer = searchCapabilities('message', surface);
+
+    expect(answer).toContain('Prefer the named tool if your tool list has it');
+    expect(answer).toContain('lanes_tools_call');
+  });
+
+  /**
+   * A miss has to say which kind of miss it is. The caller cannot distinguish
+   * "no such provider" from "not connected" from "not granted", and guessing
+   * wrong sends them to reconnect something that was denied on purpose.
+   */
+  test('a miss says it searched what is reachable, and where to look next', () => {
+    const answer = searchCapabilities('cryptocurrency', surface);
+
+    expect(answer).toContain('Nothing reachable matches');
+    expect(answer).toContain('not connected or not granted');
+    expect(answer).toContain('lanes_setup_overview');
+  });
+
+  /**
+   * `describeWithConnections` appends the same block to every description, so
+   * searching it would match its every word against everything — "profile" or
+   * an account's domain would return the whole surface.
+   */
+  test('the connections block appended to every description is not searched', () => {
+    const withBlock = new Map<string, MergedCapability>([
+      [
+        'vendor_mail.send_message',
+        entry(
+          'Send a message.\n\nAvailable connections, by profile:\n  personal:\n    vendor_mail.main — someone@example.com',
+        ),
+      ],
+    ]);
+
+    expect(searchCapabilities('personal', withBlock)).toContain('Nothing reachable matches');
+    expect(searchCapabilities('send', withBlock)).toContain('vendor_mail_send_message');
+  });
+
+  /**
+   * The narrowing makes a query's grammar load-bearing, so the grammar has to
+   * be dropped. Measured on a real endpoint: "send an email" asked for `an` as
+   * a whole word, nothing had it alongside the other two, and the query fell
+   * back to the loose ranking it was meant to replace — 93 matches of 276.
+   */
+  test('function words in a query do not narrow it', () => {
+    const plain = searchCapabilities('send message', surface);
+    const spoken = searchCapabilities('please send a message to me', surface);
+
+    expect(spoken).toContain('vendor_mail_send_message');
+    // The same matches either way, which is the whole claim. Compared as the
+    // set of results rather than the count line, so the assertion says what it
+    // means rather than depending on how the count is phrased.
+    const named = (answer: string) =>
+      answer
+        .split('\n')
+        .filter((line) => line.startsWith('## '))
+        .map((line) => line.slice(3));
+
+    expect(named(spoken)).toEqual(named(plain));
+  });
+
+  /**
+   * A query that is nothing but function words searches for them rather than
+   * for nothing, because the alternative is an empty-query answer to a caller
+   * who did type something.
+   */
+  test('a query of only function words still searches', () => {
+    expect(searchCapabilities('the a of', surface)).not.toContain('Nothing reachable matches');
+  });
+
+  test('an empty query matches nothing rather than everything', () => {
+    expect(searchCapabilities('   ', surface)).toContain('Nothing reachable matches');
+  });
+
+  /** Where a capability can be used is what the caller needs to fill in `connection`. */
+  test('a match says which profiles and connections reach it', () => {
+    expect(searchCapabilities('vendor_mail.send_message', surface)).toContain(
+      'personal: vendor_mail.main',
+    );
+  });
+});

--- a/src/server/mcp/search-index.ts
+++ b/src/server/mcp/search-index.ts
@@ -1,0 +1,306 @@
+import { isTool } from '#connectivity';
+import { z } from 'zod';
+import { toolNameFor } from './naming.ts';
+import { sanitizeSchema } from './schema.ts';
+import type { MergedCapability } from './visibility.ts';
+
+/**
+ * Finding a capability by keyword, and saying enough about it to call.
+ *
+ * The half of the stable-name surface that is a pure function of the merged
+ * capability set — no server, no dispatcher, no principal. `search.ts` serves
+ * it; this decides what the answer is, which is why the two are separate files:
+ * ranking and rendering are the part worth testing against a fixture, and
+ * everything in `search.ts` needs a wired endpoint to exercise at all.
+ *
+ * See `search.ts` for what the surface is for and why it exists (ADR-075).
+ */
+
+/** How many matches come back with their whole schema attached. */
+const DETAILED = 5;
+
+/** How many come back as a line each, after those. */
+const LISTED = 20;
+
+/**
+ * Function words, dropped from a *query* and never from the text searched.
+ *
+ * The narrowing in `rank` requires every term to match, which makes a query's
+ * grammar load-bearing: "send an email" asked for `an` as a whole word, matched
+ * nothing that also had `send` and `email`, and fell back to the loose ranking
+ * it was meant to replace — 93 matches out of 276 on a real endpoint. Removing
+ * them is what a BM25 index does implicitly by weighting a term that appears
+ * everywhere at nearly nothing; here it has to be explicit, because presence is
+ * the test.
+ *
+ * Function words only. Nothing here can name a capability: `get`, `set`, `list`,
+ * `read` and `send` are all verbs a caller means, and `all` is in a real
+ * operation id, so none of them belongs on this list however common it is.
+ *
+ * Only applied where it leaves something behind — a query that is nothing but
+ * these keeps them, so "all of it" searches for something rather than for
+ * nothing.
+ */
+const STOPWORDS = new Set([
+  'a', 'an', 'the', 'this', 'that', 'these', 'those',
+  'i', 'me', 'my', 'mine', 'we', 'our', 'you', 'your', 'it', 'its',
+  'and', 'or', 'but', 'if', 'then', 'than', 'so', 'as',
+  'of', 'to', 'for', 'from', 'in', 'into', 'on', 'at', 'by', 'with', 'about',
+  'is', 'are', 'was', 'be', 'been', 'do', 'does', 'did', 'can', 'could',
+  'would', 'should', 'will', 'shall', 'may', 'might', 'must',
+  'some', 'any', 'each', 'every', 'no', 'not',
+  // Question and request framing. A caller types "what meetings do i have",
+  // and `what` and `have` are as much grammar as `the` is.
+  'what', 'which', 'who', 'whom', 'when', 'where', 'why', 'how',
+  'have', 'has', 'had', 'please', 'want', 'wants', 'need', 'needs', 'let',
+]);
+
+/** The terms a query actually searches on. */
+function queryTerms(query: string): string[] {
+  const all = words(query);
+  const meaningful = all.filter((word) => !STOPWORDS.has(word));
+  return meaningful.length > 0 ? meaningful : all;
+}
+
+/**
+ * A word, for matching.
+ *
+ * Split on everything that separates one in an identifier — `.`, `_`, `-`, and
+ * a camelCase boundary — because the terms a caller searches for are words and
+ * the text being searched is mostly identifiers. Without the camelCase split,
+ * `copyTo` never matches *copy*.
+ */
+function words(text: string): string[] {
+  return text
+    .replace(/([a-z0-9])([A-Z])/g, '$1 $2')
+    .toLowerCase()
+    .split(/[^a-z0-9]+/)
+    .filter((word) => word.length > 0);
+}
+
+/**
+ * Whether a term is in a word list, allowing for one being a prefix of the other.
+ *
+ * The cheapest thing that stands in for stemming, and it is needed: a caller
+ * types "meetings" and the manifest says "meeting", so exact equality found
+ * nothing and the query landed on whatever else shared a word with it. Prefixes
+ * cover the endings that actually come up — plurals, `-ing`, `-ed`, `-s` — in
+ * both directions, since the query may be the longer or the shorter form.
+ *
+ * Four characters before a prefix counts, because three would make `get` match
+ * `getting` and also `getaway`, and one would make every term match everything.
+ * Equality is always enough, so short terms still work as themselves.
+ */
+function holds(list: readonly string[], term: string): boolean {
+  return list.some(
+    (word) =>
+      word === term ||
+      (term.length >= 4 && word.startsWith(term)) ||
+      (word.length >= 4 && term.startsWith(word)),
+  );
+}
+
+/** What one capability's title, description and schema are, whichever kind it is. */
+function shapeOf(entry: MergedCapability): {
+  title: string | undefined;
+  description: string;
+  inputSchema: Record<string, unknown>;
+} {
+  if (entry.discovered) {
+    return {
+      title: entry.discovered.title,
+      description: entry.discovered.description,
+      inputSchema: sanitizeSchema(entry.discovered.inputSchema),
+    };
+  }
+
+  const capability = entry.capability;
+  if (!capability || !isTool(capability)) {
+    return { title: undefined, description: '', inputSchema: { type: 'object' } };
+  }
+
+  // Authored capabilities carry Zod, so the JSON Schema a caller needs is
+  // derived here rather than stored. `registerLocalTool` hands the SDK the Zod
+  // shape and lets it do the same conversion, so this is the same schema by a
+  // different route — not a second definition of it.
+  let inputSchema: Record<string, unknown> = { type: 'object' };
+  try {
+    inputSchema = z.toJSONSchema(capability.inputSchema as z.ZodType) as Record<string, unknown>;
+  } catch {
+    // A schema Zod will not convert is still a callable tool, and a search that
+    // threw would take out every other result with it.
+  }
+
+  return { title: capability.title, description: capability.description, inputSchema };
+}
+
+interface Match {
+  readonly id: string;
+  readonly tool: string;
+  readonly score: number;
+  readonly entry: MergedCapability;
+}
+
+/**
+ * Rank the reachable capabilities against a query.
+ *
+ * Deliberately simple, and the reason is worth stating: a client that defers
+ * tool loading already runs BM25 or a regex over the same names and
+ * descriptions, locally, with no round trip. This is the fallback for clients
+ * that do not, so it needs to be good enough to find the right provider rather
+ * than good enough to replace an index. Term presence, weighted by where it
+ * appears, and no tie-breaking beyond that.
+ *
+ * An exact capability id short-circuits, because "give me the schema for
+ * `gmail.send_message`" is the second call a model makes after a search and it
+ * should not be a search.
+ */
+function rank(query: string, merged: Map<string, MergedCapability>): Match[] {
+  const exact = merged.get(query.trim());
+  if (exact) {
+    return [{ id: query.trim(), tool: toolNameFor(query.trim()), score: 1, entry: exact }];
+  }
+
+  const terms = queryTerms(query);
+  if (terms.length === 0) return [];
+
+  const matches: Match[] = [];
+
+  for (const [id, entry] of merged) {
+    if (!entry.discovered && !(entry.capability && isTool(entry.capability))) continue;
+
+    const shape = shapeOf(entry);
+    const name = words(id);
+    const title = words(shape.title ?? '');
+    // The connections block `describeWithConnections` appends is not part of
+    // what this searches — it is identical on every tool, so it would match
+    // every term in it against everything.
+    const description = words(shape.description.split('\n\nAvailable connections')[0] ?? '');
+
+    let score = 0;
+    for (const term of terms) {
+      // The name is worth most: it carries the provider id, which is how a
+      // query naming a vendor finds that vendor's tools at all.
+      if (holds(name, term)) score += 3;
+      else if (holds(title, term)) score += 2;
+      else if (holds(description, term)) score += 1;
+    }
+
+    if (score > 0) matches.push({ id, tool: toolNameFor(id), score, entry });
+  }
+
+  // Score first, then id, so the order is stable across calls — the same
+  // property `tools/list` is asked for, and for the same reason: a caller
+  // comparing two searches should be comparing results, not orderings.
+  matches.sort((a, b) => b.score - a.score || a.id.localeCompare(b.id));
+
+  // Everything at least half as good as the best match, and nothing weaker.
+  //
+  // Measured against a real endpoint serving 276 tools, returning everything
+  // that scored at all made the search look useless while behaving correctly:
+  // "create a pull request" reported 213 matches, because `create` and
+  // `request` each appear all over a large surface. The top of the ranking was
+  // right every time — the count and the tail were the lie, and the tail is
+  // twenty tools of noise in the caller's context.
+  //
+  // Two narrower rules were tried and both were worse, which is why the cut is
+  // on the score rather than on how much of the query matched:
+  //
+  //   - *Every term* is brittle. One word the surface does not contain — a typo,
+  //     a product name, "please" — and nothing matches all of them, so the query
+  //     falls back to the loose ranking it was meant to replace.
+  //   - *The most terms* inverts the weighting. "please send a message to
+  //     someone" picked a mail-filter tool over the one that sends, because
+  //     `someone` happened to appear in its description and three weak
+  //     description hits outrank two strong ones.
+  //
+  // The score already carries both halves — more of the query matched is more
+  // points, and the name is worth three times the description — so cutting
+  // relative to the best score keeps a tool named for what was asked and drops
+  // one that merely mentions it. Half is a ratio rather than a threshold
+  // because scores scale with query length, and it leaves a genuine second
+  // candidate in: two strong hits survive beside three.
+  // Strictly more than half, not at least: on a two-term query naming a
+  // provider, a tool matching only the provider half scores exactly half of
+  // one matching both, and "every other tool this provider has" is not an
+  // answer to a query that named a capability too.
+  const best = matches[0]?.score ?? 0;
+  return matches.filter((match) => match.score * 2 > best);
+}
+
+/** Where a capability can be used, as the search reports it. */
+function whereReachable(entry: MergedCapability): string {
+  return [...entry.reachable]
+    .map(([profile, connections]) => `${profile}: ${connections.join(', ')}`)
+    .join(' | ');
+}
+
+function renderMatches(query: string, matches: readonly Match[]): string {
+  if (matches.length === 0) {
+    return (
+      `Nothing reachable matches "${query}".\n\n` +
+      'This searched every capability this caller can reach, so a miss means it is ' +
+      'not connected or not granted rather than not spelled right. ' +
+      'Call lanes_setup_overview for what is connected and what connecting something else takes.'
+    );
+  }
+
+  const detailed = matches.slice(0, DETAILED);
+  const listed = matches.slice(DETAILED, DETAILED + LISTED);
+
+  const lines: string[] = [
+    `${matches.length} match${matches.length === 1 ? '' : 'es'} for "${query}".`,
+    '',
+    'Each one is invocable two ways. Prefer the named tool if your tool list has it; ' +
+      'use lanes_tools_call if it does not — which is the case when this endpoint ' +
+      'gained a connection after your client last read its tool list.',
+    '',
+  ];
+
+  for (const match of detailed) {
+    lines.push(`## ${match.tool}`);
+    const shape = shapeOf(match.entry);
+    if (shape.title) lines.push(`${shape.title}`);
+    lines.push('');
+    lines.push(shape.description.split('\n\nAvailable connections')[0] ?? '');
+    lines.push('');
+    lines.push(`capability: ${match.id}`);
+    lines.push(`reachable:  ${whereReachable(match.entry)}`);
+    lines.push('');
+    lines.push('arguments (JSON Schema — `profile` and `connection` are added by this endpoint):');
+    lines.push('```json');
+    lines.push(JSON.stringify(shape.inputSchema, null, 2));
+    lines.push('```');
+    lines.push('');
+  }
+
+  if (listed.length > 0) {
+    lines.push(`## ${listed.length} more, without schemas`);
+    lines.push('');
+    lines.push('Search again with a capability id for one of these to get its arguments.');
+    lines.push('');
+    for (const match of listed) {
+      const shape = shapeOf(match.entry);
+      const summary = (shape.description.split('\n')[0] ?? '').slice(0, 100);
+      lines.push(`- \`${match.id}\` — ${summary}`);
+    }
+    lines.push('');
+  }
+
+  const hidden = matches.length - detailed.length - listed.length;
+  if (hidden > 0) {
+    lines.push(`${hidden} further match${hidden === 1 ? '' : 'es'} not shown. Narrow the query.`);
+  }
+
+  return lines.join('\n');
+}
+
+/**
+ * Search, rendered.
+ *
+ * One entry point, because the caller is a tool handler and the only thing it
+ * has to decide is what text to return.
+ */
+export function searchCapabilities(query: string, merged: Map<string, MergedCapability>): string {
+  return renderMatches(query, rank(query, merged));
+}

--- a/src/server/mcp/search.ts
+++ b/src/server/mcp/search.ts
@@ -1,0 +1,239 @@
+import { forProfile } from '#auth';
+import { isToolResult } from '#connectivity';
+import { z } from 'zod';
+import type { McpServer } from '@modelcontextprotocol/server';
+import { searchCapabilities } from './search-index.ts';
+import { SURFACE_TOOL_NAMES, toolNameFor } from './naming.ts';
+import { mergeCapabilities, type BuildServerOptions } from './visibility.ts';
+
+/**
+ * The two tools whose names never change.
+ *
+ * Everything else on this surface is one typed tool per capability, and what a
+ * client is handed therefore grows when a provider is connected that the profile
+ * had none of. A client that re-reads its tool list is unaffected; a client that
+ * pinned it at registration serves the old one forever, and in at least one
+ * hosted client the connector has to be deleted and re-added before a newly
+ * connected provider is reachable at all. That is issue #162, ADR-032 explains
+ * why the server cannot fix it by announcing, and ADR-075 is the decision this
+ * file implements.
+ *
+ * `lanes_tools_search` and `lanes_tools_call` are in every list any client has
+ * ever fetched from this endpoint — including the first, which under ADR-032's
+ * own worst case held two setup tools and nothing else. So the answer to
+ * "connect Notion, then use Notion" stops being "start a new session" and
+ * becomes a search.
+ *
+ * **The search returns schemas, not just names.** The published evaluations that
+ * make deferred tool loading worth doing attribute its accuracy gain to the
+ * model seeing a real schema before it composes arguments — a search that
+ * returned only names would keep the token saving and give up the reason. So the
+ * strongest matches carry their whole `inputSchema`, and the tail carries a
+ * line each. An exact capability id returns that one capability.
+ *
+ * **The search says which way in to use.** Issue #162 rejected this shape as
+ * "two ways to do one thing on one surface … and a model seeing both will
+ * sometimes pick the wrong one". The answer is that the search is the authority
+ * on routing rather than a peer of it: every result names the typed tool to
+ * prefer and says `lanes_tools_call` is for when the caller's own list does not
+ * have it. The model can see its tool list and this endpoint cannot — a
+ * stateless POST has no idea what a client cached — so the decision belongs to
+ * the party holding the information.
+ *
+ * **Why this is not in the owner layer.** It looks like a ninth `lanes_`
+ * provider and it cannot be one. `ProviderContext` states its own invariant —
+ * "no `RuntimeState`, no `SecretStore`, no config, no policy engine, and **no
+ * way to reach another connection**" — and `call` is exactly a way to reach
+ * another connection. `#providers` may not import `#dispatch` or `#policy`
+ * either. Both of the things this needs, the merged capability set and the
+ * dispatcher, are already here. So it registers alongside `lanes://instructions`
+ * — the other thing on this surface that describes it rather than being part of
+ * what policy decided.
+ *
+ * **It widens nothing.** `call` resolves through the same
+ * `runtime.dispatcher.invoke` with the same principal, so `allowedConnections`,
+ * the profile floor, the rate limits and the audit row are the ones a typed tool
+ * would have produced. It refuses a capability that is not in the merged set,
+ * which is the same set the typed tools were registered from — so there is no
+ * capability reachable through it that was not already advertised. Control-plane
+ * operations stay unreachable for the reason ADR-007 gives: they are never
+ * registered, so they are never in the set.
+ */
+
+
+/**
+ * Register the pair.
+ *
+ * Unconditionally, and ahead of the loop that registers what policy decided —
+ * the same placement and the same argument as `lanes://instructions`. These
+ * describe the surface rather than being part of it, and their whole value is
+ * that a client which has fetched *any* tool list from this endpoint has them.
+ * Registering them conditionally would put the one escape hatch from a stale
+ * list behind the thing that goes stale.
+ */
+export function registerSearchSurface(server: McpServer, options: BuildServerOptions): void {
+  const merged = mergeCapabilities(options);
+  const profiles = [...options.profiles.keys()];
+
+  server.registerTool(
+    SURFACE_TOOL_NAMES[0]!,
+    {
+      title: 'Search every tool this endpoint can reach',
+      description:
+        'Find capabilities by keyword and get their argument schemas. ' +
+        'Use this when you need something this endpoint plausibly offers and you cannot see a tool for it — ' +
+        'a provider connected after your client read its tool list is reachable through here even though ' +
+        'it is not in your list. Also use it to get the arguments for one capability by passing its id. ' +
+        'Searches only what this caller may reach, so a miss means not connected or not granted.',
+      inputSchema: {
+        query: z
+          .string()
+          .min(1)
+          .describe(
+            'Keywords, or an exact capability id in the form "<provider>.<capability>". ' +
+              'Plain words work best — what you want done, not a tool name.',
+          ),
+      },
+    },
+    async ({ query }: { query: string }) => ({
+      content: [{ type: 'text' as const, text: searchCapabilities(query, merged) }],
+    }),
+  );
+
+  server.registerTool(
+    SURFACE_TOOL_NAMES[1]!,
+    {
+      title: 'Invoke any tool this endpoint can reach',
+      description:
+        'Call a capability by id, for when it is not in your tool list. ' +
+        'Get the id and its argument schema from lanes_tools_search first — the arguments are ' +
+        'that capability\'s own, and this passes them through unchanged. ' +
+        'Prefer the named tool wherever your list has one; this exists for the case where it does not. ' +
+        'Permissions are identical either way: this reaches nothing you could not otherwise reach.',
+      inputSchema: {
+        capability: z
+          .string()
+          .min(1)
+          .describe(
+            'Capability id, exactly as lanes_tools_search reports it — "<provider>.<capability>"',
+          ),
+        profile: z.enum(profiles as [string, ...string[]]).describe('Which profile to act within'),
+        connection: z
+          .string()
+          .min(1)
+          .describe('Which configured account, within that profile — from the search result'),
+        arguments: z
+          .record(z.string(), z.unknown())
+          .default({})
+          .describe("The capability's own arguments, as its schema describes them"),
+      },
+    },
+    async (input: {
+      capability: string;
+      profile: string;
+      connection: string;
+      arguments?: Record<string, unknown>;
+    }) => {
+      const { capability, profile, connection } = input;
+      const entry = merged.get(capability);
+
+      // Not in the merged set means not advertised to this caller, which is the
+      // same answer discovery gave. Said as "cannot reach" rather than "does not
+      // exist", because the two are deliberately indistinguishable from here
+      // (ADR-007's "probing must not be an oracle").
+      if (!entry) {
+        return {
+          content: [
+            {
+              type: 'text' as const,
+              text:
+                `This caller cannot reach "${capability}".\n` +
+                'Run lanes_tools_search to see what is reachable — a capability that is not ' +
+                'connected and one that is not granted look the same from here.',
+            },
+          ],
+          isError: true,
+        };
+      }
+
+      // The two tools registered here are not capabilities and are not in the
+      // merged set, so `entry` above already refuses them. This is the guard for
+      // the case where that stops being true: a generic dispatcher that can
+      // reach itself is one prompt away from a loop that costs a rate limit.
+      if (capability.startsWith('lanes_tools.')) {
+        return {
+          content: [{ type: 'text' as const, text: 'lanes_tools cannot call itself.' }],
+          isError: true,
+        };
+      }
+
+      const runtime = options.profiles.get(profile);
+      const reachable = entry.reachable.get(profile);
+
+      if (!runtime || !reachable) {
+        return {
+          content: [
+            {
+              type: 'text' as const,
+              text: `Profile "${profile}" does not offer ${capability}. Available: ${[...entry.reachable.keys()].join(', ')}`,
+            },
+          ],
+          isError: true,
+        };
+      }
+
+      // The same refusal `makeHandler` makes, for the same reason: the enums are
+      // a union across profiles, so a caller can name a valid profile and a
+      // connection belonging to a different one, and routing a `work` account
+      // through `personal` would cross exactly the boundary profiles exist to
+      // hold.
+      if (!reachable.includes(connection)) {
+        return {
+          content: [
+            {
+              type: 'text' as const,
+              text: `Connection "${connection}" is not part of profile "${profile}". Available there: ${reachable.join(', ')}`,
+            },
+          ],
+          isError: true,
+        };
+      }
+
+      const outcome = await runtime.dispatcher.invoke({
+        principal: forProfile(options.principal, profile),
+        capabilityId: capability,
+        connectionKey: connection,
+        arguments: input.arguments ?? {},
+        ...(options.clientLabel ? { clientLabel: options.clientLabel } : {}),
+      });
+
+      if (!outcome.ok) {
+        return { content: [{ type: 'text' as const, text: outcome.message }], isError: true };
+      }
+
+      if (!isToolResult(outcome.result)) {
+        return {
+          content: [{ type: 'text' as const, text: `${capability} is not a tool` }],
+          isError: true,
+        };
+      }
+
+      // Text only, unlike `makeHandler`. A `resource_link` has to be rewritten
+      // through `resourceLinkRouter` to carry the profile and connection it was
+      // produced under, and a link is a follow-up call the caller makes against
+      // a *typed* resource tool — so a caller reaching a capability through here
+      // gets the text and is told to use the named tool for the rest.
+      return {
+        content: outcome.result.content.map((block) =>
+          block.type === 'text'
+            ? { type: 'text' as const, text: block.text }
+            : {
+                type: 'text' as const,
+                text: `[${block.name ?? block.uri}] — call ${toolNameFor(capability)} directly to receive this as a resource link.`,
+              },
+        ),
+        ...(outcome.result.isError ? { isError: true } : {}),
+      };
+    },
+  );
+}

--- a/src/server/mcp/unauthorized.test.ts
+++ b/src/server/mcp/unauthorized.test.ts
@@ -1,0 +1,119 @@
+import { describe, expect, test } from 'bun:test';
+import { ownerPrincipal } from '#auth';
+import { toPolicyDocument } from '#registry';
+import { parseConfig } from '#profile';
+import { SURFACE_TOOL_NAMES } from './naming.ts';
+import { oneProfile, visibleCapabilities, visibleToolCount } from './visibility.ts';
+import type { BuildServerOptions, ProfileRuntime } from './visibility.ts';
+
+/**
+ * That a granted account with no credential is still advertised.
+ *
+ * This is the property `lanes link connection declare` is built on, and it had
+ * no test — so the thing that makes a client's tool list hold still was resting
+ * on an implementation detail nobody had written down (ADR-075).
+ *
+ * The detail is that `connectionsOf` reads `config.grants` and consults nothing
+ * else. Not `ConnectionStatus`, not the credential store, not the state record
+ * that `reconcile` writes — because the grant row *is* the grant (ADR-058). So a
+ * connection whose credential is missing is advertised exactly like one whose
+ * credential is present, and the refusal happens on the call instead
+ * (`dispatch.ts`, `denied_connection_unauthorized`).
+ *
+ * It reads like an oversight and it is the opposite. Filtering discovery on
+ * whether a credential exists would mean the advertised list changed the moment
+ * an account was authorised — which is the moment an operator is least placed to
+ * also go and refresh a client, and the whole of issue #162. Keeping it out of
+ * discovery is what lets the two events separate.
+ *
+ * Worth pinning rather than trusting, because the opposite is such a reasonable
+ * thing to implement. "Do not advertise what cannot be called" is a sentence
+ * somebody will write while tidying up, it would pass every other test here,
+ * and what it breaks is not visible from anywhere in this file's neighbourhood.
+ */
+
+/** One discovered tool, of the shape an `http` provider's connector yields. */
+const discovered = (name: string) => ({
+  name,
+  title: `Vendor Mail: ${name}`,
+  description: 'Does a thing.',
+  inputSchema: { type: 'object', properties: {} },
+});
+
+/**
+ * A profile granting one account of one provider.
+ *
+ * The registry is faked rather than built, because what is under test is what
+ * `mergeCapabilities` does with grants — and a real registry would drag a
+ * workspace, a state store and a credential store in to answer a question about
+ * neither. There is deliberately no credential anywhere in this fixture: that is
+ * the case being asserted.
+ */
+function profileGranting(connection: string, capabilities: readonly string[]): BuildServerOptions {
+  const { config } = parseConfig(`
+contract: 5
+instance:
+  profile: personal
+  port: 7300
+grants:
+  - connection: ${connection}
+    allow: ["${connection.split('.')[0]}.*"]
+    deny: []
+members: []
+`);
+
+  const runtime = {
+    config,
+    registry: {
+      capabilities: () =>
+        capabilities.map((id) => ({
+          id,
+          capability: undefined,
+          discovered: discovered(id.slice(id.indexOf('.') + 1)),
+        })),
+    },
+    policy: toPolicyDocument(config),
+  } as unknown as ProfileRuntime;
+
+  return {
+    profiles: oneProfile('personal', runtime),
+    principal: ownerPrincipal('personal'),
+  } as unknown as BuildServerOptions;
+}
+
+describe('a declared account with no credential', () => {
+  const options = profileGranting('vendor_mail.main', [
+    'vendor_mail.messages.list',
+    'vendor_mail.messages.get',
+  ]);
+
+  test('is advertised, credential or not', () => {
+    expect(visibleCapabilities(options).sort()).toEqual([
+      'vendor_mail.messages.get',
+      'vendor_mail.messages.list',
+    ]);
+  });
+
+  test('counts toward what tools/list carries', () => {
+    // Written as the arithmetic rather than as `4`, because the number is two
+    // separate claims: the capabilities the grant makes reachable, and the
+    // stable-name pair that is advertised whatever policy says (ADR-075).
+    expect(visibleToolCount(options)).toBe(2 + SURFACE_TOOL_NAMES.length);
+  });
+
+  /**
+   * The other half of the same rule, and the reason the one above is safe: a
+   * connection the profile does not grant is absent, so "advertised without a
+   * credential" is not "advertised without a grant". Default deny is untouched
+   * (ADR-058) — the grant row is doing the work, and it is the only thing that
+   * is.
+   */
+  test('but an account nothing grants is not advertised', () => {
+    const ungranted = profileGranting('vendor_mail.main', ['vendor_chat.messages.list']);
+
+    expect(visibleCapabilities(ungranted)).toEqual([]);
+    // No capability, and therefore only the pair — which reaches nothing,
+    // because it can only reach what is in the merged set.
+    expect(visibleToolCount(ungranted)).toBe(SURFACE_TOOL_NAMES.length);
+  });
+});

--- a/src/server/mcp/visibility.ts
+++ b/src/server/mcp/visibility.ts
@@ -6,6 +6,7 @@ import type { Dispatcher } from '#dispatch';
 import type { PolicyDocument, ProfilePolicy } from '#policy';
 import { allowedConnections } from '#policy';
 import { mayReach } from '#auth';
+import { SURFACE_TOOL_NAMES } from './naming.ts';
 
 /**
  * What this principal can see, and therefore what gets registered at all.
@@ -159,7 +160,10 @@ export function visibleCapabilities(options: BuildServerOptions): string[] {
  * it — a discovered capability is always a tool, an authored one is asked.
  */
 export function visibleToolCount(options: BuildServerOptions): number {
-  let count = 0;
+  // The stable-name pair is advertised unconditionally and is not a
+  // capability, so it is in `tools/list` and not in `merged` — see
+  // `SURFACE_TOOL_NAMES`.
+  let count = SURFACE_TOOL_NAMES.length;
 
   for (const entry of mergeCapabilities(options).values()) {
     if (entry.discovered) count += 1;

--- a/src/server/search.test.ts
+++ b/src/server/search.test.ts
@@ -1,0 +1,234 @@
+import { afterAll, describe, expect, test } from 'bun:test';
+import { allocatePort, rpc, startHarness } from './harness.ts';
+import { SURFACE_TOOL_NAMES } from './mcp/index.ts';
+
+/**
+ * `lanes_tools_search` and `lanes_tools_call`, against a real endpoint.
+ *
+ * The claim worth proving is the one a reviewer should be most suspicious of: a
+ * tool that can invoke any capability by name, added to a surface whose whole
+ * design is that discovery and enforcement share one answer (ADR-003, ADR-058).
+ * So most of this file is about what `lanes_tools_call` *cannot* do.
+ *
+ * It widens nothing because it resolves through the same merged capability set
+ * the typed tools were registered from, and dispatches through the same
+ * `dispatcher.invoke` with the same principal. Every refusal below is therefore
+ * the refusal a typed tool would have made — asserted here because "the same
+ * code path" is a claim about code, and this is the claim about behaviour.
+ */
+
+/** personal: everything on the example provider except one capability, denied. */
+const personal = startHarness({
+  profile: 'personal',
+  port: allocatePort(),
+  policy: `  allow:
+    - "example.*"
+  deny:
+    - "example.list_notes"`,
+});
+
+/** work: read-only, and a different token. */
+const work = startHarness({
+  profile: 'work',
+  port: allocatePort(),
+  token: 'llk_work_token_value',
+  policy: `  allow:
+    - "example.get_note"
+    - "example.list_notes"`,
+});
+
+afterAll(async () => {
+  await Promise.all([personal.stop(), work.stop()]);
+});
+
+async function names(url: string, token?: string): Promise<string[]> {
+  const response = await rpc(url, 'tools/list', {}, token ? { token } : {});
+  const tools = (response.body['result'] as { tools?: { name: string }[] })?.tools ?? [];
+  return tools.map((tool) => tool.name);
+}
+
+async function call(
+  url: string,
+  args: Record<string, unknown>,
+  token?: string,
+): Promise<{ text: string; isError: boolean }> {
+  const response = await rpc(
+    url,
+    'tools/call',
+    { name: 'lanes_tools_call', arguments: args },
+    token ? { token } : {},
+  );
+  const result = response.body['result'] as
+    | { content?: { text?: string }[]; isError?: boolean }
+    | undefined;
+
+  return {
+    text: (result?.content ?? []).map((block) => block.text ?? '').join('\n'),
+    isError: result?.isError === true,
+  };
+}
+
+async function search(url: string, query: string, token?: string): Promise<string> {
+  const response = await rpc(
+    url,
+    'tools/call',
+    { name: 'lanes_tools_search', arguments: { query } },
+    token ? { token } : {},
+  );
+  const result = response.body['result'] as { content?: { text?: string }[] } | undefined;
+  return (result?.content ?? []).map((block) => block.text ?? '').join('\n');
+}
+
+describe('the stable-name pair', () => {
+  test('is advertised to every caller', async () => {
+    for (const name of SURFACE_TOOL_NAMES) {
+      expect(await names(personal.server.url)).toContain(name);
+      expect(await names(work.server.url, 'llk_work_token_value')).toContain(name);
+    }
+  });
+
+  test('invokes a capability and returns what it returned', async () => {
+    const outcome = await call(personal.server.url, {
+      capability: 'example.echo',
+      profile: 'personal',
+      connection: 'example.a',
+      arguments: { message: 'through the dispatcher' },
+    });
+
+    expect(outcome.isError).toBe(false);
+    expect(outcome.text).toContain('through the dispatcher');
+    // The connection the call was routed to, which is what `echo` prefixes —
+    // so this also asserts the routing arguments were honoured rather than
+    // ignored.
+    expect(outcome.text).toContain('example.a');
+  });
+
+  test('search finds a reachable capability and gives its arguments', async () => {
+    const answer = await search(personal.server.url, 'echo');
+
+    expect(answer).toContain('example_echo');
+    expect(answer).toContain('capability: example.echo');
+    expect(answer).toContain('"message"');
+  });
+});
+
+describe('what it cannot do', () => {
+  /**
+   * The load-bearing one. `example.list_notes` is denied for this profile, so
+   * it was never advertised — and a generic dispatcher must not be the way
+   * around that. Denied and never-existed are deliberately indistinguishable
+   * from here, which is ADR-007's "probing must not be an oracle".
+   */
+  test('cannot reach a capability policy denied', async () => {
+    expect(await names(personal.server.url)).not.toContain('example_list_notes');
+
+    const outcome = await call(personal.server.url, {
+      capability: 'example.list_notes',
+      profile: 'personal',
+      connection: 'example.a',
+      arguments: {},
+    });
+
+    expect(outcome.isError).toBe(true);
+    expect(outcome.text).toContain('cannot reach');
+    // Says nothing about why, and nothing about it existing.
+    expect(outcome.text).not.toContain('denied');
+  });
+
+  /** The same, from the other direction: a narrower profile stays narrower. */
+  test('cannot reach a capability a narrower profile was not granted', async () => {
+    const outcome = await call(
+      work.server.url,
+      {
+        capability: 'example.set_note',
+        profile: 'work',
+        connection: 'example.a',
+        arguments: { key: 'k', value: 'v' },
+      },
+      'llk_work_token_value',
+    );
+
+    expect(outcome.isError).toBe(true);
+    expect(outcome.text).toContain('cannot reach');
+  });
+
+  /**
+   * Searching the denied id by name does not surface it. It is not an exact
+   * match either — an exact match requires the capability to be in the merged
+   * set — so the query falls through to keyword ranking and returns this
+   * provider's *other* capabilities, which is the right answer: the caller
+   * asked about something in this neighbourhood and gets what it may actually
+   * reach, with no evidence that the one it named exists.
+   */
+  test('and the search does not surface it, by id or by keyword', async () => {
+    for (const query of ['example.list_notes', 'list notes']) {
+      const answer = await search(personal.server.url, query);
+      expect(answer).not.toContain('example_list_notes');
+      expect(answer).not.toContain('capability: example.list_notes');
+    }
+  });
+
+  /**
+   * The refusal `makeHandler` makes, made here too. The `profile` enum is a
+   * union across profiles, so a caller can name a valid profile and a
+   * connection belonging to another — and routing one profile's account through
+   * another crosses exactly the boundary profiles exist to hold.
+   */
+  test('refuses a connection that is not part of the named profile', async () => {
+    const outcome = await call(personal.server.url, {
+      capability: 'example.echo',
+      profile: 'personal',
+      connection: 'example.not_this_one',
+      arguments: { message: 'hello' },
+    });
+
+    expect(outcome.isError).toBe(true);
+    expect(outcome.text).toContain('is not part of profile');
+  });
+
+  test('refuses a profile this caller cannot reach', async () => {
+    const outcome = await call(personal.server.url, {
+      capability: 'example.echo',
+      profile: 'work',
+      connection: 'example.a',
+      arguments: { message: 'hello' },
+    });
+
+    expect(outcome.isError).toBe(true);
+  });
+
+  /**
+   * It is not in the merged set, so the "cannot reach" branch already refuses
+   * it. Asserted because a dispatcher that can reach itself is one prompt away
+   * from a loop, and the guard should not depend on a fact about another file.
+   */
+  test('cannot call itself', async () => {
+    const outcome = await call(personal.server.url, {
+      capability: 'lanes_tools.call',
+      profile: 'personal',
+      connection: 'example.a',
+      arguments: {},
+    });
+
+    expect(outcome.isError).toBe(true);
+  });
+
+  /**
+   * ADR-007's walls are not policy rules, so nothing here evaluates them: a
+   * control-plane operation is never registered, so it is never in the merged
+   * set, so it refuses for the same reason a misspelling does.
+   */
+  test('cannot reach a control-plane operation', async () => {
+    for (const capability of ['config.connection.create', 'policy.allow', 'token.issue']) {
+      const outcome = await call(personal.server.url, {
+        capability,
+        profile: 'personal',
+        connection: 'example.a',
+        arguments: {},
+      });
+
+      expect(outcome.isError).toBe(true);
+      expect(outcome.text).toContain('cannot reach');
+    }
+  });
+});

--- a/src/server/skills-authoring.test.ts
+++ b/src/server/skills-authoring.test.ts
@@ -6,6 +6,7 @@ import { createSkillsProvider } from '#providers/owner.ts';
 import { createMemoryBlobStore } from '#stores/blobs/testing.ts';
 import type { BlobStore } from '#stores/blobs';
 import { allocatePort, rpc, startHarness } from './harness.ts';
+import { SURFACE_TOOL_NAMES } from './mcp/index.ts';
 
 /**
  * Authoring a skill over MCP, end to end — ADR-014.
@@ -244,7 +245,15 @@ describe('authoring is a separate grant', () => {
     const result = listed.body['result'] as { tools?: unknown[] } | undefined;
 
     expect(listed.body['error']).toBeUndefined();
-    expect(result?.tools).toEqual([]);
+    // The stable-name pair and nothing else. They are advertised to every
+    // caller regardless of policy (ADR-075) and reach only what is in the
+    // merged capability set — which for this profile is empty, so both refuse
+    // everything. What this test is about is unchanged: the four
+    // `lanes_skills.manage.*` capabilities were never advertised, rather than
+    // being withheld at call time.
+    expect((result?.tools ?? []).map((tool) => (tool as { name: string }).name).sort()).toEqual(
+      [...SURFACE_TOOL_NAMES].sort(),
+    );
   });
 
   test('it can still invoke the skills it has', async () => {


### PR DESCRIPTION
Release 0.10.4.

**The tool list keeps its typed tools and gains a search beside them** (#182). One tool per capability, filtered per person, exactly as before — plus two whose names never change:

| tool | does |
|---|---|
| `lanes_tools_search(query)` | finds any reachable capability by keyword, returns its argument schema |
| `lanes_tools_call(profile, connection, capability, arguments)` | invokes one by id |

Because both are in every tool list any client has already fetched, a provider connected today is reachable from a chat whose client cached its list yesterday. Closes #174 and #162.

**`lanes link connection declare`** names an account before it is authorised, so its tools are advertised now and connecting it later does not move the list.

**The tools became findable as well as present.** Measured over the same text a client ranks on, `email` returned two Contacts tools and nothing from either mail provider; `meeting`, `calendar invite`, `todo list`, `reminder` and `file upload` returned nothing at all. Every provider now carries a synthesised title and its own keywords, including the one authored capability that no connector builds a tool for.

Also: the whole advertised surface is budgeted rather than just one tool and one provider, and the tool list's cache hints are ours rather than the SDK's default.

The version is already set on `develop`, so this merge takes the publish path. **Merge, do not squash** — a squash writes a new commit onto `main` and the fast-forward back to `develop` is then rejected.

`bun test` 3356 pass / 12 skip / 2 fail (the known `emitted.test.ts` timeout flakes, which fail identically on the previous release), `bun run typecheck` clean, `ci` green.