### PR TITLE
An OAuth connection can refresh again

### DIFF
--- a/src/connectivity/auth/oauth-authcode/index.ts
+++ b/src/connectivity/auth/oauth-authcode/index.ts
@@ -67,6 +67,13 @@ export async function resolveUpstreamToken(
       // required", which says nothing about the real problem. Exchanging a
       // stored refresh token needs the token endpoint and the client, and
       // nothing else.
+      //
+      // That error has a second cause, and reading it as this one cost a while.
+      // Since the 2.0.0 client it is also what a *correctly discovered* MCP
+      // provider gets when its access token expires, because `fetchToken` now
+      // routes every grant through `prepareTokenRequest()` — which the provider
+      // did not implement. Same sentence, unrelated problem, and it made the
+      // MCP path below look like the working one. `provider.ts` implements it.
       if (manifest.connector.kind !== 'mcp') {
         return (await refreshDirectly(manifest, target, endpoint, credentials)) as never;
       }

--- a/src/connectivity/auth/oauth-authcode/prepare.test.ts
+++ b/src/connectivity/auth/oauth-authcode/prepare.test.ts
@@ -1,0 +1,116 @@
+import { describe, expect, test } from 'bun:test';
+import { defineProvider } from '#connectivity';
+import type { SecretRef, SecretStore } from '#secrets';
+import { CredentialOAuthProvider } from './provider.ts';
+
+/**
+ * Which grant this asks for, when the SDK asks.
+ *
+ * `prepareTokenRequest` is optional in the SDK's interface and was
+ * unnecessary until the 2.0.0 client: `auth()` exchanged a stored refresh
+ * token itself. It now routes every token request through it, so a provider
+ * without one can only complete the flow the SDK still has a default for — the
+ * authorization code.
+ *
+ * The consequence was silent and total. Every `mcp` connector using OAuth
+ * worked until its first access token expired and then failed permanently,
+ * with a message that mentions neither refresh nor expiry: "Either
+ * provider.prepareTokenRequest() or authorizationCode is required". Three
+ * separate providers were reported unreachable before the shape of it was
+ * clear.
+ *
+ * Half of what follows asserts that this stays quiet, because a token request
+ * is not a place to be helpful by default.
+ */
+
+const manifest = defineProvider({
+  id: 'vendor_notes',
+  name: 'Vendor Notes',
+  connector: { kind: 'mcp', endpoint: 'https://mcp.example.com/mcp' },
+  auth: { kind: 'oauth', registration: 'dynamic' },
+});
+
+/** A credential store over a Map, so what is stored is what was written. */
+function storeWith(rows: Record<string, unknown>): SecretStore {
+  const map = new Map(Object.entries(rows).map(([ref, value]) => [ref, JSON.stringify(value)]));
+  return {
+    get: async (ref: SecretRef) => map.get(ref) ?? null,
+    set: async (ref: SecretRef, value: string) => void map.set(ref, value),
+    delete: async (ref: SecretRef) => void map.delete(ref),
+    list: async () => [...map.keys()] as SecretRef[],
+  } as unknown as SecretStore;
+}
+
+function provider(rows: Record<string, unknown>): CredentialOAuthProvider {
+  return new CredentialOAuthProvider({
+    manifest,
+    connectionId: 'con1',
+    credentials: storeWith(rows),
+  });
+}
+
+/** Where `saveTokens` and `tokens` keep their blob for this connection. */
+const TOKENS = 'vendor_notes/con1';
+
+describe('what grant a token request asks for', () => {
+  test('a stored refresh token becomes a refresh grant', async () => {
+    const params = await provider({ [TOKENS]: { refresh_token: 'r1', access_token: 'a1' } })
+      .prepareTokenRequest();
+
+    expect(params?.get('grant_type')).toBe('refresh_token');
+    expect(params?.get('refresh_token')).toBe('r1');
+  });
+
+  /**
+   * An omitted scope on a refresh means "the same as before". Naming a narrower
+   * one would quietly downgrade the grant, so it is only sent when asked for.
+   */
+  test('a scope is passed on only when one was given', async () => {
+    const stored = { [TOKENS]: { refresh_token: 'r1' } };
+
+    expect((await provider(stored).prepareTokenRequest())?.has('scope')).toBe(false);
+    expect((await provider(stored).prepareTokenRequest(''))?.has('scope')).toBe(false);
+    expect((await provider(stored).prepareTokenRequest('read'))?.get('scope')).toBe('read');
+  });
+
+  /**
+   * The one that would be a bug rather than a nuisance.
+   *
+   * The SDK consults this *before* it looks at the authorization code, so
+   * answering with a refresh grant during a genuine re-authorization would
+   * spend a refresh token where the caller had just consented in a browser —
+   * and the consent would be thrown away. `#codeVerifier` is set for exactly
+   * the length of one exchange, which makes it the signal that one is running.
+   */
+  test('an authorization code in flight is left alone', async () => {
+    const during = provider({ [TOKENS]: { refresh_token: 'r1' } });
+    during.saveCodeVerifier('pkce-verifier');
+
+    expect(await during.prepareTokenRequest()).toBeUndefined();
+  });
+
+  /**
+   * And once that exchange is over the verifier is dropped, so the next
+   * refresh is prepared normally rather than being shadowed by a flow that has
+   * finished.
+   */
+  test('and is prepared again once that exchange has finished', async () => {
+    const after = provider({ [TOKENS]: { refresh_token: 'r1' } });
+    after.saveCodeVerifier('pkce-verifier');
+    await after.invalidateCredentials('verifier');
+
+    expect((await after.prepareTokenRequest())?.get('grant_type')).toBe('refresh_token');
+  });
+
+  /**
+   * Nothing stored is a connection that genuinely needs re-consent. Falling
+   * through leaves the SDK to start an authorization, which
+   * `redirectToAuthorization` turns into `ReauthRequired` naming the command
+   * that fixes it — a better answer than a token request that cannot succeed.
+   */
+  test('no refresh token falls through rather than guessing', async () => {
+    expect(await provider({}).prepareTokenRequest()).toBeUndefined();
+    expect(await provider({ [TOKENS]: { access_token: 'a1' } }).prepareTokenRequest()).toBeUndefined();
+    expect(await provider({ [TOKENS]: { refresh_token: '' } }).prepareTokenRequest()).toBeUndefined();
+  });
+});

--- a/src/connectivity/auth/oauth-authcode/provider.ts
+++ b/src/connectivity/auth/oauth-authcode/provider.ts
@@ -144,6 +144,48 @@ export class CredentialOAuthProvider {
     });
   }
 
+  /**
+   * The grant to ask for, when it is not an authorization code.
+   *
+   * Optional in the SDK's interface and, until 2.0.0, unnecessary: `auth()`
+   * exchanged a stored refresh token itself. It now routes **every** token
+   * request through here, so a provider that does not implement it can only
+   * ever complete the one flow the SDK still has a default for — the
+   * authorization code. Every `mcp` connector using OAuth therefore worked
+   * until its first access token expired and then failed permanently, with
+   * `fetchToken`'s own words: "Either provider.prepareTokenRequest() or
+   * authorizationCode is required". Nothing in that sentence points at a
+   * refresh, which is why it read as a discovery problem for so long.
+   *
+   * Two returns of `undefined`, and both matter:
+   *
+   * **A code exchange in flight.** The SDK consults this *before* it looks at
+   * the authorization code, so answering with a refresh grant here would
+   * hijack a genuine re-authorization and spend a refresh token where the
+   * caller had just consented in a browser. `#codeVerifier` is set for exactly
+   * the length of one exchange, which makes it the reliable signal that one is
+   * happening.
+   *
+   * **No refresh token stored.** Falling through leaves the SDK to raise its
+   * own error or start an authorization, which is the right outcome: a
+   * connection with no refresh token genuinely does need re-consent, and
+   * `redirectToAuthorization` turns that into `ReauthRequired` with the command
+   * that fixes it.
+   */
+  async prepareTokenRequest(scope?: string): Promise<URLSearchParams | undefined> {
+    if (this.#codeVerifier !== undefined) return undefined;
+
+    const stored = await this.tokens();
+    const refresh = stored?.refresh_token;
+    if (typeof refresh !== 'string' || refresh.length === 0) return undefined;
+
+    const params = new URLSearchParams({ grant_type: 'refresh_token', refresh_token: refresh });
+    // Only when asked for. An omitted `scope` on a refresh means "the same as
+    // before", and naming a narrower one would quietly downgrade the grant.
+    if (scope !== undefined && scope.length > 0) params.set('scope', scope);
+    return params;
+  }
+
   async redirectToAuthorization(authorizationUrl: URL): Promise<void> {
     if (!this.#options.openBrowser) {
       throw new ReauthRequired(


### PR DESCRIPTION
Every `mcp` connector using OAuth — Notion, Linear, Supabase, and around seventy others in the
registry — stops working the moment its first access token expires. All of them fail identically:

```
Either provider.prepareTokenRequest() or authorizationCode is required
```

`prepareTokenRequest` is optional in the SDK's `OAuthClientProvider` and was unnecessary until the
2.0.0 client: `auth()` exchanged a stored refresh token itself. It now routes **every** token
request through it, so a provider that does not implement it can only complete the one flow the SDK
still has a default for — the authorization code. A refresh has nowhere to go.

```js
// @modelcontextprotocol/client 2.0.0, fetchToken
if (provider.prepareTokenRequest) tokenRequestParams = await provider.prepareTokenRequest(effectiveScope);
if (!tokenRequestParams) {
  if (!authorizationCode) throw new Error("Either provider.prepareTokenRequest() or authorizationCode is required");
```

Nothing in that sentence mentions refresh or expiry, which is why it read as a discovery problem.
This repository had already met it from the other direction: `index.ts` routes non-MCP providers
around `auth()` precisely because a REST API describes no authorization server and fails the same
way. That comment now records both causes, since reading the second as the first is what made the
MCP path look like the working one.

## The implementation is mostly about staying quiet

Two returns of `undefined`, and both are the point:

- **An authorization code in flight.** The SDK consults this *before* it looks at the code, so
  answering with a refresh grant during a genuine re-authorization would spend a refresh token where
  the caller had just consented in a browser, and throw the consent away. `#codeVerifier` is set for
  exactly the length of one exchange.
- **No refresh token stored.** Falling through leaves the SDK to start an authorization, which
  `redirectToAuthorization` turns into `ReauthRequired` naming the command that fixes it — a better
  answer than a token request that cannot succeed.

A scope is forwarded only when asked for. Omitting it on a refresh means "the same as before";
naming a narrower one would quietly downgrade the grant.

## How it was found

While verifying an unrelated branch against a deployed endpoint, which is the only place it shows:
a fresh connection works, and the failure arrives an hour later. `link status` reports every one of
these connections as `active`, because the credential is stored — it is the refresh that cannot run.

## Checks

`bun test` 3401 pass, 0 fail. `bun run typecheck` clean. Five new tests, three of which assert the
cases where this must do nothing.

Deploying is the operator's call; the effect is not visible until an access token expires.