### PR TITLE
0.13.0

### DIFF
--- a/docs/detailed/adr/017-attachments-by-reference.md
+++ b/docs/detailed/adr/017-attachments-by-reference.md
@@ -214,3 +214,76 @@ The rule this ADR exists for is unchanged and applies in the new direction: **th
 the tool result**. A model that must read a file in order to have it has not been handed anything —
 239 KB of PDF is around 320,000 characters of base64 — so what travels through the conversation is
 a handle, exactly as it does on the way in.
+
+## Amendment: an area for the profile, and an asset as a source
+
+The six sources all assume the endpoint can already reach the bytes. A client that holds a file
+nothing else can see has none of them: `path` names the endpoint's disk, which on a hosted
+deployment is a container; `url` must be fetchable; `handle` needs a stage that only the HTTP route
+and the CLI could perform; and the mailbox sources need the file already in a mailbox. That leaves
+`data`, which is the one channel MCP actually offers a client — there is still no
+client-to-server binary transfer in the protocol, and a tool argument is the only thing that
+travels.
+
+`data` worked the whole time. What defeated it was our own copy. `gmail.send_message` described
+four of the six sources and did not list `data` among them; the IMAP description listed three and
+did not mention `handle` at all, on the providers that are the only ones able to mint one. Every
+field around `data` said to prefer something else, and the assets tool said never to use it. A
+capable client read all of that, concluded correctly that no route existed, and reported a design
+gap rather than trying the source that would have worked. Copy that is right about the common case
+and silent about the only case that matters is a defect, not a nicety.
+
+Two things change, and one deliberately does not.
+
+**`lanes_assets.stage` holds a file for the profile.** It takes the same source shape, writes into
+`attachments.d/` under the profile rather than under `<provider>/<connection>`, and returns a
+handle, a digest and an expiry — never the bytes. Bytes still cross as base64 once, because there
+is no other channel; what changes is that once is no longer once *per send*. The `.d` suffix is
+load-bearing: a provider id may be `[a-z][a-z0-9_]*`, so a bare `attachments_tmp` would be a legal
+provider id sharing that key space.
+
+**`asset` becomes a seventh source.** A file the profile keeps attaches as
+`{ "asset": "<name>" }`. It is resolved in `#dispatch`, not by a provider reaching sideways, and it
+is gated on `lanes_assets.get` for the calling principal — without that check a caller denied the
+asset store but allowed a send could read the store through an attachment argument. This is the
+case the Consequences above anticipated when they noted that staging would let cross-provider
+sources work "by staging rather than by reaching another connection's credential", and it is the
+narrow form of what `drive_file_id` was rejected for.
+
+**`POST /attachments` does not change.** Its authorization derives entirely from `?connection=`, so
+widening it to the profile would mean a second gate and a second refusal vocabulary for a case a
+capability already answers — and it answers it for the caller who cannot make an HTTP request at
+all, which is the caller this amendment exists for. A `stg_` handle is refused there by prefix
+rather than looked up and missed, so the refusal reads as "wrong door" instead of "expired".
+
+### What the per-connection scope was protecting, and what still holds
+
+The scope exists so one account's bytes are not addressable from another. That property is
+unchanged for everything that had it. The line that keeps it true is narrow enough to state in one
+sentence, and worth stating because a later change could break it without noticing:
+
+> The profile-level area only ever holds bytes the **caller** supplied — `data`, `url`, `path` on
+> `lanes_assets.stage` — or bytes the **profile already owns**, through `asset`. It never holds
+> bytes read out of a third party's account.
+
+`get_attachment` therefore keeps minting a connection-scoped `att_` handle, and nothing promotes
+one. Resolution routes on the handle prefix and never falls back between the two areas, because a
+fallback is exactly the promotion path: `lanes_assets.stage` handed a mailbox-minted `att_` handle
+would hand back a `stg_` one for the same bytes. Prefix routing leaves that nowhere to happen.
+
+What is genuinely given up is that a principal who may reach a profile, and who holds a `stg_`
+handle, can name that file on any connection in the profile they may already use. Since the bytes
+were either supplied by that caller or already sitting in that profile's store, nothing crosses a
+boundary the caller did not already hold. What remains is `mayReach`, 128 bits of unguessability,
+and the 24-hour expiry.
+
+### Consequences
+
+- An existing IMAP connection must be re-connected once before `asset` appears in its
+  `send_message` schema, for the reason recorded above: those capabilities are discovered and
+  cached. Gmail's are authored, so it picks the change up immediately.
+- "What entered this endpoint" is now two capabilities: `attachments.stage` for the HTTP and CLI
+  routes, and `lanes_assets.stage` for the tool. That shape already existed — `get_attachment`
+  stages from inside a dispatched capability and annotates rather than writing a second row.
+- The staged area is swept on the next stage, as the connection-scoped one is, because there is
+  still no scheduler in the process.

--- a/docs/detailed/adr/README.md
+++ b/docs/detailed/adr/README.md
@@ -33,7 +33,7 @@ Run.
 | [014](014-owner-layer-is-managed.md) | Skills can be written under policy; all three owner stores follow the target |
 | [015](015-one-package-under-src.md) | One package under `src/`; a provider owns its vendor code; an architecture test replaces the package graph |
 | [016](016-what-the-endpoint-says-about-itself.md) | The endpoint describes itself in `instructions`; `mcp add` writes the documents no harness has a command for |
-| [017](017-attachments-by-reference.md) | An attachment is named, not carried, so its bytes never pass through the model; and a remote provider may author a capability its vendor's document cannot express |
+| [017](017-attachments-by-reference.md) | An attachment is named, not carried, so its bytes never pass through the model; a client may hand one over once and name it afterwards; and a remote provider may author a capability its vendor's document cannot express |
 | [018](018-the-gate-is-in-the-application.md) | A deployed instance is gated inside the application rather than by the platform's front door, and issues its own tokens by default |
 | [019](019-describing-setup-is-not-performing-it.md) | A read-only setup surface describes what connecting involves; describing setup authorises nothing, so the control-plane wall has not moved |
 | [020](020-the-log-is-objects.md) | The audit log is one object per event, hash-chained, in the same layout locally and deployed |

--- a/instructions/skills/lanes-link/SKILL.md
+++ b/instructions/skills/lanes-link/SKILL.md
@@ -157,9 +157,9 @@ They manage these with `lanes link tasks list --profile <name> --workspace <name
 
 ## Assets are files kept by name
 
-Storing one names a source and the endpoint reads the bytes — the same five
-sources the attachments section below describes, and the same rule: **never
-encode a file into the call.** The name is the address; there is no id and no
+Storing one names a source and the endpoint reads the bytes — the same sources
+the attachments section below describes, and the same rule: do not encode a file
+into a call you could name it in. The name is the address; there is no id and no
 description, so what a file is *for* belongs in memory, next to its name.
 
 Reading gives you text when the file is text. Anything else comes back described
@@ -167,10 +167,14 @@ Reading gives you text when the file is text. Anything else comes back described
 no form of a read that hands you a PDF, and a megabyte of base64 in the
 conversation would not help you if there were.
 
-To attach a stored file to something you are sending, ask the owner to run
-`lanes link attach <file> --profile <name> --workspace <name> --connection <provider>.<account>`,
-which prints a handle the send tools take. An asset's own store is not reachable
-from a mailbox's, deliberately.
+To attach a stored file to something you are sending, name it as
+`{ "asset": "<name>" }`. A mailbox's attachments are still not reachable from
+here, deliberately: ask the mail connection itself for those.
+
+`lanes_assets_stage` is the other half, and a different question. `store` keeps a
+file because the owner wants it kept; `stage` holds one for a day because a call
+is about to name it. Use `stage` for something you were handed and are passing
+straight on, so their files stay theirs.
 
 They manage these with `lanes link assets list --profile <name> --workspace <name>`.
 
@@ -245,18 +249,26 @@ reads the bytes itself. Naming two is refused rather than resolved.
 { "path": "/Users/them/Downloads/invoice.pdf" }         // on the endpoint's own machine
 { "url": "https://example.com/invoice.pdf" }            // fetched here, HTTPS only
 { "message_id": "18f…", "attachment_id": "quote.pdf" }  // already on a message in that mailbox
-{ "handle": "att_01j7k…" }                              // staged out of band
-{ "data": "JVBERi0…", "filename": "invoice.pdf" }       // base64, and a last resort
+{ "asset": "invoice-2026.pdf" }                         // a file this profile keeps
+{ "handle": "stg_01j7k…" }                              // one you handed over with lanes_assets_stage
+{ "handle": "att_01j7k…" }                              // staged out of band, for one connection
+{ "data": "JVBERi0…", "filename": "invoice.pdf" }       // base64, and only when nothing else can reach it
 ```
 
 `attachment_id` takes a filename, a position, or the vendor's own id, and can be
 omitted when the message has one attachment. `filename` and `content_type`
 override what the source implies.
 
-**Never encode a file into a call.** A 239 KB PDF is roughly 320,000 characters
-of base64 — more than you can write in one message — and the way that fails is a
-mail which mentions an attachment and does not have one. The other four sources
-exist so you never have to.
+**Do not encode the same file into call after call.** A 239 KB PDF is roughly
+320,000 characters of base64 — more than you can write in one message — and the
+way that fails is a mail which mentions an attachment and does not have one. The
+other sources exist so you rarely have to.
+
+**A file only you can see is handed over once.** If it is in your own sandbox and
+nothing above can reach it, call `lanes_assets_stage` with the bytes. You get back
+a handle, not the file, and that handle names it in any send from this profile for
+the next 24 hours. That is the one time base64 is the right answer: once, to hand
+it over, rather than every time you send it.
 
 **Forwarding something that arrived by mail is free.** Use `message_id` rather
 than fetching the attachment and passing its bytes along. Reading them is not
@@ -264,9 +276,11 @@ offered anyway: the read tools report each attachment's name, type and size, not
 its content.
 
 **If the endpoint is not on the same machine as the file**, `path` names the
-*server's* filesystem rather than theirs, and will not find it. Ask them to run
-`lanes link attach <file> --profile <name> --workspace <name> --connection <provider>.<account>`, which prints a
-handle to use instead.
+*server's* filesystem rather than theirs, and will not find it. If you hold the
+file, `lanes_assets_stage` is the answer and needs nobody. If *they* hold it, ask
+them to run
+`lanes link attach <file> --profile <name> --workspace <name> --connection <provider>.<account>`,
+which prints a handle to use instead.
 
 **`draft_only: true`** saves instead of sending, where they should see it before
 it goes out.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lanes-sh/link",
-  "version": "0.12.0",
+  "version": "0.13.0",
   "description": "A self-hostable MCP gateway for all your connections, memory, tasks, files, and secrets",
   "license": "Apache-2.0",
   "homepage": "https://lanes.sh/link",

--- a/src/cli/commands/auth.ts
+++ b/src/cli/commands/auth.ts
@@ -202,7 +202,7 @@ export async function authWorkspaces(flags: AuthFlags = {}): Promise<void> {
 
   print('');
   prose(
-    'A remote lanes link workspace binds to one of these with `lanes_workspace:` in lanes-link.yaml, which is whose members a profile may delegate to.',
+    'A remote lanes link workspace binds to one of these with `lanes_workspace:` in workspaces.yaml, which is whose members a profile may delegate to.',
     { paint: style.dim },
   );
 }

--- a/src/cli/commands/members.ts
+++ b/src/cli/commands/members.ts
@@ -246,7 +246,7 @@ async function assertDelegatable(
       `Workspace "${target}" is not bound to a Lanes workspace, so it can only delegate to you.\n` +
         '  Add yourself with: lanes link profile members add --me\n' +
         '  To delegate to somebody else, bind the workspace:\n' +
-        `    lanes_workspace: <id>   # in lanes-link.yaml, under workspaces.${target}\n` +
+        `    lanes_workspace: <id>   # in workspaces.yaml, under workspaces.${target}\n` +
         '  Run "lanes auth workspaces" for the ids you belong to.',
     );
   }

--- a/src/cli/commands/profile.ts
+++ b/src/cli/commands/profile.ts
@@ -372,7 +372,7 @@ export function profileDefault(name: string | undefined): never {
     'lanes link profile default was removed.\n' +
       '  Nothing reads default_profile any more — pass --profile on every command:\n' +
       `    lanes link status --profile ${name ?? '<name>'} --workspace <name>\n` +
-      '  If the key is still in lanes-link.yaml it is inert, and safe to delete.',
+      '  If the key is still in workspaces.yaml it is inert, and safe to delete.',
   );
 }
 

--- a/src/cli/commands/sync.test.ts
+++ b/src/cli/commands/sync.test.ts
@@ -1,0 +1,200 @@
+import { afterAll, describe, expect, test } from 'bun:test';
+import { mkdir, mkdtemp, readFile, writeFile, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { syncTargets } from './sync.ts';
+
+/**
+ * Adopting a deployment this machine has no record of.
+ *
+ * The messages are the subject. Every one of them is read by someone who has
+ * just been refused, on a machine that does not have the thing they are looking
+ * for — so a message that blames the wrong cause sends them somewhere that
+ * cannot work.
+ */
+
+const roots: string[] = [];
+
+afterAll(async () => {
+  await Promise.all(roots.map((one) => rm(one, { recursive: true, force: true })));
+});
+
+/**
+ * A throwaway workspace, and the env var pointing at it.
+ *
+ * `syncTargets` calls `resolveWorkspaceRoot()` with no argument, so an unset
+ * `LANES_LINK_HOME` walks up to `~/.lanes-link` — the operator's real profiles,
+ * credentials and audit log. Every test here goes through this helper so that
+ * cannot happen.
+ */
+async function workspace(declares = '{}'): Promise<string> {
+  const root = await mkdtemp(join(tmpdir(), 'lanes-link-sync-'));
+  roots.push(root);
+  process.env['LANES_LINK_HOME'] = root;
+  await mkdir(join(root, 'profiles'), { recursive: true });
+  await writeFile(join(root, 'workspaces.yaml'), `contract: 5\nworkspaces: ${declares}\n`);
+  return root;
+}
+
+/** A second directory standing in for the bucket, since a path is a workspace too. */
+async function remote(): Promise<string> {
+  const dir = await mkdtemp(join(tmpdir(), 'lanes-link-remote-'));
+  roots.push(dir);
+  await writeFile(
+    join(dir, 'workspaces.yaml'),
+    'contract: 5\nworkspaces:\n  cloud:\n' +
+      '    credentials: { adapter: file }\n' +
+      '    storage: { adapter: filesystem }\n',
+  );
+  return dir;
+}
+
+const failing = async (call: Promise<unknown>): Promise<string> => {
+  try {
+    await call;
+  } catch (error) {
+    return (error as Error).message;
+  }
+  throw new Error('expected a refusal');
+};
+
+describe('when the bucket cannot be read', () => {
+  test('missing credentials are named, rather than blamed on the bucket', async () => {
+    await workspace();
+
+    const message = await failing(
+      syncTargets({ target: 'cloud', from: 'gs://your-bucket' } as never, {
+        probe: async () => ({
+          kind: 'unreadable',
+          reason: 'No Google credentials found. Run `gcloud auth application-default login`.',
+          credentials: true,
+        }),
+      }),
+    );
+
+    expect(message).toContain('could not be read');
+    expect(message).toContain('application-default login');
+    // The sentence the old text got most wrong: --discover runs the same chain,
+    // so recommending it here sent the reader somewhere that cannot work.
+    expect(message).toContain('--discover');
+    expect(message).toMatch(/would not get further|same credentials/);
+  });
+
+  test('a permission failure quotes the cause and does not offer a login', async () => {
+    await workspace();
+
+    const message = await failing(
+      syncTargets({ target: 'cloud', from: 'gs://your-bucket' } as never, {
+        probe: async () => ({
+          kind: 'unreadable',
+          reason: 'Cannot read your-bucket — grant roles/storage.objectAdmin.',
+          credentials: false,
+        }),
+      }),
+    );
+
+    expect(message).toContain('objectAdmin');
+    expect(message).not.toContain('application-default login');
+  });
+});
+
+describe('when the bucket holds no workspace', () => {
+  test('it names the file it looked for, and does not claim the bucket exists', async () => {
+    await workspace();
+
+    const message = await failing(
+      syncTargets({ target: 'cloud', from: 'gs://your-bucket' } as never, {
+        probe: async () => ({ kind: 'absent' }),
+      }),
+    );
+
+    expect(message).toContain('workspaces.yaml');
+    expect(message).not.toContain('lanes-link.yaml');
+    // `has` cannot tell a missing object from a missing bucket, so the message
+    // must not assert that the bucket is there.
+    expect(message).toMatch(/does not exist reads exactly the same|check the name/i);
+  });
+
+  test('a bucket still on the old filename is offered a migration, not a refusal', async () => {
+    await workspace();
+
+    const message = await failing(
+      syncTargets({ target: 'cloud', from: 'gs://your-bucket' } as never, {
+        probe: async () => ({ kind: 'legacy' }),
+      }),
+    );
+
+    expect(message).toContain('lanes-link.yaml');
+    expect(message).toContain('deploy');
+    expect(message).not.toMatch(/holds no workspace|does not hold a workspace/);
+  });
+});
+
+describe('when nothing records where the target lives', () => {
+  test('it names the file it read, and says naming the bucket is a one-off', async () => {
+    const root = await workspace();
+
+    const message = await failing(syncTargets({ target: 'cloud' } as never, {}));
+
+    expect(message).toContain(join(root, 'workspaces.yaml'));
+    expect(message).not.toContain('lanes-link.yaml');
+    expect(message).toMatch(/once/i);
+  });
+
+  test('it suggests one spelling of the command, not two', async () => {
+    await workspace();
+
+    const message = await failing(syncTargets({ target: 'cloud' } as never, {}));
+    const spellings = new Set([...message.matchAll(/lanes link sync (\w+)/g)].map((m) => m[1]));
+
+    expect([...spellings]).toEqual(['workspaces']);
+  });
+});
+
+describe('when this machine is already inside the workspace', () => {
+  test('it does not demand --from for a workspace that declares the target itself', async () => {
+    // `at` is set only on a pointer, so a root that *declares* cloud fell
+    // through to "nothing says where cloud lives" while standing in it.
+    await workspace(
+      '\n  cloud:\n' +
+        '    credentials: { adapter: file }\n' +
+        '    storage: { adapter: filesystem }',
+    );
+
+    const message = await failing(syncTargets({ target: 'cloud' } as never, {}));
+
+    expect(message).toMatch(/nothing to adopt|already/i);
+    expect(message).not.toMatch(/If you know the bucket/);
+  });
+});
+
+describe('adopting one', () => {
+  test('the pointer is written, and only the pointer', async () => {
+    const root = await workspace();
+    const dir = await remote();
+
+    await syncTargets({ target: 'cloud', from: dir } as never, {});
+
+    expect(await readFile(join(root, 'workspaces.yaml'), 'utf8')).toContain(`at: ${dir}`);
+  });
+
+  test('--dry-run leaves the file exactly as it was', async () => {
+    const root = await workspace();
+    const dir = await remote();
+    const before = await readFile(join(root, 'workspaces.yaml'), 'utf8');
+
+    await syncTargets({ target: 'cloud', from: dir, dryRun: true } as never, {});
+
+    expect(await readFile(join(root, 'workspaces.yaml'), 'utf8')).toBe(before);
+  });
+
+  test('--prefer is refused by name rather than ignored', async () => {
+    await workspace();
+
+    const message = await failing(
+      syncTargets({ target: 'cloud', prefer: 'remote' } as never, {}),
+    );
+
+    expect(message).toContain('--prefer');
+  });
+});

--- a/src/cli/commands/sync.ts
+++ b/src/cli/commands/sync.ts
@@ -1,11 +1,13 @@
-import { ConfigError, readRegistry, recordTarget, resolveWorkspaceRoot } from '#profile';
-import { discoverDeployments, holdsWorkspace } from '#deployments/discover.ts';
+import { ConfigError, readRegistry, recordTarget, resolveWorkspaceRoot, WORKSPACE_FILE } from '#profile';
+import { discoverDeployments, probeWorkspace } from '#deployments/discover.ts';
+import type { Candidate, WorkspaceProbe } from '#deployments/discover.ts';
+import { join } from 'node:path';
 import { emit, heading, ok, print, style, waiting } from '../output.ts';
 import { confirm, isInteractive } from '../prompt.ts';
 import type { GlobalFlags } from '../runtime.ts';
 
 /**
- * `lanes link sync targets` — adopt a deployment this workspace has lost track of.
+ * `lanes link sync workspaces` — adopt a deployment this workspace has lost track of.
  *
  * **This used to reconcile two copies of every profile, and there is only one
  * now.** A deploy left the workspace holding one copy and the bucket another,
@@ -32,12 +34,61 @@ import type { GlobalFlags } from '../runtime.ts';
  * command no longer has.
  */
 
+/**
+ * What the command reaches the world with. Injected in tests; every field is
+ * the real thing when absent.
+ */
+export interface SyncDeps {
+  readonly probe?: ((url: string) => Promise<WorkspaceProbe>) | undefined;
+  readonly discover?: (() => Promise<Candidate[]>) | undefined;
+}
+
 export interface SyncFlags extends GlobalFlags {
   readonly json?: boolean | undefined;
   readonly dryRun?: boolean | undefined;
   readonly from?: string | undefined;
   readonly discover?: boolean | undefined;
   readonly prefer?: string | undefined;
+}
+
+/**
+ * Refuse a bucket that cannot serve as one, saying which of four things happened.
+ *
+ * Four, because the probe distinguishes them and a reader acts on each
+ * differently: an empty bucket is a typo, an unreadable one is a login, and one
+ * on the old filename is a migration. The version of this that answered a single
+ * boolean told all three to check the bucket name.
+ */
+async function assertHoldsWorkspace(from: string, target: string, deps: SyncDeps): Promise<void> {
+  const probe = await (deps.probe ? deps.probe(from) : probeWorkspace(from));
+  if (probe.kind === 'workspace') return;
+
+  if (probe.kind === 'unreadable') {
+    throw new ConfigError(
+      `${from} could not be read, so whether it holds a workspace is not known.\n` +
+        `  ${probe.reason}\n` +
+        // Only where credentials are the cause: --discover runs the same chain,
+        // so offering it there is offering something that cannot get further.
+        (probe.credentials
+          ? '  --discover reads the same credentials, so it would not get further.'
+          : ''),
+    );
+  }
+
+  if (probe.kind === 'legacy') {
+    throw new ConfigError(
+      `${from} holds a workspace under the old name, lanes-link.yaml.\n` +
+        '  It is a workspace, but one from before the registry was renamed, and\n' +
+        '  reading it here would report that it declares nothing at all.\n' +
+        `    lanes link deploy --workspace ${target}   rewrites it in the current shape`,
+    );
+  }
+
+  throw new ConfigError(
+    `Nothing at ${from.replace(/\/$/, '')}/${WORKSPACE_FILE}, so that bucket declares no workspace.\n` +
+      '  A bucket that does not exist reads exactly the same way, so check the name first.\n' +
+      `  If you do not know it:  lanes link sync workspaces --workspace ${target} --discover`,
+  );
 }
 
 /**
@@ -52,32 +103,44 @@ async function locateRemote(
   root: string,
   target: string,
   flags: SyncFlags,
+  deps: SyncDeps,
 ): Promise<{ workspace: string; how: string }> {
   if (flags.from) {
-    if (!(await holdsWorkspace(flags.from))) {
-      throw new ConfigError(
-        `${flags.from} does not hold a workspace — no lanes-link.yaml in it.\n` +
-          '  Check the bucket name, or run with --discover to search for one.',
-      );
-    }
+    await assertHoldsWorkspace(flags.from, target, deps);
     return { workspace: flags.from.replace(/\/$/, ''), how: '--from' };
   }
 
-  const entry = (await readRegistry(root))[target];
+  const registry = await readRegistry(root);
+  const entry = registry[target];
   if (entry?.at) return { workspace: entry.at, how: 'already recorded' };
+
+  // Declared here rather than pointed at: `at` is set only on a pointer, so a
+  // root that holds the target's own declaration used to fall through to
+  // "nothing says where it lives" while standing inside it. Nothing to adopt is
+  // a different answer from nowhere to look.
+  if (entry !== undefined) {
+    throw new ConfigError(
+      `${root} declares "${target}" itself, so there is nothing to adopt —\n` +
+        '  this is already its workspace, and a pointer would only point at itself.\n' +
+        `    lanes link status --workspace ${target}`,
+    );
+  }
 
   if (flags.discover !== true) {
     throw new ConfigError(
       `Nothing here says where "${target}" lives.\n` +
-        '  No pointer to it in lanes-link.yaml, and nothing else records one.\n\n' +
-        '  If you know the bucket:  lanes link sync workspaces --workspace ' +
-        `${target} --from gs://<bucket>\n` +
-        `  If you do not:           lanes link sync targets --workspace ${target} --discover`,
+        `  ${join(root, WORKSPACE_FILE)} holds no pointer to it, and nothing else on\n` +
+        '  this machine records one.\n\n' +
+        `  If you know the bucket:  lanes link sync workspaces --workspace ${target} --from gs://<bucket>\n` +
+        `  If you do not:           lanes link sync workspaces --workspace ${target} --discover\n\n` +
+        '  Naming it once is enough: this writes the pointer, and no later command asks again.',
     );
   }
 
   const candidates = (
-    await waiting('searching your projects for a deployment', () => discoverDeployments())
+    await waiting('searching your projects for a deployment', () =>
+      deps.discover ? deps.discover() : discoverDeployments(),
+    )
   ).filter((candidate) => candidate.workspace !== undefined);
 
   if (candidates.length === 0) {
@@ -99,7 +162,7 @@ async function locateRemote(
   if (candidates.length > 1 || !isInteractive()) {
     throw new ConfigError(
       `Found ${candidates.length} deployment(s). Name the one you mean:\n` +
-        `  lanes link sync targets --workspace ${target} --from ${first.workspace}`,
+        `  lanes link sync workspaces --workspace ${target} --from ${first.workspace}`,
     );
   }
 
@@ -110,7 +173,7 @@ async function locateRemote(
   return { workspace: first.workspace!, how: 'discovered' };
 }
 
-export async function syncTargets(flags: SyncFlags): Promise<void> {
+export async function syncTargets(flags: SyncFlags, deps: SyncDeps = {}): Promise<void> {
   const target = flags.target!;
   const root = resolveWorkspaceRoot();
 
@@ -123,7 +186,7 @@ export async function syncTargets(flags: SyncFlags): Promise<void> {
     );
   }
 
-  const { workspace, how } = await locateRemote(root, target, flags);
+  const { workspace, how } = await locateRemote(root, target, flags, deps);
 
   // What is actually there, so an adoption cannot point at an empty bucket and
   // report success. This is the one read the command makes, and it is also the

--- a/src/cli/commands/target.ts
+++ b/src/cli/commands/target.ts
@@ -301,7 +301,7 @@ export function targetUse(name: string | undefined): never {
   throw new ConfigError(
     'lanes link workspace use was removed, and came back under a new name.\n' +
       '  `instance.default_target` is still inert — nothing reads it. What does\n' +
-      '  read a default is `default_workspace` in lanes-link.yaml (ADR-061):\n' +
+      '  read a default is `default_workspace` in workspaces.yaml (ADR-061):\n' +
       `    lanes set-workspace ${name ?? '<name>'}\n` +
       '  Or name it per command:\n' +
       `    lanes link status --profile <name> --workspace ${name ?? '<name>'}\n` +

--- a/src/cli/config-templates.ts
+++ b/src/cli/config-templates.ts
@@ -113,7 +113,7 @@ instance:
 # This file says nothing about where it runs, and that is the point.
 #
 # A profile lives in exactly one workspace, and that workspace declares its own
-# adapters, once, in lanes-link.yaml beside the profiles/ directory (ADR-052).
+# adapters, once, in workspaces.yaml beside the profiles/ directory (ADR-052).
 # Moving this profile somewhere else is copying the file there.
 #
 #     lanes link status --profile ${profile} --workspace <name>

--- a/src/cli/messages.test.ts
+++ b/src/cli/messages.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, test } from 'bun:test';
+import { readdir, readFile } from 'node:fs/promises';
+import { join } from 'node:path';
+
+/**
+ * What a command tells the reader to go and look at.
+ *
+ * The registry file was renamed `lanes-link.yaml` → `workspaces.yaml` in
+ * contract 4, and the rename left messages behind pointing at a file that no
+ * longer exists — including one that cites ADR-061, the decision that renamed
+ * it. Nothing failed, because a wrong sentence compiles.
+ *
+ * This is the check that stops the next rename doing the same. Prose *about*
+ * the old name is fine, in a comment or in a sentence that says it is the old
+ * name; what is refused is a message sending someone to open it.
+ */
+
+const RETIRED = 'lanes-link.yaml';
+
+async function sources(dir: string): Promise<string[]> {
+  const out: string[] = [];
+  for (const entry of await readdir(dir, { withFileTypes: true })) {
+    const path = join(dir, entry.name);
+    if (entry.isDirectory()) out.push(...(await sources(path)));
+    else if (entry.name.endsWith('.ts') && !entry.name.endsWith('.test.ts')) out.push(path);
+  }
+  return out;
+}
+
+/** A comment line, where the old name is history rather than instruction. */
+const isProse = (line: string): boolean => {
+  const trimmed = line.trimStart();
+  return trimmed.startsWith('*') || trimmed.startsWith('//') || trimmed.startsWith('/*');
+};
+
+/** A sentence that introduces it as retired, which is the one honest use. */
+const namesItAsOld = (line: string): boolean => /old name|retired|renamed|used to/i.test(line);
+
+describe('a message never sends the reader to a file that was renamed', () => {
+  test(`no command tells anyone to look in ${RETIRED}`, async () => {
+    const offenders: string[] = [];
+
+    for (const path of await sources(join(import.meta.dir, 'commands'))) {
+      const lines = (await readFile(path, 'utf8')).split('\n');
+      lines.forEach((line, index) => {
+        if (!line.includes(RETIRED)) return;
+        if (isProse(line) || namesItAsOld(line)) return;
+        offenders.push(`${path.slice(path.indexOf('src/'))}:${index + 1}`);
+      });
+    }
+
+    expect(offenders).toEqual([]);
+  });
+});

--- a/src/cli/selection.ts
+++ b/src/cli/selection.ts
@@ -193,8 +193,9 @@ export const SELECTION: Record<string, Requires> = {
   // profile's (ADR-068) — and `--only` is what narrows what is served.
   start: 'workspace',
   deploy: 'workspace',
-  // Both spellings: `sync` alone is `sync targets`, which is the only thing
-  // there is to sync, and naming it leaves room for the next one.
+  // Both spellings, and bare `sync` too. `workspaces` is the word since
+  // ADR-061 retired `target`; `targets` still parses so nothing anyone has
+  // typed breaks, but nothing prints it any more.
   sync: 'workspace',
   'sync targets': 'workspace',
   'sync workspaces': 'workspace',

--- a/src/cli/usage-data.ts
+++ b/src/cli/usage-data.ts
@@ -152,7 +152,7 @@ export const SECTIONS: readonly Section[] = [
         description: "one workspace's adapters, and its address",
       },
       {
-        command: 'sync workspaces --workspace <name> [--from gs://bucket] [--discover] [--prefer local|remote] [--dry-run]',
+        command: 'sync workspaces --workspace <name> [--from gs://bucket] [--discover] [--dry-run]',
         description: 'reconcile this workspace with the copy the deployment reads; recovers one a profile has lost',
       },
     ],

--- a/src/connectivity/auth/index.ts
+++ b/src/connectivity/auth/index.ts
@@ -25,6 +25,7 @@ export { bearerToken, bearerTokenAsStored } from './token.ts';
 export {
   CredentialOAuthProvider,
   clearUpstreamTokens,
+  distrustUpstreamToken,
   upstreamAccessToken,
   type OAuthProviderOptions,
 } from './oauth-authcode/provider.ts';

--- a/src/connectivity/auth/oauth-authcode/provider.test.ts
+++ b/src/connectivity/auth/oauth-authcode/provider.test.ts
@@ -1,0 +1,118 @@
+import { beforeEach, describe, expect, test } from 'bun:test';
+import type { CredentialOAuthProvider } from './provider.ts';
+import { clearUpstreamTokens, distrustUpstreamToken, upstreamAccessToken } from './provider.ts';
+
+/**
+ * Which access token goes out, and who gets to say it is dead.
+ *
+ * The stored `expires_at` is a claim about the future, not a fact. A token can
+ * be rejected while our clock still calls it valid — a rotated refresh token, a
+ * revoked grant, a superseded token — and until the vendor's answer could be
+ * fed back in, every call kept sending the same dead token until the clock
+ * caught up. On an hour-long token that is an hour of 401s.
+ */
+
+const KEY = 'gmail.main';
+const HOUR = 3_600_000;
+
+/** A provider whose stored blob is a plain object, so saves are observable. */
+function stubProvider(initial: Record<string, unknown>) {
+  let blob = { ...initial };
+  return {
+    connectionId: 'main',
+    tokens: async () => blob,
+    saveTokens: async (next: Record<string, unknown>) => void (blob = { ...next }),
+  } as unknown as CredentialOAuthProvider;
+}
+
+const live = () => ({
+  access_token: 'stored-token',
+  refresh_token: 'refresh-token',
+  expires_at: Date.now() + HOUR,
+});
+
+beforeEach(() => {
+  clearUpstreamTokens();
+});
+
+describe('a token the clock still calls valid', () => {
+  test('is reused, and nothing is refreshed', async () => {
+    let refreshes = 0;
+    const token = await upstreamAccessToken({
+      connectionKey: KEY,
+      provider: stubProvider(live()),
+      refresh: async () => {
+        refreshes += 1;
+        return { access_token: 'fresh-token', expires_in: 3600 };
+      },
+    });
+
+    expect(token).toBe('stored-token');
+    expect(refreshes).toBe(0);
+  });
+});
+
+describe('a token the vendor has rejected', () => {
+  test('is refreshed on the next call, whatever the stored clock says', async () => {
+    // The whole fix. Before this, the stored `expires_at` was the only opinion
+    // that counted, so a 401 changed nothing and the next call sent the same
+    // dead token.
+    const provider = stubProvider(live());
+    let refreshes = 0;
+    const refresh = async () => {
+      refreshes += 1;
+      return { access_token: 'fresh-token', expires_in: 3600 };
+    };
+
+    expect(await upstreamAccessToken({ connectionKey: KEY, provider, refresh })).toBe(
+      'stored-token',
+    );
+
+    distrustUpstreamToken(KEY);
+
+    expect(await upstreamAccessToken({ connectionKey: KEY, provider, refresh })).toBe(
+      'fresh-token',
+    );
+    expect(refreshes).toBe(1);
+  });
+
+  test('distrust is spent once, so the refreshed token is then trusted', async () => {
+    const provider = stubProvider(live());
+    let refreshes = 0;
+    const refresh = async () => {
+      refreshes += 1;
+      return { access_token: `fresh-${refreshes}`, expires_in: 3600 };
+    };
+
+    distrustUpstreamToken(KEY);
+    await upstreamAccessToken({ connectionKey: KEY, provider, refresh });
+    await upstreamAccessToken({ connectionKey: KEY, provider, refresh });
+
+    // A flag that stuck would refresh on every call for the rest of the process.
+    expect(refreshes).toBe(1);
+  });
+
+  test('one connection being rejected does not disturb another', async () => {
+    const refresh = async () => ({ access_token: 'fresh-token', expires_in: 3600 });
+    const other = stubProvider(live());
+
+    await upstreamAccessToken({ connectionKey: 'gmail.other', provider: other, refresh });
+    distrustUpstreamToken(KEY);
+
+    expect(
+      await upstreamAccessToken({ connectionKey: 'gmail.other', provider: other, refresh }),
+    ).toBe('stored-token');
+  });
+
+  test('with nothing to refresh with, the stored token is still handed back', async () => {
+    // Not every server issues a refresh token. Distrust cannot conjure one, and
+    // the honest outcome is the 401 surfacing as "re-authorise".
+    const provider = stubProvider({ access_token: 'stored-token', expires_at: Date.now() + HOUR });
+
+    distrustUpstreamToken(KEY);
+
+    expect(
+      await upstreamAccessToken({ connectionKey: KEY, provider, refresh: async () => undefined }),
+    ).toBe('stored-token');
+  });
+});

--- a/src/connectivity/auth/oauth-authcode/provider.ts
+++ b/src/connectivity/auth/oauth-authcode/provider.ts
@@ -294,6 +294,27 @@ const accessTokens = new Map<string, { token: string; expiresAt: number }>();
 
 export function clearUpstreamTokens(): void {
   accessTokens.clear();
+  rejected.clear();
+}
+
+/**
+ * Connections whose current token the vendor has refused.
+ *
+ * The stored `expires_at` is a claim about the future, not a fact: a token can
+ * be rotated, revoked or superseded while our clock still calls it valid, and
+ * the only thing that knows is the vendor. Without somewhere to record that
+ * answer, a 401 changed nothing — the next call read the same stored token,
+ * saw the same unexpired clock, and sent it again until the hour was up.
+ *
+ * A set of keys rather than a deletion, because deleting the cached token is
+ * not enough on its own: the stored blob would be re-read and believed. This is
+ * the flag that makes the *stored* clock skippable, exactly once.
+ */
+const rejected = new Set<string>();
+
+/** Record that the vendor refused this connection's token. Spent on next use. */
+export function distrustUpstreamToken(connectionKey: string): void {
+  rejected.add(connectionKey);
 }
 
 const EXPIRY_MARGIN_MS = 60_000;
@@ -305,13 +326,21 @@ export async function upstreamAccessToken(options: {
   now?: () => number;
 }): Promise<string | null> {
   const now = (options.now ?? Date.now)();
+
+  // Spent on read. A flag that stayed set would refresh on every call for the
+  // rest of the process; one that is consumed costs exactly one refresh, and a
+  // token that is still dead simply gets refused again and sets it again.
+  const distrusted = rejected.delete(options.connectionKey);
+  if (distrusted) accessTokens.delete(options.connectionKey);
+
   const cached = accessTokens.get(options.connectionKey);
   if (cached && cached.expiresAt > now + EXPIRY_MARGIN_MS) return cached.token;
 
   const stored = await options.provider.tokens();
   const expiresAt = typeof stored?.['expires_at'] === 'number' ? (stored['expires_at'] as number) : 0;
 
-  if (stored?.access_token && expiresAt > now + EXPIRY_MARGIN_MS) {
+  // The clock is only consulted where the vendor has not already contradicted it.
+  if (!distrusted && stored?.access_token && expiresAt > now + EXPIRY_MARGIN_MS) {
     accessTokens.set(options.connectionKey, { token: stored.access_token, expiresAt });
     return stored.access_token;
   }

--- a/src/connectivity/connector.ts
+++ b/src/connectivity/connector.ts
@@ -67,6 +67,12 @@ export interface DiscoveryContext {
   readonly manifest: ProviderManifest;
 }
 
+/** What a verifier can ask the transport to do about the response it just read. */
+export interface VerifyOutcome {
+  /** Make the call once more, re-authorised. Honoured at most once. */
+  readonly retry: boolean;
+}
+
 export interface ConnectorContext extends DiscoveryContext {
   /** Everything a provider is allowed to reach, unchanged from M1. */
   readonly provider: ProviderContext;
@@ -75,8 +81,16 @@ export interface ConnectorContext extends DiscoveryContext {
    * requires. Supplied by core so a connector never handles raw credentials.
    */
   authorize(request: Request): Promise<Request>;
-  /** Verify a response, where the auth strategy demands it (bunq signs replies). */
-  verify?(response: Response): Promise<void>;
+  /**
+   * Verify a response, where the auth strategy demands it (bunq signs replies),
+   * or where the credential it went out with may have been refused.
+   *
+   * Returning `{ retry: true }` says the verifier changed something that makes
+   * the same call worth making again — in practice, that it stopped trusting a
+   * token. The transport re-authorises from scratch, so the retry carries
+   * whatever core hands out the second time rather than the value that failed.
+   */
+  verify?(response: Response): Promise<VerifyOutcome | void>;
 }
 
 /**

--- a/src/connectivity/context.ts
+++ b/src/connectivity/context.ts
@@ -1,6 +1,7 @@
 import type { AuditLogger } from '#audit';
 import type { ScopedSecrets } from '#secrets';
 import type { BlobStore } from '#stores/blobs';
+import type { AttachmentBridge } from './mail/attachments.ts';
 
 /**
  * Key/value state for one provider on one connection.
@@ -91,4 +92,18 @@ export interface ProviderContext {
    * harness builds a context without one.
    */
   authorize?(request: Request): Promise<Request>;
+  /**
+   * The two file lookups this connection's own store cannot answer.
+   *
+   * A file staged for the whole profile, and a file the profile keeps by name.
+   * Both are closures dispatch binds, not stores — so this widens what a
+   * provider can *name* without widening what it can reach: there is still no
+   * way from here to another connection's data, and the bytes that pass through
+   * are either the caller's own or the profile's own.
+   *
+   * Optional because the test harness and `local` paths build a context without
+   * one, and a provider that is handed none simply cannot resolve those two
+   * sources.
+   */
+  readonly attachments?: AttachmentBridge | undefined;
 }

--- a/src/connectivity/index.ts
+++ b/src/connectivity/index.ts
@@ -92,6 +92,7 @@ export type {
   AnyConnector,
   Connector,
   ConnectorContext,
+  VerifyOutcome,
   ConnectorKind,
   DiscoveryContext,
   DiscoveredCapability,

--- a/src/connectivity/mail/attachments.ts
+++ b/src/connectivity/mail/attachments.ts
@@ -1,11 +1,11 @@
 import { createHash } from 'node:crypto';
-import { readFile } from 'node:fs/promises';
 import { z } from 'zod';
 import type { BlobStore } from '#stores/blobs';
 import type { ResolvedAttachment } from './message.ts';
-import { getStaged } from './staging.ts';
-import { fetchFromUrl, type AddressLookup } from './url.ts';
-import { basename, guessContentType } from './content-type.ts';
+import type { StagedFile } from './staging.ts';
+import type { AddressLookup } from './url.ts';
+import { guessContentType } from './content-type.ts';
+import { bytesFor } from './sources.ts';
 
 /**
  * Turning a named attachment into bytes.
@@ -36,7 +36,10 @@ import { basename, guessContentType } from './content-type.ts';
  */
 
 /** The source keys, in the order they are reported when a caller supplies two. */
-const SOURCE_KEYS = ['path', 'url', 'handle', 'message_id', 'uid', 'data'] as const;
+const SOURCE_KEYS = ['path', 'url', 'handle', 'asset', 'message_id', 'uid', 'data'] as const;
+
+/** Which source a reference named. */
+export type SourceKey = (typeof SOURCE_KEYS)[number];
 
 export const attachmentRefSchema = z
   .strictObject({
@@ -45,7 +48,16 @@ export const attachmentRefSchema = z
       .optional()
       .describe('Path to a file on the machine running this endpoint. Read as-is.'),
     url: z.string().optional().describe('HTTPS URL. The endpoint fetches it; you do not.'),
-    handle: z.string().optional().describe('Handle returned by a staged upload.'),
+    handle: z
+      .string()
+      .optional()
+      .describe(
+        'Handle from lanes_assets_stage, an upload to POST /attachments, or a get_attachment.',
+      ),
+    asset: z
+      .string()
+      .optional()
+      .describe('A file this profile keeps by name, as lanes_assets_list reports it.'),
     message_id: z
       .string()
       .optional()
@@ -70,12 +82,14 @@ export const attachmentRefSchema = z
       .string()
       .optional()
       .describe(
-        'Base64 file content, for small files only. Prefer path, url, handle, or message_id — those keep the bytes out of the conversation entirely.',
+        'Base64 file content. Right when the file exists nowhere this endpoint can reach — and then hold it once with lanes_assets_stage and name the handle afterwards, rather than encoding it into every call.',
       ),
     filename: z.string().optional().describe('Overrides the name derived from the source.'),
     content_type: z.string().optional().describe('Overrides the type derived from the source.'),
   })
-  .describe('One attachment, named by exactly one of path, url, handle, message_id, uid, or data.');
+  .describe(
+    'One attachment, named by exactly one of path, url, handle, asset, message_id, uid, or data.',
+  );
 
 export type AttachmentRef = z.infer<typeof attachmentRefSchema>;
 
@@ -120,6 +134,36 @@ export type MailboxAttachmentSource = (reference: {
   readonly contentType: string | null;
 }>;
 
+/**
+ * The two lookups a connection-scoped store cannot serve.
+ *
+ * Both reach past `<provider>/<connection>` to something the *profile* holds, so
+ * neither is built here: dispatch binds them and hands them over on the context,
+ * which is what keeps `#providers` unable to reach another connection on its own.
+ *
+ * What makes the crossing safe is not the plumbing but what may pass through it.
+ * A profile-level handle only ever holds bytes the caller supplied (`data`,
+ * `url`, `path`) or bytes the profile already owns (`asset`) — never bytes read
+ * out of a third party's account. `get_attachment` keeps minting a
+ * connection-scoped handle for exactly that reason, so a mailbox attachment
+ * stays where it landed and nothing promotes it.
+ */
+export interface SharedAttachments {
+  /** A handle staged for the whole profile, not for one connection. */
+  readonly staged?: ((handle: string) => Promise<StagedFile | null>) | undefined;
+  /** A file this profile keeps by name in `lanes_assets`. */
+  readonly asset?: ((name: string) => Promise<StagedFile | null>) | undefined;
+}
+
+/** The same, plus the write half. Only dispatch builds one. */
+export interface AttachmentBridge extends SharedAttachments {
+  stage(input: {
+    readonly bytes: Uint8Array;
+    readonly filename: string;
+    readonly contentType: string;
+  }): Promise<{ readonly handle: string; readonly sha256: string; readonly expiresAt: number }>;
+}
+
 export interface ResolveOptions {
   /**
    * Total raw bytes allowed across every attachment.
@@ -131,6 +175,12 @@ export interface ResolveOptions {
    */
   readonly maxTotalBytes: number;
   readonly storage?: BlobStore | undefined;
+  /**
+   * What the connection-scoped store cannot see. Supplied by dispatch on
+   * `ProviderContext.attachments` and passed straight through — a provider
+   * neither builds one nor can widen the one it is given.
+   */
+  readonly shared?: SharedAttachments | undefined;
   readonly mailbox?: MailboxAttachmentSource | undefined;
   readonly fetch?: typeof globalThis.fetch | undefined;
   readonly addresses?: AddressLookup | undefined;
@@ -203,139 +253,4 @@ async function resolveOne(
     sha256: createHash('sha256').update(found.bytes).digest('hex'),
     origin: found.origin,
   };
-}
-
-interface FoundBytes {
-  readonly bytes: Uint8Array;
-  readonly filename: string | null;
-  readonly contentType: string | null;
-  readonly origin: string;
-}
-
-async function bytesFor(
-  source: (typeof SOURCE_KEYS)[number],
-  ref: AttachmentRef,
-  where: string,
-  options: ResolveOptions,
-): Promise<FoundBytes> {
-  switch (source) {
-    case 'path':
-      return await fromPath(ref.path!, where, options.maxTotalBytes);
-
-    case 'url': {
-      const fetched = await fetchFromUrl({
-        url: ref.url!,
-        maxBytes: options.maxTotalBytes,
-        ...(options.fetch ? { fetch: options.fetch } : {}),
-        ...(options.addresses ? { addresses: options.addresses } : {}),
-        signal: options.signal,
-      });
-      return {
-        bytes: fetched.bytes,
-        filename: fetched.filename ?? basename(new URL(ref.url!).pathname),
-        contentType: fetched.contentType,
-        origin: `url:${ref.url!}`,
-      };
-    }
-
-    case 'handle':
-      return await fromHandle(ref.handle!, where, options.storage);
-
-    case 'message_id':
-    case 'uid': {
-      if (!options.mailbox) {
-        throw new Error(
-          `${where} uses ${source}, which only a mail connection can resolve — this one holds no mailbox. ` +
-            `Name the file with path, url, or handle instead, or ask the mail connection itself to send it somewhere.`,
-        );
-      }
-      const found = await options.mailbox({
-        messageId: ref.message_id,
-        mailbox: ref.mailbox,
-        uid: ref.uid,
-        attachmentId: ref.attachment_id,
-      });
-      return {
-        bytes: found.bytes,
-        filename: found.filename,
-        contentType: found.contentType,
-        origin: source === 'uid' ? `mailbox:${ref.mailbox ?? 'INBOX'}:${ref.uid!}` : `mailbox:${ref.message_id!}`,
-      };
-    }
-
-    case 'data': {
-      const bytes = decodeBase64(ref.data!, where);
-      return { bytes, filename: null, contentType: null, origin: 'inline' };
-    }
-  }
-}
-
-async function fromPath(path: string, where: string, maxBytes: number): Promise<FoundBytes> {
-  let bytes: Uint8Array;
-  try {
-    bytes = new Uint8Array(await readFile(path));
-  } catch (failure) {
-    const code = (failure as { code?: string }).code;
-    if (code === 'ENOENT') throw new Error(`${where}: no file at ${path}.`);
-    if (code === 'EACCES') throw new Error(`${where}: ${path} is not readable by this endpoint.`);
-    if (code === 'EISDIR') throw new Error(`${where}: ${path} is a directory, not a file.`);
-    throw new Error(`${where}: could not read ${path} — ${(failure as Error).message}`);
-  }
-
-  if (bytes.byteLength > maxBytes) {
-    throw new Error(
-      `${where}: ${path} is ${bytes.byteLength} bytes, over the ${maxBytes} byte limit for one message.`,
-    );
-  }
-
-  return {
-    bytes,
-    filename: basename(path),
-    contentType: null,
-    origin: `path:${path}`,
-  };
-}
-
-async function fromHandle(
-  handle: string,
-  where: string,
-  storage: BlobStore | undefined,
-): Promise<FoundBytes> {
-  if (!storage) {
-    throw new Error(`${where} uses a handle, but this provider has no staging store.`);
-  }
-
-  const stored = await getStaged(storage, handle);
-  if (!stored) {
-    throw new Error(
-      `${where}: no staged attachment "${handle}". Handles expire, so stage the file again.`,
-    );
-  }
-
-  return {
-    bytes: stored.bytes,
-    filename: stored.filename,
-    contentType: stored.contentType,
-    origin: `handle:${handle}`,
-  };
-}
-
-function decodeBase64(value: string, where: string): Uint8Array {
-  // Both alphabets, because the two obvious places a caller gets base64 from
-  // disagree: a mail API hands back base64url (RFC 4648 §5) while every
-  // general-purpose encoder emits the standard one. Rejecting the former would
-  // be a correct-looking failure with a corrupt-file outcome.
-  const normalized = value.replaceAll('-', '+').replaceAll('_', '/').replaceAll(/\s+/g, '');
-
-  try {
-    const buffer = Buffer.from(normalized, 'base64');
-    // Buffer.from is lenient and silently drops invalid characters, so a typo
-    // becomes a shorter file rather than an error. Re-encoding and comparing
-    // lengths catches that.
-    const expected = Math.floor((normalized.replace(/=+$/, '').length * 3) / 4);
-    if (buffer.byteLength !== expected) throw new Error('not base64');
-    return new Uint8Array(buffer);
-  } catch {
-    throw new Error(`${where}: data is not valid base64.`);
-  }
 }

--- a/src/connectivity/mail/index.ts
+++ b/src/connectivity/mail/index.ts
@@ -10,6 +10,7 @@
  * Nothing here names a vendor.
  */
 
+export type { AttachmentBridge, SharedAttachments, SourceKey } from './attachments.ts';
 export type {
   AttachmentReceipt,
   ComposedMessage,
@@ -32,8 +33,11 @@ export type { StagedFile, StagedMetadata } from './staging.ts';
 export {
   getStaged,
   isHandle,
+  isProfileHandle,
   newHandle,
   putStaged,
+  CONNECTION_HANDLE,
+  PROFILE_HANDLE,
   stagedBytesKey,
   stagedMetaKey,
   sweepStaged,

--- a/src/connectivity/mail/mail.test.ts
+++ b/src/connectivity/mail/mail.test.ts
@@ -6,6 +6,10 @@ import { createMemoryBlobStore } from '#stores/blobs/testing.ts';
 import {
   composeMime,
   isBlocked,
+  isHandle,
+  isProfileHandle,
+  newHandle,
+  PROFILE_HANDLE,
   putStaged,
   resolveAttachments,
   stagedBytesKey,
@@ -13,6 +17,7 @@ import {
   sweepStaged,
   STAGED_TTL_MS,
   type ResolvedAttachment,
+  type StagedFile,
 } from './index.ts';
 
 /**
@@ -303,7 +308,7 @@ describe('a mailbox reference', () => {
       /only a mail connection can resolve/,
     );
     await expect(resolveAttachments([{ message_id: '<a@b>' }], BUDGET)).rejects.toThrow(
-      /path, url, or handle/,
+      /path, url, handle, or asset/,
     );
   });
 
@@ -616,5 +621,125 @@ describe('composing the message', () => {
 
     expect(raw).toContain('In-Reply-To: <original@example.com>');
     expect(raw).toContain('References: <original@example.com>');
+  });
+});
+
+describe('which store a handle belongs to', () => {
+  test('a handle minted for one connection carries the att_ prefix', () => {
+    expect(newHandle()).toMatch(/^att_[0-9a-f]{32}$/);
+    expect(isProfileHandle(newHandle())).toBe(false);
+  });
+
+  test('a handle minted for the whole profile carries the stg_ prefix', () => {
+    expect(newHandle(PROFILE_HANDLE)).toMatch(/^stg_[0-9a-f]{32}$/);
+    expect(isProfileHandle(newHandle(PROFILE_HANDLE))).toBe(true);
+  });
+
+  test('both prefixes are still handles, so neither is refused at the store', () => {
+    expect(isHandle(newHandle())).toBe(true);
+    expect(isHandle(newHandle(PROFILE_HANDLE))).toBe(true);
+  });
+});
+
+describe('a file this profile keeps', () => {
+  const shared = (files: Record<string, StagedFile>) => ({
+    asset: async (name: string) => files[name] ?? null,
+  });
+
+  test('resolves by name, and records that the asset store is where it came from', async () => {
+    const attachment = only(
+      await resolveAttachments([{ asset: 'invoice-2026.pdf' }], {
+        ...BUDGET,
+        shared: shared({
+          'invoice-2026.pdf': { bytes: PDF, filename: 'invoice-2026.pdf', contentType: 'application/pdf' },
+        }),
+      }),
+    );
+
+    expect(attachment.bytes).toEqual(PDF);
+    expect(attachment.filename).toBe('invoice-2026.pdf');
+    expect(attachment.sha256).toBe(PDF_SHA256);
+    expect(attachment.origin).toBe('asset:invoice-2026.pdf');
+  });
+
+  test('a name nothing holds does not read as an empty attachment', async () => {
+    await expect(
+      resolveAttachments([{ asset: 'gone.pdf' }], { ...BUDGET, shared: shared({}) }),
+    ).rejects.toThrow(/no asset "gone.pdf"/);
+  });
+
+  test('a connection with no bridge says so rather than reading as absent', async () => {
+    await expect(
+      resolveAttachments([{ asset: 'invoice-2026.pdf' }], BUDGET),
+    ).rejects.toThrow(/cannot reach this profile's files/);
+  });
+
+  test('it is an alternative to the other sources, not a layer over them', async () => {
+    await expect(
+      resolveAttachments([{ path: '/tmp/a.pdf', asset: 'b.pdf' }], BUDGET),
+    ).rejects.toThrow(/names 2 sources \(path, asset\)/);
+  });
+});
+
+describe('which store a handle is looked up in', () => {
+  // Routing is on the prefix, never "try one and fall back". A fallback would let
+  // a mailbox-minted att_ handle be promoted into a profile-wide one for the same
+  // bytes; these two tests are what stops that being reintroduced.
+  const poisoned = () => ({
+    ...createMemoryBlobStore(),
+    get: () => {
+      throw new Error('the connection store was read');
+    },
+  });
+
+  test('a profile handle is read from the bridge, never from the connection', async () => {
+    const attachment = only(
+      await resolveAttachments([{ handle: 'stg_01j7k' }], {
+        ...BUDGET,
+        storage: poisoned(),
+        shared: { staged: async () => ({ bytes: PDF, filename: 'q.pdf', contentType: null }) },
+      }),
+    );
+
+    expect(attachment.filename).toBe('q.pdf');
+    expect(attachment.origin).toBe('handle:stg_01j7k');
+  });
+
+  test('a connection handle is read from the connection, never from the bridge', async () => {
+    const storage = createMemoryBlobStore();
+    await storage.put(stagedBytesKey('att_01j7k'), PDF);
+    await storage.put(
+      stagedMetaKey('att_01j7k'),
+      new TextEncoder().encode(JSON.stringify({ filename: 'q.pdf' })),
+    );
+
+    const attachment = only(
+      await resolveAttachments([{ handle: 'att_01j7k' }], {
+        ...BUDGET,
+        storage,
+        shared: {
+          staged: () => {
+            throw new Error('the profile bridge was read');
+          },
+        },
+      }),
+    );
+
+    expect(attachment.origin).toBe('handle:att_01j7k');
+  });
+
+  test('a profile handle with no bridge says which kind of handle this is', async () => {
+    await expect(
+      resolveAttachments([{ handle: 'stg_01j7k' }], { ...BUDGET, storage: poisoned() }),
+    ).rejects.toThrow(/no profile staging area/);
+  });
+
+  test('a missing connection handle explains that it belongs to one connection', async () => {
+    await expect(
+      resolveAttachments([{ handle: 'att_nope' }], {
+        ...BUDGET,
+        storage: createMemoryBlobStore(),
+      }),
+    ).rejects.toThrow(/belongs to one connection/);
   });
 });

--- a/src/connectivity/mail/sources.ts
+++ b/src/connectivity/mail/sources.ts
@@ -1,0 +1,215 @@
+import { readFile } from 'node:fs/promises';
+import type { BlobStore } from '#stores/blobs';
+import { getStaged, isProfileHandle, type StagedFile } from './staging.ts';
+import { fetchFromUrl } from './url.ts';
+import { basename } from './content-type.ts';
+import type { AttachmentRef, ResolveOptions, SharedAttachments, SourceKey } from './attachments.ts';
+
+/**
+ * Turning one named source into bytes.
+ *
+ * Split from `attachments.ts` when the two together passed the file-size budget,
+ * along the seam that was already there: that file owns the shape a caller may
+ * name and the rule that exactly one source is named, and this one owns what
+ * each source then means. The budget found the seam; it did not invent it.
+ */
+
+export interface FoundBytes {
+  readonly bytes: Uint8Array;
+  readonly filename: string | null;
+  readonly contentType: string | null;
+  readonly origin: string;
+}
+
+export async function bytesFor(
+  source: SourceKey,
+  ref: AttachmentRef,
+  where: string,
+  options: ResolveOptions,
+): Promise<FoundBytes> {
+  switch (source) {
+    case 'path':
+      return await fromPath(ref.path!, where, options.maxTotalBytes);
+
+    case 'url': {
+      const fetched = await fetchFromUrl({
+        url: ref.url!,
+        maxBytes: options.maxTotalBytes,
+        ...(options.fetch ? { fetch: options.fetch } : {}),
+        ...(options.addresses ? { addresses: options.addresses } : {}),
+        signal: options.signal,
+      });
+      return {
+        bytes: fetched.bytes,
+        filename: fetched.filename ?? basename(new URL(ref.url!).pathname),
+        contentType: fetched.contentType,
+        origin: `url:${ref.url!}`,
+      };
+    }
+
+    case 'handle':
+      return await fromHandle(ref.handle!, where, options);
+
+    case 'asset':
+      return await fromAsset(ref.asset!, where, options.shared);
+
+    case 'message_id':
+    case 'uid': {
+      if (!options.mailbox) {
+        throw new Error(
+          `${where} uses ${source}, which only a mail connection can resolve — this one holds no mailbox. ` +
+            `Name the file with path, url, handle, or asset instead, or ask the mail connection itself to send it somewhere.`,
+        );
+      }
+      const found = await options.mailbox({
+        messageId: ref.message_id,
+        mailbox: ref.mailbox,
+        uid: ref.uid,
+        attachmentId: ref.attachment_id,
+      });
+      return {
+        bytes: found.bytes,
+        filename: found.filename,
+        contentType: found.contentType,
+        origin: source === 'uid' ? `mailbox:${ref.mailbox ?? 'INBOX'}:${ref.uid!}` : `mailbox:${ref.message_id!}`,
+      };
+    }
+
+    case 'data': {
+      const bytes = decodeBase64(ref.data!, where);
+      return { bytes, filename: null, contentType: null, origin: 'inline' };
+    }
+  }
+}
+
+async function fromPath(path: string, where: string, maxBytes: number): Promise<FoundBytes> {
+  let bytes: Uint8Array;
+  try {
+    bytes = new Uint8Array(await readFile(path));
+  } catch (failure) {
+    const code = (failure as { code?: string }).code;
+    if (code === 'ENOENT') throw new Error(`${where}: no file at ${path}.`);
+    if (code === 'EACCES') throw new Error(`${where}: ${path} is not readable by this endpoint.`);
+    if (code === 'EISDIR') throw new Error(`${where}: ${path} is a directory, not a file.`);
+    throw new Error(`${where}: could not read ${path} — ${(failure as Error).message}`);
+  }
+
+  if (bytes.byteLength > maxBytes) {
+    throw new Error(
+      `${where}: ${path} is ${bytes.byteLength} bytes, over the ${maxBytes} byte limit for one message.`,
+    );
+  }
+
+  return {
+    bytes,
+    filename: basename(path),
+    contentType: null,
+    origin: `path:${path}`,
+  };
+}
+
+/**
+ * Routed on the prefix, and never tried in both stores.
+ *
+ * A fallback — read the connection, then the profile — would let
+ * `lanes_assets.stage` be handed a mailbox-minted `att_` handle and give back a
+ * `stg_` one for the same bytes, promoting a file scoped to one account into
+ * every connection in the profile. Routing on the prefix leaves that nowhere to
+ * happen, so the isolation holds by construction rather than by review.
+ */
+async function fromHandle(
+  handle: string,
+  where: string,
+  options: ResolveOptions,
+): Promise<FoundBytes> {
+  const profile = isProfileHandle(handle);
+
+  const stored = profile
+    ? await fromProfileArea(handle, where, options.shared)
+    : await fromConnectionArea(handle, where, options.storage);
+
+  if (!stored) {
+    throw new Error(
+      `${where}: no staged attachment "${handle}". Handles expire, so stage the file again. ` +
+        (profile
+          ? 'A handle beginning stg_ is staged for this profile by lanes_assets_stage.'
+          : 'A handle beginning att_ belongs to one connection; lanes_assets_stage returns one that works anywhere in this profile.'),
+    );
+  }
+
+  return {
+    bytes: stored.bytes,
+    filename: stored.filename,
+    contentType: stored.contentType,
+    origin: `handle:${handle}`,
+  };
+}
+
+async function fromProfileArea(
+  handle: string,
+  where: string,
+  shared: SharedAttachments | undefined,
+): Promise<StagedFile | null> {
+  if (!shared?.staged) {
+    throw new Error(
+      `${where} uses a profile handle, but this endpoint has no profile staging area.`,
+    );
+  }
+  return await shared.staged(handle);
+}
+
+async function fromConnectionArea(
+  handle: string,
+  where: string,
+  storage: BlobStore | undefined,
+): Promise<StagedFile | null> {
+  if (!storage) {
+    throw new Error(`${where} uses a handle, but this provider has no staging store.`);
+  }
+  return await getStaged(storage, handle);
+}
+
+async function fromAsset(
+  name: string,
+  where: string,
+  shared: SharedAttachments | undefined,
+): Promise<FoundBytes> {
+  if (!shared?.asset) {
+    throw new Error(
+      `${where} names an asset, but this connection cannot reach this profile's files. ` +
+        `Name the file with path, url, handle, or data instead.`,
+    );
+  }
+
+  const stored = await shared.asset(name);
+  if (!stored) {
+    throw new Error(`${where}: no asset "${name}". lanes_assets_list reports what is kept here.`);
+  }
+
+  return {
+    bytes: stored.bytes,
+    filename: stored.filename ?? name,
+    contentType: stored.contentType,
+    origin: `asset:${name}`,
+  };
+}
+
+function decodeBase64(value: string, where: string): Uint8Array {
+  // Both alphabets, because the two obvious places a caller gets base64 from
+  // disagree: a mail API hands back base64url (RFC 4648 §5) while every
+  // general-purpose encoder emits the standard one. Rejecting the former would
+  // be a correct-looking failure with a corrupt-file outcome.
+  const normalized = value.replaceAll('-', '+').replaceAll('_', '/').replaceAll(/\s+/g, '');
+
+  try {
+    const buffer = Buffer.from(normalized, 'base64');
+    // Buffer.from is lenient and silently drops invalid characters, so a typo
+    // becomes a shorter file rather than an error. Re-encoding and comparing
+    // lengths catches that.
+    const expected = Math.floor((normalized.replace(/=+$/, '').length * 3) / 4);
+    if (buffer.byteLength !== expected) throw new Error('not base64');
+    return new Uint8Array(buffer);
+  } catch {
+    throw new Error(`${where}: data is not valid base64.`);
+  }
+}

--- a/src/connectivity/mail/staging.ts
+++ b/src/connectivity/mail/staging.ts
@@ -53,9 +53,26 @@ export function isHandle(value: string): boolean {
   return HANDLE.test(value);
 }
 
-/** `att_` plus 128 bits, which is unguessable and still fits on one line. */
-export function newHandle(): string {
-  return `att_${randomBytes(16).toString('hex')}`;
+/**
+ * Which store a handle belongs to, written into the handle itself.
+ *
+ * Resolution routes on the prefix rather than trying one store and falling back
+ * to the other. A fallback would let `lanes_assets.stage` be handed an `att_`
+ * handle minted from a *mailbox* and hand back a profile-wide one for the same
+ * bytes — laundering a connection-scoped file into every connection in the
+ * profile. Routing on the prefix means that promotion has nowhere to happen.
+ */
+export const CONNECTION_HANDLE = 'att_';
+export const PROFILE_HANDLE = 'stg_';
+
+/** A prefix plus 128 bits, which is unguessable and still fits on one line. */
+export function newHandle(prefix: string = CONNECTION_HANDLE): string {
+  return `${prefix}${randomBytes(16).toString('hex')}`;
+}
+
+/** Whether this handle names the profile-level area rather than one connection. */
+export function isProfileHandle(value: string): boolean {
+  return value.startsWith(PROFILE_HANDLE);
 }
 
 export async function putStaged(

--- a/src/connectivity/transports/http/http.test.ts
+++ b/src/connectivity/transports/http/http.test.ts
@@ -574,3 +574,98 @@ describe('headers declared on the connector', () => {
     expect(record.request!.headers.get('content-type')).toBe('application/json');
   });
 });
+
+describe('a credential the vendor refuses mid-flight', () => {
+  /**
+   * The token a call goes out with can be dead while our clock still calls it
+   * valid. Core learns that only from the 401, so a verifier that asks for one
+   * retry turns an hour of refusals into a single re-authorised call.
+   */
+  const refusingOnce = async (options: { verifyRetries: boolean }) => {
+    const tokens: string[] = [];
+    let attempt = 0;
+
+    const connector = createHttpConnector({
+      baseUrl: 'https://api.acme.test/v1',
+      openapi: await specFile(),
+      fetch: (async (request: Request) => {
+        tokens.push(request.headers.get('authorization') ?? '');
+        attempt += 1;
+        return attempt === 1
+          ? new Response('{"error":"Invalid Credentials"}', {
+              status: 401,
+              statusText: 'Unauthorized',
+            })
+          : new Response('{"accounts":[]}', {
+              status: 200,
+              headers: { 'content-type': 'application/json' },
+            });
+      }) as never,
+    });
+
+    let issued = 0;
+    const context = {
+      manifest: { id: 'acme', name: 'Acme' } as never,
+      provider: { signal: new AbortController().signal } as never,
+      async authorize(request: Request) {
+        issued += 1;
+        const authorised = new Request(request, { headers: new Headers(request.headers) });
+        // A second call gets a different token, exactly as a refresh would.
+        authorised.headers.set('authorization', `Bearer token-${issued}`);
+        return authorised;
+      },
+      async verify(response: Response) {
+        if (!options.verifyRetries || response.status !== 401) return;
+        return { retry: true };
+      },
+    } as unknown as ConnectorContext;
+
+    const listAccounts = (await connector.discover(CONTEXT)).find(
+      (c) => c.name === 'listAccounts',
+    )!;
+
+    return { result: await connector.invoke(listAccounts, {}, context), tokens };
+  };
+
+  test('is retried once, with a token the verifier caused to be reissued', async () => {
+    const { result, tokens } = await refusingOnce({ verifyRetries: true });
+
+    expect(result.isError).toBeFalsy();
+    expect(tokens).toEqual(['Bearer token-1', 'Bearer token-2']);
+  });
+
+  test('is not retried when the verifier does not ask, so nothing else changes', async () => {
+    const { result, tokens } = await refusingOnce({ verifyRetries: false });
+
+    expect(result.isError).toBe(true);
+    expect(tokens).toEqual(['Bearer token-1']);
+  });
+
+  test('a second refusal is the answer, rather than a loop', async () => {
+    let attempts = 0;
+    const connector = createHttpConnector({
+      baseUrl: 'https://api.acme.test/v1',
+      openapi: await specFile(),
+      fetch: (async () => {
+        attempts += 1;
+        return new Response('{"error":"nope"}', { status: 401, statusText: 'Unauthorized' });
+      }) as never,
+    });
+
+    const context = {
+      manifest: { id: 'acme', name: 'Acme' } as never,
+      provider: { signal: new AbortController().signal } as never,
+      authorize: async (request: Request) => request,
+      verify: async (response: Response) => (response.status === 401 ? { retry: true } : undefined),
+    } as unknown as ConnectorContext;
+
+    const listAccounts = (await connector.discover(CONTEXT)).find(
+      (c) => c.name === 'listAccounts',
+    )!;
+    const result = await connector.invoke(listAccounts, {}, context);
+
+    expect(result.isError).toBe(true);
+    expect((result.content[0] as { text: string }).text).toContain('401');
+    expect(attempts).toBe(2);
+  });
+});

--- a/src/connectivity/transports/http/index.ts
+++ b/src/connectivity/transports/http/index.ts
@@ -259,22 +259,32 @@ export function createHttpConnector(options: HttpConnectorOptions): Connector {
       // silently changed it would be a bug nobody could see from the manifest.
       if (hasBody) headers.set('content-type', contentType);
 
-      // Auth is attached by core, from the manifest's auth kind or its strategy.
-      // A connector never sees a raw credential.
-      const request = await context.authorize(
+      // Built per attempt rather than once: a `Request` body can only be read
+      // once, so a retry needs its own.
+      const outbound = (): Request =>
         new Request(url.href, {
           method,
           headers,
           ...(hasBody ? { body: encodeBody(body, contentType) } : {}),
           signal: context.provider.signal,
-        }),
-      );
+        });
 
       const doFetch = options.fetch ?? globalThis.fetch;
-      const response = await doFetch(request);
+
+      // Auth is attached by core, from the manifest's auth kind or its strategy.
+      // A connector never sees a raw credential.
+      let response = await doFetch(await context.authorize(outbound()));
 
       // Cloned so a verifier can read the body without consuming it for us.
-      await context.verify?.(response.clone() as unknown as Response);
+      const outcome = await context.verify?.(response.clone() as unknown as Response);
+
+      // At most one, and only where the verifier asked. It stopped trusting
+      // something on the strength of this response — a token the vendor
+      // refused — so authorising again hands out a replacement rather than the
+      // value that just failed. A second refusal is the answer.
+      if (outcome?.retry) {
+        response = await doFetch(await context.authorize(outbound()));
+      }
 
       const text = await response.text();
       if (!response.ok) {

--- a/src/connectivity/transports/imap/capabilities.ts
+++ b/src/connectivity/transports/imap/capabilities.ts
@@ -155,7 +155,7 @@ export function imapCapabilities(input: {
         capabilities.push({
           name: OPERATIONS.sendMessage,
           description:
-            'Send a message, with attachments, filing a copy in the Sent mailbox. Attachments are named by reference — a path, an HTTPS URL, or another message in this mailbox — and this endpoint reads the bytes itself, so never encode a file into the call.',
+            'Send a message, with attachments, filing a copy in the Sent mailbox. Attachments are named by reference — a path, an HTTPS URL, a staged handle, a file this profile keeps, or another message in this mailbox — and this endpoint reads the bytes itself. A file that exists only where you are goes through lanes_assets_stage once and travels as a handle.',
           bundle: WRITE_BUNDLE,
           inputSchema: object(
             {

--- a/src/connectivity/transports/imap/commands.ts
+++ b/src/connectivity/transports/imap/commands.ts
@@ -1,7 +1,5 @@
 import PostalMime from 'postal-mime';
-import type { AuditLogger } from '#audit';
-import type { ConnectionInfo, ToolResult } from '#connectivity';
-import type { BlobStore } from '#stores/blobs';
+import type { ProviderContext, ToolResult } from '#connectivity';
 import { receiptFor, resolveAttachments } from '#connectivity/mail';
 import { mailboxAttachments } from './attachment.ts';
 import { quoted, type ImapClient, type ImapSession } from './client.ts';
@@ -236,10 +234,18 @@ export async function sendMessage(
   options: ImapConnectorOptions,
   send: Sender,
   args: Readonly<Record<string, unknown>>,
-  audit: AuditLogger,
-  storage: BlobStore,
-  connection: ConnectionInfo,
+  /**
+   * The whole provider context rather than three fields off it.
+   *
+   * It was `audit`, `storage`, `connection`; resolving an attachment now also
+   * needs the profile's file lookups and the request's abort signal, and five
+   * positional arguments of one object is worse than the object. The signal in
+   * particular was simply missing before: a `url` attachment here could not be
+   * cancelled, while the same argument on the other mail provider could.
+   */
+  context: ProviderContext,
 ): Promise<ToolResult> {
+  const { audit, storage, connection } = context;
   if (!options.smtp) return error('This account has no SMTP server configured, so it cannot send.');
 
   const to = (args['to'] as string[] | undefined) ?? [];
@@ -258,6 +264,8 @@ export async function sendMessage(
     maxTotalBytes: Math.floor((encodedLimit * 3) / 4),
     mailbox: mailboxAttachments(client),
     storage,
+    shared: context.attachments,
+    signal: context.signal,
   });
 
   // Recorded before the send, so an attachment that was read off disk is in the

--- a/src/connectivity/transports/imap/index.test.ts
+++ b/src/connectivity/transports/imap/index.test.ts
@@ -129,6 +129,20 @@ const CONTEXT = {
     // Scoped to this provider and connection by the time a connector sees it,
     // which is what confines a staged handle to the account it was staged for.
     storage,
+    signal: new AbortController().signal,
+    // The profile's own two file lookups, which dispatch binds. A mail send
+    // resolves them exactly as Gmail's does, because both share one resolver.
+    attachments: {
+      stage: async () => ({ handle: 'stg_x', sha256: '', expiresAt: 0 }),
+      staged: async (handle: string) =>
+        handle === 'stg_known'
+          ? { bytes: new Uint8Array([9, 9]), filename: 'staged.txt', contentType: 'text/plain' }
+          : null,
+      asset: async (name: string) =>
+        name === 'invoice-2026.pdf'
+          ? { bytes: new Uint8Array([1, 2, 3, 4]), filename: name, contentType: null }
+          : null,
+    },
     // `config` is where a connection keeps its own settings — `from_name` among
     // them, which is how the From header gets a display name.
     connection: {
@@ -1100,5 +1114,46 @@ describe('search criteria', () => {
     expect(searchCriteria({ unseen: true, since: '2026-08-01', from: 'sam' })).toBe(
       'FROM "sam" SINCE 1-Aug-2026 UNSEEN',
     );
+  });
+});
+
+describe('a mail send reaches the files this profile keeps', () => {
+  test('an asset is attached by name, exactly as it is on the other mail provider', async () => {
+    let handed: OutgoingMessage | undefined;
+    const { connector } = sendingConnector(async ({ message }) => {
+      handed = message;
+      return { messageId: '<generated@example.com>', raw: new TextEncoder().encode('raw') };
+    });
+
+    await connector.invoke(
+      SEND as never,
+      {
+        to: ['sam@example.com'],
+        subject: 'Invoice',
+        attachments: [{ asset: 'invoice-2026.pdf' }],
+      },
+      CONTEXT as never,
+    );
+
+    expect(handed?.attachments?.[0]?.bytes).toEqual(new Uint8Array([1, 2, 3, 4]));
+    expect(handed?.attachments?.[0]?.filename).toBe('invoice-2026.pdf');
+    await connector.close?.();
+  });
+
+  test('a profile handle resolves, so a file staged from a chat can be mailed', async () => {
+    let handed: OutgoingMessage | undefined;
+    const { connector } = sendingConnector(async ({ message }) => {
+      handed = message;
+      return { messageId: '<generated@example.com>', raw: new TextEncoder().encode('raw') };
+    });
+
+    await connector.invoke(
+      SEND as never,
+      { to: ['sam@example.com'], subject: 'Draft', attachments: [{ handle: 'stg_known' }] },
+      CONTEXT as never,
+    );
+
+    expect(handed?.attachments?.[0]?.filename).toBe('staged.txt');
+    await connector.close?.();
   });
 });

--- a/src/connectivity/transports/imap/index.ts
+++ b/src/connectivity/transports/imap/index.ts
@@ -141,15 +141,7 @@ export function createImapConnector(options: ImapConnectorOptions): Connector {
             // The only operation handed the context: what it attached is worth
             // recording in a way `redact` cannot express, since the raw argument
             // may itself be a base64 file.
-            return await sendMessage(
-              client,
-              options,
-              send,
-              args,
-              context.provider.audit,
-              context.provider.storage,
-              context.provider.connection,
-            );
+            return await sendMessage(client, options, send, args, context.provider);
           default:
             return error(`Unknown operation "${operation}".`);
         }

--- a/src/deployments/adapters/gcp-secret-manager.ts
+++ b/src/deployments/adapters/gcp-secret-manager.ts
@@ -346,6 +346,22 @@ interface CachedToken {
  * would each be a further exchange, and neither is reachable from the two
  * places this runs: an operator's laptop and Cloud Run.
  */
+/**
+ * No usable Google credentials, from any step of the ADC chain.
+ *
+ * A type rather than a message, because the chain says two different things for
+ * one condition — an unreadable key file names the path, the exhausted chain
+ * names the login command — and a caller deciding whether to suggest signing in
+ * cannot tell those apart by reading them. Still an `Error`, so nothing that
+ * catches or rethrows one needs to change.
+ */
+export class GoogleCredentialsError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'GoogleCredentialsError';
+  }
+}
+
 export class ApplicationDefaultCredentials implements AccessTokenSource {
   readonly #fetch: typeof globalThis.fetch;
   readonly #env: Record<string, string | undefined>;
@@ -389,7 +405,7 @@ export class ApplicationDefaultCredentials implements AccessTokenSource {
     try {
       key = (await Bun.file(path).json()) as Record<string, string>;
     } catch (error) {
-      throw new Error(`Could not read Google credentials from ${path}: ${(error as Error).message}`);
+      throw new GoogleCredentialsError(`Could not read Google credentials from ${path}: ${(error as Error).message}`);
     }
 
     if (key['type'] === 'authorized_user') {
@@ -408,7 +424,7 @@ export class ApplicationDefaultCredentials implements AccessTokenSource {
       }), path);
     }
 
-    throw new Error(
+    throw new GoogleCredentialsError(
       `${path}: unsupported Google credential type ${JSON.stringify(key['type'] ?? 'unknown')}. ` +
         'Expected "authorized_user" or "service_account".',
     );
@@ -423,7 +439,7 @@ export class ApplicationDefaultCredentials implements AccessTokenSource {
 
     const text = await response.text();
     if (!response.ok) {
-      throw new Error(`Could not exchange the credentials in ${source} for a token: ${text.slice(0, 300)}`);
+      throw new GoogleCredentialsError(`Could not exchange the credentials in ${source} for a token: ${text.slice(0, 300)}`);
     }
     return toCachedToken(JSON.parse(text) as { access_token?: string; expires_in?: number }, source);
   }
@@ -439,7 +455,7 @@ export class ApplicationDefaultCredentials implements AccessTokenSource {
       // The last stop in the chain, so this is where "no credentials at all"
       // surfaces — say what to do rather than reporting a DNS failure for a
       // hostname the operator has never heard of.
-      throw new Error(
+      throw new GoogleCredentialsError(
         'No Google credentials found. On Cloud Run the metadata server supplies them; ' +
           'locally run `gcloud auth application-default login`, or set ' +
           'GOOGLE_APPLICATION_CREDENTIALS to a service account key, or GOOGLE_ACCESS_TOKEN directly.',
@@ -447,7 +463,7 @@ export class ApplicationDefaultCredentials implements AccessTokenSource {
     }
 
     if (!response.ok) {
-      throw new Error(
+      throw new GoogleCredentialsError(
         `The metadata server refused a token (HTTP ${response.status}). ` +
           'Check the service account attached to this revision.',
       );

--- a/src/deployments/discover.test.ts
+++ b/src/deployments/discover.test.ts
@@ -1,0 +1,132 @@
+import { describe, expect, test } from 'bun:test';
+import { createMemoryBlobStore } from '#stores/blobs/testing.ts';
+import type { BlobStore } from '#stores/blobs';
+import { GoogleCredentialsError } from './adapters/gcp-secret-manager.ts';
+import { discoverDeployments, holdsWorkspace, probeWorkspace } from './discover.ts';
+
+/**
+ * Whether a bucket holds a workspace, and — the part that was missing — whether
+ * the question could be answered at all.
+ *
+ * The probe used to answer `false` to "is there a workspace here", "does that
+ * bucket exist" and "are you logged in to Google" alike, so a laptop with no
+ * credentials was told to check the bucket name.
+ */
+
+const WORKSPACE = 'workspaces.yaml';
+const LEGACY = 'lanes-link.yaml';
+
+const holding = async (...keys: string[]): Promise<BlobStore> => {
+  const files = createMemoryBlobStore();
+  for (const key of keys) await files.put(key, new TextEncoder().encode('contract: 5\n'));
+  return files;
+};
+
+/** A store that cannot answer, the way an unauthenticated one cannot. */
+const failing = (error: Error): BlobStore =>
+  ({
+    ...createMemoryBlobStore(),
+    has: () => Promise.reject(error),
+    get: () => Promise.reject(error),
+  }) as BlobStore;
+
+describe('what a bucket turns out to hold', () => {
+  test('a workspace file makes it a workspace', async () => {
+    expect(await probeWorkspace('gs://your-bucket', { files: await holding(WORKSPACE) })).toEqual({
+      kind: 'workspace',
+    });
+  });
+
+  test('an empty bucket declares no workspace', async () => {
+    expect(await probeWorkspace('gs://your-bucket', { files: createMemoryBlobStore() })).toEqual({
+      kind: 'absent',
+    });
+  });
+
+  test('a bucket still on the old filename is a workspace that needs migrating', async () => {
+    // The case this command exists for. `readWorkspace` accepts either name, so
+    // reporting "no workspace" here refuses exactly the recovery it is for —
+    // but calling it a workspace would be worse, since the file is keyed
+    // `targets:` and would parse as declaring nothing.
+    expect(await probeWorkspace('gs://your-bucket', { files: await holding(LEGACY) })).toEqual({
+      kind: 'legacy',
+    });
+  });
+});
+
+describe('when the question cannot be answered', () => {
+  test('missing credentials are reported as unreadable, not as absent', async () => {
+    const error = new GoogleCredentialsError(
+      'No Google credentials found. Run `gcloud auth application-default login`.',
+    );
+
+    const probe = await probeWorkspace('gs://your-bucket', { files: failing(error) });
+
+    expect(probe.kind).toBe('unreadable');
+    if (probe.kind !== 'unreadable') throw new Error('unreachable');
+    expect(probe.credentials).toBe(true);
+    expect(probe.reason).toContain('application-default login');
+  });
+
+  test('a permission failure is unreadable, but not a credentials problem', async () => {
+    const probe = await probeWorkspace('gs://your-bucket', {
+      files: failing(new Error('Cannot read your-bucket — grant roles/storage.objectAdmin.')),
+    });
+
+    expect(probe.kind).toBe('unreadable');
+    if (probe.kind !== 'unreadable') throw new Error('unreachable');
+    // Nothing to say about logging in, so the message must not offer it.
+    expect(probe.credentials).toBe(false);
+    expect(probe.reason).toContain('objectAdmin');
+  });
+
+  test('a URL naming no bucket is reported, not thrown', async () => {
+    // `workspaceFiles` throws synchronously for this, which is why the store is
+    // built inside the probe rather than defaulted in the signature.
+    const probe = await probeWorkspace('gs://');
+
+    expect(probe.kind).toBe('unreadable');
+  });
+});
+
+describe('the boolean the bucket scan uses', () => {
+  test('only a current workspace counts, so the scan is unchanged', async () => {
+    expect(await holdsWorkspace('gs://x', { files: await holding(WORKSPACE) })).toBe(true);
+    expect(await holdsWorkspace('gs://x', { files: await holding(LEGACY) })).toBe(false);
+    expect(await holdsWorkspace('gs://x', { files: createMemoryBlobStore() })).toBe(false);
+  });
+
+  test('it still cannot tell an unreadable bucket from an empty one', async () => {
+    // Deliberate: the scan sweeps every bucket in every project, and one it
+    // cannot read is not a candidate. This is the assertion that says the
+    // boolean was never the thing to fix — the caller that needed the
+    // difference is the one that names a single bucket.
+    const error = new GoogleCredentialsError('No Google credentials found.');
+
+    expect(await holdsWorkspace('gs://x', { files: failing(error) })).toBe(false);
+    expect((await probeWorkspace('gs://x', { files: failing(error) })).kind).toBe('unreadable');
+  });
+});
+
+describe('searching the platform for one', () => {
+  const gcloud = (result: { ok: boolean; stdout?: string; stderr?: string }) => async () => ({
+    ok: result.ok,
+    stdout: result.stdout ?? '',
+    stderr: result.stderr ?? '',
+  });
+
+  test('a gcloud that could not be asked is not reported as an empty account', async () => {
+    // The same defect as the probe, one level up: the project list failing
+    // became `return []`, which the caller printed as "no deployment in any
+    // project this login can see" — a sentence about a list nobody obtained.
+    const failed = discoverDeployments({
+      gcloud: gcloud({ ok: false, stderr: 'gcloud is not on your PATH.' }),
+    });
+
+    await expect(failed).rejects.toThrow(/not on your PATH/);
+  });
+
+  test('a login that genuinely holds no projects is an empty list, not an error', async () => {
+    expect(await discoverDeployments({ gcloud: gcloud({ ok: true, stdout: '' }) })).toEqual([]);
+  });
+});

--- a/src/deployments/discover.ts
+++ b/src/deployments/discover.ts
@@ -1,5 +1,8 @@
-import { readWorkspaceFile, workspaceFiles, WORKSPACE_FILE } from '#profile';
+import { LEGACY_WORKSPACE_FILE, workspaceFiles, WORKSPACE_FILE } from '#profile';
+import type { BlobStore } from '#stores/blobs';
+import { GoogleCredentialsError } from './adapters/gcp-secret-manager.ts';
 import { captureGcloud } from './gcp/gcloud.ts';
+import type { CommandResult } from './driver.ts';
 
 /**
  * Finding a deployment nothing in the workspace mentions any more.
@@ -31,18 +34,35 @@ export interface Candidate {
  * named it anything, and a name filter would hide exactly the deployment whose
  * naming convention nobody remembers.
  */
-export async function discoverDeployments(
-  onProgress?: (project: string) => void,
-): Promise<Candidate[]> {
-  const projects = await captureGcloud(['projects', 'list', '--format', 'value(projectId)']);
-  if (!projects.ok) return [];
+export interface DiscoverOptions {
+  readonly onProgress?: ((project: string) => void) | undefined;
+  /** The gcloud runner. Injected in tests; the real one when absent. */
+  readonly gcloud?: ((argv: readonly string[]) => Promise<CommandResult>) | undefined;
+}
+
+export async function discoverDeployments(options: DiscoverOptions = {}): Promise<Candidate[]> {
+  const run: (argv: readonly string[]) => Promise<CommandResult> = options.gcloud ?? captureGcloud;
+  const onProgress = options.onProgress;
+
+  const projects = await run(['projects', 'list', '--format', 'value(projectId)']);
+  // Not an empty list. "gcloud is not on your PATH" and "you are not logged in"
+  // are both failures to *ask*, and reporting them as an answer produces the
+  // sentence this used to end at: no deployment in any project this login can
+  // see, about a list nobody obtained.
+  if (!projects.ok) {
+    throw new Error(
+      `Could not list your Google Cloud projects, so there was nowhere to search.\n  ${
+        projects.stderr || 'gcloud exited non-zero and said nothing.'
+      }`,
+    );
+  }
 
   const found: Candidate[] = [];
 
   for (const project of projects.stdout.split('\n').map((line) => line.trim()).filter(Boolean)) {
     onProgress?.(project);
 
-    const services = await captureGcloud([
+    const services = await run([
       'run',
       'services',
       'list',
@@ -57,7 +77,7 @@ export async function discoverDeployments(
       const [service = '', region = ''] = line.split(/\s+/);
       if (!service || !region) continue;
 
-      found.push({ project, region, service, workspace: await workspaceBeside(project) });
+      found.push({ project, region, service, workspace: await workspaceBeside(project, run) });
     }
   }
 
@@ -71,10 +91,13 @@ export async function discoverDeployments(
  * is almost always the answer. Falling back to listing every bucket costs a
  * second call and covers a workspace whose bucket was named by hand.
  */
-async function workspaceBeside(project: string): Promise<string | undefined> {
+async function workspaceBeside(
+  project: string,
+  run: (argv: readonly string[]) => Promise<CommandResult>,
+): Promise<string | undefined> {
   if (await holdsWorkspace(`gs://${project}`)) return `gs://${project}`;
 
-  const buckets = await captureGcloud([
+  const buckets = await run([
     'storage',
     'buckets',
     'list',
@@ -93,11 +116,76 @@ async function workspaceBeside(project: string): Promise<string | undefined> {
   return undefined;
 }
 
-/** A bucket is a workspace when it has the file that says so. Never throws. */
-export async function holdsWorkspace(url: string): Promise<boolean> {
+/**
+ * What a bucket turned out to hold, including "could not tell".
+ *
+ * The fourth case is the one this exists for. `has` already distinguishes
+ * absence from failure — a 404 is `false`, everything else throws (`gcs.ts`,
+ * "Absence is a value, not an error") — and the old probe collapsed both into
+ * one boolean, so a laptop with no credentials was told to check the bucket
+ * name. Nothing new is being detected here; a distinction that was always there
+ * is being kept.
+ */
+export type WorkspaceProbe =
+  | { readonly kind: 'workspace' }
+  | { readonly kind: 'legacy' }
+  | { readonly kind: 'absent' }
+  | {
+      readonly kind: 'unreadable';
+      /** What the adapter said, which already names the fix for most causes. */
+      readonly reason: string;
+      /** Whether the cause was credentials, so the caller may offer signing in. */
+      readonly credentials: boolean;
+    };
+
+export interface ProbeOptions {
+  /** The workspace's files. Built from the URL when absent; injected in tests. */
+  readonly files?: BlobStore | undefined;
+}
+
+/**
+ * Ask one named bucket what it holds.
+ *
+ * Never rejects: every failure is a `kind`, which is what lets `holdsWorkspace`
+ * below drop its own `try` and stay a plain boolean for the scan.
+ *
+ * `has` rather than a read, because the answer is a yes-or-no and `has` is
+ * metadata-only — which pays for the second call the legacy branch makes.
+ */
+export async function probeWorkspace(
+  url: string,
+  options: ProbeOptions = {},
+): Promise<WorkspaceProbe> {
   try {
-    return (await readWorkspaceFile(workspaceFiles(url), WORKSPACE_FILE)) !== null;
-  } catch {
-    return false;
+    // Built in here rather than defaulted in the signature: `workspaceFiles`
+    // throws synchronously for a URL naming no bucket, and that should be
+    // reported like any other reason rather than rejecting out of the probe.
+    const files = options.files ?? workspaceFiles(url);
+
+    if (await files.has(WORKSPACE_FILE)) return { kind: 'workspace' };
+    // `readWorkspace` accepts either name, so a bucket restored from something
+    // older *is* a workspace — but saying so here would send the caller on to
+    // parse a file keyed `targets:` and be told it declares nothing.
+    if (await files.has(LEGACY_WORKSPACE_FILE)) return { kind: 'legacy' };
+
+    return { kind: 'absent' };
+  } catch (failure) {
+    return {
+      kind: 'unreadable',
+      reason: (failure as Error).message,
+      credentials: failure instanceof GoogleCredentialsError,
+    };
   }
+}
+
+/**
+ * A bucket is a workspace when it has the file that says so. Never throws.
+ *
+ * Deliberately still a boolean, and deliberately still blind to why: its callers
+ * sweep every bucket in every project, where one that cannot be read is simply
+ * not a candidate and a reason per bucket would be noise. The caller that names
+ * a single bucket uses `probeWorkspace`.
+ */
+export async function holdsWorkspace(url: string, options: ProbeOptions = {}): Promise<boolean> {
+  return (await probeWorkspace(url, options)).kind === 'workspace';
 }

--- a/src/deployments/serving.test.ts
+++ b/src/deployments/serving.test.ts
@@ -147,7 +147,7 @@ describe('deciding which profiles a deploy sends', () => {
 
     await expect(
       servingProfiles({ workspaceRoot: root, target: 'cloud', named: [] }),
-    ).rejects.toThrow('sync targets');
+    ).rejects.toThrow('sync workspaces');
   });
 });
 

--- a/src/deployments/serving.ts
+++ b/src/deployments/serving.ts
@@ -69,7 +69,7 @@ export async function servingProfiles(input: {
         '  it belongs to:\n' +
         `    lanes link deploy --workspace ${target} --profile <name>\n\n` +
         `  If "${target}" was deployed before and the pointer to it was lost:\n` +
-        `    lanes link sync targets --workspace ${target} --discover`,
+        `    lanes link sync workspaces --workspace ${target} --discover`,
     );
   }
 

--- a/src/dispatch/attachments.test.ts
+++ b/src/dispatch/attachments.test.ts
@@ -1,0 +1,132 @@
+import { describe, expect, test } from 'bun:test';
+import { createMemoryBlobStore } from '#stores/blobs/testing.ts';
+import { scopeBlobStore } from '#stores/blobs';
+import type { GrantConfig } from '#profile';
+import { PROFILE_HANDLE, STAGED_TTL_MS } from '#connectivity/mail';
+import { createAttachmentBridge } from './attachments.ts';
+
+/**
+ * The bridge is the one place a file crosses from one connection's world into
+ * the profile's. Everything here is either "the crossing works" or "the crossing
+ * cannot be turned into something it should not reach".
+ */
+
+const PDF = new Uint8Array([0x25, 0x50, 0x44, 0x46]);
+
+const grant = (connection: string): GrantConfig => ({
+  connection,
+  allow: [{ capability: `${connection.split('.')[0]}.*` }],
+  deny: [],
+});
+
+const bridgeOver = (
+  storage: ReturnType<typeof createMemoryBlobStore>,
+  options: { grants?: readonly GrantConfig[]; allows?: boolean } = {},
+) =>
+  createAttachmentBridge({
+    storage,
+    grants: options.grants ?? [grant('lanes_assets.lan3')],
+    allows: () => options.allows ?? true,
+  });
+
+describe('staging a file for the whole profile', () => {
+  test('the bytes land in the profile area, under a stg_ handle', async () => {
+    const storage = createMemoryBlobStore();
+    const bridge = bridgeOver(storage);
+
+    const receipt = await bridge.stage({
+      bytes: PDF,
+      filename: 'draft.pdf',
+      contentType: 'application/pdf',
+    });
+
+    expect(receipt.handle.startsWith(PROFILE_HANDLE)).toBe(true);
+    expect(await storage.get(`attachments.d/attachments/${receipt.handle}`)).toEqual(PDF);
+    expect(receipt.expiresAt).toBeGreaterThan(Date.now());
+    expect(receipt.expiresAt).toBeLessThanOrEqual(Date.now() + STAGED_TTL_MS);
+  });
+
+  test('what was staged reads back with the name and type it was given', async () => {
+    const storage = createMemoryBlobStore();
+    const bridge = bridgeOver(storage);
+
+    const { handle } = await bridge.stage({
+      bytes: PDF,
+      filename: 'draft.pdf',
+      contentType: 'application/pdf',
+    });
+    const found = await bridge.staged!(handle);
+
+    expect(found?.bytes).toEqual(PDF);
+    expect(found?.filename).toBe('draft.pdf');
+    expect(found?.contentType).toBe('application/pdf');
+  });
+
+  test('an expired handle is swept by the next stage, not left to accumulate', async () => {
+    const storage = createMemoryBlobStore();
+    const area = scopeBlobStore(storage, 'attachments.d');
+    await area.put('attachments/stg_old', PDF);
+    await area.put(
+      'attachments/stg_old.json',
+      new TextEncoder().encode(JSON.stringify({ expires_at: Date.now() - 1000 })),
+    );
+
+    await bridgeOver(storage).stage({ bytes: PDF, filename: 'a.pdf', contentType: 'text/plain' });
+
+    expect(await area.get('attachments/stg_old')).toBeNull();
+  });
+
+  test('a handle staged in one profile does not resolve in another', async () => {
+    const root = createMemoryBlobStore();
+    const a = bridgeOver(scopeBlobStore(root, 'profiles/personal'));
+    const b = bridgeOver(scopeBlobStore(root, 'profiles/work'));
+
+    const { handle } = await a.stage({ bytes: PDF, filename: 'a.pdf', contentType: 'text/plain' });
+
+    expect(await a.staged!(handle)).not.toBeNull();
+    expect(await b.staged!(handle)).toBeNull();
+  });
+});
+
+describe('reaching a file this profile keeps', () => {
+  const withAsset = async (connectionId: string, name: string) => {
+    const storage = createMemoryBlobStore();
+    await scopeBlobStore(storage, `lanes_assets/${connectionId}`).put(name, PDF);
+    return storage;
+  };
+
+  test('finds the one granted assets connection, whatever it is called', async () => {
+    const storage = await withAsset('lan3', 'invoice.pdf');
+    const bridge = bridgeOver(storage);
+
+    expect((await bridge.asset!('invoice.pdf'))?.bytes).toEqual(PDF);
+  });
+
+  test('a name the store does not hold reads as absent, not as an error', async () => {
+    const storage = await withAsset('lan3', 'invoice.pdf');
+
+    expect(await bridgeOver(storage).asset!('gone.pdf')).toBeNull();
+  });
+
+  test('two granted assets connections are ambiguous, and it refuses rather than picking', async () => {
+    const storage = await withAsset('lan3', 'invoice.pdf');
+    const bridge = bridgeOver(storage, {
+      grants: [grant('lanes_assets.lan3'), grant('lanes_assets.side')],
+    });
+
+    await expect(bridge.asset!('invoice.pdf')).rejects.toThrow(/lan3, side/);
+  });
+
+  test('a profile granting no assets connection says so', async () => {
+    const bridge = bridgeOver(createMemoryBlobStore(), { grants: [grant('gmail.con1')] });
+
+    await expect(bridge.asset!('invoice.pdf')).rejects.toThrow(/keeps no files/);
+  });
+
+  test('a caller denied the assets store cannot read it through an attachment', async () => {
+    const storage = await withAsset('lan3', 'invoice.pdf');
+    const bridge = bridgeOver(storage, { allows: false });
+
+    await expect(bridge.asset!('invoice.pdf')).rejects.toThrow(/not permitted to read/);
+  });
+});

--- a/src/dispatch/attachments.ts
+++ b/src/dispatch/attachments.ts
@@ -1,0 +1,115 @@
+import type { AttachmentBridge } from '#connectivity/mail';
+import {
+  getStaged,
+  newHandle,
+  putStaged,
+  sweepStaged,
+  PROFILE_HANDLE,
+  STAGED_TTL_MS,
+  type StagedFile,
+} from '#connectivity/mail';
+import type { GrantConfig } from '#profile';
+import { layout } from '#profile';
+import type { BlobStore } from '#stores/blobs';
+import { scopeBlobStore } from '#stores/blobs';
+import { createHash } from 'node:crypto';
+import { scopeNamespace } from './context.ts';
+
+/**
+ * The two file lookups a connection-scoped store cannot serve.
+ *
+ * Both cross the `<provider>/<connection>` boundary every other store keeps, so
+ * both are built here rather than in a provider: `ProviderContext` promises no
+ * way to reach another connection, and the way to keep that promise while still
+ * answering "attach the file I just handed you" is for dispatch to bind the two
+ * lookups and hand over closures, not stores.
+ *
+ * What makes the crossing safe is what may pass through it. The profile area
+ * only ever receives bytes the *caller* supplied — `data`, `url`, `path` on
+ * `lanes_assets.stage` — or bytes the profile already owns, through `asset`. It
+ * never receives bytes read out of a third party's account: `get_attachment`
+ * keeps minting a connection-scoped `att_` handle, and nothing here promotes
+ * one. Change that and the boundary is gone, not narrowed.
+ */
+
+const ASSETS = 'lanes_assets';
+
+export interface AttachmentBridgeDeps {
+  /** The profile's blob store, as `layout.blobs(profile)` roots it. */
+  readonly storage: BlobStore;
+  /** This profile's grants, which decide which assets connection is reachable. */
+  readonly grants: readonly GrantConfig[];
+  /** Whether this caller may run a capability on a connection. Dispatch supplies `evaluate`. */
+  readonly allows: (capability: string, connection: string) => boolean;
+  readonly now?: () => number;
+}
+
+export function createAttachmentBridge(deps: AttachmentBridgeDeps): AttachmentBridge {
+  const now = deps.now ?? (() => Date.now());
+  const area = scopeBlobStore(deps.storage, layout.attachmentsKey());
+
+  return {
+    async stage(input) {
+      // Swept here rather than on a timer: there is no scheduler in this
+      // process, and staging is the only thing that makes the garbage.
+      await sweepStaged(area).catch(() => 0);
+
+      const handle = newHandle(PROFILE_HANDLE);
+      const sha256 = createHash('sha256').update(input.bytes).digest('hex');
+      const expiresAt = now() + STAGED_TTL_MS;
+
+      await putStaged(area, {
+        handle,
+        bytes: input.bytes,
+        metadata: {
+          filename: input.filename,
+          content_type: input.contentType,
+          sha256,
+          expires_at: expiresAt,
+        },
+      });
+
+      return { handle, sha256, expiresAt };
+    },
+
+    staged: (handle: string): Promise<StagedFile | null> => getStaged(area, handle),
+
+    // Resolved on use rather than at build time. Every dispatch would otherwise
+    // pay for a policy evaluation and a grant scan that almost no call needs.
+    asset: async (name: string): Promise<StagedFile | null> => {
+      const store = assetStore(deps);
+      const bytes = await store.get(name);
+      return bytes ? { bytes, filename: name, contentType: null } : null;
+    },
+  };
+}
+
+function assetStore(deps: AttachmentBridgeDeps): BlobStore {
+  const prefix = `${ASSETS}.`;
+  // From the grants, not the workspace's connections: the question is which
+  // store *this profile* may reach. Same rule as `ownerConnection`.
+  const candidates = deps.grants
+    .filter((grant) => grant.connection.startsWith(prefix))
+    .map((grant) => grant.connection.slice(prefix.length));
+
+  if (candidates.length === 0) {
+    throw new Error('This profile keeps no files, so there is no asset to name.');
+  }
+  // Ordering is not selection. Picking one of two would turn a question for the
+  // owner into a silent choice of which store an outgoing file came from.
+  if (candidates.length > 1) {
+    throw new Error(
+      `This profile has ${candidates.length} asset stores (${candidates.join(', ')}), ` +
+        `so "asset" does not name one file. Stage the file instead, or store it in one of them.`,
+    );
+  }
+
+  const id = candidates[0]!;
+  // The gate a provider cannot apply for itself. Without it, a caller denied the
+  // asset store but allowed a send could read it through an attachment argument.
+  if (!deps.allows(`${ASSETS}.get`, `${ASSETS}.${id}`)) {
+    throw new Error('This caller is not permitted to read the files this profile keeps.');
+  }
+
+  return scopeBlobStore(deps.storage, scopeNamespace(ASSETS, id));
+}

--- a/src/dispatch/context.ts
+++ b/src/dispatch/context.ts
@@ -4,6 +4,7 @@ import { scopeSecrets } from '#secrets';
 import type { RuntimeState } from '#stores/state';
 import type { BlobStore } from '#stores/blobs';
 import { scopeBlobStore } from '#stores/blobs';
+import type { AttachmentBridge } from '#connectivity/mail';
 import type {
   ConnectionInfo,
   Logger,
@@ -133,6 +134,8 @@ export interface BuildContextOptions {
   readonly ownClients?: readonly string[] | undefined;
   /** Every profile the caller may reach. See `ProviderContext.profiles`. */
   readonly profiles: readonly string[];
+  /** The profile's file lookups. See `ProviderContext.attachments`. */
+  readonly attachments?: AttachmentBridge | undefined;
 }
 
 export function buildProviderContext(options: BuildContextOptions): ProviderContext {
@@ -159,6 +162,7 @@ export function buildProviderContext(options: BuildContextOptions): ProviderCont
     log: options.log,
     signal: options.signal,
     ...(options.authorize ? { authorize: options.authorize } : {}),
+    ...(options.attachments ? { attachments: options.attachments } : {}),
   };
 }
 

--- a/src/dispatch/dispatch.test.ts
+++ b/src/dispatch/dispatch.test.ts
@@ -6,6 +6,7 @@ import { createMemoryBlobStore } from '#stores/blobs/testing.ts';
 import { createBlobAuditStore } from '#deployments/adapters/audit-blob.ts';
 import { RateLimiter } from '#policy';
 import { createLocalConnector } from '#connectivity/transports';
+import { resolveAttachments } from '#connectivity/mail';
 import {
   defineLocalProvider,
   isToolResult,
@@ -70,6 +71,31 @@ const testProvider = defineLocalProvider({
       },
     },
     {
+      // Round-trips a file through the profile-level area: stage it, then name
+      // the handle the way a *different* connection's send would. The point
+      // under test is that dispatch hands over a working bridge at all.
+      kind: 'tool',
+      name: 'round_trip',
+      description: 'stage a file and name it back',
+      inputSchema: z.object({ text: z.string() }),
+      async handler({ text }, context) {
+        const receipt = await context.attachments!.stage({
+          bytes: new TextEncoder().encode(text),
+          filename: 'note.txt',
+          contentType: 'text/plain',
+        });
+        const [attachment] = await resolveAttachments([{ handle: receipt.handle }], {
+          maxTotalBytes: 1_000_000,
+          shared: context.attachments,
+        });
+        return {
+          content: [
+            { type: 'text', text: `${receipt.handle} ${attachment!.filename} ${new TextDecoder().decode(attachment!.bytes)}` },
+          ],
+        };
+      },
+    },
+    {
       kind: 'tool',
       name: 'get_note',
       description: 'read a note',
@@ -127,7 +153,12 @@ const CONNECTIONS = [
 const PRINCIPAL = ownerPrincipal('personal');
 const silent = { debug() {}, info() {}, warn() {}, error() {} };
 
-function harness(overrides: { limits?: { profile: number; connection: number } } = {}) {
+function harness(
+  overrides: {
+    limits?: { profile: number; connection: number };
+    storage?: ReturnType<typeof createMemoryBlobStore>;
+  } = {},
+) {
   const state = createMemoryState();
   const audit = createBlobAuditStore({ storage: createMemoryBlobStore() });
   const registry = new ProviderRegistry();
@@ -156,7 +187,7 @@ function harness(overrides: { limits?: { profile: number; connection: number } }
     state,
     audit,
     credentials: createMemoryCredentials(),
-    storage: createMemoryBlobStore(),
+    storage: overrides.storage ?? createMemoryBlobStore(),
     limiter: new RateLimiter(),
     log: silent,
   });
@@ -585,5 +616,30 @@ describe('logging', () => {
 
     expect(written.join('')).not.toContain('invisible');
     expect(written.join('')).toContain('visible');
+  });
+});
+
+describe('the profile-level file area', () => {
+  test('a provider is handed a bridge, and what it stages it can name back', async () => {
+    const { dispatcher } = harness();
+    const outcome = await dispatcher.invoke(
+      call('example.round_trip', 'example.a', { text: 'hello' }),
+    );
+
+    expect(outcome.ok).toBe(true);
+    expect(firstBlock(outcome)).toEqual({
+      type: 'text',
+      text: expect.stringMatching(/^stg_[0-9a-f]{32} note\.txt hello$/) as unknown as string,
+    });
+  });
+
+  test('the bytes land in the profile area, not under the connection that staged them', async () => {
+    const storage = createMemoryBlobStore();
+    const { dispatcher } = harness({ storage });
+    await dispatcher.invoke(call('example.round_trip', 'example.a', { text: 'hello' }));
+
+    const keys = (await storage.list('')).map((blob) => blob.key);
+    expect(keys.some((key) => key.startsWith('attachments.d/attachments/stg_'))).toBe(true);
+    expect(keys.some((key) => key.startsWith('example/a/attachments/'))).toBe(false);
   });
 });

--- a/src/dispatch/dispatch.ts
+++ b/src/dispatch/dispatch.ts
@@ -16,6 +16,7 @@ import type {
 import { isToolResult, strategyContextFrom, strategyFor } from '#connectivity';
 import type { Config, ConnectionConfig } from '#profile';
 import { buildProviderContext, createProviderLogger } from './context.ts';
+import { createAttachmentBridge } from './attachments.ts';
 import { fetchStaged, stageAttachment } from './staging.ts';
 import type { FetchStagedRequest, StagedAttachment, StageRequest } from './staging.ts';
 import type { ProviderRegistry } from '#registry';
@@ -257,6 +258,22 @@ export class Dispatcher {
             ? this.#deps.authorizeRequest(providerId, declared.id, outbound)
             : Promise.resolve(outbound);
 
+      // The profile's own two file lookups, bound here because only dispatch may
+      // cross a connection boundary. `allows` is the same `evaluate` this call
+      // already passed, asked a second question — so a caller denied the asset
+      // store cannot reach it through an attachment argument on a send it *is*
+      // allowed to make.
+      const attachments = createAttachmentBridge({
+        storage: this.#deps.storage,
+        grants: config.grants,
+        allows: (capability, connection) =>
+          evaluate(
+            { principal: request.principal.id, capability, connection },
+            this.#deps.policy,
+            this.#deps.floor,
+          ).allowed,
+      });
+
       const providerContext = buildProviderContext({
         manifest: entry.manifest,
         definition: entry.definition,
@@ -276,6 +293,7 @@ export class Dispatcher {
         // honest answer a dispatcher can give for it without knowing what the
         // endpoint is serving.
         profiles: request.principal.profiles ?? [request.principal.profile],
+        attachments,
         ...(entry.manifest.connector.kind === 'local' ? {} : { authorize }),
       });
 

--- a/src/dispatch/dispatch.ts
+++ b/src/dispatch/dispatch.ts
@@ -16,6 +16,8 @@ import type {
 import { isToolResult, strategyContextFrom, strategyFor } from '#connectivity';
 import type { Config, ConnectionConfig } from '#profile';
 import { buildProviderContext, createProviderLogger } from './context.ts';
+import { responseVerifier } from './reauthorize.ts';
+import { distrustUpstreamToken } from '#connectivity/auth/index.ts';
 import { createAttachmentBridge } from './attachments.ts';
 import { fetchStaged, stageAttachment } from './staging.ts';
 import type { FetchStagedRequest, StagedAttachment, StageRequest } from './staging.ts';
@@ -308,18 +310,26 @@ export class Dispatcher {
         });
       }
 
-      // Only where the strategy asks for it. A vendor that signs its replies
-      // expects them verified, and the transport clones the response so the
-      // check costs the caller nothing.
-      const verifyResponse = strategy?.verify?.bind(strategy);
+      // Two reasons to read a response before the caller does: a vendor that
+      // signs its replies expects them verified, and a token the vendor refuses
+      // has to be distrusted or the next call sends it again. They compose.
+      const verifyStrategy = strategy?.verify?.bind(strategy);
+      const verify = responseVerifier({
+        // Built from what was resolved, not from what was asked for: this has
+        // to be the key the token cache uses, `<manifest>.<connection>`.
+        connectionKey: `${providerId}.${declared.id}`,
+        oauth: entry.manifest.auth.kind === 'oauth',
+        distrust: distrustUpstreamToken,
+        ...(verifyStrategy
+          ? { strategy: (response: Response) => verifyStrategy(response, forStrategy()) }
+          : {}),
+      });
 
       const connectorContext: ConnectorContext = {
         manifest: entry.manifest,
         provider: providerContext,
         authorize,
-        ...(verifyResponse
-          ? { verify: (response: Response) => verifyResponse(response, forStrategy()) }
-          : {}),
+        ...(verify ? { verify } : {}),
       };
 
       // The connector owns argument validation: a local provider validates

--- a/src/dispatch/reauth.test.ts
+++ b/src/dispatch/reauth.test.ts
@@ -1,0 +1,162 @@
+import { afterAll, describe, expect, test } from 'bun:test';
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { ownerPrincipal } from '#auth';
+import { createMemoryCredentials, createMemoryState } from '#stores/state/testing.ts';
+import { createMemoryBlobStore } from '#stores/blobs/testing.ts';
+import { createBlobAuditStore } from '#deployments/adapters/audit-blob.ts';
+import { RateLimiter } from '#policy';
+import { createHttpConnector } from '#connectivity/transports';
+import { defineProvider, type AnyConnector } from '#connectivity';
+import { parseConfig } from '#profile';
+import { Dispatcher } from './dispatch.ts';
+import { ProviderRegistry, toPolicyDocument } from '#registry';
+
+/**
+ * The seam, wired.
+ *
+ * `reauthorize.test.ts` covers the decision and `http.test.ts` the retry. What
+ * neither can show is the part that was actually broken in production: that a
+ * 401 on an oauth connection reaches a verifier at all, and that a connection
+ * whose credential a person has to change does not get a second refusal.
+ */
+
+const directory = await mkdtemp(join(tmpdir(), 'reauth-spec-'));
+const specPath = join(directory, 'acme.json');
+
+await writeFile(
+  specPath,
+  JSON.stringify({
+    openapi: '3.0.3',
+    info: { title: 'Acme', version: '1.0.0' },
+    paths: {
+      '/accounts': {
+        get: { operationId: 'listAccounts', responses: { '200': { description: 'ok' } } },
+      },
+    },
+  }),
+);
+
+afterAll(async () => {
+  await rm(directory, { recursive: true, force: true });
+});
+
+const CONFIG = parseConfig(`
+contract: 5
+instance:
+  profile: personal
+limits:
+  requests_per_minute: 100
+  upstream_calls_per_minute: 100
+grants:
+  - { connection: acme.main, allow: ['acme.*'], deny: [] }
+members: []
+`).config;
+
+const connector = { kind: 'http', base_url: 'https://api.acme.test/v1', openapi: specPath } as const;
+
+const OAUTH = defineProvider({
+  id: 'acme',
+  name: 'Acme',
+  connector,
+  auth: {
+    kind: 'oauth',
+    // Dynamic registration keeps the manifest to the two fields this test is
+    // about; what it authenticates with is beside the point, only that it can
+    // be renewed without a person.
+    registration: 'dynamic',
+    scopes: ['read'],
+    authorization_url: 'https://acme.test/authorize',
+    token_url: 'https://acme.test/token',
+  },
+});
+
+const BASIC = defineProvider({
+  id: 'acme',
+  name: 'Acme',
+  connector,
+  auth: { kind: 'basic', credential_ref: 'acme/password' },
+});
+
+/** A vendor that refuses the first call and accepts the second. */
+function harness(manifest: typeof OAUTH) {
+  const tokens: string[] = [];
+  let attempt = 0;
+
+  const registry = new ProviderRegistry();
+  registry.register(manifest as never);
+
+  const http = createHttpConnector({
+    baseUrl: 'https://api.acme.test/v1',
+    openapi: specPath,
+    fetch: (async (request: Request) => {
+      tokens.push(request.headers.get('authorization') ?? '');
+      attempt += 1;
+      return attempt === 1
+        ? new Response('{"error":"Invalid Credentials"}', { status: 401, statusText: 'Unauthorized' })
+        : new Response('{"accounts":[]}', {
+            status: 200,
+            headers: { 'content-type': 'application/json' },
+          });
+    }) as unknown as typeof globalThis.fetch,
+  });
+
+  let issued = 0;
+  const dispatcher = new Dispatcher({
+    config: CONFIG,
+    connections: [{ id: 'main', provider: 'acme', account: 'A' }],
+    oauthApps: [],
+    registry,
+    connectorFor: (): AnyConnector | undefined => http as unknown as AnyConnector,
+    // Stands in for the credential resolver: a second call hands out a second
+    // token, which is what a refresh looks like from here.
+    authorizeRequest: async (_provider, _connection, request) => {
+      issued += 1;
+      const authorised = new Request(request, { headers: new Headers(request.headers) });
+      authorised.headers.set('authorization', `Bearer token-${issued}`);
+      return authorised;
+    },
+    policy: toPolicyDocument(CONFIG),
+    state: createMemoryState(),
+    audit: createBlobAuditStore({ storage: createMemoryBlobStore() }),
+    credentials: createMemoryCredentials(),
+    storage: createMemoryBlobStore(),
+    limiter: new RateLimiter(),
+    log: { debug() {}, info() {}, warn() {}, error() {} },
+  });
+
+  return { dispatcher, tokens, registry, http };
+}
+
+const call = {
+  principal: ownerPrincipal('personal'),
+  capabilityId: 'acme.listAccounts',
+  connectionKey: 'acme.main',
+  arguments: {},
+};
+
+describe('a refused token on a connection that can renew itself', () => {
+  test('is authorised again and the call succeeds, without anyone intervening', async () => {
+    const { dispatcher, tokens, registry, http } = harness(OAUTH);
+    registry.setDiscovered('acme', await http.discover({ manifest: OAUTH } as never));
+
+    const outcome = await dispatcher.invoke(call);
+
+    expect(outcome.ok).toBe(true);
+    // Two tokens, not the same one twice: the retry is only worth making
+    // because authorising again hands out a replacement.
+    expect(tokens).toEqual(['Bearer token-1', 'Bearer token-2']);
+  });
+});
+
+describe('a refused credential a person has to change', () => {
+  test('is not retried, because a second refusal is all it would buy', async () => {
+    const { dispatcher, tokens, registry, http } = harness(BASIC);
+    registry.setDiscovered('acme', await http.discover({ manifest: BASIC } as never));
+
+    await dispatcher.invoke(call);
+
+    expect(tokens).toEqual(['Bearer token-1']);
+  });
+});

--- a/src/dispatch/reauthorize.test.ts
+++ b/src/dispatch/reauthorize.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, test } from 'bun:test';
+import { responseVerifier } from './reauthorize.ts';
+
+/**
+ * Who gets told that a call came back refused.
+ *
+ * Two verifiers can want the same response: the one a signing vendor demands,
+ * and the one that exists to notice a refused token. They compose rather than
+ * exclude, because a strategy that verifies signatures has nothing to say about
+ * credentials and the reverse is equally true.
+ */
+
+const refused = new Response('', { status: 401 });
+const fine = new Response('', { status: 200 });
+
+describe('an oauth connection', () => {
+  test('stops trusting its token when the vendor refuses it, and asks for one retry', async () => {
+    const distrusted: string[] = [];
+    const verify = responseVerifier({
+      connectionKey: 'gmail.con1',
+      oauth: true,
+      distrust: (key) => distrusted.push(key),
+    })!;
+
+    expect(await verify(refused)).toEqual({ retry: true });
+    expect(distrusted).toEqual(['gmail.con1']);
+  });
+
+  test('leaves a response that was not refused alone', async () => {
+    const distrusted: string[] = [];
+    const verify = responseVerifier({
+      connectionKey: 'gmail.con1',
+      oauth: true,
+      distrust: (key) => distrusted.push(key),
+    })!;
+
+    expect(await verify(fine)).toBeUndefined();
+    expect(distrusted).toEqual([]);
+  });
+
+  test('asks for a retry once, so a second refusal is the answer', async () => {
+    // The verifier is built per invocation, so the guard lives here rather than
+    // in the transport, where it would have to be threaded through every kind.
+    const verify = responseVerifier({
+      connectionKey: 'gmail.con1',
+      oauth: true,
+      distrust: () => {},
+    })!;
+
+    expect(await verify(refused)).toEqual({ retry: true });
+    expect(await verify(refused)).toBeUndefined();
+  });
+});
+
+describe('a connection that is not oauth', () => {
+  test('gets no verifier at all, so nothing is retried', () => {
+    // Basic auth and api keys do not go stale mid-flight, and a retry would be
+    // one more refusal for a credential that needs a person to change it.
+    expect(
+      responseVerifier({ connectionKey: 'icloud_mail.con3', oauth: false, distrust: () => {} }),
+    ).toBeUndefined();
+  });
+});
+
+describe('a strategy that verifies its own replies', () => {
+  test('still runs, and its answer wins where it has one', async () => {
+    const seen: number[] = [];
+    const verify = responseVerifier({
+      connectionKey: 'bunq.con6',
+      oauth: false,
+      distrust: () => {},
+      strategy: async (response) => void seen.push(response.status),
+    })!;
+
+    expect(await verify(fine)).toBeUndefined();
+    expect(seen).toEqual([200]);
+  });
+
+  test('composes with the credential check rather than replacing it', async () => {
+    const seen: number[] = [];
+    const distrusted: string[] = [];
+    const verify = responseVerifier({
+      connectionKey: 'gmail.con1',
+      oauth: true,
+      distrust: (key) => distrusted.push(key),
+      strategy: async (response) => void seen.push(response.status),
+    })!;
+
+    expect(await verify(refused)).toEqual({ retry: true });
+    expect(seen).toEqual([401]);
+    expect(distrusted).toEqual(['gmail.con1']);
+  });
+});

--- a/src/dispatch/reauthorize.ts
+++ b/src/dispatch/reauthorize.ts
@@ -1,0 +1,54 @@
+import type { VerifyOutcome } from '#connectivity';
+
+/**
+ * Noticing that a call went out with a credential the vendor no longer accepts.
+ *
+ * A stored `expires_at` is a claim about the future. A token can be rotated,
+ * revoked or superseded while our clock still calls it valid, and the only
+ * party that knows is the vendor — which says so with a 401 and nothing else.
+ * Until that answer could be fed back in, it changed nothing: the next call
+ * re-read the same stored token, saw the same unexpired clock, and sent it
+ * again. On an hour-long token that is an hour of refusals for a connection
+ * whose sibling on the same account is working.
+ *
+ * This is where the answer is fed back in. It is deliberately not a retry loop:
+ * the outcome is handed to the transport, which re-authorises once, so the
+ * decision to spend another call lives with the layer that owns the request and
+ * the once-only guard lives here, where the verifier is built per invocation.
+ *
+ * Scoped to oauth because that is the only kind that can be renewed without a
+ * person. A basic password or an api key that stops working needs the operator,
+ * and retrying it is one more refusal.
+ */
+
+export interface VerifierOptions {
+  /** `<provider>.<connection>`, as the token cache keys it. */
+  readonly connectionKey: string;
+  /** Whether this connection's credential is renewable without a person. */
+  readonly oauth: boolean;
+  /** Stop trusting this connection's token. */
+  readonly distrust: (connectionKey: string) => void;
+  /** The strategy's own verifier, where the vendor signs its replies. */
+  readonly strategy?: ((response: Response) => Promise<VerifyOutcome | void>) | undefined;
+}
+
+export function responseVerifier(
+  options: VerifierOptions,
+): ((response: Response) => Promise<VerifyOutcome | void>) | undefined {
+  const { strategy } = options;
+  if (!options.oauth) return strategy;
+
+  // One per invocation, so this is the natural home for "at most once".
+  let asked = false;
+
+  return async (response: Response): Promise<VerifyOutcome | void> => {
+    const outcome = await strategy?.(response);
+    if (outcome?.retry) return outcome;
+
+    if (response.status !== 401 || asked) return outcome ?? undefined;
+
+    asked = true;
+    options.distrust(options.connectionKey);
+    return { retry: true };
+  };
+}

--- a/src/profile/files.ts
+++ b/src/profile/files.ts
@@ -39,7 +39,7 @@ export function isRemoteWorkspace(root: string): boolean {
 /**
  * The workspace's files.
  *
- * Rooted at the workspace, so every caller addresses `lanes-link.yaml` and
+ * Rooted at the workspace, so every caller addresses `workspaces.yaml` and
  * `profiles/<name>.yaml` by the same relative key whichever backing it has.
  */
 export function workspaceFiles(root: string): BlobStore {

--- a/src/profile/layout.ts
+++ b/src/profile/layout.ts
@@ -175,6 +175,18 @@ export const layout = {
   /** One skills connection's procedures — `<name>.md` or `<name>/SKILL.md`, either layout. */
   skills: (profile: string, connection: string): string =>
     `${PROFILES_DIR}/${profile}/skills.d/${connection}`,
+  /**
+   * Files handed to the endpoint for a later call, for this profile.
+   *
+   * Profile-level rather than under `<provider>/<connection>`, because the point
+   * of it is that a file handed over in one place is nameable in another. The
+   * `.d` suffix is load-bearing: a provider id may be `[a-z][a-z0-9_]*`, so a
+   * bare `attachments_tmp` would be a legal provider id sharing this key space,
+   * and a provider by that name would collide with the area.
+   */
+  attachmentsRoot: (profile: string): string => `${PROFILES_DIR}/${profile}/attachments.d`,
+  /** The same area, keyed relative to the blob store — see `vaultKey`. */
+  attachmentsKey: (): string => 'attachments.d',
   /** The blob root this profile's providers are namespaced under. */
   blobs: (profile: string): string => `${PROFILES_DIR}/${profile}`,
 } as const;

--- a/src/profile/registry.ts
+++ b/src/profile/registry.ts
@@ -146,7 +146,7 @@ function pointerMissesTarget(
   return new ConfigError(
     `${root} says target "${target}" lives at ${workspaceRoot}, but that workspace does not ` +
       `declare it (it declares: ${there}).\n` +
-      `  Adopt what is really there:  lanes link sync targets --workspace ${target} --from ${workspaceRoot}`,
+      `  Adopt what is really there:  lanes link sync workspaces --workspace ${target} --from ${workspaceRoot}`,
   );
 }
 

--- a/src/providers/assets/provider.test.ts
+++ b/src/providers/assets/provider.test.ts
@@ -131,7 +131,10 @@ describe('reading returns text, or a description — never base64', () => {
     expect(read).toContain('image/png');
     expect(read).toContain('sha256');
     expect(read).toContain('not text');
-    expect(read).toContain('lanes link attach');
+    // What a description of a binary asset is *for*: the next call. Naming it
+    // as an asset is something the model can do, where the CLI it used to point
+    // at is the owner's to run.
+    expect(read).toContain('{ "asset": "<name>" }');
     expect(read).not.toContain('iVBOR');
   });
 
@@ -233,7 +236,7 @@ describe('reading and writing are different capabilities', () => {
     const write = bundles.find((bundle) => bundle.name === 'write');
 
     expect(write?.default).toBeFalsy();
-    expect(write?.capabilities.sort()).toEqual(['remove', 'store']);
+    expect(write?.capabilities.sort()).toEqual(['remove', 'stage', 'store']);
   });
 });
 
@@ -275,5 +278,143 @@ describe('a store that does not know the type', () => {
     expect((await assetStorage.find(storage, 'thing.qqq'))?.contentType).toBe(
       'application/octet-stream',
     );
+  });
+});
+
+// SHA-256 of "hello", asserted against an independent value rather than against
+// whatever the code happens to produce: `printf 'hello' | shasum -a 256`.
+const HELLO_SHA256 = '2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824';
+
+describe('holding a file for a later call', () => {
+  /**
+   * The gap this closes. A client holding a file only it can see — a chat
+   * runtime's own sandbox — had no way to hand it over: `path` names the
+   * endpoint's disk, `url` must be fetchable, and a handle needed a stage that
+   * only the HTTP route and the CLI could do. `data` was the one channel MCP
+   * offers, and every description around it said not to use it.
+   */
+  const staging = () => {
+    const staged = new Map<string, { bytes: Uint8Array; filename: string; contentType: string }>();
+    return {
+      staged,
+      harness: harnessFor(assetsProvider, 'owner', {
+        attachments: {
+          stage: async (input: { bytes: Uint8Array; filename: string; contentType: string }) => {
+            const handle = `stg_${staged.size}`;
+            staged.set(handle, input);
+            return { handle, sha256: 'abc', expiresAt: 1_700_000_000_000 };
+          },
+          staged: async (handle: string) => {
+            const found = staged.get(handle);
+            return found
+              ? { bytes: found.bytes, filename: found.filename, contentType: found.contentType }
+              : null;
+          },
+          asset: async () => null,
+        },
+      }),
+    };
+  };
+
+  test('a file only the caller has crosses once, and comes back as a handle', async () => {
+    const { staged, harness } = staging();
+
+    const result = await harness.invoke('stage', {
+      source: { data: Buffer.from('hello').toString('base64') },
+      filename: 'draft.txt',
+    });
+
+    const body = JSON.parse(textOf(result));
+    expect(body['handle']).toBe('stg_0');
+    expect(body['bytes']).toBe(5);
+    expect(body['filename']).toBe('draft.txt');
+    expect(staged.get('stg_0')?.bytes).toEqual(new Uint8Array(Buffer.from('hello')));
+  });
+
+  test('the receipt carries a digest and an expiry, and never the bytes', async () => {
+    const { harness } = staging();
+    const base64 = Buffer.from('hello').toString('base64');
+
+    const result = await harness.invoke('stage', {
+      source: { data: base64 },
+      filename: 'draft.txt',
+    });
+
+    const text = textOf(result);
+    expect(JSON.parse(text)['sha256']).toBe(HELLO_SHA256);
+    expect(JSON.parse(text)['expires_at']).toBe('2023-11-14T22:13:20.000Z');
+    // The whole point of the provider: what comes back names the file, it is
+    // not the file.
+    expect(text).not.toContain(base64);
+    expect(text).not.toContain('hello');
+  });
+
+  test('what it stages, a send can name', async () => {
+    const { harness } = staging();
+
+    const staging_result = await harness.invoke('stage', {
+      source: { data: Buffer.from('hello').toString('base64') },
+      filename: 'draft.txt',
+    });
+    const handle = JSON.parse(textOf(staging_result))['handle'] as string;
+
+    // Stored through the same handle, which is what a mail send does too.
+    const stored = await harness.invoke('store', { source: { handle }, name: 'draft.txt' });
+
+    expect(textOf(stored)).toContain('draft.txt');
+  });
+
+  test('the audit record says what entered the endpoint, and where from', async () => {
+    const { harness } = staging();
+
+    await harness.invoke('stage', {
+      source: { data: Buffer.from('hello').toString('base64') },
+      filename: 'draft.txt',
+    });
+
+    expect(harness.annotations()).toMatchObject({
+      handle: 'stg_0',
+      filename: 'draft.txt',
+      bytes: 5,
+      sha256: HELLO_SHA256,
+      origin: 'inline',
+    });
+  });
+
+  test('the name given here decides the type, as it does when storing', async () => {
+    // Found against a live endpoint, not by a test: `filename` is a sibling of
+    // `source`, so the resolver never saw it and guessed the type from nothing.
+    // A .txt arriving as application/octet-stream is a file that downloads
+    // instead of opening.
+    const { staged, harness } = staging();
+
+    const result = await harness.invoke('stage', {
+      source: { data: Buffer.from('hello').toString('base64') },
+      filename: 'draft.txt',
+    });
+
+    expect(JSON.parse(textOf(result))['content_type']).toBe('text/plain');
+    expect(staged.get('stg_0')?.contentType).toBe('text/plain');
+  });
+
+  test('an explicit content_type still wins over the name', async () => {
+    const { harness } = staging();
+
+    const result = await harness.invoke('stage', {
+      source: { data: Buffer.from('hello').toString('base64') },
+      filename: 'draft.txt',
+      content_type: 'text/markdown',
+    });
+
+    expect(JSON.parse(textOf(result))['content_type']).toBe('text/markdown');
+  });
+
+  test('an endpoint with no staging area refuses legibly rather than throwing', async () => {
+    const result = await harnessFor(assetsProvider).invoke('stage', {
+      source: { data: Buffer.from('hello').toString('base64') },
+      filename: 'draft.txt',
+    });
+
+    expect(textOf(result)).toMatch(/cannot hold a file/);
   });
 });

--- a/src/providers/assets/provider.ts
+++ b/src/providers/assets/provider.ts
@@ -15,6 +15,7 @@ import {
   humanBytes,
   isTextual,
 } from './store.ts';
+import { stageCapability } from './stage.ts';
 
 /**
  * `assets` — files the owner wants kept.
@@ -48,12 +49,18 @@ import {
  * offered a route the handler never had. The description above now says so, and
  * the refusal in `#connectivity/mail` names what does work instead.
  *
- * The reason it cannot is real rather than incidental. A staged handle is scoped to `<provider>/<connection>`
- * (`#dispatch`'s `stageAttachment`), so a handle minted under `assets/main` is
- * deliberately unresolvable from `gmail/main` — bridging the two means crossing
- * the isolation every provider relies on, and that belongs in dispatch if it
- * belongs anywhere. `lanes link attach <file> --connection <provider>.<account>`
- * already prints a handle the mail tools accept.
+ * Mailbox → this store is still not done here, and for the same reason: a staged
+ * handle is scoped to `<provider>/<connection>` (`#dispatch`'s
+ * `stageAttachment`), so one minted under `gmail/main` is deliberately
+ * unresolvable from here.
+ *
+ * What has changed is the other direction. `stage` and the `asset` source do
+ * cross that boundary, built in `#dispatch` — which is exactly where the earlier
+ * version of this paragraph said such a thing would belong if it belonged
+ * anywhere. The crossing is narrow on purpose: only bytes the caller supplied,
+ * or bytes this profile already owns, ever reach the shared area. A mailbox
+ * attachment still stages under a connection-scoped `att_` handle, and nothing
+ * promotes one, so the direction that is closed stays closed.
  */
 
 const DEFAULT_LIMIT = 30;
@@ -93,7 +100,7 @@ export const assetsProvider: ProviderDefinition = defineLocalProvider({
       name: 'write',
       description: 'Store and delete files.',
       oauth_scopes: [],
-      capabilities: ['store', 'remove'],
+      capabilities: ['store', 'stage', 'remove'],
     },
   ],
 
@@ -218,10 +225,10 @@ export const assetsProvider: ProviderDefinition = defineLocalProvider({
       name: 'store',
       title: 'Store a file',
       description:
-        'Keep a file in this profile. Name exactly one source — path, url, handle, or data — and the endpoint reads the bytes itself; never base64 a file into this call when any other source will do. Storing under a name that exists replaces it. An attachment sitting in a mailbox cannot be named here: this connection holds no mailbox, so ask the mail connection to send it somewhere it can be reached from.',
+        'Keep a file in this profile, permanently and by name. Name exactly one source — path, url, handle, asset, or data — and the endpoint reads the bytes itself. Storing under a name that exists replaces it. A stored file attaches to anything afterwards as { "asset": "<name>" }. For a file needed once rather than kept, use stage. An attachment sitting in a mailbox cannot be named here: this connection holds no mailbox, so ask the mail connection to send it somewhere it can be reached from.',
       inputSchema: z.object({
         source: attachmentRefSchema.describe(
-          'Where the bytes come from. Exactly one of path, url, handle, or data. The mailbox sources — message_id and uid — are part of the shared shape but cannot resolve here.',
+          'Where the bytes come from. Exactly one of path, url, handle, asset, or data. The mailbox sources — message_id and uid — are part of the shared shape but cannot resolve here.',
         ),
         name: z
           .string()
@@ -236,6 +243,7 @@ export const assetsProvider: ProviderDefinition = defineLocalProvider({
         const [resolved] = await resolveAttachments([source], {
           maxTotalBytes: MAX_ASSET_BYTES,
           storage: context.storage,
+          shared: context.attachments,
           signal: context.signal,
         });
 
@@ -278,6 +286,8 @@ export const assetsProvider: ProviderDefinition = defineLocalProvider({
         };
       },
     },
+
+    stageCapability(),
 
     {
       kind: 'tool',
@@ -336,8 +346,7 @@ function textOrSummary(
     text:
       `${name} — ${contentType}, ${humanBytes(bytes.byteLength)}, sha256 ${digestOf(bytes)}.\n` +
       `Its contents are ${why}, so they are not returned. ` +
-      'To attach it to something, ask the owner for a handle: ' +
-      'lanes link attach <file> --connection <provider>.<account>',
+      'To attach it to something, name it as { "asset": "<name>" }.',
   };
 }
 

--- a/src/providers/assets/stage.ts
+++ b/src/providers/assets/stage.ts
@@ -1,0 +1,128 @@
+import { z } from 'zod';
+import { attachmentRefSchema, receiptFor, resolveAttachments } from '#connectivity/mail';
+import { keepKeys, type ProviderContext, type ToolCapability, type ToolResult } from '#connectivity';
+
+/**
+ * Holding a file for a later call.
+ *
+ * The gap this closes is specific. Every other attachment source names bytes the
+ * *endpoint* can already reach — a path on its disk, a URL it can fetch, a
+ * message in a mailbox it holds. A client with a file only it can see has none
+ * of them, and MCP offers no other channel: there is no client-to-server binary
+ * transfer in the protocol, and a tool argument is the only thing that travels.
+ * So the bytes do have to cross as base64 once. What was missing was somewhere
+ * for them to land, so that "once" was not "on every send".
+ *
+ * That is the whole design. `store` keeps a file by name because the owner wants
+ * it kept; this keeps one for a day because a call is about to name it, and the
+ * two are different questions. Putting a chat's scratch PDF into the owner's
+ * named files to send an email would answer the second by corrupting the first.
+ *
+ * The handle is profile-level, not connection-level, which is the point — it is
+ * staged here and named by a mail connection. `#dispatch` binds that crossing
+ * (`ProviderContext.attachments`) and is where the argument for its safety
+ * lives: only bytes the caller supplied, or bytes the profile already owns,
+ * ever reach the shared area.
+ */
+
+const schema = z.object({
+  source: attachmentRefSchema.describe(
+    'Where the bytes come from. Use data for a file only you have; url for one this endpoint can fetch.',
+  ),
+  filename: z.string().optional().describe('What to call it. Taken from the source when omitted.'),
+  content_type: z.string().optional().describe('Overrides the type derived from the source.'),
+});
+
+/** Raw bytes a caller may hand over in one call. The same ceiling `store` uses. */
+const MAX_STAGED_BYTES = 25 * 1024 * 1024;
+
+export function stageCapability(): ToolCapability<typeof schema> {
+  return {
+    kind: 'tool',
+    name: 'stage',
+    title: 'Hold a file for a later call',
+    description:
+      'Hold a file for a later call, anywhere in this profile. Name one source — data for a file ' +
+      'only you have, url for one this endpoint can fetch — and get back a handle, a digest and an ' +
+      'expiry, not the bytes. That handle names the file in any send from this profile, from any ' +
+      'connection, for 24 hours. Use it once rather than encoding the same file into every call; ' +
+      'use store instead to keep the file by name.',
+    inputSchema: schema,
+    // Never `source`, which may literally be a base64 file. The annotation below
+    // carries the resolved facts instead — the same trade `store` makes.
+    redact: keepKeys('filename', 'content_type'),
+    async handler(input, context: ProviderContext): Promise<ToolResult> {
+      if (!context.attachments) {
+        return {
+          content: [
+            {
+              type: 'text',
+              text: 'This endpoint cannot hold a file for later, so name the file directly in the call that needs it.',
+            },
+          ],
+          isError: true,
+        };
+      }
+
+      // Folded into the source rather than applied to the result. `filename` and
+      // `content_type` are siblings of `source` because that reads better than
+      // burying them inside it, but the resolver is where a name turns into a
+      // type — overriding afterwards left a `.txt` as octet-stream, because the
+      // type had already been guessed from a name the resolver never saw.
+      const source = {
+        ...input.source,
+        ...(input.filename ? { filename: input.filename } : {}),
+        ...(input.content_type ? { content_type: input.content_type } : {}),
+      };
+
+      const [resolved] = await resolveAttachments([source], {
+        maxTotalBytes: MAX_STAGED_BYTES,
+        storage: context.storage,
+        shared: context.attachments,
+        signal: context.signal,
+      });
+      if (!resolved) throw new Error('source named no file.');
+
+      const { filename, contentType } = resolved;
+
+      const receipt = await context.attachments.stage({
+        bytes: resolved.bytes,
+        filename,
+        contentType,
+      });
+
+      // `origin` is the fact that matters here and is not in `receiptFor`: it
+      // separates a file the caller handed over from one read off the endpoint's
+      // own disk, which is what makes "what entered this endpoint" answerable.
+      context.audit.annotate({
+        handle: receipt.handle,
+        ...receiptFor(resolved),
+        origin: resolved.origin,
+        expires_at: new Date(receipt.expiresAt).toISOString(),
+      });
+
+      return {
+        content: [
+          {
+            type: 'text',
+            text: JSON.stringify(
+              {
+                handle: receipt.handle,
+                filename,
+                content_type: contentType,
+                bytes: resolved.bytes.byteLength,
+                // The digest the resolver computed over the bytes it read, not
+                // the one the staging area reports back. One fact, one source.
+                sha256: resolved.sha256,
+                expires_at: new Date(receipt.expiresAt).toISOString(),
+                hint: 'Name this handle as an attachment, or store it under a name to keep it.',
+              },
+              null,
+              2,
+            ),
+          },
+        ],
+      };
+    },
+  };
+}

--- a/src/providers/google/gmail/send.test.ts
+++ b/src/providers/google/gmail/send.test.ts
@@ -25,7 +25,9 @@ interface Call {
 }
 
 /** A harness whose `fetch` records what went out and answers as Gmail would. */
-const sending = (options: { answers?: Record<string, unknown>[] } = {}) => {
+const sending = (
+  options: { answers?: Record<string, unknown>[]; files?: Record<string, Uint8Array> } = {},
+) => {
   const calls: Call[] = [];
   const answers = [...(options.answers ?? [])];
 
@@ -44,9 +46,18 @@ const sending = (options: { answers?: Record<string, unknown>[] } = {}) => {
     }) as never,
   });
 
+  const files = options.files ?? {};
   const harness = harnessFor(
     defineProviderWithCapabilities({ manifest: manifestOf(gmail), capabilities: [capability] }),
     'main',
+    {
+      attachments: {
+        stage: async () => ({ handle: 'stg_x', sha256: '', expiresAt: 0 }),
+        staged: async () => null,
+        asset: async (name: string) =>
+          files[name] ? { bytes: files[name]!, filename: name, contentType: null } : null,
+      },
+    },
   );
 
   return { calls, harness };
@@ -532,5 +543,44 @@ describe('when Gmail refuses', () => {
     const text = (result.content[0] as { text: string }).text;
     expect(text).toContain('400');
     expect(text).toContain('Invalid to header');
+  });
+});
+
+describe('a file this profile keeps', () => {
+  test('is attached by name, and the log records the asset store as its origin', async () => {
+    const { calls, harness } = sending({
+      files: { 'invoice-2026.pdf': new Uint8Array([1, 2, 3, 4]) },
+    });
+
+    const result = await harness.invoke('send_message', {
+      to: ['sam@example.com'],
+      subject: 'Invoice',
+      text: 'Attached.',
+      attachments: [{ asset: 'invoice-2026.pdf' }],
+    });
+
+    expect(rawOf(calls[0]!)).toMatch(
+      /Content-Disposition: attachment; filename="?invoice-2026\.pdf"?/,
+    );
+    // A receipt, never the bytes — and the log says which store it came out of.
+    expect(parsed(result)['attachments']).toMatchObject([
+      { filename: 'invoice-2026.pdf', bytes: 4 },
+    ]);
+    expect(harness.annotations()).toMatchObject({
+      attachments: [{ filename: 'invoice-2026.pdf', origin: 'asset:invoice-2026.pdf' }],
+    });
+  });
+
+  test('a name this profile does not keep refuses instead of sending an empty file', async () => {
+    const { calls, harness } = sending();
+
+    const result = await harness.invoke('send_message', {
+      to: ['sam@example.com'],
+      subject: 'Invoice',
+      attachments: [{ asset: 'gone.pdf' }],
+    });
+
+    expect(JSON.stringify(result)).toMatch(/no asset .*gone\.pdf/);
+    expect(calls).toHaveLength(0);
   });
 });

--- a/src/providers/google/gmail/send.ts
+++ b/src/providers/google/gmail/send.ts
@@ -70,7 +70,7 @@ const schema = z.object({
     .array(attachmentRefSchema)
     .optional()
     .describe(
-      'Files to attach, each named by reference. This endpoint reads the bytes itself — never encode a file into this call.',
+      'Files to attach, each named by reference — a path, an HTTPS URL, a staged handle, a file this profile keeps, or another message in this mailbox. This endpoint reads the bytes itself. A file you hold and nothing here can reach is staged once with lanes_assets_stage, then named by handle.',
     ),
   // The warning in the description is there because the failure happened. A
   // draft carrying a 204 KB PDF took 19 seconds — the bytes were pulled back
@@ -110,7 +110,7 @@ export function gmailSend(
     kind: 'tool',
     name: 'send_message',
     description:
-      'Send a message, with attachments, or save it as a draft. Attachments are named by reference — a path on this machine, an HTTPS URL, a staged handle, or another message in this mailbox — and this endpoint fetches the bytes itself, so never encode a file into the call.',
+      'Send a message, with attachments, or save it as a draft. Attachments are named by reference — a path on this machine, an HTTPS URL, a staged handle, a file this profile keeps, or another message in this mailbox — and this endpoint fetches the bytes itself. A file that exists only where you are goes through lanes_assets_stage once and travels as a handle.',
     inputSchema: schema,
 
     async handler(input, context): Promise<ToolResult> {
@@ -132,6 +132,7 @@ export function gmailSend(
           signal: context.signal,
           mailbox: gmailAttachments({ authorize, fetch: doFetch, signal: context.signal }),
           storage: context.storage,
+          shared: context.attachments,
         });
       } catch (failure) {
         return fail((failure as Error).message);

--- a/src/providers/harness.ts
+++ b/src/providers/harness.ts
@@ -1,5 +1,6 @@
 import { createLocalConnector } from '#connectivity/transports';
 import { buildProviderContext } from '#dispatch';
+import type { AttachmentBridge } from '#connectivity/mail';
 import { createMemoryCredentials, createMemoryState } from '#stores/state/testing.ts';
 import { createMemoryBlobStore } from '#stores/blobs/testing.ts';
 import type {
@@ -29,6 +30,14 @@ export interface ProviderHarness {
 export function harnessFor(
   definition: ProviderDefinition,
   connectionId = 'owner',
+  /**
+   * The profile's file lookups, which the real runtime binds in `#dispatch`.
+   *
+   * A stub here rather than the real bridge, deliberately: this harness must not
+   * import `#dispatch`, and a provider only ever sees the two closures anyway.
+   * `src/dispatch/attachments.test.ts` is what tests the real one.
+   */
+  options: { attachments?: AttachmentBridge } = {},
 ): ProviderHarness {
   const annotations: Record<string, unknown> = {};
 
@@ -55,6 +64,7 @@ export function harnessFor(
     // The runtime hands this to any provider that is not `local`, so a provider
     // authoring a capability against its own vendor's API has it here too.
     authorize: async (request) => request,
+    ...(options.attachments ? { attachments: options.attachments } : {}),
   });
 
   const connector = createLocalConnector(definition);

--- a/src/server/attachments.test.ts
+++ b/src/server/attachments.test.ts
@@ -341,3 +341,14 @@ describe('the audit log', () => {
     });
   });
 });
+
+describe('a profile handle is not this route to serve', () => {
+  test('a stg_ handle is refused by its prefix, without a lookup', async () => {
+    const response = await collect(endpoint.server.url, { handle: 'stg_0123456789abcdef' });
+
+    // A prefix rule, not an existence check — so it discloses nothing about what
+    // the profile area holds, and replaces a 404 that reads as "expired".
+    expect(response.status).toBe(400);
+    expect(await response.text()).toMatch(/staged for this profile/);
+  });
+});

--- a/src/server/attachments.ts
+++ b/src/server/attachments.ts
@@ -1,4 +1,4 @@
-import { isHandle } from '#connectivity/mail';
+import { isHandle, isProfileHandle } from '#connectivity/mail';
 import { mergeCapabilities, type ProfileRuntime } from './mcp/index.ts';
 import type { Principal } from '#auth';
 
@@ -25,6 +25,14 @@ import type { Principal } from '#auth';
  * shared area would quietly widen it. So an upload names its target, the
  * principal has to be able to reach that target, and the handle resolves only
  * from there.
+ *
+ * That still holds for this route, and deliberately did not change when a
+ * profile-level area was added beside it. `lanes_assets.stage` serves the caller
+ * who cannot make an HTTP request at all, and it is gated as a capability —
+ * policy, grants, one audit row. This route's whole authorization derives from
+ * `?connection=`, so widening it to the profile would mean a second gate and a
+ * second refusal vocabulary for a case a capability already answers. A `stg_`
+ * handle is therefore refused here by prefix rather than served.
  *
  * This file does HTTP and authorization; the write itself is
  * `Dispatcher.stageAttachment`. Not a split for its own sake — `server` may not
@@ -167,6 +175,16 @@ async function fetchAttachment(input: {
   }
   if (!isHandle(handle)) {
     return problem(400, `"${handle}" is not a handle.`);
+  }
+  // Refused on the prefix rather than looked up and missed. This route serves
+  // one connection's staging area; a profile-level handle is resolvable only by
+  // naming it in a call, so a 404 here would read as "expired" and send the
+  // caller to stage the file again.
+  if (isProfileHandle(handle)) {
+    return problem(
+      400,
+      `"${handle}" is staged for this profile, not for one connection, so it is not fetched here. Name it directly in the call that needs it.`,
+    );
   }
 
   const found = await input.runtime.dispatcher.fetchStagedAttachment({

--- a/src/server/mcp/guide.ts
+++ b/src/server/mcp/guide.ts
@@ -136,8 +136,19 @@ owner's audit log.
 
 ## Files are named, not carried
 
-Where a tool takes attachments, give a path, an HTTPS URL, or an attachment
-already on another message. Do not base64 a file into an argument: it is recorded
-in the audit log, and the log is something the owner reads.
+Where a tool takes attachments, give a path, an HTTPS URL, an attachment already
+on another message, or a file this profile keeps, as \`{ "asset": "<name>" }\`.
+
+**A file you hold and nothing here can reach is staged once.** Call
+\`lanes_assets_stage\` with the bytes and you get back a handle — not the bytes —
+which names that file in any send from this profile for the next 24 hours. If
+your client can make an HTTP call of its own,
+\`POST /attachments?profile=<name>&connection=<provider>.<account>\` takes the
+bytes out of band and returns a handle for that one connection, which costs
+nothing in the conversation at all.
+
+What you must not do is base64 the same file into call after call. Once, to stage
+it, is a cost; every time is the cost this whole mechanism exists to remove — and
+each one is recorded in a log the owner reads.
 `;
 }

--- a/src/server/mcp/instructions.ts
+++ b/src/server/mcp/instructions.ts
@@ -86,8 +86,9 @@ tasks, not memory — "remember to…" is a task, and it has a status. Both are
 served back to every later session, so write when asked, not by habit.`;
 
 const ASSETS = `**Assets are the owner's own files**, kept by name in this profile. Storing one
-names a source, exactly as an attachment does; a text asset reads back as text
-and anything else is described rather than encoded.`;
+names a source, exactly as an attachment does. \`lanes_assets_stage\` takes a file
+you hold and returns a handle any send accepts; a stored file attaches as
+\`{ "asset": "<name>" }\`.`;
 
 const SKILLS = `**Skills are the owner's procedures**, surfaced as prompts rather than tools.
 That is deliberate: a procedure is selected by the person, not chosen by the
@@ -174,7 +175,7 @@ more than one means ask which is meant, not take the first.`;
 
 const FILES = `**Files are named, not carried.** Where a tool takes attachments, give a path, an
 HTTPS URL, or an attachment already on another message; the endpoint reads the
-bytes. Never encode a file into a call — that is the thing this replaces.`;
+bytes. A file that exists only where you are is staged once, then named by handle.`;
 
 /**
  * The paragraph for the client that never re-reads its tool list.


### PR DESCRIPTION
Release 0.13.0.

**A client can hand over a file it holds** (#208). Every attachment source assumed the endpoint could already reach the bytes — a path on its disk, a fetchable URL, a message already in the mailbox — so a chat runtime holding a PDF had no route in. `lanes_assets_stage` takes the bytes once and returns a handle, a digest and an expiry, never the file; the handle then names it in any send from that profile for 24 hours. `{ "asset": "<name>" }` joins the sources too, so a file already kept can be mailed. Both resolve in `#dispatch`, gated on `lanes_assets.get`, so a caller denied the asset store cannot reach it through an attachment argument.

**A workspace probe stops reporting failure as absence** (#208). `holdsWorkspace` caught everything and returned `false`, so "you are not signed in to Google" read as "that bucket holds no workspace — check the name", and the suggested fallback needed the same credentials. Six messages that still cited `lanes-link.yaml`, renamed by the contract-4 migration, now name `workspaces.yaml`; a new test fails the build on the next one.

**A refused token is distrusted rather than re-sent** (#209). The stored `expires_at` was the only opinion that counted, so a token the vendor had already rejected went out again on every call until the clock caught up — an hour of 401s on an hour-long token. A 401 now makes the next authorisation refresh.

`bun test` 3520 pass / 0 fail, `bun run typecheck` clean.

**Upgrade note:** an existing IMAP connection must be reconnected once before `asset` appears in its `send_message` schema — those capabilities are discovered and cached, so `lanes link connect <provider>` refreshes it. Gmail's are authored and pick it up immediately.