### PR TITLE
0.11.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lanes-sh/link",
-  "version": "0.11.1",
+  "version": "0.11.2",
   "description": "A self-hostable MCP gateway for all your connections, memory, tasks, files, and secrets",
   "license": "Apache-2.0",
   "homepage": "https://lanes.sh/link",

--- a/src/server/boot.test.ts
+++ b/src/server/boot.test.ts
@@ -3,6 +3,8 @@ import { mkdtemp, rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { profileAdd } from '#cli/commands/profile.ts';
+import { tokenIssue, tokenShow } from '#cli/commands/operate/token.ts';
+import { version } from '#cli/version.ts';
 import { primaryProfile } from '#cli/runtime.ts';
 import { startEndpoint } from './endpoint.ts';
 import { allocatePort } from './harness.ts';
@@ -53,6 +55,24 @@ async function workspace(): Promise<string> {
   return home;
 }
 
+/** Run a command that reports on stdout, and hand back what it wrote. */
+async function capture(run: () => Promise<void>): Promise<string> {
+  const write = process.stdout.write.bind(process.stdout);
+  let out = '';
+  try {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (process.stdout as any).write = (chunk: unknown): boolean => {
+      out += String(chunk);
+      return true;
+    };
+    await run();
+  } finally {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (process.stdout as any).write = write;
+  }
+  return out;
+}
+
 describe('a workspace that has issued no token', () => {
   test('boots, serves, and says how to authorise', async () => {
     const home = await workspace();
@@ -88,6 +108,72 @@ describe('a workspace that has issued no token', () => {
       expect(refused.headers.get('www-authenticate')).toContain(
         'oauth-protected-resource',
       );
+    } finally {
+      await endpoint?.stop();
+      if (previous === undefined) delete process.env['LANES_LINK_HOME'];
+      else process.env['LANES_LINK_HOME'] = previous;
+    }
+  });
+
+
+  test('and tells a client which release it is', async () => {
+    // `serverInfo.version` is the only place a client or an operator can see
+    // what a running instance actually is, and it answered `0.0.0` on every
+    // endpoint this project has ever served. The value was read here and handed
+    // to the read surface alone, so `buildMcpServer` fell through to its
+    // fallback — over HTTP and over stdio alike.
+    //
+    // Asserted through `startEndpoint` rather than the harness, deliberately.
+    // The harness wires `serveOverStdio` and `buildMcpServer` itself, so it
+    // would have passed throughout: what broke is the wiring, and only a real
+    // boot exercises it.
+    const home = await workspace();
+    const previous = process.env['LANES_LINK_HOME'];
+    process.env['LANES_LINK_HOME'] = home;
+
+    const port = allocatePort();
+    let endpoint: Awaited<ReturnType<typeof startEndpoint>> | null = null;
+
+    try {
+      const issue = { target: 'local', quiet: true, subject: 'lanes:boottest01' };
+      await capture(() => tokenIssue(issue));
+      const token = (await capture(() => tokenShow({ ...issue, raw: true }))).trim();
+
+      const flags = { target: 'local', quiet: true, profile: await primaryProfile({ target: 'local' }) };
+      endpoint = await startEndpoint({ flags, port, host: '127.0.0.1' });
+
+      const response = await fetch(`http://127.0.0.1:${port}/mcp`, {
+        method: 'POST',
+        headers: {
+          'content-type': 'application/json',
+          accept: 'application/json, text/event-stream',
+          authorization: `Bearer ${token}`,
+        },
+        body: JSON.stringify({
+          jsonrpc: '2.0',
+          id: 1,
+          method: 'initialize',
+          params: {
+            protocolVersion: '2025-06-18',
+            capabilities: {},
+            clientInfo: { name: 'boot-test', version: '1' },
+          },
+        }),
+      });
+
+      const raw = await response.text();
+      const line = raw
+        .split('\n')
+        .map((part) => (part.startsWith('data:') ? part.slice(5).trim() : part.trim()))
+        .find((part) => part.startsWith('{'));
+      const info = (JSON.parse(line ?? '{}').result ?? {}).serverInfo as
+        | { name?: string; version?: string }
+        | undefined;
+
+      expect(info?.name).toBe('lanes-link');
+      expect(info?.version).toBe(version());
+      // Named, because it is what the whole test is about.
+      expect(info?.version).not.toBe('0.0.0');
     } finally {
       await endpoint?.stop();
       if (previous === undefined) delete process.env['LANES_LINK_HOME'];

--- a/src/server/endpoint.ts
+++ b/src/server/endpoint.ts
@@ -239,6 +239,12 @@ export async function startEndpoint(options: EndpointOptions): Promise<RunningEn
     // a reload replaces (ADR-029). Retiring that generation stays safe for them
     // because `Runtime.close()` ends connector sessions and the audit log — it
     // does not close the credential store or the state handle these hold.
+    // Read once, and before the generations that carry it. `version()` walks up
+    // to the install root and parses `package.json`; doing it per request would
+    // put a synchronous file read on a hot path to answer a value that cannot
+    // change while this process lives.
+    const runningVersion = version();
+
     const generations = new Generations(
       { profiles: profileRuntimes(runtimes), close: () => closeAll(runtimes).then(() => {}) },
       async (): Promise<OpenedWorkspace> => {
@@ -258,14 +264,20 @@ export async function startEndpoint(options: EndpointOptions): Promise<RunningEn
       // `remoteClients` is the gate's existence, not a second setting: a profile
       // declaring `auth.authorization` is one a connector reaches by URL, which
       // is exactly the client the extra paragraph is written for.
-      { primary: primary.resolution.profile, log, ...(gate ? { remoteClients: true } : {}) },
+      //
+      // `version` is what the endpoint calls itself in `serverInfo`, and it was
+      // computed here and then handed only to the read surface — so every
+      // instance this has ever served, over HTTP and over stdio, answered
+      // `initialize` with `buildMcpServer`'s `0.0.0` fallback. The value exists
+      // for exactly the case that misses: two machines a release apart with
+      // nothing on either to say so (`#cli/version.ts`).
+      {
+        primary: primary.resolution.profile,
+        log,
+        version: runningVersion,
+        ...(gate ? { remoteClients: true } : {}),
+      },
     );
-
-    // Read once. `version()` walks up to the install root and parses
-    // `package.json`; doing it per request would put a synchronous file read on
-    // the read surface's hot path to answer a value that cannot change while
-    // this process lives.
-    const runningVersion = version();
 
     const server = serve({
       generations,
@@ -364,6 +376,10 @@ export async function startStdioEndpoint(
       profiles: profileRuntimes(runtimes),
       primary: primary.resolution.profile,
       log: options.log ?? silentLogger(),
+      // The same omission as the HTTP path above, and the same fix. A client
+      // reaching this over a pipe is the one most likely to be a release behind
+      // the workspace it opens, since nothing redeployed it.
+      version: version(),
       ...(options.clientLabel ? { clientLabel: options.clientLabel } : {}),
     });
 


### PR DESCRIPTION
Release. `package.json` is at 0.11.2 and that version carries no tag, so this merge publishes it
and cuts the tag rather than proposing a patch.

## An endpoint says which release it is

`serverInfo.version` has answered `0.0.0` on every endpoint this project has ever served —
deployed and local, over HTTP and over stdio. `ServerOptions.version` was optional, threaded
through `GenerationDeps` to `buildMcpServer`, and set by nobody, so `?? '0.0.0'` was the only value
that path could produce. `endpoint.ts` computed the real one, four lines below the `Generations` it
needed to reach, and sent it to the dashboard read surface — the one surface an MCP client cannot
see.

It surfaced from the other end: releasing 0.11.1 and redeploying changed nothing, because there was
nothing for the redeploy to change. That is exactly the case `#cli/version.ts` was written for —
*"two machines can now be a release apart with nothing on either to say so"* — and a client's
connector dialog shows this string, with `initialize` the only surface that carries it.

The fix reads the version before the generations rather than after, and passes it, on the HTTP path
and the stdio one both. `boot.test.ts` covers it through a real `startEndpoint` and a real socket,
because the harness wires `buildMcpServer` itself and a harness test would have passed throughout:
what broke is the wiring, and only a boot exercises it.

## Measured

Verifying 0.11.1 meant reading back a transcript, because the endpoint could not be asked. This one
was verified by asking it. Deployed from the release branch to a real target before this pull
request was opened:

| | before | after |
|---|---|---|
| `initialize` → `serverInfo.version` | `0.0.0` | `0.11.2` |

The same revision answers `/reload` with its two profiles and 28 tools, and `/health` `ok` — the
version is the only thing that moved.

A patch: no configuration changes, no name changes, and no shape a client depends on moves. It
fills in a field that was already advertised and already wrong.
