### PR TITLE
chore: 0.14.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lanes-sh/link",
-  "version": "0.13.0",
+  "version": "0.14.0",
   "description": "A self-hostable MCP gateway for all your connections, memory, tasks, files, and secrets",
   "license": "Apache-2.0",
   "homepage": "https://lanes.sh/link",


### PR DESCRIPTION
Sets the version on `develop` before the release pull request, which is what makes this a declared
minor rather than the proposed patch the workflow would otherwise open. #213 and #215 both change
what a client receives, not only what happens inside.

**#213 — expansion fills in a compact record.** A list that comes back as bare identifiers is filled
in before it is returned. Until now that was five rows at whatever representation the vendor
defaults to — for a mailbox, 193,271 characters, with two further rows discarded along with the
identifiers a caller would have needed to fetch them. The bound is bytes now, rows are filled in at
a projection the provider declares, and every identifier survives. Measured against a real mailbox:
the same message is **77,857** characters at the vendor's default and **904** at the declared
projection.

`expand` widens from a boolean to `false | 'compact' | 'full'`. The boolean it shipped as is still
accepted and no longer advertised, because a client that pinned its tool list at registration cannot
be told otherwise (ADR-032).

**#215 — a refused credential is distrusted everywhere.** 0.13.0 stopped one transport resending a
token the vendor had already refused. This reaches the three places it still could not be noticed —
an authored send path, the `mcp` transport, and the service-account token cache — and adds the
distinction none of them had: a 401 that outlives its own refresh is a grant that has ended rather
than a token that went stale. It is now said so in the result and recorded as `needs_reauth` in the
audit row.

## Compatibility

`compact` is a new optional manifest key, so every profile and manifest written before this loads
unchanged. The `expand` argument accepts everything it accepted before.

## Checks

`bun test` 3581 pass, 0 fail. `bun run typecheck` clean. The bump touches `package.json` only.