### PR TITLE
A deployed workspace pairs on its own address, so no profile has to agree on a port

### DIFF
--- a/src/cli/commands/operate/pair.test.ts
+++ b/src/cli/commands/operate/pair.test.ts
@@ -1,6 +1,6 @@
-import { describe, expect, test } from 'bun:test';
+import { afterAll, describe, expect, test } from 'bun:test';
 import { isValidSecretRef } from '#secrets';
-import { pairingLink, PAIR_CERT_REF, PAIR_KEY_REF, PAIR_TOKEN_REF } from './pair.ts';
+import { pair, pairingLink, PAIR_CERT_REF, PAIR_KEY_REF, PAIR_TOKEN_REF } from './pair.ts';
 
 /**
  * The three references `lanes link pair` writes.
@@ -81,3 +81,164 @@ describe('the pairing link', () => {
     expect(raw).toContain('at=https%3A%2F%2F127.0.0.1%3A7401');
   });
 });
+
+/**
+ * Which endpoint a workspace is paired at, when its profiles do not agree on a
+ * port.
+ *
+ * The port refusal is right on loopback and was wrong everywhere else, because
+ * it was asked before the thing that decides the address. A deployed workspace
+ * is reached at the URL the platform assigned it — one service, in front of
+ * every profile in the workspace — and `instance.port` is not part of that URL,
+ * is not what the revision binds, and is not consulted anywhere on that path.
+ * Two profiles created on different days therefore refused to pair at all, and
+ * the `--profile` the refusal demanded settled nothing: both answers produce
+ * the same link, which is the assertion below that says why this is a bug
+ * rather than a preference.
+ *
+ * These run `pair` itself rather than a helper, because the defect was an
+ * ordering between two checks and neither check is wrong in isolation.
+ */
+
+const homes: string[] = [];
+const previousHome = process.env['LANES_LINK_HOME'];
+
+/**
+ * A workspace holding two profiles on different ports.
+ *
+ * `edge` declares a deployment and keeps the *file* adapters, which is not a
+ * combination a real deploy produces and is deliberate here: the target's
+ * cloud adapters have nothing to do with what is being tested, and reaching
+ * Secret Manager to assert an ordering would make this a test of the network.
+ *
+ * `LANES_LINK_HOME` is set before anything calls `pair`, and that is not
+ * hygiene. `resolveWorkspaceRoot` falls back to `~/.lanes-link` when nothing
+ * names a root — so a test that forgot this would mint a pairing token into
+ * whoever ran it's real workspace.
+ */
+async function twoProfiles(ports: Record<string, number>): Promise<string> {
+  const { mkdtemp, writeFile } = await import('node:fs/promises');
+  const { tmpdir } = await import('node:os');
+  const { join } = await import('node:path');
+  const { SUPPORTED_CONTRACT } = await import('#profile');
+  const { writeProfileFixture } = await import('#profile/testing.ts');
+
+  const root = await mkdtemp(join(tmpdir(), 'lanes-link-pair-'));
+  homes.push(root);
+  process.env['LANES_LINK_HOME'] = root;
+
+  await writeFile(
+    join(root, 'workspaces.yaml'),
+    `contract: ${SUPPORTED_CONTRACT}\n` +
+      'workspaces:\n' +
+      '  here:\n' +
+      '    credentials: { adapter: file }\n' +
+      '    storage: { adapter: filesystem }\n' +
+      '  edge:\n' +
+      '    credentials: { adapter: file }\n' +
+      '    storage: { adapter: filesystem }\n' +
+      '    deploy:\n' +
+      '      platform: cloudrun\n' +
+      '      project: my-project\n' +
+      '      region: europe-west1\n' +
+      '      service: my-service\n',
+  );
+
+  for (const [profile, port] of Object.entries(ports)) {
+    await writeProfileFixture(
+      root,
+      profile,
+      `contract: ${SUPPORTED_CONTRACT}\n` +
+        `instance: { profile: ${profile}, port: ${port}, host: 127.0.0.1 }\n`,
+    );
+  }
+
+  return root;
+}
+
+/** The address `pair` is told the platform assigned, instead of asking it. */
+const DEPLOYED = { address: async () => 'https://link.example.test/mcp' };
+
+/** Everything written to stdout while `body` runs. */
+async function captureStdout(body: () => Promise<void>): Promise<string> {
+  const original = process.stdout.write.bind(process.stdout);
+  let captured = '';
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (process.stdout as any).write = (chunk: string | Uint8Array): boolean => {
+    captured += typeof chunk === 'string' ? chunk : new TextDecoder().decode(chunk);
+    return true;
+  };
+
+  try {
+    await body();
+  } finally {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (process.stdout as any).write = original;
+  }
+
+  return captured;
+}
+
+afterAll(async () => {
+  const { rm } = await import('node:fs/promises');
+  if (previousHome === undefined) delete process.env['LANES_LINK_HOME'];
+  else process.env['LANES_LINK_HOME'] = previousHome;
+  await Promise.all(homes.map((root) => rm(root, { recursive: true, force: true })));
+});
+
+describe('pairing a workspace whose profiles disagree on a port', () => {
+  test('deployed, it pairs without being told which profile', async () => {
+    await twoProfiles({ personal: 7337, projects: 7338 });
+
+    const printed = await captureStdout(async () => {
+      await pair({ target: 'edge' }, DEPLOYED);
+    });
+
+    expect(printed).toContain('at=https%3A%2F%2Flink.example.test');
+    expect(printed).not.toContain('do not agree on a port');
+  });
+
+  test('deployed, naming a profile changes nothing about the link', async () => {
+    // The whole of the argument. A refusal that can be settled by either answer
+    // was not resolving an ambiguity; it was asking a question with no bearing
+    // on the outcome, and stopping until it got one.
+    await twoProfiles({ personal: 7337, projects: 7338 });
+
+    const first = await captureStdout(async () => {
+      await pair({ target: 'edge', profile: 'personal' }, DEPLOYED);
+    });
+    const second = await captureStdout(async () => {
+      await pair({ target: 'edge', profile: 'projects' }, DEPLOYED);
+    });
+
+    expect(link(first)).toBe(link(second));
+  });
+
+  test('deployed, a profile the workspace does not hold is still refused', async () => {
+    // `--profile` decides nothing here, which is not the same as meaning
+    // nothing: a name that is not in the workspace is a typo either way, and
+    // accepting it silently would teach that the flag was read.
+    await twoProfiles({ personal: 7337, projects: 7338 });
+
+    await expect(pair({ target: 'edge', profile: 'personel' }, DEPLOYED)).rejects.toThrow(
+      'has no profile "personel"',
+    );
+  });
+
+  test('on loopback, the ambiguity is real and is still refused', async () => {
+    // The guard on the fix. Here the port *is* the address — the read listener
+    // sits one above `instance.port` — so picking one of two would pair a
+    // dashboard to an endpoint that is not the one being run.
+    await twoProfiles({ personal: 7337, projects: 7338 });
+
+    await expect(pair({ target: 'here' }, DEPLOYED)).rejects.toThrow('do not agree on a port');
+  });
+});
+
+/** The pairing link out of a captured run, so two runs can be compared. */
+function link(printed: string): string {
+  const found = printed.match(/https?:\/\/\S*#pair=\S+/);
+  expect(found).not.toBeNull();
+  return found![0];
+}

--- a/src/cli/commands/operate/pair.ts
+++ b/src/cli/commands/operate/pair.ts
@@ -54,7 +54,12 @@ import { openSecretStoreFor, type GlobalFlags } from '../../runtime.ts';
  * and the credential it mints reads all of them — so asking which profile was
  * asking a question with no answer, and implying a per-profile pairing that does
  * not exist. `--profile` is still accepted, and picks the port when profiles
- * disagree about one.
+ * disagree about one *and a port is what the address is built from*. Deployed,
+ * it is not: the platform assigns one address for the whole workspace, so the
+ * flag decides nothing there and is not asked for. It was asked for, for one
+ * release — the ports were compared before the deployment was, so a cloud
+ * workspace whose profiles had been created on different days refused to pair
+ * at all, and the flag that unblocked it produced the same link either way.
  */
 
 /**
@@ -86,6 +91,18 @@ export interface PairDeps {
   readonly run?: (command: readonly string[]) => Promise<string | null>;
   readonly confirm?: (question: string) => Promise<boolean>;
   readonly interactive?: boolean;
+  /**
+   * Where the platform put this workspace's service.
+   *
+   * Injected for the same reason `which` and `run` are: the deployed path
+   * otherwise reaches a driver, a subprocess and a live project, and the
+   * decisions worth asserting on here — that no port is consulted, that the
+   * link carries the platform's address — are all upstream of that. Defaults
+   * to asking the platform, which is what every real run does.
+   */
+  readonly address?: (
+    deploy: NonNullable<ResolvedTarget['declared']['deploy']>,
+  ) => Promise<string | null>;
 }
 
 export async function pair(flags: PairFlags, deps: PairDeps = {}): Promise<void> {
@@ -101,11 +118,6 @@ export async function pair(flags: PairFlags, deps: PairDeps = {}): Promise<void>
     );
   }
 
-  // One endpoint serves every profile in a workspace, so they normally agree on
-  // a port and the choice is not a choice. Where they do not, the ambiguity is
-  // real and `--profile` is how it is settled — refused rather than guessed,
-  // because pairing the wrong port produces a dashboard that says "not
-  // connected" with everything working.
   const named = flags.profile
     ? profiles.find((one: LoadedProfile) => one.profile === flags.profile)
     : undefined;
@@ -117,6 +129,39 @@ export async function pair(flags: PairFlags, deps: PairDeps = {}): Promise<void>
     );
   }
 
+  // A workspace that declares a deployment is paired over the address the
+  // platform gave it, not over loopback — which is what `declared.deploy`
+  // answers and what `instance.host` does not: a deployed revision takes its
+  // host from the container's environment, so a profile bound to `127.0.0.1`
+  // in config is still serving `0.0.0.0` on Cloud Run.
+  //
+  // **Decided before any port is looked at**, because on this path there is no
+  // port to look at. The address comes from the platform, one service answers
+  // for the whole workspace, and `instance.port` reaches neither. Asked after
+  // the ports were compared, this refused a perfectly unambiguous pairing for
+  // two profiles that had merely been created on different days — and the
+  // `--profile` it demanded settled nothing, since both answers produce the
+  // same link. A question whose answer cannot change the outcome is not a
+  // question.
+  if (resolved.declared.deploy) {
+    await pairDeployed({
+      flags,
+      target,
+      chosen: named ?? profiles[0]!,
+      root,
+      credentials: await openSecretStoreFor(root, target),
+      deploy: resolved.declared.deploy,
+      address: deps.address ?? deployedUrl,
+    });
+    return;
+  }
+
+  // Loopback, where the port *is* the address. One endpoint serves every
+  // profile in a workspace, so they normally agree on a port and the choice is
+  // not a choice. Where they do not, the ambiguity is real and `--profile` is
+  // how it is settled — refused rather than guessed, because pairing the wrong
+  // port produces a dashboard that says "not connected" with everything
+  // working.
   const ports = new Set(profiles.map((one: LoadedProfile) => one.config.instance.port));
   if (!named && ports.size > 1) {
     throw new ConfigError(
@@ -131,16 +176,6 @@ export async function pair(flags: PairFlags, deps: PairDeps = {}): Promise<void>
   const chosen = named ?? profiles[0]!;
   const host = chosen.config.instance.host;
   const credentials = await openSecretStoreFor(root, target);
-
-  // A workspace that declares a deployment is paired over the address the
-  // platform gave it, not over loopback — which is what `declared.deploy`
-  // answers and what `instance.host` does not: a deployed revision takes its
-  // host from the container's environment, so a profile bound to `127.0.0.1`
-  // in config is still serving `0.0.0.0` on Cloud Run.
-  if (resolved.declared.deploy) {
-    await pairDeployed({ flags, target, chosen, root, credentials, deploy: resolved.declared.deploy });
-    return;
-  }
 
   if (!isLoopback(host)) {
     // Not deployed, and not on this machine either. There is no certificate
@@ -232,14 +267,16 @@ async function pairDeployed(input: {
   root: string;
   credentials: SecretStore;
   deploy: NonNullable<ResolvedTarget['declared']['deploy']>;
+  address: (deploy: NonNullable<ResolvedTarget['declared']['deploy']>) => Promise<string | null>;
 }): Promise<void> {
   const { flags, target, chosen, root, credentials } = input;
 
-  // `deployedUrl` asks the platform where the service ended up and degrades to
-  // null for every reason that is not this command's business — no driver, not
-  // deployed yet, no credentials for the project. A link with no address in it
-  // reads nothing, so this refuses rather than printing half of one.
-  const mcpUrl = await deployedUrl(input.deploy);
+  // `deployedUrl`, unless a test named something else, asks the platform where
+  // the service ended up and degrades to null for every reason that is not this
+  // command's business — no driver, not deployed yet, no credentials for the
+  // project. A link with no address in it reads nothing, so this refuses rather
+  // than printing half of one.
+  const mcpUrl = await input.address(input.deploy);
   if (mcpUrl === null) {
     throw new ConfigError(
       `Could not find the address of "${target}".\n` +

--- a/src/cli/selection.ts
+++ b/src/cli/selection.ts
@@ -210,7 +210,10 @@ export const SELECTION: Record<string, Requires> = {
   // What it pairs is the workspace: the surface it opens lists every connection
   // and profile there, and the credential it mints reads all of them. Asking
   // which profile was a question with no answer. `--profile` still narrows, and
-  // is how a port is chosen when profiles disagree about one.
+  // is how a port is chosen when profiles disagree about one *and* a port is
+  // what the address is built from — which is loopback only. A deployed
+  // workspace has one address for the whole of it, so the flag decides nothing
+  // there and is not asked for.
   pair: 'workspace',
   'token show': 'workspace',
   'token rotate': 'workspace',


### PR DESCRIPTION
`lanes link pair --workspace <deployed>` refused with

```
error  The profiles in "cloud" do not agree on a port, so it is not clear which endpoint to pair.
    personal  7337
    projects  7338
  Name one: lanes link pair --profile <name>
```

whenever a workspace held two profiles created on different days.

It is the wrong question on that path. A deployed workspace is reached at the URL the platform
assigned it — one service, in front of every profile in the workspace — and `instance.port` is not
part of that URL, is not what the revision binds, and is consulted nowhere in `pairDeployed`. The
`--profile` the refusal demanded settled nothing: both answers produce a byte-identical link, which
is now asserted directly.

## The cause was an ordering, not a check

The port comparison sat above the `declared.deploy` branch, so it ran on a path that never reads a
port. Moving the branch up is the whole fix. The refusal is kept intact below it, where the port
*is* the address — the read listener sits one above `instance.port`, so picking one of two there
really would pair the dashboard to an endpoint nobody is running.

| target | before | after |
| --- | --- | --- |
| deployed, ports differ | refused, `--profile` demanded | pairs at the platform's address |
| deployed, `--profile` given | pairs | pairs, same link either way |
| loopback, ports differ | refused | refused, unchanged |
| `--profile` names nothing | refused | refused, unchanged |

## Rejected

- **Dropping the refusal outright** — it loses a real loopback ambiguity that produces a dashboard
  reporting "not connected" with everything working.
- **Deriving the port from `primary`** — answers a question this path does not ask, and
  `choosePrimary` throws where pairing has no need to.

`--profile` is still validated against the workspace on the deployed path. It decides nothing
there, which is not the same as meaning nothing: a name that is not in the workspace is a typo
either way.

## Tests

`PairDeps` gains `address`, injected for the reason `which` and `run` already are — the deployed
path otherwise reaches a driver, a subprocess and a live project, and everything worth asserting on
happens before that.

Four tests, one of which fails against the previous ordering with exactly the reported error.
`bun test` 3524 pass / 0 fail, `bun run typecheck` clean.