### PR TITLE
nodemailer 9.1.1, which is where four advisories stop applying

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -10,7 +10,7 @@
         "@modelcontextprotocol/server": "2.0.0",
         "@rgrove/parse-xml": "4.2.3",
         "mcp-from-openapi": "2.5.1",
-        "nodemailer": "9.0.3",
+        "nodemailer": "9.1.1",
         "postal-mime": "2.7.5",
         "yaml": "2.9.0",
         "zod": "4.4.3",
@@ -56,7 +56,7 @@
 
     "mcp-from-openapi": ["mcp-from-openapi@2.5.1", "", { "dependencies": { "@apidevtools/json-schema-ref-parser": "^15.3.5", "openapi-types": "^12.1.3", "yaml": "^2.8.3" }, "peerDependencies": { "zod": "^4.0.0" } }, "sha512-tcP3lMFaDOpNn0pED6Oq2HU1gyQy8d0VATtHws2OkqCNVwJKElEJdFTSAR8894tuKWc9JSbyW2EMVzGeR3M7cA=="],
 
-    "nodemailer": ["nodemailer@9.0.3", "", {}, "sha512-n+YP+NKwR5zRWa60k3GiQ6Q3B4KXCoAw40dAKeCtYn020iNN74aWK2liXIC3ZEATeGql7we3tE3t8QwhY0eskw=="],
+    "nodemailer": ["nodemailer@9.1.1", "", {}, "sha512-izw9mVKFix6YSnC9eLgV6g1opl9DUlRio9ZNcq+Wu9Ujn2UwF+8Nl0B8nz22kEC+CTZCvinkxwJ0DeFbb6NwcQ=="],
 
     "openapi-types": ["openapi-types@12.1.3", "", {}, "sha512-N4YtSYJqghVu4iek2ZUvcN/0aqH1kRDuNqzcycDxhOUpg7GdvLa2F3DgS6yBNhInhv2r/6I0Flkn7CqL8+nIcw=="],
 

--- a/package.json
+++ b/package.json
@@ -91,7 +91,7 @@
     "@modelcontextprotocol/server": "2.0.0",
     "@rgrove/parse-xml": "4.2.3",
     "mcp-from-openapi": "2.5.1",
-    "nodemailer": "9.0.3",
+    "nodemailer": "9.1.1",
     "postal-mime": "2.7.5",
     "yaml": "2.9.0",
     "zod": "4.4.3"


### PR DESCRIPTION
`bun audit` fails on `develop`, so every open pull request fails CI for a reason none of them
introduced. Four advisories against nodemailer, one high:

- quadratic time in `addressparser` — a crafted address list is a denial of service;
- `resolveContent()` on a `MailMessage` bypassing `disableFileAccess` / `disableUrlAccess` under the
  legacy signature;
- an IDN/punycode allow-list bypass, and an RFC 5322 comment mis-parse, both delivering mail to an
  attacker-controlled domain.

The last three are recipient-validation bypasses, on a codebase whose two mail providers both send.
They apply to `<= 9.1.0`; **9.1.1 is the first release they do not**.

## Why 9.1.1 and not 10

The fix is also in 10.0.1, but `bunfig.toml` keeps anything younger than seven days out of the
lockfile — the common supply-chain attack publishes a compromised version and yanks it within hours,
and this repository holds live OAuth refresh tokens. 10.0.0 and 10.0.1 are five and one days old.

9.1.1 is seven days old, clears every advisory, and is a patch bump rather than a major one — so it
needs neither the `minimumReleaseAgeExcludes` exception that file describes for an urgent fix, nor a
review of breaking changes.

Only the two send paths import it, through the sliver of API declared in `nodemailer.d.ts`.

## Checks

`bun audit` clean (was 1 high, 3 moderate). `bun test` 3396 pass, 0 fail. `bun run typecheck` clean.

Unblocks #202 and #203, both of which fail CI on this and nothing else.