### PR TITLE
A refused credential is distrusted everywhere, and a grant that has ended says so

### DIFF
--- a/src/connectivity/auth/distrust.ts
+++ b/src/connectivity/auth/distrust.ts
@@ -1,0 +1,23 @@
+import { distrustUpstreamToken } from './oauth-authcode/provider.ts';
+import { distrustMintedToken } from './oauth-jwt/index.ts';
+
+/**
+ * Stop trusting a connection's access token, wherever it is being remembered.
+ *
+ * A connection is keyed `<provider>.<connection>` in both token caches, and
+ * which one holds it is a property of how the credential was obtained rather
+ * than of anything the caller did: an authorization-code grant caches under
+ * `oauth-authcode`, a service-account key under `oauth-jwt`. Both are reached
+ * through the same manifest `auth.kind: 'oauth'`, because an assertion is an
+ * optional second way in to the same block — so the layer that sees a 401
+ * cannot tell them apart, and should not have to.
+ *
+ * Its own file rather than a line in the barrel, because it is the one place
+ * that has to know both halves exist. Missing the second half is what left a
+ * service-account connection resending a refused token for an hour while the
+ * connection beside it recovered.
+ */
+export function distrustConnectionToken(connectionKey: string): void {
+  distrustUpstreamToken(connectionKey);
+  distrustMintedToken(connectionKey);
+}

--- a/src/connectivity/auth/index.ts
+++ b/src/connectivity/auth/index.ts
@@ -19,6 +19,7 @@
 
 export { credentialResolver, type ResolvedCredential } from './resolve.ts';
 export { requestAuthorizer } from './authorize.ts';
+export { distrustConnectionToken } from './distrust.ts';
 export { ReauthRequired, statusMeansGrantIsDead } from './reauth.ts';
 export { basicCredential } from './basic/index.ts';
 export { bearerToken, bearerTokenAsStored } from './token.ts';
@@ -33,6 +34,7 @@ export { resolveUpstreamToken } from './oauth-authcode/index.ts';
 export {
   ASSERTION_GRANT,
   clearMintedTokens,
+  distrustMintedToken,
   isStoredAssertion,
   resolveAssertionToken,
   storedAssertionFor,

--- a/src/connectivity/auth/oauth-jwt/index.ts
+++ b/src/connectivity/auth/oauth-jwt/index.ts
@@ -118,6 +118,23 @@ export function clearMintedTokens(): void {
   minted.clear();
 }
 
+/**
+ * Stop trusting this connection's minted token.
+ *
+ * Simpler than the authorization-code side, and for a reason worth stating: the
+ * only thing that remembers a token here is the map above. There is no stored
+ * blob carrying an `expires_at` for a later call to read and believe, so there
+ * is nothing to mark skippable — dropping the entry *is* the distrust, and the
+ * next call signs a fresh assertion.
+ *
+ * Without this a service-account connection was the one arrangement that kept
+ * the behaviour the 401 handling was written to remove: a token the vendor had
+ * already refused, resent until the clock aged it out.
+ */
+export function distrustMintedToken(connectionKey: string): void {
+  minted.delete(connectionKey);
+}
+
 interface TokenResponse {
   readonly access_token?: string;
   readonly expires_in?: number;

--- a/src/connectivity/auth/oauth-jwt/oauth-jwt.test.ts
+++ b/src/connectivity/auth/oauth-jwt/oauth-jwt.test.ts
@@ -1,10 +1,12 @@
 import { describe, expect, test, beforeEach } from 'bun:test';
 import { defineProvider, type ProviderManifest } from '#connectivity';
+import { distrustConnectionToken } from '../distrust.ts';
 import { parseAssertionKey, signAssertion } from './key.ts';
 import {
   ASSERTION_GRANT,
   clearMintedTokens,
   isStoredAssertion,
+  distrustMintedToken,
   resolveAssertionToken,
   storedAssertionFor,
 } from './index.ts';
@@ -276,6 +278,63 @@ describe('the exchange', () => {
     expect(await mint()).toBe('minted-1');
     expect(await mint()).toBe('minted-1');
     expect(calls).toBe(1);
+  });
+
+  /**
+   * The arrangement that kept the old behaviour after the 401 handling landed.
+   * A service-account connection caches here and nowhere else, so a distrust
+   * that only reached the authorization-code caches left it resending a token
+   * the vendor had already refused until the clock aged it out.
+   */
+  test('mints again once the vendor has refused what was cached', async () => {
+    const { manifest, secrets, stored } = await fixture();
+    let calls = 0;
+
+    const mint = () =>
+      resolveAssertionToken({
+        manifest,
+        connectionId: 'main',
+        stored,
+        credentials: secrets,
+        fetch: (async () => {
+          calls += 1;
+          return Response.json({ access_token: `minted-${calls}`, expires_in: 3600 });
+        }) as unknown as typeof fetch,
+      });
+
+    expect(await mint()).toBe('minted-1');
+
+    // Through the combined entry point the dispatcher actually calls, not the
+    // half of it this file owns: reaching only one cache was the defect.
+    distrustConnectionToken('vendor_thing.main');
+    expect(await mint()).toBe('minted-2');
+    expect(calls).toBe(2);
+  });
+
+  /** Keyed per connection, so distrusting one leaves its sibling alone. */
+  test('one connection being refused does not disturb another', async () => {
+    const { manifest, secrets, stored } = await fixture();
+    let calls = 0;
+
+    const mint = (connectionId: string) =>
+      resolveAssertionToken({
+        manifest,
+        connectionId,
+        stored,
+        credentials: secrets,
+        fetch: (async () => {
+          calls += 1;
+          return Response.json({ access_token: `minted-${calls}`, expires_in: 3600 });
+        }) as unknown as typeof fetch,
+      });
+
+    expect(await mint('main')).toBe('minted-1');
+    expect(await mint('other')).toBe('minted-2');
+
+    distrustMintedToken('vendor_thing.main');
+
+    expect(await mint('other')).toBe('minted-2');
+    expect(await mint('main')).toBe('minted-3');
   });
 
   test('mints again once the cached token is close to expiring', async () => {

--- a/src/connectivity/connector.ts
+++ b/src/connectivity/connector.ts
@@ -174,8 +174,16 @@ export interface AuthStrategy {
   /** Per-request: sign it, add headers, refresh a session if one has expired. */
   authorize(request: Request, context: AuthStrategyContext): Promise<Request>;
 
-  /** Optional response check — bunq signs its replies and expects them verified. */
-  verify?(response: Response, context: AuthStrategyContext): Promise<void>;
+  /**
+   * Optional response check — bunq signs its replies and expects them verified.
+   *
+   * Returns the same outcome a connector's own verifier does, so a strategy
+   * that recognises a refused credential can ask for the one retry rather than
+   * only recording it. It was declared `Promise<void>` while the composing
+   * verifier already read `retry` off it, which made asking for one impossible
+   * to write down.
+   */
+  verify?(response: Response, context: AuthStrategyContext): Promise<VerifyOutcome | void>;
 }
 
 export interface AuthStrategyContext {

--- a/src/connectivity/context.ts
+++ b/src/connectivity/context.ts
@@ -1,6 +1,7 @@
 import type { AuditLogger } from '#audit';
 import type { ScopedSecrets } from '#secrets';
 import type { BlobStore } from '#stores/blobs';
+import type { VerifyOutcome } from './connector.ts';
 import type { AttachmentBridge } from './mail/attachments.ts';
 
 /**
@@ -92,6 +93,22 @@ export interface ProviderContext {
    * harness builds a context without one.
    */
   authorize?(request: Request): Promise<Request>;
+  /**
+   * Hand a vendor's reply back for the checks a connector's own reply gets.
+   *
+   * The companion to `authorize`, and offered for the same reason: a capability
+   * authored because the generic transport cannot express the call still has
+   * to be a normal call in every other respect. Chief among those is that a
+   * token the vendor refuses must be distrusted, or the next call sends it
+   * again — for as long as the stored clock still says it is valid.
+   *
+   * A caller may ignore the returned outcome, and one authoring a *write*
+   * should: `{ retry: true }` is safe for a read and not for a send, where the
+   * first attempt may well have been delivered. Distrusting without retrying
+   * still repairs the connection for the call after it, which is the part worth
+   * having.
+   */
+  verify?(response: Response): Promise<VerifyOutcome | void>;
   /**
    * The two file lookups this connection's own store cannot answer.
    *

--- a/src/connectivity/transports/http/index.ts
+++ b/src/connectivity/transports/http/index.ts
@@ -282,8 +282,16 @@ export function createHttpConnector(options: HttpConnectorOptions): Connector {
       // something on the strength of this response — a token the vendor
       // refused — so authorising again hands out a replacement rather than the
       // value that just failed. A second refusal is the answer.
+      //
+      // The replacement's reply is verified too, and that is not symmetry for
+      // its own sake: refusing a *reissued* credential is the only evidence
+      // anywhere that the grant itself has ended rather than the token having
+      // gone stale, and it is available exactly once, here. Left unverified,
+      // the distinction could not be drawn by anything downstream — by then
+      // there is one 401 and no record that a retry was already spent.
       if (outcome?.retry) {
         response = await doFetch(await context.authorize(outbound()));
+        await context.verify?.(response.clone() as unknown as Response);
       }
 
       const text = await response.text();

--- a/src/connectivity/transports/mcp/index.ts
+++ b/src/connectivity/transports/mcp/index.ts
@@ -6,6 +6,7 @@ import type {
   ToolResult,
 } from '#connectivity';
 import { READ_BUNDLE, WRITE_BUNDLE } from '#connectivity';
+import { distrustIfRefused } from './refused.ts';
 
 /**
  * The `mcp` connector — proxy an upstream MCP server.
@@ -354,6 +355,8 @@ export function createMcpConnector(options: McpConnectorOptions): Connector {
           target: { tool: tool.name },
         }));
       } catch (error) {
+        // No `verify`: a `DiscoveryContext` has none, because discovery is not
+        // a call anyone made. See `refused.ts`.
         throw readableUpstreamError(error, options.endpoint);
       } finally {
         await client.close().catch(() => {});
@@ -361,10 +364,10 @@ export function createMcpConnector(options: McpConnectorOptions): Connector {
     },
 
     async invoke(capability, args, context): Promise<ToolResult> {
-      const client = await connect(context);
       const upstreamName = (capability.target?.['tool'] as string | undefined) ?? capability.name;
-
+      let client: Client | undefined;
       try {
+        client = await connect(context);
         const result = (await client.callTool({
           name: upstreamName,
           arguments: args as Record<string, unknown>,
@@ -386,9 +389,10 @@ export function createMcpConnector(options: McpConnectorOptions): Connector {
           ...(result.isError ? { isError: true } : {}),
         };
       } catch (error) {
+        await distrustIfRefused(context.verify, error);
         throw readableUpstreamError(error, options.endpoint);
       } finally {
-        await client.close().catch(() => {});
+        await client?.close().catch(() => {});
       }
     },
   };

--- a/src/connectivity/transports/mcp/refused.test.ts
+++ b/src/connectivity/transports/mcp/refused.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, test } from 'bun:test';
+import { UnauthorizedError } from '@modelcontextprotocol/client';
+import { distrustIfRefused } from './refused.ts';
+
+/**
+ * Noticing a refused credential on the transport that could not see one.
+ *
+ * The `http` connector reads `response.status`. Here the reply is consumed by a
+ * client library that turns a 401 into an exception, so there was no status for
+ * anything to check — and this is the larger half of the estate.
+ */
+
+describe('an upstream server that refused the credential', () => {
+  test('is handed back for the same check a transported reply gets', async () => {
+    const seen: number[] = [];
+
+    await distrustIfRefused(async (response) => void seen.push(response.status), new UnauthorizedError('nope'));
+
+    expect(seen).toEqual([401]);
+  });
+
+  /**
+   * Everything else is left alone. The whole trade is that a false positive
+   * spends a refresh on a guess, so this is matched on the library's own error
+   * type rather than on the message text, which is where a guess would live.
+   */
+  test('an ordinary upstream failure is not mistaken for one', async () => {
+    const seen: number[] = [];
+    const verify = async (response: Response) => void seen.push(response.status);
+
+    await distrustIfRefused(verify, new Error('the server returned 401 in some other sentence'));
+    await distrustIfRefused(verify, new Error('upstream timed out'));
+    await distrustIfRefused(verify, 'not an error at all');
+
+    expect(seen).toEqual([]);
+  });
+
+  /** Discovery has no verifier, and must not throw for the want of one. */
+  test('does nothing where there is no verifier to tell', async () => {
+    await expect(distrustIfRefused(undefined, new UnauthorizedError('nope'))).resolves.toBeUndefined();
+  });
+});

--- a/src/connectivity/transports/mcp/refused.ts
+++ b/src/connectivity/transports/mcp/refused.ts
@@ -1,0 +1,34 @@
+import { UnauthorizedError } from '@modelcontextprotocol/client';
+
+/**
+ * A credential the upstream server refused, told to the layer that caches it.
+ *
+ * This transport had no way to say it. The `http` one reads `response.status`;
+ * here the reply is consumed by a client library that turns a 401 into an
+ * exception, so there was no status for anything to check — and a refused token
+ * went on being sent until its stored clock ran out. That is the failure the
+ * distrust path exists to end, left in place on the largest share of the
+ * estate: 77 of roughly 105 providers declare `connector.kind: 'mcp'`.
+ *
+ * `UnauthorizedError` is the library's own answer, and it is brand-based, so it
+ * survives two copies of the package in one process. Matching on the message
+ * text was the alternative, and that is a guess.
+ *
+ * A `Response` is synthesised because it is the shared vocabulary for "the
+ * vendor said no", not because one was received. The retry the verifier offers
+ * is dropped: this connector opens a client, calls, and closes it, so honouring
+ * a retry means running all of that again. Worth doing, and a larger change
+ * than telling the truth about the token.
+ *
+ * Its own file because `index.ts` is four lines under the budget and this is a
+ * subject rather than a line — the same reason `expand.ts` sits beside the
+ * gateway that uses it.
+ */
+export async function distrustIfRefused(
+  verify: ((response: Response) => Promise<unknown>) | undefined,
+  error: unknown,
+): Promise<void> {
+  if (verify && error instanceof UnauthorizedError) {
+    await verify(new Response(null, { status: 401 }));
+  }
+}

--- a/src/dispatch/context.ts
+++ b/src/dispatch/context.ts
@@ -12,6 +12,7 @@ import type {
   ProviderDefinition,
   ProviderManifest,
   ScopedStore,
+  VerifyOutcome,
 } from '#connectivity';
 import { credentialRefForConnection } from '#connectivity';
 import type { ConnectionConfig } from '#profile';
@@ -130,6 +131,8 @@ export interface BuildContextOptions {
   readonly signal: AbortSignal;
   /** The same closure the connector context gets. Absent for `local` providers. */
   readonly authorize?: ((request: Request) => Promise<Request>) | undefined;
+  /** The same reply check the connector context gets. See `ProviderContext.verify`. */
+  readonly verify?: ((response: Response) => Promise<VerifyOutcome | void>) | undefined;
   /** `oauth_apps` entries this profile declares. See `resolveSecretRefs`. */
   readonly ownClients?: readonly string[] | undefined;
   /** Every profile the caller may reach. See `ProviderContext.profiles`. */
@@ -162,6 +165,7 @@ export function buildProviderContext(options: BuildContextOptions): ProviderCont
     log: options.log,
     signal: options.signal,
     ...(options.authorize ? { authorize: options.authorize } : {}),
+    ...(options.verify ? { verify: options.verify } : {}),
     ...(options.attachments ? { attachments: options.attachments } : {}),
   };
 }

--- a/src/dispatch/dispatch.ts
+++ b/src/dispatch/dispatch.ts
@@ -1,5 +1,5 @@
 import type { AuditDraft, AuditLogger, AuditSink, AuthorizationResult } from '#audit';
-import { keepKeys, redactAllValues } from '#audit';
+import { redactAllValues } from '#audit';
 import { mayReach, type Principal } from '#auth';
 import type { SecretStore } from '#secrets';
 import type { RuntimeState } from '#stores/state';
@@ -16,8 +16,9 @@ import type {
 import { isToolResult, strategyContextFrom, strategyFor } from '#connectivity';
 import type { Config, ConnectionConfig } from '#profile';
 import { buildProviderContext, createProviderLogger } from './context.ts';
-import { responseVerifier } from './reauthorize.ts';
-import { distrustUpstreamToken } from '#connectivity/auth/index.ts';
+import { auditArgumentsFor } from './redaction.ts';
+import { reauthResult, verifierFor } from './reauthorize.ts';
+import { ReauthRequired, distrustConnectionToken } from '#connectivity/auth/index.ts';
 import { createAttachmentBridge } from './attachments.ts';
 import { fetchStaged, stageAttachment } from './staging.ts';
 import type { FetchStagedRequest, StagedAttachment, StageRequest } from './staging.ts';
@@ -116,6 +117,8 @@ export class Dispatcher {
     let status: AuditDraft['status'] = 'not_invoked';
     let auditArguments: Record<string, unknown> = redactAllValues(request.arguments);
     let error: { kind: string; message: string } | undefined;
+    // Set when a reissued token was refused too, which means a person is needed.
+    let needsReauth = false;
     let outcome: DispatchOutcome = {
       ok: false,
       authorization: 'denied_default',
@@ -134,17 +137,14 @@ export class Dispatcher {
 
       const entry = registry.get(providerId)!;
 
-      // Apply redaction now that we know which capability this is, so a denial
-      // is logged with the same redaction an allowed call would get.
-      //
-      // Local capabilities carry their own rule. Discovered ones cannot: we did
-      // not author them and cannot know what is sensitive, so the default
-      // withholds every value and a manifest opts specific keys back in.
-      const declaredKeys = entry.manifest.redact?.[registered.capability?.name ?? registered.discovered?.name ?? ''];
-      const redact =
-        registered.capability?.redact ?? (declaredKeys ? keepKeys(...declaredKeys) : undefined);
-
-      auditArguments = (redact ?? redactAllValues)(request.arguments);
+      // Now that we know which capability this is — and before the allow/deny
+      // branch, so a denial is recorded the same way an allowed call would be.
+      auditArguments = auditArgumentsFor({
+        manifest: entry.manifest,
+        name: registered.capability?.name ?? registered.discovered?.name,
+        own: registered.capability?.redact,
+        arguments: request.arguments,
+      });
 
       // **Who, before what.** A caller reaches a profile only if that profile's
       // `members:` names them (ADR-060), and this is checked before the
@@ -276,6 +276,19 @@ export class Dispatcher {
           ).allowed,
       });
 
+      // Resolved, not asked for: this has to be the key the token caches use.
+      // Built before the provider context because an authored capability calls
+      // its vendor directly and needs the same check a transport's reply gets.
+      const connectionKey = `${providerId}.${declared.id}`;
+      const verify = verifierFor({
+        connectionKey,
+        manifest: entry.manifest,
+        strategy,
+        context: forStrategy,
+        distrust: distrustConnectionToken,
+        exhausted: () => void (needsReauth = true),
+      });
+
       const providerContext = buildProviderContext({
         manifest: entry.manifest,
         definition: entry.definition,
@@ -297,6 +310,7 @@ export class Dispatcher {
         profiles: request.principal.profiles ?? [request.principal.profile],
         attachments,
         ...(entry.manifest.connector.kind === 'local' ? {} : { authorize }),
+        ...(verify ? { verify } : {}),
       });
 
       const connector = this.#deps.connectorFor(providerId, declared.id);
@@ -309,21 +323,6 @@ export class Dispatcher {
           message: `Provider ${providerId} has no usable connector.`,
         });
       }
-
-      // Two reasons to read a response before the caller does: a vendor that
-      // signs its replies expects them verified, and a token the vendor refuses
-      // has to be distrusted or the next call sends it again. They compose.
-      const verifyStrategy = strategy?.verify?.bind(strategy);
-      const verify = responseVerifier({
-        // Built from what was resolved, not from what was asked for: this has
-        // to be the key the token cache uses, `<manifest>.<connection>`.
-        connectionKey: `${providerId}.${declared.id}`,
-        oauth: entry.manifest.auth.kind === 'oauth',
-        distrust: distrustUpstreamToken,
-        ...(verifyStrategy
-          ? { strategy: (response: Response) => verifyStrategy(response, forStrategy()) }
-          : {}),
-      });
 
       const connectorContext: ConnectorContext = {
         manifest: entry.manifest,
@@ -345,10 +344,20 @@ export class Dispatcher {
       // Only a tool can report a soft failure. A resource or a prompt that
       // cannot produce its answer throws, and lands in the catch below.
       status = isToolResult(result) && result.isError ? 'error' : 'ok';
-      return (outcome = { ok: true, result });
+
+      // A 401 that outlived its refresh arrives as an ordinary failed result
+      // carrying whatever the vendor writes. Said plainly instead, here, in the
+      // one place that knows a retry was already spent.
+      const dead = needsReauth && status === 'error';
+      if (dead) error = { kind: 'needs_reauth', message: `${connectionKey} must be reconnected` };
+
+      return (outcome = { ok: true, result: dead ? reauthResult(connectionKey, result) : result });
     } catch (caught) {
       status = 'error';
-      error = { kind: 'provider_error', message: (caught as Error).message };
+      // `ReauthRequired` already says a person is needed; flattening every throw
+      // to `provider_error` discarded that.
+      const kind = caught instanceof ReauthRequired ? 'needs_reauth' : 'provider_error';
+      error = { kind, message: (caught as Error).message };
       return (outcome = {
         ok: false,
         authorization,

--- a/src/dispatch/reauth.test.ts
+++ b/src/dispatch/reauth.test.ts
@@ -79,8 +79,8 @@ const BASIC = defineProvider({
   auth: { kind: 'basic', credential_ref: 'acme/password' },
 });
 
-/** A vendor that refuses the first call and accepts the second. */
-function harness(manifest: typeof OAUTH) {
+/** A vendor that refuses the first call and accepts the second — or refuses both. */
+function harness(manifest: typeof OAUTH, alwaysRefuse = false) {
   const tokens: string[] = [];
   let attempt = 0;
 
@@ -93,7 +93,7 @@ function harness(manifest: typeof OAUTH) {
     fetch: (async (request: Request) => {
       tokens.push(request.headers.get('authorization') ?? '');
       attempt += 1;
-      return attempt === 1
+      return attempt === 1 || alwaysRefuse
         ? new Response('{"error":"Invalid Credentials"}', { status: 401, statusText: 'Unauthorized' })
         : new Response('{"accounts":[]}', {
             status: 200,
@@ -103,6 +103,7 @@ function harness(manifest: typeof OAUTH) {
   });
 
   let issued = 0;
+  const audit = createBlobAuditStore({ storage: createMemoryBlobStore() });
   const dispatcher = new Dispatcher({
     config: CONFIG,
     connections: [{ id: 'main', provider: 'acme', account: 'A' }],
@@ -119,14 +120,14 @@ function harness(manifest: typeof OAUTH) {
     },
     policy: toPolicyDocument(CONFIG),
     state: createMemoryState(),
-    audit: createBlobAuditStore({ storage: createMemoryBlobStore() }),
+    audit,
     credentials: createMemoryCredentials(),
     storage: createMemoryBlobStore(),
     limiter: new RateLimiter(),
     log: { debug() {}, info() {}, warn() {}, error() {} },
   });
 
-  return { dispatcher, tokens, registry, http };
+  return { dispatcher, tokens, registry, http, audit };
 }
 
 const call = {
@@ -158,5 +159,65 @@ describe('a refused credential a person has to change', () => {
     await dispatcher.invoke(call);
 
     expect(tokens).toEqual(['Bearer token-1']);
+  });
+});
+
+describe('a credential a person has to replace', () => {
+  /** Discovery first, as the tests above do: an undiscovered capability is not callable. */
+  const ready = async (alwaysRefuse: boolean) => {
+    const built = harness(OAUTH, alwaysRefuse);
+    built.registry.setDiscovered('acme', await built.http.discover({ manifest: OAUTH } as never));
+    return built;
+  };
+
+  /**
+   * Two tokens, both refused. This is the shape the retry cannot fix, and until
+   * now it was indistinguishable from the shape it can — the caller received
+   * the vendor's own sentence about credentials either way.
+   */
+  test('is refused twice, and then said to be a grant rather than a token', async () => {
+    const { dispatcher, tokens } = await ready(true);
+    const outcome = await dispatcher.invoke(call);
+
+    expect(tokens).toEqual(['Bearer token-1', 'Bearer token-2']);
+    expect(outcome.ok).toBe(true);
+
+    const result = (outcome as unknown as { result: { content: { text: string }[]; isError?: boolean } }).result;
+    expect(result.isError).toBe(true);
+    expect(result.content[0]?.text).toContain('acme.main needs to be connected again');
+    expect(result.content[0]?.text).toContain('Retrying will not help');
+  });
+
+  /** And the vendor's own words survive underneath it. */
+  test('keeps what the vendor said', async () => {
+    const { dispatcher } = await ready(true);
+    const outcome = await dispatcher.invoke(call);
+
+    const result = (outcome as unknown as { result: { content: { text: string }[] } }).result;
+    expect(result.content.map((block) => block.text).join('\n')).toContain('Invalid Credentials');
+  });
+
+  /**
+   * The audit row is where "how often is this happening" gets answered, and a
+   * dead grant recorded as `provider_error` is indistinguishable from a vendor
+   * having a bad afternoon.
+   */
+  test('is recorded as needing re-auth, not as a provider error', async () => {
+    const { dispatcher, audit } = await ready(true);
+    await dispatcher.invoke(call);
+
+    const events = await audit.tail({});
+    expect(events[0]?.error?.kind).toBe('needs_reauth');
+  });
+
+  /** A refusal the retry *did* fix is an ordinary success, and says nothing. */
+  test('a token that was merely stale is not reported as either', async () => {
+    const { dispatcher, audit } = await ready(false);
+    const outcome = await dispatcher.invoke(call);
+
+    expect(outcome.ok).toBe(true);
+    const events = await audit.tail({});
+    expect(events[0]?.error).toBeUndefined();
+    expect(events[0]?.status).toBe('ok');
   });
 });

--- a/src/dispatch/reauthorize.test.ts
+++ b/src/dispatch/reauthorize.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from 'bun:test';
-import { responseVerifier } from './reauthorize.ts';
+import { reauthResult, responseVerifier } from './reauthorize.ts';
 
 /**
  * Who gets told that a call came back refused.
@@ -89,5 +89,85 @@ describe('a strategy that verifies its own replies', () => {
     expect(await verify(refused)).toEqual({ retry: true });
     expect(seen).toEqual([401]);
     expect(distrusted).toEqual(['gmail.con1']);
+  });
+});
+
+describe('telling a dead grant from a stale token', () => {
+  const verifier = (exhausted: string[]) =>
+    responseVerifier({
+      connectionKey: 'gmail.con1',
+      oauth: true,
+      distrust: () => {},
+      exhausted: (key) => exhausted.push(key),
+    })!;
+
+  /**
+   * The first refusal says nothing. A token can be stale for reasons that fix
+   * themselves, and usually is — reporting it would turn every recovered call
+   * into an instruction to go and reconnect something that is working.
+   */
+  test('a first refusal is not reported, because a retry may still fix it', async () => {
+    const exhausted: string[] = [];
+
+    expect(await verifier(exhausted)(refused)).toEqual({ retry: true });
+    expect(exhausted).toEqual([]);
+  });
+
+  /**
+   * The second one says everything. The token being presented is the one the
+   * refresh just produced, so what is being refused is the grant.
+   */
+  test('a refusal that outlived the refresh is reported', async () => {
+    const exhausted: string[] = [];
+    const verify = verifier(exhausted);
+
+    await verify(refused);
+    await verify(refused);
+
+    expect(exhausted).toEqual(['gmail.con1']);
+  });
+
+  test('and it is not asked to retry a second time', async () => {
+    const verify = verifier([]);
+
+    await verify(refused);
+    expect(await verify(refused)).toBeUndefined();
+  });
+
+  test('a call that recovered reports nothing', async () => {
+    const exhausted: string[] = [];
+    const verify = verifier(exhausted);
+
+    await verify(refused);
+    await verify(fine);
+
+    expect(exhausted).toEqual([]);
+  });
+});
+
+describe('what a dead grant is said to be', () => {
+  const vendor = {
+    content: [{ type: 'text' as const, text: '401 Unauthorized\n{"error":"invalid_grant"}' }],
+    isError: true,
+  };
+
+  test('names the connection, and says retrying will not help', async () => {
+    const said = reauthResult('gmail.con1', vendor) as unknown as { content: { text: string }[] };
+
+    expect(said.content[0]?.text).toContain('gmail.con1');
+    expect(said.content[0]?.text).toContain('connected again');
+    expect(said.content[0]?.text).toContain('Retrying will not help');
+  });
+
+  /** The vendor's own words stay: they are the evidence for whoever debugs it. */
+  test("keeps what the vendor said, after what it means", async () => {
+    const said = reauthResult('gmail.con1', vendor) as unknown as {
+      content: { text: string }[];
+      isError: boolean;
+    };
+
+    expect(said.content).toHaveLength(2);
+    expect(said.content[1]?.text).toContain('invalid_grant');
+    expect(said.isError).toBe(true);
   });
 });

--- a/src/dispatch/reauthorize.ts
+++ b/src/dispatch/reauthorize.ts
@@ -1,4 +1,10 @@
-import type { VerifyOutcome } from '#connectivity';
+import type {
+  AuthStrategy,
+  AuthStrategyContext,
+  CapabilityResult,
+  ProviderManifest,
+  VerifyOutcome,
+} from '#connectivity';
 
 /**
  * Noticing that a call went out with a credential the vendor no longer accepts.
@@ -28,8 +34,46 @@ export interface VerifierOptions {
   readonly oauth: boolean;
   /** Stop trusting this connection's token. */
   readonly distrust: (connectionKey: string) => void;
+  /**
+   * A refusal that outlived the refresh, which means a person is needed.
+   *
+   * This is the only place the two are distinguishable. A 401 on the first
+   * attempt says nothing — a token can be stale for reasons that fix
+   * themselves, and usually is. The same answer to a *reissued* token says the
+   * grant itself is gone: revoked in the vendor's console, scopes withdrawn,
+   * the account removed. Everything downstream sees one 401 and cannot tell,
+   * because by then the retry has already happened.
+   */
+  readonly exhausted?: ((connectionKey: string) => void) | undefined;
   /** The strategy's own verifier, where the vendor signs its replies. */
   readonly strategy?: ((response: Response) => Promise<VerifyOutcome | void>) | undefined;
+}
+
+/**
+ * The verifier for one invocation, assembled from what the connection is.
+ *
+ * Here rather than at the call site because every input is about credentials
+ * and none is about dispatch: which caches hold this connection's token, which
+ * auth kinds can be renewed without a person, and whether the vendor signs its
+ * replies. `invoke` should name the connection and be handed the check.
+ */
+export function verifierFor(options: {
+  readonly connectionKey: string;
+  readonly manifest: ProviderManifest;
+  readonly strategy: AuthStrategy | undefined;
+  readonly context: () => AuthStrategyContext;
+  readonly distrust: (connectionKey: string) => void;
+  readonly exhausted: (connectionKey: string) => void;
+}): ((response: Response) => Promise<VerifyOutcome | void>) | undefined {
+  const verify = options.strategy?.verify?.bind(options.strategy);
+
+  return responseVerifier({
+    connectionKey: options.connectionKey,
+    oauth: options.manifest.auth.kind === 'oauth',
+    distrust: options.distrust,
+    exhausted: options.exhausted,
+    ...(verify ? { strategy: (response: Response) => verify(response, options.context()) } : {}),
+  });
 }
 
 export function responseVerifier(
@@ -45,10 +89,41 @@ export function responseVerifier(
     const outcome = await strategy?.(response);
     if (outcome?.retry) return outcome;
 
-    if (response.status !== 401 || asked) return outcome ?? undefined;
+    if (response.status !== 401) return outcome ?? undefined;
+
+    // Asked once already, and refused again with the token that refresh
+    // produced. Reported rather than retried: a second retry would spend
+    // another call to be told the same thing.
+    if (asked) {
+      options.exhausted?.(options.connectionKey);
+      return outcome ?? undefined;
+    }
 
     asked = true;
     options.distrust(options.connectionKey);
     return { retry: true };
   };
+}
+
+/**
+ * The same failure, said to the party that can act on it.
+ *
+ * What the vendor returns for a dead grant is written for whoever is reading
+ * its logs: `invalid_grant`, `UNAUTHENTICATED`, a link to a console. An agent
+ * holding that cannot tell it from the transient case it has no part in, and
+ * the honest instruction — stop retrying, ask the owner to reconnect — appears
+ * nowhere in it. Prepended rather than replacing, because the vendor's own
+ * words are still the evidence for anyone debugging it.
+ */
+export function reauthResult(connectionKey: string, result: unknown): CapabilityResult {
+  const said =
+    `${connectionKey} needs to be connected again: the credential was refused, renewed, and ` +
+    'refused again, so this is a grant that has ended rather than a token that went stale. ' +
+    'Retrying will not help. The owner reconnects it in a terminal; this endpoint cannot.';
+
+  const blocks = (result as { content?: unknown[] }).content ?? [];
+  return {
+    content: [{ type: 'text' as const, text: said }, ...blocks],
+    isError: true,
+  } as CapabilityResult;
 }

--- a/src/dispatch/redaction.ts
+++ b/src/dispatch/redaction.ts
@@ -1,0 +1,28 @@
+import { keepKeys, redactAllValues } from '#audit';
+import type { ProviderManifest } from '#connectivity';
+
+/**
+ * What an invocation's arguments look like once they are in the audit log.
+ *
+ * Its own file because it answers a different question from the one the
+ * dispatcher is asking. `invoke` decides whether a call may happen; this
+ * decides what is written down about it either way — which is why it runs
+ * before the allow/deny branch rather than after, so a denial is recorded with
+ * the same redaction an allowed call would have got.
+ *
+ * Two sources, one precedence. A capability we authored carries its own rule
+ * and knows what is sensitive in its own arguments. A discovered one cannot: we
+ * did not write it, so the default withholds every value and a manifest opts
+ * specific keys back in by name.
+ */
+export function auditArgumentsFor(input: {
+  readonly manifest: ProviderManifest;
+  readonly name: string | undefined;
+  readonly own: ((args: Record<string, unknown>) => Record<string, unknown>) | undefined;
+  readonly arguments: Record<string, unknown>;
+}): Record<string, unknown> {
+  const declaredKeys = input.manifest.redact?.[input.name ?? ''];
+  const redact = input.own ?? (declaredKeys ? keepKeys(...declaredKeys) : undefined);
+
+  return (redact ?? redactAllValues)(input.arguments);
+}

--- a/src/providers/google/gmail/send.test.ts
+++ b/src/providers/google/gmail/send.test.ts
@@ -584,3 +584,60 @@ describe('a file this profile keeps', () => {
     expect(calls).toHaveLength(0);
   });
 });
+
+describe('a credential the vendor refuses mid-send', () => {
+  /**
+   * This capability is authored, so it calls Gmail itself and skipped the one
+   * thing every transported call gets: a refused token being distrusted. Left
+   * as it was, a send that came back 401 left that token trusted for the rest
+   * of the hour — and sending is exactly where an agent then retries.
+   */
+  const refusing = () => {
+    const seen: number[] = [];
+    const capability = gmailSend({
+      fetch: (async () =>
+        new Response('{"error":{"code":401,"message":"Invalid Credentials"}}', {
+          status: 401,
+          statusText: 'Unauthorized',
+        })) as never,
+    });
+
+    const harness = harnessFor(
+      defineProviderWithCapabilities({ manifest: manifestOf(gmail), capabilities: [capability] }),
+      'main',
+      { verify: async (response) => void seen.push(response.status) },
+    );
+
+    return { seen, harness };
+  };
+
+  test('is handed back for the same check a transported reply gets', async () => {
+    const { seen, harness } = refusing();
+
+    const result = await harness.invoke('send_message', {
+      to: ['ada.lovelace@example.com'],
+      subject: 'x',
+      text: 'y',
+    });
+
+    expect((result as ToolResult).isError).toBe(true);
+    expect(seen).toEqual([401]);
+  });
+
+  /**
+   * Distrust without retry, and the asymmetry is deliberate: a send that was
+   * refused may still have been delivered, so repeating it is not a decision
+   * this layer gets to make. The connection is repaired for the *next* call.
+   */
+  test('and the send is not repeated', async () => {
+    const { seen, harness } = refusing();
+
+    await harness.invoke('send_message', {
+      to: ['ada.lovelace@example.com'],
+      subject: 'x',
+      text: 'y',
+    });
+
+    expect(seen).toHaveLength(1);
+  });
+});

--- a/src/providers/google/gmail/send.ts
+++ b/src/providers/google/gmail/send.ts
@@ -256,6 +256,28 @@ export const gmailSendMessage = gmailSend();
  * `uploadType=media`, no multipart assembly, no resumable session — which is what
  * lifts the ceiling from "what fits in a JSON string" to Gmail's own 35 MiB.
  */
+/**
+ * Hand a refusal back for the credential check a transport's reply would get.
+ *
+ * This capability is authored because no OpenAPI document describes composing
+ * an RFC 2822 message, and calling the vendor directly meant skipping the one
+ * thing every other call gets for free: a token the vendor refuses is
+ * distrusted, so the next call renews it instead of resending it for the rest
+ * of the hour.
+ *
+ * Distrust without retry, deliberately. `verify` may answer `{ retry: true }`
+ * and that is right for a read; a send that came back 401 may still have been
+ * delivered, and deciding to repeat it is not this function's to make. The
+ * outcome is dropped on purpose — what is wanted is the connection repaired
+ * for the call after this one.
+ *
+ * Cloned before the body is read, because a response cannot be cloned once it
+ * has been.
+ */
+async function noteRefusal(context: ProviderContext, refused: Response | undefined): Promise<void> {
+  if (refused) await context.verify?.(refused);
+}
+
 async function submit(input: {
   readonly raw: Uint8Array;
   readonly draftOnly: boolean;
@@ -298,9 +320,13 @@ async function submit(input: {
   );
 
   const response = await input.fetch(request);
+  // Cast as the http transport does: the fetch types and the global Response
+  // disagree about `headers`, and the verifier reads neither.
+  const refused = response.ok ? undefined : (response.clone() as unknown as Response);
   const text = await response.text();
 
   if (!response.ok) {
+    await noteRefusal(context, refused);
     throw new Error(`Gmail refused the message with ${response.status}: ${text}`);
   }
 
@@ -334,9 +360,13 @@ async function sendDraft(input: {
   );
 
   const response = await input.fetch(request);
+  // Cast as the http transport does: the fetch types and the global Response
+  // disagree about `headers`, and the verifier reads neither.
+  const refused = response.ok ? undefined : (response.clone() as unknown as Response);
   const text = await response.text();
 
   if (!response.ok) {
+    await noteRefusal(input.context, refused);
     throw new Error(`Gmail refused to send the draft with ${response.status}: ${text}`);
   }
 

--- a/src/providers/harness.ts
+++ b/src/providers/harness.ts
@@ -9,6 +9,7 @@ import type {
   ConnectorContext,
   ProviderContext,
   ProviderDefinition,
+  VerifyOutcome,
 } from '#connectivity';
 
 /**
@@ -37,7 +38,11 @@ export function harnessFor(
    * import `#dispatch`, and a provider only ever sees the two closures anyway.
    * `src/dispatch/attachments.test.ts` is what tests the real one.
    */
-  options: { attachments?: AttachmentBridge } = {},
+  options: {
+    attachments?: AttachmentBridge;
+    /** The reply check the runtime binds, for a provider that calls its vendor itself. */
+    verify?: (response: Response) => Promise<VerifyOutcome | void>;
+  } = {},
 ): ProviderHarness {
   const annotations: Record<string, unknown> = {};
 
@@ -64,6 +69,7 @@ export function harnessFor(
     // The runtime hands this to any provider that is not `local`, so a provider
     // authoring a capability against its own vendor's API has it here too.
     authorize: async (request) => request,
+    ...(options.verify ? { verify: options.verify } : {}),
     ...(options.attachments ? { attachments: options.attachments } : {}),
   });
 


### PR DESCRIPTION
#209 taught this endpoint that a token the vendor refuses must be distrusted rather than resent for
an hour. It reached **one transport and one cache**. This finishes it, and answers the half of the
client's report #209 did not: telling "retry later" from "the owner must reconnect".

## A 401 that outlived its refresh is now said plainly

The verifier is the only place the two are distinguishable — on the second call the credential being
refused is the one the refresh just produced. Everything downstream sees one 401, by which time the
evidence has been spent.

It reports that now. The result names the connection and says retrying will not help, keeping the
vendor's own words underneath as evidence for whoever debugs it. The audit row carries
`error.kind: 'needs_reauth'` rather than `provider_error`, so *how often is this happening* becomes
answerable. A `ReauthRequired` thrown from refresh keeps its identity through the catch for the same
reason — it already knew, and was being flattened.

**The retried response is verified too**, which is what makes any of this possible. It was not, so
the second refusal was never seen by anything: the distinction existed in principle and could not be
drawn in practice. The integration test found this; the unit test passed either way, which is the
honest argument for having written both.

## Three places a refusal could not be noticed at all

| | why it was invisible |
|---|---|
| `gmail.send_message` | Authored because no OpenAPI document describes composing RFC 2822, so it calls the vendor itself and skipped the check every transported call gets |
| the `mcp` transport | No `Response` to read — the client library turns a 401 into an exception. **77 of ~105 providers**, the largest share of the estate |
| service-account connections | Cache in `oauth-jwt` and nowhere else; `distrustUpstreamToken` never touched that map |

`ProviderContext` now offers `verify` beside `authorize`, for the same reason it offers `authorize`
at all. On the send path it is **distrust without retry**, deliberately: a send refused with a 401
may still have been delivered, and repeating it is not this layer's decision to make. The connection
is repaired for the *next* call.

For `mcp`, `UnauthorizedError` is the library's own answer and is brand-based, so it survives two
copies of the package in one process. Matching on message text was the alternative, and that is a
guess.

Both service-account and authorization-code connections arrive through `auth.kind: 'oauth'` — an
assertion is an optional second way into the same block — so the layer seeing the 401 cannot tell
them apart and should not have to. `distrustConnectionToken` is the one entry point that knows both
halves exist.

## Also

`AuthStrategy.verify` was declared `Promise<void>` while the composing verifier already read `retry`
off it, so a strategy could not legally ask for the retry the code was prepared to give it.

Two extractions, both forced by the 400-line budget and both real seams. `redaction.ts` answers what
is *written down* about a call rather than whether it may happen — which is why it always ran before
the allow/deny branch. `verifierFor` moved beside the rules it assembles: every input is about
credentials, none is about dispatch.

## Checks

`bun test` 3537 pass, 0 fail (3520 before). `bun run typecheck` clean. Every file inside the budget.

## Not covered, and why

Discovery has no verifier: a `DiscoveryContext` carries none, because discovery is not a call anyone
made. A token refused there surfaces as the provider having no capabilities, which is a different
problem. Recorded in `refused.ts`.

The `mcp` retry is not taken either — that connector opens a client, calls, and closes it, so
honouring one means running all of it again. Worth doing, larger than telling the truth about the
token.