### PR TITLE
chore: 0.11.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lanes-sh/link",
-  "version": "0.10.5",
+  "version": "0.11.0",
   "description": "A self-hostable MCP gateway for all your connections, memory, tasks, files, and secrets",
   "license": "Apache-2.0",
   "homepage": "https://lanes.sh/link",


### PR DESCRIPTION
Sets the version deliberately, so the merge to `main` takes the publish path
rather than the propose path.

**Minor rather than patch.** It adds something an operator configures —
`surface: crunched` (ADR-076) — and amends an accepted ADR. Calibrated against
0.10.0, which was earned by a single notable change rather than by a breaking
one.

Measured on a deployed endpoint, both ways, same generation:

| | tools | on the wire | ≈ tokens |
|---|---|---|---|
| `full` | 278 | 702 KB | 180,000 |
| `crunched` | 28 | 31 KB | 8,000 |

**Nothing here is breaking.** `full` is the default and is bit-identical, so an
endpoint upgraded without setting `surface:` serves the list it served before.

The rest of the release is availability: cold start ~10.5s → 6.3s, the refusal
audit and stale-config probe now running for 2025-era clients, 503 instead of an
unlogged 500 on a store outage, `WWW-Authenticate` on the 429 that replaces a
401, and a rotated refresh token no longer discarded.