### PR TITLE
chore: 0.11.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lanes-sh/link",
-  "version": "0.11.0",
+  "version": "0.11.1",
   "description": "A self-hostable MCP gateway for all your connections, memory, tasks, files, and secrets",
   "license": "Apache-2.0",
   "homepage": "https://lanes.sh/link",


### PR DESCRIPTION
A patch: one fix to something 0.11.0 shipped, changing no configuration and no name.

`surface: crunched` made both halves of the stable-name pair the way calls arrive, and both names
are always advertised — so the stale-config probe, which keyed on a call naming a tool the endpoint
does not serve, could never fire for either. An instance that missed the notify (ADR-029) answered
"cannot reach" for a provider connected since it booted, and `Nothing reachable matches` for a
search naming one.

The search is the half that matters more, because it comes first: under `crunched` nothing outside
the owner layer is called until it has been found, so a wrong miss ends the attempt before a
capability id is ever composed. `Generation.knows()` now asks the gateway about the capability it
names and the search about whether anything it holds matches, and either miss re-reads the config
before answering — before dispatch, so the recovery happens inside the call the model already made.

Measured on a deployed endpoint, same script and same config on both revisions:

| | before | after |
|---|---|---|
| stale search | `Nothing reachable matches` | its 11 matches |
| reloads over the run | 1 (only the explicit one) | 3 (two probes + the reload) |

Bounded by the same rate limit as before — one probe per ten seconds — and neither a reachable
capability nor a matching query provokes one.