### PR TITLE
Expansion fills in a compact record, and stops dropping the rows it did not fetch

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -243,6 +243,17 @@ It is a data change, not code: an entry in `SELECTION` in
   (`https://sheets.googleapis.com` + `/v4/spreadsheets/...`). Copying the wrong one 404s every
   call.
 
+A read capability the gateway may *fill in* needs a `compact` block, and it is the third record
+keyed the same way as `redact` and `hints` — so it carries the same trap, one step quieter. When a
+list comes back as bare identifiers, `lanes_tools_call` fetches the rows before returning them, and
+without a `compact` entry it does so at whatever the vendor's default representation is. For Gmail
+that was `format=full` — five messages, 193,271 characters, and an overflowed reply. `compact` names
+the vendor's *own* projection arguments (`format`, `metadataHeaders`, `fields`, `$select`), because
+the saving has to happen at the source. A key that misses does not error; it asks for the default and
+reads exactly like working expansion. Two tests in `specs.test.ts` hold it: every key names a real
+capability, and every argument it names is a real parameter of that capability. Only a `<x>.list`
+with an `<x>.get` beside it can ever reach this, which across the vendored surface is seven pairs.
+
 New write capabilities need a `redact` block on the manifest. The default withholds every
 value, which makes a write log useless — it records that something changed without recording
 what. Keep identifiers, withhold the user's content.

--- a/src/cli/instructions.test.ts
+++ b/src/cli/instructions.test.ts
@@ -3,7 +3,7 @@ import type { Flags } from './argv.ts';
 import { ASSETS, readAsset } from './commands/mcp/assets.ts';
 import { assertKnownFlags, requirementFor, selectionKey } from './selection.ts';
 import { PROGRAM, usage } from './usage.ts';
-import { RESERVED_PROVIDER_IDS } from '#connectivity/manifest/provider.ts';
+import { RESERVED_PROVIDER_IDS } from '#connectivity/manifest/owner-ids.ts';
 
 /**
  * The documents we install into someone's agent must describe this CLI.

--- a/src/connectivity/manifest/index.ts
+++ b/src/connectivity/manifest/index.ts
@@ -37,12 +37,8 @@ export { setupPromptSchema, setupSchema, type SetupDeclaration, type SetupPrompt
 export { READ_BUNDLE, WRITE_BUNDLE, bundleSchema, type ScopeBundle } from './bundles.ts';
 export { identitySchema, type IdentityDeclaration } from './identity.ts';
 export { credentialRefForConnection, rotatableCredentialRefs } from './credential-ref.ts';
-export {
-  RESERVED_PROVIDER_IDS,
-  defineProvider,
-  providerManifestSchema,
-  type ProviderManifest,
-} from './provider.ts';
+export { defineProvider, providerManifestSchema, type ProviderManifest } from './provider.ts';
+export { RESERVED_PROVIDER_IDS, RENAMED_OWNER_PROVIDERS } from './owner-ids.ts';
 
 export type { SetupRequirement, SetupNeeds } from './requirements.ts';
 export { hasOwnClientPath, setupRequirements, UNNAMED_ID } from './requirements.ts';

--- a/src/connectivity/manifest/manifest.test.ts
+++ b/src/connectivity/manifest/manifest.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from 'bun:test';
-import { credentialRefForConnection, defineProvider } from './index.ts';
+import { credentialRefForConnection, defineProvider, providerManifestSchema } from './index.ts';
 
 /**
  * Where a credential lives, which used to have two answers.
@@ -371,5 +371,36 @@ describe('connector headers may not carry the credential', () => {
         auth: { kind: 'bearer' },
       }),
     ).not.toThrow();
+  });
+});
+
+describe('a compact projection', () => {
+  const base = {
+    id: 'vendor_mail',
+    name: 'Vendor Mail',
+    connector: { kind: 'http' as const, base_url: 'https://api.example.com', openapi: '/tmp/x.json' },
+  };
+
+  test('is per capability, and holds the arguments a vendor takes', () => {
+    const manifest = providerManifestSchema.parse({
+      ...base,
+      compact: { 'messages.get': { format: 'metadata', metadataHeaders: ['From', 'Subject'] } },
+    });
+
+    expect(manifest.compact?.['messages.get']).toEqual({
+      format: 'metadata',
+      metadataHeaders: ['From', 'Subject'],
+    });
+  });
+
+  test('is optional, because most providers have nothing to say here', () => {
+    expect(providerManifestSchema.parse(base).compact).toBeUndefined();
+  });
+
+  /** A capability maps to a set of arguments, never to a single value. */
+  test('refuses a scalar where a projection belongs', () => {
+    expect(() =>
+      providerManifestSchema.parse({ ...base, compact: { 'messages.get': 'metadata' } }),
+    ).toThrow();
   });
 });

--- a/src/connectivity/manifest/owner-ids.ts
+++ b/src/connectivity/manifest/owner-ids.ts
@@ -1,0 +1,62 @@
+/**
+ * The owner layer's provider ids, and the map from what they used to be called.
+ *
+ * Their own file because `provider.ts` is a schema and the cross-field rules a
+ * schema cannot express, and these are neither — they are a fixed list of ids
+ * that happens to have been declared beside the thing that once reserved them.
+ * The budget in `architecture.test.ts` names exactly this as what earns a split:
+ * "something that is not a schema appearing beside them". It came out when a
+ * third per-capability record needed room next to `redact` and `hints`, and the
+ * file was at 400 lines to the line.
+ *
+ * Nothing about the values changed in the move, and every consumer reads them
+ * through `#connectivity` rather than this path.
+ */
+
+
+/**
+ * The owner layer's provider ids — Lanes' own surfaces.
+ *
+ * **`lanes_` on each, which is what stops them needing to be reserved.** They
+ * were `memory`, `tasks`, `assets`, `skills`, `vault`, `entities` — six of the
+ * most obvious words a vendor manifest might want, held back from every
+ * operator so the built-ins could have them. `buildRegistry` registers these
+ * before `PROVIDERS`, so a manifest claiming one threw at startup rather than
+ * being shadowed (ADR-051); the reservation is what made that a refusal instead
+ * of a collision. Prefixed, there is nothing to reserve: an operator's own
+ * `memory` connector is now a legal thing to declare.
+ *
+ * It is also the shape the vendor-qualified providers already use —
+ * `google_tasks`, `gmail_imap`, `icloud_mail` — and it reads the same way: the
+ * half before the underscore says whose surface this is.
+ *
+ * The order is read: `#server/mcp`'s instructions emit one paragraph per
+ * reachable id in this sequence, so it is the order an agent meets them in.
+ * `lanes_entities` is appended rather than inserted alphabetically so that it
+ * lands beside `lanes_identity`: the two answer the same question about
+ * different people, and the instructions collapse them into one paragraph when
+ * both are reachable.
+ */
+export const RESERVED_PROVIDER_IDS: readonly string[] = [
+  'lanes_memory',
+  'lanes_tasks',
+  'lanes_assets',
+  'lanes_skills',
+  'lanes_vault',
+  'lanes_setup',
+  'lanes_identity',
+  'lanes_entities',
+];
+
+/**
+ * Old id to new, for a refusal that can name what a stale client is asking for.
+ *
+ * Nothing consumes it yet. The migration builds its own map from
+ * `C3_OWNER_PROVIDERS` (`src/cli/contract4-rename.ts`), and a `tools/call` on a
+ * pre-0.9.0 name is answered by the SDK's exact-match lookup before anything
+ * here sees it — so the refusal this exists for is still unwritten. ADR-066
+ * records the failure it would address.
+ */
+export const RENAMED_OWNER_PROVIDERS: ReadonlyMap<string, string> = new Map(
+  RESERVED_PROVIDER_IDS.map((id) => [id.slice('lanes_'.length), id]),
+);

--- a/src/connectivity/manifest/provider.ts
+++ b/src/connectivity/manifest/provider.ts
@@ -63,6 +63,36 @@ export const providerManifestSchema = z.object({
    * not silently discarded.
    */
   hints: z.record(z.string(), z.string()).optional(),
+
+  /**
+   * Per-capability arguments that ask a vendor for a smaller record: capability
+   * name → the vendor's own projection parameters.
+   *
+   * Keyed exactly like `redact` and `hints`, and read on a call this endpoint
+   * makes *for* the caller rather than one the caller wrote. When a list comes
+   * back as bare identifiers the gateway fills it in, and without this it does
+   * so at whatever representation the vendor defaults to — which for a mail API
+   * is the entire message, transport headers and base64 body included. Five of
+   * those measured 193,271 characters and overflowed the reply.
+   *
+   * These are the vendor's argument names, not ours, because the saving has to
+   * happen at the source: trimming a response we already paid to receive spends
+   * the owner's quota to save our own bytes. The parameters exist and are
+   * deliberately preserved by the vendoring script — Google's `fields` and
+   * `format`, Graph's `$select` — and nothing used them until now.
+   *
+   * A key that misses does nothing at all, which is the same trap `redact`
+   * carries, so two tests hold it: one that every key names a capability that
+   * exists, and one that every argument it names is a real parameter of that
+   * capability. Nothing checks them against a *response* schema, because the
+   * vendored specs have none — `vendor-spec.ts` explains why they cannot.
+   */
+  compact: z
+    .record(
+      z.string(),
+      z.record(z.string(), z.union([z.string(), z.number(), z.boolean(), z.array(z.string())])),
+    )
+    .optional(),
   /**
    * The words a person would search for that the vendor never writes.
    *
@@ -87,53 +117,6 @@ export const providerManifestSchema = z.object({
 });
 
 export type ProviderManifest = z.infer<typeof providerManifestSchema>;
-
-/**
- * The owner layer's provider ids — Lanes' own surfaces.
- *
- * **`lanes_` on each, which is what stops them needing to be reserved.** They
- * were `memory`, `tasks`, `assets`, `skills`, `vault`, `entities` — six of the
- * most obvious words a vendor manifest might want, held back from every
- * operator so the built-ins could have them. `buildRegistry` registers these
- * before `PROVIDERS`, so a manifest claiming one threw at startup rather than
- * being shadowed (ADR-051); the reservation is what made that a refusal instead
- * of a collision. Prefixed, there is nothing to reserve: an operator's own
- * `memory` connector is now a legal thing to declare.
- *
- * It is also the shape the vendor-qualified providers already use —
- * `google_tasks`, `gmail_imap`, `icloud_mail` — and it reads the same way: the
- * half before the underscore says whose surface this is.
- *
- * The order is read: `#server/mcp`'s instructions emit one paragraph per
- * reachable id in this sequence, so it is the order an agent meets them in.
- * `lanes_entities` is appended rather than inserted alphabetically so that it
- * lands beside `lanes_identity`: the two answer the same question about
- * different people, and the instructions collapse them into one paragraph when
- * both are reachable.
- */
-export const RESERVED_PROVIDER_IDS: readonly string[] = [
-  'lanes_memory',
-  'lanes_tasks',
-  'lanes_assets',
-  'lanes_skills',
-  'lanes_vault',
-  'lanes_setup',
-  'lanes_identity',
-  'lanes_entities',
-];
-
-/**
- * Old id to new, for a refusal that can name what a stale client is asking for.
- *
- * Nothing consumes it yet. The migration builds its own map from
- * `C3_OWNER_PROVIDERS` (`src/cli/contract4-rename.ts`), and a `tools/call` on a
- * pre-0.9.0 name is answered by the SDK's exact-match lookup before anything
- * here sees it — so the refusal this exists for is still unwritten. ADR-066
- * records the failure it would address.
- */
-export const RENAMED_OWNER_PROVIDERS: ReadonlyMap<string, string> = new Map(
-  RESERVED_PROVIDER_IDS.map((id) => [id.slice('lanes_'.length), id]),
-);
 
 /**
  * Validate a manifest, with the cross-field rules the schema alone cannot

--- a/src/providers/google/gmail/compact.ts
+++ b/src/providers/google/gmail/compact.ts
@@ -1,0 +1,35 @@
+/**
+ * What to ask for when a message is being filled in rather than asked for.
+ *
+ * The gateway fills in a list that came back as identifiers (`server/mcp/expand.ts`),
+ * and without this it does so at whatever the vendor returns by default. Gmail's
+ * default is `format=full`: every `Received:` hop, the DKIM and ARC headers, and
+ * the body as base64. Five of those measured 193,271 characters and overflowed
+ * the reply — for a caller who had asked to see what was in their inbox.
+ *
+ * `metadata` answers that question instead. It carries the envelope headers
+ * named here plus `snippet`, which is the preview, and drops the body — so a
+ * whole page of mail costs less than one message did, and the row that needs
+ * reading in full is one `users.messages.get` away.
+ *
+ * Two capabilities and not four, because the others cannot reach this code:
+ * `threads.list` rows carry three keys and `labels.list` returns whole labels,
+ * so `referencesIn` rejects both and no follow-up is ever made. If a vendor
+ * change makes either return bare references, adding the line here is the fix.
+ *
+ * `drafts.get` takes no `metadataHeaders` — the parameter is not in its spec —
+ * so `metadata` there returns the full header set. That is cheap for the one
+ * message kind that was never delivered, so it has no `Received:` chain.
+ *
+ * `fields` would compose with this and is deliberately not used. `metadata`
+ * already drops the body, which is the whole of the saving, and a second
+ * shaping parameter adds a way for the call to fail with a 400 for about a
+ * hundred bytes.
+ */
+export const GMAIL_COMPACT: Record<string, Record<string, unknown>> = {
+  'users.messages.get': {
+    format: 'metadata',
+    metadataHeaders: ['From', 'To', 'Cc', 'Subject', 'Date'],
+  },
+  'users.drafts.get': { format: 'metadata' },
+};

--- a/src/providers/google/gmail/index.ts
+++ b/src/providers/google/gmail/index.ts
@@ -4,6 +4,7 @@ import { GMAIL_IDENTITY, GOOGLE_APP, GOOGLE_OAUTH, specPath } from '../shared/oa
 import { googleServiceAccount } from '../shared/service-account.ts';
 import { googleSetup } from '../shared/setup.ts';
 import { GMAIL_HOST } from './api.ts';
+import { GMAIL_COMPACT } from './compact.ts';
 import { GMAIL_HINTS } from './hints.ts';
 import { GMAIL_REDACT } from './redact.ts';
 import { gmailSendMessage } from './send.ts';
@@ -96,6 +97,7 @@ const manifest = defineProvider({
   setup: googleSetup('Gmail', GMAIL_SCOPES),
   redact: GMAIL_REDACT,
   hints: GMAIL_HINTS,
+  compact: GMAIL_COMPACT,
   // Named here because an `http` connector otherwise assigns bundles by HTTP
   // method during discovery, and an authored capability is never discovered.
   bundles: [{ name: 'write', capabilities: ['send_message'] }],

--- a/src/providers/google/specs/specs.test.ts
+++ b/src/providers/google/specs/specs.test.ts
@@ -264,6 +264,45 @@ describe.each([
       declared.filter((name) => !capabilities.has(name) && !authored.has(name)),
     ).toEqual([]);
   });
+
+  test('compact names capabilities that exist, and arguments they actually take', async () => {
+    // The third record keyed this way, and the one whose miss is quietest of
+    // all: `redact` withholds, `hints` says nothing, and a missed `compact` key
+    // simply asks the vendor for its default — which is the behaviour this
+    // exists to stop, arriving as though nothing were wrong.
+    //
+    // The second half has no counterpart on the other two, because these are
+    // the *vendor's* argument names rather than ours. `collect()` drops
+    // anything the operation's mapper does not declare, so a parameter spelled
+    // singular, or renamed upstream, is discarded on the way out with no error
+    // anywhere.
+    const declared = Object.entries(manifest.compact ?? {});
+    if (declared.length === 0) return;
+
+    const operations = new Map(
+      (await operationsOf(manifest)).flatMap((operation) => {
+        const id = operation.operationId;
+        if (typeof id !== 'string') return [];
+
+        const parameters = (operation as { parameters?: { name?: string }[] }).parameters ?? [];
+        const names = parameters
+          .map((parameter) => parameter.name)
+          .filter((name): name is string => typeof name === 'string');
+
+        const short = id.startsWith(`${manifest.id}.`) ? id.slice(manifest.id.length + 1) : id;
+        return [[short, new Set(names)] as const];
+      }),
+    );
+
+    expect(declared.filter(([name]) => !operations.has(name)).map(([name]) => name)).toEqual([]);
+
+    const unknown = declared.flatMap(([name, projection]) =>
+      Object.keys(projection)
+        .filter((argument) => !operations.get(name)?.has(argument))
+        .map((argument) => `${name} takes no ${argument}`),
+    );
+    expect(unknown).toEqual([]);
+  });
 });
 
 /**

--- a/src/server/mcp/expand-result.test.ts
+++ b/src/server/mcp/expand-result.test.ts
@@ -1,0 +1,294 @@
+import { describe, expect, test } from 'bun:test';
+import type { DispatchOutcome } from '#dispatch';
+import { expandIfReferences } from './expand-result.ts';
+import type { MergedCapability } from './visibility.ts';
+
+/**
+ * The gateway half, which had no tests at all when it overflowed a reply.
+ *
+ * `expand.test.ts` covers the decisions in isolation. What is left — and what
+ * the reported failure actually exercised — is the wiring: whether the
+ * projection reaches the call, whether the arguments a caller wrote survive it,
+ * and whether everything the list returned comes back.
+ */
+
+const LIST = 'vendor_mail.messages.list';
+const GET = 'vendor_mail.messages.get';
+
+const reachable = (compact?: Record<string, unknown>): Map<string, MergedCapability> =>
+  new Map([
+    [LIST, {} as MergedCapability],
+    [GET, (compact === undefined ? {} : { compact }) as MergedCapability],
+  ]);
+
+const listing = (rows: readonly Record<string, unknown>[], extra: Record<string, unknown> = {}) => ({
+  content: [{ type: 'text' as const, text: JSON.stringify({ messages: rows, ...extra }) }],
+});
+
+const references = (count: number): Record<string, unknown>[] =>
+  Array.from({ length: count }, (_, at) => ({ id: `id${at}`, threadId: `t${at}` }));
+
+/** A dispatcher that records what it was asked and answers with a small record. */
+function recorder(record: (id: string) => Record<string, unknown> = (id) => ({ id, subject: id })) {
+  const calls: { capability: string; args: Record<string, unknown> }[] = [];
+  const dispatch = async (
+    capability: string,
+    args: Record<string, unknown>,
+  ): Promise<DispatchOutcome> => {
+    calls.push({ capability, args });
+    return {
+      ok: true,
+      result: {
+        content: [{ type: 'text' as const, text: JSON.stringify(record(args['id'] as string)) }],
+      },
+    } as DispatchOutcome;
+  };
+  return { calls, dispatch };
+}
+
+const bodyOf = (filled: { content: { type: 'text'; text: string }[] } | undefined) =>
+  JSON.parse((filled?.content[0]?.text ?? '').split('\n\n')[0] ?? '') as Record<string, unknown>;
+
+describe('when it declines to fill anything in', () => {
+  /**
+   * Each of these must cost nothing. Expanding is somebody else's rate limit,
+   * so a path that decides not to must not have already spent one.
+   */
+  test('a caller who said no is not expanded, and nothing is dispatched', async () => {
+    const { calls, dispatch } = recorder();
+
+    const filled = await expandIfReferences({
+      capability: LIST,
+      result: listing(references(3)),
+      asked: false,
+      merged: reachable(),
+      listArguments: {},
+      dispatch,
+    });
+
+    expect(filled).toBeUndefined();
+    expect(calls).toEqual([]);
+  });
+
+  test('a list with no get beside it is left alone', async () => {
+    const { calls, dispatch } = recorder();
+
+    const filled = await expandIfReferences({
+      capability: LIST,
+      result: listing(references(3)),
+      asked: undefined,
+      merged: new Map([[LIST, {} as MergedCapability]]),
+      listArguments: {},
+      dispatch,
+    });
+
+    expect(filled).toBeUndefined();
+    expect(calls).toEqual([]);
+  });
+
+  test('rows that are already records are left alone', async () => {
+    const { calls, dispatch } = recorder();
+
+    const filled = await expandIfReferences({
+      capability: LIST,
+      result: listing([{ id: 'a', subject: 'Standup', when: 'today' }]),
+      asked: undefined,
+      merged: reachable(),
+      listArguments: {},
+      dispatch,
+    });
+
+    expect(filled).toBeUndefined();
+    expect(calls).toEqual([]);
+  });
+
+  test('prose is not a result to expand', async () => {
+    const { calls, dispatch } = recorder();
+
+    const filled = await expandIfReferences({
+      capability: LIST,
+      result: { content: [{ type: 'text' as const, text: 'Deleted 3 messages.' }] },
+      asked: undefined,
+      merged: reachable(),
+      listArguments: {},
+      dispatch,
+    });
+
+    expect(filled).toBeUndefined();
+    expect(calls).toEqual([]);
+  });
+});
+
+describe('asking the provider for a smaller record', () => {
+  /**
+   * The fix, in one assertion. Without this the follow-up goes out with the
+   * caller's arguments alone and comes back at whatever the vendor defaults to,
+   * which is what made five rows 193,271 characters.
+   */
+  test('the projection the provider declared reaches the follow-up', async () => {
+    const { calls, dispatch } = recorder();
+
+    await expandIfReferences({
+      capability: LIST,
+      result: listing(references(2)),
+      asked: undefined,
+      merged: reachable({ view: 'summary' }),
+      listArguments: {},
+      dispatch,
+    });
+
+    expect(calls).toHaveLength(2);
+    expect(calls[0]?.capability).toBe(GET);
+    expect(calls[0]?.args).toEqual({ view: 'summary', id: 'id0' });
+  });
+
+  test('whole records are asked for by sending no projection at all', async () => {
+    const { calls, dispatch } = recorder();
+
+    await expandIfReferences({
+      capability: LIST,
+      result: listing(references(1)),
+      asked: 'full',
+      merged: reachable({ view: 'summary' }),
+      listArguments: {},
+      dispatch,
+    });
+
+    expect(calls[0]?.args).toEqual({ id: 'id0' });
+  });
+
+  test('a provider that declared nothing still expands', async () => {
+    const { calls, dispatch } = recorder();
+
+    await expandIfReferences({
+      capability: LIST,
+      result: listing(references(1)),
+      asked: undefined,
+      merged: reachable(),
+      listArguments: {},
+      dispatch,
+    });
+
+    expect(calls[0]?.args).toEqual({ id: 'id0' });
+  });
+
+  /**
+   * The list's own arguments are inherited so a `userId` reaches the get, the
+   * projection wins over them, and the identifier wins over everything — it is
+   * the one argument that is not a preference.
+   */
+  test('the list arguments are inherited, the projection beats them, and the id beats both', async () => {
+    const { calls, dispatch } = recorder();
+
+    await expandIfReferences({
+      capability: LIST,
+      result: listing(references(1)),
+      asked: undefined,
+      merged: reachable({ view: 'summary' }),
+      listArguments: { userId: 'me', view: 'everything', id: 'ignored' },
+      dispatch,
+    });
+
+    expect(calls[0]?.args).toEqual({ userId: 'me', view: 'summary', id: 'id0' });
+  });
+});
+
+describe('what comes back', () => {
+  /** The client's acceptance criterion: all of them, at the smaller shape. */
+  test('every row the list returned is present', async () => {
+    const { dispatch } = recorder();
+
+    const filled = await expandIfReferences({
+      capability: LIST,
+      result: listing(references(20)),
+      asked: undefined,
+      merged: reachable(),
+      listArguments: {},
+      dispatch,
+    });
+
+    expect(bodyOf(filled)['messages']).toHaveLength(20);
+  });
+
+  /**
+   * The rows that did not fit come back exactly as the vendor wrote them. The
+   * old code replaced the array with the ones it had filled, so the note telling
+   * a caller to fetch the rest named identifiers it had just thrown away.
+   */
+  test('rows that did not fit survive as the references they were', async () => {
+    const heavy = 'x'.repeat(12 * 1024);
+    const { dispatch } = recorder((id) => ({ id, body: heavy }));
+
+    const filled = await expandIfReferences({
+      capability: LIST,
+      result: listing(references(20)),
+      asked: undefined,
+      merged: reachable(),
+      listArguments: {},
+      dispatch,
+    });
+
+    const rows = bodyOf(filled)['messages'] as Record<string, unknown>[];
+    expect(rows).toHaveLength(20);
+    expect(rows[19]).toEqual({ id: 'id19', threadId: 't19' });
+    expect(filled?.content[0]?.text).toContain('came back as identifiers only');
+    expect(filled?.content[0]?.text).toContain(GET);
+  });
+
+  /** Paging was impossible while the fill discarded everything beside the array. */
+  test("the vendor's own page token survives the fill", async () => {
+    const { dispatch } = recorder();
+
+    const filled = await expandIfReferences({
+      capability: LIST,
+      result: listing(references(2), { nextPageToken: 'page-2', resultSizeEstimate: 40 }),
+      asked: undefined,
+      merged: reachable(),
+      listArguments: {},
+      dispatch,
+    });
+
+    expect(bodyOf(filled)['nextPageToken']).toBe('page-2');
+    expect(bodyOf(filled)['resultSizeEstimate']).toBe(40);
+  });
+
+  test('a reply with nothing left over says nothing about rows left over', async () => {
+    const { dispatch } = recorder();
+
+    const filled = await expandIfReferences({
+      capability: LIST,
+      result: listing(references(3)),
+      asked: undefined,
+      merged: reachable(),
+      listArguments: {},
+      dispatch,
+    });
+
+    expect(filled?.content[0]?.text).not.toContain('identifiers only');
+  });
+
+  /** A follow-up failing is not the list call failing. */
+  test('a follow-up that fails leaves its reference and counts as unfilled', async () => {
+    const dispatch = async (_capability: string, args: Record<string, unknown>) =>
+      (args['id'] === 'id0'
+        ? { ok: false, authorization: 'denied_by_policy', message: 'no' }
+        : {
+            ok: true,
+            result: { content: [{ type: 'text' as const, text: JSON.stringify({ id: args['id'] }) }] },
+          }) as DispatchOutcome;
+
+    const filled = await expandIfReferences({
+      capability: LIST,
+      result: listing(references(2)),
+      asked: undefined,
+      merged: reachable(),
+      listArguments: {},
+      dispatch,
+    });
+
+    const rows = bodyOf(filled)['messages'] as Record<string, unknown>[];
+    expect(rows[0]).toEqual({ id: 'id0', threadId: 't0' });
+    expect(rows[1]).toEqual({ id: 'id1' });
+    expect(filled?.content[0]?.text).toContain('1 further row came back as identifiers only');
+  });
+});

--- a/src/server/mcp/expand-result.ts
+++ b/src/server/mcp/expand-result.ts
@@ -1,9 +1,9 @@
 import { isToolResult } from '#connectivity';
 import type { DispatchOutcome } from '#dispatch';
-import { fill, referencesIn, sibling } from './expand.ts';
+import { type ExpandArgument, expandMode, fill, noteFor, referencesIn, sibling } from './expand.ts';
 import type { MergedCapability } from './visibility.ts';
 
-export { sibling };
+export { EXPAND, type ExpandArgument } from './expand.ts';
 
 /**
  * The gateway's half of filling in a list of references.
@@ -21,51 +21,71 @@ export { sibling };
  * is also the honest description of what it is, since the provider being called
  * cannot tell either.
  *
+ * It is also why the projection is merged *here* rather than at the seam in
+ * `invoke` where `redact` is read. The dispatcher logs `request.arguments` and
+ * sends `request.arguments`; arguments injected below that seam would make the
+ * audit row and the wire disagree about what was asked for. Building them into
+ * the request keeps the row true, and keeps a direct call to the same `.get`
+ * answering with what the vendor's own default returns rather than quietly
+ * receiving less than the caller asked for.
+ *
  * What that costs: only calls arriving through `lanes_tools_call` are filled in.
  * Under `surface: crunched` that is every provider call, which is the case this
  * was built for. Under `full` a typed tool still returns what the provider
  * returned.
  */
-export async function expandIfReferences(
-  capability: string,
-  result: unknown,
-  wanted: boolean,
-  merged: Map<string, MergedCapability>,
-  fetch: (id: string) => Promise<DispatchOutcome>,
-): Promise<{ content: { type: 'text'; text: string }[] } | undefined> {
-  if (!wanted) return undefined;
-  if (sibling(capability, merged) === undefined) return undefined;
-  if (!isTool_(result)) return undefined;
+export interface ExpandRequest {
+  /** The list capability that was called. */
+  readonly capability: string;
+  /** What it answered with. */
+  readonly result: unknown;
+  /** What the caller asked for, if anything. */
+  readonly asked: ExpandArgument | undefined;
+  /** Everything this caller can reach, which is where the sibling and its projection live. */
+  readonly merged: ReadonlyMap<string, MergedCapability>;
+  /** The list's own arguments, which the follow-up inherits. */
+  readonly listArguments: Readonly<Record<string, unknown>>;
+  /** One ordinary top-level call, exactly as the caller's own would be. */
+  readonly dispatch: (
+    capabilityId: string,
+    args: Record<string, unknown>,
+  ) => Promise<DispatchOutcome>;
+}
 
-  const text = textOf(result);
-  const references = referencesIn(text);
+export async function expandIfReferences(
+  request: ExpandRequest,
+): Promise<{ content: { type: 'text'; text: string }[] } | undefined> {
+  const mode = expandMode(request.asked);
+  if (mode === undefined) return undefined;
+
+  const paired = sibling(request.capability, request.merged);
+  if (paired === undefined) return undefined;
+  if (!isToolResult(request.result as never)) return undefined;
+
+  const references = referencesIn(textOf(request.result));
   if (!references) return undefined;
 
-  const { filled, capped } = await fill(references.ids, async (id) => {
-    const outcome = await fetch(id);
+  // `full` merges nothing, so a caller who wants the vendor's own default
+  // representation has a way to say so.
+  const projection = mode === 'compact' ? (request.merged.get(paired)?.compact ?? {}) : {};
+
+  const { rows, fetched } = await fill(references.rows, async (id) => {
+    const outcome = await request.dispatch(paired, {
+      ...request.listArguments,
+      ...projection,
+      id,
+    });
     if (!outcome.ok || !isToolResult(outcome.result)) return undefined;
     return textOf(outcome.result);
   });
 
-  const note =
-    capped > 0
-      ? `\n\n${capped} further row${capped === 1 ? '' : 's'} came back as identifiers only and were ` +
-        'not fetched. Narrow the list, or call the get capability for the ones you want.'
-      : '';
+  // The whole body, not just the array: a page token or a total sat beside it,
+  // and replacing the body with the rows threw those away — which is what made
+  // the old note's advice impossible to act on.
+  const body = { ...references.body, [references.at]: rows };
+  const note = noteFor(mode, paired, references.rows.length - fetched);
 
-  return {
-    content: [
-      {
-        type: 'text' as const,
-        text: `${JSON.stringify({ [references.at]: filled }, null, 2)}${note}`,
-      },
-    ],
-  };
-}
-
-/** Whether a dispatch result is a tool result at all. */
-function isTool_(result: unknown): boolean {
-  return isToolResult(result as never);
+  return { content: [{ type: 'text' as const, text: `${JSON.stringify(body, null, 2)}${note}` }] };
 }
 
 /** The text of a tool result, with non-text blocks left out. */

--- a/src/server/mcp/expand.test.ts
+++ b/src/server/mcp/expand.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from 'bun:test';
-import { fill, referencesIn, sibling } from './expand.ts';
+import { expandMode, fill, noteFor, referencesIn, sibling } from './expand.ts';
 import type { MergedCapability } from './visibility.ts';
 
 /**
@@ -57,7 +57,20 @@ describe('deciding whether a result is references', () => {
       nextPageToken: 'x',
     });
 
-    expect(referencesIn(body)).toEqual({ at: 'messages', ids: ['a1', 'a2'] });
+    expect(referencesIn(body)).toEqual({
+      at: 'messages',
+      rows: [
+        { id: 'a1', threadId: 't1' },
+        { id: 'a2', threadId: 't2' },
+      ],
+      body: {
+        messages: [
+          { id: 'a1', threadId: 't1' },
+          { id: 'a2', threadId: 't2' },
+        ],
+        nextPageToken: 'x',
+      },
+    });
   });
 
   /**
@@ -102,49 +115,155 @@ describe('deciding whether a result is references', () => {
 });
 
 describe('doing the follow-ups', () => {
+  const references = (count: number): Record<string, unknown>[] =>
+    Array.from({ length: count }, (_, at) => ({ id: `id${at}`, threadId: `t${at}` }));
+
   test('each reference becomes the record it names', async () => {
-    const { filled, capped } = await fill(['a', 'b'], async (id) =>
+    const { rows, fetched } = await fill(references(2), async (id) =>
       JSON.stringify({ id, subject: `re: ${id}` }),
     );
 
-    expect(capped).toBe(0);
-    expect(filled).toEqual([
-      { id: 'a', subject: 're: a' },
-      { id: 'b', subject: 're: b' },
+    expect(fetched).toBe(2);
+    expect(rows).toEqual([
+      { id: 'id0', subject: 're: id0' },
+      { id: 'id1', subject: 're: id1' },
     ]);
   });
 
   /**
-   * Bounded, and it says so. A silent truncation reads as "that is all there
-   * was", which is the failure mode worth more than the rows it saves.
+   * The whole point of the rewrite. A page of small records is a page, not five
+   * of them, because what a reply costs is bytes and five was a count.
    */
-  test('a long list is capped, and the remainder is reported', async () => {
-    const many = Array.from({ length: 12 }, (_, at) => `id${at}`);
-    const { filled, capped } = await fill(many, async (id) => JSON.stringify({ id }));
+  test('a page of compact rows is filled in completely', async () => {
+    const { rows, fetched } = await fill(references(20), async (id) => JSON.stringify({ id }));
 
-    expect(filled).toHaveLength(5);
-    expect(capped).toBe(7);
+    expect(fetched).toBe(20);
+    expect(rows).toHaveLength(20);
+    // Every row is the record, not the reference it started as.
+    expect(rows.every((row) => !('threadId' in (row as Record<string, unknown>)))).toBe(true);
+  });
+
+  /**
+   * The reported failure, in one test. Records this large are what turned a
+   * question about an inbox into 193,271 characters, and the budget is what
+   * stops it — but every row still comes back, which is what the note that
+   * mentions them is now able to assume.
+   */
+  test('records too large to all fit stop at the budget, and the rest survive as references', async () => {
+    const heavy = 'x'.repeat(12 * 1024);
+    const { rows, fetched } = await fill(references(20), async (id) =>
+      JSON.stringify({ id, body: heavy }),
+    );
+
+    expect(fetched).toBeLessThan(20);
+    expect(rows).toHaveLength(20);
+    expect(rows[19]).toEqual({ id: 'id19', threadId: 't19' });
+  });
+
+  /**
+   * `FEWEST`, and the reason the first row is fetched on its own: a record big
+   * enough to spend the whole budget has to be seen to be measured, and a first
+   * wave of three would have paid for three of them to find that out.
+   */
+  test('a single record larger than the whole budget is still filled in, and costs one call', async () => {
+    const asked: string[] = [];
+    const { rows, fetched } = await fill(references(6), async (id) => {
+      asked.push(id);
+      return JSON.stringify({ id, body: 'x'.repeat(64 * 1024) });
+    });
+
+    expect(asked).toEqual(['id0']);
+    expect(fetched).toBe(1);
+    expect(rows).toHaveLength(6);
+    expect(rows[1]).toEqual({ id: 'id1', threadId: 't1' });
+  });
+
+  /** Somebody else's quota, not the caller's context — the other bound. */
+  test('a very long list stops at the fan-out ceiling', async () => {
+    const asked: string[] = [];
+    const { rows, fetched } = await fill(references(200), async (id) => {
+      asked.push(id);
+      return JSON.stringify({ id });
+    });
+
+    expect(asked.length).toBeLessThanOrEqual(25);
+    expect(fetched).toBe(asked.length);
+    expect(rows).toHaveLength(200);
   });
 
   /**
    * One row failing must not fail the call that found it. The reference is
-   * returned as it arrived, which is no worse than not having expanded at all.
+   * returned exactly as it arrived — `threadId` and all — so a caller told to
+   * fetch it by hand is holding what that takes.
    */
-  test('a follow-up that fails leaves its reference behind', async () => {
-    const { filled } = await fill(['a', 'b'], async (id) =>
-      id === 'a' ? undefined : JSON.stringify({ id, subject: 'ok' }),
+  test('a follow-up that fails leaves its reference behind, verbatim', async () => {
+    const { rows, fetched } = await fill(references(2), async (id) =>
+      id === 'id0' ? undefined : JSON.stringify({ id, subject: 'ok' }),
     );
 
-    expect(filled[0]).toEqual({ id: 'a' });
-    expect(filled[1]).toEqual({ id: 'b', subject: 'ok' });
+    expect(fetched).toBe(1);
+    expect(rows[0]).toEqual({ id: 'id0', threadId: 't0' });
+    expect(rows[1]).toEqual({ id: 'id1', subject: 'ok' });
   });
 
   test('order is the order the list gave, not the order they arrived', async () => {
-    const { filled } = await fill(['a', 'b', 'c', 'd'], async (id) => {
-      await new Promise((resolve) => setTimeout(resolve, id === 'a' ? 20 : 1));
+    const { rows } = await fill(references(4), async (id) => {
+      await new Promise((resolve) => setTimeout(resolve, id === 'id0' ? 20 : 1));
       return JSON.stringify({ id });
     });
 
-    expect(filled).toEqual([{ id: 'a' }, { id: 'b' }, { id: 'c' }, { id: 'd' }]);
+    expect(rows).toEqual([{ id: 'id0' }, { id: 'id1' }, { id: 'id2' }, { id: 'id3' }]);
+  });
+});
+
+describe('which representation to fill in with', () => {
+  test('nothing said means the small one', () => {
+    expect(expandMode(undefined)).toBe('compact');
+    expect(expandMode('compact')).toBe('compact');
+  });
+
+  test('whole records are asked for by name', () => {
+    expect(expandMode('full')).toBe('full');
+  });
+
+  test('false declines', () => {
+    expect(expandMode(false)).toBeUndefined();
+  });
+
+  /**
+   * Accepted and never advertised. `expand` shipped as a boolean, and ADR-032 is
+   * the record that a client which pinned its tool list at registration serves
+   * that schema forever — so refusing `true` would break exactly the clients the
+   * stable-name pair exists to rescue.
+   */
+  test('the boolean this shipped as still means what it meant', () => {
+    expect(expandMode(true)).toBe('compact');
+  });
+});
+
+describe('saying what is still an identifier', () => {
+  test('nothing left means nothing to say', () => {
+    expect(noteFor('compact', 'vendor_mail.messages.get', 0)).toBe('');
+  });
+
+  /** Naming it saves the caller a search for the thing it was just told to call. */
+  test('the note names the capability that resolves one', () => {
+    expect(noteFor('compact', 'vendor_mail.messages.get', 2)).toContain(
+      'vendor_mail.messages.get',
+    );
+    expect(noteFor('compact', 'vendor_mail.messages.get', 2)).toContain('2 further rows');
+  });
+
+  test('one row left is said in the singular', () => {
+    expect(noteFor('compact', 'vendor_mail.messages.get', 1)).toContain('1 further row came');
+  });
+
+  /**
+   * Under `full` the better answer is usually to ask for less, so the note says
+   * so. Under `compact` there is no smaller mode to point at.
+   */
+  test('asking for whole records is told there is a smaller way', () => {
+    expect(noteFor('full', 'vendor_mail.messages.get', 3)).toContain('expand: "compact"');
+    expect(noteFor('compact', 'vendor_mail.messages.get', 3)).not.toContain('expand:');
   });
 });

--- a/src/server/mcp/expand.ts
+++ b/src/server/mcp/expand.ts
@@ -1,3 +1,4 @@
+import { z } from 'zod';
 import type { MergedCapability } from './visibility.ts';
 
 /**
@@ -16,20 +17,116 @@ import type { MergedCapability } from './visibility.ts';
  * cost being removed — but it means spending someone else's rate limit on an
  * inference, and that is a real objection rather than a hypothetical one. Three
  * things keep it honest: the detection is strict enough that a false positive
- * is close to impossible, the fan-out is small and reported, and `expand:
+ * is close to impossible, the fan-out is bounded and reported, and `expand:
  * false` turns it off.
  *
  * Derived, never declared. The pairing comes from the names — a rule that finds
  * every list/get sibling across the vendored surface and nothing spurious — and
  * whether a list actually returned references is read off the response, because
  * the specs here do not say (`vendor-spec.ts` explains why they cannot).
+ *
+ * **What deciding cost, the first time it met a real mailbox.** Five rows came
+ * back as 193,271 characters and overflowed the reply, because a row was filled
+ * in at whatever representation the vendor defaults to and a Gmail message's
+ * default carries every `Received:` hop, the DKIM and ARC headers, and the body
+ * as base64. Two further rows were dropped to fit, and the note explaining that
+ * told the caller to fetch them itself — from an array the fill had already
+ * replaced, so the identifiers to do it with were gone.
+ *
+ * Three things follow, and none of them is the decision above.
+ *
+ * **A count was the wrong unit**, which `render.ts` had already worked out one
+ * file away for search answers: five rows is a few kilobytes of one provider's
+ * records and two hundred of another's, so a fixed number either truncates the
+ * useful answer or floods the context, and which it does depends on whose API
+ * the caller happened to ask about. The bound is bytes.
+ *
+ * **A row has to be worth filling in.** A vendor that will answer with a
+ * summary should be asked for one, and most will: `compact` merges the
+ * projection arguments the provider declared (`manifest.compact`) into the
+ * follow-up, so the saving happens at the source rather than by trimming a
+ * response we already paid to receive. That is what makes filling in *every*
+ * row affordable, which is the shape the caller wanted in the first place.
+ *
+ * **Nothing is dropped.** Every reference the list returned comes back, filled
+ * or not, and an unfilled one comes back exactly as the vendor wrote it — so
+ * the note telling a caller to fetch the rest is one it can act on.
+ *
+ * The only difference between `compact` and `full` is which arguments are
+ * merged. Both are bounded the same way, because the reported failure *is*
+ * `full` semantics with a row cap instead of a byte cap: exempting it would
+ * leave the bug in place for anyone who asked for it by name.
  */
 
-/** The most rows filled in for one call, however many came back. */
-const MOST = 5;
+/**
+ * What a filled-in reply may cost, in bytes of the caller's context.
+ *
+ * Deliberately not shared with `render.ts`'s budget. They bound different
+ * things — a search answer against a capability result — and that file can
+ * price an entry before spending it because it holds the schema, while this one
+ * has to fetch a row to learn its size. One number serving both would mean
+ * tuning the search surface silently changed how much mail came back.
+ */
+const BUDGET = 32 * 1024;
+
+/**
+ * Always filled, however large.
+ *
+ * `render.ts` takes the same floor for the same reason: a reply that names an
+ * identifier and withholds what it points at costs a round trip *and* looks
+ * like an answer. It is also why the first row is fetched on its own — a record
+ * big enough to spend the whole budget has to be seen to be measured, and a
+ * first wave of three would have paid for three of them before anything could
+ * check.
+ */
+const FEWEST = 1;
+
+/**
+ * The most rows filled in for one call, however small they are.
+ *
+ * No longer a bound on the caller's context — `BUDGET` is that — but on
+ * somebody else's quota, which is the objection the header concedes. A profile
+ * allows 60 upstream calls a minute by default, so one expansion may spend at
+ * most a little over a third of them. In practice this ceiling is what binds
+ * under `compact`, where rows are small, and the budget binds under `full`.
+ */
+const MOST = 25;
 
 /** How many at once. Bounded because they are somebody else's API. */
 const AT_ONCE = 3;
+
+/** Whole records, or the smaller one the provider declared. */
+export type ExpandMode = 'compact' | 'full';
+
+/** What a caller may pass. `true` is accepted and never advertised — see `EXPAND`. */
+export type ExpandArgument = boolean | ExpandMode;
+
+/**
+ * The argument, colocated with the rules that read it.
+ *
+ * `true` is accepted and deliberately undocumented. The shipped description
+ * never told anyone to pass it, and the new one teaches `compact`, `full` and
+ * `false` only — but `expand` was released as a boolean, and ADR-032 is the
+ * record that a client which pinned its tool list at registration serves that
+ * schema forever with no way for this endpoint to make it re-read. Refusing
+ * `true` would break exactly the clients `lanes_tools_search` exists to rescue.
+ * One spelling in the documentation, two in the parser, and the second is there
+ * for a client that cannot be told.
+ */
+export const EXPAND = z
+  .union([z.boolean(), z.enum(['compact', 'full'])])
+  .optional()
+  .describe(
+    'Fill in a list that comes back as bare identifiers. "compact" (the default) asks the ' +
+      'provider for a summary of every row; "full" asks for whole records and fills in fewer. ' +
+      'Pass false for the identifiers exactly as the provider returned them.',
+  );
+
+/** Which representation to fill in with, or nothing when the caller declined. */
+export function expandMode(asked: ExpandArgument | undefined): ExpandMode | undefined {
+  if (asked === false) return undefined;
+  return asked === 'full' ? 'full' : 'compact';
+}
 
 /**
  * The capability that turns one of these references into a record.
@@ -41,6 +138,16 @@ const AT_ONCE = 3;
 export function sibling(id: string, reachable: ReadonlyMap<string, MergedCapability>): string | undefined {
   const paired = id.endsWith('.list') ? `${id.slice(0, -'.list'.length)}.get` : undefined;
   return paired !== undefined && reachable.has(paired) ? paired : undefined;
+}
+
+/** A list body that holds nothing but references, and the rows themselves. */
+export interface References {
+  /** The property the array sat under. */
+  readonly at: string;
+  /** The reference objects, exactly as the vendor wrote them. */
+  readonly rows: readonly Record<string, unknown>[];
+  /** The whole body, so its siblings — a page token, a total — survive the fill. */
+  readonly body: Record<string, unknown>;
 }
 
 /**
@@ -58,7 +165,7 @@ export function sibling(id: string, reachable: ReadonlyMap<string, MergedCapabil
  * second call for something already in hand. `calendar.events.list` returns
  * whole events and is left alone by exactly this test.
  */
-export function referencesIn(text: string): { at: string; ids: string[] } | undefined {
+export function referencesIn(text: string): References | undefined {
   let body: unknown;
   try {
     body = JSON.parse(text);
@@ -67,59 +174,93 @@ export function referencesIn(text: string): { at: string; ids: string[] } | unde
   }
   if (typeof body !== 'object' || body === null || Array.isArray(body)) return undefined;
 
-  const arrays = Object.entries(body as Record<string, unknown>).filter(
+  const record = body as Record<string, unknown>;
+  const arrays = Object.entries(record).filter(
     ([, value]) => Array.isArray(value) && value.length > 0,
   );
   if (arrays.length !== 1) return undefined;
 
   const [at, rows] = arrays[0] as [string, unknown[]];
-  const ids: string[] = [];
 
   for (const row of rows) {
     if (typeof row !== 'object' || row === null || Array.isArray(row)) return undefined;
     const keys = Object.keys(row as Record<string, unknown>);
     if (keys.length > 2 || !keys.includes('id')) return undefined;
-    const id = (row as Record<string, unknown>)['id'];
-    if (typeof id !== 'string') return undefined;
-    ids.push(id);
+    if (typeof (row as Record<string, unknown>)['id'] !== 'string') return undefined;
   }
 
-  return ids.length > 0 ? { at, ids } : undefined;
+  return { at, rows: rows as Record<string, unknown>[], body: record };
 }
 
 /**
- * Run the follow-ups, a few at a time.
+ * Run the follow-ups, a few at a time, until the budget or the ceiling stops it.
  *
  * Each one goes through the same dispatcher as any other call, so it is
  * authorised, redacted, rate-limited and audited exactly as though the caller
  * had made it — which, in every sense that matters to the provider being
  * called, they did. A row that fails is left as the reference it was rather
- * than failing the call that found it.
+ * than failing the call that found it, and counts as unfilled, so the note at
+ * the end is about what the caller actually holds rather than what was tried.
+ *
+ * The budget is checked between waves rather than within one, so a reply may
+ * overshoot by up to `AT_ONCE - 1` rows. Serialising the fetches to make it
+ * exact would cost a round trip per row to save a few kilobytes of a bound that
+ * is itself a judgement.
  */
 export async function fill(
-  ids: readonly string[],
+  references: readonly Record<string, unknown>[],
   fetch: (id: string) => Promise<string | undefined>,
-): Promise<{ filled: unknown[]; capped: number }> {
-  const wanted = ids.slice(0, MOST);
-  const filled: unknown[] = new Array(wanted.length);
+): Promise<{ rows: unknown[]; fetched: number }> {
+  // Seeded from the references, so every position is present by construction
+  // and an unfilled one is the vendor's own object rather than a rebuild of it.
+  const rows: unknown[] = [...references];
+  const ceiling = Math.min(references.length, MOST);
 
-  for (let start = 0; start < wanted.length; start += AT_ONCE) {
-    const batch = wanted.slice(start, start + AT_ONCE);
-    const done = await Promise.all(batch.map(async (id) => fetch(id)));
+  let spent = 0;
+  let fetched = 0;
+  let at = 0;
+
+  while (at < ceiling) {
+    const width = at < FEWEST ? FEWEST : AT_ONCE;
+    const batch = references.slice(at, at + width);
+    const done = await Promise.all(batch.map(async (row) => fetch(row['id'] as string)));
 
     done.forEach((text, offset) => {
-      const at = start + offset;
-      if (text === undefined) {
-        filled[at] = { id: wanted[at] };
-        return;
-      }
+      if (text === undefined) return;
+      spent += text.length;
+      fetched += 1;
       try {
-        filled[at] = JSON.parse(text);
+        rows[at + offset] = JSON.parse(text);
       } catch {
-        filled[at] = { id: wanted[at], result: text };
+        rows[at + offset] = { ...references[at + offset], result: text };
       }
     });
+
+    at += width;
+    if (spent >= BUDGET) break;
   }
 
-  return { filled, capped: ids.length - wanted.length };
+  return { rows, fetched };
+}
+
+/**
+ * What to say about the rows that are still identifiers.
+ *
+ * Names the capability that turns one into a record, because the caller would
+ * otherwise have to search for it, and — under `full` — names the other mode,
+ * because asking for less is usually the better answer to "there were more of
+ * them". It says nothing about paging: the vendor's own page token is back in
+ * the body now, and guessing which key is one would be vendor knowledge dressed
+ * up as a heuristic.
+ */
+export function noteFor(mode: ExpandMode, getCapability: string, left: number): string {
+  if (left <= 0) return '';
+
+  const rows = `${left} further row${left === 1 ? '' : 's'}`;
+  const byHand = `call ${getCapability} for the ones you want`;
+
+  return mode === 'full'
+    ? `\n\n${rows} came back as identifiers only, because whole records are large. ` +
+        `Pass expand: "compact" to fill in every row at once, or ${byHand}.`
+    : `\n\n${rows} came back as identifiers only. Narrow the list, or ${byHand}.`;
 }

--- a/src/server/mcp/search.ts
+++ b/src/server/mcp/search.ts
@@ -8,7 +8,7 @@ import {
   searchCapabilities,
   searchResults,
 } from './search-index.ts';
-import { expandIfReferences, sibling } from './expand-result.ts';
+import { EXPAND, type ExpandArgument, expandIfReferences } from './expand-result.ts';
 import { validate } from './validate.ts';
 import { SURFACE_TOOL_NAMES, toolNameFor } from './naming.ts';
 import {
@@ -210,13 +210,7 @@ export function registerSearchSurface(
           .record(z.string(), z.unknown())
           .default({})
           .describe("The capability's own arguments, as its schema describes them"),
-        expand: z
-          .boolean()
-          .optional()
-          .describe(
-            'Fill in a list that comes back as bare identifiers, by fetching the first few. ' +
-              'On by default. Pass false to get the identifiers as the provider returned them.',
-          ),
+        expand: EXPAND,
       },
     },
     async (input: {
@@ -224,7 +218,7 @@ export function registerSearchSurface(
       profile: string;
       connection: string;
       arguments?: Record<string, unknown>;
-      expand?: boolean | undefined;
+      expand?: ExpandArgument | undefined;
     }) => {
       const { capability, profile, connection } = input;
       const entry = merged.get(capability);
@@ -347,20 +341,21 @@ export function registerSearchSurface(
       // is strict — see `expand.ts` — and a list already holding whole records
       // fails them and is left alone, which is what happens to almost every
       // provider here.
-      const filled = await expandIfReferences(
+      const filled = await expandIfReferences({
         capability,
-        outcome.result,
-        input.expand !== false,
+        result: outcome.result,
+        asked: input.expand,
         merged,
-        async (id) =>
+        listArguments: input.arguments ?? {},
+        dispatch: async (capabilityId, args) =>
           runtime.dispatcher.invoke({
             principal: forProfile(options.principal, profile),
-            capabilityId: sibling(capability, merged) as string,
+            capabilityId,
             connectionKey: connection,
-            arguments: { ...(input.arguments ?? {}), id },
+            arguments: args,
             ...(options.clientLabel ? { clientLabel: options.clientLabel } : {}),
           }),
-      );
+      });
       if (filled) return filled;
 
       // Text only, unlike `makeHandler`. A `resource_link` has to be rewritten

--- a/src/server/mcp/unauthorized.test.ts
+++ b/src/server/mcp/unauthorized.test.ts
@@ -74,6 +74,10 @@ members: []
       // This fake declares no bundles, so nothing here reads-only. What is
       // under test is grants, and the read/write split does not enter into it.
       expandBundle: () => [],
+      // Nor a manifest, so no capability here declares a compact projection.
+      // Same reason: what a filled-in list asks the provider for is not what
+      // this file is about.
+      manifest: () => undefined,
     },
     policy: toPolicyDocument(config),
   } as unknown as ProfileRuntime;

--- a/src/server/mcp/visibility.ts
+++ b/src/server/mcp/visibility.ts
@@ -132,6 +132,13 @@ export interface MergedCapability {
    * three places need it and only this one holds the registry.
    */
   readonly reads: boolean;
+
+  /**
+   * The arguments that ask this capability's provider for a smaller record.
+   * Resolved here for the same reason `reads` is: the gateway that fills in a
+   * list holds the merged entry and not the registry.
+   */
+  readonly compact?: Readonly<Record<string, unknown>>;
 }
 
 export function mergeCapabilities(options: BuildServerOptions): Map<string, MergedCapability> {
@@ -167,6 +174,7 @@ export function mergeCapabilities(options: BuildServerOptions): Map<string, Merg
         capability,
         discovered,
         reads: readsOnly(id, discovered, runtime.registry),
+        ...compactFor(id, capability, discovered, runtime.registry),
       });
     }
   }
@@ -367,4 +375,24 @@ export function accountsByProfile(
   }
 
   return accounts;
+}
+
+/**
+ * The projection a provider declared for one capability, if it declared one.
+ * Keyed by the unqualified name, exactly as `redact` and `hints` are.
+ */
+function compactFor(
+  id: string,
+  capability: ReturnType<ProviderRegistry['capabilities']>[number]['capability'],
+  discovered: ReturnType<ProviderRegistry['capabilities']>[number]['discovered'],
+  registry: ProviderRegistry,
+): { compact?: Record<string, unknown> } {
+  const [provider] = id.split('.');
+  const name = capability?.name ?? discovered?.name;
+  if (provider === undefined || name === undefined) return {};
+
+  // Spread rather than assigned, because `exactOptionalPropertyTypes` refuses
+  // an explicit `undefined` where the field is declared optional.
+  const compact = registry.manifest(provider)?.compact?.[name];
+  return compact === undefined ? {} : { compact };
 }

--- a/src/server/search.test.ts
+++ b/src/server/search.test.ts
@@ -1,5 +1,7 @@
 import { afterAll, describe, expect, test } from 'bun:test';
-import { allocatePort, rpc, startHarness } from './harness.ts';
+import { z } from 'zod';
+import { defineLocalProvider } from '#connectivity';
+import { allocatePort, parseConfig, rpc, startHarness } from './harness.ts';
 import { SURFACE_TOOL_NAMES } from './mcp/index.ts';
 
 /**
@@ -37,8 +39,83 @@ const work = startHarness({
     - "example.list_notes"`,
 });
 
+/**
+ * A provider shaped like the one that overflowed a reply: a list that answers
+ * with bare references, and a get beside it whose record can be made any size.
+ *
+ * `example` cannot stand in for it — `list_notes` and `get_note` do not pair,
+ * because pairing is `<x>.list` with `<x>.get` and nothing else.
+ */
+const fixtureMail = defineLocalProvider({
+  id: 'fixture_mail',
+  name: 'Fixture Mail',
+  description: 'A list of references and the get that resolves one.',
+  configSchema: z.object({}),
+  connectionSchema: z.object({}),
+  bundles: [
+    { name: 'read', description: 'Read.', oauth_scopes: [], capabilities: ['notes.list', 'notes.get'], default: true },
+  ],
+  capabilities: [
+    {
+      kind: 'tool',
+      name: 'notes.list',
+      title: 'List notes',
+      description: 'Identifiers of the notes in this account, and a token for the next page.',
+      inputSchema: z.object({ count: z.number().optional(), bytes: z.number().optional() }),
+      async handler({ count }) {
+        const notes = Array.from({ length: count ?? 20 }, (_, at) => ({
+          id: `n${at}`,
+          threadId: `t${at}`,
+        }));
+        return {
+          content: [
+            { type: 'text', text: JSON.stringify({ notes, nextPageToken: 'page-2' }) },
+          ],
+        };
+      },
+    },
+    {
+      kind: 'tool',
+      name: 'notes.get',
+      title: 'Get a note',
+      description: 'One note, by identifier.',
+      inputSchema: z.object({ id: z.string(), bytes: z.number().optional() }),
+      async handler({ id, bytes }) {
+        const note = { id, subject: `re: ${id}`, ...(bytes ? { body: 'x'.repeat(bytes) } : {}) };
+        return { content: [{ type: 'text', text: JSON.stringify(note) }] };
+      },
+    },
+  ],
+});
+
+/** An endpoint serving it, so expansion can be watched end to end. */
+const mailPort = allocatePort();
+const mail = startHarness({
+  profile: 'personal',
+  port: mailPort,
+  providers: [fixtureMail],
+  // Required by the options type, and unused: `config` replaces what it builds.
+  policy: '',
+  // Written out rather than taken from `policy`, which grants the two `example`
+  // connections the harness always makes and cannot name another provider.
+  config: parseConfig(`
+contract: 5
+instance:
+  profile: personal
+  port: ${mailPort}
+limits:
+  requests_per_minute: 1000
+  upstream_calls_per_minute: 1000
+grants:
+  - connection: fixture_mail.main
+    allow:
+      - "fixture_mail.*"
+members: []
+`).config,
+});
+
 afterAll(async () => {
-  await Promise.all([personal.stop(), work.stop()]);
+  await Promise.all([personal.stop(), work.stop(), mail.stop()]);
 });
 
 async function names(url: string, token?: string): Promise<string[]> {
@@ -292,5 +369,90 @@ describe('what is checked before the call goes out', () => {
     expect(outcome.isError).toBe(true);
     expect(outcome.text).not.toContain('was not called');
     expect(outcome.text).not.toContain('json');
+  });
+});
+
+describe('filling in a list that came back as references', () => {
+  const listing = async (args: Record<string, unknown>) =>
+    call(mail.server.url, {
+      capability: 'fixture_mail.notes.list',
+      profile: 'personal',
+      connection: 'fixture_mail.main',
+      ...args,
+    });
+
+  const bodyOf = (text: string) =>
+    JSON.parse(text.split('\n\n')[0] ?? '') as Record<string, unknown>;
+
+  /**
+   * The reported failure, end to end. Twenty references went out and five
+   * records came back, because the bound was a row count — so the answer to
+   * "what is in this account" was four fifths a list of identifiers, and the
+   * identifiers it did not fill in had been dropped to make room.
+   */
+  test('every row comes back, as a record', async () => {
+    const { text, isError } = await listing({ arguments: { count: 20 } });
+    expect(isError).toBe(false);
+
+    const notes = bodyOf(text)['notes'] as Record<string, unknown>[];
+    expect(notes).toHaveLength(20);
+    expect(notes.every((note) => typeof note['subject'] === 'string')).toBe(true);
+    expect(text).not.toContain('identifiers only');
+  });
+
+  /** Paging was impossible while the fill replaced the whole body with the rows. */
+  test('what sat beside the array survives it', async () => {
+    const { text } = await listing({ arguments: { count: 5 } });
+
+    expect(bodyOf(text)['nextPageToken']).toBe('page-2');
+  });
+
+  test('a caller who declines gets what the provider returned', async () => {
+    const { text } = await listing({ arguments: { count: 3 }, expand: false });
+
+    const notes = bodyOf(text)['notes'] as Record<string, unknown>[];
+    expect(notes).toEqual([
+      { id: 'n0', threadId: 't0' },
+      { id: 'n1', threadId: 't1' },
+      { id: 'n2', threadId: 't2' },
+    ]);
+  });
+
+  /**
+   * Records this size are what 193,271 characters was made of. The budget stops
+   * the reply growing without bound, and every row is still there — so the note
+   * naming the rest is advice the caller can act on.
+   */
+  test('records too large to all fit are bounded, and the rest stay as references', async () => {
+    const { text } = await listing({ arguments: { count: 20, bytes: 12 * 1024 } });
+
+    const notes = bodyOf(text)['notes'] as Record<string, unknown>[];
+    expect(notes).toHaveLength(20);
+    expect(notes.at(-1)).toEqual({ id: 'n19', threadId: 't19' });
+    expect(text).toContain('came back as identifiers only');
+    expect(text).toContain('fixture_mail.notes.get');
+    expect(text.length).toBeLessThan(128 * 1024);
+  });
+
+  /** `full` is bounded the same way — the reported failure *was* `full` semantics. */
+  test('asking for whole records is bounded too, and says where the smaller one is', async () => {
+    const { text } = await listing({
+      arguments: { count: 20, bytes: 12 * 1024 },
+      expand: 'full',
+    });
+
+    expect((bodyOf(text)['notes'] as unknown[])).toHaveLength(20);
+    expect(text).toContain('expand: "compact"');
+    expect(text.length).toBeLessThan(128 * 1024);
+  });
+
+  /** The boolean it shipped as still means what it meant, for a client that pinned the schema. */
+  test('the boolean this shipped as is still accepted', async () => {
+    const { text, isError } = await listing({ arguments: { count: 4 }, expand: true });
+
+    expect(isError).toBe(false);
+    expect((bodyOf(text)['notes'] as Record<string, unknown>[])[0]).toMatchObject({
+      subject: 're: n0',
+    });
   });
 });


### PR DESCRIPTION
A client ran a real multi-account mail workload through a deployed endpoint and reported five
issues. This is the first two, which turn out to be one fix.

Asking for a day of mail returned **193,271 characters** — five rows filled in, two more reported
as "identifiers only".

## What was actually wrong

Not the fan-out. It was capped at five and the list held seven. Each of those five was fetched at
whatever representation the vendor returns by default, and Gmail's default is `format=full`: every
`Received:` hop, the DKIM and ARC headers, the body as base64. **There was no compact
representation to fill in with.**

So the contested decision in `expand.ts` stands — this endpoint still decides rather than making
the caller ask, for the reason recorded there. Three things around it change.

**A count was the wrong unit.** `render.ts` had already reached that conclusion one file away, for
search answers, in the same pull request that shipped `expand`:

> A count was the wrong unit. Three matches is 900 bytes of one provider's schemas and 40 KB of
> another's, so a fixed number either truncates the useful answer or floods the context — and which
> it does depends on whose API the caller happened to ask about.

The bound is bytes now, with the same floor: the first row is filled however large it is, and it is
fetched on its own so that floor can mean anything. `MOST` survives, repurposed from a bound on the
caller's context to one on somebody else's quota.

**A row is worth filling in only if the vendor will answer with a summary.** `compact` is a third
per-capability record on the manifest, keyed exactly like `redact` and `hints`, holding the vendor's
*own* projection arguments. The saving has to happen at the source — trimming a response we already
paid to receive spends the owner's quota to save our bytes. Those parameters were already there and
deliberately preserved (Google's `format` and `fields`, Graph's `$select`); nothing had used them.

**Nothing is dropped.** The old code replaced the array with the rows it had filled, so the note
telling a caller to fetch the rest named identifiers it had just discarded — advice that could not
be followed. Every reference comes back now, and so does the rest of the body, so a page token
survives and paging is possible at all.

## Measured

On representative payloads, through `fill`:

| | rows filled | reply |
|---|---|---|
| `full` | 1 of 20 | 41.8 KB |
| `compact` | **20 of 20** | **11.8 KB** |

## The surface

`expand` widens from a boolean to `false | 'compact' | 'full'`, defaulting to `compact`. `true` is
accepted and never advertised: it shipped as a boolean one release ago, and ADR-032 is the record
that a client which pinned its tool list at registration serves that schema forever. Refusing it
would break exactly the clients the stable-name pair exists to rescue.

## Two notes for review

**Why the gateway and not `invoke`.** The dispatcher logs `request.arguments` and sends
`request.arguments`, so a projection injected below that seam would make the audit row and the wire
disagree. It also keeps a *direct* call to the same `.get` answering with what the vendor returns,
rather than quietly handing back less than was asked for.

**`owner-ids.ts` is a forced, behaviour-free extraction.** `provider.ts` was at 400 lines to the
line, and the budget's own docstring names what earns a split — "something that is not a schema
appearing beside them". A fixed list of owner provider ids is not a schema. Every consumer reads it
through `#connectivity`; one test imported the deep path and was repointed.

## Checks

`bun test` 3560 pass, 0 fail (3520 before). `bun run typecheck` clean. Every file inside the budget.

`expandIfReferences` had no tests at all and has fourteen now. The two `compact` guard tests were
verified by breaking the data both ways — a key naming no capability, and the singular-plural
argument typo that `collect()` would otherwise discard with no error anywhere.

## Not in this pull request

- **Batch get** (client's #3) dissolves: the 29 separate `messages.get` calls happened *because* the
  list failed to hydrate. Reconsider if measurement still shows a hydrate loop.
- **Spill-to-file shape** (#4) is the client's own MCP handling, not this repository — there is no
  such threshold, file write, or note anywhere in the tree.
- **The 401 handling** (#5) largely shipped in 0.13.0 (#209). The remaining gaps are their own
  change.