### PR TITLE
chore: 0.11.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lanes-sh/link",
-  "version": "0.11.1",
+  "version": "0.11.2",
   "description": "A self-hostable MCP gateway for all your connections, memory, tasks, files, and secrets",
   "license": "Apache-2.0",
   "homepage": "https://lanes.sh/link",


### PR DESCRIPTION
A patch, because it fills in a field that was already advertised and already wrong. No
configuration changes, no name changes, and no shape a client depends on moves.

`serverInfo.version` has answered `0.0.0` on every endpoint this project has ever served —
deployed and local, over HTTP and over stdio. `ServerOptions.version` was optional and set by
nobody, so `?? '0.0.0'` was the only value that path produced. `endpoint.ts` computed the real
one four lines too late and sent it to the dashboard read surface, the one surface an MCP client
cannot see.

It surfaced from the 0.11.1 release itself: redeploying afterwards changed nothing, because
there was nothing for the redeploy to change. That is exactly the case `#cli/version.ts` was
written for — *"two machines can now be a release apart with nothing on either to say so"* — and
until this ships, an operator asking a deployed instance which release it holds gets the same
answer before and after every release.

Which makes this the first release whose own shipping can be confirmed by the surface it adds,
rather than by reading back a transcript.

The version is set here, on `develop`, before the pull request to `main`, so the merge arrives
untagged and takes the publish path rather than the propose one.
