### PR TITLE
chore: 0.13.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lanes-sh/link",
-  "version": "0.12.0",
+  "version": "0.13.0",
   "description": "A self-hostable MCP gateway for all your connections, memory, tasks, files, and secrets",
   "license": "Apache-2.0",
   "homepage": "https://lanes.sh/link",


### PR DESCRIPTION
Sets the version on `develop` before the release pull request, so the merge to `main` runs the publish path rather than the propose path.

**Minor, not patch:** 0.13.0 advertises a tool 0.12.0 did not. `lanes_assets_stage` is new (#208), and `asset` joins the attachment sources shared by Gmail and all six IMAP providers. A client that cached its tool list at 0.12.0 holds a shorter one than the endpoint now serves.

Since 0.12.0:

- **#208** — a client can hand over a file it holds and name it afterwards: `lanes_assets.stage` returns a handle, never bytes, and `{ "asset": "<name>" }` attaches a stored file. Also a workspace probe that stops reporting "no credentials" as "no workspace", and six messages that stopped citing a filename the contract-4 migration renamed.
- **#209** — a token the vendor refuses is distrusted and refreshed on the next call, instead of being re-sent until the stored clock catches up.

`bun test` 3520 pass / 0 fail, `bun run typecheck` clean on the merged tree.

**Upgrade note:** an existing IMAP connection must be reconnected once before `asset` appears in its `send_message` schema — those capabilities are discovered and cached. Gmail's are authored and pick it up immediately.