### PR TITLE
chore: 0.12.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lanes-sh/link",
-  "version": "0.11.2",
+  "version": "0.12.0",
   "description": "A self-hostable MCP gateway for all your connections, memory, tasks, files, and secrets",
   "license": "Apache-2.0",
   "homepage": "https://lanes.sh/link",


### PR DESCRIPTION
Sets the version on `develop` ahead of the release pull request to `main`, so the merge publishes
directly rather than taking the propose path and leaving `develop` a commit behind.

A **minor**: the surface gains fields and behaviour a client can rely on, and nothing it relies on
is removed.

## Gained

- All four behaviour hints on every advertised tool, so a client can tell a read from a write.
- `structuredContent` on results where a provider declares an output schema, and an output schema on
  the search itself.
- `provider`, `profile`, `connection`, `readOnly` and `limit` filters on the search, and a box at the
  top of every answer naming the profiles and accounts a call can be routed to.

## Changed shape

- A search answer no longer ends in twenty capability ids without schemas. Everything named arrives
  callable; the remainder is counted. Anything parsing that tail sees it stop appearing.
- A list result that came back as bare identifiers is filled in before it is returned. `expand: false`
  restores the previous shape per call.

## Fixed

- Every `mcp` connector using OAuth — around seventy — could not refresh an upstream token since the
  2.0.0 client. Each worked until its first access token expired, then failed permanently while still
  reporting `active`.
- Four nodemailer advisories, one high; three are recipient-validation bypasses.

## Measured

On a deployed endpoint, not a fixture. `"latest email in inbox"`: 27 matches and 11,893 bytes with a
schemaless tail → 7 matches and 5,815 bytes with every match callable. Reading the last email: four
calls → two.

`bun test` 3461 pass, 0 fail. `bun audit` clean.