### PR TITLE
A token the vendor refuses is distrusted, rather than sent again for an hour

### DIFF
--- a/src/connectivity/auth/index.ts
+++ b/src/connectivity/auth/index.ts
@@ -25,6 +25,7 @@ export { bearerToken, bearerTokenAsStored } from './token.ts';
 export {
   CredentialOAuthProvider,
   clearUpstreamTokens,
+  distrustUpstreamToken,
   upstreamAccessToken,
   type OAuthProviderOptions,
 } from './oauth-authcode/provider.ts';

--- a/src/connectivity/auth/oauth-authcode/provider.test.ts
+++ b/src/connectivity/auth/oauth-authcode/provider.test.ts
@@ -1,0 +1,118 @@
+import { beforeEach, describe, expect, test } from 'bun:test';
+import type { CredentialOAuthProvider } from './provider.ts';
+import { clearUpstreamTokens, distrustUpstreamToken, upstreamAccessToken } from './provider.ts';
+
+/**
+ * Which access token goes out, and who gets to say it is dead.
+ *
+ * The stored `expires_at` is a claim about the future, not a fact. A token can
+ * be rejected while our clock still calls it valid — a rotated refresh token, a
+ * revoked grant, a superseded token — and until the vendor's answer could be
+ * fed back in, every call kept sending the same dead token until the clock
+ * caught up. On an hour-long token that is an hour of 401s.
+ */
+
+const KEY = 'gmail.main';
+const HOUR = 3_600_000;
+
+/** A provider whose stored blob is a plain object, so saves are observable. */
+function stubProvider(initial: Record<string, unknown>) {
+  let blob = { ...initial };
+  return {
+    connectionId: 'main',
+    tokens: async () => blob,
+    saveTokens: async (next: Record<string, unknown>) => void (blob = { ...next }),
+  } as unknown as CredentialOAuthProvider;
+}
+
+const live = () => ({
+  access_token: 'stored-token',
+  refresh_token: 'refresh-token',
+  expires_at: Date.now() + HOUR,
+});
+
+beforeEach(() => {
+  clearUpstreamTokens();
+});
+
+describe('a token the clock still calls valid', () => {
+  test('is reused, and nothing is refreshed', async () => {
+    let refreshes = 0;
+    const token = await upstreamAccessToken({
+      connectionKey: KEY,
+      provider: stubProvider(live()),
+      refresh: async () => {
+        refreshes += 1;
+        return { access_token: 'fresh-token', expires_in: 3600 };
+      },
+    });
+
+    expect(token).toBe('stored-token');
+    expect(refreshes).toBe(0);
+  });
+});
+
+describe('a token the vendor has rejected', () => {
+  test('is refreshed on the next call, whatever the stored clock says', async () => {
+    // The whole fix. Before this, the stored `expires_at` was the only opinion
+    // that counted, so a 401 changed nothing and the next call sent the same
+    // dead token.
+    const provider = stubProvider(live());
+    let refreshes = 0;
+    const refresh = async () => {
+      refreshes += 1;
+      return { access_token: 'fresh-token', expires_in: 3600 };
+    };
+
+    expect(await upstreamAccessToken({ connectionKey: KEY, provider, refresh })).toBe(
+      'stored-token',
+    );
+
+    distrustUpstreamToken(KEY);
+
+    expect(await upstreamAccessToken({ connectionKey: KEY, provider, refresh })).toBe(
+      'fresh-token',
+    );
+    expect(refreshes).toBe(1);
+  });
+
+  test('distrust is spent once, so the refreshed token is then trusted', async () => {
+    const provider = stubProvider(live());
+    let refreshes = 0;
+    const refresh = async () => {
+      refreshes += 1;
+      return { access_token: `fresh-${refreshes}`, expires_in: 3600 };
+    };
+
+    distrustUpstreamToken(KEY);
+    await upstreamAccessToken({ connectionKey: KEY, provider, refresh });
+    await upstreamAccessToken({ connectionKey: KEY, provider, refresh });
+
+    // A flag that stuck would refresh on every call for the rest of the process.
+    expect(refreshes).toBe(1);
+  });
+
+  test('one connection being rejected does not disturb another', async () => {
+    const refresh = async () => ({ access_token: 'fresh-token', expires_in: 3600 });
+    const other = stubProvider(live());
+
+    await upstreamAccessToken({ connectionKey: 'gmail.other', provider: other, refresh });
+    distrustUpstreamToken(KEY);
+
+    expect(
+      await upstreamAccessToken({ connectionKey: 'gmail.other', provider: other, refresh }),
+    ).toBe('stored-token');
+  });
+
+  test('with nothing to refresh with, the stored token is still handed back', async () => {
+    // Not every server issues a refresh token. Distrust cannot conjure one, and
+    // the honest outcome is the 401 surfacing as "re-authorise".
+    const provider = stubProvider({ access_token: 'stored-token', expires_at: Date.now() + HOUR });
+
+    distrustUpstreamToken(KEY);
+
+    expect(
+      await upstreamAccessToken({ connectionKey: KEY, provider, refresh: async () => undefined }),
+    ).toBe('stored-token');
+  });
+});

--- a/src/connectivity/auth/oauth-authcode/provider.ts
+++ b/src/connectivity/auth/oauth-authcode/provider.ts
@@ -252,6 +252,27 @@ const accessTokens = new Map<string, { token: string; expiresAt: number }>();
 
 export function clearUpstreamTokens(): void {
   accessTokens.clear();
+  rejected.clear();
+}
+
+/**
+ * Connections whose current token the vendor has refused.
+ *
+ * The stored `expires_at` is a claim about the future, not a fact: a token can
+ * be rotated, revoked or superseded while our clock still calls it valid, and
+ * the only thing that knows is the vendor. Without somewhere to record that
+ * answer, a 401 changed nothing — the next call read the same stored token,
+ * saw the same unexpired clock, and sent it again until the hour was up.
+ *
+ * A set of keys rather than a deletion, because deleting the cached token is
+ * not enough on its own: the stored blob would be re-read and believed. This is
+ * the flag that makes the *stored* clock skippable, exactly once.
+ */
+const rejected = new Set<string>();
+
+/** Record that the vendor refused this connection's token. Spent on next use. */
+export function distrustUpstreamToken(connectionKey: string): void {
+  rejected.add(connectionKey);
 }
 
 const EXPIRY_MARGIN_MS = 60_000;
@@ -263,13 +284,21 @@ export async function upstreamAccessToken(options: {
   now?: () => number;
 }): Promise<string | null> {
   const now = (options.now ?? Date.now)();
+
+  // Spent on read. A flag that stayed set would refresh on every call for the
+  // rest of the process; one that is consumed costs exactly one refresh, and a
+  // token that is still dead simply gets refused again and sets it again.
+  const distrusted = rejected.delete(options.connectionKey);
+  if (distrusted) accessTokens.delete(options.connectionKey);
+
   const cached = accessTokens.get(options.connectionKey);
   if (cached && cached.expiresAt > now + EXPIRY_MARGIN_MS) return cached.token;
 
   const stored = await options.provider.tokens();
   const expiresAt = typeof stored?.['expires_at'] === 'number' ? (stored['expires_at'] as number) : 0;
 
-  if (stored?.access_token && expiresAt > now + EXPIRY_MARGIN_MS) {
+  // The clock is only consulted where the vendor has not already contradicted it.
+  if (!distrusted && stored?.access_token && expiresAt > now + EXPIRY_MARGIN_MS) {
     accessTokens.set(options.connectionKey, { token: stored.access_token, expiresAt });
     return stored.access_token;
   }

--- a/src/connectivity/connector.ts
+++ b/src/connectivity/connector.ts
@@ -59,6 +59,12 @@ export interface DiscoveryContext {
   readonly manifest: ProviderManifest;
 }
 
+/** What a verifier can ask the transport to do about the response it just read. */
+export interface VerifyOutcome {
+  /** Make the call once more, re-authorised. Honoured at most once. */
+  readonly retry: boolean;
+}
+
 export interface ConnectorContext extends DiscoveryContext {
   /** Everything a provider is allowed to reach, unchanged from M1. */
   readonly provider: ProviderContext;
@@ -67,8 +73,16 @@ export interface ConnectorContext extends DiscoveryContext {
    * requires. Supplied by core so a connector never handles raw credentials.
    */
   authorize(request: Request): Promise<Request>;
-  /** Verify a response, where the auth strategy demands it (bunq signs replies). */
-  verify?(response: Response): Promise<void>;
+  /**
+   * Verify a response, where the auth strategy demands it (bunq signs replies),
+   * or where the credential it went out with may have been refused.
+   *
+   * Returning `{ retry: true }` says the verifier changed something that makes
+   * the same call worth making again — in practice, that it stopped trusting a
+   * token. The transport re-authorises from scratch, so the retry carries
+   * whatever core hands out the second time rather than the value that failed.
+   */
+  verify?(response: Response): Promise<VerifyOutcome | void>;
 }
 
 /**

--- a/src/connectivity/index.ts
+++ b/src/connectivity/index.ts
@@ -92,6 +92,7 @@ export type {
   AnyConnector,
   Connector,
   ConnectorContext,
+  VerifyOutcome,
   ConnectorKind,
   DiscoveryContext,
   DiscoveredCapability,

--- a/src/connectivity/transports/http/http.test.ts
+++ b/src/connectivity/transports/http/http.test.ts
@@ -574,3 +574,98 @@ describe('headers declared on the connector', () => {
     expect(record.request!.headers.get('content-type')).toBe('application/json');
   });
 });
+
+describe('a credential the vendor refuses mid-flight', () => {
+  /**
+   * The token a call goes out with can be dead while our clock still calls it
+   * valid. Core learns that only from the 401, so a verifier that asks for one
+   * retry turns an hour of refusals into a single re-authorised call.
+   */
+  const refusingOnce = async (options: { verifyRetries: boolean }) => {
+    const tokens: string[] = [];
+    let attempt = 0;
+
+    const connector = createHttpConnector({
+      baseUrl: 'https://api.acme.test/v1',
+      openapi: await specFile(),
+      fetch: (async (request: Request) => {
+        tokens.push(request.headers.get('authorization') ?? '');
+        attempt += 1;
+        return attempt === 1
+          ? new Response('{"error":"Invalid Credentials"}', {
+              status: 401,
+              statusText: 'Unauthorized',
+            })
+          : new Response('{"accounts":[]}', {
+              status: 200,
+              headers: { 'content-type': 'application/json' },
+            });
+      }) as never,
+    });
+
+    let issued = 0;
+    const context = {
+      manifest: { id: 'acme', name: 'Acme' } as never,
+      provider: { signal: new AbortController().signal } as never,
+      async authorize(request: Request) {
+        issued += 1;
+        const authorised = new Request(request, { headers: new Headers(request.headers) });
+        // A second call gets a different token, exactly as a refresh would.
+        authorised.headers.set('authorization', `Bearer token-${issued}`);
+        return authorised;
+      },
+      async verify(response: Response) {
+        if (!options.verifyRetries || response.status !== 401) return;
+        return { retry: true };
+      },
+    } as unknown as ConnectorContext;
+
+    const listAccounts = (await connector.discover(CONTEXT)).find(
+      (c) => c.name === 'listAccounts',
+    )!;
+
+    return { result: await connector.invoke(listAccounts, {}, context), tokens };
+  };
+
+  test('is retried once, with a token the verifier caused to be reissued', async () => {
+    const { result, tokens } = await refusingOnce({ verifyRetries: true });
+
+    expect(result.isError).toBeFalsy();
+    expect(tokens).toEqual(['Bearer token-1', 'Bearer token-2']);
+  });
+
+  test('is not retried when the verifier does not ask, so nothing else changes', async () => {
+    const { result, tokens } = await refusingOnce({ verifyRetries: false });
+
+    expect(result.isError).toBe(true);
+    expect(tokens).toEqual(['Bearer token-1']);
+  });
+
+  test('a second refusal is the answer, rather than a loop', async () => {
+    let attempts = 0;
+    const connector = createHttpConnector({
+      baseUrl: 'https://api.acme.test/v1',
+      openapi: await specFile(),
+      fetch: (async () => {
+        attempts += 1;
+        return new Response('{"error":"nope"}', { status: 401, statusText: 'Unauthorized' });
+      }) as never,
+    });
+
+    const context = {
+      manifest: { id: 'acme', name: 'Acme' } as never,
+      provider: { signal: new AbortController().signal } as never,
+      authorize: async (request: Request) => request,
+      verify: async (response: Response) => (response.status === 401 ? { retry: true } : undefined),
+    } as unknown as ConnectorContext;
+
+    const listAccounts = (await connector.discover(CONTEXT)).find(
+      (c) => c.name === 'listAccounts',
+    )!;
+    const result = await connector.invoke(listAccounts, {}, context);
+
+    expect(result.isError).toBe(true);
+    expect((result.content[0] as { text: string }).text).toContain('401');
+    expect(attempts).toBe(2);
+  });
+});

--- a/src/connectivity/transports/http/index.ts
+++ b/src/connectivity/transports/http/index.ts
@@ -259,22 +259,32 @@ export function createHttpConnector(options: HttpConnectorOptions): Connector {
       // silently changed it would be a bug nobody could see from the manifest.
       if (hasBody) headers.set('content-type', contentType);
 
-      // Auth is attached by core, from the manifest's auth kind or its strategy.
-      // A connector never sees a raw credential.
-      const request = await context.authorize(
+      // Built per attempt rather than once: a `Request` body can only be read
+      // once, so a retry needs its own.
+      const outbound = (): Request =>
         new Request(url.href, {
           method,
           headers,
           ...(hasBody ? { body: encodeBody(body, contentType) } : {}),
           signal: context.provider.signal,
-        }),
-      );
+        });
 
       const doFetch = options.fetch ?? globalThis.fetch;
-      const response = await doFetch(request);
+
+      // Auth is attached by core, from the manifest's auth kind or its strategy.
+      // A connector never sees a raw credential.
+      let response = await doFetch(await context.authorize(outbound()));
 
       // Cloned so a verifier can read the body without consuming it for us.
-      await context.verify?.(response.clone() as unknown as Response);
+      const outcome = await context.verify?.(response.clone() as unknown as Response);
+
+      // At most one, and only where the verifier asked. It stopped trusting
+      // something on the strength of this response — a token the vendor
+      // refused — so authorising again hands out a replacement rather than the
+      // value that just failed. A second refusal is the answer.
+      if (outcome?.retry) {
+        response = await doFetch(await context.authorize(outbound()));
+      }
 
       const text = await response.text();
       if (!response.ok) {

--- a/src/dispatch/dispatch.ts
+++ b/src/dispatch/dispatch.ts
@@ -16,6 +16,8 @@ import type {
 import { isToolResult, strategyContextFrom, strategyFor } from '#connectivity';
 import type { Config, ConnectionConfig } from '#profile';
 import { buildProviderContext, createProviderLogger } from './context.ts';
+import { responseVerifier } from './reauthorize.ts';
+import { distrustUpstreamToken } from '#connectivity/auth/index.ts';
 import { fetchStaged, stageAttachment } from './staging.ts';
 import type { FetchStagedRequest, StagedAttachment, StageRequest } from './staging.ts';
 import type { ProviderRegistry } from '#registry';
@@ -290,18 +292,26 @@ export class Dispatcher {
         });
       }
 
-      // Only where the strategy asks for it. A vendor that signs its replies
-      // expects them verified, and the transport clones the response so the
-      // check costs the caller nothing.
-      const verifyResponse = strategy?.verify?.bind(strategy);
+      // Two reasons to read a response before the caller does: a vendor that
+      // signs its replies expects them verified, and a token the vendor refuses
+      // has to be distrusted or the next call sends it again. They compose.
+      const verifyStrategy = strategy?.verify?.bind(strategy);
+      const verify = responseVerifier({
+        // Built from what was resolved, not from what was asked for: this has
+        // to be the key the token cache uses, `<manifest>.<connection>`.
+        connectionKey: `${providerId}.${declared.id}`,
+        oauth: entry.manifest.auth.kind === 'oauth',
+        distrust: distrustUpstreamToken,
+        ...(verifyStrategy
+          ? { strategy: (response: Response) => verifyStrategy(response, forStrategy()) }
+          : {}),
+      });
 
       const connectorContext: ConnectorContext = {
         manifest: entry.manifest,
         provider: providerContext,
         authorize,
-        ...(verifyResponse
-          ? { verify: (response: Response) => verifyResponse(response, forStrategy()) }
-          : {}),
+        ...(verify ? { verify } : {}),
       };
 
       // The connector owns argument validation: a local provider validates

--- a/src/dispatch/reauth.test.ts
+++ b/src/dispatch/reauth.test.ts
@@ -1,0 +1,162 @@
+import { afterAll, describe, expect, test } from 'bun:test';
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { ownerPrincipal } from '#auth';
+import { createMemoryCredentials, createMemoryState } from '#stores/state/testing.ts';
+import { createMemoryBlobStore } from '#stores/blobs/testing.ts';
+import { createBlobAuditStore } from '#deployments/adapters/audit-blob.ts';
+import { RateLimiter } from '#policy';
+import { createHttpConnector } from '#connectivity/transports';
+import { defineProvider, type AnyConnector } from '#connectivity';
+import { parseConfig } from '#profile';
+import { Dispatcher } from './dispatch.ts';
+import { ProviderRegistry, toPolicyDocument } from '#registry';
+
+/**
+ * The seam, wired.
+ *
+ * `reauthorize.test.ts` covers the decision and `http.test.ts` the retry. What
+ * neither can show is the part that was actually broken in production: that a
+ * 401 on an oauth connection reaches a verifier at all, and that a connection
+ * whose credential a person has to change does not get a second refusal.
+ */
+
+const directory = await mkdtemp(join(tmpdir(), 'reauth-spec-'));
+const specPath = join(directory, 'acme.json');
+
+await writeFile(
+  specPath,
+  JSON.stringify({
+    openapi: '3.0.3',
+    info: { title: 'Acme', version: '1.0.0' },
+    paths: {
+      '/accounts': {
+        get: { operationId: 'listAccounts', responses: { '200': { description: 'ok' } } },
+      },
+    },
+  }),
+);
+
+afterAll(async () => {
+  await rm(directory, { recursive: true, force: true });
+});
+
+const CONFIG = parseConfig(`
+contract: 5
+instance:
+  profile: personal
+limits:
+  requests_per_minute: 100
+  upstream_calls_per_minute: 100
+grants:
+  - { connection: acme.main, allow: ['acme.*'], deny: [] }
+members: []
+`).config;
+
+const connector = { kind: 'http', base_url: 'https://api.acme.test/v1', openapi: specPath } as const;
+
+const OAUTH = defineProvider({
+  id: 'acme',
+  name: 'Acme',
+  connector,
+  auth: {
+    kind: 'oauth',
+    // Dynamic registration keeps the manifest to the two fields this test is
+    // about; what it authenticates with is beside the point, only that it can
+    // be renewed without a person.
+    registration: 'dynamic',
+    scopes: ['read'],
+    authorization_url: 'https://acme.test/authorize',
+    token_url: 'https://acme.test/token',
+  },
+});
+
+const BASIC = defineProvider({
+  id: 'acme',
+  name: 'Acme',
+  connector,
+  auth: { kind: 'basic', credential_ref: 'acme/password' },
+});
+
+/** A vendor that refuses the first call and accepts the second. */
+function harness(manifest: typeof OAUTH) {
+  const tokens: string[] = [];
+  let attempt = 0;
+
+  const registry = new ProviderRegistry();
+  registry.register(manifest as never);
+
+  const http = createHttpConnector({
+    baseUrl: 'https://api.acme.test/v1',
+    openapi: specPath,
+    fetch: (async (request: Request) => {
+      tokens.push(request.headers.get('authorization') ?? '');
+      attempt += 1;
+      return attempt === 1
+        ? new Response('{"error":"Invalid Credentials"}', { status: 401, statusText: 'Unauthorized' })
+        : new Response('{"accounts":[]}', {
+            status: 200,
+            headers: { 'content-type': 'application/json' },
+          });
+    }) as unknown as typeof globalThis.fetch,
+  });
+
+  let issued = 0;
+  const dispatcher = new Dispatcher({
+    config: CONFIG,
+    connections: [{ id: 'main', provider: 'acme', account: 'A' }],
+    oauthApps: [],
+    registry,
+    connectorFor: (): AnyConnector | undefined => http as unknown as AnyConnector,
+    // Stands in for the credential resolver: a second call hands out a second
+    // token, which is what a refresh looks like from here.
+    authorizeRequest: async (_provider, _connection, request) => {
+      issued += 1;
+      const authorised = new Request(request, { headers: new Headers(request.headers) });
+      authorised.headers.set('authorization', `Bearer token-${issued}`);
+      return authorised;
+    },
+    policy: toPolicyDocument(CONFIG),
+    state: createMemoryState(),
+    audit: createBlobAuditStore({ storage: createMemoryBlobStore() }),
+    credentials: createMemoryCredentials(),
+    storage: createMemoryBlobStore(),
+    limiter: new RateLimiter(),
+    log: { debug() {}, info() {}, warn() {}, error() {} },
+  });
+
+  return { dispatcher, tokens, registry, http };
+}
+
+const call = {
+  principal: ownerPrincipal('personal'),
+  capabilityId: 'acme.listAccounts',
+  connectionKey: 'acme.main',
+  arguments: {},
+};
+
+describe('a refused token on a connection that can renew itself', () => {
+  test('is authorised again and the call succeeds, without anyone intervening', async () => {
+    const { dispatcher, tokens, registry, http } = harness(OAUTH);
+    registry.setDiscovered('acme', await http.discover({ manifest: OAUTH } as never));
+
+    const outcome = await dispatcher.invoke(call);
+
+    expect(outcome.ok).toBe(true);
+    // Two tokens, not the same one twice: the retry is only worth making
+    // because authorising again hands out a replacement.
+    expect(tokens).toEqual(['Bearer token-1', 'Bearer token-2']);
+  });
+});
+
+describe('a refused credential a person has to change', () => {
+  test('is not retried, because a second refusal is all it would buy', async () => {
+    const { dispatcher, tokens, registry, http } = harness(BASIC);
+    registry.setDiscovered('acme', await http.discover({ manifest: BASIC } as never));
+
+    await dispatcher.invoke(call);
+
+    expect(tokens).toEqual(['Bearer token-1']);
+  });
+});

--- a/src/dispatch/reauthorize.test.ts
+++ b/src/dispatch/reauthorize.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, test } from 'bun:test';
+import { responseVerifier } from './reauthorize.ts';
+
+/**
+ * Who gets told that a call came back refused.
+ *
+ * Two verifiers can want the same response: the one a signing vendor demands,
+ * and the one that exists to notice a refused token. They compose rather than
+ * exclude, because a strategy that verifies signatures has nothing to say about
+ * credentials and the reverse is equally true.
+ */
+
+const refused = new Response('', { status: 401 });
+const fine = new Response('', { status: 200 });
+
+describe('an oauth connection', () => {
+  test('stops trusting its token when the vendor refuses it, and asks for one retry', async () => {
+    const distrusted: string[] = [];
+    const verify = responseVerifier({
+      connectionKey: 'gmail.con1',
+      oauth: true,
+      distrust: (key) => distrusted.push(key),
+    })!;
+
+    expect(await verify(refused)).toEqual({ retry: true });
+    expect(distrusted).toEqual(['gmail.con1']);
+  });
+
+  test('leaves a response that was not refused alone', async () => {
+    const distrusted: string[] = [];
+    const verify = responseVerifier({
+      connectionKey: 'gmail.con1',
+      oauth: true,
+      distrust: (key) => distrusted.push(key),
+    })!;
+
+    expect(await verify(fine)).toBeUndefined();
+    expect(distrusted).toEqual([]);
+  });
+
+  test('asks for a retry once, so a second refusal is the answer', async () => {
+    // The verifier is built per invocation, so the guard lives here rather than
+    // in the transport, where it would have to be threaded through every kind.
+    const verify = responseVerifier({
+      connectionKey: 'gmail.con1',
+      oauth: true,
+      distrust: () => {},
+    })!;
+
+    expect(await verify(refused)).toEqual({ retry: true });
+    expect(await verify(refused)).toBeUndefined();
+  });
+});
+
+describe('a connection that is not oauth', () => {
+  test('gets no verifier at all, so nothing is retried', () => {
+    // Basic auth and api keys do not go stale mid-flight, and a retry would be
+    // one more refusal for a credential that needs a person to change it.
+    expect(
+      responseVerifier({ connectionKey: 'icloud_mail.con3', oauth: false, distrust: () => {} }),
+    ).toBeUndefined();
+  });
+});
+
+describe('a strategy that verifies its own replies', () => {
+  test('still runs, and its answer wins where it has one', async () => {
+    const seen: number[] = [];
+    const verify = responseVerifier({
+      connectionKey: 'bunq.con6',
+      oauth: false,
+      distrust: () => {},
+      strategy: async (response) => void seen.push(response.status),
+    })!;
+
+    expect(await verify(fine)).toBeUndefined();
+    expect(seen).toEqual([200]);
+  });
+
+  test('composes with the credential check rather than replacing it', async () => {
+    const seen: number[] = [];
+    const distrusted: string[] = [];
+    const verify = responseVerifier({
+      connectionKey: 'gmail.con1',
+      oauth: true,
+      distrust: (key) => distrusted.push(key),
+      strategy: async (response) => void seen.push(response.status),
+    })!;
+
+    expect(await verify(refused)).toEqual({ retry: true });
+    expect(seen).toEqual([401]);
+    expect(distrusted).toEqual(['gmail.con1']);
+  });
+});

--- a/src/dispatch/reauthorize.ts
+++ b/src/dispatch/reauthorize.ts
@@ -1,0 +1,54 @@
+import type { VerifyOutcome } from '#connectivity';
+
+/**
+ * Noticing that a call went out with a credential the vendor no longer accepts.
+ *
+ * A stored `expires_at` is a claim about the future. A token can be rotated,
+ * revoked or superseded while our clock still calls it valid, and the only
+ * party that knows is the vendor — which says so with a 401 and nothing else.
+ * Until that answer could be fed back in, it changed nothing: the next call
+ * re-read the same stored token, saw the same unexpired clock, and sent it
+ * again. On an hour-long token that is an hour of refusals for a connection
+ * whose sibling on the same account is working.
+ *
+ * This is where the answer is fed back in. It is deliberately not a retry loop:
+ * the outcome is handed to the transport, which re-authorises once, so the
+ * decision to spend another call lives with the layer that owns the request and
+ * the once-only guard lives here, where the verifier is built per invocation.
+ *
+ * Scoped to oauth because that is the only kind that can be renewed without a
+ * person. A basic password or an api key that stops working needs the operator,
+ * and retrying it is one more refusal.
+ */
+
+export interface VerifierOptions {
+  /** `<provider>.<connection>`, as the token cache keys it. */
+  readonly connectionKey: string;
+  /** Whether this connection's credential is renewable without a person. */
+  readonly oauth: boolean;
+  /** Stop trusting this connection's token. */
+  readonly distrust: (connectionKey: string) => void;
+  /** The strategy's own verifier, where the vendor signs its replies. */
+  readonly strategy?: ((response: Response) => Promise<VerifyOutcome | void>) | undefined;
+}
+
+export function responseVerifier(
+  options: VerifierOptions,
+): ((response: Response) => Promise<VerifyOutcome | void>) | undefined {
+  const { strategy } = options;
+  if (!options.oauth) return strategy;
+
+  // One per invocation, so this is the natural home for "at most once".
+  let asked = false;
+
+  return async (response: Response): Promise<VerifyOutcome | void> => {
+    const outcome = await strategy?.(response);
+    if (outcome?.retry) return outcome;
+
+    if (response.status !== 401 || asked) return outcome ?? undefined;
+
+    asked = true;
+    options.distrust(options.connectionKey);
+    return { retry: true };
+  };
+}


### PR DESCRIPTION
## What happened

A scheduled agent got HTTP 401 from Google on **every** call to `gmail.con1`, while `gmail.con2` on the same account and the iCloud connection kept working. It recovered on its own later.

```json
{ "code": 401, "message": "Request had invalid authentication credentials…",
  "reason": "authError", "status": "UNAUTHENTICATED" }
```

## Why

`upstreamAccessToken` decided what to send from the stored `expires_at` alone:

```ts
if (stored?.access_token && expiresAt > now + EXPIRY_MARGIN_MS) {
  return stored.access_token;      // trusted purely on the stored clock
}
```

That is a claim about the future, not a fact. A token can be rotated, revoked or superseded while our clock still calls it valid, and the only party that knows is the vendor — which says so with a 401 and nothing else. **There was nowhere to put that answer**, so it changed nothing: the next call re-read the same stored blob, saw the same unexpired clock, and sent the same dead token. On an hour-long token that is an hour of refusals, and "recovered on its own" is just the clock catching up.

Rolling a revision is what exposed it: the `accessTokens` cache is a process-local `Map`, so a cold start drops it and the next call goes down the trust-the-stored-clock branch. The gap it lands in predates that.

## The fix

**1. Somewhere to record the vendor's answer.** Evicting the cached token is not enough on its own — the stored blob would be re-read and believed. A set of connection keys makes the stored clock skippable, and is **spent on read**: a flag that stayed set would refresh on every call for the rest of the process; one that is consumed costs exactly one refresh, and a token that is still dead simply gets refused again and sets it again.

**2. `verify` may return `{ retry: true }`.** It was already wired end to end for the vendor that signs its replies, already clones the response, and is already where bunq drops a session it saw refused — but it returned `void`, so it could only ever fix the *next* call. The transport honours the outcome **at most once**.

The retry re-authorises from scratch rather than replaying the request:

```ts
let response = await doFetch(await context.authorize(outbound()));
const outcome = await context.verify?.(response.clone());
if (outcome?.retry) {
  response = await doFetch(await context.authorize(outbound()));
}
```

`authorize` re-enters the resolver, which now refreshes — so the second attempt carries a **different** token rather than the one that just failed. (`outbound()` is a factory because a `Request` body can only be read once.)

**3. Dispatch composes the two verifiers** rather than choosing between them: a strategy that checks signatures has nothing to say about credentials, and the reverse is equally true.

## Scoping

Only oauth. A basic password or an api key that stops working needs a person to change it, and retrying buys one more refusal — so those get **no verifier at all**, which `reauth.test.ts` pins directly.

## Rejected

**Threading `{ fresh: true }` down through `authorize`.** It reads like the obvious fix and costs eight signatures — `ConnectorContext`, `ProviderContext`, `DispatchDeps`, `RuntimeHandle` and the four resolver hops — to arrive somewhere the existing `verify` seam already reaches. Evicting first and re-authorising second gets a fresh token without widening anything, because `authorize` was always re-entrant.

## Known gaps, deliberately out of scope

- **`gmail.send_message`** fetches directly rather than through the http transport, so it has no verifier. A send is also the one call where a blind retry would be wrong, so it wants its own thinking.
- **The `mcp` transport** receives a 401 as a thrown SDK error with no `Response` to read.

Neither is the path that failed here — the observed failure was `gmail.users.messages.list`, a vendored operation, which goes through the http transport.

## Tests

`provider.ts` had **no test file at all**; it does now. Four layers:

| File | Proves |
| --- | --- |
| `oauth-authcode/provider.test.ts` | distrust forces a refresh past a valid-looking clock; the flag is spent once; one connection does not disturb another; with no refresh token the stored value is still handed back |
| `dispatch/reauthorize.test.ts` | the decision, the once-only guard, oauth scoping, composition with a strategy verifier |
| `transports/http/http.test.ts` | retried once with a reissued token; **not** retried when the verifier stays silent; a second refusal is the answer rather than a loop |
| `dispatch/reauth.test.ts` | end to end through a real `Dispatcher`: an oauth 401 yields `['Bearer token-1', 'Bearer token-2']`, a basic 401 yields `['Bearer token-1']` |

`bun test` 3400 pass / 0 fail (baseline 3384), `bun run typecheck` clean.

## Note

Not exercised against a live deployment — reproducing it needs a token the vendor has actually revoked, which I cannot manufacture on someone's real account. The `Dispatcher`-level test is the closest honest substitute.