### PR TITLE
Every connector makes its tools findable, and every provider says what it is for

### DIFF
--- a/src/connectivity/transports/dav/index.test.ts
+++ b/src/connectivity/transports/dav/index.test.ts
@@ -172,13 +172,37 @@ const invoke = (
 const parsed = (result: ToolResult): Record<string, unknown> =>
   JSON.parse((result.content[0] as { text?: string }).text!);
 
+const CONTEXT = {
+  manifest: { id: 'icloud_calendar', name: 'iCloud Calendar', keywords: ['meeting', 'invite'] },
+} as unknown as DiscoveryContext;
+
+
+/**
+ * The searchable fields, applied by the connector rather than by the caller.
+ *
+ * `titleFor` and `withKeywords` are unit-tested in `../searchability.test.ts`,
+ * and that was the whole of it for a while — which missed the actual defect,
+ * because the helpers were right and this connector was not calling them. A
+ * fixed capability set is written here and returned from `discover` as it
+ * stands, so there was no rewriting step to apply them in.
+ */
 describe('discovery', () => {
+  test('the searchable fields are applied to a fixed capability set', async () => {
+    const capabilities = await calendarConnector(harness().doFetch).discover(CONTEXT);
+
+    expect(capabilities.every((capability) => capability.title !== undefined)).toBe(true);
+    expect(capabilities.every((capability) => capability.description.includes('Also:'))).toBe(true);
+    expect(capabilities.find((capability) => capability.name === 'list_calendars')?.title).toBe(
+      'iCloud Calendar: list calendars',
+    );
+  });
+
   test('capabilities carry no account-specific routing', async () => {
     // The discovery cache is keyed by provider, so a partition host in `target`
     // would point a second Apple Account at the first one's calendars.
     const connector = calendarConnector(harness().doFetch);
 
-    for (const capability of await connector.discover({} as DiscoveryContext)) {
+    for (const capability of await connector.discover(CONTEXT)) {
       expect(Object.keys(capability.target ?? {})).toEqual(['operation']);
       expect(JSON.stringify(capability.target)).not.toContain('icloud.com');
     }
@@ -191,10 +215,10 @@ describe('discovery', () => {
       fetch: harness().doFetch,
     });
 
-    const calendarNames = (await calendarConnector(harness().doFetch).discover({} as DiscoveryContext)).map(
+    const calendarNames = (await calendarConnector(harness().doFetch).discover(CONTEXT)).map(
       (c) => c.name,
     );
-    const contactNames = (await contacts.discover({} as DiscoveryContext)).map((c) => c.name);
+    const contactNames = (await contacts.discover(CONTEXT)).map((c) => c.name);
 
     expect(calendarNames).toEqual([
       'list_calendars',

--- a/src/connectivity/transports/dav/index.ts
+++ b/src/connectivity/transports/dav/index.ts
@@ -1,5 +1,6 @@
 import type { Connector, ToolResult } from '#connectivity';
 import { davCapabilities } from './capabilities.ts';
+import { searchableCapabilities } from '../mcp/index.ts';
 import { createContact, searchContacts } from './contacts.ts';
 import {
   createEvent,
@@ -73,8 +74,11 @@ export function createDavConnector(options: DavConnectorOptions): Connector {
   return {
     kind: 'dav',
 
-    async discover() {
-      const capabilities = davCapabilities(options.service);
+    async discover(context) {
+      const capabilities = searchableCapabilities(
+        davCapabilities(options.service),
+        context.manifest,
+      );
 
       // Prove the credential before declaring the connection good. Without this
       // a wrong app-specific password surfaces as a failed tool call days later

--- a/src/connectivity/transports/fs/index.test.ts
+++ b/src/connectivity/transports/fs/index.test.ts
@@ -226,9 +226,33 @@ describe('writing', () => {
   });
 });
 
+const CONTEXT = {
+  manifest: { id: 'icloud_drive', name: 'iCloud Drive', keywords: ['document', 'storage'] },
+} as unknown as DiscoveryContext;
+
+
+/**
+ * The searchable fields, applied by the connector rather than by the caller.
+ *
+ * `titleFor` and `withKeywords` are unit-tested in `../searchability.test.ts`,
+ * and that was the whole of it for a while — which missed the actual defect,
+ * because the helpers were right and this connector was not calling them. A
+ * fixed capability set is written here and returned from `discover` as it
+ * stands, so there was no rewriting step to apply them in.
+ */
 describe('discovery', () => {
+  test('the searchable fields are applied to a fixed capability set', async () => {
+    const capabilities = await connector().discover(CONTEXT);
+
+    expect(capabilities.every((capability) => capability.title !== undefined)).toBe(true);
+    expect(capabilities.every((capability) => capability.description.includes('Also:'))).toBe(true);
+    expect(capabilities.find((capability) => capability.name === 'list_files')?.title).toBe(
+      'iCloud Drive: list files',
+    );
+  });
+
   test('the capability set, and no account-specific routing', async () => {
-    const capabilities = await connector().discover({} as DiscoveryContext);
+    const capabilities = await connector().discover(CONTEXT);
 
     expect(capabilities.map((capability) => capability.name).sort()).toEqual([
       'create_folder',
@@ -246,7 +270,7 @@ describe('discovery', () => {
   });
 
   test('nothing offers a permanent delete', async () => {
-    const capabilities = await connector().discover({} as DiscoveryContext);
+    const capabilities = await connector().discover(CONTEXT);
     const names = capabilities.map((capability) => capability.name);
 
     // The only removal on offer moves to the Trash, which is recoverable.
@@ -262,6 +286,6 @@ describe('discovery', () => {
       exclude: [],
     });
 
-    expect(elsewhere.discover({} as DiscoveryContext)).rejects.toThrow(/only works where they are/);
+    expect(elsewhere.discover(CONTEXT)).rejects.toThrow(/only works where they are/);
   });
 });

--- a/src/connectivity/transports/fs/index.ts
+++ b/src/connectivity/transports/fs/index.ts
@@ -46,6 +46,7 @@ export interface FsConnectorOptions {
 
 
 import { fsCapabilities } from './capabilities.ts';
+import { searchableCapabilities } from '../mcp/index.ts';
 import { ALWAYS_EXCLUDED, OPERATIONS } from './operations.ts';
 import { rootOf } from './paths.ts';
 import { error } from './result.ts';
@@ -66,13 +67,13 @@ export function createFsConnector(options: FsConnectorOptions): Connector {
   return {
     kind: 'fs',
 
-    async discover(): Promise<DiscoveredCapability[]> {
+    async discover(context): Promise<DiscoveredCapability[]> {
       // The root has to exist and be readable. On a machine that is not the one
       // holding the files this fails here, at `connect`, rather than as a
       // puzzling empty listing later.
       await rootOf(options);
 
-      return fsCapabilities();
+      return searchableCapabilities(fsCapabilities(), context.manifest);
     },
 
     /**

--- a/src/connectivity/transports/imap/index.test.ts
+++ b/src/connectivity/transports/imap/index.test.ts
@@ -123,7 +123,7 @@ const connectorWith = (steps: readonly Step[], options: { smtp?: boolean; move?:
 const annotations: Record<string, unknown>[] = [];
 const storage = createMemoryBlobStore();
 const CONTEXT = {
-  manifest: { id: 'icloud_mail' },
+  manifest: { id: 'icloud_mail', name: 'iCloud Mail' },
   provider: {
     audit: { annotate: (detail: Record<string, unknown>) => annotations.push(detail) },
     // Scoped to this provider and connection by the time a connector sees it,
@@ -143,7 +143,28 @@ const CONTEXT = {
 const parsed = (result: { content: readonly { text?: string }[] }): Record<string, unknown> =>
   JSON.parse(result.content[0]!.text!);
 
+
+/**
+ * The searchable fields, applied by the connector rather than by the caller.
+ *
+ * `titleFor` and `withKeywords` are unit-tested in `../searchability.test.ts`,
+ * and that was the whole of it for a while — which missed the actual defect,
+ * because the helpers were right and this connector was not calling them. A
+ * fixed capability set is written here and returned from `discover` as it
+ * stands, so there was no rewriting step to apply them in.
+ */
 describe('discovery', () => {
+  test('the searchable fields are applied to a fixed capability set', async () => {
+    const { connector } = connectorWith([]);
+
+    const capabilities = await connector.discover(CONTEXT);
+
+    expect(capabilities.every((capability) => capability.title !== undefined)).toBe(true);
+    expect(capabilities.find((capability) => capability.name === 'list_mailboxes')?.title).toBe(
+      'iCloud Mail: list mailboxes',
+    );
+  });
+
   test('the capability set is fixed, because the protocol fixes it', async () => {
     const { connector } = connectorWith([]);
 

--- a/src/connectivity/transports/imap/index.ts
+++ b/src/connectivity/transports/imap/index.ts
@@ -44,6 +44,7 @@ import type { SocketFactory } from './socket.ts';
  */
 
 import { imapCapabilities } from './capabilities.ts';
+import { searchableCapabilities } from '../mcp/index.ts';
 import { mailboxAttachments } from './attachment.ts';
 import { getAttachment } from './download.ts';
 import { OPERATIONS } from './operations.ts';
@@ -90,12 +91,15 @@ export function createImapConnector(options: ImapConnectorOptions): Connector {
   return {
     kind: 'imap',
 
-    async discover(): Promise<DiscoveredCapability[]> {
+    async discover(context): Promise<DiscoveredCapability[]> {
       // Logging in is the point of discovering: a rejected app-specific
       // password should stop `connect`, not surface later as a failed tool call.
       const supportsMove = await client.run(async (session) => session.capabilities.has('MOVE'));
 
-      return imapCapabilities({ supportsMove, canSend: options.smtp !== undefined });
+      return searchableCapabilities(
+        imapCapabilities({ supportsMove, canSend: options.smtp !== undefined }),
+        context.manifest,
+      );
     },
 
     async identify(): Promise<string | null> {

--- a/src/connectivity/transports/index.ts
+++ b/src/connectivity/transports/index.ts
@@ -9,6 +9,7 @@ export { createLocalConnector } from './local/index.ts';
 export {
   createMcpConnector,
   inferBundle,
+  searchableCapabilities,
   shortenName,
   titleFor,
   withKeywords,

--- a/src/connectivity/transports/mcp/index.ts
+++ b/src/connectivity/transports/mcp/index.ts
@@ -143,6 +143,35 @@ export function withKeywords(description: string, keywords: readonly string[] = 
 }
 
 /**
+ * Both of the above, over a capability set a connector already holds.
+ *
+ * `http` and `mcp` apply the two helpers as they build each tool, because both
+ * are turning something foreign — an OpenAPI operation, an upstream tool — into
+ * ours and are already rewriting every field. `dav`, `imap` and `fs` are not:
+ * their capability sets are fixed in code, written here, and returned from
+ * `discover` as they stand. So they had no rewriting step to apply this in, and
+ * for the same reason nobody noticed they were skipping it.
+ *
+ * The result was a whole class of provider with no `title` at all and no way to
+ * benefit from `keywords` even once its manifest declared some: thirteen
+ * providers, every mailbox that is not Gmail among them. This is the rewriting
+ * step, so that a fixed set is as findable as a discovered one.
+ *
+ * A `title` already on the capability wins, on the same principle `titleFor`
+ * states for an upstream one: whoever wrote it knew more than a synthesis does.
+ */
+export function searchableCapabilities(
+  capabilities: readonly DiscoveredCapability[],
+  manifest: { readonly name: string; readonly keywords?: readonly string[] | undefined },
+): DiscoveredCapability[] {
+  return capabilities.map((capability) => ({
+    ...capability,
+    title: capability.title ?? titleFor(manifest.name, capability.name),
+    description: withKeywords(capability.description, manifest.keywords),
+  }));
+}
+
+/**
  * Turn an upstream transport error into something readable.
  *
  * The SDK reports a bad HTTP status by appending the whole response body,

--- a/src/providers/airtable/index.ts
+++ b/src/providers/airtable/index.ts
@@ -5,6 +5,7 @@ export const airtable = defineProvider({
   id: 'airtable',
   name: 'Airtable',
   description: 'Bases, tables, records, fields, and schema, via Airtable\'s official MCP server.',
+  keywords: ['table', 'record', 'database', 'spreadsheet', 'base'],
   connector: { kind: 'mcp', endpoint: 'https://mcp.airtable.com/mcp' },
   auth: { kind: 'oauth', registration: 'dynamic' },
 });

--- a/src/providers/algolia/index.ts
+++ b/src/providers/algolia/index.ts
@@ -5,6 +5,7 @@ export const algolia = defineProvider({
   id: 'algolia',
   name: 'Algolia',
   description: 'Search indices, records, queries, and synonyms, via Algolia\'s official MCP server.',
+  keywords: ['search', 'index', 'query', 'relevance', 'autocomplete'],
   connector: { kind: 'mcp', endpoint: 'https://mcp.algolia.com/mcp' },
   auth: { kind: 'oauth', registration: 'dynamic' },
 });

--- a/src/providers/amplitude/index.ts
+++ b/src/providers/amplitude/index.ts
@@ -5,6 +5,7 @@ export const amplitude = defineProvider({
   id: 'amplitude',
   name: 'Amplitude',
   description: 'Events, charts, cohorts, and user activity, via Amplitude\'s official MCP server.',
+  keywords: ['analytics', 'event', 'funnel', 'cohort', 'product analytics'],
   connector: { kind: 'mcp', endpoint: 'https://mcp.amplitude.com/mcp' },
   auth: { kind: 'oauth', registration: 'dynamic' },
 });

--- a/src/providers/apify/index.ts
+++ b/src/providers/apify/index.ts
@@ -5,6 +5,7 @@ export const apify = defineProvider({
   id: 'apify',
   name: 'Apify',
   description: 'Actors, runs, datasets, and scraped results, via Apify\'s official MCP server.',
+  keywords: ['scraping', 'crawler', 'automation', 'dataset', 'web data'],
   connector: { kind: 'mcp', endpoint: 'https://mcp.apify.com' },
   auth: { kind: 'oauth', registration: 'dynamic' },
 });

--- a/src/providers/asana/index.ts
+++ b/src/providers/asana/index.ts
@@ -5,6 +5,7 @@ export const asana = defineProvider({
   id: 'asana',
   name: 'Asana',
   description: 'Tasks, projects, portfolios, and workspaces, via Asana\'s official MCP server.',
+  keywords: ['task', 'project', 'todo', 'assignment', 'workflow'],
   connector: { kind: 'mcp', endpoint: 'https://mcp.asana.com/mcp' },
   auth: { kind: 'oauth', registration: 'dynamic' },
   /**

--- a/src/providers/atlassian/index.ts
+++ b/src/providers/atlassian/index.ts
@@ -14,6 +14,7 @@ export const atlassian = defineProvider({
   name: 'Atlassian',
   description:
     'Jira issues, Confluence pages, and Compass components, via Atlassian\'s official MCP server.',
+  keywords: ['jira', 'confluence', 'issue', 'ticket', 'wiki'],
   connector: { kind: 'mcp', endpoint: 'https://mcp.atlassian.com/v1/mcp/authv2' },
   auth: { kind: 'oauth', registration: 'dynamic' },
 });

--- a/src/providers/attio/index.ts
+++ b/src/providers/attio/index.ts
@@ -5,6 +5,7 @@ export const attio = defineProvider({
   id: 'attio',
   name: 'Attio',
   description: 'Records, lists, notes, and tasks in the CRM, via Attio\'s official MCP server.',
+  keywords: ['crm', 'contact', 'company', 'deal', 'pipeline'],
   connector: { kind: 'mcp', endpoint: 'https://mcp.attio.com/mcp' },
   auth: { kind: 'oauth', registration: 'dynamic' },
 });

--- a/src/providers/betterstack/index.ts
+++ b/src/providers/betterstack/index.ts
@@ -5,6 +5,7 @@ export const betterstack = defineProvider({
   id: 'betterstack',
   name: 'Better Stack',
   description: 'Incidents, monitors, heartbeats, and logs, via Better Stack\'s official MCP server.',
+  keywords: ['uptime', 'monitoring', 'incident', 'logs', 'alert'],
   connector: { kind: 'mcp', endpoint: 'https://mcp.betterstack.com' },
   auth: { kind: 'oauth', registration: 'dynamic' },
 });

--- a/src/providers/box/index.ts
+++ b/src/providers/box/index.ts
@@ -18,6 +18,7 @@ export const box = defineProvider({
   id: 'box',
   name: 'Box',
   description: 'Files, folders, and metadata in Box, via Box\'s official MCP server.',
+  keywords: ['file', 'folder', 'upload', 'download', 'storage'],
   connector: { kind: 'mcp', endpoint: 'https://mcp.box.com/' },
   auth: {
     kind: 'oauth',

--- a/src/providers/brightdata/index.ts
+++ b/src/providers/brightdata/index.ts
@@ -5,6 +5,7 @@ export const brightdata = defineProvider({
   id: 'brightdata',
   name: 'Bright Data',
   description: 'Web scraping, search results, and datasets, via Bright Data\'s official MCP server.',
+  keywords: ['scraping', 'proxy', 'web data', 'crawler', 'dataset'],
   connector: { kind: 'mcp', endpoint: 'https://mcp.brightdata.com/mcp' },
   auth: { kind: 'oauth', registration: 'dynamic' },
 });

--- a/src/providers/buildkite/index.ts
+++ b/src/providers/buildkite/index.ts
@@ -5,6 +5,7 @@ export const buildkite = defineProvider({
   id: 'buildkite',
   name: 'Buildkite',
   description: 'Pipelines, builds, jobs, and artifacts, via Buildkite\'s official MCP server.',
+  keywords: ['ci', 'pipeline', 'build', 'deployment', 'agent'],
   connector: { kind: 'mcp', endpoint: 'https://mcp.buildkite.com/mcp' },
   auth: { kind: 'oauth', registration: 'dynamic' },
 });

--- a/src/providers/bunq/index.ts
+++ b/src/providers/bunq/index.ts
@@ -35,6 +35,7 @@ const manifest = defineProvider({
   name: 'bunq',
   description:
     'Bank accounts, balances, transaction history, and payments — including batches and drafts that wait for approval in the bunq app.',
+  keywords: ['bank', 'payment', 'balance', 'transaction', 'account'],
   connector: {
     kind: 'http',
     base_url: 'https://api.bunq.com/v1',

--- a/src/providers/calendly/index.ts
+++ b/src/providers/calendly/index.ts
@@ -5,6 +5,7 @@ export const calendly = defineProvider({
   id: 'calendly',
   name: 'Calendly',
   description: 'Scheduled events, invitees, event types, and availability, via Calendly\'s official MCP server.',
+  keywords: ['booking', 'meeting', 'schedule', 'availability', 'appointment'],
   connector: { kind: 'mcp', endpoint: 'https://mcp.calendly.com' },
   auth: { kind: 'oauth', registration: 'dynamic' },
 });

--- a/src/providers/canva/index.ts
+++ b/src/providers/canva/index.ts
@@ -5,6 +5,7 @@ export const canva = defineProvider({
   id: 'canva',
   name: 'Canva',
   description: 'Designs, folders, brand templates, assets, and exports, via Canva\'s official MCP server.',
+  keywords: ['design', 'graphic', 'template', 'poster', 'presentation'],
   connector: { kind: 'mcp', endpoint: 'https://mcp.canva.com/mcp' },
   auth: { kind: 'oauth', registration: 'dynamic' },
 });

--- a/src/providers/circleci/index.ts
+++ b/src/providers/circleci/index.ts
@@ -5,6 +5,7 @@ export const circleci = defineProvider({
   id: 'circleci',
   name: 'CircleCI',
   description: 'Pipelines, workflows, jobs, and test results, via CircleCI\'s official MCP server.',
+  keywords: ['ci', 'pipeline', 'build', 'workflow', 'deployment'],
   connector: { kind: 'mcp', endpoint: 'https://mcp.circleci.com/v1/mcp' },
   auth: { kind: 'oauth', registration: 'dynamic' },
 });

--- a/src/providers/clickup/index.ts
+++ b/src/providers/clickup/index.ts
@@ -5,6 +5,7 @@ export const clickup = defineProvider({
   id: 'clickup',
   name: 'ClickUp',
   description: 'Tasks, lists, spaces, docs, and time entries, via ClickUp\'s official MCP server.',
+  keywords: ['task', 'project', 'todo', 'workflow', 'sprint'],
   connector: { kind: 'mcp', endpoint: 'https://mcp.clickup.com/mcp' },
   auth: { kind: 'oauth', registration: 'dynamic' },
 });

--- a/src/providers/close/index.ts
+++ b/src/providers/close/index.ts
@@ -5,6 +5,7 @@ export const close = defineProvider({
   id: 'close',
   name: 'Close',
   description: 'Leads, contacts, opportunities, and activities in the CRM, via Close\'s official MCP server.',
+  keywords: ['crm', 'lead', 'deal', 'pipeline', 'sales'],
   connector: { kind: 'mcp', endpoint: 'https://mcp.close.com/mcp' },
   auth: { kind: 'oauth', registration: 'dynamic' },
 });

--- a/src/providers/cloudflare_bindings/index.ts
+++ b/src/providers/cloudflare_bindings/index.ts
@@ -9,6 +9,7 @@ export const cloudflareBindings = defineProvider({
   id: 'cloudflare_bindings',
   name: 'Cloudflare Bindings',
   description: 'Workers KV, R2, D1, and Durable Objects, via Cloudflare\'s official MCP server.',
+  keywords: ['worker', 'kv', 'r2', 'd1', 'edge'],
   connector: { kind: 'mcp', endpoint: 'https://bindings.mcp.cloudflare.com/mcp' },
   auth: { kind: 'oauth', registration: 'dynamic' },
 });

--- a/src/providers/cloudflare_observability/index.ts
+++ b/src/providers/cloudflare_observability/index.ts
@@ -5,6 +5,7 @@ export const cloudflareObservability = defineProvider({
   id: 'cloudflare_observability',
   name: 'Cloudflare Observability',
   description: 'Workers logs, analytics, and traces, via Cloudflare\'s official MCP server.',
+  keywords: ['logs', 'metrics', 'monitoring', 'analytics', 'traffic'],
   connector: { kind: 'mcp', endpoint: 'https://observability.mcp.cloudflare.com/mcp' },
   auth: { kind: 'oauth', registration: 'dynamic' },
 });

--- a/src/providers/contentful/index.ts
+++ b/src/providers/contentful/index.ts
@@ -5,6 +5,7 @@ export const contentful = defineProvider({
   id: 'contentful',
   name: 'Contentful',
   description: 'Entries, assets, content types, and spaces, via Contentful\'s official MCP server.',
+  keywords: ['cms', 'content', 'entry', 'publishing', 'model'],
   connector: { kind: 'mcp', endpoint: 'https://mcp.contentful.com/mcp' },
   auth: { kind: 'oauth', registration: 'dynamic' },
 });

--- a/src/providers/datadog/index.ts
+++ b/src/providers/datadog/index.ts
@@ -5,6 +5,7 @@ export const datadog = defineProvider({
   id: 'datadog',
   name: 'Datadog',
   description: 'Metrics, logs, monitors, incidents, and dashboards, via Datadog\'s official MCP server.',
+  keywords: ['monitoring', 'metrics', 'logs', 'alert', 'observability'],
   connector: { kind: 'mcp', endpoint: 'https://mcp.datadoghq.com/api/unstable/mcp-server/mcp' },
   auth: { kind: 'oauth', registration: 'dynamic' },
 });

--- a/src/providers/discord/index.ts
+++ b/src/providers/discord/index.ts
@@ -69,6 +69,7 @@ export const discord = defineProvider({
   name: 'Discord',
   description:
     'Post announcements, read channels, and triage messages in the servers your bot has been added to, via the Discord v10 HTTP API.',
+  keywords: ['chat', 'server', 'channel', 'message', 'community'],
   connector: {
     kind: 'http',
     base_url: 'https://discord.com/api/v10',

--- a/src/providers/dropbox/index.ts
+++ b/src/providers/dropbox/index.ts
@@ -5,6 +5,7 @@ export const dropbox = defineProvider({
   id: 'dropbox',
   name: 'Dropbox',
   description: 'Files, folders, shared links, and file requests, via Dropbox\'s official MCP server.',
+  keywords: ['file', 'folder', 'upload', 'download', 'storage'],
   connector: { kind: 'mcp', endpoint: 'https://mcp.dropbox.com/mcp' },
   auth: { kind: 'oauth', registration: 'dynamic' },
 });

--- a/src/providers/expensify/index.ts
+++ b/src/providers/expensify/index.ts
@@ -5,6 +5,7 @@ export const expensify = defineProvider({
   id: 'expensify',
   name: 'Expensify',
   description: 'Expenses, reports, and receipts, via Expensify\'s official MCP server.',
+  keywords: ['expense', 'receipt', 'reimbursement', 'report', 'spending'],
   connector: { kind: 'mcp', endpoint: 'https://mcp.expensify.com/mcp/' },
   auth: { kind: 'oauth', registration: 'dynamic' },
 });

--- a/src/providers/fastmail/calendar/index.ts
+++ b/src/providers/fastmail/calendar/index.ts
@@ -5,6 +5,7 @@ export const fastmailCalendar = defineProvider({
   id: 'fastmail_calendar',
   name: 'Fastmail Calendar',
   description: 'Read and create events in Fastmail calendars over CalDAV.',
+  keywords: ['meeting', 'invite', 'appointment', 'schedule', 'availability'],
   connector: { kind: 'dav', base_url: 'https://caldav.fastmail.com', service: 'caldav' },
   auth: { kind: 'basic', app: FASTMAIL_APP },
   identity: { kind: 'connector' },

--- a/src/providers/fastmail/contacts/index.ts
+++ b/src/providers/fastmail/contacts/index.ts
@@ -5,6 +5,7 @@ export const fastmailContacts = defineProvider({
   id: 'fastmail_contacts',
   name: 'Fastmail Contacts',
   description: 'Search and read contacts in a Fastmail address book over CardDAV.',
+  keywords: ['address book', 'directory', 'people', 'email address'],
   connector: { kind: 'dav', base_url: 'https://carddav.fastmail.com', service: 'carddav' },
   auth: { kind: 'basic', app: FASTMAIL_APP },
   identity: { kind: 'connector' },

--- a/src/providers/fastmail/mail/index.ts
+++ b/src/providers/fastmail/mail/index.ts
@@ -9,6 +9,7 @@ export const fastmailMail = defineProvider({
   name: 'Fastmail Mail',
   description:
     'Read, search, and send mail in a Fastmail mailbox over IMAP and SMTP, with an app password that does not expire.',
+  keywords: ['email', 'message', 'inbox', 'reply', 'correspondence'],
   connector: {
     kind: 'imap',
     host: 'imap.fastmail.com',

--- a/src/providers/figma/index.ts
+++ b/src/providers/figma/index.ts
@@ -32,6 +32,7 @@ export const figma = defineProvider({
   id: 'figma',
   name: 'Figma',
   description: 'Files, designs, components, and Dev Mode context, via Figma\'s official MCP server.',
+  keywords: ['design', 'mockup', 'prototype', 'canvas', 'component'],
   connector: { kind: 'mcp', endpoint: 'https://mcp.figma.com/mcp' },
   auth: { kind: 'oauth', registration: 'dynamic' },
   setup: {

--- a/src/providers/fireflies/index.ts
+++ b/src/providers/fireflies/index.ts
@@ -5,6 +5,7 @@ export const fireflies = defineProvider({
   id: 'fireflies',
   name: 'Fireflies',
   description: 'Meeting transcripts, summaries, and action items, via Fireflies\'s official MCP server.',
+  keywords: ['meeting notes', 'transcript', 'recording', 'summary', 'call'],
   connector: { kind: 'mcp', endpoint: 'https://api.fireflies.ai/mcp' },
   auth: { kind: 'oauth', registration: 'dynamic' },
 });

--- a/src/providers/flagsmith/index.ts
+++ b/src/providers/flagsmith/index.ts
@@ -5,6 +5,7 @@ export const flagsmith = defineProvider({
   id: 'flagsmith',
   name: 'Flagsmith',
   description: 'Feature flags, segments, and environments, via Flagsmith\'s official MCP server.',
+  keywords: ['feature flag', 'toggle', 'rollout', 'experiment', 'remote config'],
   connector: { kind: 'mcp', endpoint: 'https://mcp.flagsmith.com/mcp' },
   auth: { kind: 'oauth', registration: 'dynamic' },
 });

--- a/src/providers/gamma/index.ts
+++ b/src/providers/gamma/index.ts
@@ -5,6 +5,7 @@ export const gamma = defineProvider({
   id: 'gamma',
   name: 'Gamma',
   description: 'Presentations and documents, generated and read back, via Gamma\'s official MCP server.',
+  keywords: ['presentation', 'slides', 'deck', 'document', 'design'],
   connector: { kind: 'mcp', endpoint: 'https://mcp.gamma.app/mcp' },
   auth: { kind: 'oauth', registration: 'dynamic' },
 });

--- a/src/providers/github/index.ts
+++ b/src/providers/github/index.ts
@@ -23,6 +23,7 @@ export const github = defineProvider({
   id: 'github',
   name: 'GitHub',
   description: 'Repositories, issues, pull requests, and workflow runs, via GitHub\'s official MCP server.',
+  keywords: ['repository', 'pull request', 'commit', 'issue', 'code review'],
   connector: {
     kind: 'mcp',
     endpoint: 'https://api.githubcopilot.com/mcp/',

--- a/src/providers/grafana/index.ts
+++ b/src/providers/grafana/index.ts
@@ -5,6 +5,7 @@ export const grafana = defineProvider({
   id: 'grafana',
   name: 'Grafana',
   description: 'Dashboards, datasources, queries, and alert rules, via Grafana\'s official MCP server.',
+  keywords: ['dashboard', 'metrics', 'monitoring', 'alert', 'observability'],
   connector: { kind: 'mcp', endpoint: 'https://mcp.grafana.com/mcp' },
   auth: { kind: 'oauth', registration: 'dynamic' },
 });

--- a/src/providers/heroku/index.ts
+++ b/src/providers/heroku/index.ts
@@ -5,6 +5,7 @@ export const heroku = defineProvider({
   id: 'heroku',
   name: 'Heroku',
   description: 'Apps, dynos, add-ons, releases, and logs, via Heroku\'s official MCP server.',
+  keywords: ['deployment', 'hosting', 'dyno', 'app', 'infrastructure'],
   connector: { kind: 'mcp', endpoint: 'https://mcp.heroku.com/mcp' },
   auth: { kind: 'oauth', registration: 'dynamic' },
 });

--- a/src/providers/hubspot/index.ts
+++ b/src/providers/hubspot/index.ts
@@ -30,6 +30,7 @@ export const hubspot = defineProvider({
   id: 'hubspot',
   name: 'HubSpot',
   description: 'CRM contacts, companies, deals, and engagements, via HubSpot\'s official MCP server.',
+  keywords: ['crm', 'contact', 'deal', 'pipeline', 'marketing'],
   connector: { kind: 'mcp', endpoint: 'https://mcp.hubspot.com' },
   auth: {
     kind: 'oauth',

--- a/src/providers/hygraph/index.ts
+++ b/src/providers/hygraph/index.ts
@@ -5,6 +5,7 @@ export const hygraph = defineProvider({
   id: 'hygraph',
   name: 'Hygraph',
   description: 'Content entries, models, and schema, via Hygraph\'s official MCP server.',
+  keywords: ['cms', 'content', 'graphql', 'schema', 'publishing'],
   connector: { kind: 'mcp', endpoint: 'https://mcp.hygraph.com/mcp' },
   auth: { kind: 'oauth', registration: 'dynamic' },
 });

--- a/src/providers/icloud/calendar/index.ts
+++ b/src/providers/icloud/calendar/index.ts
@@ -5,6 +5,7 @@ export const icloudCalendar = defineProvider({
   id: 'icloud_calendar',
   name: 'iCloud Calendar',
   description: 'Read and create events in iCloud calendars over CalDAV.',
+  keywords: ['meeting', 'invite', 'appointment', 'schedule', 'availability'],
   connector: {
     kind: 'dav',
     base_url: 'https://caldav.icloud.com',

--- a/src/providers/icloud/contacts/index.ts
+++ b/src/providers/icloud/contacts/index.ts
@@ -5,6 +5,7 @@ export const icloudContacts = defineProvider({
   id: 'icloud_contacts',
   name: 'iCloud Contacts',
   description: 'Search and read contacts in an iCloud address book over CardDAV.',
+  keywords: ['address book', 'directory', 'people', 'email address'],
   connector: { kind: 'dav', base_url: 'https://contacts.icloud.com', service: 'carddav' },
   auth: { kind: 'basic', app: ICLOUD_APP },
   identity: { kind: 'connector' },

--- a/src/providers/icloud/drive/index.ts
+++ b/src/providers/icloud/drive/index.ts
@@ -14,6 +14,7 @@ export const icloudDrive = defineProvider({
   id: 'icloud_drive',
   name: 'iCloud Drive',
   description: 'Read and organise files in iCloud Drive, on the Mac that syncs them.',
+  keywords: ['document', 'upload', 'download', 'attachment', 'storage'],
   connector: {
     kind: 'fs',
     root: '~/Library/Mobile Documents/com~apple~CloudDocs',

--- a/src/providers/icloud/mail/index.ts
+++ b/src/providers/icloud/mail/index.ts
@@ -5,6 +5,7 @@ export const icloudMail = defineProvider({
   id: 'icloud_mail',
   name: 'iCloud Mail',
   description: 'Read, search, and send mail in an iCloud mailbox over IMAP and SMTP.',
+  keywords: ['email', 'message', 'inbox', 'reply', 'correspondence'],
   connector: {
     kind: 'imap',
     host: 'imap.mail.me.com',

--- a/src/providers/insightly/index.ts
+++ b/src/providers/insightly/index.ts
@@ -5,6 +5,7 @@ export const insightly = defineProvider({
   id: 'insightly',
   name: 'Insightly',
   description: 'Contacts, organisations, opportunities, and projects, via Insightly\'s official MCP server.',
+  keywords: ['crm', 'contact', 'lead', 'opportunity', 'pipeline'],
   connector: { kind: 'mcp', endpoint: 'https://mcp.insightly.com/mcp' },
   auth: { kind: 'oauth', registration: 'dynamic' },
 });

--- a/src/providers/jam/index.ts
+++ b/src/providers/jam/index.ts
@@ -5,6 +5,7 @@ export const jam = defineProvider({
   id: 'jam',
   name: 'Jam',
   description: 'Bug reports, with their console logs, network calls, and repro steps, via Jam\'s official MCP server.',
+  keywords: ['bug report', 'screen recording', 'issue', 'feedback', 'replay'],
   connector: { kind: 'mcp', endpoint: 'https://mcp.jam.dev/mcp' },
   auth: { kind: 'oauth', registration: 'dynamic' },
 });

--- a/src/providers/klaviyo/index.ts
+++ b/src/providers/klaviyo/index.ts
@@ -5,6 +5,7 @@ export const klaviyo = defineProvider({
   id: 'klaviyo',
   name: 'Klaviyo',
   description: 'Profiles, lists, segments, campaigns, and flows, via Klaviyo\'s official MCP server.',
+  keywords: ['email marketing', 'campaign', 'segment', 'subscriber', 'flow'],
   connector: { kind: 'mcp', endpoint: 'https://mcp.klaviyo.com/mcp' },
   auth: { kind: 'oauth', registration: 'dynamic' },
 });

--- a/src/providers/linear/index.ts
+++ b/src/providers/linear/index.ts
@@ -5,6 +5,7 @@ export const linear = defineProvider({
   id: 'linear',
   name: 'Linear',
   description: 'Issues, projects, comments, and cycles, via Linear\'s official MCP server.',
+  keywords: ['issue', 'ticket', 'bug', 'sprint', 'backlog'],
   connector: { kind: 'mcp', endpoint: 'https://mcp.linear.app/mcp' },
   auth: { kind: 'oauth', registration: 'dynamic', scopes: ['read', 'write'] },
   identity: { kind: 'tool', tool: 'get_workspace', field: 'name' },

--- a/src/providers/mailbox/index.ts
+++ b/src/providers/mailbox/index.ts
@@ -22,6 +22,7 @@ export const mailbox = defineProvider({
   name: 'Mailbox (any IMAP server)',
   description:
     'Read, search, and send mail in any IMAP mailbox — a company server, or a host with no provider of its own.',
+  keywords: ['email', 'message', 'inbox', 'reply', 'correspondence'],
   connector: {
     kind: 'imap',
     host: '{imap_host}',

--- a/src/providers/mercury/index.ts
+++ b/src/providers/mercury/index.ts
@@ -5,6 +5,7 @@ export const mercury = defineProvider({
   id: 'mercury',
   name: 'Mercury',
   description: 'Accounts, balances, transactions, and cards, via Mercury\'s official MCP server.',
+  keywords: ['bank', 'account', 'payment', 'balance', 'transaction'],
   connector: { kind: 'mcp', endpoint: 'https://mcp.mercury.com/mcp' },
   auth: { kind: 'oauth', registration: 'dynamic' },
 });

--- a/src/providers/miro/index.ts
+++ b/src/providers/miro/index.ts
@@ -5,6 +5,7 @@ export const miro = defineProvider({
   id: 'miro',
   name: 'Miro',
   description: 'Boards, frames, sticky notes, and shapes, via Miro\'s official MCP server.',
+  keywords: ['whiteboard', 'diagram', 'sticky note', 'canvas', 'brainstorm'],
   connector: { kind: 'mcp', endpoint: 'https://mcp.miro.com/mcp' },
   auth: { kind: 'oauth', registration: 'dynamic' },
 });

--- a/src/providers/mixpanel/index.ts
+++ b/src/providers/mixpanel/index.ts
@@ -5,6 +5,7 @@ export const mixpanel = defineProvider({
   id: 'mixpanel',
   name: 'Mixpanel',
   description: 'Events, funnels, retention, and cohorts, via Mixpanel\'s official MCP server.',
+  keywords: ['analytics', 'event', 'funnel', 'cohort', 'product analytics'],
   connector: { kind: 'mcp', endpoint: 'https://mcp.mixpanel.com/mcp' },
   auth: { kind: 'oauth', registration: 'dynamic' },
 });

--- a/src/providers/monday/index.ts
+++ b/src/providers/monday/index.ts
@@ -5,6 +5,7 @@ export const monday = defineProvider({
   id: 'monday',
   name: 'monday.com',
   description: 'Boards, items, groups, columns, and updates, via monday.com\'s official MCP server.',
+  keywords: ['board', 'task', 'project', 'workflow', 'status'],
   connector: { kind: 'mcp', endpoint: 'https://mcp.monday.com/mcp' },
   auth: { kind: 'oauth', registration: 'dynamic' },
 });

--- a/src/providers/mux/index.ts
+++ b/src/providers/mux/index.ts
@@ -5,6 +5,7 @@ export const mux = defineProvider({
   id: 'mux',
   name: 'Mux',
   description: 'Video assets, live streams, and playback analytics, via Mux\'s official MCP server.',
+  keywords: ['video', 'streaming', 'encoding', 'playback', 'asset'],
   connector: { kind: 'mcp', endpoint: 'https://mcp.mux.com' },
   auth: { kind: 'oauth', registration: 'dynamic' },
 });

--- a/src/providers/navan/index.ts
+++ b/src/providers/navan/index.ts
@@ -5,6 +5,7 @@ export const navan = defineProvider({
   id: 'navan',
   name: 'Navan',
   description: 'Trips, bookings, and travel expenses, via Navan\'s official MCP server.',
+  keywords: ['travel', 'booking', 'expense', 'trip', 'flight'],
   connector: { kind: 'mcp', endpoint: 'https://mcp.navan.com/mcp' },
   auth: { kind: 'oauth', registration: 'dynamic' },
 });

--- a/src/providers/neon/index.ts
+++ b/src/providers/neon/index.ts
@@ -5,6 +5,7 @@ export const neon = defineProvider({
   id: 'neon',
   name: 'Neon',
   description: 'Postgres projects, branches, SQL, and docs, via Neon\'s official MCP server.',
+  keywords: ['database', 'postgres', 'branch', 'serverless', 'sql'],
   connector: { kind: 'mcp', endpoint: 'https://mcp.neon.tech/mcp' },
   auth: { kind: 'oauth', registration: 'dynamic' },
 });

--- a/src/providers/netlify/index.ts
+++ b/src/providers/netlify/index.ts
@@ -5,6 +5,7 @@ export const netlify = defineProvider({
   id: 'netlify',
   name: 'Netlify',
   description: 'Sites, deploys, functions, and environment variables, via Netlify\'s official MCP server.',
+  keywords: ['deployment', 'hosting', 'build', 'domain', 'site'],
   connector: { kind: 'mcp', endpoint: 'https://netlify-mcp.netlify.app/mcp' },
   auth: { kind: 'oauth', registration: 'dynamic' },
 });

--- a/src/providers/nextcloud/calendar/index.ts
+++ b/src/providers/nextcloud/calendar/index.ts
@@ -13,6 +13,7 @@ export const nextcloudCalendar = defineProvider({
   id: 'nextcloud_calendar',
   name: 'Nextcloud Calendar',
   description: 'Read and create events in Nextcloud calendars over CalDAV, on your own server.',
+  keywords: ['meeting', 'invite', 'appointment', 'schedule', 'availability'],
   connector: { kind: 'dav', base_url: 'https://{host}', service: 'caldav' },
   auth: { kind: 'basic', app: NEXTCLOUD_APP },
   identity: { kind: 'connector' },

--- a/src/providers/nextcloud/contacts/index.ts
+++ b/src/providers/nextcloud/contacts/index.ts
@@ -5,6 +5,7 @@ export const nextcloudContacts = defineProvider({
   id: 'nextcloud_contacts',
   name: 'Nextcloud Contacts',
   description: 'Search and read contacts in a Nextcloud address book over CardDAV, on your own server.',
+  keywords: ['address book', 'directory', 'people', 'email address'],
   connector: { kind: 'dav', base_url: 'https://{host}', service: 'carddav' },
   auth: { kind: 'basic', app: NEXTCLOUD_APP },
   identity: { kind: 'connector' },

--- a/src/providers/notion/index.ts
+++ b/src/providers/notion/index.ts
@@ -9,6 +9,7 @@ export const notion = defineProvider({
   id: 'notion',
   name: 'Notion',
   description: 'Pages, databases, comments, and workspace search, via Notion\'s official MCP server.',
+  keywords: ['notes', 'wiki', 'page', 'database', 'knowledge base'],
   connector: { kind: 'mcp', endpoint: 'https://mcp.notion.com/mcp' },
   auth: { kind: 'oauth', registration: 'dynamic' },
   /**

--- a/src/providers/paddle/index.ts
+++ b/src/providers/paddle/index.ts
@@ -5,6 +5,7 @@ export const paddle = defineProvider({
   id: 'paddle',
   name: 'Paddle',
   description: 'Products, prices, subscriptions, and transactions, via Paddle\'s official MCP server.',
+  keywords: ['payment', 'subscription', 'invoice', 'billing', 'checkout'],
   connector: { kind: 'mcp', endpoint: 'https://mcp.paddle.com/mcp' },
   auth: { kind: 'oauth', registration: 'dynamic' },
 });

--- a/src/providers/paypal/index.ts
+++ b/src/providers/paypal/index.ts
@@ -5,6 +5,7 @@ export const paypal = defineProvider({
   id: 'paypal',
   name: 'PayPal',
   description: 'Invoices, orders, payments, subscriptions, and disputes, via PayPal\'s official MCP server.',
+  keywords: ['payment', 'invoice', 'transaction', 'money', 'checkout'],
   connector: { kind: 'mcp', endpoint: 'https://mcp.paypal.com/mcp' },
   auth: { kind: 'oauth', registration: 'dynamic' },
 });

--- a/src/providers/posthog/index.ts
+++ b/src/providers/posthog/index.ts
@@ -5,6 +5,7 @@ export const posthog = defineProvider({
   id: 'posthog',
   name: 'PostHog',
   description: 'Events, insights, feature flags, and session replays, via PostHog\'s official MCP server.',
+  keywords: ['analytics', 'event', 'funnel', 'session replay', 'feature flag'],
   connector: { kind: 'mcp', endpoint: 'https://mcp.posthog.com/mcp' },
   auth: { kind: 'oauth', registration: 'dynamic' },
 });

--- a/src/providers/prisma/index.ts
+++ b/src/providers/prisma/index.ts
@@ -5,6 +5,7 @@ export const prisma = defineProvider({
   id: 'prisma',
   name: 'Prisma',
   description: 'Postgres databases, schema, and migrations, via Prisma\'s official MCP server.',
+  keywords: ['database', 'orm', 'schema', 'migration', 'query'],
   connector: { kind: 'mcp', endpoint: 'https://mcp.prisma.io/mcp' },
   auth: { kind: 'oauth', registration: 'dynamic' },
 });

--- a/src/providers/ramp/index.ts
+++ b/src/providers/ramp/index.ts
@@ -5,6 +5,7 @@ export const ramp = defineProvider({
   id: 'ramp',
   name: 'Ramp',
   description: 'Cards, transactions, reimbursements, and spend limits, via Ramp\'s official MCP server.',
+  keywords: ['expense', 'card', 'spending', 'transaction', 'reimbursement'],
   connector: { kind: 'mcp', endpoint: 'https://mcp.ramp.com/mcp' },
   auth: { kind: 'oauth', registration: 'dynamic' },
 });

--- a/src/providers/recurly/index.ts
+++ b/src/providers/recurly/index.ts
@@ -5,6 +5,7 @@ export const recurly = defineProvider({
   id: 'recurly',
   name: 'Recurly',
   description: 'Subscriptions, invoices, and accounts, via Recurly\'s official MCP server.',
+  keywords: ['subscription', 'billing', 'invoice', 'payment', 'recurring'],
   connector: { kind: 'mcp', endpoint: 'https://mcp.recurly.com/mcp' },
   auth: { kind: 'oauth', registration: 'dynamic' },
 });

--- a/src/providers/reddit/index.ts
+++ b/src/providers/reddit/index.ts
@@ -28,6 +28,7 @@ export const reddit = defineProvider({
   name: 'Reddit',
   description:
     'Read subreddits, posts, comments, and search, and post, comment, vote, and edit as your account, via the Reddit API.',
+  keywords: ['forum', 'subreddit', 'post', 'comment', 'discussion'],
   connector: {
     kind: 'http',
     // Host only. Reddit puts no version in the path, and this must equal the

--- a/src/providers/remote/index.ts
+++ b/src/providers/remote/index.ts
@@ -5,6 +5,7 @@ export const remote = defineProvider({
   id: 'remote',
   name: 'Remote',
   description: 'Employees, contracts, payroll, and time off, via Remote\'s official MCP server.',
+  keywords: ['payroll', 'employment', 'contractor', 'hr', 'onboarding'],
   connector: { kind: 'mcp', endpoint: 'https://mcp.remote.com/mcp' },
   auth: { kind: 'oauth', registration: 'dynamic' },
 });

--- a/src/providers/render/index.ts
+++ b/src/providers/render/index.ts
@@ -13,6 +13,7 @@ export const render = defineProvider({
   id: 'render',
   name: 'Render',
   description: 'Services, deploys, logs, and environment variables, via Render\'s official MCP server.',
+  keywords: ['deployment', 'hosting', 'service', 'build', 'infrastructure'],
   connector: { kind: 'mcp', endpoint: 'https://mcp.render.com/mcp' },
   auth: { kind: 'bearer' },
   setup: {

--- a/src/providers/replicate/index.ts
+++ b/src/providers/replicate/index.ts
@@ -5,6 +5,7 @@ export const replicate = defineProvider({
   id: 'replicate',
   name: 'Replicate',
   description: 'Models, predictions, and deployments, via Replicate\'s official MCP server.',
+  keywords: ['model', 'inference', 'machine learning', 'prediction', 'ai'],
   connector: { kind: 'mcp', endpoint: 'https://mcp.replicate.com/mcp' },
   auth: { kind: 'oauth', registration: 'dynamic' },
 });

--- a/src/providers/resend/index.ts
+++ b/src/providers/resend/index.ts
@@ -5,6 +5,7 @@ export const resend = defineProvider({
   id: 'resend',
   name: 'Resend',
   description: 'Transactional email, domains, and delivery events, via Resend\'s official MCP server.',
+  keywords: ['email', 'transactional email', 'send', 'delivery', 'template'],
   connector: { kind: 'mcp', endpoint: 'https://mcp.resend.com/mcp' },
   auth: { kind: 'oauth', registration: 'dynamic' },
 });

--- a/src/providers/riverside/index.ts
+++ b/src/providers/riverside/index.ts
@@ -5,6 +5,7 @@ export const riverside = defineProvider({
   id: 'riverside',
   name: 'Riverside',
   description: 'Recordings, transcripts, and clips, via Riverside\'s official MCP server.',
+  keywords: ['recording', 'podcast', 'video', 'transcript', 'studio'],
   connector: { kind: 'mcp', endpoint: 'https://mcp.riverside.com/mcp' },
   auth: { kind: 'oauth', registration: 'dynamic' },
 });

--- a/src/providers/rootly/index.ts
+++ b/src/providers/rootly/index.ts
@@ -5,6 +5,7 @@ export const rootly = defineProvider({
   id: 'rootly',
   name: 'Rootly',
   description: 'Incidents, alerts, retrospectives, and on-call schedules, via Rootly\'s official MCP server.',
+  keywords: ['incident', 'on call', 'postmortem', 'alert', 'response'],
   connector: { kind: 'mcp', endpoint: 'https://mcp.rootly.com/mcp' },
   auth: { kind: 'oauth', registration: 'dynamic' },
 });

--- a/src/providers/rudderstack/index.ts
+++ b/src/providers/rudderstack/index.ts
@@ -5,6 +5,7 @@ export const rudderstack = defineProvider({
   id: 'rudderstack',
   name: 'RudderStack',
   description: 'Sources, destinations, and event streams, via RudderStack\'s official MCP server.',
+  keywords: ['event', 'pipeline', 'analytics', 'customer data', 'tracking'],
   connector: { kind: 'mcp', endpoint: 'https://mcp.rudderstack.com/mcp' },
   auth: { kind: 'oauth', registration: 'dynamic' },
 });

--- a/src/providers/salesloft/index.ts
+++ b/src/providers/salesloft/index.ts
@@ -5,6 +5,7 @@ export const salesloft = defineProvider({
   id: 'salesloft',
   name: 'Salesloft',
   description: 'Cadences, people, and sales activity, via Salesloft\'s official MCP server.',
+  keywords: ['sales', 'cadence', 'outreach', 'prospect', 'crm'],
   connector: { kind: 'mcp', endpoint: 'https://mcp.salesloft.com/mcp' },
   auth: { kind: 'oauth', registration: 'dynamic' },
 });

--- a/src/providers/sanity/index.ts
+++ b/src/providers/sanity/index.ts
@@ -5,6 +5,7 @@ export const sanity = defineProvider({
   id: 'sanity',
   name: 'Sanity',
   description: 'Documents, datasets, schema, and content releases, via Sanity\'s official MCP server.',
+  keywords: ['cms', 'content', 'document', 'schema', 'publishing'],
   connector: { kind: 'mcp', endpoint: 'https://mcp.sanity.io/mcp' },
   auth: { kind: 'oauth', registration: 'dynamic' },
 });

--- a/src/providers/sentry/index.ts
+++ b/src/providers/sentry/index.ts
@@ -5,6 +5,7 @@ export const sentry = defineProvider({
   id: 'sentry',
   name: 'Sentry',
   description: 'Issues, events, stack traces, and releases, via Sentry\'s official MCP server.',
+  keywords: ['error', 'exception', 'crash', 'stack trace', 'monitoring'],
   connector: { kind: 'mcp', endpoint: 'https://mcp.sentry.dev/mcp' },
   auth: { kind: 'oauth', registration: 'dynamic' },
 });

--- a/src/providers/shortcut/index.ts
+++ b/src/providers/shortcut/index.ts
@@ -5,6 +5,7 @@ export const shortcut = defineProvider({
   id: 'shortcut',
   name: 'Shortcut',
   description: 'Stories, epics, iterations, and workflows, via Shortcut\'s official MCP server.',
+  keywords: ['issue', 'story', 'ticket', 'sprint', 'backlog'],
   connector: { kind: 'mcp', endpoint: 'https://mcp.shortcut.com/mcp' },
   auth: { kind: 'oauth', registration: 'dynamic' },
 });

--- a/src/providers/slack/index.ts
+++ b/src/providers/slack/index.ts
@@ -28,6 +28,7 @@ export const slack = defineProvider({
   id: 'slack',
   name: 'Slack',
   description: 'Messages, threads, channels, files, and canvases, via Slack\'s official MCP server.',
+  keywords: ['chat', 'channel', 'message', 'direct message', 'team'],
   connector: { kind: 'mcp', endpoint: 'https://mcp.slack.com/mcp' },
   /**
    * An mcp connector that names its own endpoints, which is what takes it off

--- a/src/providers/square/index.ts
+++ b/src/providers/square/index.ts
@@ -5,6 +5,7 @@ export const square = defineProvider({
   id: 'square',
   name: 'Square',
   description: 'Payments, orders, catalog, inventory, and customers, via Square\'s official MCP server.',
+  keywords: ['payment', 'point of sale', 'invoice', 'transaction', 'merchant'],
   connector: { kind: 'mcp', endpoint: 'https://mcp.squareup.com/mcp' },
   auth: { kind: 'oauth', registration: 'dynamic' },
 });

--- a/src/providers/storyblok/index.ts
+++ b/src/providers/storyblok/index.ts
@@ -5,6 +5,7 @@ export const storyblok = defineProvider({
   id: 'storyblok',
   name: 'Storyblok',
   description: 'Stories, components, assets, and spaces, via Storyblok\'s official MCP server.',
+  keywords: ['cms', 'content', 'story', 'publishing', 'component'],
   connector: { kind: 'mcp', endpoint: 'https://mcp.storyblok.com/mcp' },
   auth: { kind: 'oauth', registration: 'dynamic' },
 });

--- a/src/providers/stripe/index.ts
+++ b/src/providers/stripe/index.ts
@@ -5,6 +5,7 @@ export const stripe = defineProvider({
   id: 'stripe',
   name: 'Stripe',
   description: 'Payments, customers, invoices, subscriptions, and balances, via Stripe\'s official MCP server.',
+  keywords: ['payment', 'invoice', 'subscription', 'customer', 'billing'],
   connector: { kind: 'mcp', endpoint: 'https://mcp.stripe.com' },
   auth: { kind: 'oauth', registration: 'dynamic' },
 });

--- a/src/providers/supabase/index.ts
+++ b/src/providers/supabase/index.ts
@@ -5,6 +5,7 @@ export const supabase = defineProvider({
   id: 'supabase',
   name: 'Supabase',
   description: 'Projects, database schema, SQL, edge functions, and docs, via Supabase\'s official MCP server.',
+  keywords: ['database', 'postgres', 'auth', 'storage', 'backend'],
   connector: { kind: 'mcp', endpoint: 'https://mcp.supabase.com/mcp' },
   auth: { kind: 'oauth', registration: 'dynamic' },
   /**

--- a/src/providers/tavily/index.ts
+++ b/src/providers/tavily/index.ts
@@ -5,6 +5,7 @@ export const tavily = defineProvider({
   id: 'tavily',
   name: 'Tavily',
   description: 'Web search and page content extraction, via Tavily\'s official MCP server.',
+  keywords: ['search', 'web search', 'research', 'query', 'answer'],
   connector: { kind: 'mcp', endpoint: 'https://mcp.tavily.com/mcp' },
   auth: { kind: 'oauth', registration: 'dynamic' },
 });

--- a/src/providers/todoist/index.ts
+++ b/src/providers/todoist/index.ts
@@ -5,6 +5,7 @@ export const todoist = defineProvider({
   id: 'todoist',
   name: 'Todoist',
   description: 'Tasks, projects, sections, labels, and filters, via Todoist\'s official MCP server.',
+  keywords: ['todo', 'task', 'reminder', 'checklist', 'due date'],
   connector: { kind: 'mcp', endpoint: 'https://ai.todoist.net/mcp' },
   auth: { kind: 'oauth', registration: 'dynamic' },
 });

--- a/src/providers/vercel/index.ts
+++ b/src/providers/vercel/index.ts
@@ -5,6 +5,7 @@ export const vercel = defineProvider({
   id: 'vercel',
   name: 'Vercel',
   description: 'Projects, deployments, build logs, and domains, via Vercel\'s official MCP server.',
+  keywords: ['deployment', 'hosting', 'build', 'domain', 'preview'],
   connector: { kind: 'mcp', endpoint: 'https://mcp.vercel.com' },
   auth: { kind: 'oauth', registration: 'dynamic' },
 });

--- a/src/providers/vimeo/index.ts
+++ b/src/providers/vimeo/index.ts
@@ -5,6 +5,7 @@ export const vimeo = defineProvider({
   id: 'vimeo',
   name: 'Vimeo',
   description: 'Videos, folders, showcases, and analytics, via Vimeo\'s official MCP server.',
+  keywords: ['video', 'upload', 'streaming', 'player', 'library'],
   connector: { kind: 'mcp', endpoint: 'https://mcp.vimeo.com/mcp' },
   auth: { kind: 'oauth', registration: 'dynamic' },
 });

--- a/src/providers/webflow/index.ts
+++ b/src/providers/webflow/index.ts
@@ -5,6 +5,7 @@ export const webflow = defineProvider({
   id: 'webflow',
   name: 'Webflow',
   description: 'Sites, pages, CMS collections, and items, via Webflow\'s official MCP server.',
+  keywords: ['website', 'cms', 'design', 'publishing', 'page'],
   connector: { kind: 'mcp', endpoint: 'https://mcp.webflow.com/mcp' },
   auth: { kind: 'oauth', registration: 'dynamic' },
 });

--- a/src/providers/whimsical/index.ts
+++ b/src/providers/whimsical/index.ts
@@ -5,6 +5,7 @@ export const whimsical = defineProvider({
   id: 'whimsical',
   name: 'Whimsical',
   description: 'Boards, flowcharts, wireframes, and mind maps, via Whimsical\'s official MCP server.',
+  keywords: ['diagram', 'flowchart', 'wireframe', 'mind map', 'canvas'],
   connector: { kind: 'mcp', endpoint: 'https://mcp.whimsical.com/mcp' },
   auth: { kind: 'oauth', registration: 'dynamic' },
 });

--- a/src/providers/wix/index.ts
+++ b/src/providers/wix/index.ts
@@ -5,6 +5,7 @@ export const wix = defineProvider({
   id: 'wix',
   name: 'Wix',
   description: 'Sites, stores, bookings, and CMS data, via Wix\'s official MCP server.',
+  keywords: ['website', 'cms', 'store', 'page', 'publishing'],
   connector: { kind: 'mcp', endpoint: 'https://mcp.wix.com/mcp' },
   auth: { kind: 'oauth', registration: 'dynamic' },
 });

--- a/src/providers/workable/index.ts
+++ b/src/providers/workable/index.ts
@@ -5,6 +5,7 @@ export const workable = defineProvider({
   id: 'workable',
   name: 'Workable',
   description: 'Jobs, candidates, and interviews, via Workable\'s official MCP server.',
+  keywords: ['hiring', 'candidate', 'job', 'recruiting', 'applicant'],
   connector: { kind: 'mcp', endpoint: 'https://mcp.workable.com/mcp' },
   auth: { kind: 'oauth', registration: 'dynamic' },
 });

--- a/src/providers/yahoo_mail/index.ts
+++ b/src/providers/yahoo_mail/index.ts
@@ -13,6 +13,7 @@ export const yahooMail = defineProvider({
   name: 'Yahoo Mail',
   description:
     'Read, search, and send mail in a Yahoo mailbox over IMAP and SMTP, with an app password.',
+  keywords: ['email', 'message', 'inbox', 'reply', 'correspondence'],
   connector: {
     kind: 'imap',
     host: 'imap.mail.yahoo.com',

--- a/src/providers/zapier/index.ts
+++ b/src/providers/zapier/index.ts
@@ -5,6 +5,7 @@ export const zapier = defineProvider({
   id: 'zapier',
   name: 'Zapier',
   description: 'Zaps, and the actions they reach across thousands of apps, via Zapier\'s official MCP server.',
+  keywords: ['automation', 'workflow', 'integration', 'trigger', 'connect'],
   connector: { kind: 'mcp', endpoint: 'https://mcp.zapier.com/api/mcp/mcp' },
   auth: { kind: 'oauth', registration: 'dynamic' },
 });

--- a/src/providers/zoho_mail/index.ts
+++ b/src/providers/zoho_mail/index.ts
@@ -16,6 +16,7 @@ export const zohoMail = defineProvider({
   name: 'Zoho Mail',
   description:
     'Read, search, and send mail in a Zoho mailbox over IMAP and SMTP, with an application-specific password.',
+  keywords: ['email', 'message', 'inbox', 'reply', 'correspondence'],
   connector: {
     kind: 'imap',
     host: 'imap.zoho.com',


### PR DESCRIPTION
0.10.4 made the surface searchable and reached two thirds of it. This is the rest, and it is two halves of one gap.

## The connectors

`titleFor` and `withKeywords` were applied by `http` and `mcp`. Both turn something foreign into ours and are already rewriting every field, so there was an obvious place to put them. `dav`, `imap` and `fs` are not: their capability sets are fixed in code and returned from `discover` as they stand, so there was no rewriting step to apply them in, and for the same reason nobody noticed they were skipping it.

Thirteen providers were affected, every mailbox that is not Gmail among them. They carried no `title` at all, and could not have benefited from `keywords` even once their manifests declared some.

Found by searching the live 278-tool endpoint for *send an email*: `icloud_mail_send_message` came back third, with no title and no keywords, while the two Gmail tools above it had both.

`searchableCapabilities` is that missing step, and it prefers a `title` the capability already declares on the same principle `titleFor` states for an upstream one.

## The manifests

90 of 105 providers declared no keywords, so 0.10.4's vocabulary fix reached Google and Microsoft and stopped there.

| kind | providers | had keywords before | now |
|---|---|---|---|
| `dav` | 6 | 0 | 6 |
| `fs` | 1 | 0 | 1 |
| `http` | 15 | 12 | 15 |
| `imap` | 6 | 1 | 6 |
| `mcp` | 77 | 2 | 77 |

The categories reuse the sets already established rather than inventing new ones: mail is the same five words on iCloud, Fastmail, Yahoo, Zoho and mailbox.org as on Gmail, because somebody asking for "email" should not have to know whose mailbox it is. The other 78 say what the product is for in the words a person would use, which is the whole point of the field. A vendor names its own concepts, and `subreddit` is not what somebody types when they want a forum.

## The test is the part worth reading

`searchability.test.ts` covered `titleFor` and `withKeywords` thoroughly and never that a connector calls them, which is exactly how this survived 0.10.4. The new tests go through `discover` on each of the three connectors. Reverting any one of them fails its own test, checked rather than assumed.

The dav and fs tests were passing `{} as DiscoveryContext`, which is why they had nothing to say about this. They now pass a manifest, like the imap tests already did.

## Verification

- `bun test`: 3359 pass, 12 skip, 2 fail, against 3356/12/2 on `develop`. The two failures are the `emitted.test.ts` timeout flakes, which fail identically on `develop`.
- `bun run typecheck` clean. `architecture.test.ts` passes, including the file-size budget.
- The per-tool (64 KB) and per-provider (192 KB) size budgets pass unchanged.

## What could not be checked here

A `dav`, `imap` or `fs` connection has no capability list until it authenticates, so `connection declare` on a scratch workspace advertises nothing for them and the fix cannot be demonstrated end to end without real credentials. That is the same constraint ADR-075 records for the `mcp` providers. The wiring tests are the substitute; the live check is a search for *send an email* on a deployed endpoint with iCloud connected, which should now put `icloud_mail_send_message` above nothing and carry a title.