### PR TITLE
The workspace moves under the Lanes home, and a checkout gets its own

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,23 +42,28 @@ The one pull request that is not squashed is the release; see below.
 URL, or a "Generated with Claude Code" footer, to a pull request body. This repository is public
 and the link is noise to everyone reading it. The `Co-Authored-By` trailer on commits is fine.
 
-## Never run `lanes link` from a worktree without `LANES_LINK_HOME`
+## A worktree gets its own workspace, and you should still read the path it prints
 
-`resolveWorkspaceRoot` (`src/profile/workspace.ts`) checks `LANES_LINK_HOME`, then
-walks ancestors for `lanes-link.yaml`, then falls back to `~/.lanes-link`. A worktree has neither
-of the first two — so a verification command run from one writes into the operator's real
-workspace, which holds their live profiles, credentials, state, and audit log. Worse than reading
-it: `lanes link deploy` and `lanes link sync targets` both *write* there — one uploads config to a
-bucket and records the deployment, the other merges a remote copy into their profiles.
+This used to be a rule you had to remember: export `LANES_LINK_HOME` before running anything from a
+worktree, because the fallback reached the operator's real workspace. It is now handled — ADR-077,
+`src/home/index.ts`. A checkout resolves to `~/.lanes-dev/link` and cannot reach `~/.lanes/link` by
+accident, because `homeWorkspaceRoot` refuses to hand a checkout the real root at all.
 
-```console
-$ export LANES_LINK_HOME=/tmp/lanes-link-scratch
-$ lanes link start --port 7401     # the usual port is already serving the real endpoint
-```
+The chain is `LANES_LINK_HOME`, then an ancestor holding `workspaces.yaml`, then `~/.lanes-dev/link`
+from a checkout or `~/.lanes/link` from an install. Dev mode is decided by whether `tsconfig.json`
+sits at the install root, which is true in a checkout and in nothing that ships.
 
-Nothing in the output distinguishes the scratch workspace from the real one except the path it
-prints, so check it. A `/health` response naming a profile you did not create means you are
-talking to their server.
+Two things still bite:
+
+- **`LANES_LINK_DEV=0` turns it off**, and is the only way to reach a real workspace from here. That
+  is deliberate — see the deploy section below, which is the one place it is the right thing to do.
+- **A dev run has its own Lanes session**, at `~/.lanes-dev/credentials.json`. `lanes link start`
+  requires a session (ADR-060), so expect to `lanes auth login` once inside dev mode. It is a
+  separate sign-in on purpose: signing out in a test must not sign the operator out.
+
+Nothing in the output distinguishes the dev workspace from the real one except the path it prints,
+so check it. A `/health` response naming a profile you did not create means you are talking to their
+server.
 
 ## Anything touching a real account is the operator's call
 
@@ -82,9 +87,15 @@ $ bun run ./src/cli/lanes.ts link deploy --workspace <target>
 
 That builds an image from the branch and rolls a revision on a real target. Three things about it:
 
-- **`LANES_LINK_HOME` stays unset for this, deliberately** — the opposite of the rule above,
-  because the point is to reach a real deployment. So the target is the operator's, the deploy is
-  theirs to authorise, and a broken revision is theirs to live with until the next one. Ask.
+- **`LANES_LINK_DEV=0` is required for this, deliberately** — the opposite of the rule above,
+  because the point is to reach a real deployment. A worktree is a checkout, so without it the
+  command reads `~/.lanes-dev/link` and finds no target to deploy to. So the target is the
+  operator's, the deploy is theirs to authorise, and a broken revision is theirs to live with until
+  the next one. Ask.
+
+  ```console
+  $ LANES_LINK_DEV=0 bun run ./src/cli/lanes.ts link deploy --workspace <target>
+  ```
 - **A previous revision is still there.** Cloud Run keeps them and traffic can be moved back, which
   is what makes this recoverable and a bad npm publish not.
 - **Verify against the endpoint, not the command's exit code.** `POST /reload` returns the
@@ -160,7 +171,7 @@ cannot work, because writing the name into it is the thing being prevented.
 
 ## Where things are
 
-One package, one `src/`, thirteen components. Cross-component imports go through the
+One package, one `src/`, fourteen components. Cross-component imports go through the
 package.json `imports` map: `#policy`, `#stores/state`, `#providers/google/gmail`. There
 are no workspace packages and no `apps/` or `packages/` — see the layout table in
 [Architecture](https://lanes.sh/docs/link/architecture).

--- a/docs/detailed/adr/077-the-workspace-lives-under-the-lanes-home.md
+++ b/docs/detailed/adr/077-the-workspace-lives-under-the-lanes-home.md
@@ -1,0 +1,134 @@
+# ADR-077: The workspace lives under the Lanes home
+
+**Status:** accepted · **Amends** [ADR-052](052-a-target-owns-its-workspace.md) and
+[ADR-037](037-a-command-names-what-it-acts-on.md) on the last step of the root-resolution chain
+only — `LANES_LINK_HOME` and the ancestor walk are unchanged
+
+## Context
+
+`~/.lanes` is where Lanes keeps things on a machine, and it predates this CLI. The desktop app owns
+`auth.json`, `settings.json`, `database.db` and `integrations.json` there, and `#auth/lanes/session.ts`
+put the signed-in session beside them for the reason its docstring gives: it is not workspace state,
+and it must not be uploaded to a bucket on the next deploy.
+
+The workspace was the one thing outside it, at `~/.lanes-link`. Nothing chose that. It is what a
+single-word product name produces when the directory is created before there is a second thing to sit
+beside — and the cost is that one product has two conventions, so a reader has two directories to know
+about and neither name says the other exists.
+
+There is a second cost, and it is the expensive one.
+
+**Running this CLI out of a checkout reached the operator's real workspace.** The chain was
+`LANES_LINK_HOME`, then an ancestor holding a registry, then `~/.lanes-link`. A worktree has neither of
+the first two, so a verification command run from one resolved to live profiles, credentials, state and
+an audit log — and `deploy` and `sync targets` both *write* there, one uploading config to a bucket and
+the other merging a remote copy into somebody's profiles.
+
+The remedy was a house rule: export `LANES_LINK_HOME` before running anything from a worktree. It has a
+section in `CLAUDE.md` and three test files carry docstrings explaining that they pin the variable
+because otherwise the suite reads real credentials. A rule that works exactly as often as it is
+remembered, defended by prose, in a repository where the thing being protected is an encrypted
+credential store.
+
+## Decision
+
+**The workspace root is `~/.lanes/link`, and a checkout gets `~/.lanes-dev/link`.**
+
+The dev split moves the whole Lanes home rather than just the workspace, so a `lanes auth login` while
+testing a branch cannot sign the operator out of the install they actually use. `~/.lanes-dev/credentials.json`
+is the session in dev; `~/.lanes/credentials.json` is the session otherwise.
+
+**Dev mode is detected, not configured.** The signal is `tsconfig.json` at the install root, which is in
+neither `package.json`'s `files` array nor the Dockerfile's `COPY` — so it exists in a checkout and
+nowhere else. `LANES_LINK_DEV=0|1` overrides in both directions.
+
+The obvious alternative — is the install root under `node_modules`, which is what `updatePlan` asks —
+was rejected on one case. `bun link` symlinks the *directory* `node_modules/@lanes-sh/link` at a
+checkout, and `bin/lanes` resolves its own path logically rather than with `-P`, so a bun-linked
+checkout has an install root containing `node_modules`. Deciding where somebody's credentials live on a
+resolver detail is not a trade worth making; a file that is either in the tarball or not is. `.git` was
+the other candidate and is rejected for the reason `updatePlan` already gives against it: a tarball
+could carry one and a shallow export could lack it.
+
+**`~/.lanes-link` is recognised, never written.** The same rule `LEGACY_WORKSPACE_FILE` follows, for
+the same reason: a root that cannot be found cannot be migrated, and a workspace that stops resolving
+the moment its owner upgrades is a wall with no door. `resolveWorkspaceRoot` returns it when a
+workspace is there and this is not a checkout.
+
+**The move runs from `update` and from `doctor --fix`, and from nowhere else.** The alternative — the
+first command to notice the old root moves it — relocates the directory holding somebody's credentials,
+audit log and every profile they have. A `status` that quietly did that is one they cannot audit
+afterwards, and nothing is lost by waiting, because the old root goes on resolving until it moves.
+
+## What the resolution chain is now
+
+```
+1. LANES_LINK_HOME              explicit; a path or a gs:// bucket (ADR-023)
+2. ancestor workspaces.yaml     or lanes-link.yaml — a per-repository workspace
+3. ~/.lanes/link                when a workspace is there
+4. ~/.lanes-link                when one is there instead, and this is not a checkout
+5. ~/.lanes/link                otherwise, so a fresh install creates it
+```
+
+Steps 3 and 4 test for a **marker file**, never for the directory. That is not pedantry: `~/.lanes`
+belongs to the desktop app, so `~/.lanes/link` can come into existence without a workspace in it, and
+an interrupted move leaves exactly that. A directory test would prefer the empty new root, report "no
+profiles here", and strand the intact old one from the command that migrates it — with the migration
+itself then refusing, because two roots exist. The failure would be permanent and the repair path would
+be the one that was blocked.
+
+## What the migration refuses
+
+Everything is checked before the first byte moves, which is `migrateWorkspace`'s rule and matters more
+here than usual: the thing being moved is the only remaining description of where somebody's accounts
+live.
+
+- **A checkout**, because applying it from one would move the real workspace into a scratch home — the
+  accident dev mode exists to prevent, reached from the other side.
+- **`LANES_LINK_HOME` set**, because an explicit root is a decision and in a container it is a bucket.
+- **Both roots holding different things**, because merging two workspaces is not reversible. Both are
+  reported and neither is touched. Where the new root already holds everything the old one does, that
+  is not two workspaces — it is an interrupted copy, and the rerun finishes it.
+- **A live endpoint**, by the pid check `readEndpointRecord` already does. A running `start` holds the
+  old path, and moving out from under it leaves a process serving a directory nobody can find.
+- **A target naming an absolute path inside the old root.** This is the one that would have been
+  silent. `credentials.path`, `storage.path` and `vault.path` are optional, and `workspacePath` honours
+  an absolute path verbatim — so a relative one travels with the directory while an absolute one goes
+  on naming a location the migration has just emptied. For `credentials.path` that is the encrypted
+  credential store.
+
+`rename` does the move where both paths are on one volume, which under `$HOME` they nearly always are:
+atomic, no window in which a reader sees half a workspace, nothing left to delete. On `EXDEV` it is
+copy, read back, delete, in that order — the order that survives interruption, because a crash after
+the copy leaves both and the rerun finishes, where a crash after a delete leaves neither.
+
+Not a key-by-key drain through `workspaceFiles()`, which is the other obvious way and is wrong four
+times over: the filesystem blob store's `list` skips `.meta` sidecars, so content types are silently
+dropped; it returns files only, so empty directories do not survive; `entry.isDirectory()` is false for
+a symlinked directory; and a drain has an observable half-state where `rename` has none.
+
+## Consequences
+
+**A new component.** `#home` answers where Lanes keeps things, and it imports nothing. `#profile`
+resolves the workspace root and `#auth` resolves the session path, and `auth` may not import `profile`
+— so the alternative to a leaf both may reach is the same directory spelled in two files, which is the
+failure `layout.ts` records for a filename and would be worse for a credential store. `installRoot`
+moved there too: it is a fact about the install, and dev mode is the question that needs it.
+
+**The house rule retires.** "Never run `lanes link` from a worktree without `LANES_LINK_HOME`" existed
+only because the fallback reached real credentials. It cannot now.
+
+**And the one it costs.** Proving a fix against a real deployment deliberately ran the CLI from a
+worktree with `LANES_LINK_HOME` unset, because the point was to reach a real target. That now resolves
+to `~/.lanes-dev/link`, so the step has to say what it means — `LANES_LINK_DEV=0`, or an explicit
+`LANES_LINK_HOME`. This is the safer default making the dangerous thing explicit rather than the other
+way round, which is the trade the whole decision is.
+
+**Two sessions in dev.** A contributor testing a branch signs in once more, because `start` requires a
+session for a local endpoint (ADR-060). That is the price of a dev run being unable to sign the
+operator out of their real one, and it was taken knowingly.
+
+**A cross-repository contract.** ADR-065 records that the desktop app runs this CLI from the home
+directory and relies on the walk landing on `~/.lanes-link`. It lands on `~/.lanes/link` now, which is
+correct once migrated and is a change the app repository has to be told about; nothing on this side can
+assert it.

--- a/docs/detailed/adr/README.md
+++ b/docs/detailed/adr/README.md
@@ -89,6 +89,7 @@ Run.
 | [074](074-the-endpoint-records-where-it-bound.md) | The endpoint records where it bound, so an edit reaches the one that is running rather than a port derived from the profile it edited |
 | [075](075-the-list-a-client-caches-must-stop-changing.md) | The typed tool list stays and gains a search beside it, so a client that never re-reads can still reach a new connection |
 | [076](076-an-endpoint-may-advertise-less-than-it-reaches.md) | An endpoint may advertise less than it reaches, so a catalogue too large for its clients can shrink without any capability leaving it |
+| [077](077-the-workspace-lives-under-the-lanes-home.md) | The workspace moves to `~/.lanes/link`, a checkout gets `~/.lanes-dev`, and the old root is recognised until `update` moves it |
 
 Where an ADR departs from init.md, it says so at the top. Three are significant:
 

--- a/docs/detailed/init.md
+++ b/docs/detailed/init.md
@@ -582,6 +582,11 @@ profiles/
 
 Workspace root resolves from `LANES_LINK_HOME`, else the nearest ancestor directory containing `workspaces.yaml`, else `~/.lanes-link`.
 
+> **Amended by [ADR-077](adr/077-the-workspace-lives-under-the-lanes-home.md).** The last step is
+> `~/.lanes/link`, under the Lanes home the desktop app already uses — or `~/.lanes-dev/link` when the
+> CLI is running out of a checkout. `~/.lanes-link` is still recognised where a workspace is there, so
+> nothing goes missing before `lanes link update` moves it.
+
 > **Amended by [ADR-066](adr/066-a-profile-owns-its-data-again.md) and
 > [ADR-067](adr/067-one-directory-per-profile.md).** A profile is one directory holding its
 > declaration and every byte it owns; `data/` is gone, and `lanes-link.yaml` is now

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lanes-sh/link",
-  "version": "0.13.0",
+  "version": "0.14.0",
   "description": "A self-hostable MCP gateway for all your connections, memory, tasks, files, and secrets",
   "license": "Apache-2.0",
   "homepage": "https://lanes.sh/link",
@@ -70,6 +70,7 @@
     "#connectivity/transports": "./src/connectivity/transports/index.ts",
     "#deployments/*": "./src/deployments/*",
     "#dispatch": "./src/dispatch/index.ts",
+    "#home": "./src/home/index.ts",
     "#policy": "./src/policy/index.ts",
     "#profile": "./src/profile/index.ts",
     "#profile/*": "./src/profile/*",

--- a/src/architecture.test.ts
+++ b/src/architecture.test.ts
@@ -66,17 +66,25 @@ function componentOf(path: string): string {
  */
 const MAY_IMPORT: Record<string, readonly string[]> = {
   audit: [],
+  // Where Lanes keeps things on this machine, and nothing else. It imports
+  // nothing on purpose: `auth` and `profile` both need the answer, `auth` may
+  // not reach `profile` (see below), and the alternative to a shared leaf is
+  // the same directory spelled in two files. That is the failure `layout.ts`
+  // records for a filename; for a home directory it would be the two halves of
+  // this CLI disagreeing about where the credentials are.
+  home: [],
   // `stores` because issuing a token means remembering it, and a registered
   // client, an authorization code and a live token all outlive the instance
   // that created them — Cloud Run replaces instances between requests, so
   // in-memory would mean every connector logging out at random. It stays
   // downward: `stores` is at the bottom and `secrets` already depends on it.
-  auth: ['secrets', 'stores'],
+  // `home` for the session path, which is `~/.lanes/credentials.json`.
+  auth: ['home', 'secrets', 'stores'],
   policy: ['audit'],
   stores: ['audit'],
   secrets: ['stores'],
   connectivity: ['audit', 'secrets', 'stores', 'registry'],
-  profile: ['deployments', 'providers', 'secrets', 'stores'],
+  profile: ['deployments', 'home', 'providers', 'secrets', 'stores'],
   // Reconcile writes connection rows and reports which credentials are missing,
   // so it reaches both stores; it never opens one.
   registry: ['audit', 'connectivity', 'policy', 'profile', 'secrets', 'stores'],
@@ -92,7 +100,7 @@ const MAY_IMPORT: Record<string, readonly string[]> = {
   // is its own store, the dependency is stated instead of laundered. It stays
   // downward — `audit` sits at the bottom and imports nothing.
   cli: [
-    'audit', 'auth', 'connectivity', 'deployments', 'dispatch', 'policy',
+    'audit', 'auth', 'connectivity', 'deployments', 'dispatch', 'home', 'policy',
     'profile', 'providers', 'registry', 'secrets', 'server', 'stores',
   ],
 };

--- a/src/auth/lanes/members.test.ts
+++ b/src/auth/lanes/members.test.ts
@@ -1,7 +1,7 @@
 import { afterAll, describe, expect, test } from 'bun:test';
 import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
-import { join } from 'node:path';
+import { dirname, join } from 'node:path';
 import { describeMember, workspaceMembers } from './members.ts';
 import { sessionPath } from './session.ts';
 
@@ -21,7 +21,7 @@ const homes: string[] = [];
 async function signedIn(): Promise<string> {
   const root = await mkdtemp(join(tmpdir(), 'lanes-members-'));
   homes.push(root);
-  await mkdir(join(root, '.lanes'), { recursive: true });
+  await mkdir(dirname(sessionPath(root)), { recursive: true });
   await writeFile(
     sessionPath(root),
     JSON.stringify({

--- a/src/auth/lanes/session.test.ts
+++ b/src/auth/lanes/session.test.ts
@@ -1,7 +1,7 @@
 import { afterAll, describe, expect, test } from 'bun:test';
 import { mkdtemp, rm, stat, writeFile, mkdir } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
-import { join } from 'node:path';
+import { dirname, join } from 'node:path';
 import {
   clearSession,
   isFresh,
@@ -67,7 +67,7 @@ describe('the session file', () => {
     // nothing to do with auth, and a JSON parse error surfacing out of
     // `lanes link memory list` would send somebody to entirely the wrong place.
     const root = await home();
-    await mkdir(join(root, '.lanes'), { recursive: true });
+    await mkdir(dirname(sessionPath(root)), { recursive: true });
     await writeFile(sessionPath(root), '{ not json');
 
     expect(await readSession(root)).toBeNull();
@@ -78,7 +78,7 @@ describe('the session file', () => {
     // token would otherwise present as signed in and fail on the first refresh,
     // which is the same failure one step later and harder to read.
     const root = await home();
-    await mkdir(join(root, '.lanes'), { recursive: true });
+    await mkdir(dirname(sessionPath(root)), { recursive: true });
     await writeFile(sessionPath(root), JSON.stringify({ subject: 'lanes:x' }));
 
     expect(await readSession(root)).toBeNull();

--- a/src/auth/lanes/session.ts
+++ b/src/auth/lanes/session.ts
@@ -1,6 +1,7 @@
 import { chmod, mkdir, readFile, writeFile } from 'node:fs/promises';
 import { homedir } from 'node:os';
 import { dirname, join } from 'node:path';
+import { lanesHome } from '#home';
 
 /**
  * The Lanes identity this machine is signed in as.
@@ -11,14 +12,27 @@ import { dirname, join } from 'node:path';
  * Two files, one of which is `0600`, is the honest arrangement.
  *
  * **Not in the workspace.** A workspace is a set of accounts and profiles and
- * may be a bucket; who is at the keyboard is neither. Putting this in
- * `~/.lanes-link` would also mean a second workspace signs you out of the
- * first, and would upload the session to a bucket on the next deploy.
+ * may be a bucket; who is at the keyboard is neither. Putting this inside one
+ * would mean a second workspace signs you out of the first, and would upload
+ * the session to a bucket on the next deploy.
+ *
+ * That argument is unchanged by the workspace moving to `~/.lanes/link`: this
+ * is now a *sibling* of the workspace rather than a stranger to it, which is
+ * the arrangement the sentence above always described. What it does mean is
+ * that both paths compose from `lanesHome()` — so a checkout gets a session in
+ * `~/.lanes-dev` along with its workspace, and testing a branch cannot sign the
+ * operator out of the install they actually use.
  */
 
-/** Where the session lives. Overridable for tests, and for nothing else. */
+/**
+ * Where the session lives.
+ *
+ * `home` is overridable for tests, and for nothing else — but note that the
+ * directory under it is `lanesHome`'s to decide, so a test cannot assume
+ * `.lanes` and must ask. `bun test` runs from a checkout, which is dev mode.
+ */
 export function sessionPath(home = homedir()): string {
-  return join(home, '.lanes', 'credentials.json');
+  return join(lanesHome({ home }), 'credentials.json');
 }
 
 export interface LanesSession {

--- a/src/cli/commands/operate/inspect.ts
+++ b/src/cli/commands/operate/inspect.ts
@@ -1,7 +1,7 @@
 import { formatPlan, planIsNoop, planReconcile } from '#registry';
 import { readEndpointTokens, type ConnectionConfig, type SelectedConnection } from '#profile';
 import { DEFAULT_SURFACES } from '../../config-repair.ts';
-import { announce, announceProfile, emit, fail, ok, print, warn } from '../../output.ts';
+import { announce, announceProfile, emit, fail, ok, print, progress, warn } from '../../output.ts';
 import { staleNudge } from '../../release.ts';
 import { openRuntime, resolveProfileOnly, type GlobalFlags, type Runtime } from '../../runtime.ts';
 import type { FetchLike } from '#deployments/knowledge.ts';
@@ -9,6 +9,7 @@ import { unboundRotatableRefs } from '#deployments/bind.ts';
 import { duplicateAccountFindings, reportCapabilityDrift } from './findings.ts';
 import { probeConnections } from './auth.ts';
 import { migratedContract, migratedRenamedProviders } from './migrate.ts';
+import { reportWorkspaceHomeMove } from '../../workspace-home-migrate.ts';
 
 /**
  * The gate order — check, doctor, plan, start — exists so failures surface in
@@ -92,6 +93,16 @@ export interface DoctorFinding {
  * touch nothing.
  */
 export async function doctor(flags: DoctorFlags): Promise<void> {
+  // Before the runtime, not after, and not as a finding. `--fix` moves the
+  // workspace directory itself, and doing that underneath a runtime would be
+  // relocating the files its stores are already holding open. Reported either
+  // way, because someone who does not pass `--fix` still needs to know their
+  // workspace is at an address the next release will stop looking at.
+  const moved = await reportWorkspaceHomeMove(flags.json === true ? progress : print, {
+    apply: flags.fix === true,
+  });
+  if (moved.blocked.length > 0) process.exitCode = 1;
+
   // The one check that cannot use a runtime, because it answers for the profiles
   // that cannot open one. A provider rename left in the config refuses at load,
   // which takes every command down together — including the rest of this one —

--- a/src/cli/commands/operate/outputs.ts
+++ b/src/cli/commands/operate/outputs.ts
@@ -187,14 +187,21 @@ export async function tokenInvocation(
       // Pinned to the workspace this command already resolved, rather than
       // letting the child resolve its own. `resolveWorkspaceRoot` checks
       // `LANES_LINK_HOME`, then walks ancestors, then falls back to
-      // `~/.lanes-link` — so a bare spawn asks a *different* question than the
+      // `~/.lanes/link` — so a bare spawn asks a *different* question than the
       // one being answered, and the answer it gives is about somebody else's
       // workspace. That is the failure this function's own history records:
       // the equality check that used to catch "a `lanes` on PATH belonging to a
       // different workspace" had to be dropped, and nothing replaced it.
       //
-      // It also stops the test suite reaching the operator's real workspace.
-      // `bun test` from a worktree ran this against `~/.lanes-link` with
+      // The child is the *installed* `lanes`, so it is not in dev mode even
+      // when this process is. Pinning the root is what keeps the two agreeing
+      // about the workspace; they still disagree about the Lanes session, which
+      // costs nothing here because `token show --raw` needs none.
+      //
+      // It also stops the test suite reaching the operator's real workspace —
+      // belt to dev mode's braces, now that a checkout resolves to
+      // `~/.lanes-dev/link` and cannot reach the real one by accident at all.
+      // `bun test` from a worktree used to run this against the old root with
       // `--workspace cloud`, which is a network call to a live bucket from a
       // unit test — and the five-second timeout it hit is what made a green
       // checkout look red.

--- a/src/cli/commands/profile.ts
+++ b/src/cli/commands/profile.ts
@@ -150,7 +150,12 @@ export async function createProfile(
     }
 
     if (!existsSync(join(local, WORKSPACE_FILE))) {
-      await mkdir(local, { recursive: true });
+      // `0700`, not the ambient umask. This creates `~/.lanes/link` and, on a
+      // machine without the desktop app, `~/.lanes` above it — and what lands
+      // inside is `credentials.enc` and its key. The blob store already writes
+      // its directories this way (`deployments/adapters/filesystem.ts`); this
+      // was the one path that did not, and it is the path that goes first.
+      await mkdir(local, { recursive: true, mode: 0o700 });
       await writeFile(join(local, WORKSPACE_FILE), newWorkspaceTemplate(), { mode: 0o600 });
     }
   }

--- a/src/cli/commands/sync.test.ts
+++ b/src/cli/commands/sync.test.ts
@@ -22,10 +22,12 @@ afterAll(async () => {
 /**
  * A throwaway workspace, and the env var pointing at it.
  *
- * `syncTargets` calls `resolveWorkspaceRoot()` with no argument, so an unset
- * `LANES_LINK_HOME` walks up to `~/.lanes-link` — the operator's real profiles,
- * credentials and audit log. Every test here goes through this helper so that
- * cannot happen.
+ * `syncTargets` calls `resolveWorkspaceRoot()` with no argument, and this used
+ * to be the only thing standing between the suite and `~/.lanes-link` — the
+ * operator's real profiles, credentials and audit log. Dev mode moved that
+ * floor: a checkout resolves to `~/.lanes-dev/link` and cannot reach the real
+ * root at all. This helper stays because `sync` *writes*, and a test that writes
+ * should name where.
  */
 async function workspace(declares = '{}'): Promise<string> {
   const root = await mkdtemp(join(tmpdir(), 'lanes-link-sync-'));

--- a/src/cli/commands/target.test.ts
+++ b/src/cli/commands/target.test.ts
@@ -62,9 +62,10 @@ workspaces:
  *
  * Both, deliberately. An injected `env` replaces `process.env` wholesale — so
  * `{ env: {} }` does not mean "no variables set", it means `LANES_LINK_HOME` is
- * gone too, and `resolveWorkspaceRoot` then walks up to `~/.lanes-link`: the
- * operator's real profiles, credentials and audit log. Every call here passes
- * `env` from this helper so that cannot happen.
+ * gone too and the fallback decides. That fallback is `~/.lanes-dev/link` while
+ * the suite runs from a checkout, rather than the operator's real workspace as
+ * it once was; every call here still passes `env` from this helper, so the root
+ * under test is named rather than inferred.
  */
 async function workspace(): Promise<{
   root: string;

--- a/src/cli/commands/update.ts
+++ b/src/cli/commands/update.ts
@@ -3,6 +3,7 @@ import { join, sep } from 'node:path';
 import { installRoot, resolveWorkspaceRoot } from '#profile';
 import { repairOwnerLayer } from '../config-repair-sweep.ts';
 import { migrateToCurrentContract, needsMigration, type ContractMigration } from '../workspace-migrate.ts';
+import { reportWorkspaceHomeMove } from '../workspace-home-migrate.ts';
 import { needsContract3, type Contract3Migration } from '../contract3.ts';
 import { needsContract4 } from '../contract4.ts';
 import { sayContract3, sayContract4 } from './update-migration.ts';
@@ -174,6 +175,11 @@ export async function update(flags: UpdateFlags): Promise<void> {
   // profile of someone already on the latest version is exactly the one this was
   // reported against.
   if (flags.check !== true) {
+    // Before the root is resolved, because it is the root that moves. Everything
+    // below then reads the new location, and a workspace that did not move —
+    // most of them — resolves exactly as it did.
+    await reportWorkspaceHomeMove(flags.json === true ? progress : print, { apply: true });
+
     const root = resolveWorkspaceRoot();
 
     // The contract migration before the owner-layer repair, and the order is not

--- a/src/cli/lanes.test.ts
+++ b/src/cli/lanes.test.ts
@@ -14,9 +14,11 @@ import { join } from 'node:path';
  * little while the binary and the command were the same word; `lanes link`
  * peels a token before dispatching, and peeling the wrong one is silent.
  *
- * These three cases need no workspace, but `LANES_LINK_HOME` is set anyway:
- * `resolveWorkspaceRoot` falls back to the operator's real `~/.lanes-link`,
- * and a test must never be one bug away from reading it.
+ * These three cases need no workspace, but `LANES_LINK_HOME` is set anyway.
+ * Dev mode means an unset one now falls back to `~/.lanes-dev/link` rather than
+ * to the operator's real workspace — but that holds because the suite runs from
+ * a checkout, which is a property of how it is invoked rather than of this file.
+ * Pinning it costs one line and does not depend on that staying true.
  */
 
 const BIN = fileURLToPath(new URL('./lanes.ts', import.meta.url));

--- a/src/cli/messages.test.ts
+++ b/src/cli/messages.test.ts
@@ -13,9 +13,14 @@ import { join } from 'node:path';
  * This is the check that stops the next rename doing the same. Prose *about*
  * the old name is fine, in a comment or in a sentence that says it is the old
  * name; what is refused is a message sending someone to open it.
+ *
+ * It has stopped one since: 0.14.0 moved the workspace root from `~/.lanes-link`
+ * to `~/.lanes/link`, which is the same shape of rename one directory up — and
+ * the same shape of leftover, a command cheerfully naming a path that the
+ * migration it just ran has deleted.
  */
 
-const RETIRED = 'lanes-link.yaml';
+const RETIRED = ['lanes-link.yaml', '.lanes-link'] as const;
 
 async function sources(dir: string): Promise<string[]> {
   const out: string[] = [];
@@ -36,19 +41,21 @@ const isProse = (line: string): boolean => {
 /** A sentence that introduces it as retired, which is the one honest use. */
 const namesItAsOld = (line: string): boolean => /old name|retired|renamed|used to/i.test(line);
 
-describe('a message never sends the reader to a file that was renamed', () => {
-  test(`no command tells anyone to look in ${RETIRED}`, async () => {
-    const offenders: string[] = [];
+describe('a message never sends the reader to a name that was retired', () => {
+  for (const retired of RETIRED) {
+    test(`no command tells anyone to look in ${retired}`, async () => {
+      const offenders: string[] = [];
 
-    for (const path of await sources(join(import.meta.dir, 'commands'))) {
-      const lines = (await readFile(path, 'utf8')).split('\n');
-      lines.forEach((line, index) => {
-        if (!line.includes(RETIRED)) return;
-        if (isProse(line) || namesItAsOld(line)) return;
-        offenders.push(`${path.slice(path.indexOf('src/'))}:${index + 1}`);
-      });
-    }
+      for (const path of await sources(join(import.meta.dir, 'commands'))) {
+        const lines = (await readFile(path, 'utf8')).split('\n');
+        lines.forEach((line, index) => {
+          if (!line.includes(retired)) return;
+          if (isProse(line) || namesItAsOld(line)) return;
+          offenders.push(`${path.slice(path.indexOf('src/'))}:${index + 1}`);
+        });
+      }
 
-    expect(offenders).toEqual([]);
-  });
+      expect(offenders).toEqual([]);
+    });
+  }
 });

--- a/src/cli/output.ts
+++ b/src/cli/output.ts
@@ -1,3 +1,4 @@
+import { legacyRootNotice, onLegacyRoot } from './workspace-home-migrate.ts';
 import { wasDefaulted } from './selection-require.ts';
 import { columns, style, width } from './terminal.ts';
 import { numbered, rule, truncate, visibleWidth, wrap } from './typeset.ts';
@@ -139,6 +140,24 @@ export function announceProfile(selection: {
   readonly workspaceRoot: string;
 }): void {
   print(style.dim(`profile ${style.bold(selection.profile)}  ${selection.workspaceRoot}`));
+  sayIfLegacyRoot(selection.workspaceRoot);
+}
+
+/**
+ * The second dim line, on a workspace that has not been moved yet.
+ *
+ * Here rather than in a `doctor` finding because the audience is different:
+ * `doctor` is what somebody runs when they already suspect something, and this
+ * has to reach the person who suspects nothing. It sits under the line that
+ * already prints the root on every command, which is the one place a reader is
+ * looking at that path anyway.
+ *
+ * It says nothing on a workspace that is already at `~/.lanes/link`, which is
+ * almost all of them almost all of the time — so this is a string compare per
+ * command and silence thereafter, not a permanent second line for everyone.
+ */
+function sayIfLegacyRoot(workspaceRoot: string): void {
+  if (onLegacyRoot(workspaceRoot)) print(style.dim(`  ${legacyRootNotice()}`));
 }
 
 /**
@@ -161,6 +180,7 @@ export function announce(resolution: Resolution): void {
         `${resolution.workspaceRoot}`,
     ),
   );
+  sayIfLegacyRoot(resolution.workspaceRoot);
 }
 
 /**
@@ -181,6 +201,7 @@ export function announceWorkspace(resolution: Resolution): void {
       `workspace ${style.bold(resolution.target)}${provenance}  ${resolution.workspaceRoot}`,
     ),
   );
+  sayIfLegacyRoot(resolution.workspaceRoot);
 }
 
 /**

--- a/src/cli/workspace-home-migrate.test.ts
+++ b/src/cli/workspace-home-migrate.test.ts
@@ -1,0 +1,254 @@
+import { afterAll, describe, expect, test } from 'bun:test';
+import { existsSync } from 'node:fs';
+import { chmod, cp, mkdir, mkdtemp, readFile, rm, stat, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { migrateWorkspaceHome } from './workspace-home-migrate.ts';
+
+/**
+ * Moving `~/.lanes-link` to `~/.lanes/link`.
+ *
+ * Written against outcomes rather than internals — what is on disk afterwards —
+ * for the reason `contract4.test.ts` states: the defects the last two
+ * migrations shipped had in common that they lost, leaked or misrouted data
+ * while reporting success.
+ *
+ * Every case gets a `$HOME` of its own and an install directory of its own,
+ * because the two things that decide what this does are where home is and
+ * whether this is a checkout. The suite itself runs from one, so a test that
+ * did not pin the second would find every case skipped.
+ */
+
+const homes: string[] = [];
+
+/** A `$HOME` holding a workspace at the old address, and an install to judge. */
+async function machine(
+  kind: 'checkout' | 'published' = 'published',
+): Promise<{ home: string; from: string; to: string; options: { env: {}; home: string; dir: string } }> {
+  const home = await mkdtemp(join(tmpdir(), 'lanes-home-'));
+  homes.push(home);
+
+  const dir = join(home, 'install');
+  await mkdir(dir, { recursive: true });
+  await writeFile(join(dir, 'package.json'), '{"name":"@lanes-sh/link"}\n');
+  if (kind === 'checkout') await writeFile(join(dir, 'tsconfig.json'), '{}\n');
+
+  return { home, from: join(home, '.lanes-link'), to: join(home, '.lanes', 'link'), options: { env: {}, home, dir } };
+}
+
+/** A workspace with a registry, a credential store, and one profile. */
+async function workspaceAt(root: string): Promise<void> {
+  await mkdir(join(root, 'profiles', 'ada'), { recursive: true });
+  await writeFile(join(root, 'workspaces.yaml'), 'contract: 5\ntargets:\n  local:\n    storage:\n      adapter: filesystem\n');
+  await writeFile(join(root, 'credentials.enc'), 'ciphertext', { mode: 0o600 });
+  await writeFile(join(root, 'profiles', 'ada', 'profile.yaml'), 'contract: 5\n');
+  await chmod(root, 0o700);
+}
+
+afterAll(async () => {
+  await Promise.all(homes.map((home) => rm(home, { recursive: true, force: true })));
+});
+
+describe('moving the workspace', () => {
+  test('apply: false reports the move and writes nothing', async () => {
+    const { from, to, options } = await machine();
+    await workspaceAt(from);
+
+    const migration = await migrateWorkspaceHome({ ...options, apply: false });
+
+    expect(migration.alreadyCurrent).toBe(false);
+    expect(migration.changes).toEqual([`workspace ${from} → ${to}`]);
+    expect(existsSync(to)).toBe(false);
+    expect(await readFile(join(from, 'credentials.enc'), 'utf8')).toBe('ciphertext');
+  });
+
+  test('the whole workspace arrives, and the old root is gone', async () => {
+    const { from, to, options } = await machine();
+    await workspaceAt(from);
+
+    const migration = await migrateWorkspaceHome({ ...options, apply: true });
+
+    expect(migration.blocked).toEqual([]);
+    expect(existsSync(from)).toBe(false);
+    expect(await readFile(join(to, 'credentials.enc'), 'utf8')).toBe('ciphertext');
+    expect(await readFile(join(to, 'profiles', 'ada', 'profile.yaml'), 'utf8')).toBe('contract: 5\n');
+  });
+
+  test('a second run has nothing to do', async () => {
+    const { from, options } = await machine();
+    await workspaceAt(from);
+
+    await migrateWorkspaceHome({ ...options, apply: true });
+    expect((await migrateWorkspaceHome({ ...options, apply: true })).alreadyCurrent).toBe(true);
+  });
+
+  test('nothing to do on a machine that never had one', async () => {
+    const { options } = await machine();
+    expect((await migrateWorkspaceHome({ ...options, apply: true })).alreadyCurrent).toBe(true);
+  });
+
+  test('the credential store stays 0600 and neither directory becomes readable', async () => {
+    const { from, to, options } = await machine();
+    await workspaceAt(from);
+
+    await migrateWorkspaceHome({ ...options, apply: true });
+
+    expect((await stat(join(to, 'credentials.enc'))).mode & 0o777).toBe(0o600);
+    expect((await stat(to)).mode & 0o777).toBe(0o700);
+    // `~/.lanes` is created by this command when the desktop app has not already
+    // made it, and what goes inside is a credential store.
+    expect((await stat(join(options.home, '.lanes'))).mode & 0o777).toBe(0o700);
+  });
+});
+
+describe('what it will not do', () => {
+  test('nothing, from a checkout', async () => {
+    // Applying this from a worktree would move the operator's real workspace
+    // into a scratch home — the accident dev mode exists to prevent, reached
+    // from the other side.
+    const { from, to, options } = await machine('checkout');
+    await workspaceAt(from);
+
+    expect((await migrateWorkspaceHome({ ...options, apply: true })).alreadyCurrent).toBe(true);
+    expect(existsSync(from)).toBe(true);
+    expect(existsSync(to)).toBe(false);
+  });
+
+  test('nothing, when LANES_LINK_HOME names a root', async () => {
+    const { from, options } = await machine();
+    await workspaceAt(from);
+
+    const pinned = { ...options, env: { LANES_LINK_HOME: '/somewhere/else' }, apply: true };
+    expect((await migrateWorkspaceHome(pinned)).alreadyCurrent).toBe(true);
+    expect(existsSync(from)).toBe(true);
+  });
+
+  test('refuses when both roots hold a workspace, and moves neither', async () => {
+    const { from, to, options } = await machine();
+    await workspaceAt(from);
+    await workspaceAt(to);
+    await writeFile(join(to, 'credentials.enc'), 'a different one', { mode: 0o600 });
+
+    const migration = await migrateWorkspaceHome({ ...options, apply: true });
+
+    expect(migration.blocked).toHaveLength(1);
+    expect(migration.blocked[0]).toContain('two workspaces');
+    expect(await readFile(join(from, 'credentials.enc'), 'utf8')).toBe('ciphertext');
+    expect(await readFile(join(to, 'credentials.enc'), 'utf8')).toBe('a different one');
+  });
+
+  test('refuses while an endpoint is serving the old root', async () => {
+    // A running `start` holds that path. Moving out from under it leaves a
+    // process serving a directory nobody can find.
+    const { from, to, options } = await machine();
+    await workspaceAt(from);
+    await writeFile(
+      join(from, 'endpoint.json'),
+      JSON.stringify({ url: 'http://127.0.0.1:7400/mcp', pid: process.pid, profiles: ['ada'], startedAt: new Date().toISOString() }),
+    );
+
+    const migration = await migrateWorkspaceHome({ ...options, apply: true });
+
+    expect(migration.blocked[0]).toContain('an endpoint is serving');
+    expect(existsSync(to)).toBe(false);
+  });
+
+  test('a dead pid is not a running endpoint', async () => {
+    const { from, to, options } = await machine();
+    await workspaceAt(from);
+    await writeFile(
+      join(from, 'endpoint.json'),
+      JSON.stringify({ url: 'http://127.0.0.1:7400/mcp', pid: 2 ** 30, profiles: ['ada'], startedAt: new Date().toISOString() }),
+    );
+
+    expect((await migrateWorkspaceHome({ ...options, apply: true })).blocked).toEqual([]);
+    expect(existsSync(to)).toBe(true);
+  });
+
+  test('refuses when a target names an absolute path inside the old root', async () => {
+    // The one that would otherwise be silent: `workspacePath` honours an
+    // absolute path verbatim, so this would go on naming a directory the
+    // migration had just emptied — and here that is the credential store.
+    const { from, to, options } = await machine();
+    await workspaceAt(from);
+    await writeFile(
+      join(from, 'workspaces.yaml'),
+      `contract: 5\ntargets:\n  local:\n    credentials:\n      adapter: file\n      path: ${join(from, 'credentials.enc')}\n`,
+    );
+
+    const migration = await migrateWorkspaceHome({ ...options, apply: true });
+
+    expect(migration.blocked).toHaveLength(1);
+    expect(migration.blocked[0]).toContain('credentials.enc is an absolute path');
+    expect(existsSync(to)).toBe(false);
+  });
+
+  test('a relative path is fine, because it travels with the workspace', async () => {
+    const { from, to, options } = await machine();
+    await workspaceAt(from);
+    await writeFile(
+      join(from, 'workspaces.yaml'),
+      'contract: 5\ntargets:\n  local:\n    credentials:\n      adapter: file\n      path: credentials.enc\n',
+    );
+
+    expect((await migrateWorkspaceHome({ ...options, apply: true })).blocked).toEqual([]);
+    expect(existsSync(to)).toBe(true);
+  });
+});
+
+describe('across two filesystems, where rename cannot help', () => {
+  /** What `rename` does when the two paths are on different volumes. */
+  const crossDevice = async (): Promise<void> => {
+    const error = new Error('EXDEV: cross-device link not permitted') as NodeJS.ErrnoException;
+    error.code = 'EXDEV';
+    throw error;
+  };
+
+  test('it copies, verifies, and only then deletes', async () => {
+    const { from, to, options } = await machine();
+    await workspaceAt(from);
+
+    const migration = await migrateWorkspaceHome({ ...options, apply: true, deps: { rename: crossDevice } });
+
+    expect(migration.blocked).toEqual([]);
+    expect(existsSync(from)).toBe(false);
+    expect(await readFile(join(to, 'credentials.enc'), 'utf8')).toBe('ciphertext');
+    expect((await stat(join(to, 'credentials.enc'))).mode & 0o777).toBe(0o600);
+    // `cp` carries every file's mode and every nested directory's, but leaves
+    // the destination root at the umask — 0755 — unless it is set explicitly.
+    expect((await stat(to)).mode & 0o777).toBe(0o700);
+  });
+
+  test('an interrupted copy is finished by the next run, not refused by it', async () => {
+    // A crash between the copy and the delete leaves both roots. That is the
+    // one shape of "both exist" that is not two workspaces, and the evidence
+    // separating them is whether the new root already holds everything.
+    const { from, to, options } = await machine();
+    await workspaceAt(from);
+    await mkdir(to, { recursive: true, mode: 0o700 });
+    await cp(from, to, { recursive: true });
+
+    const migration = await migrateWorkspaceHome({ ...options, apply: true });
+
+    expect(migration.blocked).toEqual([]);
+    expect(migration.changes[0]).toContain('already copied');
+    expect(existsSync(from)).toBe(false);
+    expect(await readFile(join(to, 'credentials.enc'), 'utf8')).toBe('ciphertext');
+  });
+
+  test('a copy that stopped partway deletes nothing', async () => {
+    const { from, to, options } = await machine();
+    await workspaceAt(from);
+
+    // Half a workspace at the destination: the registry made it, the credential
+    // store did not. A directory test would call this a workspace and refuse
+    // forever; the read-back sees what is missing.
+    await mkdir(to, { recursive: true, mode: 0o700 });
+    await writeFile(join(to, 'workspaces.yaml'), 'contract: 5\n');
+
+    const migration = await migrateWorkspaceHome({ ...options, apply: true });
+
+    expect(migration.blocked).toHaveLength(1);
+    expect(await readFile(join(from, 'credentials.enc'), 'utf8')).toBe('ciphertext');
+  });
+});

--- a/src/cli/workspace-home-migrate.ts
+++ b/src/cli/workspace-home-migrate.ts
@@ -1,0 +1,366 @@
+import { existsSync } from 'node:fs';
+import { chmod, cp, mkdir, readFile, readdir, rename, rm, stat } from 'node:fs/promises';
+import { dirname, isAbsolute, join, relative, sep } from 'node:path';
+import { parse as parseYaml } from 'yaml';
+import { readEndpointRecord } from '#profile';
+import {
+  defaultWorkspaceRoot,
+  isDevInstall,
+  legacyWorkspaceRoot,
+  type HomeOptions,
+} from '#home';
+
+/**
+ * Moving the workspace out of `~/.lanes-link` and into `~/.lanes/link`.
+ *
+ * Not a contract migration, and it cannot be one. Every migration in
+ * `workspace-migrate.ts` rewrites files *inside* a workspace whose root is
+ * already known, and stamps a number in a file to record that it finished. This
+ * one moves the root itself, before anything has been read, and its record that
+ * it finished is that the old directory is not there any more.
+ *
+ * It runs from `update` and from `doctor --fix`, and from nowhere else. The
+ * alternative — the first command to notice the old root moves it — was
+ * rejected for a reason worth writing down: this relocates the directory
+ * holding somebody's credentials, their audit log and every profile they have,
+ * and a `status` that quietly did that is one they cannot audit afterwards.
+ * `resolveWorkspaceRoot` keeps resolving the old root in the meantime, so
+ * nothing is lost by waiting and nobody is stranded by not upgrading.
+ *
+ * ## What it refuses, and why each one is a refusal rather than a warning
+ *
+ * All four are checked before the first byte moves — `migrateWorkspace`'s rule,
+ * for the same reason: a refusal has to leave the workspace exactly as it was,
+ * and the thing being moved is the only remaining description of where
+ * somebody's accounts live.
+ *
+ *  - **A checkout.** Dev mode resolves to `~/.lanes-dev/link`, so applying this
+ *    from one would move the operator's real workspace into a scratch home. The
+ *    exact accident `#home` exists to prevent, arrived at from the other side.
+ *  - **`LANES_LINK_HOME` is set.** An explicit root is a decision, and in a
+ *    container it is a bucket. Neither is ours to relocate.
+ *  - **Both roots exist.** Two workspaces is not a state this can resolve:
+ *    merging them is not reversible and picking one silently discards the
+ *    other's profiles. It reports both and stops.
+ *  - **An endpoint is running.** `readEndpointRecord` already rejects a record
+ *    whose pid is gone, so a live one means a `start` is holding the old path.
+ *    Moving out from under it strands `endpoint.json` at a directory that no
+ *    longer exists and leaves a process serving from one nobody can find —
+ *    which presents as an endpoint that answers but cannot be reloaded.
+ *  - **A target declares an absolute path inside the old root.** This is the
+ *    one that would have been silent. `credentials.path`, `storage.path` and
+ *    `vault.path` are optional, and `workspacePath` honours an absolute one
+ *    verbatim — so a relative path (the default) travels with the directory
+ *    while an absolute one goes on naming a location this migration just
+ *    emptied. For `credentials.path` that is the encrypted credential store.
+ */
+
+/**
+ * The one thing this takes from its caller rather than from the filesystem.
+ *
+ * `rename` succeeds on any machine where `$HOME` is one volume, which is nearly
+ * all of them — so the copy fallback below, which is the half that handles
+ * somebody's credentials in two steps instead of one, is unreachable from a
+ * test without a second filesystem to mount. Injected on the same grounds
+ * `PairDeps` injects `which` and `run`: the alternative is that the riskiest
+ * code here is the only code with no test.
+ */
+export interface HomeMigrationDeps {
+  readonly rename?: (from: string, to: string) => Promise<void>;
+}
+
+/** What the migration did, or would do. */
+export interface HomeMigration {
+  readonly from: string;
+  readonly to: string;
+  /** What happened, or would — spelled for display. */
+  readonly changes: readonly string[];
+  /** What stopped it, each a whole sentence naming the way out. */
+  readonly blocked: readonly string[];
+  /** Nothing to do: no legacy root, or this is not a machine that should move one. */
+  readonly alreadyCurrent: boolean;
+}
+
+/**
+ * Whether a resolved root is the one this migration moves.
+ *
+ * A string compare, so the commands that only *mention* the migration pay
+ * nothing for it. `announce` calls this on every command.
+ */
+export function onLegacyRoot(root: string, options: HomeOptions = {}): boolean {
+  return root === legacyWorkspaceRoot(options);
+}
+
+/** The line every other command prints, so nobody has to discover this by reading a changelog. */
+export function legacyRootNotice(): string {
+  return 'this workspace is at the old ~/.lanes-link — move it with: lanes link update';
+}
+
+/**
+ * Run it and say what happened, for the two commands that may.
+ *
+ * Narrated rather than silent, on the same grounds `migrateLocal` states: this
+ * relocates every byte somebody's workspace holds, and a command that does that
+ * without a word is one they cannot audit afterwards. Routed through `say` so
+ * `--json` can send it to stderr, where a line of prose does not corrupt the
+ * document on stdout.
+ *
+ * **It never throws.** `update`'s job is to install a version and `doctor`'s is
+ * to report; neither should fail because a directory would not move. What a
+ * failure costs is one release cycle of staying where it is, since
+ * `resolveWorkspaceRoot` still finds the old root — so the honest response is a
+ * sentence, and the caller decides whether that is worth an exit code.
+ */
+export async function reportWorkspaceHomeMove(
+  say: (line: string) => void,
+  options: HomeOptions & { readonly apply: boolean; readonly deps?: HomeMigrationDeps },
+): Promise<HomeMigration> {
+  let migration: HomeMigration;
+
+  try {
+    migration = await migrateWorkspaceHome(options);
+  } catch (error) {
+    const from = legacyWorkspaceRoot(options);
+    const reason = error instanceof Error ? error.message : String(error);
+    say(`could not move ${from}: ${reason}`);
+    return { from, to: defaultWorkspaceRoot(options), changes: [], blocked: [reason], alreadyCurrent: false };
+  }
+
+  if (migration.alreadyCurrent) return migration;
+
+  for (const line of migration.blocked) say(`this workspace has not been moved: ${line}`);
+  for (const line of migration.changes) {
+    say(options.apply ? line : `${line} — run with --fix to do it`);
+  }
+
+  return migration;
+}
+
+export async function migrateWorkspaceHome(
+  options: HomeOptions & { readonly apply: boolean; readonly deps?: HomeMigrationDeps },
+): Promise<HomeMigration> {
+  const env = options.env ?? (process.env as Record<string, string | undefined>);
+  const from = legacyWorkspaceRoot(options);
+  const to = defaultWorkspaceRoot(options);
+  const nothing = { from, to, changes: [], blocked: [], alreadyCurrent: true } as const;
+
+  // Ordered cheapest first, and the three that mean "not this machine's job"
+  // report `alreadyCurrent` rather than `blocked`: a checkout running `update`
+  // has not failed at anything, and printing a refusal at it every time would
+  // train the reader to skip the ones that matter.
+  if (env['LANES_LINK_HOME']) return nothing;
+  if (isDevInstall(options)) return nothing;
+  if (!existsSync(from)) return nothing;
+
+  const blocked: string[] = [];
+
+  // Both present has two readings, and they want opposite things. It is either
+  // two real workspaces — which this must not touch — or the copy path below
+  // having been interrupted between writing the new one and deleting the old,
+  // which a rerun is supposed to finish rather than refuse. The evidence that
+  // separates them is whether the new root already holds everything the old one
+  // does; if it does, there is nothing here to merge and this is the delete
+  // that did not happen.
+  if (existsSync(to)) {
+    if (await holdsEverything(from, to)) {
+      const changes = [`${from} was already copied to ${to} — removing what is left`];
+      if (options.apply) await rm(from, { recursive: true, force: true });
+      return { from, to, changes, blocked, alreadyCurrent: false };
+    }
+
+    blocked.push(
+      `${to} already exists and holds something different, so there are two workspaces\n` +
+        '  and only one can have that name. Merging them is not something this can undo,\n' +
+        `  so it has not been attempted. Look at both, then move or delete ${from} yourself.`,
+    );
+  }
+
+  const running = await readEndpointRecord(from);
+  if (running !== null) {
+    blocked.push(
+      `an endpoint is serving ${from} (pid ${running.pid}, ${running.url}).\n` +
+        '  Moving the workspace while it is open would leave it serving a directory that\n' +
+        '  no longer exists. Stop it, run this again, and start it back up.',
+    );
+  }
+
+  for (const stranded of await absolutePathsWithin(from)) {
+    blocked.push(
+      `${stranded} is an absolute path inside ${from}, so it would not travel with the\n` +
+        '  workspace — it would go on naming a directory this migration had emptied.\n' +
+        '  Make it relative to the workspace root, or point it somewhere else, then run this again.',
+    );
+  }
+
+  if (blocked.length > 0) return { from, to, changes: [], blocked, alreadyCurrent: false };
+
+  const changes = [`workspace ${from} → ${to}`];
+  if (!options.apply) return { from, to, changes, blocked, alreadyCurrent: false };
+
+  // `0700` on anything this creates. `~/.lanes` may already exist — the desktop
+  // app owns it too — in which case `recursive` leaves its mode alone, which is
+  // right: it is not ours to tighten or loosen. What must not happen is this
+  // command creating it at the default umask, because what goes inside is
+  // `credentials.enc` and its key.
+  await mkdir(dirname(to), { recursive: true, mode: 0o700 });
+  await move(from, to, options.deps?.rename ?? rename);
+
+  return { from, to, changes, blocked, alreadyCurrent: false };
+}
+
+/**
+ * `rename` where it works, a verified copy where it does not.
+ *
+ * `rename` is the whole migration in one syscall when both paths are on one
+ * filesystem, which under `$HOME` they almost always are: atomic, no window
+ * where a reader sees half a workspace, and nothing left behind to delete.
+ *
+ * `EXDEV` is the case that is not — a home directory on a different volume from
+ * `~/.lanes-link`, which happens on machines where one of them is a mount. Then
+ * it is copy, read back, delete, in that order, because that is the order that
+ * survives being interrupted: a crash after the copy leaves both and the rerun
+ * finishes, where a crash after a delete leaves neither.
+ *
+ * Not a key-by-key drain through `workspaceFiles()`, which is the other obvious
+ * way to move a workspace and is wrong here twice over: the filesystem blob
+ * store's `list` skips the `.meta` and `.tmp` sidecars, so content types would
+ * be silently dropped, and its `delete` prunes empty parents but never the root
+ * — so the directory this is supposed to remove would still be sitting there.
+ */
+async function move(
+  from: string,
+  to: string,
+  attemptRename: (from: string, to: string) => Promise<void>,
+): Promise<void> {
+  try {
+    await attemptRename(from, to);
+    return;
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== 'EXDEV') throw error;
+  }
+
+  // `cp` carries the mode of every file and every nested directory, but not of
+  // the destination root — that one arrives at the default umask, measured at
+  // 0755. Left alone it would publish a directory listing of somebody's
+  // profiles, so it is set from the source rather than to a constant: whatever
+  // the old root was is what the new one should be.
+  const mode = (await stat(from)).mode & 0o777;
+  await cp(from, to, { recursive: true, preserveTimestamps: true });
+  await chmod(to, mode);
+
+  if (!(await holdsEverything(from, to))) {
+    throw new Error(
+      `${to} does not hold everything in ${from}, so the copy did not finish. Nothing has ` +
+        `been deleted and ${from} is still intact — run this again.`,
+    );
+  }
+
+  await rm(from, { recursive: true, force: true });
+}
+
+/**
+ * Whether every file under `from` is present under `to`, at the same size.
+ *
+ * The read-back half of the rule this repository's migrations all follow —
+ * nothing is deleted until what replaced it has been read back. Not a checksum,
+ * and it does not need to be: what it defends against is a copy that stopped
+ * partway, which is otherwise a failure discovered by the delete.
+ *
+ * A superset is a pass. The new root may legitimately hold more — a `.tmp` from
+ * a write that was in flight, or the sidecars `cp` carried over — and requiring
+ * the two listings to be equal would fail a copy that had in fact worked.
+ */
+async function holdsEverything(from: string, to: string): Promise<boolean> {
+  const before = await inventory(from);
+  const after = await inventory(to);
+
+  return [...before].every(([key, size]) => after.get(key) === size);
+}
+
+/** Every file under a root, keyed by its path relative to it, valued by size. */
+async function inventory(root: string): Promise<Map<string, number>> {
+  const found = new Map<string, number>();
+
+  const walk = async (directory: string): Promise<void> => {
+    for (const entry of await readdir(directory, { withFileTypes: true })) {
+      const full = join(directory, entry.name);
+      if (entry.isDirectory()) {
+        await walk(full);
+      } else if (entry.isFile()) {
+        found.set(relative(root, full), (await stat(full)).size);
+      }
+    }
+  };
+
+  await walk(root);
+  return found;
+}
+
+/**
+ * Every `path:` in this workspace's YAML that points inside it absolutely.
+ *
+ * Every `.yaml` under the root rather than only the registry, because the
+ * question is "does anything name this directory in a way that will not move",
+ * and answering it from the schema would mean knowing which schema — a
+ * workspace still at contract 2 has its targets somewhere else entirely. A deep
+ * walk over the parsed document cannot be wrong about the shape because it does
+ * not assume one.
+ */
+async function absolutePathsWithin(root: string): Promise<string[]> {
+  const inside = `${root}${sep}`;
+  const stranded: string[] = [];
+
+  const scan = (value: unknown, where: string): void => {
+    if (Array.isArray(value)) {
+      value.forEach((item, index) => scan(item, `${where}[${index}]`));
+      return;
+    }
+    if (value === null || typeof value !== 'object') return;
+
+    for (const [key, held] of Object.entries(value as Record<string, unknown>)) {
+      const at = where === '' ? key : `${where}.${key}`;
+      if (key === 'path' && typeof held === 'string' && isAbsolute(held) && held.startsWith(inside)) {
+        stranded.push(`${at}: ${held}`);
+      } else {
+        scan(held, at);
+      }
+    }
+  };
+
+  for (const file of await yamlFiles(root)) {
+    let parsed: unknown;
+    try {
+      parsed = parseYaml(await readFile(file, 'utf8'));
+    } catch {
+      // A file that will not parse is not this function's problem to report.
+      // `doctor` gives it a better sentence than "blocks the migration" would,
+      // and a workspace is not made unmovable by one unreadable file.
+      continue;
+    }
+    scan(parsed, relative(root, file));
+  }
+
+  return stranded;
+}
+
+/** The registry and every profile declaration, wherever this workspace's contract put them. */
+async function yamlFiles(root: string): Promise<string[]> {
+  const found: string[] = [];
+
+  const walk = async (directory: string): Promise<void> => {
+    for (const entry of await readdir(directory, { withFileTypes: true })) {
+      const full = join(directory, entry.name);
+      // `.d` and `.kv` directories hold a provider's own bytes and a store's
+      // keys. Neither declares a path, both can be large, and `skills.d` in
+      // particular is somebody's prose.
+      if (entry.isDirectory()) {
+        if (!entry.name.includes('.')) await walk(full);
+      } else if (entry.name.endsWith('.yaml')) {
+        found.push(full);
+      }
+    }
+  };
+
+  await walk(root);
+  return found;
+}

--- a/src/cli/workspace-migrate.ts
+++ b/src/cli/workspace-migrate.ts
@@ -27,7 +27,7 @@ import { C3 } from './contract3-layout.ts';
  *
  * Under contract 1 every profile carried a `targets:` block naming the adapter
  * sets it could be opened against. That is what made a deploy leave two copies
- * of each profile — one in `~/.lanes-link`, one in the bucket the endpoint reads
+ * of each profile — one under the Lanes home, one in the bucket the endpoint reads
  * — and gave them nothing to keep them honest. It failed the way it was always
  * going to: a local file was rewritten, lost its cloud target and eight
  * connections, and `status --workspace cloud` reported seven where the endpoint was

--- a/src/deployments/gcp/Dockerfile
+++ b/src/deployments/gcp/Dockerfile
@@ -95,8 +95,8 @@ COPY src/ src/
 
 # Set at deploy time, not here: a bucket URL is the operator's, not the image's.
 # `lanes link deploy` passes it as `LANES_LINK_HOME=gs://<bucket>`. Left unset,
-# `resolveWorkspaceRoot` would walk ancestors for `lanes-link.yaml` and fall
-# back to `~/.lanes-link`, which in a container is a directory nobody wrote —
+# `resolveWorkspaceRoot` would walk ancestors for `workspaces.yaml` and fall
+# back to `~/.lanes/link`, which in a container is a directory nobody wrote —
 # so the endpoint refuses rather than serving an empty workspace.
 # Which adapter set to open. The whole point of the milestone is that this is
 # the only thing that differs from a local run.

--- a/src/home/home.test.ts
+++ b/src/home/home.test.ts
@@ -1,0 +1,145 @@
+import { afterAll, describe, expect, test } from 'bun:test';
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import {
+  defaultWorkspaceRoot,
+  homeWorkspaceRoot,
+  installRoot,
+  isDevInstall,
+  lanesHome,
+  legacyWorkspaceRoot,
+} from './index.ts';
+
+/**
+ * Where Lanes keeps things, asserted against a `$HOME` this file owns.
+ *
+ * Every function here takes its home, its environment and the directory that
+ * decides dev mode as arguments, and the reason is this file: the suite runs
+ * from a checkout, so a test that read the real `homedir()` or the real
+ * `import.meta.dir` would be asserting against whichever machine ran it.
+ */
+
+const made: string[] = [];
+
+async function scratch(prefix: string): Promise<string> {
+  const path = await mkdtemp(join(tmpdir(), prefix));
+  made.push(path);
+  return path;
+}
+
+/** A directory shaped like whichever of the two things dev mode distinguishes. */
+async function install(kind: 'checkout' | 'published'): Promise<string> {
+  const root = await scratch(`lanes-${kind}-`);
+  await writeFile(join(root, 'package.json'), '{"name":"@lanes-sh/link"}\n');
+  if (kind === 'checkout') await writeFile(join(root, 'tsconfig.json'), '{}\n');
+  return root;
+}
+
+afterAll(async () => {
+  await Promise.all(made.map((path) => rm(path, { recursive: true, force: true })));
+});
+
+describe('telling a checkout from an install', () => {
+  test('a tsconfig.json at the install root means a checkout', async () => {
+    expect(isDevInstall({ env: {}, dir: await install('checkout') })).toBe(true);
+  });
+
+  test('and its absence means a published copy', async () => {
+    // The file is in neither `package.json`'s `files` array nor the Dockerfile's
+    // COPY, which is the whole reason it is the signal: a published tarball
+    // cannot carry one, and — unlike a `node_modules` path test — a `bun link`
+    // symlink cannot make a checkout look like one either.
+    expect(isDevInstall({ env: {}, dir: await install('published') })).toBe(false);
+  });
+
+  test('nothing above at all is not a checkout, and does not throw', async () => {
+    // `installRoot` throws when there is no `package.json` anywhere above. That
+    // is a real answer to a different question, and no reason to fail a command
+    // that was only asking where to look for a file.
+    const orphan = await scratch('lanes-orphan-');
+    expect(() => installRoot(orphan)).toThrow('No package.json');
+    expect(isDevInstall({ env: {}, dir: orphan })).toBe(false);
+  });
+
+  test('LANES_LINK_DEV overrides in both directions', async () => {
+    const published = await install('published');
+    const checkout = await install('checkout');
+
+    expect(isDevInstall({ env: { LANES_LINK_DEV: '1' }, dir: published })).toBe(true);
+    expect(isDevInstall({ env: { LANES_LINK_DEV: 'true' }, dir: published })).toBe(true);
+    expect(isDevInstall({ env: { LANES_LINK_DEV: '0' }, dir: checkout })).toBe(false);
+    expect(isDevInstall({ env: { LANES_LINK_DEV: 'false' }, dir: checkout })).toBe(false);
+  });
+
+  test('an exported-but-empty LANES_LINK_DEV is not an answer', async () => {
+    // `export LANES_LINK_DEV=` is a shell artefact. Reading it as `true` would
+    // put somebody in a scratch home with nothing on screen to say why.
+    expect(isDevInstall({ env: { LANES_LINK_DEV: '' }, dir: await install('published') })).toBe(false);
+  });
+});
+
+describe('the directories', () => {
+  test('an install keeps ~/.lanes, a checkout gets ~/.lanes-dev', async () => {
+    const home = '/home/ada';
+    const published = { env: {}, home, dir: await install('published') };
+    const checkout = { env: {}, home, dir: await install('checkout') };
+
+    expect(lanesHome(published)).toBe('/home/ada/.lanes');
+    expect(defaultWorkspaceRoot(published)).toBe('/home/ada/.lanes/link');
+    expect(lanesHome(checkout)).toBe('/home/ada/.lanes-dev');
+    expect(defaultWorkspaceRoot(checkout)).toBe('/home/ada/.lanes-dev/link');
+  });
+
+  test('the legacy root is not under the Lanes home, in either mode', async () => {
+    // There was never a dev copy of `~/.lanes-link`, so it composes from $HOME
+    // directly. A checkout asking for it is asking about the operator's real
+    // workspace, which is the thing `homeWorkspaceRoot` will not hand back.
+    const home = '/home/ada';
+    for (const kind of ['published', 'checkout'] as const) {
+      expect(legacyWorkspaceRoot({ env: {}, home, dir: await install(kind) })).toBe(
+        '/home/ada/.lanes-link',
+      );
+    }
+  });
+});
+
+describe('which root a command falls back to', () => {
+  const home = '/home/ada';
+  const only = (workspace: string) => (directory: string) => directory === workspace;
+  const none = () => false;
+
+  test('the new root, when a workspace is there', async () => {
+    const options = { env: {}, home, dir: await install('published') };
+    expect(homeWorkspaceRoot(only('/home/ada/.lanes/link'), options)).toBe('/home/ada/.lanes/link');
+  });
+
+  test('the legacy root, when the workspace is still there', async () => {
+    const options = { env: {}, home, dir: await install('published') };
+    expect(homeWorkspaceRoot(only('/home/ada/.lanes-link'), options)).toBe('/home/ada/.lanes-link');
+  });
+
+  test('the new root when neither exists, so a fresh install creates that one', async () => {
+    const options = { env: {}, home, dir: await install('published') };
+    expect(homeWorkspaceRoot(none, options)).toBe('/home/ada/.lanes/link');
+  });
+
+  test('a checkout is never handed the legacy root', async () => {
+    // The whole point of dev mode. Falling back onto `~/.lanes-link` from a
+    // worktree reaches live profiles, credentials and an audit log, and both
+    // `deploy` and `sync targets` write there.
+    const options = { env: {}, home, dir: await install('checkout') };
+    expect(homeWorkspaceRoot(only('/home/ada/.lanes-link'), options)).toBe(
+      '/home/ada/.lanes-dev/link',
+    );
+  });
+
+  test('a bare directory is not a workspace — the predicate decides, not the path', async () => {
+    // `~/.lanes` belongs to the desktop app, so `~/.lanes/link` can come into
+    // existence without a workspace in it, and an interrupted copy leaves
+    // exactly that. Preferring it would report "no profiles here" and strand
+    // the intact old root from the command that migrates it.
+    const options = { env: {}, home, dir: await install('published') };
+    expect(homeWorkspaceRoot(only('/home/ada/.lanes-link'), options)).toBe('/home/ada/.lanes-link');
+  });
+});

--- a/src/home/index.ts
+++ b/src/home/index.ts
@@ -1,0 +1,208 @@
+import { existsSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { dirname, join, resolve } from 'node:path';
+
+/**
+ * Where Lanes keeps things on this machine, in one place.
+ *
+ * `~/.lanes` is the Lanes home and it is older than this CLI: the desktop app
+ * keeps `auth.json`, `settings.json`, `database.db` and `integrations.json`
+ * there, and `#auth/lanes/session.ts` keeps the signed-in session beside them.
+ * The workspace was the one thing that lived outside it, at `~/.lanes-link`,
+ * for no reason anybody could state — so one product had two conventions and a
+ * reader had two directories to know about. It is `~/.lanes/link` now.
+ *
+ * ## Why this is a component of its own
+ *
+ * Two callers need the same answer and neither may import the other. `#profile`
+ * resolves the workspace root; `#auth` resolves the session path; and
+ * `src/architecture.test.ts` gives `auth` only `secrets` and `stores`, which is
+ * the right layering and not worth breaking for a path. Spelling the answer
+ * twice is the failure `layout.ts` already records — "two spellings of one
+ * filename is how a listing and a loader come to disagree about what exists" —
+ * and it would be worse here, because the two would disagree about *which
+ * machine directory holds the operator's credentials*.
+ *
+ * So it is a leaf: it imports nothing, and everything may import it.
+ *
+ * ## Dev mode
+ *
+ * A checkout gets `~/.lanes-dev` instead, and the whole home moves rather than
+ * just the workspace — a `lanes auth login` run while testing a branch must not
+ * sign the operator out of the install they actually use.
+ *
+ * This closes a hazard that used to be handled by remembering. Running the CLI
+ * out of a worktree resolved to the operator's real `~/.lanes-link` — live
+ * profiles, credentials, state, audit log — and `deploy` and `sync targets`
+ * both *write* there. The remedy was an exported `LANES_LINK_HOME`, which works
+ * exactly as often as it is remembered. Now the safe answer is the default, and
+ * reaching the real workspace from a checkout is what you have to say out loud.
+ */
+
+/** The Lanes home directory name, under `$HOME`. */
+export const LANES_DIR = '.lanes';
+
+/** The same, for a CLI running out of a checkout. */
+export const LANES_DEV_DIR = '.lanes-dev';
+
+/**
+ * What the workspace root was called through 0.13.
+ *
+ * Recognised, never written — the rule `LEGACY_WORKSPACE_FILE` follows, for the
+ * same reason: a root that cannot be found cannot be migrated, and a workspace
+ * that stops resolving the moment its owner upgrades is a wall with no door.
+ * `#cli/workspace-home-migrate.ts` is what moves it.
+ */
+export const LEGACY_LINK_DIR = '.lanes-link';
+
+/** This CLI's room inside the Lanes home. */
+export const LINK_DIR = 'link';
+
+/**
+ * Everything here is a pure function of three inputs, all injectable.
+ *
+ * Not for tidiness: `bun test` runs from the checkout, so the whole suite is in
+ * dev mode by the rule below, and a test that could not pin these would be
+ * asserting against wherever the runner happened to be installed.
+ */
+export interface HomeOptions {
+  readonly env?: Record<string, string | undefined>;
+  /** `$HOME`. */
+  readonly home?: string;
+  /** The directory to judge dev mode from. Defaults to this module's own. */
+  readonly dir?: string;
+}
+
+/**
+ * Where Lanes Link itself is installed — the directory with `package.json`,
+ * and with it `skills/` and `docs/`.
+ *
+ * Not the workspace: this is the code, not the operator's data. Found by
+ * walking up rather than by counting `..` segments, because the count is a
+ * function of where the calling file sits and a file that moves one level takes
+ * a silently wrong path with it. Both callers had already been through that
+ * once.
+ *
+ * It lives here rather than in `#profile` — where it was, and from where it is
+ * still re-exported — because dev mode is a question about the install, and the
+ * component that answers "where does Lanes keep things" is the one that has to
+ * know where the code came from.
+ */
+export function installRoot(from: string): string {
+  let directory = resolve(from);
+  for (;;) {
+    if (existsSync(join(directory, 'package.json'))) return directory;
+    const parent = dirname(directory);
+    if (parent === directory) {
+      throw new Error(`No package.json in any directory above ${from}`);
+    }
+    directory = parent;
+  }
+}
+
+/**
+ * Whether this is a checkout rather than a published install.
+ *
+ * **The signal is `tsconfig.json` at the install root**, which is in neither
+ * `package.json`'s `files` array nor the Dockerfile's `COPY`, so it exists in a
+ * checkout and nowhere else.
+ *
+ * The obvious alternative — is the install root under `node_modules`, which is
+ * what `updatePlan` asks — cannot be used here, and the reason is worth
+ * recording because the two now disagree on one case. `bun link` symlinks the
+ * *directory* `node_modules/@lanes-sh/link` at a checkout, and `bin/lanes`
+ * resolves its path logically rather than with `-P`, so the install root of a
+ * bun-linked checkout is a path containing `node_modules`. Deciding where
+ * somebody's credentials live on a resolver detail like that is not a trade
+ * worth making; a file that is either in the tarball or not is.
+ *
+ * `.git` was the other candidate and is rejected for the reason `updatePlan`
+ * gives against it: a tarball could carry one and a shallow export could lack it.
+ *
+ * `LANES_LINK_DEV` overrides in both directions, and both are used. `=1` gets a
+ * scratch home out of an installed copy; `=0` is what lets a checkout reach a
+ * real deployment on purpose, which is the one legitimate reason to want the
+ * old behaviour back.
+ */
+export function isDevInstall(options: HomeOptions = {}): boolean {
+  const env = options.env ?? (process.env as Record<string, string | undefined>);
+  const flag = env['LANES_LINK_DEV'];
+
+  // An exported-but-empty variable is a shell artefact, not an answer. Treating
+  // it as `true` would put anyone with `export LANES_LINK_DEV=` in a scratch
+  // home with no way to see why.
+  if (flag !== undefined && flag !== '') return !(flag === '0' || flag === 'false');
+
+  // This module's own path, not the process's cwd or argv: those describe where
+  // the command was typed, and the question is where the code came from.
+  try {
+    return existsSync(join(installRoot(options.dir ?? import.meta.dir), 'tsconfig.json'));
+  } catch {
+    // No `package.json` above us at all. Not a checkout by any reading, and not
+    // a reason to fail a command that was only asking where to look for a file.
+    return false;
+  }
+}
+
+/** `~/.lanes`, or `~/.lanes-dev` out of a checkout. */
+export function lanesHome(options: HomeOptions = {}): string {
+  return join(options.home ?? homedir(), isDevInstall(options) ? LANES_DEV_DIR : LANES_DIR);
+}
+
+/** `~/.lanes/link` — where a workspace lives when nothing else names one. */
+export function defaultWorkspaceRoot(options: HomeOptions = {}): string {
+  return join(lanesHome(options), LINK_DIR);
+}
+
+/**
+ * `~/.lanes-link`, wherever it still is.
+ *
+ * Not under `lanesHome`, and that is the point: there was never a dev copy of
+ * this, so it is composed from `$HOME` directly. A checkout asking for it is
+ * asking about the operator's real workspace, which is why `homeWorkspaceRoot`
+ * refuses to return it in dev mode.
+ */
+export function legacyWorkspaceRoot(options: HomeOptions = {}): string {
+  return join(options.home ?? homedir(), LEGACY_LINK_DIR);
+}
+
+/**
+ * The workspace root under `$HOME`, for a command that found none anywhere else.
+ *
+ * The last step of `resolveWorkspaceRoot`'s chain, which used to be one line
+ * returning `~/.lanes-link`. It is three answers now, and which one it gives is
+ * the whole of what moving the workspace into `~/.lanes` costs:
+ *
+ *  - **`~/.lanes/link` when a workspace is there**, which is the answer after a
+ *    migration and on every install that never had the old one.
+ *  - **`~/.lanes-link` when one is there instead** and this is not a checkout.
+ *    Recognised, never written. Somebody who upgrades and does not run `update`
+ *    still has a workspace, and `update` and `doctor --fix` still have something
+ *    to find and move.
+ *  - **`~/.lanes/link` otherwise**, so a fresh install creates the new one.
+ *
+ * **`isWorkspace` is a marker-file test, not a directory test**, and passing it
+ * in is what keeps this component free of `#profile`. The distinction is not
+ * pedantry: `~/.lanes` already belongs to the desktop app, so a bare
+ * `~/.lanes/link` directory can come into existence without this CLI having put
+ * a workspace in it — and an interrupted copy leaves exactly that. A directory
+ * test would then prefer the empty new root, report "no profiles here", and
+ * leave the intact old one unreachable by the command that migrates it.
+ *
+ * The checkout condition is not a detail either. Falling back onto the
+ * operator's real `~/.lanes-link` from a worktree is precisely the accident dev
+ * mode exists to stop, and a legacy root that outlived its migration would be a
+ * standing invitation to it.
+ */
+export function homeWorkspaceRoot(
+  isWorkspace: (directory: string) => boolean,
+  options: HomeOptions = {},
+): string {
+  const preferred = defaultWorkspaceRoot(options);
+  if (isWorkspace(preferred)) return preferred;
+
+  const legacy = legacyWorkspaceRoot(options);
+  if (!isDevInstall(options) && isWorkspace(legacy)) return legacy;
+
+  return preferred;
+}

--- a/src/profile/docs.test.ts
+++ b/src/profile/docs.test.ts
@@ -3,7 +3,7 @@ import { readdir, readFile } from 'node:fs/promises';
 import { isAbsolute, join } from 'node:path';
 import { parse as parseYaml } from 'yaml';
 import { workspaceSchema } from './schema.ts';
-import { installRoot } from './workspace.ts';
+import { installRoot } from '#home';
 import { parseConfig } from './load.ts';
 import { parseManifest } from '#providers/custom/index.ts';
 

--- a/src/profile/index.ts
+++ b/src/profile/index.ts
@@ -87,9 +87,16 @@ export {
   type SecretFinding,
 } from './secret-detection.ts';
 
+/**
+ * `installRoot` lives in `#home` now — it is a fact about the install, and
+ * `#home` needs it to tell a checkout from a published copy. Re-exported from
+ * here because eight files import it from `#profile` and the move renamed
+ * nothing.
+ */
+export { installRoot } from '#home';
+
 export {
   WORKSPACE_FILE,
-  installRoot,
   listProfiles,
   loadProfileConfig,
   loadWorkspaceProfiles,

--- a/src/profile/layout.ts
+++ b/src/profile/layout.ts
@@ -2,7 +2,7 @@
  * Where a workspace's files live, in one place.
  *
  * ```
- * ~/.lanes-link/
+ * ~/.lanes/link/
  * ├── workspaces.yaml           the workspaces this machine knows, and the default
  * ├── connections.yaml          every account authorised in this workspace
  * ├── credentials.enc           system credentials, and its .key

--- a/src/profile/registry.ts
+++ b/src/profile/registry.ts
@@ -14,7 +14,7 @@ import {
  *
  * A target names an adapter set. Under contract 1 a *profile* declared one per
  * target it could be opened against, which is what made a deploy leave two
- * copies of every profile — one in `~/.lanes-link`, one in the bucket the
+ * copies of every profile — one under the Lanes home, one in the bucket the
  * endpoint reads — with nothing keeping them honest. The reported failure is in
  * `sync-apply.ts`'s header and it happened again while this was being written:
  * a rewritten local file reported seven connections for a target whose bucket

--- a/src/profile/schema.ts
+++ b/src/profile/schema.ts
@@ -672,7 +672,7 @@ export type { IdentityEntry } from './identity.ts';
  * Two shapes, and which one a workspace writes says who owns the target:
  *
  * - **A declaration** — `credentials` and `storage`, and whatever else the
- *   adapter set needs. This workspace *is* that target. `~/.lanes-link` writes
+ *   adapter set needs. This workspace *is* that target. `~/.lanes/link` writes
  *   one of these for `local`.
  * - **A pointer** — `workspace: gs://bucket[/prefix]`, and nothing else. The
  *   target lives elsewhere and the workspace at that URI declares it. This is

--- a/src/profile/workspace.test.ts
+++ b/src/profile/workspace.test.ts
@@ -2,7 +2,8 @@ import { workspaceYaml, writeProfileFixture } from '#profile/testing.ts';
 import { afterAll, describe, expect, test } from 'bun:test';
 import { mkdtemp, mkdir, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
-import { join } from 'node:path';
+import { join, sep } from 'node:path';
+import { defaultWorkspaceRoot } from '#home';
 import {
   listProfiles,
   loadWorkspaceProfiles,
@@ -45,9 +46,22 @@ describe('workspace root resolution', () => {
     expect(resolveWorkspaceRoot({ env: {}, cwd: nested })).toBe(root);
   });
 
-  test('falls back to ~/.lanes-link when there is no workspace above', () => {
-    const resolved = resolveWorkspaceRoot({ env: {}, cwd: tmpdir() });
-    expect(resolved.endsWith('.lanes-link')).toBe(true);
+  test('falls back to the workspace root under the Lanes home', () => {
+    // Against `#home`'s own answer rather than a literal, because the literal
+    // is what the three-branch chain in `homeWorkspaceRoot` decides — and
+    // `home.test.ts` is where each of its branches is pinned, with a `$HOME`
+    // it controls. This asserts the join, which is the part `resolveWorkspaceRoot`
+    // is responsible for.
+    expect(resolveWorkspaceRoot({ env: {}, cwd: tmpdir() })).toBe(defaultWorkspaceRoot({ env: {} }));
+  });
+
+  test('which under `bun test` is the dev home, so the suite cannot reach a real workspace', () => {
+    // Worth asserting rather than assuming. Before dev mode, a test that forgot
+    // to pin `LANES_LINK_HOME` fell through to the operator's live profiles,
+    // credentials and audit log — which is why three test files carry a
+    // docstring warning about it. The suite runs from a checkout, so this is
+    // now structurally impossible, and this is the line that keeps it so.
+    expect(resolveWorkspaceRoot({ env: {}, cwd: tmpdir() }).split(sep)).toContain('.lanes-dev');
   });
 });
 

--- a/src/profile/workspace.ts
+++ b/src/profile/workspace.ts
@@ -3,7 +3,7 @@ import { layout, legacyProfileConfig, LEGACY_WORKSPACE_FILE, PROFILE_FILE } from
 import { isRemoteWorkspace, readWorkspaceFile, workspaceFiles } from './files.ts';
 import { parseConfig, type LoadedConfig } from './load.ts';
 import { dirname, isAbsolute, join, resolve } from 'node:path';
-import { homedir } from 'node:os';
+import { homeWorkspaceRoot } from '#home';
 import { parse as parseYaml } from 'yaml';
 import { ConfigError } from './load.ts';
 import {
@@ -38,7 +38,7 @@ import { findSecrets, formatSecretFindings } from './secret-detection.ts';
  *
  * The workspace root is deliberately not part of this and keeps its chain —
  * `LANES_LINK_HOME`, then an ancestor holding `workspaces.yaml` (or the
- * `lanes-link.yaml` it was called before contract 4), then `~/.lanes-link`.
+ * `lanes-link.yaml` it was called before contract 4), then `~/.lanes/link`.
  * Getting it wrong yields "no profiles here" rather than an
  * action against the wrong account, it is the only channel a container has for
  * its bucket (ADR-023), and the ancestor walk is what makes a per-repository
@@ -84,8 +84,34 @@ export interface ResolveOptions {
 }
 
 /**
- * `LANES_LINK_HOME`, else the nearest ancestor containing `lanes-link.yaml`,
- * else `~/.lanes-link`.
+ * Whether a directory is a workspace, by the only evidence there is.
+ *
+ * A marker file, never the directory itself. `existsSync`, not
+ * `Bun.file(path).size`: a missing file reports size 0, so a `>= 0` check would
+ * call every candidate a workspace and stop at the first directory it looked at.
+ *
+ * **Either name.** A root that cannot be found cannot be migrated, so the walk
+ * and the fallback both have to recognise the registry contract 3 wrote.
+ *
+ * Hoisted out of the walk because the fallback needs the identical test:
+ * `~/.lanes` belongs to the desktop app, so `~/.lanes/link` existing is not
+ * evidence that a workspace is in it, and an interrupted move leaves exactly
+ * that directory. Asking the same question in both places is what stops the
+ * fallback preferring an empty new root over an intact old one.
+ */
+function holdsWorkspace(directory: string): boolean {
+  return (
+    existsSync(join(directory, WORKSPACE_FILE)) || existsSync(join(directory, LEGACY_WORKSPACE_FILE))
+  );
+}
+
+/**
+ * `LANES_LINK_HOME`, else the nearest ancestor holding a registry, else the
+ * default root under the Lanes home.
+ *
+ * `homeWorkspaceRoot` is the last step, and its docstring carries what that
+ * step now decides — the new root, the legacy one, and why a checkout may not
+ * be given the second.
  */
 export function resolveWorkspaceRoot(options: ResolveOptions = {}): string {
   const env = options.env ?? (process.env as Record<string, string | undefined>);
@@ -97,40 +123,13 @@ export function resolveWorkspaceRoot(options: ResolveOptions = {}): string {
 
   let directory = resolve(options.cwd ?? process.cwd());
   for (;;) {
-    // `existsSync`, not `Bun.file(path).size`: a missing file reports size 0,
-    // so a `>= 0` check would call every candidate a workspace and stop at the
-    // first directory it looked at.
-    // Either name: a root that cannot be found cannot be migrated.
-    const marker = (name: string): boolean => existsSync(join(directory, name));
-    if (marker(WORKSPACE_FILE) || marker(LEGACY_WORKSPACE_FILE)) return directory;
+    if (holdsWorkspace(directory)) return directory;
     const parent = dirname(directory);
     if (parent === directory) break;
     directory = parent;
   }
 
-  return join(homedir(), '.lanes-link');
-}
-
-/**
- * Where Lanes Link itself is installed — the directory with `package.json`,
- * and with it `skills/` and `docs/`.
- *
- * Not the workspace: this is the code, not the operator's data. Found by
- * walking up rather than by counting `..` segments, because the count is a
- * function of where the calling file sits and a file that moves one level takes
- * a silently wrong path with it. Both callers had already been through that
- * once.
- */
-export function installRoot(from: string): string {
-  let directory = resolve(from);
-  for (;;) {
-    if (existsSync(join(directory, 'package.json'))) return directory;
-    const parent = dirname(directory);
-    if (parent === directory) {
-      throw new Error(`No package.json in any directory above ${from}`);
-    }
-    directory = parent;
-  }
+  return homeWorkspaceRoot(holdsWorkspace, { env });
 }
 
 /**

--- a/src/providers/assets/store.ts
+++ b/src/providers/assets/store.ts
@@ -16,7 +16,7 @@ import type { BlobStore } from '#connectivity';
  * an index-plus-body split for exactly this reason, and it applies harder here,
  * because a sidecar holding an asset's name would be a second name for a file
  * that already has one. What the owner sees under
- * `~/.lanes-link/data/<profile>/assets/main/` is a directory of their files,
+ * `~/.lanes/link/profiles/<profile>/assets/main/` is a directory of their files,
  * with their names, openable by anything.
  *
  * The cost is that an asset carries no description, and that is deliberate:

--- a/src/providers/custom/index.ts
+++ b/src/providers/custom/index.ts
@@ -1,7 +1,7 @@
 /**
  * Custom providers — the ones an operator writes.
  *
- * A YAML manifest in `~/.lanes-link/data/<profile>/providers.d/`, validated by
+ * A YAML manifest in `~/.lanes/link/providers.d/`, validated by
  * exactly the schema the built-ins are validated by, registered into exactly
  * the same registry. A service nobody has integrated is a file, not a pull
  * request someone waits on.

--- a/src/server/container.ts
+++ b/src/server/container.ts
@@ -20,7 +20,7 @@ import { streamLogger } from './logging.ts';
  *                      the image, because the bucket is the operator's and the
  *                      image is meant to serve any workspace (ADR-023).
  *                      Unset, `resolveWorkspaceRoot` falls back to
- *                      `~/.lanes-link`, which in a container is a directory
+ *                      `~/.lanes/link`, which in a container is a directory
  *                      nobody wrote — so the endpoint refuses rather than
  *                      serving an empty workspace.
  *   LANES_LINK_TARGET   which target's adapters to open. Baked to `cloud`.


### PR DESCRIPTION
`~/.lanes` is where Lanes keeps things on a machine and predates this CLI — the desktop app owns `auth.json`, `settings.json` and `database.db` there, and the signed-in session already sat beside them. The workspace was the one thing outside it, at `~/.lanes-link`. Nothing chose that, and it left one product with two conventions.

The workspace root is `~/.lanes/link` now, and a CLI running out of a checkout gets `~/.lanes-dev` — home and session both, so testing a branch cannot sign you out of the install you actually use.

```
resolveWorkspaceRoot:
  1. LANES_LINK_HOME              explicit path or gs:// bucket
  2. ancestor workspaces.yaml     per-repository workspace
  3. ~/.lanes/link                when a workspace is there
  4. ~/.lanes-link                when one is there instead, and not a checkout
  5. ~/.lanes/link                otherwise
```

## Why the dev split is the half that pays for itself

Running from a worktree used to resolve to the operator's real workspace — live profiles, credentials, state, audit log — and `deploy` and `sync targets` both *write* there. The defence was a house rule to export `LANES_LINK_HOME`, which works exactly as often as it is remembered, backed by three test files carrying docstrings about why they pin it. `homeWorkspaceRoot` now refuses to hand a checkout the real root at all, so the rule retires and the suite cannot reach real credentials by forgetting.

Dev mode is detected from `tsconfig.json` at the install root, which is in neither `package.json`'s `files` nor the Dockerfile's `COPY`. The obvious signal — an install root under `node_modules`, which `updatePlan` uses — was rejected on one case: `bun link` symlinks the package *directory* at a checkout and `bin/lanes` resolves its path logically rather than with `-P`, so a bun-linked checkout has an install root containing `node_modules`. Deciding where somebody's credentials live on a resolver detail is not a trade worth making. `LANES_LINK_DEV` overrides both ways.

## The old root is recognised, never written

The rule `LEGACY_WORKSPACE_FILE` already follows: a root that cannot be found cannot be migrated. Steps 3 and 4 test for a **marker file** rather than for the directory, which is not pedantry — `~/.lanes` belongs to the desktop app, so `~/.lanes/link` can exist without a workspace in it, and an interrupted copy leaves exactly that. A directory test would prefer the empty new root, report "no profiles here", and strand the intact old one behind a migration refusing because two roots exist. Permanent, with the repair path the blocked one.

## The move

Runs from `update` and `doctor --fix` and nowhere else. Letting the first command that noticed do it would relocate somebody's credentials, audit log and every profile without a word they could audit afterwards — and nothing is lost by waiting, because the old root goes on resolving. Every other command prints one dim line under the root it already announces.

It refuses, before the first byte moves, on:

- **a checkout**, since applying it from one would move the real workspace into a scratch home;
- **`LANES_LINK_HOME` set**, since an explicit root is a decision and in a container it is a bucket;
- **a live endpoint**, by the pid check `readEndpointRecord` already does — a running `start` holds the old path;
- **two roots holding different things**, since merging is not reversible. Where the new root already holds everything, that is an interrupted copy and the rerun finishes it;
- **a target naming an absolute path inside the old root.** The one that would otherwise have been silent: `workspacePath` honours an absolute path verbatim, so it would go on naming a directory the migration had just emptied — and for `credentials.path` that is the encrypted credential store.

`rename` does the move, falling back on `EXDEV` to copy, read back, delete — the order that survives interruption. Not a key-by-key drain through `workspaceFiles()`: its `list` skips `.meta` sidecars, returns no empty directories, and reports a symlinked directory as a file, and it has an observable half-state where `rename` has none. `cp` carries every file's mode but leaves the destination root at the umask, so that one is set from the source; `profile add` also stops creating the root at the ambient umask, now that what lands inside it is a credential store.

## `#home`

A new leaf component, because `auth` may not import `profile` and both need this answer — and the alternative is one directory spelled in two files, which is the failure `layout.ts` records for a filename and worse for a credential store. `installRoot` moved there with it: it is a fact about the install, and dev mode is the question that needs it. `#profile` re-exports it, so no call site moved.

## Verification

`bun test` (3549 pass, 0 fail) and `bun run typecheck` both green. Rehearsed end to end against a scratch `$HOME` rather than only in unit tests: the move preserves `0600` on `credentials.enc` and `0700` on both directories, the old root is gone afterwards, an un-migrated workspace still resolves and prints the notice, `doctor` reports without `--fix` and moves with it, and both the live-endpoint and two-workspaces refusals hold with nothing touched.

**Pairing needs nothing.** Certificate, key and pair token ride in the workspace's `credentials.enc`; mkcert's CA is in the system trust store, not the workspace; the dashboard reads a port derived from `profile.yaml`, not a path. The running endpoint is the only non-automatic part, which is what the refusal above covers.

## Two things to know

**A dev run signs in separately.** `start` requires a Lanes session (ADR-060), so a contributor testing a branch does `lanes auth login` once inside dev mode. That is the price of a dev run being unable to sign the operator out of their real one.

**ADR-065 is a cross-repository contract this cannot enforce.** The desktop app runs this CLI from the home directory and expects the walk to land on `~/.lanes-link`. It lands on `~/.lanes/link` now — correct once migrated, and a change the app repository has to be told about.

`0.14.0` rather than a patch: it relocates every existing workspace. ADR-077 has the whole argument.
