### PR TITLE
0.11.0

### DIFF
--- a/docs/detailed/adr/076-an-endpoint-may-advertise-less-than-it-reaches.md
+++ b/docs/detailed/adr/076-an-endpoint-may-advertise-less-than-it-reaches.md
@@ -1,0 +1,152 @@
+# ADR-076: An endpoint may advertise less than it reaches
+
+**Status:** accepted · **Amends** [ADR-075](075-the-list-a-client-caches-must-stop-changing.md) by
+taking the decision it deferred · **Depends on** [ADR-032](032-a-stateless-endpoint-does-not-announce-its-tools.md)
+
+## Context
+
+ADR-075 built `lanes_tools_search` and `lanes_tools_call`, measured the eager surface at 428 KB for
+the `http` providers alone, and then declined to shrink anything:
+
+> Nothing is removed, and no threshold is introduced. Two small tools cost a client almost nothing,
+> so they are unconditional. Whether typed tools should ever *stop* being advertised above some size
+> is a different decision, it needs a measurement of this surface against them that no published
+> evaluation can supply, and it is not taken here.
+
+And, in what it does not do:
+
+> It does not decide that typed tools have a size limit. Only that if they ever do, the number comes
+> from measuring this surface against them.
+
+This ADR takes that decision. It is an amendment rather than a reversal: every mechanism ADR-075
+built is what makes this possible, and the default is unchanged.
+
+**What the measurement now says.** Taken from a deployed endpoint serving two profiles and eleven
+providers, by asking it — one `tools/list`, both ways, same generation:
+
+| | tools | on the wire | ≈ tokens |
+|---|---|---|---|
+| `full` | 278 | 702 KB | 180,000 |
+| `crunched` | 28 | 31 KB | 8,000 |
+
+ADR-075's table measured 428 KB across every `http` provider. This is larger because it is the
+whole surface: 77 of ~105 providers declare `connector.kind: 'mcp'` and their schemas are the
+upstream server's verbatim, which is the part that ADR paragraph said no care here can move.
+
+**180,000 tokens is not a large fraction of a context window. It is most of one**, spent before
+the agent has read the request. That is the number the decision turns on, and it was not available
+when ADR-075 deferred it.
+
+The clients this is advertised to do not all accept it either:
+
+- Hosted Claude surfaces are reported to cap the aggregate tool list at 256 across all connectors,
+  keeping the alphabetically-first 256 and truncating the namespace that straddles the boundary. At
+  278 that boundary falls inside one provider, which disappears with no error anywhere.
+- The cost is not only the ceiling, and the ceiling is not the worst of it. ADR-075 already
+  recorded the accuracy figures — 49% to 74% on one model, 79.5% to 88.1% on another — and
+  attributed them to a discovery step not being a tax on selection. Those numbers cut the other way
+  too: a catalogue large enough to displace the request is a catalogue the model selects from worse.
+  A client that truncates at 256 at least still holds 256 usable tools; one that accepts all 278
+  carries 180,000 tokens of schema into every turn.
+
+The observed failure is the one that motivated the measurement. An agent holding this surface
+reported that it could not see the endpoint's tools at all, then found them when asked a second
+time — behaviour consistent with a list too large to be usefully attended to, and indistinguishable
+by the operator from the endpoint being down.
+
+## Decision
+
+A profile may declare `surface: crunched`. It defaults to `full`, which is what every profile
+written before this keeps getting and what the endpoint has always served.
+
+Under `crunched` the endpoint registers the owner layer and the stable-name pair, and nothing else.
+Every other capability stays in the merged set: reachable through `lanes_tools_call`, resolved
+through the same dispatcher, evaluated against the same policy, redacted by the same rules, and
+written to the same audit row. **No capability is lost. What shrinks is exposition, not authority.**
+
+That distinction is load-bearing and is the reason this is not `grants:`. A `deny:` rule removes a
+capability from the merged set, so `lanes_tools_call` cannot reach it either — which is correct for
+a capability the operator does not want reachable, and wrong for one they merely do not want in
+every client's context.
+
+**The owner layer is the line, and it is not a shortlist somebody tuned.** It is the material this
+endpoint holds itself rather than anybody's API, it is small, and the instructions name several of
+its tools directly: an agent is told to call `lanes_setup_overview` before saying something cannot
+be reached, and `lanes_entities.find` before using anyone's address. Advertising less than this
+would leave those sentences pointing at tools the client cannot see.
+
+**It is read from the primary profile only.** One endpoint serves several profiles and `tools/list`
+is their union, so how much of it is advertised is a property of the endpoint rather than of a row
+in it. `instance.port` already follows that rule.
+
+## Why this is not the thing ADR-075 refused
+
+ADR-075 refused two shapes, and this is neither.
+
+**It is not per-client.** The mode comes from configuration the operator wrote, not from anything on
+the request. `clientLabel` is still self-reported, still recorded for audit, and still never
+consulted. The 2026-07-28 revision's requirement that the tool set not vary per-connection or as a
+side effect of other requests is met: it varies per *deployment*, and does not move until the
+operator changes it and a generation reloads.
+
+**It is not a per-connection `lazy: true`.** ADR-075 gave three objections to that and named the
+right granularity in the same breath — "what makes a surface too large is the endpoint's total,
+which is a property of the profile and not of one row in it". This takes that conclusion. The three
+objections are answered rather than dodged: there is one dispatch path and always was
+(`dispatcher.invoke`), the model is told which shape it is looking at by a substituted paragraph in
+`instructions`, and the operator sees the result in `lanes link tools`, which asks the endpoint.
+
+**It is not a threshold.** Nothing switches itself on at a size. ADR-075's strongest argument
+against removal was that clients which defer well already do it better than a server can — with a
+local index, no round trip, and their prompt cache intact — and that removing typed tools would make
+those clients worse to help the ones that pin a stale list. That argument is undefeated, and it is
+exactly why this is opt-in and defaults to `full`. An operator whose clients handle 278 tools should
+change nothing.
+
+## Consequences
+
+**The advertised count and the wire must agree.** `visibleToolCount` feeds `/reload`, the
+`advertising` log line, and what `connect` prints, and ADR-032 exists because an operator compares
+that number against what their client shows. A mode that advertised less than it counted would turn
+that comparison into a false alarm. So the registration loop, the count, and the visible set consume
+one function, and a test asserts the reported count equals the length of `tools/list` in both modes.
+
+**`Generation.visible()` is no longer "everything reachable".** It is what the built server will
+answer, which under `crunched` is a smaller set. This matters in the direction that fails silently:
+a name left in that set but absent from the wire means a call to it is answered by the SDK and
+recorded nowhere, against `audit.every-invocation`. Prompts and resources are unaffected by the mode
+and stay in regardless — a skill is a prompt, and was never on the tool count.
+
+**A `resource_link` cannot be handed back through the gateway.** `lanes_tools_call` returns text, and
+ADR-075 accepted that because the caller could be told to use the typed tool instead. Under
+`crunched` there is no typed tool to name, so the message says the link cannot be returned rather
+than naming one the client cannot call. This is the one thing the mode genuinely costs.
+
+**Flipping the mode changes a list clients cache.** `listChanged` is `false` (ADR-032) and nothing
+here makes a client re-read. So this is a deliberate operation with the same consequence as
+connecting a new provider — issue #162's consequence — and not a setting to toggle casually. It is
+declared in config for that reason: an operator sets it before registering a client, which is the
+same remedy ADR-075 reached for.
+
+## What this does not do
+
+**It does not change what `full` serves.** The mode is spread into the options object, so `full`
+passes nothing and cannot be told apart from a caller that never heard of the setting. The test
+suite asserts it: every existing test passes unchanged.
+
+**It does not make the core configurable.** A `core:` list of patterns was considered and left out.
+The owner layer is a principled line rather than a preference, and a knob would invite a surface
+tuned per deployment — which is how two endpoints running the same version come to disagree about
+what they advertise. If a deployment needs a different core, that is a decision with its own
+evidence, taken then.
+
+**It does not move `contract`.** The key is optional and additive, so every profile written before
+it loads unchanged — the same reasoning as `identity`.
+
+**It does not retire the typed tools.** They are what `full` serves, what most deployments should
+keep serving, and what the search surface still describes. ADR-075's two-directions argument stands:
+this is a remedy for the clients that need one, not a claim that eager exposition was a mistake.
+
+**It does not fix cold start, and should not be mistaken for it.** The endpoint that produced the
+278 also takes roughly ten seconds to bind, because it opens every profile before it listens. A
+smaller list is served no sooner. That is a separate problem with a separate remedy.

--- a/docs/detailed/adr/README.md
+++ b/docs/detailed/adr/README.md
@@ -88,6 +88,7 @@ Run.
 | [073](073-a-connection-names-its-own-account.md) | A connection names its own account; the operator is asked last, and never handed a uuid to live with |
 | [074](074-the-endpoint-records-where-it-bound.md) | The endpoint records where it bound, so an edit reaches the one that is running rather than a port derived from the profile it edited |
 | [075](075-the-list-a-client-caches-must-stop-changing.md) | The typed tool list stays and gains a search beside it, so a client that never re-reads can still reach a new connection |
+| [076](076-an-endpoint-may-advertise-less-than-it-reaches.md) | An endpoint may advertise less than it reaches, so a catalogue too large for its clients can shrink without any capability leaving it |
 
 Where an ADR departs from init.md, it says so at the top. Three are significant:
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lanes-sh/link",
-  "version": "0.10.5",
+  "version": "0.11.0",
   "description": "A self-hostable MCP gateway for all your connections, memory, tasks, files, and secrets",
   "license": "Apache-2.0",
   "homepage": "https://lanes.sh/link",

--- a/src/cli/commands/operate.test.ts
+++ b/src/cli/commands/operate.test.ts
@@ -53,7 +53,7 @@ describe('the token command outputs prints', () => {
   test('names the workspace and not a profile, on either path', async () => {
     // Whichever branch is taken — a `lanes` on PATH, or the checkout-relative
     // fallback — the selection has to survive into the line somebody pastes.
-    const invocation = await tokenInvocation('cloud');
+    const invocation = await tokenInvocation('cloud', '/nonexistent-workspace-for-this-test');
 
     expect(invocation.command).toContain('--workspace cloud');
     expect(invocation.command).not.toContain('--profile');

--- a/src/cli/commands/operate/outputs.ts
+++ b/src/cli/commands/operate/outputs.ts
@@ -125,7 +125,10 @@ export async function outputs(flags: OutputsFlags): Promise<void> {
         paint: style.dim,
       });
     } else {
-      const invocation = await tokenInvocation(runtime.resolution.target);
+      const invocation = await tokenInvocation(
+        runtime.resolution.target,
+        runtime.resolution.workspaceRoot,
+      );
       print(
         `  claude mcp add --transport http lanes-link ${url} \\\n` +
           `    --header "Authorization: Bearer $(${invocation.command})"`,
@@ -165,6 +168,7 @@ export async function outputs(flags: OutputsFlags): Promise<void> {
  */
 export async function tokenInvocation(
   target: string,
+  workspaceRoot: string,
 ): Promise<{ command: string; onPath: boolean }> {
   // `--workspace`, always, and from the *resolved* selection rather than the
   // flags. A token is per-workspace, so `outputs --workspace cloud` printing a
@@ -180,7 +184,23 @@ export async function tokenInvocation(
   const resolved = Bun.which('lanes');
   if (resolved) {
     try {
-      const result = Bun.spawnSync([resolved, ...argv]);
+      // Pinned to the workspace this command already resolved, rather than
+      // letting the child resolve its own. `resolveWorkspaceRoot` checks
+      // `LANES_LINK_HOME`, then walks ancestors, then falls back to
+      // `~/.lanes-link` — so a bare spawn asks a *different* question than the
+      // one being answered, and the answer it gives is about somebody else's
+      // workspace. That is the failure this function's own history records:
+      // the equality check that used to catch "a `lanes` on PATH belonging to a
+      // different workspace" had to be dropped, and nothing replaced it.
+      //
+      // It also stops the test suite reaching the operator's real workspace.
+      // `bun test` from a worktree ran this against `~/.lanes-link` with
+      // `--workspace cloud`, which is a network call to a live bucket from a
+      // unit test — and the five-second timeout it hit is what made a green
+      // checkout look red.
+      const result = Bun.spawnSync([resolved, ...argv], {
+        env: { ...process.env, LANES_LINK_HOME: workspaceRoot },
+      });
       // Exit status and a plausible token, rather than a comparison against a
       // known value. This used to be handed the expected token and check for
       // equality, which caught a `lanes` on PATH belonging to a different

--- a/src/cli/emitted.test.ts
+++ b/src/cli/emitted.test.ts
@@ -67,7 +67,7 @@ describe('what setup tells someone to run', () => {
 
 describe('what outputs tells someone to run', () => {
   test('the token command names the workspace, and never a profile', async () => {
-    const invocation = await tokenInvocation('cloud');
+    const invocation = await tokenInvocation('cloud', '/nonexistent-workspace-for-this-test');
 
     expect(invocation.command).toContain('--workspace cloud');
     // A token is the workspace's since ADR-068 and `token show` refuses

--- a/src/cli/endpoint-url.ts
+++ b/src/cli/endpoint-url.ts
@@ -58,7 +58,7 @@ export async function endpointHealth(
     probe.pathname = '/health';
     const response = await fetch(probe, {
       ...(token === undefined ? {} : { headers: { authorization: `Bearer ${token}` } }),
-      signal: AbortSignal.timeout(700),
+      signal: AbortSignal.timeout(probeTimeoutMs(probe)),
     });
     if (!response.ok) return null;
 
@@ -72,6 +72,32 @@ export async function endpointHealth(
   } catch {
     return null;
   }
+}
+
+/** Loopback hosts, where "not answering quickly" really does mean "not there". */
+const LOOPBACK = new Set(['localhost', '127.0.0.1', '[::1]', '::1']);
+
+/**
+ * How long to wait for `/health` before calling an endpoint absent.
+ *
+ * Two different questions wear the same shape. A loopback endpoint is a process
+ * on this machine: it answers in single-digit milliseconds or it is not running,
+ * and making a caller wait seconds to be told a port is closed is a cost paid
+ * for nothing.
+ *
+ * A deployed one is a container that may not be running *yet*. `min_instances`
+ * defaults to 0, so the endpoint scales to zero when idle and the next request
+ * starts it — measured between 9.8 and 11.9 seconds on a real deployment before
+ * the boot reads were made concurrent. Against that, a 700ms probe reported a
+ * perfectly healthy endpoint as not answering, and `outputs` printed it as
+ * down: the built-in diagnostic confirming the false alarm rather than
+ * correcting it, in precisely the situation someone runs it to check.
+ *
+ * The two callers are both diagnostics, so waiting for a true answer beats
+ * returning a fast wrong one.
+ */
+function probeTimeoutMs(url: URL): number {
+  return LOOPBACK.has(url.hostname) ? 700 : 12_000;
 }
 
 export interface EndpointHealth {

--- a/src/cli/runtime/discovery.test.ts
+++ b/src/cli/runtime/discovery.test.ts
@@ -6,7 +6,9 @@ import { join } from 'node:path';
 import { defineProvider, type DiscoveredCapability } from '#connectivity';
 import { PROVIDER_MANIFESTS } from '#providers/index.ts';
 import { openRuntime } from '../runtime.ts';
-import { capabilityDiff, discoveryProbe, isEmptyDiff } from './discovery.ts';
+import { capabilityDiff, discoveryProbe, isEmptyDiff, primeDiscovery } from './discovery.ts';
+import { ProviderRegistry } from '#registry';
+import type { RuntimeState } from '#stores/state';
 import { DISCOVERY_NAMESPACE } from '#stores/state';
 
 /**
@@ -182,5 +184,85 @@ describe('capabilityDiff', () => {
   test('identical sets are empty', () => {
     const set = [capability('a'), capability('b')];
     expect(isEmptyDiff(capabilityDiff(set, [...set]))).toBe(true);
+  });
+});
+
+/**
+ * The cache reads that stand between a cold instance and its open port.
+ *
+ * `primeDiscovery` runs before the endpoint binds, once per profile, over every
+ * provider the catalogue registers rather than every one the operator
+ * connected. Serially that is of the order of eighty round trips against a
+ * bucket, and it was the largest single term in a ten-second cold start.
+ *
+ * Concurrency is the fix and it is invisible in the result — the registry ends
+ * up holding the same thing either way — so it is asserted directly, against a
+ * store that records how many reads were in flight at once.
+ */
+describe('priming discovery', () => {
+  /** A store that answers slowly enough to overlap, and counts the overlap. */
+  function countingState(): { state: RuntimeState; peak: () => number; order: () => string[] } {
+    let inFlight = 0;
+    let peak = 0;
+    const order: string[] = [];
+
+    const kv = {
+      get: async (_namespace: string, key: string): Promise<string | null> => {
+        inFlight += 1;
+        peak = Math.max(peak, inFlight);
+        order.push(key);
+        await Bun.sleep(5);
+        inFlight -= 1;
+        return null;
+      },
+      set: async () => {},
+      delete: async () => {},
+      keys: async () => [],
+      clearNamespace: async () => {},
+    };
+
+    return {
+      state: { kv, connections: {}, cursors: {} } as unknown as RuntimeState,
+      peak: () => peak,
+      order: () => order,
+    };
+  }
+
+  /** `count` providers the cache has to be consulted for — no committed spec. */
+  function registryOf(count: number): ProviderRegistry {
+    const registry = new ProviderRegistry();
+
+    for (let index = 0; index < count; index += 1) {
+      registry.register(
+        defineProvider({
+          id: `probe_${index}`,
+          name: `Probe ${index}`,
+          summary: 'A provider whose capabilities are not derivable offline.',
+          connector: { kind: 'mcp', endpoint: 'https://mcp.example.com/mcp' },
+          auth: { kind: 'none' },
+        }) as never,
+      );
+    }
+
+    return registry;
+  }
+
+  test('reads the cache concurrently rather than one round trip at a time', async () => {
+    const { state, peak } = countingState();
+
+    await primeDiscovery(registryOf(40), state);
+
+    // The bound is 16; the assertion is that it overlaps at all, because the
+    // number is a tuning choice and "serial" is the regression.
+    expect(peak()).toBeGreaterThan(1);
+  });
+
+  test('asks for every provider it could not derive, exactly once', async () => {
+    const { state, order } = countingState();
+
+    await primeDiscovery(registryOf(40), state);
+
+    expect(order()).toHaveLength(40);
+    expect(new Set(order()).size).toBe(40);
   });
 });

--- a/src/cli/runtime/discovery.ts
+++ b/src/cli/runtime/discovery.ts
@@ -1,5 +1,7 @@
 import type { AnyConnector, DiscoveredCapability, ProviderManifest } from '#connectivity';
 import { createHttpConnector } from '#connectivity/transports';
+import type { ProviderRegistry } from '#registry';
+import { DISCOVERY_NAMESPACE, type RuntimeState } from '#stores/state';
 
 /**
  * What it costs to ask a provider what it can do.
@@ -120,4 +122,91 @@ export function capabilityDiff(
 
 export function isEmptyDiff(diff: CapabilityDiff): boolean {
   return diff.added.length === 0 && diff.removed.length === 0 && diff.changed.length === 0;
+}
+
+/**
+ * How many discovery-cache entries are read at once.
+ *
+ * The same bound, and the same reasoning, as the memory provider's listing: on
+ * a bucket each of these is an HTTPS request, and a workspace registers of the
+ * order of a hundred providers whether or not the operator connected them. The
+ * cap is what keeps a cold start from trading serial round trips for
+ * rate-limited ones.
+ */
+const READ_CONCURRENCY = 16;
+
+/**
+ * Fill the registry in with what each provider can do, before anything serves.
+ *
+ * Discovered capabilities never come from a live call on the dispatch path —
+ * that is what keeps the server stateless. But "not live" is not the same as
+ * "cached", and conflating the two was a bug: `connect` was the only writer of
+ * this cache, so an operator who upgraded without re-authorising kept whatever
+ * their last consent screen happened to discover. Drive shipped nine operations
+ * and served six; Gmail served a `drafts.create` this repository had deleted,
+ * because the spec is read by the tests and the cache is read by the endpoint.
+ *
+ * So: derive it where deriving is free, and read the cache only where it is
+ * not. An `http` provider's capabilities are a pure function of a document
+ * committed here — reviewed in a diff, not fetched from a vendor — which is the
+ * property that makes re-deriving safe as well as cheap.
+ *
+ * **The cache reads are concurrent, and that is what this costs on a cold
+ * start.** The endpoint does not bind its port until every profile is open, and
+ * open includes this — so one serial round trip per unconnected provider, of
+ * which there are of the order of eighty, was the largest single term in the
+ * time between a request arriving and the port answering. Most of them are
+ * misses, for providers the operator has never connected.
+ */
+export async function primeDiscovery(
+  registry: ProviderRegistry,
+  state: RuntimeState,
+): Promise<void> {
+  // Offline first and one at a time, because deriving from a committed document
+  // is CPU with no round trip in it and there is nothing to overlap.
+  const uncached: string[] = [];
+
+  for (const entry of registry.list()) {
+    if (entry.manifest.connector.kind === 'local') continue;
+
+    const probe = discoveryProbe(entry.manifest);
+    if (probe?.cost === 'offline') {
+      try {
+        registry.setDiscovered(entry.manifest.id, await probe.run());
+        continue;
+      } catch {
+        // A malformed committed spec is a build problem, not a reason to refuse
+        // to start — fall through to whatever the cache last held.
+      }
+    }
+
+    uncached.push(entry.manifest.id);
+  }
+
+  const cached: (string | null)[] = [];
+
+  for (let start = 0; start < uncached.length; start += READ_CONCURRENCY) {
+    cached.push(
+      ...(await Promise.all(
+        uncached
+          .slice(start, start + READ_CONCURRENCY)
+          .map((id) => state.kv.get(DISCOVERY_NAMESPACE, id)),
+      )),
+    );
+  }
+
+  // Applied in list order rather than completion order. `setDiscovered` mutates
+  // the registry, and a registry whose contents depend on which read returned
+  // first is one that differs between boots of the same configuration.
+  uncached.forEach((id, index) => {
+    const raw = cached[index];
+    if (!raw) return;
+
+    try {
+      registry.setDiscovered(id, JSON.parse(raw));
+    } catch {
+      // A corrupt cache entry means "not discovered yet", which `plan` reports
+      // and `connect` fixes — never a reason to fail startup.
+    }
+  });
 }

--- a/src/cli/runtime/open.ts
+++ b/src/cli/runtime/open.ts
@@ -1,7 +1,7 @@
 import { BearerAuthenticator, ownerPrincipal } from '#auth';
 import type { SecretStore } from '#secrets';
 import type { AuditReader } from '#audit';
-import { DISCOVERY_NAMESPACE, type RuntimeState } from '#stores/state';
+import type { RuntimeState } from '#stores/state';
 import type { BlobStore } from '#stores/blobs';
 import type { AnyConnector, ProviderManifest } from '#connectivity';
 import { RateLimiter, allowedConnections } from '#policy';
@@ -38,7 +38,7 @@ import { connectorFactory } from '#connectivity/transports';
 import { requestAuthorizer } from '#connectivity/auth/index.ts';
 import { resolveProfile, type GlobalFlags } from './select.ts';
 import { buildRegistryWithWorkspace, readSkillsForStart, reloadSkills } from './registry.ts';
-import { discoveryProbe } from './discovery.ts';
+import { primeDiscovery } from './discovery.ts';
 import { openVault } from './vault.ts';
 import { EMPTY_SKILL_STORE, skillStore } from './stores.ts';
 import type { Runtime } from './types.ts';
@@ -253,43 +253,9 @@ export async function openRuntime(
   // registered rather than rebuilding once to find out.
   fingerprint = loaded.fingerprint;
 
-  // Discovered capabilities never come from a live call on the dispatch path —
-  // that is what keeps the server stateless. But "not live" is not the same as
-  // "cached", and conflating the two was a bug: `connect` was the only writer of
-  // this cache, so an operator who upgraded without re-authorising kept whatever
-  // their last consent screen happened to discover. Drive shipped nine
-  // operations and served six; Gmail served a `drafts.create` this repository
-  // had deleted, because the spec is read by the tests and the cache is read by
-  // the endpoint.
-  //
-  // So: derive it where deriving is free, and cache it only where it is not. An
-  // `http` provider's capabilities are a pure function of a document committed
-  // here — reviewed in a diff, not fetched from a vendor — which is the property
-  // that makes re-deriving safe as well as cheap.
-  for (const entry of registry.list()) {
-    if (entry.manifest.connector.kind === 'local') continue;
-
-    const probe = discoveryProbe(entry.manifest);
-    if (probe?.cost === 'offline') {
-      try {
-        registry.setDiscovered(entry.manifest.id, await probe.run());
-        continue;
-      } catch {
-        // A malformed committed spec is a build problem, not a reason to refuse
-        // to start — fall through to whatever the cache last held.
-      }
-    }
-
-    const cached = await state.kv.get(DISCOVERY_NAMESPACE, entry.manifest.id);
-    if (cached) {
-      try {
-        registry.setDiscovered(entry.manifest.id, JSON.parse(cached));
-      } catch {
-        // A corrupt cache entry means "not discovered yet", which `plan`
-        // reports and `connect` fixes — never a reason to fail startup.
-      }
-    }
-  }
+  // Re-derived where deriving is free, read from the cache where it is not.
+  // `primeDiscovery` carries the reasoning and the bound it reads under.
+  await primeDiscovery(registry, state);
 
   // One factory for the whole runtime, so its cache actually holds. The
   // dispatcher and the CLI share it deliberately: a stateful connector must be

--- a/src/connectivity/auth/oauth-authcode/refresh.test.ts
+++ b/src/connectivity/auth/oauth-authcode/refresh.test.ts
@@ -145,6 +145,26 @@ describe('refreshDirectly', () => {
     });
   });
 
+  test('a rotated refresh token replaces the stored one', async () => {
+    // The other direction of the test above, and the one that was missing. An
+    // issuer that rotates on every refresh invalidates the token it just
+    // replaced, so keeping the old one leaves the *next* refresh presenting a
+    // dead credential — an `invalid_grant` that reads exactly like a revoked
+    // consent, arriving an hour later with nothing to connect it to this.
+    //
+    // Google's token endpoint does not rotate, which is why this went unnoticed;
+    // the broker is under no such obligation.
+    const { fetch } = recording(200, {
+      success: true,
+      data: { access_token: 'fresh', refresh_token: 'rotated' },
+    });
+    const { provider, current } = stubProvider({ refresh_token: 'rt', authorized_via: 'broker' });
+
+    await refreshDirectly(manifest(), provider, 'https://oauth2.example.com/token', store(), fetch);
+
+    expect(current()).toMatchObject({ refresh_token: 'rotated', access_token: 'fresh' });
+  });
+
   test('a fresher assertion from the broker replaces the stored one', async () => {
     const { fetch } = recording(200, {
       success: true,

--- a/src/connectivity/auth/oauth-authcode/refresh.ts
+++ b/src/connectivity/auth/oauth-authcode/refresh.ts
@@ -61,7 +61,25 @@ export async function refreshDirectly(
   // `authorized_via` unless there is a new one, and dropping any of the three
   // would leave the *next* refresh with no token, no attribution, or pointed at
   // the wrong client.
-  await provider.saveTokens({ ...existing, ...refreshed, refresh_token: refreshToken } as never);
+  //
+  // `refresh_token` then falls back rather than being pinned. Pinning it to the
+  // value read at the top of this function was the same sentence read one way
+  // too far: it made the old token survive an absence, and also survive a
+  // *replacement*. An issuer that rotates on each refresh invalidates the one it
+  // just replaced, so storing the old one leaves the next refresh presenting a
+  // dead credential — an `invalid_grant` an hour later, indistinguishable from a
+  // revoked consent and with nothing to connect it back to here.
+  //
+  // Google's token endpoint does not rotate, which is why this was invisible.
+  // The broker is under no such obligation, and neither is any provider added
+  // later.
+  const rotated = (refreshed as { refresh_token?: unknown }).refresh_token;
+
+  await provider.saveTokens({
+    ...existing,
+    ...refreshed,
+    refresh_token: typeof rotated === 'string' && rotated.length > 0 ? rotated : refreshToken,
+  } as never);
   return (await provider.tokens()) as unknown;
 }
 

--- a/src/profile/schema.ts
+++ b/src/profile/schema.ts
@@ -543,6 +543,38 @@ export const configSchema = z.object({
   description: z.string().min(1).optional(),
 
   /**
+   * How much of the reachable surface goes into `tools/list`.
+   *
+   * `full` is every capability policy allows, one typed tool each, which is what
+   * this endpoint has always served and what ADR-001 describes. `crunched`
+   * advertises the owner layer and the stable-name pair, and leaves everything
+   * else reachable through `lanes_tools_search` and `lanes_tools_call` — the
+   * same dispatcher, the same policy, the same audit row. **No capability is
+   * lost either way**; what changes is how much of the catalogue a client loads
+   * before it has been asked anything.
+   *
+   * It exists because the eager list outgrew its clients. ADR-075 measured 428
+   * KB for the `http` providers alone and deferred the question of whether the
+   * typed tools should ever stop being advertised, on the grounds that the
+   * number had to come from measuring this surface. ADR-076 takes that decision
+   * with the measurement: a real endpoint serving 278 tools, against a hosted
+   * client that keeps 256.
+   *
+   * Opt-in, and `full` by default, because the argument cuts both ways —
+   * a client that defers well does it better than this can, with no round trip
+   * and its prompt cache intact, and making that client worse to help one that
+   * pins its list would be the wrong trade to force on everybody. Read from the
+   * primary profile only: one endpoint serves several profiles and `tools/list`
+   * is their union, so this is a property of the endpoint rather than of a row
+   * in it — the granularity ADR-075 named when it refused a per-connection flag.
+   *
+   * Optional and additive, so every profile written before it keeps loading
+   * unchanged — the same reasoning as `identity` below, and the reason
+   * `contract` does not move.
+   */
+  surface: z.enum(['full', 'crunched']).default('full'),
+
+  /**
    * The connections this profile selects, and what may be done with each.
    *
    * There is no `connections:` block here any more — a connection belongs to

--- a/src/server/crunched.test.ts
+++ b/src/server/crunched.test.ts
@@ -1,0 +1,212 @@
+import { afterAll, describe, expect, test } from 'bun:test';
+import { parseConfig } from '#profile';
+import { createSkillsProvider, memoryProvider } from '#providers/owner.ts';
+import { allocatePort, rpc, startHarness } from './harness.ts';
+import { SURFACE_TOOL_NAMES } from './mcp/index.ts';
+
+/**
+ * `surface: crunched`, against a real endpoint.
+ *
+ * The claim is narrow and the whole design rests on it: **the advertised list
+ * shrinks and the reachable set does not**. So the assertions come in pairs —
+ * what left `tools/list`, and the same capability still answering through
+ * `lanes_tools_call`, with the refusals a typed tool would have made still
+ * refusing.
+ *
+ * The control profile is the same wiring under `full`. Where a test asserts an
+ * absence it asserts the presence beside it, because "no tools advertised"
+ * would pass every absence in this file while meaning the endpoint is broken.
+ */
+
+const SKILL = {
+  name: 'review-diff',
+  description: 'Review a diff for correctness',
+  arguments: [{ name: 'diff', description: 'The unified diff', required: true }],
+  body: 'Review this diff:\n\n{{diff}}',
+  path: '/w/skills/review-diff.md',
+};
+
+/**
+ * One profile reaching a third-party provider and an owner-layer one.
+ *
+ * Both halves are needed: `example` is what a crunched surface stops
+ * advertising, and `lanes_memory` is what it keeps. A fixture with only one of
+ * them cannot tell "the owner layer survived" from "nothing was filtered".
+ */
+function config(profile: string, port: number, surface: 'full' | 'crunched') {
+  return parseConfig(`
+contract: 5
+instance:
+  profile: ${profile}
+  port: ${port}
+surface: ${surface}
+limits:
+  requests_per_minute: 1000
+  upstream_calls_per_minute: 1000
+grants:
+  - connection: example.a
+    allow: ["example.*"]
+    deny: ["example.list_notes"]
+  - connection: lanes_memory.owner
+    allow: ["lanes_memory.*"]
+  - connection: lanes_skills.owner
+    allow: ["lanes_skills.*"]
+members: []
+`).config;
+}
+
+const providers = () => [memoryProvider, createSkillsProvider({ skills: [SKILL] })];
+
+const crunchedPort = allocatePort();
+const fullPort = allocatePort();
+
+const crunched = startHarness({
+  profile: 'personal',
+  port: crunchedPort,
+  policy: '',
+  providers: providers(),
+  config: config('personal', crunchedPort, 'crunched'),
+});
+
+/** The same wiring, unchanged — every assertion below is read against this. */
+const full = startHarness({
+  profile: 'personal',
+  port: fullPort,
+  policy: '',
+  providers: providers(),
+  config: config('personal', fullPort, 'full'),
+});
+
+afterAll(async () => {
+  await Promise.all([crunched.stop(), full.stop()]);
+});
+
+async function names(url: string): Promise<string[]> {
+  const response = await rpc(url, 'tools/list', {});
+  const tools = (response.body['result'] as { tools?: { name: string }[] })?.tools ?? [];
+  return tools.map((tool) => tool.name);
+}
+
+async function callGateway(
+  url: string,
+  args: Record<string, unknown>,
+): Promise<{ text: string; isError: boolean }> {
+  const response = await rpc(url, 'tools/call', { name: 'lanes_tools_call', arguments: args });
+  const result = response.body['result'] as
+    | { content?: { text?: string }[]; isError?: boolean }
+    | undefined;
+  return { text: result?.content?.[0]?.text ?? '', isError: result?.isError === true };
+}
+
+describe('a crunched surface', () => {
+  test('advertises the owner layer and the stable-name pair, and nothing else', async () => {
+    const advertised = await names(crunched.server.url);
+
+    for (const name of SURFACE_TOOL_NAMES) expect(advertised).toContain(name);
+    expect(advertised).toContain('lanes_memory_write');
+
+    // The third-party provider is the thing that left. Asserted against the
+    // control below, so this cannot pass by advertising nothing at all.
+    expect(advertised).not.toContain('example_echo');
+    expect(await names(full.server.url)).toContain('example_echo');
+  });
+
+  test('full is what it always was', async () => {
+    const advertised = await names(full.server.url);
+
+    expect(advertised).toContain('example_echo');
+    expect(advertised).toContain('lanes_memory_write');
+    for (const name of SURFACE_TOOL_NAMES) expect(advertised).toContain(name);
+  });
+
+  test('a de-advertised capability still runs, and answers the same', async () => {
+    const args = {
+      capability: 'example.echo',
+      profile: 'personal',
+      connection: 'example.a',
+      arguments: { message: 'still here' },
+    };
+
+    const viaGateway = await callGateway(crunched.server.url, args);
+
+    expect(viaGateway.isError).toBe(false);
+    expect(viaGateway.text).toContain('still here');
+
+    // The same call on the control, where the typed tool exists, to show the
+    // gateway is not a second implementation that happens to agree.
+    expect(await callGateway(full.server.url, args)).toEqual(viaGateway);
+  });
+
+  test('search finds what is no longer advertised, with its schema', async () => {
+    const response = await rpc(crunched.server.url, 'tools/call', {
+      name: 'lanes_tools_search',
+      arguments: { query: 'example.echo' },
+    });
+    const text =
+      (response.body['result'] as { content?: { text?: string }[] })?.content?.[0]?.text ?? '';
+
+    expect(text).toContain('example.echo');
+    // Without the arguments a model cannot compose the call, which would make
+    // the whole mode unusable rather than merely smaller.
+    expect(text).toContain('arguments');
+    expect(text).toContain('message');
+
+    // And it must not tell the model to prefer a typed tool that this mode
+    // never advertises — the reason a tool is absent is the part acted on.
+    expect(text).toContain('advertises a small surface on purpose');
+    expect(text).not.toContain('Prefer the named tool');
+  });
+
+  test('a denied capability is no more reachable than before', async () => {
+    // The load-bearing one. `crunched` removes capabilities from the *list*; if
+    // it removed them from the merged set instead, this would start passing for
+    // the wrong reason, so the assertion is that the refusal is unchanged.
+    const outcome = await callGateway(crunched.server.url, {
+      capability: 'example.list_notes',
+      profile: 'personal',
+      connection: 'example.a',
+      arguments: {},
+    });
+
+    expect(outcome.isError).toBe(true);
+    expect(await names(crunched.server.url)).not.toContain('example_list_notes');
+  });
+
+  test('the count the endpoint reports is the count on the wire', async () => {
+    // ADR-032's whole reason for existing: an operator compares the number
+    // `/reload` and `connect` print against what their client shows. A mode that
+    // advertised less than it counted would make that comparison a false alarm,
+    // and it is the drift `advertisedTools` is shared to prevent.
+    for (const harness of [crunched, full]) {
+      const response = await fetch(harness.server.url.replace('/mcp', '/reload'), {
+        method: 'POST',
+        headers: { authorization: `Bearer ${harness.token}` },
+      });
+      const body = (await response.json()) as { tools?: number };
+
+      expect(body.tools).toBe((await names(harness.server.url)).length);
+    }
+  });
+
+  test('prompts are untouched — a skill is not a tool', async () => {
+    const response = await rpc(crunched.server.url, 'prompts/list', {});
+    const prompts = (response.body['result'] as { prompts?: { name: string }[] })?.prompts ?? [];
+
+    expect(prompts.map((prompt) => prompt.name)).toContain('lanes_skills_review-diff');
+  });
+
+  test('a call through the gateway is not recorded as a refusal', async () => {
+    await callGateway(crunched.server.url, {
+      capability: 'example.echo',
+      profile: 'personal',
+      connection: 'example.a',
+      arguments: { message: 'audited' },
+    });
+
+    await Bun.sleep(50);
+
+    // De-advertising a tool must not make its own successful invocation look
+    // like an agent reaching for something it was never offered.
+    expect(await crunched.audit.tail({ deniedOnly: true })).toHaveLength(0);
+  });
+});

--- a/src/server/edge.test.ts
+++ b/src/server/edge.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, test } from 'bun:test';
+import { authenticateRequest, tooManyAttempts } from './edge.ts';
+import type { Authenticator } from '#auth';
+import type { Logger } from '#connectivity';
+
+/**
+ * What this endpoint does about a caller it cannot authenticate — including the
+ * case where the reason has nothing to do with the caller.
+ *
+ * Both of these are about a client being told something it can act on. A bearer
+ * token is refreshed because a `WWW-Authenticate` header said to, and a request
+ * is retried because a status said it was worth retrying. Getting either wrong
+ * does not fail loudly: it produces a connector that works, then does not, then
+ * does again, which is indistinguishable from an unreliable endpoint.
+ */
+
+function recordingLogger(): { log: Logger; errors: string[] } {
+  const errors: string[] = [];
+  const noop = () => {};
+
+  return {
+    errors,
+    log: {
+      debug: noop,
+      info: noop,
+      warn: noop,
+      error: (message: string) => errors.push(message),
+    } as unknown as Logger,
+  };
+}
+
+const request = (): Request =>
+  new Request('https://endpoint.example/mcp', { headers: { authorization: 'Bearer llk_whatever' } });
+
+describe('authenticating a request', () => {
+  test('a credential store that throws answers 503, not a bare 500', async () => {
+    // There is no `catch` in the router, so before this an unreachable bucket
+    // escaped the fetch handler: no log line, no audit, and a 500 that every
+    // client renders as "the connector is unavailable".
+    const authenticator: Authenticator = {
+      authenticate: async () => {
+        throw new Error('bucket said 503');
+      },
+    };
+    const { log, errors } = recordingLogger();
+
+    const outcome = await authenticateRequest(authenticator, request(), log);
+
+    expect(outcome).toBeInstanceOf(Response);
+    const response = outcome as Response;
+    expect(response.status).toBe(503);
+    expect(response.headers.get('retry-after')).toBe('2');
+
+    // And it is not a 401: the credential may be perfectly good, and telling a
+    // client to refresh a token that is not the problem is how a transient
+    // bucket error turns into someone being asked to authorise again.
+    expect(response.status).not.toBe(401);
+    expect(await response.json()).toMatchObject({ error: 'unavailable' });
+
+    // The failure that used to be invisible is now in the log.
+    expect(errors).toContain('could not authenticate');
+  });
+
+  test('an outcome is passed through untouched', async () => {
+    const authenticator: Authenticator = {
+      authenticate: async () => ({ ok: false, reason: 'invalid' }) as never,
+    };
+
+    const outcome = await authenticateRequest(authenticator, request(), recordingLogger().log);
+
+    expect(outcome).not.toBeInstanceOf(Response);
+    expect(outcome).toMatchObject({ ok: false, reason: 'invalid' });
+  });
+});
+
+describe('the ceiling on failed authentication', () => {
+  test('still tells a client how to authenticate', () => {
+    // The 429 stands in for a 401, and the header is the whole reason a client
+    // refreshes rather than giving up. Without it, a connector with several
+    // sessions retrying a lapsed token spends the budget in seconds, gets an
+    // opaque rate limit, and recovers a minute later on its own — which reads as
+    // an endpoint that is intermittently down.
+    const refused = tooManyAttempts(30_000, 'https://endpoint.example/.well-known/oauth-protected-resource');
+
+    expect(refused.status).toBe(429);
+    expect(refused.headers.get('www-authenticate')).toContain('Bearer');
+    expect(refused.headers.get('www-authenticate')).toContain('invalid_token');
+    expect(refused.headers.get('retry-after')).toBe('30');
+  });
+
+  test('says nothing about credentials where there is no credential to challenge for', () => {
+    // The pre-auth ceilings meter `.well-known` and `/register`, which no token
+    // opens. A challenge there would be an invitation to refresh nothing.
+    expect(tooManyAttempts(1_000).headers.get('www-authenticate')).toBeNull();
+  });
+});

--- a/src/server/edge.ts
+++ b/src/server/edge.ts
@@ -1,4 +1,5 @@
-import { challenge, type AuthOutcome, type ChallengeError } from '#auth';
+import { challenge, type AuthOutcome, type Authenticator, type ChallengeError } from '#auth';
+import type { Logger } from '#connectivity';
 import { RateLimiter } from '#policy';
 
 /**
@@ -90,8 +91,22 @@ export function callerKey(request: Request): string {
   return request.headers.get('x-forwarded-for')?.split(',')[0]?.trim() || 'direct';
 }
 
-/** Refused for rate rather than for credential — deliberately a different status. */
-export function tooManyAttempts(retryAfterMs: number): Response {
+/**
+ * Refused for rate rather than for credential — deliberately a different status.
+ *
+ * **It still carries the challenge when it is standing in for a 401.** The whole
+ * point of the `WWW-Authenticate` header is that a client whose access token has
+ * lapsed reads it and refreshes; the ceiling below turns some of those 401s into
+ * 429s, and a 429 without the header is one the client cannot act on. A
+ * connector with several sessions retrying an expired token spends the budget in
+ * seconds, and then recovers a minute later on its own — which reads as an
+ * endpoint that is intermittently unavailable rather than one asking to be
+ * re-authorised.
+ *
+ * Absent for the pre-auth ceilings, which meter `.well-known` and `/register`
+ * and have no credential to challenge for.
+ */
+export function tooManyAttempts(retryAfterMs: number, metadataUrl?: string | null): Response {
   return new Response(
     JSON.stringify({
       error: 'too_many_requests',
@@ -102,6 +117,9 @@ export function tooManyAttempts(retryAfterMs: number): Response {
       headers: {
         'content-type': 'application/json',
         'retry-after': String(Math.max(1, Math.ceil(retryAfterMs / 1000))),
+        ...(metadataUrl === undefined
+          ? {}
+          : { 'www-authenticate': challenge(metadataUrl, CHALLENGE.invalid) }),
       },
     },
   );
@@ -249,5 +267,99 @@ export function authRefusal(input: {
   const budget = input.limiter.take(callerKey(input.request), FAILED_AUTH_PER_MINUTE);
   return budget.allowed
     ? unauthorized(input.reason, input.metadataUrl)
-    : tooManyAttempts(budget.retryAfterMs);
+    : tooManyAttempts(budget.retryAfterMs, input.metadataUrl);
+}
+
+/** What a request says it is calling, and on what. */
+export interface NamedTarget {
+  readonly method: string | null;
+  readonly name: string | null;
+}
+
+/**
+ * The method and target of a request, whichever revision it speaks.
+ *
+ * The 2026-07-28 envelope requires both in headers and rejects a request whose
+ * headers and body disagree, so for an envelope client this is exact and free.
+ *
+ * **A 2025-era request carries neither**, and those are most of the clients this
+ * endpoint is actually advertised to — the hosted connectors reach it by URL and
+ * speak the older revision. Reading the header alone therefore short-circuited
+ * for exactly the callers the refusal audit and the stale-config probe were
+ * written for: a call naming a tool the protocol layer rejects left no trace,
+ * and an instance holding config older than the account being named never
+ * re-read it. Both are documented in `index.ts` as the second exception to
+ * `audit.every-invocation`, and the fix named there is this one — clone and
+ * parse the body when the header is absent, which is what `stdio.ts` already
+ * does for want of headers.
+ *
+ * The clone is what makes it safe: the handler still gets an unconsumed body.
+ * The cost is bounded by the same rule that bounds everything else on this path
+ * — attachments are named rather than carried (ADR-017), so an MCP request body
+ * is small.
+ */
+export async function namedTarget(request: Request): Promise<NamedTarget> {
+  const method = request.headers.get('mcp-method');
+  if (method !== null) return { method, name: request.headers.get('mcp-name') };
+
+  try {
+    const body = (await request.clone().json()) as {
+      method?: unknown;
+      params?: { name?: unknown };
+    };
+
+    return {
+      method: typeof body.method === 'string' ? body.method : null,
+      name: typeof body.params?.name === 'string' ? body.params.name : null,
+    };
+  } catch {
+    // A body that is not JSON is one the handler refuses on its own, and a
+    // refusal that cannot be named is not worth failing the request over.
+    return { method: null, name: null };
+  }
+}
+
+/**
+ * Authenticate, and turn a store outage into an answer rather than a stack.
+ *
+ * `authenticate` is not a pure check: both authenticators in the chain read the
+ * credential store, and on a deployed instance that is a network call — a GCS
+ * GET for the hashed token object, and a Secret Manager read behind the bearer
+ * path. Neither was guarded, and there is no `catch` anywhere in the router, so
+ * a 429 or a 503 from either store escaped the fetch handler entirely: the
+ * client got a bare 500, nothing was logged, and "the connector is unavailable"
+ * is how every client renders that.
+ *
+ * **503, not 401.** The credential presented may well be perfectly good; what
+ * failed is this endpoint's ability to check it. Answering 401 would tell a
+ * client to refresh a token that is not the problem, and a client that cannot
+ * refresh then asks the person to authorise again — user-visible churn caused by
+ * a transient bucket error. `Retry-After` says the useful thing instead.
+ *
+ * This is deliberately not the same choice `OidcAuthenticator` makes internally.
+ * There, an unreachable issuer means the claim cannot be established at all and
+ * failing closed is the safe reading. Here the failure is ours and is transient,
+ * and both readings are closed — so the one that does not misattribute the fault
+ * wins.
+ */
+export async function authenticateRequest(
+  authenticator: Authenticator,
+  request: Request,
+  log: Logger,
+): Promise<AuthOutcome | Response> {
+  try {
+    return await authenticator.authenticate(request.headers.get('authorization'));
+  } catch (error) {
+    log.error('could not authenticate', {
+      message: error instanceof Error ? error.message : String(error),
+    });
+
+    return new Response(
+      JSON.stringify({
+        error: 'unavailable',
+        hint: 'This endpoint could not reach its credential store. The credential was not rejected.',
+      }),
+      { status: 503, headers: { 'content-type': 'application/json', 'retry-after': '2' } },
+    );
+  }
 }

--- a/src/server/generation.ts
+++ b/src/server/generation.ts
@@ -1,10 +1,9 @@
 import { createMcpHandler, type McpHttpHandler, type McpRequestContext } from '@modelcontextprotocol/server';
 import { ownerPrincipal, type Principal } from '#auth';
 import {
+  advertisedNames,
   buildMcpServer,
-  toolNameFor,
   SURFACE_TOOL_NAMES,
-  visibleCapabilities,
   visibleToolCount,
   type ProfileRuntime,
 } from '#server/mcp';
@@ -65,6 +64,25 @@ export class Generation {
    */
   readonly toolCount: () => number;
 
+  /**
+   * The surface mode, read from the primary profile and from nowhere else.
+   *
+   * One endpoint serves several profiles and `tools/list` is their union, so
+   * "how much of it is advertised" is a property of the endpoint rather than of
+   * a row in it — the granularity ADR-075 named when it declined a
+   * per-connection flag, and the same rule `instance.port` already follows.
+   *
+   * Read per generation rather than pinned at bind time, so a reload picks up a
+   * changed value the way it picks up a changed grant. Spread into the options
+   * object so `full` passes nothing at all and cannot be told apart from a
+   * caller that never heard of the setting.
+   */
+  #surface(): { surface?: 'crunched' } {
+    return this.profiles.get(this.#deps.primary)?.config.surface === 'crunched'
+      ? { surface: 'crunched' }
+      : {};
+  }
+
   constructor(epoch: number, opened: OpenedWorkspace, deps: GenerationDeps) {
     this.epoch = epoch;
     this.profiles = opened.profiles;
@@ -83,12 +101,13 @@ export class Generation {
       () =>
         new Set(
           [
-            ...visibleCapabilities({
+            ...advertisedNames({
               profiles: this.profiles,
               principal: ownerPrincipal(deps.primary),
-            }).map(toolNameFor),
+              ...this.#surface(),
+            }),
             // Advertised without being capabilities, so they are absent from
-            // `visibleCapabilities` and have to be added here or every
+            // `mergeCapabilities` and have to be added here or every
             // successful call to one is recorded as a refusal.
             ...SURFACE_TOOL_NAMES,
           ],
@@ -96,7 +115,11 @@ export class Generation {
     );
 
     this.toolCount = this.#memo(() =>
-      visibleToolCount({ profiles: this.profiles, principal: ownerPrincipal(deps.primary) }),
+      visibleToolCount({
+        profiles: this.profiles,
+        principal: ownerPrincipal(deps.primary),
+        ...this.#surface(),
+      }),
     );
   }
 
@@ -221,6 +244,7 @@ export class Generation {
           clientLabel,
           ...(this.#deps.version ? { version: this.#deps.version } : {}),
           ...(this.#deps.remoteClients ? { remoteClients: true } : {}),
+          ...this.#surface(),
         }),
       {
         onerror: (error: Error) =>

--- a/src/server/index.test.ts
+++ b/src/server/index.test.ts
@@ -528,23 +528,23 @@ describe('audit over the wire', () => {
     }
   });
 
-  test('a pre-envelope call to a hidden tool leaves no trace — a known gap', async () => {
+  test('a pre-envelope call to a hidden tool is recorded too', async () => {
     // Asserting the gap rather than hiding it, the way `resources.test.ts` does
     // for `resources/read`.
     //
-    // The test above works because the edge reads `mcp-method` and `mcp-name`,
-    // which the 2026-07-28 envelope requires and validates against the body. A
-    // 2025-era client sends neither, and `createMcpHandler` is constructed
-    // without a `legacy` option — whose default is `'stateless'`, so those
-    // requests are *served*, not refused. The header read short-circuits, the
-    // legacy leg answers `-32602 Tool ... not found`, and nothing is recorded.
+    // This was the second documented exception to `audit.every-invocation`, and
+    // it is closed. The test above works because the edge reads `mcp-method` and
+    // `mcp-name`, which the 2026-07-28 envelope requires and validates against
+    // the body. A 2025-era client sends neither — and is most of what reaches a
+    // deployed endpoint, since the hosted connectors speak the older revision.
+    // The header read short-circuited, the legacy leg answered `-32602 Tool ...
+    // not found`, and nothing was recorded.
     //
-    // Documented as the second exception to `audit.every-invocation` in
-    // `https://lanes.sh/docs/link/security`. Closing it means reading the body at the edge
-    // — `request.clone()` and a parse — which is what `stdio.ts` already does
-    // because a pipe has no headers to read instead.
-    //
-    // Change this expectation when it is closed; do not delete it.
+    // `namedTarget` now falls back to `request.clone()` and a parse, which is
+    // what `stdio.ts` already did for want of headers. The assertion is that
+    // both legs produce the same row, because "the same surface over a different
+    // transport" is the claim, and an audit gap on one of them is a real
+    // difference dressed as an implementation detail.
     const harness = startHarness({
       profile: 'legacy_denials',
       port: allocatePort(),
@@ -573,10 +573,17 @@ describe('audit over the wire', () => {
       expect(response.status).toBe(200);
       expect(await response.text()).toContain('not found');
 
-      // And this is the gap: the same probe that produces a row above produces
-      // none here.
-      expect(await harness.audit.tail({ deniedOnly: true })).toHaveLength(0);
-      expect(await harness.audit.tail()).toHaveLength(0);
+      // The same probe that produces a row for an envelope client produces one
+      // here, spelled with the capability id rather than the wire name.
+      const denied = await harness.audit.tail({ deniedOnly: true });
+
+      expect(denied).toHaveLength(1);
+      expect(denied[0]).toMatchObject({
+        capability: 'example.set_note',
+        authorization: 'denied_default',
+        status: 'not_invoked',
+        error: { kind: 'not_available' },
+      });
     } finally {
       await harness.stop();
     }

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -9,7 +9,9 @@ import type { Generation } from './generation.ts';
 import type { Generations } from './generations.ts';
 import {
   authRefusal,
+  authenticateRequest,
   failedAuthLimiter,
+  namedTarget,
   unauthenticatedLimiter,
   unauthenticatedRefusal,
 } from './edge.ts';
@@ -220,9 +222,9 @@ export function createRequestHandler(options: ServerOptions): RequestHandler {
         return new Response('Not found', { status: 404 });
       }
 
-      const outcome = await options.authenticator.authenticate(
-        request.headers.get('authorization'),
-      );
+      const attempt = await authenticateRequest(options.authenticator, request, options.log);
+      if (attempt instanceof Response) return attempt;
+      const outcome = attempt;
 
       // The refusal, and the ceiling on how often one may be provoked. Both in
       // `./edge.ts`, which is the subject: what this endpoint does about a
@@ -281,15 +283,9 @@ export function createRequestHandler(options: ServerOptions): RequestHandler {
         // request whose headers and body disagree, so reading them here is exact
         // without parsing (and consuming) the body.
         //
-        // **Only for an envelope client.** A 2025-era request carries neither
-        // header, and `createMcpHandler` is built without a `legacy` option —
-        // whose default is `'stateless'`, so those requests are served rather
-        // than refused. This check short-circuits and the refusal goes
-        // unrecorded. That is the second documented exception to
-        // `audit.every-invocation` in `https://lanes.sh/docs/link/security`, asserted in
-        // `index.test.ts`. Closing it means cloning and parsing the body when
-        // the header is absent, which is what `stdio.ts` does for want of
-        // headers.
+        // A 2025-era request carries neither header, which is most of what
+        // reaches a deployed endpoint — `namedTarget` reads its body instead, so
+        // this no longer short-circuits for the clients it was written for.
         //
         // `prompts/get` is included because a prompt is named exactly as a tool
         // is — `skills_review-diff` — so the same lookup is exact.
@@ -300,9 +296,9 @@ export function createRequestHandler(options: ServerOptions): RequestHandler {
         // matching it against each registered template, which is a real design
         // decision — not least about what to record when it matches nothing —
         // and M4 did not take it. `resources.test.ts` asserts the gap.
-        const method = request.headers.get('mcp-method');
-        if (method === 'tools/call' || method === 'prompts/get') {
-          const toolName = request.headers.get('mcp-name');
+        const named = await namedTarget(request);
+        if (named.method === 'tools/call' || named.method === 'prompts/get') {
+          const toolName = named.name;
 
           if (toolName && !generation.visible().has(toolName)) {
             // Before recording it as a refusal: this instance may simply be

--- a/src/server/mcp/build.ts
+++ b/src/server/mcp/build.ts
@@ -8,7 +8,7 @@ import { registerPrompt } from './prompts.ts';
 import { registerResource } from './resources.ts';
 import { registerDiscoveredTool, registerLocalTool } from './tools.ts';
 import { registerSearchSurface } from './search.ts';
-import { mergeCapabilities, type BuildServerOptions } from './visibility.ts';
+import { advertisedTools, mergeCapabilities, type BuildServerOptions } from './visibility.ts';
 
 /**
  * Building the MCP surface for one principal.
@@ -48,7 +48,7 @@ export function buildMcpServer(options: BuildServerOptions): McpServer {
     // and `Implementation` would take it as an unknown extra and drop it from
     // `initialize` without complaining.
     {
-      instructions: serverInstructions(names, merged, options.remoteClients),
+      instructions: serverInstructions(names, merged, options.remoteClients, options.surface),
       // Declared `false` because it is false, and the SDK defaults it to `true`.
       //
       // `listChanged` is a promise to send `notifications/tools/list_changed`
@@ -109,19 +109,27 @@ export function buildMcpServer(options: BuildServerOptions): McpServer {
   // any tool list from this endpoint has them. See `search.ts`.
   registerSearchSurface(server, options);
 
+  // Which capabilities get a typed tool. Under `full` this is every tool the
+  // loop would have registered anyway, so the guards below are no-ops; under
+  // `crunched` the rest stay reachable through the surface registered above.
+  // Computed here and not asked per entry, because `visibleToolCount` and
+  // `advertisedNames` consume the same function and the three must agree.
+  const advertised = advertisedTools(merged, options.surface);
+
   for (const [id, entry] of merged) {
     // Discovered first: an upstream MCP server or an OpenAPI document supplies
     // the schema, and there is no local capability object to inspect.
     if (entry.discovered) {
-      registerDiscoveredTool(server, id, entry, options);
+      if (advertised.has(id)) registerDiscoveredTool(server, id, entry, options);
       continue;
     }
 
     const capability = entry.capability;
     if (!capability) continue;
 
-    if (isTool(capability)) registerLocalTool(server, id, entry, capability, options);
-    else if (isResource(capability)) registerResource(server, id, entry, capability, options);
+    if (isTool(capability)) {
+      if (advertised.has(id)) registerLocalTool(server, id, entry, capability, options);
+    } else if (isResource(capability)) registerResource(server, id, entry, capability, options);
     else if (isPrompt(capability)) registerPrompt(server, id, entry, capability, options);
   }
 

--- a/src/server/mcp/index.ts
+++ b/src/server/mcp/index.ts
@@ -23,6 +23,8 @@ export { SERVER_NAME, SURFACE_TOOL_NAMES, capabilityIdForToolName, toolNameFor }
 export { scopeResourceUri } from './routing.ts';
 export { sanitizeSchema } from './schema.ts';
 export {
+  advertisedNames,
+  advertisedTools,
   mergeCapabilities,
   oneProfile,
   visibleCapabilities,

--- a/src/server/mcp/instructions.test.ts
+++ b/src/server/mcp/instructions.test.ts
@@ -62,6 +62,29 @@ describe('reaching the endpoint at all', () => {
     expect(text).toContain('personal: example.a, example.b, example.c, example.d, example.e');
     expect(text.length).toBeLessThan(MAX_INSTRUCTIONS);
   });
+
+  test('a crunched surface is told why its tool list is short, and costs no more', () => {
+    const connections = new Map([
+      ['a.read', reaching({ personal: ['example.a', 'example.b', 'example.c'] })],
+      ['a.write', reaching({ personal: ['example.d', 'example.e'] })],
+    ]);
+
+    const full = serverInstructions(['personal'], connections, true, 'full');
+    const crunched = serverInstructions(['personal'], connections, true, 'crunched');
+
+    // The reason an absent tool is absent is the part a model acts on, and it
+    // differs by mode: a stale snapshot can be re-read, a surface that never
+    // advertised the tool cannot.
+    expect(full).toContain('snapshot');
+    expect(crunched).toContain('advertises a\nsmall surface deliberately');
+    expect(crunched).not.toContain('snapshot');
+
+    // Substituted rather than added. The budget is the reason the paragraph was
+    // written to the length it was, so this is the assertion that keeps a later
+    // edit honest.
+    expect(crunched.length).toBeLessThan(MAX_INSTRUCTIONS);
+    expect(crunched.length).toBeLessThanOrEqual(full.length);
+  });
 });
 
 describe('the facts under the prose', () => {
@@ -134,6 +157,16 @@ describe('the habits it teaches', () => {
 
   test('states the profile rule as a rule, not as advice', () => {
     expect(text).toContain('Do not default to whichever is listed first');
+  });
+
+  test('says a partial look is not a negative answer', () => {
+    // Observed with two profiles served: an agent searched one, answered
+    // "nothing filed under that name", and found the entry on the other only
+    // when pushed. Nothing else catches that — the endpoint answered correctly,
+    // policy allowed both, and the audit log shows two successful searches — so
+    // this sentence is the only thing standing between a partial look and a
+    // confident negative, and a confident negative ends the turn.
+    expect(text).toContain('absence is per profile');
   });
 
   test('covers each thing a client would otherwise have to guess', () => {

--- a/src/server/mcp/instructions.ts
+++ b/src/server/mcp/instructions.ts
@@ -57,7 +57,9 @@ have to. Read \`lanes://instructions\` for the whole account of how it works.`;
 
 const ROUTING = `**Routing.** Every tool takes \`profile\` and \`connection\`. A profile is how
 someone separates work from personal — when it is ambiguous which one is meant,
-ask. Do not default to whichever is listed first.`;
+ask. Do not default to whichever is listed first, and do not report something
+missing on the strength of one profile: absence is per profile, and the other one
+is where the answer usually is.`;
 
 const MEMORY = `**Memory is worth consulting.** Before concluding you do not know something
 about this person or their work, search it. Writing to memory is a separate
@@ -186,6 +188,24 @@ from when your client connected, and a connection made since is missing from it.
 concluding you cannot do something, call \`lanes_tools_search\` — then \`lanes_tools_call\` to
 invoke what it names, under the permissions the named tool would have had.`;
 
+/**
+ * The same paragraph, for an endpoint that advertises a small surface on purpose.
+ *
+ * `SEARCH` explains an absent tool as a stale snapshot, which is the true
+ * reason under `full` and the wrong one under `crunched`: there the tool was
+ * never advertised and re-reading the list will not produce it. A model told
+ * the wrong reason waits for the wrong remedy.
+ *
+ * Two characters shorter than the paragraph it replaces, so it cannot push the
+ * assembled instructions past `MAX_INSTRUCTIONS` — the arithmetic at the
+ * budget's docstring holds unchanged, and this substitution can only reduce the
+ * measured maximum.
+ */
+const SEARCH_CRUNCHED = `**Most of what this endpoint reaches is not in your tool list.** It advertises a
+small surface deliberately, so a missing tool is normal rather than a fault. Before
+concluding you cannot do something, call \`lanes_tools_search\` — then \`lanes_tools_call\` to
+invoke what it names, under the permissions the named tool would have had.`;
+
 const REFUSAL = `**A refused call is the permission system working**, not an obstacle to route
 around. Report what was refused and let the owner decide whether to widen it.
 Every call, including a refused one, is recorded.`;
@@ -303,10 +323,30 @@ function habitsFor(reachable: readonly string[]): string[] {
  * now taken from what the test measures rather than composed by hand, so the
  * next paragraph cannot be certified against a case nothing serves:
  *
- *   the paired branch, every owner provider, remote clients   3102
- *   the unpaired branch, which is the real maximum            3216
+ *   the paired branch, every owner provider, remote clients   3358
+ *   the unpaired branch, which is the real maximum            3361
  *
  * `SEARCH` costs 338 of that — 336 of prose and the two characters `join` adds.
+ *
+ * Raised a sixth time, to 3450, for one sentence in `ROUTING` — that absence is
+ * per profile, and one profile having nothing is not grounds for saying a thing
+ * does not exist. It costs 145 characters and the two branches above moved from
+ * 3102 and 3216.
+ *
+ * The case for it is `ENTITIES`' case one step further out, and it was observed
+ * rather than reasoned about: with two profiles served, an agent searched one,
+ * answered "nothing filed under that name", and found the entry on the other
+ * only when pushed. Every guard that would otherwise catch this is on the wrong
+ * side of it — the endpoint answered correctly, policy allowed both, and the
+ * audit log records two successful searches. Only prose stands between a partial
+ * look and a confident negative, and a confident negative ends the turn, so
+ * there is no later moment at which a skill loaded when relevant would help.
+ * That is the same argument `SEARCH` and `AVAILABILITY` are already here on.
+ *
+ * The ceiling keeps roughly the headroom the fifth raise left it: 89 characters
+ * against 84. That is deliberate — this docstring's own warning is that the
+ * widest case gets recertified when the number moves and not when the prose
+ * does, so the margin is small enough that the next paragraph has to measure.
  *
  * The arithmetic, because the number is a measurement and not a round figure.
  * Twenty profiles, twenty connections each, every owner provider reachable,
@@ -334,7 +374,7 @@ function habitsFor(reachable: readonly string[]): string[] {
  * exactly the final length, because `join` adds the same two characters the
  * reduce already counted.
  */
-export const MAX_INSTRUCTIONS = 3300;
+export const MAX_INSTRUCTIONS = 3450;
 
 /** Which of the owner-layer providers this principal can actually reach. */
 function ownerProviders(merged: ReadonlyMap<string, MergedCapability>): string[] {
@@ -391,6 +431,8 @@ export function serverInstructions(
   /** Whether a client authorises against this endpoint rather than being handed
    * a token — see `AVAILABILITY`, the only paragraph that reads it. */
   remoteClients = false,
+  /** How much of the surface is advertised — see `config.surface`. */
+  surface: 'full' | 'crunched' = 'full',
 ): string {
   const reachable = connectionsByProfile(profiles, merged);
   const owner = ownerProviders(merged);
@@ -405,7 +447,7 @@ export function serverInstructions(
     FILES,
     // Between "the tool is not there" and "the call was refused", which is the
     // order a caller meets them in: absent, then present and denied.
-    SEARCH,
+    surface === 'crunched' ? SEARCH_CRUNCHED : SEARCH,
     REFUSAL,
     ...(remoteClients ? [AVAILABILITY] : []),
   ];

--- a/src/server/mcp/search-index.ts
+++ b/src/server/mcp/search-index.ts
@@ -235,7 +235,11 @@ function whereReachable(entry: MergedCapability): string {
     .join(' | ');
 }
 
-function renderMatches(query: string, matches: readonly Match[]): string {
+function renderMatches(
+  query: string,
+  matches: readonly Match[],
+  surface?: 'full' | 'crunched',
+): string {
   if (matches.length === 0) {
     return (
       `Nothing reachable matches "${query}".\n\n` +
@@ -251,14 +255,26 @@ function renderMatches(query: string, matches: readonly Match[]): string {
   const lines: string[] = [
     `${matches.length} match${matches.length === 1 ? '' : 'es'} for "${query}".`,
     '',
-    'Each one is invocable two ways. Prefer the named tool if your tool list has it; ' +
-      'use lanes_tools_call if it does not — which is the case when this endpoint ' +
-      'gained a connection after your client last read its tool list.',
+    // Why the tool is missing differs by mode, and the reason is the part a
+    // model acts on. Under `full` an absent tool means the client's list is
+    // stale; under `crunched` it means the endpoint never advertised it and
+    // never will, so telling the model to prefer a named tool would be telling
+    // it to wait for something that is not coming.
+    surface === 'crunched'
+      ? 'This endpoint advertises a small surface on purpose: the owner layer and these two ' +
+        'tools. Everything below is reachable through lanes_tools_call and will not appear in ' +
+        'your tool list, so call it with the capability id and the arguments shown.'
+      : 'Each one is invocable two ways. Prefer the named tool if your tool list has it; ' +
+        'use lanes_tools_call if it does not — which is the case when this endpoint ' +
+        'gained a connection after your client last read its tool list.',
     '',
   ];
 
   for (const match of detailed) {
-    lines.push(`## ${match.tool}`);
+    // The wire name is the address under `full`. Under `crunched` it names no
+    // tool the client can call, so the id — which is what `lanes_tools_call`
+    // takes — leads instead.
+    lines.push(`## ${surface === 'crunched' ? match.id : match.tool}`);
     const shape = shapeOf(match.entry);
     if (shape.title) lines.push(`${shape.title}`);
     lines.push('');
@@ -301,6 +317,10 @@ function renderMatches(query: string, matches: readonly Match[]): string {
  * One entry point, because the caller is a tool handler and the only thing it
  * has to decide is what text to return.
  */
-export function searchCapabilities(query: string, merged: Map<string, MergedCapability>): string {
-  return renderMatches(query, rank(query, merged));
+export function searchCapabilities(
+  query: string,
+  merged: Map<string, MergedCapability>,
+  surface?: 'full' | 'crunched',
+): string {
+  return renderMatches(query, rank(query, merged), surface);
 }

--- a/src/server/mcp/search.ts
+++ b/src/server/mcp/search.ts
@@ -96,7 +96,9 @@ export function registerSearchSurface(server: McpServer, options: BuildServerOpt
       },
     },
     async ({ query }: { query: string }) => ({
-      content: [{ type: 'text' as const, text: searchCapabilities(query, merged) }],
+      content: [
+        { type: 'text' as const, text: searchCapabilities(query, merged, options.surface) },
+      ],
     }),
   );
 
@@ -223,13 +225,23 @@ export function registerSearchSurface(server: McpServer, options: BuildServerOpt
       // produced under, and a link is a follow-up call the caller makes against
       // a *typed* resource tool — so a caller reaching a capability through here
       // gets the text and is told to use the named tool for the rest.
+      //
+      // Under `crunched` there is no named tool to be told about, so the
+      // message says what is actually true rather than naming one the client
+      // cannot call. This is the one thing the mode genuinely costs, and it is
+      // recorded in ADR-076 rather than papered over.
+      const linkAdvice =
+        options.surface === 'crunched'
+          ? 'this endpoint does not advertise its typed tools, so the resource link cannot be handed back through here'
+          : `call ${toolNameFor(capability)} directly to receive this as a resource link`;
+
       return {
         content: outcome.result.content.map((block) =>
           block.type === 'text'
             ? { type: 'text' as const, text: block.text }
             : {
                 type: 'text' as const,
-                text: `[${block.name ?? block.uri}] — call ${toolNameFor(capability)} directly to receive this as a resource link.`,
+                text: `[${block.name ?? block.uri}] — ${linkAdvice}.`,
               },
         ),
         ...(outcome.result.isError ? { isError: true } : {}),

--- a/src/server/mcp/visibility.ts
+++ b/src/server/mcp/visibility.ts
@@ -1,4 +1,4 @@
-import { isTool } from '#connectivity';
+import { RESERVED_PROVIDER_IDS, isTool } from '#connectivity';
 import type { Principal } from '#auth';
 import type { Config, SelectedConnection } from '#profile';
 import type { ProviderRegistry } from '#registry';
@@ -6,7 +6,7 @@ import type { Dispatcher } from '#dispatch';
 import type { PolicyDocument, ProfilePolicy } from '#policy';
 import { allowedConnections } from '#policy';
 import { mayReach } from '#auth';
-import { SURFACE_TOOL_NAMES } from './naming.ts';
+import { SURFACE_TOOL_NAMES, toolNameFor } from './naming.ts';
 
 /**
  * What this principal can see, and therefore what gets registered at all.
@@ -73,6 +73,15 @@ export interface BuildServerOptions {
    * transport cannot fail the way this describes.
    */
   readonly remoteClients?: boolean | undefined;
+  /**
+   * How much of the reachable surface is advertised. See `config.surface`.
+   *
+   * Absent means `full`, which is what every caller that does not set it gets
+   * and what this endpoint served before the option existed. Taken from the
+   * primary profile, because `tools/list` is the union across profiles and a
+   * union has one shape.
+   */
+  readonly surface?: 'full' | 'crunched' | undefined;
 }
 
 /** One profile as the map the builder wants. */
@@ -163,14 +172,85 @@ export function visibleToolCount(options: BuildServerOptions): number {
   // The stable-name pair is advertised unconditionally and is not a
   // capability, so it is in `tools/list` and not in `merged` — see
   // `SURFACE_TOOL_NAMES`.
-  let count = SURFACE_TOOL_NAMES.length;
+  return SURFACE_TOOL_NAMES.length + advertisedTools(mergeCapabilities(options), options.surface).size;
+}
 
-  for (const entry of mergeCapabilities(options).values()) {
-    if (entry.discovered) count += 1;
-    else if (entry.capability && isTool(entry.capability)) count += 1;
+/** Whether this entry registers as a tool, as `buildMcpServer` decides it. */
+function registersAsTool(entry: MergedCapability): boolean {
+  return entry.discovered ? true : !!entry.capability && isTool(entry.capability);
+}
+
+/** Whether this capability belongs to the owner layer — the endpoint's own material. */
+function isOwnerLayer(capabilityId: string): boolean {
+  const dot = capabilityId.indexOf('.');
+  return RESERVED_PROVIDER_IDS.includes(dot === -1 ? capabilityId : capabilityId.slice(0, dot));
+}
+
+/**
+ * Which reachable capabilities get a typed tool of their own.
+ *
+ * The one evaluation three places consume — the registration loop in
+ * `build.ts`, the count `/reload` returns, and the visible set that decides
+ * whether a call is recorded as a refusal. They were separate before there was
+ * anything to disagree about; a mode that advertises less than it can reach is
+ * exactly the thing that makes them able to drift, so they share this.
+ *
+ * `crunched` keeps the owner layer and nothing else. That line is not a
+ * shortlist someone tuned: the owner layer is the material this endpoint holds
+ * itself rather than anybody's API, it is small, and the instructions name
+ * several of its tools directly — an agent is told to call `lanes_setup_overview`
+ * before saying something cannot be reached, and `lanes_entities.find` before
+ * using anyone's address. Advertising less than this would leave those
+ * sentences pointing at tools the client cannot see.
+ *
+ * Everything omitted stays in `merged`, which is what `lanes_tools_call`
+ * dispatches against — so it is still reachable, still policy-checked, still
+ * audited. Omission is exposition, not authority. `grants:` is the lever that
+ * changes authority, and it removes the capability from `merged` entirely.
+ */
+export function advertisedTools(
+  merged: ReadonlyMap<string, MergedCapability>,
+  surface: 'full' | 'crunched' | undefined,
+): ReadonlySet<string> {
+  const advertised = new Set<string>();
+
+  for (const [id, entry] of merged) {
+    if (!registersAsTool(entry)) continue;
+    if (surface === 'crunched' && !isOwnerLayer(id)) continue;
+    advertised.add(id);
   }
 
-  return count;
+  return advertised;
+}
+
+/**
+ * Every wire name the built server will answer, for the refusal audit.
+ *
+ * Not `visibleCapabilities().map(toolNameFor)` any more: that was the same set
+ * while everything reachable was advertised, and stops being so under
+ * `crunched`. A name in this set and not on the wire means a call to it is
+ * answered by the SDK and recorded nowhere, which is the half of the drift that
+ * fails silently.
+ *
+ * Resources and prompts are unaffected by the mode and stay in regardless — a
+ * skill is a prompt (ADR-032), and neither was ever on the tool count.
+ */
+export function advertisedNames(options: BuildServerOptions): string[] {
+  const merged = mergeCapabilities(options);
+
+  // Identical to what this returned before the option existed, deliberately:
+  // `full` must not be a different code path that happens to agree.
+  if (options.surface !== 'crunched') return [...merged.keys()].map(toolNameFor);
+
+  const advertised = advertisedTools(merged, options.surface);
+  const names: string[] = [];
+
+  for (const [id, entry] of merged) {
+    if (registersAsTool(entry) && !advertised.has(id)) continue;
+    names.push(id);
+  }
+
+  return names.map(toolNameFor);
 }
 
 /**

--- a/src/server/stdio.test.ts
+++ b/src/server/stdio.test.ts
@@ -116,6 +116,32 @@ describe('the stdio surface', () => {
     }
   });
 
+  test('a call to the stable-name surface is not mistaken for a refusal', async () => {
+    const harness = await startStdioHarness({
+      profile: 'allowed',
+      port: allocatePort(),
+      policy: `  allow:\n    - "example.*"`,
+    });
+
+    try {
+      // `lanes_tools_search` is advertised without being a capability, so it is
+      // absent from `visibleCapabilities` and has to be added to the visible set
+      // explicitly. The HTTP path does that; this asserts the pipe does too,
+      // because otherwise every successful call to the surface writes a row
+      // saying the caller reached for something that was never advertised.
+      await harness.client.callTool({
+        name: 'lanes_tools_search',
+        arguments: { query: 'echo' },
+      });
+
+      await Bun.sleep(50);
+
+      expect(await harness.audit.tail({ deniedOnly: true })).toHaveLength(0);
+    } finally {
+      await harness.stop();
+    }
+  });
+
   test('every profile in the workspace is reachable through the one pipe', async () => {
     const harness = await startStdioHarness({
       profile: 'personal',

--- a/src/server/stdio.ts
+++ b/src/server/stdio.ts
@@ -3,10 +3,10 @@ import type { JSONRPCMessage, Transport } from '@modelcontextprotocol/server';
 import { ownerPrincipal } from '#auth';
 import type { Logger } from '#connectivity';
 import {
+  SURFACE_TOOL_NAMES,
+  advertisedNames,
   buildMcpServer,
   capabilityIdForToolName,
-  toolNameFor,
-  visibleCapabilities,
   type ProfileRuntime,
 } from './mcp/index.ts';
 
@@ -75,9 +75,22 @@ export function serveOverStdio(options: StdioOptions): StdioSurface {
    * connection anyway — the memoisation the HTTP path needs exists only because
    * it rebuilds per request.
    */
-  const visible = new Set(
-    visibleCapabilities({ profiles: options.profiles, principal }).map(toolNameFor),
-  );
+  // Same rule as the HTTP path: the primary profile decides, because the list
+  // this serves is the union across profiles and a union has one shape.
+  const surface: { surface?: 'crunched' } =
+    options.profiles.get(options.primary)?.config.surface === 'crunched'
+      ? { surface: 'crunched' }
+      : {};
+
+  const visible = new Set([
+    ...advertisedNames({ profiles: options.profiles, principal, ...surface }),
+    // Advertised without being capabilities, so they are absent from
+    // `visibleCapabilities` and have to be added here or every successful call
+    // to one is recorded as a refusal. `Generation.visible` makes the same
+    // addition over HTTP; this path was written before the surface existed and
+    // did not gain it, so the pipe has been writing that false row ever since.
+    ...SURFACE_TOOL_NAMES,
+  ]);
   const allCapabilityIds = [
     ...new Set(
       [...options.profiles.values()].flatMap((runtime) =>
@@ -93,6 +106,7 @@ export function serveOverStdio(options: StdioOptions): StdioSurface {
         principal,
         ...(options.clientLabel ? { clientLabel: options.clientLabel } : {}),
         ...(options.version ? { version: options.version } : {}),
+        ...surface,
       }),
     {
       transport: auditRefusals(options.transport ?? new StdioServerTransport(), (message) =>


### PR DESCRIPTION
Release. `package.json` is at 0.11.0 and that version carries no tag, so this
merge publishes it and cuts the tag rather than proposing a patch.

## `surface: crunched` (ADR-076)

An endpoint may now advertise the owner layer and the two stable-name tools, and
leave everything else reachable through `lanes_tools_search` and
`lanes_tools_call`. Measured on a deployed endpoint, both ways, same generation:

| | tools | on the wire | ≈ tokens |
|---|---|---|---|
| `full` | 278 | 702 KB | 180,000 |
| `crunched` | 28 | 31 KB | 8,000 |

No capability is lost — same merged set, same policy evaluation, same redaction,
same audit row. What shrinks is exposition, not authority.

ADR-075 deferred this decision explicitly, on the grounds that the number had to
come from measuring this surface rather than from a published evaluation.
ADR-076 takes it with that measurement.

## Availability

- A cold start no longer pays one serial round trip per provider it never
  connected. Measured boot on a real target: ~10.5s → 6.3s.
- The refusal audit and the stale-config probe now run for 2025-era clients,
  which is most of what reaches a deployed endpoint. That closes the second
  documented exception to `audit.every-invocation`; `resources/read` remains.
- A credential-store outage answers 503 with `Retry-After` instead of escaping
  the router as an unlogged 500.
- The 429 that stands in for a 401 now carries `WWW-Authenticate`, so a client
  with a lapsed token learns to refresh instead of recovering a minute later.
- A rotated refresh token is no longer discarded.
- Over stdio, a successful call to the search surface no longer writes an audit
  row claiming the caller reached for something unadvertised.

## Not breaking

`full` is the default and is bit-identical. An endpoint upgraded without setting
`surface:` serves exactly the list it served before. `contract` does not move.

## Note for the docs

The security page lists two standing exceptions to `audit.every-invocation`.
There is one left.