### PR TITLE
0.14.0

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -243,6 +243,17 @@ It is a data change, not code: an entry in `SELECTION` in
   (`https://sheets.googleapis.com` + `/v4/spreadsheets/...`). Copying the wrong one 404s every
   call.
 
+A read capability the gateway may *fill in* needs a `compact` block, and it is the third record
+keyed the same way as `redact` and `hints` — so it carries the same trap, one step quieter. When a
+list comes back as bare identifiers, `lanes_tools_call` fetches the rows before returning them, and
+without a `compact` entry it does so at whatever the vendor's default representation is. For Gmail
+that was `format=full` — five messages, 193,271 characters, and an overflowed reply. `compact` names
+the vendor's *own* projection arguments (`format`, `metadataHeaders`, `fields`, `$select`), because
+the saving has to happen at the source. A key that misses does not error; it asks for the default and
+reads exactly like working expansion. Two tests in `specs.test.ts` hold it: every key names a real
+capability, and every argument it names is a real parameter of that capability. Only a `<x>.list`
+with an `<x>.get` beside it can ever reach this, which across the vendored surface is seven pairs.
+
 New write capabilities need a `redact` block on the manifest. The default withholds every
 value, which makes a write log useless — it records that something changed without recording
 what. Keep identifiers, withhold the user's content.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lanes-sh/link",
-  "version": "0.13.0",
+  "version": "0.14.0",
   "description": "A self-hostable MCP gateway for all your connections, memory, tasks, files, and secrets",
   "license": "Apache-2.0",
   "homepage": "https://lanes.sh/link",

--- a/src/cli/commands/operate/pair.test.ts
+++ b/src/cli/commands/operate/pair.test.ts
@@ -1,6 +1,6 @@
-import { describe, expect, test } from 'bun:test';
+import { afterAll, describe, expect, test } from 'bun:test';
 import { isValidSecretRef } from '#secrets';
-import { pairingLink, PAIR_CERT_REF, PAIR_KEY_REF, PAIR_TOKEN_REF } from './pair.ts';
+import { pair, pairingLink, PAIR_CERT_REF, PAIR_KEY_REF, PAIR_TOKEN_REF } from './pair.ts';
 
 /**
  * The three references `lanes link pair` writes.
@@ -81,3 +81,164 @@ describe('the pairing link', () => {
     expect(raw).toContain('at=https%3A%2F%2F127.0.0.1%3A7401');
   });
 });
+
+/**
+ * Which endpoint a workspace is paired at, when its profiles do not agree on a
+ * port.
+ *
+ * The port refusal is right on loopback and was wrong everywhere else, because
+ * it was asked before the thing that decides the address. A deployed workspace
+ * is reached at the URL the platform assigned it — one service, in front of
+ * every profile in the workspace — and `instance.port` is not part of that URL,
+ * is not what the revision binds, and is not consulted anywhere on that path.
+ * Two profiles created on different days therefore refused to pair at all, and
+ * the `--profile` the refusal demanded settled nothing: both answers produce
+ * the same link, which is the assertion below that says why this is a bug
+ * rather than a preference.
+ *
+ * These run `pair` itself rather than a helper, because the defect was an
+ * ordering between two checks and neither check is wrong in isolation.
+ */
+
+const homes: string[] = [];
+const previousHome = process.env['LANES_LINK_HOME'];
+
+/**
+ * A workspace holding two profiles on different ports.
+ *
+ * `edge` declares a deployment and keeps the *file* adapters, which is not a
+ * combination a real deploy produces and is deliberate here: the target's
+ * cloud adapters have nothing to do with what is being tested, and reaching
+ * Secret Manager to assert an ordering would make this a test of the network.
+ *
+ * `LANES_LINK_HOME` is set before anything calls `pair`, and that is not
+ * hygiene. `resolveWorkspaceRoot` falls back to `~/.lanes-link` when nothing
+ * names a root — so a test that forgot this would mint a pairing token into
+ * whoever ran it's real workspace.
+ */
+async function twoProfiles(ports: Record<string, number>): Promise<string> {
+  const { mkdtemp, writeFile } = await import('node:fs/promises');
+  const { tmpdir } = await import('node:os');
+  const { join } = await import('node:path');
+  const { SUPPORTED_CONTRACT } = await import('#profile');
+  const { writeProfileFixture } = await import('#profile/testing.ts');
+
+  const root = await mkdtemp(join(tmpdir(), 'lanes-link-pair-'));
+  homes.push(root);
+  process.env['LANES_LINK_HOME'] = root;
+
+  await writeFile(
+    join(root, 'workspaces.yaml'),
+    `contract: ${SUPPORTED_CONTRACT}\n` +
+      'workspaces:\n' +
+      '  here:\n' +
+      '    credentials: { adapter: file }\n' +
+      '    storage: { adapter: filesystem }\n' +
+      '  edge:\n' +
+      '    credentials: { adapter: file }\n' +
+      '    storage: { adapter: filesystem }\n' +
+      '    deploy:\n' +
+      '      platform: cloudrun\n' +
+      '      project: my-project\n' +
+      '      region: europe-west1\n' +
+      '      service: my-service\n',
+  );
+
+  for (const [profile, port] of Object.entries(ports)) {
+    await writeProfileFixture(
+      root,
+      profile,
+      `contract: ${SUPPORTED_CONTRACT}\n` +
+        `instance: { profile: ${profile}, port: ${port}, host: 127.0.0.1 }\n`,
+    );
+  }
+
+  return root;
+}
+
+/** The address `pair` is told the platform assigned, instead of asking it. */
+const DEPLOYED = { address: async () => 'https://link.example.test/mcp' };
+
+/** Everything written to stdout while `body` runs. */
+async function captureStdout(body: () => Promise<void>): Promise<string> {
+  const original = process.stdout.write.bind(process.stdout);
+  let captured = '';
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (process.stdout as any).write = (chunk: string | Uint8Array): boolean => {
+    captured += typeof chunk === 'string' ? chunk : new TextDecoder().decode(chunk);
+    return true;
+  };
+
+  try {
+    await body();
+  } finally {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (process.stdout as any).write = original;
+  }
+
+  return captured;
+}
+
+afterAll(async () => {
+  const { rm } = await import('node:fs/promises');
+  if (previousHome === undefined) delete process.env['LANES_LINK_HOME'];
+  else process.env['LANES_LINK_HOME'] = previousHome;
+  await Promise.all(homes.map((root) => rm(root, { recursive: true, force: true })));
+});
+
+describe('pairing a workspace whose profiles disagree on a port', () => {
+  test('deployed, it pairs without being told which profile', async () => {
+    await twoProfiles({ personal: 7337, projects: 7338 });
+
+    const printed = await captureStdout(async () => {
+      await pair({ target: 'edge' }, DEPLOYED);
+    });
+
+    expect(printed).toContain('at=https%3A%2F%2Flink.example.test');
+    expect(printed).not.toContain('do not agree on a port');
+  });
+
+  test('deployed, naming a profile changes nothing about the link', async () => {
+    // The whole of the argument. A refusal that can be settled by either answer
+    // was not resolving an ambiguity; it was asking a question with no bearing
+    // on the outcome, and stopping until it got one.
+    await twoProfiles({ personal: 7337, projects: 7338 });
+
+    const first = await captureStdout(async () => {
+      await pair({ target: 'edge', profile: 'personal' }, DEPLOYED);
+    });
+    const second = await captureStdout(async () => {
+      await pair({ target: 'edge', profile: 'projects' }, DEPLOYED);
+    });
+
+    expect(link(first)).toBe(link(second));
+  });
+
+  test('deployed, a profile the workspace does not hold is still refused', async () => {
+    // `--profile` decides nothing here, which is not the same as meaning
+    // nothing: a name that is not in the workspace is a typo either way, and
+    // accepting it silently would teach that the flag was read.
+    await twoProfiles({ personal: 7337, projects: 7338 });
+
+    await expect(pair({ target: 'edge', profile: 'personel' }, DEPLOYED)).rejects.toThrow(
+      'has no profile "personel"',
+    );
+  });
+
+  test('on loopback, the ambiguity is real and is still refused', async () => {
+    // The guard on the fix. Here the port *is* the address — the read listener
+    // sits one above `instance.port` — so picking one of two would pair a
+    // dashboard to an endpoint that is not the one being run.
+    await twoProfiles({ personal: 7337, projects: 7338 });
+
+    await expect(pair({ target: 'here' }, DEPLOYED)).rejects.toThrow('do not agree on a port');
+  });
+});
+
+/** The pairing link out of a captured run, so two runs can be compared. */
+function link(printed: string): string {
+  const found = printed.match(/https?:\/\/\S*#pair=\S+/);
+  expect(found).not.toBeNull();
+  return found![0];
+}

--- a/src/cli/commands/operate/pair.ts
+++ b/src/cli/commands/operate/pair.ts
@@ -54,7 +54,12 @@ import { openSecretStoreFor, type GlobalFlags } from '../../runtime.ts';
  * and the credential it mints reads all of them — so asking which profile was
  * asking a question with no answer, and implying a per-profile pairing that does
  * not exist. `--profile` is still accepted, and picks the port when profiles
- * disagree about one.
+ * disagree about one *and a port is what the address is built from*. Deployed,
+ * it is not: the platform assigns one address for the whole workspace, so the
+ * flag decides nothing there and is not asked for. It was asked for, for one
+ * release — the ports were compared before the deployment was, so a cloud
+ * workspace whose profiles had been created on different days refused to pair
+ * at all, and the flag that unblocked it produced the same link either way.
  */
 
 /**
@@ -86,6 +91,18 @@ export interface PairDeps {
   readonly run?: (command: readonly string[]) => Promise<string | null>;
   readonly confirm?: (question: string) => Promise<boolean>;
   readonly interactive?: boolean;
+  /**
+   * Where the platform put this workspace's service.
+   *
+   * Injected for the same reason `which` and `run` are: the deployed path
+   * otherwise reaches a driver, a subprocess and a live project, and the
+   * decisions worth asserting on here — that no port is consulted, that the
+   * link carries the platform's address — are all upstream of that. Defaults
+   * to asking the platform, which is what every real run does.
+   */
+  readonly address?: (
+    deploy: NonNullable<ResolvedTarget['declared']['deploy']>,
+  ) => Promise<string | null>;
 }
 
 export async function pair(flags: PairFlags, deps: PairDeps = {}): Promise<void> {
@@ -101,11 +118,6 @@ export async function pair(flags: PairFlags, deps: PairDeps = {}): Promise<void>
     );
   }
 
-  // One endpoint serves every profile in a workspace, so they normally agree on
-  // a port and the choice is not a choice. Where they do not, the ambiguity is
-  // real and `--profile` is how it is settled — refused rather than guessed,
-  // because pairing the wrong port produces a dashboard that says "not
-  // connected" with everything working.
   const named = flags.profile
     ? profiles.find((one: LoadedProfile) => one.profile === flags.profile)
     : undefined;
@@ -117,6 +129,39 @@ export async function pair(flags: PairFlags, deps: PairDeps = {}): Promise<void>
     );
   }
 
+  // A workspace that declares a deployment is paired over the address the
+  // platform gave it, not over loopback — which is what `declared.deploy`
+  // answers and what `instance.host` does not: a deployed revision takes its
+  // host from the container's environment, so a profile bound to `127.0.0.1`
+  // in config is still serving `0.0.0.0` on Cloud Run.
+  //
+  // **Decided before any port is looked at**, because on this path there is no
+  // port to look at. The address comes from the platform, one service answers
+  // for the whole workspace, and `instance.port` reaches neither. Asked after
+  // the ports were compared, this refused a perfectly unambiguous pairing for
+  // two profiles that had merely been created on different days — and the
+  // `--profile` it demanded settled nothing, since both answers produce the
+  // same link. A question whose answer cannot change the outcome is not a
+  // question.
+  if (resolved.declared.deploy) {
+    await pairDeployed({
+      flags,
+      target,
+      chosen: named ?? profiles[0]!,
+      root,
+      credentials: await openSecretStoreFor(root, target),
+      deploy: resolved.declared.deploy,
+      address: deps.address ?? deployedUrl,
+    });
+    return;
+  }
+
+  // Loopback, where the port *is* the address. One endpoint serves every
+  // profile in a workspace, so they normally agree on a port and the choice is
+  // not a choice. Where they do not, the ambiguity is real and `--profile` is
+  // how it is settled — refused rather than guessed, because pairing the wrong
+  // port produces a dashboard that says "not connected" with everything
+  // working.
   const ports = new Set(profiles.map((one: LoadedProfile) => one.config.instance.port));
   if (!named && ports.size > 1) {
     throw new ConfigError(
@@ -131,16 +176,6 @@ export async function pair(flags: PairFlags, deps: PairDeps = {}): Promise<void>
   const chosen = named ?? profiles[0]!;
   const host = chosen.config.instance.host;
   const credentials = await openSecretStoreFor(root, target);
-
-  // A workspace that declares a deployment is paired over the address the
-  // platform gave it, not over loopback — which is what `declared.deploy`
-  // answers and what `instance.host` does not: a deployed revision takes its
-  // host from the container's environment, so a profile bound to `127.0.0.1`
-  // in config is still serving `0.0.0.0` on Cloud Run.
-  if (resolved.declared.deploy) {
-    await pairDeployed({ flags, target, chosen, root, credentials, deploy: resolved.declared.deploy });
-    return;
-  }
 
   if (!isLoopback(host)) {
     // Not deployed, and not on this machine either. There is no certificate
@@ -232,14 +267,16 @@ async function pairDeployed(input: {
   root: string;
   credentials: SecretStore;
   deploy: NonNullable<ResolvedTarget['declared']['deploy']>;
+  address: (deploy: NonNullable<ResolvedTarget['declared']['deploy']>) => Promise<string | null>;
 }): Promise<void> {
   const { flags, target, chosen, root, credentials } = input;
 
-  // `deployedUrl` asks the platform where the service ended up and degrades to
-  // null for every reason that is not this command's business — no driver, not
-  // deployed yet, no credentials for the project. A link with no address in it
-  // reads nothing, so this refuses rather than printing half of one.
-  const mcpUrl = await deployedUrl(input.deploy);
+  // `deployedUrl`, unless a test named something else, asks the platform where
+  // the service ended up and degrades to null for every reason that is not this
+  // command's business — no driver, not deployed yet, no credentials for the
+  // project. A link with no address in it reads nothing, so this refuses rather
+  // than printing half of one.
+  const mcpUrl = await input.address(input.deploy);
   if (mcpUrl === null) {
     throw new ConfigError(
       `Could not find the address of "${target}".\n` +

--- a/src/cli/instructions.test.ts
+++ b/src/cli/instructions.test.ts
@@ -3,7 +3,7 @@ import type { Flags } from './argv.ts';
 import { ASSETS, readAsset } from './commands/mcp/assets.ts';
 import { assertKnownFlags, requirementFor, selectionKey } from './selection.ts';
 import { PROGRAM, usage } from './usage.ts';
-import { RESERVED_PROVIDER_IDS } from '#connectivity/manifest/provider.ts';
+import { RESERVED_PROVIDER_IDS } from '#connectivity/manifest/owner-ids.ts';
 
 /**
  * The documents we install into someone's agent must describe this CLI.

--- a/src/cli/selection.ts
+++ b/src/cli/selection.ts
@@ -210,7 +210,10 @@ export const SELECTION: Record<string, Requires> = {
   // What it pairs is the workspace: the surface it opens lists every connection
   // and profile there, and the credential it mints reads all of them. Asking
   // which profile was a question with no answer. `--profile` still narrows, and
-  // is how a port is chosen when profiles disagree about one.
+  // is how a port is chosen when profiles disagree about one *and* a port is
+  // what the address is built from — which is loopback only. A deployed
+  // workspace has one address for the whole of it, so the flag decides nothing
+  // there and is not asked for.
   pair: 'workspace',
   'token show': 'workspace',
   'token rotate': 'workspace',

--- a/src/connectivity/auth/distrust.ts
+++ b/src/connectivity/auth/distrust.ts
@@ -1,0 +1,23 @@
+import { distrustUpstreamToken } from './oauth-authcode/provider.ts';
+import { distrustMintedToken } from './oauth-jwt/index.ts';
+
+/**
+ * Stop trusting a connection's access token, wherever it is being remembered.
+ *
+ * A connection is keyed `<provider>.<connection>` in both token caches, and
+ * which one holds it is a property of how the credential was obtained rather
+ * than of anything the caller did: an authorization-code grant caches under
+ * `oauth-authcode`, a service-account key under `oauth-jwt`. Both are reached
+ * through the same manifest `auth.kind: 'oauth'`, because an assertion is an
+ * optional second way in to the same block — so the layer that sees a 401
+ * cannot tell them apart, and should not have to.
+ *
+ * Its own file rather than a line in the barrel, because it is the one place
+ * that has to know both halves exist. Missing the second half is what left a
+ * service-account connection resending a refused token for an hour while the
+ * connection beside it recovered.
+ */
+export function distrustConnectionToken(connectionKey: string): void {
+  distrustUpstreamToken(connectionKey);
+  distrustMintedToken(connectionKey);
+}

--- a/src/connectivity/auth/index.ts
+++ b/src/connectivity/auth/index.ts
@@ -19,6 +19,7 @@
 
 export { credentialResolver, type ResolvedCredential } from './resolve.ts';
 export { requestAuthorizer } from './authorize.ts';
+export { distrustConnectionToken } from './distrust.ts';
 export { ReauthRequired, statusMeansGrantIsDead } from './reauth.ts';
 export { basicCredential } from './basic/index.ts';
 export { bearerToken, bearerTokenAsStored } from './token.ts';
@@ -33,6 +34,7 @@ export { resolveUpstreamToken } from './oauth-authcode/index.ts';
 export {
   ASSERTION_GRANT,
   clearMintedTokens,
+  distrustMintedToken,
   isStoredAssertion,
   resolveAssertionToken,
   storedAssertionFor,

--- a/src/connectivity/auth/oauth-jwt/index.ts
+++ b/src/connectivity/auth/oauth-jwt/index.ts
@@ -118,6 +118,23 @@ export function clearMintedTokens(): void {
   minted.clear();
 }
 
+/**
+ * Stop trusting this connection's minted token.
+ *
+ * Simpler than the authorization-code side, and for a reason worth stating: the
+ * only thing that remembers a token here is the map above. There is no stored
+ * blob carrying an `expires_at` for a later call to read and believe, so there
+ * is nothing to mark skippable — dropping the entry *is* the distrust, and the
+ * next call signs a fresh assertion.
+ *
+ * Without this a service-account connection was the one arrangement that kept
+ * the behaviour the 401 handling was written to remove: a token the vendor had
+ * already refused, resent until the clock aged it out.
+ */
+export function distrustMintedToken(connectionKey: string): void {
+  minted.delete(connectionKey);
+}
+
 interface TokenResponse {
   readonly access_token?: string;
   readonly expires_in?: number;

--- a/src/connectivity/auth/oauth-jwt/oauth-jwt.test.ts
+++ b/src/connectivity/auth/oauth-jwt/oauth-jwt.test.ts
@@ -1,10 +1,12 @@
 import { describe, expect, test, beforeEach } from 'bun:test';
 import { defineProvider, type ProviderManifest } from '#connectivity';
+import { distrustConnectionToken } from '../distrust.ts';
 import { parseAssertionKey, signAssertion } from './key.ts';
 import {
   ASSERTION_GRANT,
   clearMintedTokens,
   isStoredAssertion,
+  distrustMintedToken,
   resolveAssertionToken,
   storedAssertionFor,
 } from './index.ts';
@@ -276,6 +278,63 @@ describe('the exchange', () => {
     expect(await mint()).toBe('minted-1');
     expect(await mint()).toBe('minted-1');
     expect(calls).toBe(1);
+  });
+
+  /**
+   * The arrangement that kept the old behaviour after the 401 handling landed.
+   * A service-account connection caches here and nowhere else, so a distrust
+   * that only reached the authorization-code caches left it resending a token
+   * the vendor had already refused until the clock aged it out.
+   */
+  test('mints again once the vendor has refused what was cached', async () => {
+    const { manifest, secrets, stored } = await fixture();
+    let calls = 0;
+
+    const mint = () =>
+      resolveAssertionToken({
+        manifest,
+        connectionId: 'main',
+        stored,
+        credentials: secrets,
+        fetch: (async () => {
+          calls += 1;
+          return Response.json({ access_token: `minted-${calls}`, expires_in: 3600 });
+        }) as unknown as typeof fetch,
+      });
+
+    expect(await mint()).toBe('minted-1');
+
+    // Through the combined entry point the dispatcher actually calls, not the
+    // half of it this file owns: reaching only one cache was the defect.
+    distrustConnectionToken('vendor_thing.main');
+    expect(await mint()).toBe('minted-2');
+    expect(calls).toBe(2);
+  });
+
+  /** Keyed per connection, so distrusting one leaves its sibling alone. */
+  test('one connection being refused does not disturb another', async () => {
+    const { manifest, secrets, stored } = await fixture();
+    let calls = 0;
+
+    const mint = (connectionId: string) =>
+      resolveAssertionToken({
+        manifest,
+        connectionId,
+        stored,
+        credentials: secrets,
+        fetch: (async () => {
+          calls += 1;
+          return Response.json({ access_token: `minted-${calls}`, expires_in: 3600 });
+        }) as unknown as typeof fetch,
+      });
+
+    expect(await mint('main')).toBe('minted-1');
+    expect(await mint('other')).toBe('minted-2');
+
+    distrustMintedToken('vendor_thing.main');
+
+    expect(await mint('other')).toBe('minted-2');
+    expect(await mint('main')).toBe('minted-3');
   });
 
   test('mints again once the cached token is close to expiring', async () => {

--- a/src/connectivity/connector.ts
+++ b/src/connectivity/connector.ts
@@ -174,8 +174,16 @@ export interface AuthStrategy {
   /** Per-request: sign it, add headers, refresh a session if one has expired. */
   authorize(request: Request, context: AuthStrategyContext): Promise<Request>;
 
-  /** Optional response check — bunq signs its replies and expects them verified. */
-  verify?(response: Response, context: AuthStrategyContext): Promise<void>;
+  /**
+   * Optional response check — bunq signs its replies and expects them verified.
+   *
+   * Returns the same outcome a connector's own verifier does, so a strategy
+   * that recognises a refused credential can ask for the one retry rather than
+   * only recording it. It was declared `Promise<void>` while the composing
+   * verifier already read `retry` off it, which made asking for one impossible
+   * to write down.
+   */
+  verify?(response: Response, context: AuthStrategyContext): Promise<VerifyOutcome | void>;
 }
 
 export interface AuthStrategyContext {

--- a/src/connectivity/context.ts
+++ b/src/connectivity/context.ts
@@ -1,6 +1,7 @@
 import type { AuditLogger } from '#audit';
 import type { ScopedSecrets } from '#secrets';
 import type { BlobStore } from '#stores/blobs';
+import type { VerifyOutcome } from './connector.ts';
 import type { AttachmentBridge } from './mail/attachments.ts';
 
 /**
@@ -92,6 +93,22 @@ export interface ProviderContext {
    * harness builds a context without one.
    */
   authorize?(request: Request): Promise<Request>;
+  /**
+   * Hand a vendor's reply back for the checks a connector's own reply gets.
+   *
+   * The companion to `authorize`, and offered for the same reason: a capability
+   * authored because the generic transport cannot express the call still has
+   * to be a normal call in every other respect. Chief among those is that a
+   * token the vendor refuses must be distrusted, or the next call sends it
+   * again — for as long as the stored clock still says it is valid.
+   *
+   * A caller may ignore the returned outcome, and one authoring a *write*
+   * should: `{ retry: true }` is safe for a read and not for a send, where the
+   * first attempt may well have been delivered. Distrusting without retrying
+   * still repairs the connection for the call after it, which is the part worth
+   * having.
+   */
+  verify?(response: Response): Promise<VerifyOutcome | void>;
   /**
    * The two file lookups this connection's own store cannot answer.
    *

--- a/src/connectivity/manifest/index.ts
+++ b/src/connectivity/manifest/index.ts
@@ -37,12 +37,8 @@ export { setupPromptSchema, setupSchema, type SetupDeclaration, type SetupPrompt
 export { READ_BUNDLE, WRITE_BUNDLE, bundleSchema, type ScopeBundle } from './bundles.ts';
 export { identitySchema, type IdentityDeclaration } from './identity.ts';
 export { credentialRefForConnection, rotatableCredentialRefs } from './credential-ref.ts';
-export {
-  RESERVED_PROVIDER_IDS,
-  defineProvider,
-  providerManifestSchema,
-  type ProviderManifest,
-} from './provider.ts';
+export { defineProvider, providerManifestSchema, type ProviderManifest } from './provider.ts';
+export { RESERVED_PROVIDER_IDS, RENAMED_OWNER_PROVIDERS } from './owner-ids.ts';
 
 export type { SetupRequirement, SetupNeeds } from './requirements.ts';
 export { hasOwnClientPath, setupRequirements, UNNAMED_ID } from './requirements.ts';

--- a/src/connectivity/manifest/manifest.test.ts
+++ b/src/connectivity/manifest/manifest.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from 'bun:test';
-import { credentialRefForConnection, defineProvider } from './index.ts';
+import { credentialRefForConnection, defineProvider, providerManifestSchema } from './index.ts';
 
 /**
  * Where a credential lives, which used to have two answers.
@@ -371,5 +371,36 @@ describe('connector headers may not carry the credential', () => {
         auth: { kind: 'bearer' },
       }),
     ).not.toThrow();
+  });
+});
+
+describe('a compact projection', () => {
+  const base = {
+    id: 'vendor_mail',
+    name: 'Vendor Mail',
+    connector: { kind: 'http' as const, base_url: 'https://api.example.com', openapi: '/tmp/x.json' },
+  };
+
+  test('is per capability, and holds the arguments a vendor takes', () => {
+    const manifest = providerManifestSchema.parse({
+      ...base,
+      compact: { 'messages.get': { format: 'metadata', metadataHeaders: ['From', 'Subject'] } },
+    });
+
+    expect(manifest.compact?.['messages.get']).toEqual({
+      format: 'metadata',
+      metadataHeaders: ['From', 'Subject'],
+    });
+  });
+
+  test('is optional, because most providers have nothing to say here', () => {
+    expect(providerManifestSchema.parse(base).compact).toBeUndefined();
+  });
+
+  /** A capability maps to a set of arguments, never to a single value. */
+  test('refuses a scalar where a projection belongs', () => {
+    expect(() =>
+      providerManifestSchema.parse({ ...base, compact: { 'messages.get': 'metadata' } }),
+    ).toThrow();
   });
 });

--- a/src/connectivity/manifest/owner-ids.ts
+++ b/src/connectivity/manifest/owner-ids.ts
@@ -1,0 +1,62 @@
+/**
+ * The owner layer's provider ids, and the map from what they used to be called.
+ *
+ * Their own file because `provider.ts` is a schema and the cross-field rules a
+ * schema cannot express, and these are neither — they are a fixed list of ids
+ * that happens to have been declared beside the thing that once reserved them.
+ * The budget in `architecture.test.ts` names exactly this as what earns a split:
+ * "something that is not a schema appearing beside them". It came out when a
+ * third per-capability record needed room next to `redact` and `hints`, and the
+ * file was at 400 lines to the line.
+ *
+ * Nothing about the values changed in the move, and every consumer reads them
+ * through `#connectivity` rather than this path.
+ */
+
+
+/**
+ * The owner layer's provider ids — Lanes' own surfaces.
+ *
+ * **`lanes_` on each, which is what stops them needing to be reserved.** They
+ * were `memory`, `tasks`, `assets`, `skills`, `vault`, `entities` — six of the
+ * most obvious words a vendor manifest might want, held back from every
+ * operator so the built-ins could have them. `buildRegistry` registers these
+ * before `PROVIDERS`, so a manifest claiming one threw at startup rather than
+ * being shadowed (ADR-051); the reservation is what made that a refusal instead
+ * of a collision. Prefixed, there is nothing to reserve: an operator's own
+ * `memory` connector is now a legal thing to declare.
+ *
+ * It is also the shape the vendor-qualified providers already use —
+ * `google_tasks`, `gmail_imap`, `icloud_mail` — and it reads the same way: the
+ * half before the underscore says whose surface this is.
+ *
+ * The order is read: `#server/mcp`'s instructions emit one paragraph per
+ * reachable id in this sequence, so it is the order an agent meets them in.
+ * `lanes_entities` is appended rather than inserted alphabetically so that it
+ * lands beside `lanes_identity`: the two answer the same question about
+ * different people, and the instructions collapse them into one paragraph when
+ * both are reachable.
+ */
+export const RESERVED_PROVIDER_IDS: readonly string[] = [
+  'lanes_memory',
+  'lanes_tasks',
+  'lanes_assets',
+  'lanes_skills',
+  'lanes_vault',
+  'lanes_setup',
+  'lanes_identity',
+  'lanes_entities',
+];
+
+/**
+ * Old id to new, for a refusal that can name what a stale client is asking for.
+ *
+ * Nothing consumes it yet. The migration builds its own map from
+ * `C3_OWNER_PROVIDERS` (`src/cli/contract4-rename.ts`), and a `tools/call` on a
+ * pre-0.9.0 name is answered by the SDK's exact-match lookup before anything
+ * here sees it — so the refusal this exists for is still unwritten. ADR-066
+ * records the failure it would address.
+ */
+export const RENAMED_OWNER_PROVIDERS: ReadonlyMap<string, string> = new Map(
+  RESERVED_PROVIDER_IDS.map((id) => [id.slice('lanes_'.length), id]),
+);

--- a/src/connectivity/manifest/provider.ts
+++ b/src/connectivity/manifest/provider.ts
@@ -63,6 +63,36 @@ export const providerManifestSchema = z.object({
    * not silently discarded.
    */
   hints: z.record(z.string(), z.string()).optional(),
+
+  /**
+   * Per-capability arguments that ask a vendor for a smaller record: capability
+   * name → the vendor's own projection parameters.
+   *
+   * Keyed exactly like `redact` and `hints`, and read on a call this endpoint
+   * makes *for* the caller rather than one the caller wrote. When a list comes
+   * back as bare identifiers the gateway fills it in, and without this it does
+   * so at whatever representation the vendor defaults to — which for a mail API
+   * is the entire message, transport headers and base64 body included. Five of
+   * those measured 193,271 characters and overflowed the reply.
+   *
+   * These are the vendor's argument names, not ours, because the saving has to
+   * happen at the source: trimming a response we already paid to receive spends
+   * the owner's quota to save our own bytes. The parameters exist and are
+   * deliberately preserved by the vendoring script — Google's `fields` and
+   * `format`, Graph's `$select` — and nothing used them until now.
+   *
+   * A key that misses does nothing at all, which is the same trap `redact`
+   * carries, so two tests hold it: one that every key names a capability that
+   * exists, and one that every argument it names is a real parameter of that
+   * capability. Nothing checks them against a *response* schema, because the
+   * vendored specs have none — `vendor-spec.ts` explains why they cannot.
+   */
+  compact: z
+    .record(
+      z.string(),
+      z.record(z.string(), z.union([z.string(), z.number(), z.boolean(), z.array(z.string())])),
+    )
+    .optional(),
   /**
    * The words a person would search for that the vendor never writes.
    *
@@ -87,53 +117,6 @@ export const providerManifestSchema = z.object({
 });
 
 export type ProviderManifest = z.infer<typeof providerManifestSchema>;
-
-/**
- * The owner layer's provider ids — Lanes' own surfaces.
- *
- * **`lanes_` on each, which is what stops them needing to be reserved.** They
- * were `memory`, `tasks`, `assets`, `skills`, `vault`, `entities` — six of the
- * most obvious words a vendor manifest might want, held back from every
- * operator so the built-ins could have them. `buildRegistry` registers these
- * before `PROVIDERS`, so a manifest claiming one threw at startup rather than
- * being shadowed (ADR-051); the reservation is what made that a refusal instead
- * of a collision. Prefixed, there is nothing to reserve: an operator's own
- * `memory` connector is now a legal thing to declare.
- *
- * It is also the shape the vendor-qualified providers already use —
- * `google_tasks`, `gmail_imap`, `icloud_mail` — and it reads the same way: the
- * half before the underscore says whose surface this is.
- *
- * The order is read: `#server/mcp`'s instructions emit one paragraph per
- * reachable id in this sequence, so it is the order an agent meets them in.
- * `lanes_entities` is appended rather than inserted alphabetically so that it
- * lands beside `lanes_identity`: the two answer the same question about
- * different people, and the instructions collapse them into one paragraph when
- * both are reachable.
- */
-export const RESERVED_PROVIDER_IDS: readonly string[] = [
-  'lanes_memory',
-  'lanes_tasks',
-  'lanes_assets',
-  'lanes_skills',
-  'lanes_vault',
-  'lanes_setup',
-  'lanes_identity',
-  'lanes_entities',
-];
-
-/**
- * Old id to new, for a refusal that can name what a stale client is asking for.
- *
- * Nothing consumes it yet. The migration builds its own map from
- * `C3_OWNER_PROVIDERS` (`src/cli/contract4-rename.ts`), and a `tools/call` on a
- * pre-0.9.0 name is answered by the SDK's exact-match lookup before anything
- * here sees it — so the refusal this exists for is still unwritten. ADR-066
- * records the failure it would address.
- */
-export const RENAMED_OWNER_PROVIDERS: ReadonlyMap<string, string> = new Map(
-  RESERVED_PROVIDER_IDS.map((id) => [id.slice('lanes_'.length), id]),
-);
 
 /**
  * Validate a manifest, with the cross-field rules the schema alone cannot

--- a/src/connectivity/transports/http/index.ts
+++ b/src/connectivity/transports/http/index.ts
@@ -282,8 +282,16 @@ export function createHttpConnector(options: HttpConnectorOptions): Connector {
       // something on the strength of this response — a token the vendor
       // refused — so authorising again hands out a replacement rather than the
       // value that just failed. A second refusal is the answer.
+      //
+      // The replacement's reply is verified too, and that is not symmetry for
+      // its own sake: refusing a *reissued* credential is the only evidence
+      // anywhere that the grant itself has ended rather than the token having
+      // gone stale, and it is available exactly once, here. Left unverified,
+      // the distinction could not be drawn by anything downstream — by then
+      // there is one 401 and no record that a retry was already spent.
       if (outcome?.retry) {
         response = await doFetch(await context.authorize(outbound()));
+        await context.verify?.(response.clone() as unknown as Response);
       }
 
       const text = await response.text();

--- a/src/connectivity/transports/mcp/index.ts
+++ b/src/connectivity/transports/mcp/index.ts
@@ -6,6 +6,7 @@ import type {
   ToolResult,
 } from '#connectivity';
 import { READ_BUNDLE, WRITE_BUNDLE } from '#connectivity';
+import { distrustIfRefused } from './refused.ts';
 
 /**
  * The `mcp` connector — proxy an upstream MCP server.
@@ -354,6 +355,8 @@ export function createMcpConnector(options: McpConnectorOptions): Connector {
           target: { tool: tool.name },
         }));
       } catch (error) {
+        // No `verify`: a `DiscoveryContext` has none, because discovery is not
+        // a call anyone made. See `refused.ts`.
         throw readableUpstreamError(error, options.endpoint);
       } finally {
         await client.close().catch(() => {});
@@ -361,10 +364,10 @@ export function createMcpConnector(options: McpConnectorOptions): Connector {
     },
 
     async invoke(capability, args, context): Promise<ToolResult> {
-      const client = await connect(context);
       const upstreamName = (capability.target?.['tool'] as string | undefined) ?? capability.name;
-
+      let client: Client | undefined;
       try {
+        client = await connect(context);
         const result = (await client.callTool({
           name: upstreamName,
           arguments: args as Record<string, unknown>,
@@ -386,9 +389,10 @@ export function createMcpConnector(options: McpConnectorOptions): Connector {
           ...(result.isError ? { isError: true } : {}),
         };
       } catch (error) {
+        await distrustIfRefused(context.verify, error);
         throw readableUpstreamError(error, options.endpoint);
       } finally {
-        await client.close().catch(() => {});
+        await client?.close().catch(() => {});
       }
     },
   };

--- a/src/connectivity/transports/mcp/refused.test.ts
+++ b/src/connectivity/transports/mcp/refused.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, test } from 'bun:test';
+import { UnauthorizedError } from '@modelcontextprotocol/client';
+import { distrustIfRefused } from './refused.ts';
+
+/**
+ * Noticing a refused credential on the transport that could not see one.
+ *
+ * The `http` connector reads `response.status`. Here the reply is consumed by a
+ * client library that turns a 401 into an exception, so there was no status for
+ * anything to check — and this is the larger half of the estate.
+ */
+
+describe('an upstream server that refused the credential', () => {
+  test('is handed back for the same check a transported reply gets', async () => {
+    const seen: number[] = [];
+
+    await distrustIfRefused(async (response) => void seen.push(response.status), new UnauthorizedError('nope'));
+
+    expect(seen).toEqual([401]);
+  });
+
+  /**
+   * Everything else is left alone. The whole trade is that a false positive
+   * spends a refresh on a guess, so this is matched on the library's own error
+   * type rather than on the message text, which is where a guess would live.
+   */
+  test('an ordinary upstream failure is not mistaken for one', async () => {
+    const seen: number[] = [];
+    const verify = async (response: Response) => void seen.push(response.status);
+
+    await distrustIfRefused(verify, new Error('the server returned 401 in some other sentence'));
+    await distrustIfRefused(verify, new Error('upstream timed out'));
+    await distrustIfRefused(verify, 'not an error at all');
+
+    expect(seen).toEqual([]);
+  });
+
+  /** Discovery has no verifier, and must not throw for the want of one. */
+  test('does nothing where there is no verifier to tell', async () => {
+    await expect(distrustIfRefused(undefined, new UnauthorizedError('nope'))).resolves.toBeUndefined();
+  });
+});

--- a/src/connectivity/transports/mcp/refused.ts
+++ b/src/connectivity/transports/mcp/refused.ts
@@ -1,0 +1,34 @@
+import { UnauthorizedError } from '@modelcontextprotocol/client';
+
+/**
+ * A credential the upstream server refused, told to the layer that caches it.
+ *
+ * This transport had no way to say it. The `http` one reads `response.status`;
+ * here the reply is consumed by a client library that turns a 401 into an
+ * exception, so there was no status for anything to check — and a refused token
+ * went on being sent until its stored clock ran out. That is the failure the
+ * distrust path exists to end, left in place on the largest share of the
+ * estate: 77 of roughly 105 providers declare `connector.kind: 'mcp'`.
+ *
+ * `UnauthorizedError` is the library's own answer, and it is brand-based, so it
+ * survives two copies of the package in one process. Matching on the message
+ * text was the alternative, and that is a guess.
+ *
+ * A `Response` is synthesised because it is the shared vocabulary for "the
+ * vendor said no", not because one was received. The retry the verifier offers
+ * is dropped: this connector opens a client, calls, and closes it, so honouring
+ * a retry means running all of that again. Worth doing, and a larger change
+ * than telling the truth about the token.
+ *
+ * Its own file because `index.ts` is four lines under the budget and this is a
+ * subject rather than a line — the same reason `expand.ts` sits beside the
+ * gateway that uses it.
+ */
+export async function distrustIfRefused(
+  verify: ((response: Response) => Promise<unknown>) | undefined,
+  error: unknown,
+): Promise<void> {
+  if (verify && error instanceof UnauthorizedError) {
+    await verify(new Response(null, { status: 401 }));
+  }
+}

--- a/src/dispatch/context.ts
+++ b/src/dispatch/context.ts
@@ -12,6 +12,7 @@ import type {
   ProviderDefinition,
   ProviderManifest,
   ScopedStore,
+  VerifyOutcome,
 } from '#connectivity';
 import { credentialRefForConnection } from '#connectivity';
 import type { ConnectionConfig } from '#profile';
@@ -130,6 +131,8 @@ export interface BuildContextOptions {
   readonly signal: AbortSignal;
   /** The same closure the connector context gets. Absent for `local` providers. */
   readonly authorize?: ((request: Request) => Promise<Request>) | undefined;
+  /** The same reply check the connector context gets. See `ProviderContext.verify`. */
+  readonly verify?: ((response: Response) => Promise<VerifyOutcome | void>) | undefined;
   /** `oauth_apps` entries this profile declares. See `resolveSecretRefs`. */
   readonly ownClients?: readonly string[] | undefined;
   /** Every profile the caller may reach. See `ProviderContext.profiles`. */
@@ -162,6 +165,7 @@ export function buildProviderContext(options: BuildContextOptions): ProviderCont
     log: options.log,
     signal: options.signal,
     ...(options.authorize ? { authorize: options.authorize } : {}),
+    ...(options.verify ? { verify: options.verify } : {}),
     ...(options.attachments ? { attachments: options.attachments } : {}),
   };
 }

--- a/src/dispatch/dispatch.ts
+++ b/src/dispatch/dispatch.ts
@@ -1,5 +1,5 @@
 import type { AuditDraft, AuditLogger, AuditSink, AuthorizationResult } from '#audit';
-import { keepKeys, redactAllValues } from '#audit';
+import { redactAllValues } from '#audit';
 import { mayReach, type Principal } from '#auth';
 import type { SecretStore } from '#secrets';
 import type { RuntimeState } from '#stores/state';
@@ -16,8 +16,9 @@ import type {
 import { isToolResult, strategyContextFrom, strategyFor } from '#connectivity';
 import type { Config, ConnectionConfig } from '#profile';
 import { buildProviderContext, createProviderLogger } from './context.ts';
-import { responseVerifier } from './reauthorize.ts';
-import { distrustUpstreamToken } from '#connectivity/auth/index.ts';
+import { auditArgumentsFor } from './redaction.ts';
+import { reauthResult, verifierFor } from './reauthorize.ts';
+import { ReauthRequired, distrustConnectionToken } from '#connectivity/auth/index.ts';
 import { createAttachmentBridge } from './attachments.ts';
 import { fetchStaged, stageAttachment } from './staging.ts';
 import type { FetchStagedRequest, StagedAttachment, StageRequest } from './staging.ts';
@@ -116,6 +117,8 @@ export class Dispatcher {
     let status: AuditDraft['status'] = 'not_invoked';
     let auditArguments: Record<string, unknown> = redactAllValues(request.arguments);
     let error: { kind: string; message: string } | undefined;
+    // Set when a reissued token was refused too, which means a person is needed.
+    let needsReauth = false;
     let outcome: DispatchOutcome = {
       ok: false,
       authorization: 'denied_default',
@@ -134,17 +137,14 @@ export class Dispatcher {
 
       const entry = registry.get(providerId)!;
 
-      // Apply redaction now that we know which capability this is, so a denial
-      // is logged with the same redaction an allowed call would get.
-      //
-      // Local capabilities carry their own rule. Discovered ones cannot: we did
-      // not author them and cannot know what is sensitive, so the default
-      // withholds every value and a manifest opts specific keys back in.
-      const declaredKeys = entry.manifest.redact?.[registered.capability?.name ?? registered.discovered?.name ?? ''];
-      const redact =
-        registered.capability?.redact ?? (declaredKeys ? keepKeys(...declaredKeys) : undefined);
-
-      auditArguments = (redact ?? redactAllValues)(request.arguments);
+      // Now that we know which capability this is — and before the allow/deny
+      // branch, so a denial is recorded the same way an allowed call would be.
+      auditArguments = auditArgumentsFor({
+        manifest: entry.manifest,
+        name: registered.capability?.name ?? registered.discovered?.name,
+        own: registered.capability?.redact,
+        arguments: request.arguments,
+      });
 
       // **Who, before what.** A caller reaches a profile only if that profile's
       // `members:` names them (ADR-060), and this is checked before the
@@ -276,6 +276,19 @@ export class Dispatcher {
           ).allowed,
       });
 
+      // Resolved, not asked for: this has to be the key the token caches use.
+      // Built before the provider context because an authored capability calls
+      // its vendor directly and needs the same check a transport's reply gets.
+      const connectionKey = `${providerId}.${declared.id}`;
+      const verify = verifierFor({
+        connectionKey,
+        manifest: entry.manifest,
+        strategy,
+        context: forStrategy,
+        distrust: distrustConnectionToken,
+        exhausted: () => void (needsReauth = true),
+      });
+
       const providerContext = buildProviderContext({
         manifest: entry.manifest,
         definition: entry.definition,
@@ -297,6 +310,7 @@ export class Dispatcher {
         profiles: request.principal.profiles ?? [request.principal.profile],
         attachments,
         ...(entry.manifest.connector.kind === 'local' ? {} : { authorize }),
+        ...(verify ? { verify } : {}),
       });
 
       const connector = this.#deps.connectorFor(providerId, declared.id);
@@ -309,21 +323,6 @@ export class Dispatcher {
           message: `Provider ${providerId} has no usable connector.`,
         });
       }
-
-      // Two reasons to read a response before the caller does: a vendor that
-      // signs its replies expects them verified, and a token the vendor refuses
-      // has to be distrusted or the next call sends it again. They compose.
-      const verifyStrategy = strategy?.verify?.bind(strategy);
-      const verify = responseVerifier({
-        // Built from what was resolved, not from what was asked for: this has
-        // to be the key the token cache uses, `<manifest>.<connection>`.
-        connectionKey: `${providerId}.${declared.id}`,
-        oauth: entry.manifest.auth.kind === 'oauth',
-        distrust: distrustUpstreamToken,
-        ...(verifyStrategy
-          ? { strategy: (response: Response) => verifyStrategy(response, forStrategy()) }
-          : {}),
-      });
 
       const connectorContext: ConnectorContext = {
         manifest: entry.manifest,
@@ -345,10 +344,20 @@ export class Dispatcher {
       // Only a tool can report a soft failure. A resource or a prompt that
       // cannot produce its answer throws, and lands in the catch below.
       status = isToolResult(result) && result.isError ? 'error' : 'ok';
-      return (outcome = { ok: true, result });
+
+      // A 401 that outlived its refresh arrives as an ordinary failed result
+      // carrying whatever the vendor writes. Said plainly instead, here, in the
+      // one place that knows a retry was already spent.
+      const dead = needsReauth && status === 'error';
+      if (dead) error = { kind: 'needs_reauth', message: `${connectionKey} must be reconnected` };
+
+      return (outcome = { ok: true, result: dead ? reauthResult(connectionKey, result) : result });
     } catch (caught) {
       status = 'error';
-      error = { kind: 'provider_error', message: (caught as Error).message };
+      // `ReauthRequired` already says a person is needed; flattening every throw
+      // to `provider_error` discarded that.
+      const kind = caught instanceof ReauthRequired ? 'needs_reauth' : 'provider_error';
+      error = { kind, message: (caught as Error).message };
       return (outcome = {
         ok: false,
         authorization,

--- a/src/dispatch/reauth.test.ts
+++ b/src/dispatch/reauth.test.ts
@@ -79,8 +79,8 @@ const BASIC = defineProvider({
   auth: { kind: 'basic', credential_ref: 'acme/password' },
 });
 
-/** A vendor that refuses the first call and accepts the second. */
-function harness(manifest: typeof OAUTH) {
+/** A vendor that refuses the first call and accepts the second — or refuses both. */
+function harness(manifest: typeof OAUTH, alwaysRefuse = false) {
   const tokens: string[] = [];
   let attempt = 0;
 
@@ -93,7 +93,7 @@ function harness(manifest: typeof OAUTH) {
     fetch: (async (request: Request) => {
       tokens.push(request.headers.get('authorization') ?? '');
       attempt += 1;
-      return attempt === 1
+      return attempt === 1 || alwaysRefuse
         ? new Response('{"error":"Invalid Credentials"}', { status: 401, statusText: 'Unauthorized' })
         : new Response('{"accounts":[]}', {
             status: 200,
@@ -103,6 +103,7 @@ function harness(manifest: typeof OAUTH) {
   });
 
   let issued = 0;
+  const audit = createBlobAuditStore({ storage: createMemoryBlobStore() });
   const dispatcher = new Dispatcher({
     config: CONFIG,
     connections: [{ id: 'main', provider: 'acme', account: 'A' }],
@@ -119,14 +120,14 @@ function harness(manifest: typeof OAUTH) {
     },
     policy: toPolicyDocument(CONFIG),
     state: createMemoryState(),
-    audit: createBlobAuditStore({ storage: createMemoryBlobStore() }),
+    audit,
     credentials: createMemoryCredentials(),
     storage: createMemoryBlobStore(),
     limiter: new RateLimiter(),
     log: { debug() {}, info() {}, warn() {}, error() {} },
   });
 
-  return { dispatcher, tokens, registry, http };
+  return { dispatcher, tokens, registry, http, audit };
 }
 
 const call = {
@@ -158,5 +159,65 @@ describe('a refused credential a person has to change', () => {
     await dispatcher.invoke(call);
 
     expect(tokens).toEqual(['Bearer token-1']);
+  });
+});
+
+describe('a credential a person has to replace', () => {
+  /** Discovery first, as the tests above do: an undiscovered capability is not callable. */
+  const ready = async (alwaysRefuse: boolean) => {
+    const built = harness(OAUTH, alwaysRefuse);
+    built.registry.setDiscovered('acme', await built.http.discover({ manifest: OAUTH } as never));
+    return built;
+  };
+
+  /**
+   * Two tokens, both refused. This is the shape the retry cannot fix, and until
+   * now it was indistinguishable from the shape it can — the caller received
+   * the vendor's own sentence about credentials either way.
+   */
+  test('is refused twice, and then said to be a grant rather than a token', async () => {
+    const { dispatcher, tokens } = await ready(true);
+    const outcome = await dispatcher.invoke(call);
+
+    expect(tokens).toEqual(['Bearer token-1', 'Bearer token-2']);
+    expect(outcome.ok).toBe(true);
+
+    const result = (outcome as unknown as { result: { content: { text: string }[]; isError?: boolean } }).result;
+    expect(result.isError).toBe(true);
+    expect(result.content[0]?.text).toContain('acme.main needs to be connected again');
+    expect(result.content[0]?.text).toContain('Retrying will not help');
+  });
+
+  /** And the vendor's own words survive underneath it. */
+  test('keeps what the vendor said', async () => {
+    const { dispatcher } = await ready(true);
+    const outcome = await dispatcher.invoke(call);
+
+    const result = (outcome as unknown as { result: { content: { text: string }[] } }).result;
+    expect(result.content.map((block) => block.text).join('\n')).toContain('Invalid Credentials');
+  });
+
+  /**
+   * The audit row is where "how often is this happening" gets answered, and a
+   * dead grant recorded as `provider_error` is indistinguishable from a vendor
+   * having a bad afternoon.
+   */
+  test('is recorded as needing re-auth, not as a provider error', async () => {
+    const { dispatcher, audit } = await ready(true);
+    await dispatcher.invoke(call);
+
+    const events = await audit.tail({});
+    expect(events[0]?.error?.kind).toBe('needs_reauth');
+  });
+
+  /** A refusal the retry *did* fix is an ordinary success, and says nothing. */
+  test('a token that was merely stale is not reported as either', async () => {
+    const { dispatcher, audit } = await ready(false);
+    const outcome = await dispatcher.invoke(call);
+
+    expect(outcome.ok).toBe(true);
+    const events = await audit.tail({});
+    expect(events[0]?.error).toBeUndefined();
+    expect(events[0]?.status).toBe('ok');
   });
 });

--- a/src/dispatch/reauthorize.test.ts
+++ b/src/dispatch/reauthorize.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from 'bun:test';
-import { responseVerifier } from './reauthorize.ts';
+import { reauthResult, responseVerifier } from './reauthorize.ts';
 
 /**
  * Who gets told that a call came back refused.
@@ -89,5 +89,85 @@ describe('a strategy that verifies its own replies', () => {
     expect(await verify(refused)).toEqual({ retry: true });
     expect(seen).toEqual([401]);
     expect(distrusted).toEqual(['gmail.con1']);
+  });
+});
+
+describe('telling a dead grant from a stale token', () => {
+  const verifier = (exhausted: string[]) =>
+    responseVerifier({
+      connectionKey: 'gmail.con1',
+      oauth: true,
+      distrust: () => {},
+      exhausted: (key) => exhausted.push(key),
+    })!;
+
+  /**
+   * The first refusal says nothing. A token can be stale for reasons that fix
+   * themselves, and usually is — reporting it would turn every recovered call
+   * into an instruction to go and reconnect something that is working.
+   */
+  test('a first refusal is not reported, because a retry may still fix it', async () => {
+    const exhausted: string[] = [];
+
+    expect(await verifier(exhausted)(refused)).toEqual({ retry: true });
+    expect(exhausted).toEqual([]);
+  });
+
+  /**
+   * The second one says everything. The token being presented is the one the
+   * refresh just produced, so what is being refused is the grant.
+   */
+  test('a refusal that outlived the refresh is reported', async () => {
+    const exhausted: string[] = [];
+    const verify = verifier(exhausted);
+
+    await verify(refused);
+    await verify(refused);
+
+    expect(exhausted).toEqual(['gmail.con1']);
+  });
+
+  test('and it is not asked to retry a second time', async () => {
+    const verify = verifier([]);
+
+    await verify(refused);
+    expect(await verify(refused)).toBeUndefined();
+  });
+
+  test('a call that recovered reports nothing', async () => {
+    const exhausted: string[] = [];
+    const verify = verifier(exhausted);
+
+    await verify(refused);
+    await verify(fine);
+
+    expect(exhausted).toEqual([]);
+  });
+});
+
+describe('what a dead grant is said to be', () => {
+  const vendor = {
+    content: [{ type: 'text' as const, text: '401 Unauthorized\n{"error":"invalid_grant"}' }],
+    isError: true,
+  };
+
+  test('names the connection, and says retrying will not help', async () => {
+    const said = reauthResult('gmail.con1', vendor) as unknown as { content: { text: string }[] };
+
+    expect(said.content[0]?.text).toContain('gmail.con1');
+    expect(said.content[0]?.text).toContain('connected again');
+    expect(said.content[0]?.text).toContain('Retrying will not help');
+  });
+
+  /** The vendor's own words stay: they are the evidence for whoever debugs it. */
+  test("keeps what the vendor said, after what it means", async () => {
+    const said = reauthResult('gmail.con1', vendor) as unknown as {
+      content: { text: string }[];
+      isError: boolean;
+    };
+
+    expect(said.content).toHaveLength(2);
+    expect(said.content[1]?.text).toContain('invalid_grant');
+    expect(said.isError).toBe(true);
   });
 });

--- a/src/dispatch/reauthorize.ts
+++ b/src/dispatch/reauthorize.ts
@@ -1,4 +1,10 @@
-import type { VerifyOutcome } from '#connectivity';
+import type {
+  AuthStrategy,
+  AuthStrategyContext,
+  CapabilityResult,
+  ProviderManifest,
+  VerifyOutcome,
+} from '#connectivity';
 
 /**
  * Noticing that a call went out with a credential the vendor no longer accepts.
@@ -28,8 +34,46 @@ export interface VerifierOptions {
   readonly oauth: boolean;
   /** Stop trusting this connection's token. */
   readonly distrust: (connectionKey: string) => void;
+  /**
+   * A refusal that outlived the refresh, which means a person is needed.
+   *
+   * This is the only place the two are distinguishable. A 401 on the first
+   * attempt says nothing — a token can be stale for reasons that fix
+   * themselves, and usually is. The same answer to a *reissued* token says the
+   * grant itself is gone: revoked in the vendor's console, scopes withdrawn,
+   * the account removed. Everything downstream sees one 401 and cannot tell,
+   * because by then the retry has already happened.
+   */
+  readonly exhausted?: ((connectionKey: string) => void) | undefined;
   /** The strategy's own verifier, where the vendor signs its replies. */
   readonly strategy?: ((response: Response) => Promise<VerifyOutcome | void>) | undefined;
+}
+
+/**
+ * The verifier for one invocation, assembled from what the connection is.
+ *
+ * Here rather than at the call site because every input is about credentials
+ * and none is about dispatch: which caches hold this connection's token, which
+ * auth kinds can be renewed without a person, and whether the vendor signs its
+ * replies. `invoke` should name the connection and be handed the check.
+ */
+export function verifierFor(options: {
+  readonly connectionKey: string;
+  readonly manifest: ProviderManifest;
+  readonly strategy: AuthStrategy | undefined;
+  readonly context: () => AuthStrategyContext;
+  readonly distrust: (connectionKey: string) => void;
+  readonly exhausted: (connectionKey: string) => void;
+}): ((response: Response) => Promise<VerifyOutcome | void>) | undefined {
+  const verify = options.strategy?.verify?.bind(options.strategy);
+
+  return responseVerifier({
+    connectionKey: options.connectionKey,
+    oauth: options.manifest.auth.kind === 'oauth',
+    distrust: options.distrust,
+    exhausted: options.exhausted,
+    ...(verify ? { strategy: (response: Response) => verify(response, options.context()) } : {}),
+  });
 }
 
 export function responseVerifier(
@@ -45,10 +89,41 @@ export function responseVerifier(
     const outcome = await strategy?.(response);
     if (outcome?.retry) return outcome;
 
-    if (response.status !== 401 || asked) return outcome ?? undefined;
+    if (response.status !== 401) return outcome ?? undefined;
+
+    // Asked once already, and refused again with the token that refresh
+    // produced. Reported rather than retried: a second retry would spend
+    // another call to be told the same thing.
+    if (asked) {
+      options.exhausted?.(options.connectionKey);
+      return outcome ?? undefined;
+    }
 
     asked = true;
     options.distrust(options.connectionKey);
     return { retry: true };
   };
+}
+
+/**
+ * The same failure, said to the party that can act on it.
+ *
+ * What the vendor returns for a dead grant is written for whoever is reading
+ * its logs: `invalid_grant`, `UNAUTHENTICATED`, a link to a console. An agent
+ * holding that cannot tell it from the transient case it has no part in, and
+ * the honest instruction — stop retrying, ask the owner to reconnect — appears
+ * nowhere in it. Prepended rather than replacing, because the vendor's own
+ * words are still the evidence for anyone debugging it.
+ */
+export function reauthResult(connectionKey: string, result: unknown): CapabilityResult {
+  const said =
+    `${connectionKey} needs to be connected again: the credential was refused, renewed, and ` +
+    'refused again, so this is a grant that has ended rather than a token that went stale. ' +
+    'Retrying will not help. The owner reconnects it in a terminal; this endpoint cannot.';
+
+  const blocks = (result as { content?: unknown[] }).content ?? [];
+  return {
+    content: [{ type: 'text' as const, text: said }, ...blocks],
+    isError: true,
+  } as CapabilityResult;
 }

--- a/src/dispatch/redaction.ts
+++ b/src/dispatch/redaction.ts
@@ -1,0 +1,28 @@
+import { keepKeys, redactAllValues } from '#audit';
+import type { ProviderManifest } from '#connectivity';
+
+/**
+ * What an invocation's arguments look like once they are in the audit log.
+ *
+ * Its own file because it answers a different question from the one the
+ * dispatcher is asking. `invoke` decides whether a call may happen; this
+ * decides what is written down about it either way — which is why it runs
+ * before the allow/deny branch rather than after, so a denial is recorded with
+ * the same redaction an allowed call would have got.
+ *
+ * Two sources, one precedence. A capability we authored carries its own rule
+ * and knows what is sensitive in its own arguments. A discovered one cannot: we
+ * did not write it, so the default withholds every value and a manifest opts
+ * specific keys back in by name.
+ */
+export function auditArgumentsFor(input: {
+  readonly manifest: ProviderManifest;
+  readonly name: string | undefined;
+  readonly own: ((args: Record<string, unknown>) => Record<string, unknown>) | undefined;
+  readonly arguments: Record<string, unknown>;
+}): Record<string, unknown> {
+  const declaredKeys = input.manifest.redact?.[input.name ?? ''];
+  const redact = input.own ?? (declaredKeys ? keepKeys(...declaredKeys) : undefined);
+
+  return (redact ?? redactAllValues)(input.arguments);
+}

--- a/src/providers/google/gmail/compact.ts
+++ b/src/providers/google/gmail/compact.ts
@@ -1,0 +1,35 @@
+/**
+ * What to ask for when a message is being filled in rather than asked for.
+ *
+ * The gateway fills in a list that came back as identifiers (`server/mcp/expand.ts`),
+ * and without this it does so at whatever the vendor returns by default. Gmail's
+ * default is `format=full`: every `Received:` hop, the DKIM and ARC headers, and
+ * the body as base64. Five of those measured 193,271 characters and overflowed
+ * the reply — for a caller who had asked to see what was in their inbox.
+ *
+ * `metadata` answers that question instead. It carries the envelope headers
+ * named here plus `snippet`, which is the preview, and drops the body — so a
+ * whole page of mail costs less than one message did, and the row that needs
+ * reading in full is one `users.messages.get` away.
+ *
+ * Two capabilities and not four, because the others cannot reach this code:
+ * `threads.list` rows carry three keys and `labels.list` returns whole labels,
+ * so `referencesIn` rejects both and no follow-up is ever made. If a vendor
+ * change makes either return bare references, adding the line here is the fix.
+ *
+ * `drafts.get` takes no `metadataHeaders` — the parameter is not in its spec —
+ * so `metadata` there returns the full header set. That is cheap for the one
+ * message kind that was never delivered, so it has no `Received:` chain.
+ *
+ * `fields` would compose with this and is deliberately not used. `metadata`
+ * already drops the body, which is the whole of the saving, and a second
+ * shaping parameter adds a way for the call to fail with a 400 for about a
+ * hundred bytes.
+ */
+export const GMAIL_COMPACT: Record<string, Record<string, unknown>> = {
+  'users.messages.get': {
+    format: 'metadata',
+    metadataHeaders: ['From', 'To', 'Cc', 'Subject', 'Date'],
+  },
+  'users.drafts.get': { format: 'metadata' },
+};

--- a/src/providers/google/gmail/index.ts
+++ b/src/providers/google/gmail/index.ts
@@ -4,6 +4,7 @@ import { GMAIL_IDENTITY, GOOGLE_APP, GOOGLE_OAUTH, specPath } from '../shared/oa
 import { googleServiceAccount } from '../shared/service-account.ts';
 import { googleSetup } from '../shared/setup.ts';
 import { GMAIL_HOST } from './api.ts';
+import { GMAIL_COMPACT } from './compact.ts';
 import { GMAIL_HINTS } from './hints.ts';
 import { GMAIL_REDACT } from './redact.ts';
 import { gmailSendMessage } from './send.ts';
@@ -96,6 +97,7 @@ const manifest = defineProvider({
   setup: googleSetup('Gmail', GMAIL_SCOPES),
   redact: GMAIL_REDACT,
   hints: GMAIL_HINTS,
+  compact: GMAIL_COMPACT,
   // Named here because an `http` connector otherwise assigns bundles by HTTP
   // method during discovery, and an authored capability is never discovered.
   bundles: [{ name: 'write', capabilities: ['send_message'] }],

--- a/src/providers/google/gmail/send.test.ts
+++ b/src/providers/google/gmail/send.test.ts
@@ -584,3 +584,60 @@ describe('a file this profile keeps', () => {
     expect(calls).toHaveLength(0);
   });
 });
+
+describe('a credential the vendor refuses mid-send', () => {
+  /**
+   * This capability is authored, so it calls Gmail itself and skipped the one
+   * thing every transported call gets: a refused token being distrusted. Left
+   * as it was, a send that came back 401 left that token trusted for the rest
+   * of the hour — and sending is exactly where an agent then retries.
+   */
+  const refusing = () => {
+    const seen: number[] = [];
+    const capability = gmailSend({
+      fetch: (async () =>
+        new Response('{"error":{"code":401,"message":"Invalid Credentials"}}', {
+          status: 401,
+          statusText: 'Unauthorized',
+        })) as never,
+    });
+
+    const harness = harnessFor(
+      defineProviderWithCapabilities({ manifest: manifestOf(gmail), capabilities: [capability] }),
+      'main',
+      { verify: async (response) => void seen.push(response.status) },
+    );
+
+    return { seen, harness };
+  };
+
+  test('is handed back for the same check a transported reply gets', async () => {
+    const { seen, harness } = refusing();
+
+    const result = await harness.invoke('send_message', {
+      to: ['ada.lovelace@example.com'],
+      subject: 'x',
+      text: 'y',
+    });
+
+    expect((result as ToolResult).isError).toBe(true);
+    expect(seen).toEqual([401]);
+  });
+
+  /**
+   * Distrust without retry, and the asymmetry is deliberate: a send that was
+   * refused may still have been delivered, so repeating it is not a decision
+   * this layer gets to make. The connection is repaired for the *next* call.
+   */
+  test('and the send is not repeated', async () => {
+    const { seen, harness } = refusing();
+
+    await harness.invoke('send_message', {
+      to: ['ada.lovelace@example.com'],
+      subject: 'x',
+      text: 'y',
+    });
+
+    expect(seen).toHaveLength(1);
+  });
+});

--- a/src/providers/google/gmail/send.ts
+++ b/src/providers/google/gmail/send.ts
@@ -256,6 +256,28 @@ export const gmailSendMessage = gmailSend();
  * `uploadType=media`, no multipart assembly, no resumable session — which is what
  * lifts the ceiling from "what fits in a JSON string" to Gmail's own 35 MiB.
  */
+/**
+ * Hand a refusal back for the credential check a transport's reply would get.
+ *
+ * This capability is authored because no OpenAPI document describes composing
+ * an RFC 2822 message, and calling the vendor directly meant skipping the one
+ * thing every other call gets for free: a token the vendor refuses is
+ * distrusted, so the next call renews it instead of resending it for the rest
+ * of the hour.
+ *
+ * Distrust without retry, deliberately. `verify` may answer `{ retry: true }`
+ * and that is right for a read; a send that came back 401 may still have been
+ * delivered, and deciding to repeat it is not this function's to make. The
+ * outcome is dropped on purpose — what is wanted is the connection repaired
+ * for the call after this one.
+ *
+ * Cloned before the body is read, because a response cannot be cloned once it
+ * has been.
+ */
+async function noteRefusal(context: ProviderContext, refused: Response | undefined): Promise<void> {
+  if (refused) await context.verify?.(refused);
+}
+
 async function submit(input: {
   readonly raw: Uint8Array;
   readonly draftOnly: boolean;
@@ -298,9 +320,13 @@ async function submit(input: {
   );
 
   const response = await input.fetch(request);
+  // Cast as the http transport does: the fetch types and the global Response
+  // disagree about `headers`, and the verifier reads neither.
+  const refused = response.ok ? undefined : (response.clone() as unknown as Response);
   const text = await response.text();
 
   if (!response.ok) {
+    await noteRefusal(context, refused);
     throw new Error(`Gmail refused the message with ${response.status}: ${text}`);
   }
 
@@ -334,9 +360,13 @@ async function sendDraft(input: {
   );
 
   const response = await input.fetch(request);
+  // Cast as the http transport does: the fetch types and the global Response
+  // disagree about `headers`, and the verifier reads neither.
+  const refused = response.ok ? undefined : (response.clone() as unknown as Response);
   const text = await response.text();
 
   if (!response.ok) {
+    await noteRefusal(input.context, refused);
     throw new Error(`Gmail refused to send the draft with ${response.status}: ${text}`);
   }
 

--- a/src/providers/google/specs/specs.test.ts
+++ b/src/providers/google/specs/specs.test.ts
@@ -264,6 +264,45 @@ describe.each([
       declared.filter((name) => !capabilities.has(name) && !authored.has(name)),
     ).toEqual([]);
   });
+
+  test('compact names capabilities that exist, and arguments they actually take', async () => {
+    // The third record keyed this way, and the one whose miss is quietest of
+    // all: `redact` withholds, `hints` says nothing, and a missed `compact` key
+    // simply asks the vendor for its default — which is the behaviour this
+    // exists to stop, arriving as though nothing were wrong.
+    //
+    // The second half has no counterpart on the other two, because these are
+    // the *vendor's* argument names rather than ours. `collect()` drops
+    // anything the operation's mapper does not declare, so a parameter spelled
+    // singular, or renamed upstream, is discarded on the way out with no error
+    // anywhere.
+    const declared = Object.entries(manifest.compact ?? {});
+    if (declared.length === 0) return;
+
+    const operations = new Map(
+      (await operationsOf(manifest)).flatMap((operation) => {
+        const id = operation.operationId;
+        if (typeof id !== 'string') return [];
+
+        const parameters = (operation as { parameters?: { name?: string }[] }).parameters ?? [];
+        const names = parameters
+          .map((parameter) => parameter.name)
+          .filter((name): name is string => typeof name === 'string');
+
+        const short = id.startsWith(`${manifest.id}.`) ? id.slice(manifest.id.length + 1) : id;
+        return [[short, new Set(names)] as const];
+      }),
+    );
+
+    expect(declared.filter(([name]) => !operations.has(name)).map(([name]) => name)).toEqual([]);
+
+    const unknown = declared.flatMap(([name, projection]) =>
+      Object.keys(projection)
+        .filter((argument) => !operations.get(name)?.has(argument))
+        .map((argument) => `${name} takes no ${argument}`),
+    );
+    expect(unknown).toEqual([]);
+  });
 });
 
 /**

--- a/src/providers/harness.ts
+++ b/src/providers/harness.ts
@@ -9,6 +9,7 @@ import type {
   ConnectorContext,
   ProviderContext,
   ProviderDefinition,
+  VerifyOutcome,
 } from '#connectivity';
 
 /**
@@ -37,7 +38,11 @@ export function harnessFor(
    * import `#dispatch`, and a provider only ever sees the two closures anyway.
    * `src/dispatch/attachments.test.ts` is what tests the real one.
    */
-  options: { attachments?: AttachmentBridge } = {},
+  options: {
+    attachments?: AttachmentBridge;
+    /** The reply check the runtime binds, for a provider that calls its vendor itself. */
+    verify?: (response: Response) => Promise<VerifyOutcome | void>;
+  } = {},
 ): ProviderHarness {
   const annotations: Record<string, unknown> = {};
 
@@ -64,6 +69,7 @@ export function harnessFor(
     // The runtime hands this to any provider that is not `local`, so a provider
     // authoring a capability against its own vendor's API has it here too.
     authorize: async (request) => request,
+    ...(options.verify ? { verify: options.verify } : {}),
     ...(options.attachments ? { attachments: options.attachments } : {}),
   });
 

--- a/src/server/mcp/expand-result.test.ts
+++ b/src/server/mcp/expand-result.test.ts
@@ -1,0 +1,294 @@
+import { describe, expect, test } from 'bun:test';
+import type { DispatchOutcome } from '#dispatch';
+import { expandIfReferences } from './expand-result.ts';
+import type { MergedCapability } from './visibility.ts';
+
+/**
+ * The gateway half, which had no tests at all when it overflowed a reply.
+ *
+ * `expand.test.ts` covers the decisions in isolation. What is left — and what
+ * the reported failure actually exercised — is the wiring: whether the
+ * projection reaches the call, whether the arguments a caller wrote survive it,
+ * and whether everything the list returned comes back.
+ */
+
+const LIST = 'vendor_mail.messages.list';
+const GET = 'vendor_mail.messages.get';
+
+const reachable = (compact?: Record<string, unknown>): Map<string, MergedCapability> =>
+  new Map([
+    [LIST, {} as MergedCapability],
+    [GET, (compact === undefined ? {} : { compact }) as MergedCapability],
+  ]);
+
+const listing = (rows: readonly Record<string, unknown>[], extra: Record<string, unknown> = {}) => ({
+  content: [{ type: 'text' as const, text: JSON.stringify({ messages: rows, ...extra }) }],
+});
+
+const references = (count: number): Record<string, unknown>[] =>
+  Array.from({ length: count }, (_, at) => ({ id: `id${at}`, threadId: `t${at}` }));
+
+/** A dispatcher that records what it was asked and answers with a small record. */
+function recorder(record: (id: string) => Record<string, unknown> = (id) => ({ id, subject: id })) {
+  const calls: { capability: string; args: Record<string, unknown> }[] = [];
+  const dispatch = async (
+    capability: string,
+    args: Record<string, unknown>,
+  ): Promise<DispatchOutcome> => {
+    calls.push({ capability, args });
+    return {
+      ok: true,
+      result: {
+        content: [{ type: 'text' as const, text: JSON.stringify(record(args['id'] as string)) }],
+      },
+    } as DispatchOutcome;
+  };
+  return { calls, dispatch };
+}
+
+const bodyOf = (filled: { content: { type: 'text'; text: string }[] } | undefined) =>
+  JSON.parse((filled?.content[0]?.text ?? '').split('\n\n')[0] ?? '') as Record<string, unknown>;
+
+describe('when it declines to fill anything in', () => {
+  /**
+   * Each of these must cost nothing. Expanding is somebody else's rate limit,
+   * so a path that decides not to must not have already spent one.
+   */
+  test('a caller who said no is not expanded, and nothing is dispatched', async () => {
+    const { calls, dispatch } = recorder();
+
+    const filled = await expandIfReferences({
+      capability: LIST,
+      result: listing(references(3)),
+      asked: false,
+      merged: reachable(),
+      listArguments: {},
+      dispatch,
+    });
+
+    expect(filled).toBeUndefined();
+    expect(calls).toEqual([]);
+  });
+
+  test('a list with no get beside it is left alone', async () => {
+    const { calls, dispatch } = recorder();
+
+    const filled = await expandIfReferences({
+      capability: LIST,
+      result: listing(references(3)),
+      asked: undefined,
+      merged: new Map([[LIST, {} as MergedCapability]]),
+      listArguments: {},
+      dispatch,
+    });
+
+    expect(filled).toBeUndefined();
+    expect(calls).toEqual([]);
+  });
+
+  test('rows that are already records are left alone', async () => {
+    const { calls, dispatch } = recorder();
+
+    const filled = await expandIfReferences({
+      capability: LIST,
+      result: listing([{ id: 'a', subject: 'Standup', when: 'today' }]),
+      asked: undefined,
+      merged: reachable(),
+      listArguments: {},
+      dispatch,
+    });
+
+    expect(filled).toBeUndefined();
+    expect(calls).toEqual([]);
+  });
+
+  test('prose is not a result to expand', async () => {
+    const { calls, dispatch } = recorder();
+
+    const filled = await expandIfReferences({
+      capability: LIST,
+      result: { content: [{ type: 'text' as const, text: 'Deleted 3 messages.' }] },
+      asked: undefined,
+      merged: reachable(),
+      listArguments: {},
+      dispatch,
+    });
+
+    expect(filled).toBeUndefined();
+    expect(calls).toEqual([]);
+  });
+});
+
+describe('asking the provider for a smaller record', () => {
+  /**
+   * The fix, in one assertion. Without this the follow-up goes out with the
+   * caller's arguments alone and comes back at whatever the vendor defaults to,
+   * which is what made five rows 193,271 characters.
+   */
+  test('the projection the provider declared reaches the follow-up', async () => {
+    const { calls, dispatch } = recorder();
+
+    await expandIfReferences({
+      capability: LIST,
+      result: listing(references(2)),
+      asked: undefined,
+      merged: reachable({ view: 'summary' }),
+      listArguments: {},
+      dispatch,
+    });
+
+    expect(calls).toHaveLength(2);
+    expect(calls[0]?.capability).toBe(GET);
+    expect(calls[0]?.args).toEqual({ view: 'summary', id: 'id0' });
+  });
+
+  test('whole records are asked for by sending no projection at all', async () => {
+    const { calls, dispatch } = recorder();
+
+    await expandIfReferences({
+      capability: LIST,
+      result: listing(references(1)),
+      asked: 'full',
+      merged: reachable({ view: 'summary' }),
+      listArguments: {},
+      dispatch,
+    });
+
+    expect(calls[0]?.args).toEqual({ id: 'id0' });
+  });
+
+  test('a provider that declared nothing still expands', async () => {
+    const { calls, dispatch } = recorder();
+
+    await expandIfReferences({
+      capability: LIST,
+      result: listing(references(1)),
+      asked: undefined,
+      merged: reachable(),
+      listArguments: {},
+      dispatch,
+    });
+
+    expect(calls[0]?.args).toEqual({ id: 'id0' });
+  });
+
+  /**
+   * The list's own arguments are inherited so a `userId` reaches the get, the
+   * projection wins over them, and the identifier wins over everything — it is
+   * the one argument that is not a preference.
+   */
+  test('the list arguments are inherited, the projection beats them, and the id beats both', async () => {
+    const { calls, dispatch } = recorder();
+
+    await expandIfReferences({
+      capability: LIST,
+      result: listing(references(1)),
+      asked: undefined,
+      merged: reachable({ view: 'summary' }),
+      listArguments: { userId: 'me', view: 'everything', id: 'ignored' },
+      dispatch,
+    });
+
+    expect(calls[0]?.args).toEqual({ userId: 'me', view: 'summary', id: 'id0' });
+  });
+});
+
+describe('what comes back', () => {
+  /** The client's acceptance criterion: all of them, at the smaller shape. */
+  test('every row the list returned is present', async () => {
+    const { dispatch } = recorder();
+
+    const filled = await expandIfReferences({
+      capability: LIST,
+      result: listing(references(20)),
+      asked: undefined,
+      merged: reachable(),
+      listArguments: {},
+      dispatch,
+    });
+
+    expect(bodyOf(filled)['messages']).toHaveLength(20);
+  });
+
+  /**
+   * The rows that did not fit come back exactly as the vendor wrote them. The
+   * old code replaced the array with the ones it had filled, so the note telling
+   * a caller to fetch the rest named identifiers it had just thrown away.
+   */
+  test('rows that did not fit survive as the references they were', async () => {
+    const heavy = 'x'.repeat(12 * 1024);
+    const { dispatch } = recorder((id) => ({ id, body: heavy }));
+
+    const filled = await expandIfReferences({
+      capability: LIST,
+      result: listing(references(20)),
+      asked: undefined,
+      merged: reachable(),
+      listArguments: {},
+      dispatch,
+    });
+
+    const rows = bodyOf(filled)['messages'] as Record<string, unknown>[];
+    expect(rows).toHaveLength(20);
+    expect(rows[19]).toEqual({ id: 'id19', threadId: 't19' });
+    expect(filled?.content[0]?.text).toContain('came back as identifiers only');
+    expect(filled?.content[0]?.text).toContain(GET);
+  });
+
+  /** Paging was impossible while the fill discarded everything beside the array. */
+  test("the vendor's own page token survives the fill", async () => {
+    const { dispatch } = recorder();
+
+    const filled = await expandIfReferences({
+      capability: LIST,
+      result: listing(references(2), { nextPageToken: 'page-2', resultSizeEstimate: 40 }),
+      asked: undefined,
+      merged: reachable(),
+      listArguments: {},
+      dispatch,
+    });
+
+    expect(bodyOf(filled)['nextPageToken']).toBe('page-2');
+    expect(bodyOf(filled)['resultSizeEstimate']).toBe(40);
+  });
+
+  test('a reply with nothing left over says nothing about rows left over', async () => {
+    const { dispatch } = recorder();
+
+    const filled = await expandIfReferences({
+      capability: LIST,
+      result: listing(references(3)),
+      asked: undefined,
+      merged: reachable(),
+      listArguments: {},
+      dispatch,
+    });
+
+    expect(filled?.content[0]?.text).not.toContain('identifiers only');
+  });
+
+  /** A follow-up failing is not the list call failing. */
+  test('a follow-up that fails leaves its reference and counts as unfilled', async () => {
+    const dispatch = async (_capability: string, args: Record<string, unknown>) =>
+      (args['id'] === 'id0'
+        ? { ok: false, authorization: 'denied_by_policy', message: 'no' }
+        : {
+            ok: true,
+            result: { content: [{ type: 'text' as const, text: JSON.stringify({ id: args['id'] }) }] },
+          }) as DispatchOutcome;
+
+    const filled = await expandIfReferences({
+      capability: LIST,
+      result: listing(references(2)),
+      asked: undefined,
+      merged: reachable(),
+      listArguments: {},
+      dispatch,
+    });
+
+    const rows = bodyOf(filled)['messages'] as Record<string, unknown>[];
+    expect(rows[0]).toEqual({ id: 'id0', threadId: 't0' });
+    expect(rows[1]).toEqual({ id: 'id1' });
+    expect(filled?.content[0]?.text).toContain('1 further row came back as identifiers only');
+  });
+});

--- a/src/server/mcp/expand-result.ts
+++ b/src/server/mcp/expand-result.ts
@@ -1,9 +1,9 @@
 import { isToolResult } from '#connectivity';
 import type { DispatchOutcome } from '#dispatch';
-import { fill, referencesIn, sibling } from './expand.ts';
+import { type ExpandArgument, expandMode, fill, noteFor, referencesIn, sibling } from './expand.ts';
 import type { MergedCapability } from './visibility.ts';
 
-export { sibling };
+export { EXPAND, type ExpandArgument } from './expand.ts';
 
 /**
  * The gateway's half of filling in a list of references.
@@ -21,51 +21,71 @@ export { sibling };
  * is also the honest description of what it is, since the provider being called
  * cannot tell either.
  *
+ * It is also why the projection is merged *here* rather than at the seam in
+ * `invoke` where `redact` is read. The dispatcher logs `request.arguments` and
+ * sends `request.arguments`; arguments injected below that seam would make the
+ * audit row and the wire disagree about what was asked for. Building them into
+ * the request keeps the row true, and keeps a direct call to the same `.get`
+ * answering with what the vendor's own default returns rather than quietly
+ * receiving less than the caller asked for.
+ *
  * What that costs: only calls arriving through `lanes_tools_call` are filled in.
  * Under `surface: crunched` that is every provider call, which is the case this
  * was built for. Under `full` a typed tool still returns what the provider
  * returned.
  */
-export async function expandIfReferences(
-  capability: string,
-  result: unknown,
-  wanted: boolean,
-  merged: Map<string, MergedCapability>,
-  fetch: (id: string) => Promise<DispatchOutcome>,
-): Promise<{ content: { type: 'text'; text: string }[] } | undefined> {
-  if (!wanted) return undefined;
-  if (sibling(capability, merged) === undefined) return undefined;
-  if (!isTool_(result)) return undefined;
+export interface ExpandRequest {
+  /** The list capability that was called. */
+  readonly capability: string;
+  /** What it answered with. */
+  readonly result: unknown;
+  /** What the caller asked for, if anything. */
+  readonly asked: ExpandArgument | undefined;
+  /** Everything this caller can reach, which is where the sibling and its projection live. */
+  readonly merged: ReadonlyMap<string, MergedCapability>;
+  /** The list's own arguments, which the follow-up inherits. */
+  readonly listArguments: Readonly<Record<string, unknown>>;
+  /** One ordinary top-level call, exactly as the caller's own would be. */
+  readonly dispatch: (
+    capabilityId: string,
+    args: Record<string, unknown>,
+  ) => Promise<DispatchOutcome>;
+}
 
-  const text = textOf(result);
-  const references = referencesIn(text);
+export async function expandIfReferences(
+  request: ExpandRequest,
+): Promise<{ content: { type: 'text'; text: string }[] } | undefined> {
+  const mode = expandMode(request.asked);
+  if (mode === undefined) return undefined;
+
+  const paired = sibling(request.capability, request.merged);
+  if (paired === undefined) return undefined;
+  if (!isToolResult(request.result as never)) return undefined;
+
+  const references = referencesIn(textOf(request.result));
   if (!references) return undefined;
 
-  const { filled, capped } = await fill(references.ids, async (id) => {
-    const outcome = await fetch(id);
+  // `full` merges nothing, so a caller who wants the vendor's own default
+  // representation has a way to say so.
+  const projection = mode === 'compact' ? (request.merged.get(paired)?.compact ?? {}) : {};
+
+  const { rows, fetched } = await fill(references.rows, async (id) => {
+    const outcome = await request.dispatch(paired, {
+      ...request.listArguments,
+      ...projection,
+      id,
+    });
     if (!outcome.ok || !isToolResult(outcome.result)) return undefined;
     return textOf(outcome.result);
   });
 
-  const note =
-    capped > 0
-      ? `\n\n${capped} further row${capped === 1 ? '' : 's'} came back as identifiers only and were ` +
-        'not fetched. Narrow the list, or call the get capability for the ones you want.'
-      : '';
+  // The whole body, not just the array: a page token or a total sat beside it,
+  // and replacing the body with the rows threw those away — which is what made
+  // the old note's advice impossible to act on.
+  const body = { ...references.body, [references.at]: rows };
+  const note = noteFor(mode, paired, references.rows.length - fetched);
 
-  return {
-    content: [
-      {
-        type: 'text' as const,
-        text: `${JSON.stringify({ [references.at]: filled }, null, 2)}${note}`,
-      },
-    ],
-  };
-}
-
-/** Whether a dispatch result is a tool result at all. */
-function isTool_(result: unknown): boolean {
-  return isToolResult(result as never);
+  return { content: [{ type: 'text' as const, text: `${JSON.stringify(body, null, 2)}${note}` }] };
 }
 
 /** The text of a tool result, with non-text blocks left out. */

--- a/src/server/mcp/expand.test.ts
+++ b/src/server/mcp/expand.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from 'bun:test';
-import { fill, referencesIn, sibling } from './expand.ts';
+import { expandMode, fill, noteFor, referencesIn, sibling } from './expand.ts';
 import type { MergedCapability } from './visibility.ts';
 
 /**
@@ -57,7 +57,20 @@ describe('deciding whether a result is references', () => {
       nextPageToken: 'x',
     });
 
-    expect(referencesIn(body)).toEqual({ at: 'messages', ids: ['a1', 'a2'] });
+    expect(referencesIn(body)).toEqual({
+      at: 'messages',
+      rows: [
+        { id: 'a1', threadId: 't1' },
+        { id: 'a2', threadId: 't2' },
+      ],
+      body: {
+        messages: [
+          { id: 'a1', threadId: 't1' },
+          { id: 'a2', threadId: 't2' },
+        ],
+        nextPageToken: 'x',
+      },
+    });
   });
 
   /**
@@ -102,49 +115,155 @@ describe('deciding whether a result is references', () => {
 });
 
 describe('doing the follow-ups', () => {
+  const references = (count: number): Record<string, unknown>[] =>
+    Array.from({ length: count }, (_, at) => ({ id: `id${at}`, threadId: `t${at}` }));
+
   test('each reference becomes the record it names', async () => {
-    const { filled, capped } = await fill(['a', 'b'], async (id) =>
+    const { rows, fetched } = await fill(references(2), async (id) =>
       JSON.stringify({ id, subject: `re: ${id}` }),
     );
 
-    expect(capped).toBe(0);
-    expect(filled).toEqual([
-      { id: 'a', subject: 're: a' },
-      { id: 'b', subject: 're: b' },
+    expect(fetched).toBe(2);
+    expect(rows).toEqual([
+      { id: 'id0', subject: 're: id0' },
+      { id: 'id1', subject: 're: id1' },
     ]);
   });
 
   /**
-   * Bounded, and it says so. A silent truncation reads as "that is all there
-   * was", which is the failure mode worth more than the rows it saves.
+   * The whole point of the rewrite. A page of small records is a page, not five
+   * of them, because what a reply costs is bytes and five was a count.
    */
-  test('a long list is capped, and the remainder is reported', async () => {
-    const many = Array.from({ length: 12 }, (_, at) => `id${at}`);
-    const { filled, capped } = await fill(many, async (id) => JSON.stringify({ id }));
+  test('a page of compact rows is filled in completely', async () => {
+    const { rows, fetched } = await fill(references(20), async (id) => JSON.stringify({ id }));
 
-    expect(filled).toHaveLength(5);
-    expect(capped).toBe(7);
+    expect(fetched).toBe(20);
+    expect(rows).toHaveLength(20);
+    // Every row is the record, not the reference it started as.
+    expect(rows.every((row) => !('threadId' in (row as Record<string, unknown>)))).toBe(true);
+  });
+
+  /**
+   * The reported failure, in one test. Records this large are what turned a
+   * question about an inbox into 193,271 characters, and the budget is what
+   * stops it — but every row still comes back, which is what the note that
+   * mentions them is now able to assume.
+   */
+  test('records too large to all fit stop at the budget, and the rest survive as references', async () => {
+    const heavy = 'x'.repeat(12 * 1024);
+    const { rows, fetched } = await fill(references(20), async (id) =>
+      JSON.stringify({ id, body: heavy }),
+    );
+
+    expect(fetched).toBeLessThan(20);
+    expect(rows).toHaveLength(20);
+    expect(rows[19]).toEqual({ id: 'id19', threadId: 't19' });
+  });
+
+  /**
+   * `FEWEST`, and the reason the first row is fetched on its own: a record big
+   * enough to spend the whole budget has to be seen to be measured, and a first
+   * wave of three would have paid for three of them to find that out.
+   */
+  test('a single record larger than the whole budget is still filled in, and costs one call', async () => {
+    const asked: string[] = [];
+    const { rows, fetched } = await fill(references(6), async (id) => {
+      asked.push(id);
+      return JSON.stringify({ id, body: 'x'.repeat(64 * 1024) });
+    });
+
+    expect(asked).toEqual(['id0']);
+    expect(fetched).toBe(1);
+    expect(rows).toHaveLength(6);
+    expect(rows[1]).toEqual({ id: 'id1', threadId: 't1' });
+  });
+
+  /** Somebody else's quota, not the caller's context — the other bound. */
+  test('a very long list stops at the fan-out ceiling', async () => {
+    const asked: string[] = [];
+    const { rows, fetched } = await fill(references(200), async (id) => {
+      asked.push(id);
+      return JSON.stringify({ id });
+    });
+
+    expect(asked.length).toBeLessThanOrEqual(25);
+    expect(fetched).toBe(asked.length);
+    expect(rows).toHaveLength(200);
   });
 
   /**
    * One row failing must not fail the call that found it. The reference is
-   * returned as it arrived, which is no worse than not having expanded at all.
+   * returned exactly as it arrived — `threadId` and all — so a caller told to
+   * fetch it by hand is holding what that takes.
    */
-  test('a follow-up that fails leaves its reference behind', async () => {
-    const { filled } = await fill(['a', 'b'], async (id) =>
-      id === 'a' ? undefined : JSON.stringify({ id, subject: 'ok' }),
+  test('a follow-up that fails leaves its reference behind, verbatim', async () => {
+    const { rows, fetched } = await fill(references(2), async (id) =>
+      id === 'id0' ? undefined : JSON.stringify({ id, subject: 'ok' }),
     );
 
-    expect(filled[0]).toEqual({ id: 'a' });
-    expect(filled[1]).toEqual({ id: 'b', subject: 'ok' });
+    expect(fetched).toBe(1);
+    expect(rows[0]).toEqual({ id: 'id0', threadId: 't0' });
+    expect(rows[1]).toEqual({ id: 'id1', subject: 'ok' });
   });
 
   test('order is the order the list gave, not the order they arrived', async () => {
-    const { filled } = await fill(['a', 'b', 'c', 'd'], async (id) => {
-      await new Promise((resolve) => setTimeout(resolve, id === 'a' ? 20 : 1));
+    const { rows } = await fill(references(4), async (id) => {
+      await new Promise((resolve) => setTimeout(resolve, id === 'id0' ? 20 : 1));
       return JSON.stringify({ id });
     });
 
-    expect(filled).toEqual([{ id: 'a' }, { id: 'b' }, { id: 'c' }, { id: 'd' }]);
+    expect(rows).toEqual([{ id: 'id0' }, { id: 'id1' }, { id: 'id2' }, { id: 'id3' }]);
+  });
+});
+
+describe('which representation to fill in with', () => {
+  test('nothing said means the small one', () => {
+    expect(expandMode(undefined)).toBe('compact');
+    expect(expandMode('compact')).toBe('compact');
+  });
+
+  test('whole records are asked for by name', () => {
+    expect(expandMode('full')).toBe('full');
+  });
+
+  test('false declines', () => {
+    expect(expandMode(false)).toBeUndefined();
+  });
+
+  /**
+   * Accepted and never advertised. `expand` shipped as a boolean, and ADR-032 is
+   * the record that a client which pinned its tool list at registration serves
+   * that schema forever — so refusing `true` would break exactly the clients the
+   * stable-name pair exists to rescue.
+   */
+  test('the boolean this shipped as still means what it meant', () => {
+    expect(expandMode(true)).toBe('compact');
+  });
+});
+
+describe('saying what is still an identifier', () => {
+  test('nothing left means nothing to say', () => {
+    expect(noteFor('compact', 'vendor_mail.messages.get', 0)).toBe('');
+  });
+
+  /** Naming it saves the caller a search for the thing it was just told to call. */
+  test('the note names the capability that resolves one', () => {
+    expect(noteFor('compact', 'vendor_mail.messages.get', 2)).toContain(
+      'vendor_mail.messages.get',
+    );
+    expect(noteFor('compact', 'vendor_mail.messages.get', 2)).toContain('2 further rows');
+  });
+
+  test('one row left is said in the singular', () => {
+    expect(noteFor('compact', 'vendor_mail.messages.get', 1)).toContain('1 further row came');
+  });
+
+  /**
+   * Under `full` the better answer is usually to ask for less, so the note says
+   * so. Under `compact` there is no smaller mode to point at.
+   */
+  test('asking for whole records is told there is a smaller way', () => {
+    expect(noteFor('full', 'vendor_mail.messages.get', 3)).toContain('expand: "compact"');
+    expect(noteFor('compact', 'vendor_mail.messages.get', 3)).not.toContain('expand:');
   });
 });

--- a/src/server/mcp/expand.ts
+++ b/src/server/mcp/expand.ts
@@ -1,3 +1,4 @@
+import { z } from 'zod';
 import type { MergedCapability } from './visibility.ts';
 
 /**
@@ -16,20 +17,116 @@ import type { MergedCapability } from './visibility.ts';
  * cost being removed — but it means spending someone else's rate limit on an
  * inference, and that is a real objection rather than a hypothetical one. Three
  * things keep it honest: the detection is strict enough that a false positive
- * is close to impossible, the fan-out is small and reported, and `expand:
+ * is close to impossible, the fan-out is bounded and reported, and `expand:
  * false` turns it off.
  *
  * Derived, never declared. The pairing comes from the names — a rule that finds
  * every list/get sibling across the vendored surface and nothing spurious — and
  * whether a list actually returned references is read off the response, because
  * the specs here do not say (`vendor-spec.ts` explains why they cannot).
+ *
+ * **What deciding cost, the first time it met a real mailbox.** Five rows came
+ * back as 193,271 characters and overflowed the reply, because a row was filled
+ * in at whatever representation the vendor defaults to and a Gmail message's
+ * default carries every `Received:` hop, the DKIM and ARC headers, and the body
+ * as base64. Two further rows were dropped to fit, and the note explaining that
+ * told the caller to fetch them itself — from an array the fill had already
+ * replaced, so the identifiers to do it with were gone.
+ *
+ * Three things follow, and none of them is the decision above.
+ *
+ * **A count was the wrong unit**, which `render.ts` had already worked out one
+ * file away for search answers: five rows is a few kilobytes of one provider's
+ * records and two hundred of another's, so a fixed number either truncates the
+ * useful answer or floods the context, and which it does depends on whose API
+ * the caller happened to ask about. The bound is bytes.
+ *
+ * **A row has to be worth filling in.** A vendor that will answer with a
+ * summary should be asked for one, and most will: `compact` merges the
+ * projection arguments the provider declared (`manifest.compact`) into the
+ * follow-up, so the saving happens at the source rather than by trimming a
+ * response we already paid to receive. That is what makes filling in *every*
+ * row affordable, which is the shape the caller wanted in the first place.
+ *
+ * **Nothing is dropped.** Every reference the list returned comes back, filled
+ * or not, and an unfilled one comes back exactly as the vendor wrote it — so
+ * the note telling a caller to fetch the rest is one it can act on.
+ *
+ * The only difference between `compact` and `full` is which arguments are
+ * merged. Both are bounded the same way, because the reported failure *is*
+ * `full` semantics with a row cap instead of a byte cap: exempting it would
+ * leave the bug in place for anyone who asked for it by name.
  */
 
-/** The most rows filled in for one call, however many came back. */
-const MOST = 5;
+/**
+ * What a filled-in reply may cost, in bytes of the caller's context.
+ *
+ * Deliberately not shared with `render.ts`'s budget. They bound different
+ * things — a search answer against a capability result — and that file can
+ * price an entry before spending it because it holds the schema, while this one
+ * has to fetch a row to learn its size. One number serving both would mean
+ * tuning the search surface silently changed how much mail came back.
+ */
+const BUDGET = 32 * 1024;
+
+/**
+ * Always filled, however large.
+ *
+ * `render.ts` takes the same floor for the same reason: a reply that names an
+ * identifier and withholds what it points at costs a round trip *and* looks
+ * like an answer. It is also why the first row is fetched on its own — a record
+ * big enough to spend the whole budget has to be seen to be measured, and a
+ * first wave of three would have paid for three of them before anything could
+ * check.
+ */
+const FEWEST = 1;
+
+/**
+ * The most rows filled in for one call, however small they are.
+ *
+ * No longer a bound on the caller's context — `BUDGET` is that — but on
+ * somebody else's quota, which is the objection the header concedes. A profile
+ * allows 60 upstream calls a minute by default, so one expansion may spend at
+ * most a little over a third of them. In practice this ceiling is what binds
+ * under `compact`, where rows are small, and the budget binds under `full`.
+ */
+const MOST = 25;
 
 /** How many at once. Bounded because they are somebody else's API. */
 const AT_ONCE = 3;
+
+/** Whole records, or the smaller one the provider declared. */
+export type ExpandMode = 'compact' | 'full';
+
+/** What a caller may pass. `true` is accepted and never advertised — see `EXPAND`. */
+export type ExpandArgument = boolean | ExpandMode;
+
+/**
+ * The argument, colocated with the rules that read it.
+ *
+ * `true` is accepted and deliberately undocumented. The shipped description
+ * never told anyone to pass it, and the new one teaches `compact`, `full` and
+ * `false` only — but `expand` was released as a boolean, and ADR-032 is the
+ * record that a client which pinned its tool list at registration serves that
+ * schema forever with no way for this endpoint to make it re-read. Refusing
+ * `true` would break exactly the clients `lanes_tools_search` exists to rescue.
+ * One spelling in the documentation, two in the parser, and the second is there
+ * for a client that cannot be told.
+ */
+export const EXPAND = z
+  .union([z.boolean(), z.enum(['compact', 'full'])])
+  .optional()
+  .describe(
+    'Fill in a list that comes back as bare identifiers. "compact" (the default) asks the ' +
+      'provider for a summary of every row; "full" asks for whole records and fills in fewer. ' +
+      'Pass false for the identifiers exactly as the provider returned them.',
+  );
+
+/** Which representation to fill in with, or nothing when the caller declined. */
+export function expandMode(asked: ExpandArgument | undefined): ExpandMode | undefined {
+  if (asked === false) return undefined;
+  return asked === 'full' ? 'full' : 'compact';
+}
 
 /**
  * The capability that turns one of these references into a record.
@@ -41,6 +138,16 @@ const AT_ONCE = 3;
 export function sibling(id: string, reachable: ReadonlyMap<string, MergedCapability>): string | undefined {
   const paired = id.endsWith('.list') ? `${id.slice(0, -'.list'.length)}.get` : undefined;
   return paired !== undefined && reachable.has(paired) ? paired : undefined;
+}
+
+/** A list body that holds nothing but references, and the rows themselves. */
+export interface References {
+  /** The property the array sat under. */
+  readonly at: string;
+  /** The reference objects, exactly as the vendor wrote them. */
+  readonly rows: readonly Record<string, unknown>[];
+  /** The whole body, so its siblings — a page token, a total — survive the fill. */
+  readonly body: Record<string, unknown>;
 }
 
 /**
@@ -58,7 +165,7 @@ export function sibling(id: string, reachable: ReadonlyMap<string, MergedCapabil
  * second call for something already in hand. `calendar.events.list` returns
  * whole events and is left alone by exactly this test.
  */
-export function referencesIn(text: string): { at: string; ids: string[] } | undefined {
+export function referencesIn(text: string): References | undefined {
   let body: unknown;
   try {
     body = JSON.parse(text);
@@ -67,59 +174,93 @@ export function referencesIn(text: string): { at: string; ids: string[] } | unde
   }
   if (typeof body !== 'object' || body === null || Array.isArray(body)) return undefined;
 
-  const arrays = Object.entries(body as Record<string, unknown>).filter(
+  const record = body as Record<string, unknown>;
+  const arrays = Object.entries(record).filter(
     ([, value]) => Array.isArray(value) && value.length > 0,
   );
   if (arrays.length !== 1) return undefined;
 
   const [at, rows] = arrays[0] as [string, unknown[]];
-  const ids: string[] = [];
 
   for (const row of rows) {
     if (typeof row !== 'object' || row === null || Array.isArray(row)) return undefined;
     const keys = Object.keys(row as Record<string, unknown>);
     if (keys.length > 2 || !keys.includes('id')) return undefined;
-    const id = (row as Record<string, unknown>)['id'];
-    if (typeof id !== 'string') return undefined;
-    ids.push(id);
+    if (typeof (row as Record<string, unknown>)['id'] !== 'string') return undefined;
   }
 
-  return ids.length > 0 ? { at, ids } : undefined;
+  return { at, rows: rows as Record<string, unknown>[], body: record };
 }
 
 /**
- * Run the follow-ups, a few at a time.
+ * Run the follow-ups, a few at a time, until the budget or the ceiling stops it.
  *
  * Each one goes through the same dispatcher as any other call, so it is
  * authorised, redacted, rate-limited and audited exactly as though the caller
  * had made it — which, in every sense that matters to the provider being
  * called, they did. A row that fails is left as the reference it was rather
- * than failing the call that found it.
+ * than failing the call that found it, and counts as unfilled, so the note at
+ * the end is about what the caller actually holds rather than what was tried.
+ *
+ * The budget is checked between waves rather than within one, so a reply may
+ * overshoot by up to `AT_ONCE - 1` rows. Serialising the fetches to make it
+ * exact would cost a round trip per row to save a few kilobytes of a bound that
+ * is itself a judgement.
  */
 export async function fill(
-  ids: readonly string[],
+  references: readonly Record<string, unknown>[],
   fetch: (id: string) => Promise<string | undefined>,
-): Promise<{ filled: unknown[]; capped: number }> {
-  const wanted = ids.slice(0, MOST);
-  const filled: unknown[] = new Array(wanted.length);
+): Promise<{ rows: unknown[]; fetched: number }> {
+  // Seeded from the references, so every position is present by construction
+  // and an unfilled one is the vendor's own object rather than a rebuild of it.
+  const rows: unknown[] = [...references];
+  const ceiling = Math.min(references.length, MOST);
 
-  for (let start = 0; start < wanted.length; start += AT_ONCE) {
-    const batch = wanted.slice(start, start + AT_ONCE);
-    const done = await Promise.all(batch.map(async (id) => fetch(id)));
+  let spent = 0;
+  let fetched = 0;
+  let at = 0;
+
+  while (at < ceiling) {
+    const width = at < FEWEST ? FEWEST : AT_ONCE;
+    const batch = references.slice(at, at + width);
+    const done = await Promise.all(batch.map(async (row) => fetch(row['id'] as string)));
 
     done.forEach((text, offset) => {
-      const at = start + offset;
-      if (text === undefined) {
-        filled[at] = { id: wanted[at] };
-        return;
-      }
+      if (text === undefined) return;
+      spent += text.length;
+      fetched += 1;
       try {
-        filled[at] = JSON.parse(text);
+        rows[at + offset] = JSON.parse(text);
       } catch {
-        filled[at] = { id: wanted[at], result: text };
+        rows[at + offset] = { ...references[at + offset], result: text };
       }
     });
+
+    at += width;
+    if (spent >= BUDGET) break;
   }
 
-  return { filled, capped: ids.length - wanted.length };
+  return { rows, fetched };
+}
+
+/**
+ * What to say about the rows that are still identifiers.
+ *
+ * Names the capability that turns one into a record, because the caller would
+ * otherwise have to search for it, and — under `full` — names the other mode,
+ * because asking for less is usually the better answer to "there were more of
+ * them". It says nothing about paging: the vendor's own page token is back in
+ * the body now, and guessing which key is one would be vendor knowledge dressed
+ * up as a heuristic.
+ */
+export function noteFor(mode: ExpandMode, getCapability: string, left: number): string {
+  if (left <= 0) return '';
+
+  const rows = `${left} further row${left === 1 ? '' : 's'}`;
+  const byHand = `call ${getCapability} for the ones you want`;
+
+  return mode === 'full'
+    ? `\n\n${rows} came back as identifiers only, because whole records are large. ` +
+        `Pass expand: "compact" to fill in every row at once, or ${byHand}.`
+    : `\n\n${rows} came back as identifiers only. Narrow the list, or ${byHand}.`;
 }

--- a/src/server/mcp/search.ts
+++ b/src/server/mcp/search.ts
@@ -8,7 +8,7 @@ import {
   searchCapabilities,
   searchResults,
 } from './search-index.ts';
-import { expandIfReferences, sibling } from './expand-result.ts';
+import { EXPAND, type ExpandArgument, expandIfReferences } from './expand-result.ts';
 import { validate } from './validate.ts';
 import { SURFACE_TOOL_NAMES, toolNameFor } from './naming.ts';
 import {
@@ -210,13 +210,7 @@ export function registerSearchSurface(
           .record(z.string(), z.unknown())
           .default({})
           .describe("The capability's own arguments, as its schema describes them"),
-        expand: z
-          .boolean()
-          .optional()
-          .describe(
-            'Fill in a list that comes back as bare identifiers, by fetching the first few. ' +
-              'On by default. Pass false to get the identifiers as the provider returned them.',
-          ),
+        expand: EXPAND,
       },
     },
     async (input: {
@@ -224,7 +218,7 @@ export function registerSearchSurface(
       profile: string;
       connection: string;
       arguments?: Record<string, unknown>;
-      expand?: boolean | undefined;
+      expand?: ExpandArgument | undefined;
     }) => {
       const { capability, profile, connection } = input;
       const entry = merged.get(capability);
@@ -347,20 +341,21 @@ export function registerSearchSurface(
       // is strict — see `expand.ts` — and a list already holding whole records
       // fails them and is left alone, which is what happens to almost every
       // provider here.
-      const filled = await expandIfReferences(
+      const filled = await expandIfReferences({
         capability,
-        outcome.result,
-        input.expand !== false,
+        result: outcome.result,
+        asked: input.expand,
         merged,
-        async (id) =>
+        listArguments: input.arguments ?? {},
+        dispatch: async (capabilityId, args) =>
           runtime.dispatcher.invoke({
             principal: forProfile(options.principal, profile),
-            capabilityId: sibling(capability, merged) as string,
+            capabilityId,
             connectionKey: connection,
-            arguments: { ...(input.arguments ?? {}), id },
+            arguments: args,
             ...(options.clientLabel ? { clientLabel: options.clientLabel } : {}),
           }),
-      );
+      });
       if (filled) return filled;
 
       // Text only, unlike `makeHandler`. A `resource_link` has to be rewritten

--- a/src/server/mcp/unauthorized.test.ts
+++ b/src/server/mcp/unauthorized.test.ts
@@ -74,6 +74,10 @@ members: []
       // This fake declares no bundles, so nothing here reads-only. What is
       // under test is grants, and the read/write split does not enter into it.
       expandBundle: () => [],
+      // Nor a manifest, so no capability here declares a compact projection.
+      // Same reason: what a filled-in list asks the provider for is not what
+      // this file is about.
+      manifest: () => undefined,
     },
     policy: toPolicyDocument(config),
   } as unknown as ProfileRuntime;

--- a/src/server/mcp/visibility.ts
+++ b/src/server/mcp/visibility.ts
@@ -132,6 +132,13 @@ export interface MergedCapability {
    * three places need it and only this one holds the registry.
    */
   readonly reads: boolean;
+
+  /**
+   * The arguments that ask this capability's provider for a smaller record.
+   * Resolved here for the same reason `reads` is: the gateway that fills in a
+   * list holds the merged entry and not the registry.
+   */
+  readonly compact?: Readonly<Record<string, unknown>>;
 }
 
 export function mergeCapabilities(options: BuildServerOptions): Map<string, MergedCapability> {
@@ -167,6 +174,7 @@ export function mergeCapabilities(options: BuildServerOptions): Map<string, Merg
         capability,
         discovered,
         reads: readsOnly(id, discovered, runtime.registry),
+        ...compactFor(id, capability, discovered, runtime.registry),
       });
     }
   }
@@ -367,4 +375,24 @@ export function accountsByProfile(
   }
 
   return accounts;
+}
+
+/**
+ * The projection a provider declared for one capability, if it declared one.
+ * Keyed by the unqualified name, exactly as `redact` and `hints` are.
+ */
+function compactFor(
+  id: string,
+  capability: ReturnType<ProviderRegistry['capabilities']>[number]['capability'],
+  discovered: ReturnType<ProviderRegistry['capabilities']>[number]['discovered'],
+  registry: ProviderRegistry,
+): { compact?: Record<string, unknown> } {
+  const [provider] = id.split('.');
+  const name = capability?.name ?? discovered?.name;
+  if (provider === undefined || name === undefined) return {};
+
+  // Spread rather than assigned, because `exactOptionalPropertyTypes` refuses
+  // an explicit `undefined` where the field is declared optional.
+  const compact = registry.manifest(provider)?.compact?.[name];
+  return compact === undefined ? {} : { compact };
 }

--- a/src/server/search.test.ts
+++ b/src/server/search.test.ts
@@ -1,5 +1,7 @@
 import { afterAll, describe, expect, test } from 'bun:test';
-import { allocatePort, rpc, startHarness } from './harness.ts';
+import { z } from 'zod';
+import { defineLocalProvider } from '#connectivity';
+import { allocatePort, parseConfig, rpc, startHarness } from './harness.ts';
 import { SURFACE_TOOL_NAMES } from './mcp/index.ts';
 
 /**
@@ -37,8 +39,83 @@ const work = startHarness({
     - "example.list_notes"`,
 });
 
+/**
+ * A provider shaped like the one that overflowed a reply: a list that answers
+ * with bare references, and a get beside it whose record can be made any size.
+ *
+ * `example` cannot stand in for it — `list_notes` and `get_note` do not pair,
+ * because pairing is `<x>.list` with `<x>.get` and nothing else.
+ */
+const fixtureMail = defineLocalProvider({
+  id: 'fixture_mail',
+  name: 'Fixture Mail',
+  description: 'A list of references and the get that resolves one.',
+  configSchema: z.object({}),
+  connectionSchema: z.object({}),
+  bundles: [
+    { name: 'read', description: 'Read.', oauth_scopes: [], capabilities: ['notes.list', 'notes.get'], default: true },
+  ],
+  capabilities: [
+    {
+      kind: 'tool',
+      name: 'notes.list',
+      title: 'List notes',
+      description: 'Identifiers of the notes in this account, and a token for the next page.',
+      inputSchema: z.object({ count: z.number().optional(), bytes: z.number().optional() }),
+      async handler({ count }) {
+        const notes = Array.from({ length: count ?? 20 }, (_, at) => ({
+          id: `n${at}`,
+          threadId: `t${at}`,
+        }));
+        return {
+          content: [
+            { type: 'text', text: JSON.stringify({ notes, nextPageToken: 'page-2' }) },
+          ],
+        };
+      },
+    },
+    {
+      kind: 'tool',
+      name: 'notes.get',
+      title: 'Get a note',
+      description: 'One note, by identifier.',
+      inputSchema: z.object({ id: z.string(), bytes: z.number().optional() }),
+      async handler({ id, bytes }) {
+        const note = { id, subject: `re: ${id}`, ...(bytes ? { body: 'x'.repeat(bytes) } : {}) };
+        return { content: [{ type: 'text', text: JSON.stringify(note) }] };
+      },
+    },
+  ],
+});
+
+/** An endpoint serving it, so expansion can be watched end to end. */
+const mailPort = allocatePort();
+const mail = startHarness({
+  profile: 'personal',
+  port: mailPort,
+  providers: [fixtureMail],
+  // Required by the options type, and unused: `config` replaces what it builds.
+  policy: '',
+  // Written out rather than taken from `policy`, which grants the two `example`
+  // connections the harness always makes and cannot name another provider.
+  config: parseConfig(`
+contract: 5
+instance:
+  profile: personal
+  port: ${mailPort}
+limits:
+  requests_per_minute: 1000
+  upstream_calls_per_minute: 1000
+grants:
+  - connection: fixture_mail.main
+    allow:
+      - "fixture_mail.*"
+members: []
+`).config,
+});
+
 afterAll(async () => {
-  await Promise.all([personal.stop(), work.stop()]);
+  await Promise.all([personal.stop(), work.stop(), mail.stop()]);
 });
 
 async function names(url: string, token?: string): Promise<string[]> {
@@ -292,5 +369,90 @@ describe('what is checked before the call goes out', () => {
     expect(outcome.isError).toBe(true);
     expect(outcome.text).not.toContain('was not called');
     expect(outcome.text).not.toContain('json');
+  });
+});
+
+describe('filling in a list that came back as references', () => {
+  const listing = async (args: Record<string, unknown>) =>
+    call(mail.server.url, {
+      capability: 'fixture_mail.notes.list',
+      profile: 'personal',
+      connection: 'fixture_mail.main',
+      ...args,
+    });
+
+  const bodyOf = (text: string) =>
+    JSON.parse(text.split('\n\n')[0] ?? '') as Record<string, unknown>;
+
+  /**
+   * The reported failure, end to end. Twenty references went out and five
+   * records came back, because the bound was a row count — so the answer to
+   * "what is in this account" was four fifths a list of identifiers, and the
+   * identifiers it did not fill in had been dropped to make room.
+   */
+  test('every row comes back, as a record', async () => {
+    const { text, isError } = await listing({ arguments: { count: 20 } });
+    expect(isError).toBe(false);
+
+    const notes = bodyOf(text)['notes'] as Record<string, unknown>[];
+    expect(notes).toHaveLength(20);
+    expect(notes.every((note) => typeof note['subject'] === 'string')).toBe(true);
+    expect(text).not.toContain('identifiers only');
+  });
+
+  /** Paging was impossible while the fill replaced the whole body with the rows. */
+  test('what sat beside the array survives it', async () => {
+    const { text } = await listing({ arguments: { count: 5 } });
+
+    expect(bodyOf(text)['nextPageToken']).toBe('page-2');
+  });
+
+  test('a caller who declines gets what the provider returned', async () => {
+    const { text } = await listing({ arguments: { count: 3 }, expand: false });
+
+    const notes = bodyOf(text)['notes'] as Record<string, unknown>[];
+    expect(notes).toEqual([
+      { id: 'n0', threadId: 't0' },
+      { id: 'n1', threadId: 't1' },
+      { id: 'n2', threadId: 't2' },
+    ]);
+  });
+
+  /**
+   * Records this size are what 193,271 characters was made of. The budget stops
+   * the reply growing without bound, and every row is still there — so the note
+   * naming the rest is advice the caller can act on.
+   */
+  test('records too large to all fit are bounded, and the rest stay as references', async () => {
+    const { text } = await listing({ arguments: { count: 20, bytes: 12 * 1024 } });
+
+    const notes = bodyOf(text)['notes'] as Record<string, unknown>[];
+    expect(notes).toHaveLength(20);
+    expect(notes.at(-1)).toEqual({ id: 'n19', threadId: 't19' });
+    expect(text).toContain('came back as identifiers only');
+    expect(text).toContain('fixture_mail.notes.get');
+    expect(text.length).toBeLessThan(128 * 1024);
+  });
+
+  /** `full` is bounded the same way — the reported failure *was* `full` semantics. */
+  test('asking for whole records is bounded too, and says where the smaller one is', async () => {
+    const { text } = await listing({
+      arguments: { count: 20, bytes: 12 * 1024 },
+      expand: 'full',
+    });
+
+    expect((bodyOf(text)['notes'] as unknown[])).toHaveLength(20);
+    expect(text).toContain('expand: "compact"');
+    expect(text.length).toBeLessThan(128 * 1024);
+  });
+
+  /** The boolean it shipped as still means what it meant, for a client that pinned the schema. */
+  test('the boolean this shipped as is still accepted', async () => {
+    const { text, isError } = await listing({ arguments: { count: 4 }, expand: true });
+
+    expect(isError).toBe(false);
+    expect((bodyOf(text)['notes'] as Record<string, unknown>[])[0]).toMatchObject({
+      subject: 're: n0',
+    });
   });
 });


### PR DESCRIPTION
Two changes, both altering what a client receives rather than only what happens inside — which is
why the version is declared here rather than proposed as a patch.

## Expansion fills in a compact record, and stops dropping the rows it did not fetch (#213)

A list that comes back as bare identifiers is filled in before it is returned. Until now that was
five rows at whatever representation the vendor defaults to: for a mailbox, **193,271 characters**,
with two further rows discarded — along with the identifiers a caller would have needed to fetch
them, so the note advising exactly that could not be acted on.

The bound is bytes rather than a row count, rows are filled in at a projection the provider declares
(`compact`, a new optional manifest key beside `redact` and `hints`), and every identifier survives
whether it was filled or not. Verified against a real mailbox: the same message is **77,857**
characters at the vendor's default and **904** at the declared projection, and a fourteen-row list
now returns every row inline where two rows previously overflowed.

`expand` widens from a boolean to `false | 'compact' | 'full'`. The boolean it shipped as is still
accepted and no longer advertised, because a client that pinned its tool list at registration cannot
be told otherwise (ADR-032).

## A refused credential is distrusted everywhere, and a grant that has ended says so (#215)

0.13.0 stopped one transport resending a token the vendor had already refused. It reached one
transport and one cache. This reaches the three places it still could not be noticed at all — an
authored send path that calls its vendor directly, the `mcp` transport where the reply is consumed
by a client library, and the service-account token cache — and adds the distinction none of them
had.

A 401 that outlives its own refresh is a grant that has ended rather than a token that went stale.
That is now said in the result, naming the connection and keeping the vendor's own words as
evidence, and recorded as `error.kind: needs_reauth` in the audit row. The retried response is
verified too, which is what makes the distinction observable at all — it was not, so the evidence
was being discarded at the only moment it existed.

## Compatibility

`compact` is optional and additive: every profile and manifest written before this loads unchanged.
The `expand` argument accepts everything it accepted before.

## Checks

`bun test` 3581 pass, 0 fail. `bun run typecheck` clean. Both gates run again in `release.yml`
against the exact tree being published.