### PR TITLE
The stale-instance self-heal follows both halves of the stable-name pair

### DIFF
--- a/docs/detailed/adr/076-an-endpoint-may-advertise-less-than-it-reaches.md
+++ b/docs/detailed/adr/076-an-endpoint-may-advertise-less-than-it-reaches.md
@@ -122,6 +122,26 @@ ADR-075 accepted that because the caller could be told to use the typed tool ins
 `crunched` there is no typed tool to name, so the message says the link cannot be returned rather
 than naming one the client cannot call. This is the one thing the mode genuinely costs.
 
+**The stale-instance self-heal had to follow the calls.** `probeForNewConfig` exists because one
+`/reload` reaches one instance (ADR-029), so an instance can hold configuration older than the
+account a caller is naming; the recovery is to re-read when a call names something the generation
+cannot reach. That check was on the *tool name*, which works while every capability has a tool of
+its own — and stops working here, because the tool name is `lanes_tools_call` and that is always
+advertised. Left as it was, a provider connected after an instance booted would be answered
+"cannot reach", which is indistinguishable from never having connected it.
+
+So `Generation.knows()` asks the gateway one level down, about the capability it names, against
+the reachable set rather than the registry — the registry holds what the catalogue defines whether
+or not a grant reaches it, and so does not move when a connection is made. Reachability is also
+what the tool-name check always meant: a denied capability is not advertised either, so it too
+provoked one reload before its refusal. Policy denial and stale config are identical from inside
+the instance, and telling them apart is the probe's whole job.
+
+What this costs is bounded by the same rate limit as before — one probe per ten seconds — and a
+test asserts the inverse, that a *reachable* capability does not send the instance back to its
+config, because a reload per gateway call would re-open the whole workspace to learn what it
+already knew.
+
 **Flipping the mode changes a list clients cache.** `listChanged` is `false` (ADR-032) and nothing
 here makes a client re-read. So this is a deliberate operation with the same consequence as
 connecting a new provider — issue #162's consequence — and not a setting to toggle casually. It is

--- a/docs/detailed/adr/076-an-endpoint-may-advertise-less-than-it-reaches.md
+++ b/docs/detailed/adr/076-an-endpoint-may-advertise-less-than-it-reaches.md
@@ -122,7 +122,7 @@ ADR-075 accepted that because the caller could be told to use the typed tool ins
 `crunched` there is no typed tool to name, so the message says the link cannot be returned rather
 than naming one the client cannot call. This is the one thing the mode genuinely costs.
 
-**The stale-instance self-heal had to follow the calls.** `probeForNewConfig` exists because one
+**The stale-instance self-heal had to follow both halves of the pair.** `probeForNewConfig` exists because one
 `/reload` reaches one instance (ADR-029), so an instance can hold configuration older than the
 account a caller is naming; the recovery is to re-read when a call names something the generation
 cannot reach. That check was on the *tool name*, which works while every capability has a tool of
@@ -137,10 +137,32 @@ what the tool-name check always meant: a denied capability is not advertised eit
 provoked one reload before its refusal. Policy denial and stale config are identical from inside
 the instance, and telling them apart is the probe's whole job.
 
-What this costs is bounded by the same rate limit as before — one probe per ten seconds — and a
-test asserts the inverse, that a *reachable* capability does not send the instance back to its
-config, because a reload per gateway call would re-open the whole workspace to learn what it
-already knew.
+**The search is the half that comes first, and it needed a different question.** Under `crunched`
+nothing outside the owner layer is *called* until it has been *found*, so the realistic order after
+connecting a provider is search, then call. A stale instance answers `Nothing reachable matches`,
+and that sentence is not a hedge a model retries — it is a claim that the account does not have the
+thing, and it ends the attempt before a capability id is ever composed. Fixing only the call path
+would have left the endpoint able to recover from a mistake a model had already been told not to
+make.
+
+A search names no capability, so there is nothing to look up one level down. What it names is a
+query, and "has this instance heard of it" therefore means *does anything it holds match* — which
+is the ranking the search is about to run anyway. So `knows()` runs that ranking, stopped at the
+first hit, and a miss provokes the same probe: the reload lands before dispatch, the request is
+re-pinned to the new generation, and the search then answers from the config that was just read.
+The recovery happens inside the one call the model made, rather than on a retry nobody issues.
+
+`matchesQuery` and `rank` share their scoring for that reason. Two readings of "does this match"
+would drift into an endpoint that reloads for queries which then succeed anyway, and skips the
+reload for the ones that needed it — both silent, and the second one indistinguishable from the bug
+this closes.
+
+What this costs is bounded by the same rate limit as before — one probe per ten seconds, for both
+halves together — and tests assert the inverse for each: a *reachable* capability and a *matching*
+query do not send the instance back to its config, because a reload per call would re-open the
+whole workspace to learn what it already knew. A query that matches pays for a partial pass and
+nothing else; only one that matches nothing pays for the whole ranking twice, and that is the query
+about to cost a network round trip regardless.
 
 **Flipping the mode changes a list clients cache.** `listChanged` is `false` (ADR-032) and nothing
 here makes a client re-read. So this is a deliberate operation with the same consequence as

--- a/src/server/crunched.test.ts
+++ b/src/server/crunched.test.ts
@@ -195,6 +195,35 @@ describe('a crunched surface', () => {
     expect(prompts.map((prompt) => prompt.name)).toContain('lanes_skills_review-diff');
   });
 
+  test('a reachable capability does not send the instance back to its config', async () => {
+    // The inverse of the stale-instance fix: `knows()` asks about the capability
+    // the gateway names, and if it answered "unknown" for one that is merely
+    // de-advertised, every call under this mode would provoke a reload — the
+    // whole workspace re-opened, per call, to learn what it already knew.
+    const epoch = async () => {
+      const response = await fetch(crunched.server.url.replace('/mcp', '/reload'), {
+        method: 'POST',
+        headers: { authorization: `Bearer ${crunched.token}` },
+      });
+      return ((await response.json()) as { epoch?: number }).epoch;
+    };
+
+    const before = await epoch();
+
+    for (let attempt = 0; attempt < 3; attempt += 1) {
+      await callGateway(crunched.server.url, {
+        capability: 'example.echo',
+        profile: 'personal',
+        connection: 'example.a',
+        arguments: { message: 'again' },
+      });
+    }
+
+    // One epoch for the explicit reload above, one for the one below, and none
+    // in between — the calls did not add any.
+    expect(await epoch()).toBe((before ?? 0) + 1);
+  });
+
   test('a call through the gateway is not recorded as a refusal', async () => {
     await callGateway(crunched.server.url, {
       capability: 'example.echo',

--- a/src/server/crunched.test.ts
+++ b/src/server/crunched.test.ts
@@ -195,11 +195,13 @@ describe('a crunched surface', () => {
     expect(prompts.map((prompt) => prompt.name)).toContain('lanes_skills_review-diff');
   });
 
-  test('a reachable capability does not send the instance back to its config', async () => {
-    // The inverse of the stale-instance fix: `knows()` asks about the capability
-    // the gateway names, and if it answered "unknown" for one that is merely
-    // de-advertised, every call under this mode would provoke a reload — the
-    // whole workspace re-opened, per call, to learn what it already knew.
+  test('neither half of the pair sends the instance back to its config on a hit', async () => {
+    // The inverse of the stale-instance fix, and it has to hold for both halves.
+    // `knows()` asks the gateway about the capability it names and the search
+    // about whether anything matches its query; if either answered "unknown" for
+    // something this instance can perfectly well reach, every call under this
+    // mode would provoke a reload — the whole workspace re-opened, per call, to
+    // learn what it already knew.
     const epoch = async () => {
       const response = await fetch(crunched.server.url.replace('/mcp', '/reload'), {
         method: 'POST',
@@ -217,11 +219,32 @@ describe('a crunched surface', () => {
         connection: 'example.a',
         arguments: { message: 'again' },
       });
+      await rpc(crunched.server.url, 'tools/call', {
+        name: SURFACE_TOOL_NAMES[0]!,
+        arguments: { query: 'echo a message' },
+      });
     }
 
     // One epoch for the explicit reload above, one for the one below, and none
     // in between — the calls did not add any.
     expect(await epoch()).toBe((before ?? 0) + 1);
+  });
+
+  test('a search that matches nothing is answered, not refused', async () => {
+    // The probe fires here — nothing reachable matches — and this asserts what
+    // happens *after* it: one reload finds the config unchanged, and the search
+    // still answers with the same sentence it always did. The self-heal is a
+    // retry of the question, never a different answer to it.
+    const response = await rpc(crunched.server.url, 'tools/call', {
+      name: SURFACE_TOOL_NAMES[0]!,
+      arguments: { query: 'quantumfoobarbaz' },
+    });
+    const result = response.body['result'] as
+      | { content?: { text?: string }[]; isError?: boolean }
+      | undefined;
+
+    expect(result?.isError).toBeFalsy();
+    expect(result?.content?.[0]?.text ?? '').toContain('Nothing reachable matches');
   });
 
   test('a call through the gateway is not recorded as a refusal', async () => {

--- a/src/server/edge.ts
+++ b/src/server/edge.ts
@@ -282,6 +282,14 @@ export interface NamedTarget {
    * it does. Absent for every other tool, and for a body that does not carry it.
    */
   readonly capability: string | null;
+  /**
+   * The keywords, when the tool being called is `lanes_tools_search`.
+   *
+   * The same problem as `capability` and not the same shape: a search names no
+   * capability to look up, so what "this instance knows about it" means is
+   * whether anything it holds matches. Absent for every other tool.
+   */
+  readonly query: string | null;
 }
 
 /**
@@ -308,16 +316,17 @@ export interface NamedTarget {
  */
 export async function namedTarget(request: Request): Promise<NamedTarget> {
   // The envelope mirrors the method and the target name into headers, but not
-  // a tool's arguments — so the gateway's capability is only ever in the body,
-  // and reading it is the one thing an envelope client does not save us.
+  // a tool's arguments — so the stable-name pair's own arguments are only ever
+  // in the body, and reading them is the one thing an envelope client does not
+  // save us.
   const header = request.headers.get('mcp-method');
 
   try {
     const body = (await request.clone().json()) as {
       method?: unknown;
-      params?: { name?: unknown; arguments?: { capability?: unknown } };
+      params?: { name?: unknown; arguments?: { capability?: unknown; query?: unknown } };
     };
-    const capability = body.params?.arguments?.capability;
+    const { capability, query } = body.params?.arguments ?? {};
 
     return {
       method: header ?? (typeof body.method === 'string' ? body.method : null),
@@ -325,12 +334,13 @@ export async function namedTarget(request: Request): Promise<NamedTarget> {
         request.headers.get('mcp-name') ??
         (typeof body.params?.name === 'string' ? body.params.name : null),
       capability: typeof capability === 'string' ? capability : null,
+      query: typeof query === 'string' ? query : null,
     };
   } catch {
     // A body that is not JSON is one the handler refuses on its own, and a
     // refusal that cannot be named is not worth failing the request over. The
     // headers still stand where an envelope client sent them.
-    return { method: header, name: request.headers.get('mcp-name'), capability: null };
+    return { method: header, name: request.headers.get('mcp-name'), capability: null, query: null };
   }
 }
 

--- a/src/server/edge.ts
+++ b/src/server/edge.ts
@@ -274,6 +274,14 @@ export function authRefusal(input: {
 export interface NamedTarget {
   readonly method: string | null;
   readonly name: string | null;
+  /**
+   * The capability id, when the tool being called is `lanes_tools_call`.
+   *
+   * The gateway's own name is always advertised, so the tool name says nothing
+   * about whether this instance knows what is being asked for. One level down
+   * it does. Absent for every other tool, and for a body that does not carry it.
+   */
+  readonly capability: string | null;
 }
 
 /**
@@ -299,23 +307,30 @@ export interface NamedTarget {
  * is small.
  */
 export async function namedTarget(request: Request): Promise<NamedTarget> {
-  const method = request.headers.get('mcp-method');
-  if (method !== null) return { method, name: request.headers.get('mcp-name') };
+  // The envelope mirrors the method and the target name into headers, but not
+  // a tool's arguments — so the gateway's capability is only ever in the body,
+  // and reading it is the one thing an envelope client does not save us.
+  const header = request.headers.get('mcp-method');
 
   try {
     const body = (await request.clone().json()) as {
       method?: unknown;
-      params?: { name?: unknown };
+      params?: { name?: unknown; arguments?: { capability?: unknown } };
     };
+    const capability = body.params?.arguments?.capability;
 
     return {
-      method: typeof body.method === 'string' ? body.method : null,
-      name: typeof body.params?.name === 'string' ? body.params.name : null,
+      method: header ?? (typeof body.method === 'string' ? body.method : null),
+      name:
+        request.headers.get('mcp-name') ??
+        (typeof body.params?.name === 'string' ? body.params.name : null),
+      capability: typeof capability === 'string' ? capability : null,
     };
   } catch {
     // A body that is not JSON is one the handler refuses on its own, and a
-    // refusal that cannot be named is not worth failing the request over.
-    return { method: null, name: null };
+    // refusal that cannot be named is not worth failing the request over. The
+    // headers still stand where an envelope client sent them.
+    return { method: header, name: request.headers.get('mcp-name'), capability: null };
   }
 }
 

--- a/src/server/generation.ts
+++ b/src/server/generation.ts
@@ -3,12 +3,17 @@ import { ownerPrincipal, type Principal } from '#auth';
 import {
   advertisedNames,
   buildMcpServer,
-  visibleCapabilities,
+  matchesQuery,
+  mergeCapabilities,
   SURFACE_TOOL_NAMES,
   visibleToolCount,
+  type MergedCapability,
   type ProfileRuntime,
 } from '#server/mcp';
 import type { GenerationDeps, OpenedWorkspace } from './generations.ts';
+
+/** The search, whose own name never says what it is looking for. */
+const SEARCH_TOOL = SURFACE_TOOL_NAMES[0]!;
 
 /** The gateway, whose own name never says what it is reaching for. */
 const GATEWAY_TOOL = SURFACE_TOOL_NAMES[1]!;
@@ -61,13 +66,19 @@ export class Generation {
   readonly visible: () => ReadonlySet<string>;
 
   /**
-   * Every capability id this generation can reach, advertised or not.
+   * Every capability this generation can reach, advertised or not.
    *
    * Wider than `visible()` under `surface: crunched`, where most of what is
    * reachable is deliberately not advertised — which is exactly the gap the
-   * gateway is for, and the reason it needs its own set to check against.
+   * stable-name pair is for, and the reason it needs its own set to check
+   * against.
+   *
+   * The whole merged entry rather than the id alone, because the two halves of
+   * that pair ask different questions of it: `lanes_tools_call` names an id and
+   * wants a lookup, `lanes_tools_search` names keywords and wants the same
+   * ranking the search itself runs.
    */
-  readonly reachable: () => ReadonlySet<string>;
+  readonly reachable: () => ReadonlyMap<string, MergedCapability>;
 
   /**
    * How many tools this generation advertises (ADR-032).
@@ -99,13 +110,32 @@ export class Generation {
    * reload before the refusal — policy denial and stale config look identical
    * from here, and resolving that is the probe's whole job. The gateway now
    * gets the same treatment rather than a stricter one.
+   *
+   * **The search is the half that matters more**, because it comes first. Under
+   * `crunched` a client's list holds the owner layer and this pair, so nothing
+   * else is *called* until it has been *found* — and a stale instance answering
+   * "nothing reachable matches" ends the attempt before a capability id is ever
+   * composed. Fixing only the call path would have left the endpoint able to
+   * recover from a mistake a model had already been told not to make.
+   *
+   * A search names no capability, so there is nothing to look up; the question
+   * one level down is instead whether anything it holds matches, which is the
+   * ranking the search is about to run. `matchesQuery` is that ranking, stopped
+   * at the first hit — see `#server/mcp/search-index.ts` for why it must be the
+   * same one.
    */
-  knows(named: { name: string | null; capability: string | null }): boolean {
+  knows(named: { name: string | null; capability: string | null; query: string | null }): boolean {
     if (named.name === null) return true;
     if (!this.visible().has(named.name)) return false;
-    if (named.name !== GATEWAY_TOOL || named.capability === null) return true;
 
-    return this.reachable().has(named.capability);
+    if (named.name === GATEWAY_TOOL) {
+      return named.capability === null || this.reachable().has(named.capability);
+    }
+    if (named.name === SEARCH_TOOL) {
+      return named.query === null || matchesQuery(named.query, this.reachable());
+    }
+
+    return true;
   }
 
   /**
@@ -158,14 +188,8 @@ export class Generation {
         ),
     );
 
-    this.reachable = this.#memo(
-      () =>
-        new Set(
-          visibleCapabilities({
-            profiles: this.profiles,
-            principal: ownerPrincipal(deps.primary),
-          }),
-        ),
+    this.reachable = this.#memo(() =>
+      mergeCapabilities({ profiles: this.profiles, principal: ownerPrincipal(deps.primary) }),
     );
 
     this.toolCount = this.#memo(() =>

--- a/src/server/generation.ts
+++ b/src/server/generation.ts
@@ -3,11 +3,15 @@ import { ownerPrincipal, type Principal } from '#auth';
 import {
   advertisedNames,
   buildMcpServer,
+  visibleCapabilities,
   SURFACE_TOOL_NAMES,
   visibleToolCount,
   type ProfileRuntime,
 } from '#server/mcp';
 import type { GenerationDeps, OpenedWorkspace } from './generations.ts';
+
+/** The gateway, whose own name never says what it is reaching for. */
+const GATEWAY_TOOL = SURFACE_TOOL_NAMES[1]!;
 
 /**
  * One boot's worth of runtimes, and everything derived from them.
@@ -57,12 +61,52 @@ export class Generation {
   readonly visible: () => ReadonlySet<string>;
 
   /**
+   * Every capability id this generation can reach, advertised or not.
+   *
+   * Wider than `visible()` under `surface: crunched`, where most of what is
+   * reachable is deliberately not advertised — which is exactly the gap the
+   * gateway is for, and the reason it needs its own set to check against.
+   */
+  readonly reachable: () => ReadonlySet<string>;
+
+  /**
    * How many tools this generation advertises (ADR-032).
    *
    * Not `visible().size`: that set spans every reachable capability, and a
    * resource or a prompt is in it without being in `tools/list`.
    */
   readonly toolCount: () => number;
+
+  /**
+   * Whether this generation has heard of what a request is asking for.
+   *
+   * The question a stale instance has to answer before it refuses. It was once
+   * the same as "is the tool name advertised", and that stopped being enough
+   * when `surface: crunched` made `lanes_tools_call` the way most calls arrive:
+   * the gateway's own name is always advertised, so the tool-name check can
+   * never fire for it, and a call naming a provider connected since this
+   * instance booted was answered "cannot reach" — indistinguishable, to whoever
+   * asked, from never having connected it.
+   *
+   * So the gateway is asked one level down, about the capability it names,
+   * against the same reachable set `lanes_tools_call` dispatches from. Not the
+   * registry: that holds every capability the catalogue defines whether or not
+   * a grant reaches it, so it does not move when a connection is made and would
+   * answer "known" for something this instance cannot actually call.
+   *
+   * Reachability is also what the tool-name check has always meant. A denied
+   * capability is not advertised, so calling it by name already provokes one
+   * reload before the refusal — policy denial and stale config look identical
+   * from here, and resolving that is the probe's whole job. The gateway now
+   * gets the same treatment rather than a stricter one.
+   */
+  knows(named: { name: string | null; capability: string | null }): boolean {
+    if (named.name === null) return true;
+    if (!this.visible().has(named.name)) return false;
+    if (named.name !== GATEWAY_TOOL || named.capability === null) return true;
+
+    return this.reachable().has(named.capability);
+  }
 
   /**
    * The surface mode, read from the primary profile and from nowhere else.
@@ -111,6 +155,16 @@ export class Generation {
             // successful call to one is recorded as a refusal.
             ...SURFACE_TOOL_NAMES,
           ],
+        ),
+    );
+
+    this.reachable = this.#memo(
+      () =>
+        new Set(
+          visibleCapabilities({
+            profiles: this.profiles,
+            principal: ownerPrincipal(deps.primary),
+          }),
         ),
     );
 

--- a/src/server/index.test.ts
+++ b/src/server/index.test.ts
@@ -1093,6 +1093,32 @@ members: []
       await harness.stop();
     }
   });
+
+  test('a search finding nothing reloads before it reports the absence', async () => {
+    // The half that comes first, and the one a model acts on hardest. A search
+    // names no capability, so the check above has nothing to look up — what it
+    // names is a query, and "has this instance heard of it" means whether
+    // anything it holds matches. Without this, the same stale instance answers
+    // "Nothing reachable matches", which is not a hedge a model retries: it
+    // says the provider is not connected, and under `surface: crunched` the
+    // gateway call that would have self-healed is never composed at all.
+    const port = allocatePort();
+    const { harness, edit } = reloadable(port, configWith('personal', port, ['a'], READ_ONLY));
+
+    try {
+      // `echo` is reachable under EVERYTHING and under READ_ONLY is not — and
+      // nothing READ_ONLY leaves reachable mentions the word, so the stale
+      // instance's own ranking genuinely finds nothing.
+      edit(configWith('personal', port, ['a'], EVERYTHING));
+
+      const result = await callTool(harness.server.url, 'lanes_tools_search', { query: 'echo' });
+
+      expect(result.text).not.toContain('Nothing reachable matches');
+      expect(result.text).toContain('example.echo');
+    } finally {
+      await harness.stop();
+    }
+  });
 });
 
 describe('the authentication edge', () => {

--- a/src/server/index.test.ts
+++ b/src/server/index.test.ts
@@ -1068,6 +1068,31 @@ members: []
       await harness.stop();
     }
   });
+
+  test('a gateway call naming a capability this instance has not heard of reloads too', async () => {
+    // The same stale instance, reached the way `surface: crunched` makes every
+    // non-owner call arrive: through `lanes_tools_call`. The check above cannot
+    // fire for it — `lanes_tools_call` is always advertised, so the tool name is
+    // always known — and without this the gateway answers "cannot reach", which
+    // reads exactly like the provider was never connected.
+    const port = allocatePort();
+    const { harness, edit } = reloadable(port, configWith('personal', port, ['a'], READ_ONLY));
+
+    try {
+      edit(configWith('personal', port, ['a'], EVERYTHING));
+
+      const result = await callTool(harness.server.url, 'lanes_tools_call', {
+        capability: 'example.echo',
+        connection: 'example.a',
+        arguments: { message: 'hello' },
+      });
+
+      expect(result.isError).toBeFalsy();
+      expect(result.text).toContain('hello');
+    } finally {
+      await harness.stop();
+    }
+  });
 });
 
 describe('the authentication edge', () => {

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -300,7 +300,7 @@ export function createRequestHandler(options: ServerOptions): RequestHandler {
         if (named.method === 'tools/call' || named.method === 'prompts/get') {
           const toolName = named.name;
 
-          if (toolName && !generation.visible().has(toolName)) {
+          if (!generation.knows(named)) {
             // Before recording it as a refusal: this instance may simply be
             // holding config older than the account the caller is naming.
             if (await probeForNewConfig()) {

--- a/src/server/mcp/index.ts
+++ b/src/server/mcp/index.ts
@@ -21,6 +21,7 @@ export { buildMcpServer } from './build.ts';
 export { serverInstructions } from './instructions.ts';
 export { SERVER_NAME, SURFACE_TOOL_NAMES, capabilityIdForToolName, toolNameFor } from './naming.ts';
 export { scopeResourceUri } from './routing.ts';
+export { matchesQuery } from './search-index.ts';
 export { sanitizeSchema } from './schema.ts';
 export {
   advertisedNames,

--- a/src/server/mcp/search-index.ts
+++ b/src/server/mcp/search-index.ts
@@ -100,24 +100,71 @@ function holds(list: readonly string[], term: string): boolean {
   );
 }
 
+/** What one capability's title and description are, whichever kind it is. */
+function summaryOf(entry: MergedCapability): { title: string | undefined; description: string } {
+  if (entry.discovered) {
+    return { title: entry.discovered.title, description: entry.discovered.description };
+  }
+
+  const capability = entry.capability;
+  if (!capability || !isTool(capability)) return { title: undefined, description: '' };
+
+  return { title: capability.title, description: capability.description };
+}
+
+/** Whether the search considers this entry at all. */
+function searchable(entry: MergedCapability): boolean {
+  return entry.discovered !== undefined || (!!entry.capability && isTool(entry.capability));
+}
+
+/**
+ * How well one entry answers the query — the whole of the ranking.
+ *
+ * Its own function because two callers have to agree exactly: the search, and
+ * the check in front of it that decides whether a miss is worth re-reading the
+ * config for. A second reading of "does this match" would make the endpoint
+ * reload for queries that then succeed anyway, and skip the reload for the ones
+ * that needed it — both silent.
+ *
+ * Deliberately reads `summaryOf` rather than `shapeOf`: nothing here looks at a
+ * schema, and `shapeOf` converts Zod to JSON Schema for every authored
+ * capability it is handed.
+ */
+function scoreEntry(id: string, entry: MergedCapability, terms: readonly string[]): number {
+  const summary = summaryOf(entry);
+  const name = words(id);
+  const title = words(summary.title ?? '');
+  // The connections block `describeWithConnections` appends is not part of
+  // what this searches — it is identical on every tool, so it would match
+  // every term in it against everything.
+  const description = words(summary.description.split('\n\nAvailable connections')[0] ?? '');
+
+  let score = 0;
+  for (const term of terms) {
+    // The name is worth most: it carries the provider id, which is how a
+    // query naming a vendor finds that vendor's tools at all.
+    if (holds(name, term)) score += 3;
+    else if (holds(title, term)) score += 2;
+    else if (holds(description, term)) score += 1;
+  }
+
+  return score;
+}
+
 /** What one capability's title, description and schema are, whichever kind it is. */
 function shapeOf(entry: MergedCapability): {
   title: string | undefined;
   description: string;
   inputSchema: Record<string, unknown>;
 } {
+  const summary = summaryOf(entry);
+
   if (entry.discovered) {
-    return {
-      title: entry.discovered.title,
-      description: entry.discovered.description,
-      inputSchema: sanitizeSchema(entry.discovered.inputSchema),
-    };
+    return { ...summary, inputSchema: sanitizeSchema(entry.discovered.inputSchema) };
   }
 
   const capability = entry.capability;
-  if (!capability || !isTool(capability)) {
-    return { title: undefined, description: '', inputSchema: { type: 'object' } };
-  }
+  if (!capability || !isTool(capability)) return { ...summary, inputSchema: { type: 'object' } };
 
   // Authored capabilities carry Zod, so the JSON Schema a caller needs is
   // derived here rather than stored. `registerLocalTool` hands the SDK the Zod
@@ -131,7 +178,7 @@ function shapeOf(entry: MergedCapability): {
     // threw would take out every other result with it.
   }
 
-  return { title: capability.title, description: capability.description, inputSchema };
+  return { ...summary, inputSchema };
 }
 
 interface Match {
@@ -167,25 +214,9 @@ function rank(query: string, merged: Map<string, MergedCapability>): Match[] {
   const matches: Match[] = [];
 
   for (const [id, entry] of merged) {
-    if (!entry.discovered && !(entry.capability && isTool(entry.capability))) continue;
+    if (!searchable(entry)) continue;
 
-    const shape = shapeOf(entry);
-    const name = words(id);
-    const title = words(shape.title ?? '');
-    // The connections block `describeWithConnections` appends is not part of
-    // what this searches — it is identical on every tool, so it would match
-    // every term in it against everything.
-    const description = words(shape.description.split('\n\nAvailable connections')[0] ?? '');
-
-    let score = 0;
-    for (const term of terms) {
-      // The name is worth most: it carries the provider id, which is how a
-      // query naming a vendor finds that vendor's tools at all.
-      if (holds(name, term)) score += 3;
-      else if (holds(title, term)) score += 2;
-      else if (holds(description, term)) score += 1;
-    }
-
+    const score = scoreEntry(id, entry, terms);
     if (score > 0) matches.push({ id, tool: toolNameFor(id), score, entry });
   }
 
@@ -323,4 +354,41 @@ export function searchCapabilities(
   surface?: 'full' | 'crunched',
 ): string {
   return renderMatches(query, rank(query, merged), surface);
+}
+
+/**
+ * Whether anything at all would come back for this query.
+ *
+ * `searchCapabilities` renders "Nothing reachable matches" from an empty
+ * ranking, and that sentence is a claim about what this *instance* holds rather
+ * than about the account. An instance that missed the notify (ADR-029) makes it
+ * about a provider connected minutes ago, and it is the answer a model acts on:
+ * a search is how anything outside the owner layer is found under
+ * `surface: crunched`, so a wrong miss here ends the attempt before a call is
+ * ever composed.
+ *
+ * So the endpoint asks this before dispatching a search, and treats a miss the
+ * way it already treats a call naming a tool it does not serve — see
+ * `Generation.knows`.
+ *
+ * The same ranking `rank` runs, stopped at the first hit instead of sorted.
+ * A query that matches costs a partial pass and no reload; only one that
+ * matches nothing pays for the whole pass, and that is the query about to cost
+ * a network round trip regardless.
+ */
+export function matchesQuery(
+  query: string,
+  merged: ReadonlyMap<string, MergedCapability>,
+): boolean {
+  if (merged.has(query.trim())) return true;
+
+  const terms = queryTerms(query);
+  if (terms.length === 0) return false;
+
+  for (const [id, entry] of merged) {
+    if (!searchable(entry)) continue;
+    if (scoreEntry(id, entry, terms) > 0) return true;
+  }
+
+  return false;
 }


### PR DESCRIPTION
`probeForNewConfig` exists because one `/reload` reaches one instance (ADR-029), so an instance can
serve configuration older than the account a caller is naming. The recovery is to re-read when a
call names something the generation cannot reach — and the check was on the *tool name*, which
works only while every capability has a tool of its own.

`surface: crunched` (0.11.0, ADR-076) removed that property without failing anywhere. Both halves
of the stable-name pair are always advertised, so the tool-name check can never fire for either,
and both were answering out of stale config.

### The call path

`lanes_tools_call` names a capability, so `Generation.knows()` asks about it one level down —
against the *reachable* set, not the registry. The registry holds every capability the catalogue
defines whether or not a grant reaches it, so it does not move when a connection is made and would
answer "known" for something the instance cannot call. That was the first attempt and a test caught
it.

### The search path — the half that comes first

`lanes_tools_search` names no capability, so there was nothing to ask. It is also the half that
matters more: under `crunched` a client's list holds the owner layer and this pair, so nothing else
is *called* until it has been *found*. A stale instance answers `Nothing reachable matches`, which
is not a hedge a model retries — it says the account does not have the thing, and the gateway call
that would have self-healed is never composed.

A query is not an id, so the question has a different shape: whether anything this instance holds
matches, which is the ranking the search is about to run anyway. `matchesQuery` is that ranking
stopped at the first hit. The reload lands before dispatch and the request re-pins to the new
generation, so the search answers from the config just read — the recovery happens inside the one
call the model made.

`rank` and `matchesQuery` share `scoreEntry`, because two readings of "does this match" would drift
into an endpoint that reloads for queries which then succeed anyway and skips the reload for the
ones that needed it. Extracting it also took `shapeOf` off the scoring path, which was converting
Zod to JSON Schema for every authored capability on every search.

### Measured

The call path was verified against a real Cloud Run deployment before and after, by denying a
capability on every grant that reaches it, reloading so the instance believes it, restoring the
config in the bucket *without* reloading, then calling through the gateway.

| | pre-fix revision | with the fix |
|---|---|---|
| stale gateway call | `isError: true` — "cannot reach" | returns real data |
| reloads observed | 1 (only the explicit one) | 2 (the probe fired) |

`epoch` from `/reload` is the instrument, not the error message — and note that `RELOAD_PROBE_MS`
is 10s, so two probing calls inside that window will show only one reload.

### Cost

Bounded by the same rate limit as before, one probe per ten seconds for both halves together. Tests
assert the inverse for each: a reachable capability and a matching query both leave the instance
alone, because a reload per call would re-open the whole workspace to learn what it already knew. A
query that matches pays for a partial pass; only one that matches nothing pays for the full ranking
twice, and that is the query about to cost a round trip regardless.

ADR-076 is amended rather than contradicted — it claimed the mode cost only the `resource_link`
case, and it did not.

### Note for whoever is next

`src/server/mcp/search-index.ts` is now 394 lines against the 400-line budget. Splitting rendering
(`renderMatches`, `shapeOf`, `whereReachable`) out of ranking is the natural seam, and was left out
of this change to keep the diff readable against the behaviour it is about.