### PR TITLE
A profile name is refused before anything is written for it

### DIFF
--- a/src/cli/commands/profile.test.ts
+++ b/src/cli/commands/profile.test.ts
@@ -1,7 +1,7 @@
 import { afterAll, describe, expect, test } from 'bun:test';
 import { workspaceYaml } from '#profile/testing.ts';
 import { assertGrantsResolve, loadProfileConfig, readConnections } from '#profile';
-import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { mkdir, mkdtemp, readFile, readdir, rm, writeFile } from 'node:fs/promises';
 import { existsSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
@@ -203,6 +203,52 @@ describe('createProfile', () => {
     await createProfile('personal', { targets: ['local'] });
 
     await expect(createProfile('personal', { targets: ['local'] })).rejects.toThrow(/already exists/);
+  });
+
+  /**
+   * The leftover, not the error — issue #219.
+   *
+   * A name the contract does not accept used to be written and *then* parsed
+   * back, so the command reported a failure and left a profile behind that
+   * nothing in the CLI could remove: `remove` and `doctor --fix` both resolve
+   * the profile first and failed on the same parse. So the assertion that
+   * matters here is the second one in each test. The first only says the
+   * command still complains.
+   */
+  test('a name the contract refuses leaves nothing behind', async () => {
+    const root = await workspace();
+
+    await expect(createProfile('my-profile', { targets: ['local'] })).rejects.toThrow(
+      /must be lowercase letters/,
+    );
+
+    expect(existsSync(join(root, 'profiles', 'my-profile'))).toBe(false);
+    expect((await readProfiles('local')).profiles).toEqual([]);
+  });
+
+  test('a refused name does not bring a workspace into existence', async () => {
+    // The sibling of the seeding test above, and the reason the guard is the
+    // first statement in `createProfile` rather than the line before the write:
+    // on a bare directory this command writes `workspaces.yaml` and
+    // `connections.yaml` before it gets anywhere near the profile, and a name
+    // that cannot be used should not leave either of them.
+    const root = await mkdtemp(join(tmpdir(), 'lanes-link-refused-'));
+    roots.push(root);
+    process.env['LANES_LINK_HOME'] = root;
+
+    await expect(createProfile('My.Profile', { targets: ['local'] })).rejects.toThrow(
+      /must be lowercase letters/,
+    );
+
+    expect(await readdir(root)).toEqual([]);
+  });
+
+  test('names the corrected name and the workspace it was asked for', async () => {
+    await workspace();
+
+    await expect(createProfile('my-profile', { targets: ['local'] })).rejects.toThrow(
+      'lanes link profile add my_profile --workspace local',
+    );
   });
 });
 

--- a/src/cli/commands/profile.ts
+++ b/src/cli/commands/profile.ts
@@ -21,6 +21,7 @@ import {
   layout,
 } from '#profile';
 
+import { assertProfileName } from './profile/name.ts';
 import { recordConfigChange } from '../audit-change.ts';
 import { nextAfterEdit, publishProfileEdit, type PublishOutcome } from '../publish.ts';
 import { resolveProfile } from '../runtime.ts';
@@ -126,8 +127,16 @@ export async function createProfile(
   name: string,
   options: { targets: readonly string[]; nonInteractive?: boolean },
 ): Promise<ProfileCreated> {
-  const local = resolveWorkspaceRoot();
   const target = options.targets[0]!;
+
+  // Before the workspace root is even resolved, because on an empty directory
+  // this call is what brings a workspace into existence and a name that cannot
+  // be used should not leave one behind on its way to being refused. The rule
+  // lives in the schema, so until this guard existed it was enforced by reading
+  // the profile back — after it had been written (#219).
+  assertProfileName(name, target);
+
+  const local = resolveWorkspaceRoot();
 
   // The workspace file before the target is resolved, not after. `profile add
   // <name> --workspace local` on an empty directory is how a workspace comes into

--- a/src/cli/commands/profile/name.test.ts
+++ b/src/cli/commands/profile/name.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, test } from 'bun:test';
+import { assertProfileName, nearestProfileName } from './name.ts';
+
+/**
+ * The guard in front of the first write — issue #219.
+ *
+ * `profile.test.ts` holds the property that matters, which is that a refused
+ * name leaves nothing on disk. This file holds the two things that are easier
+ * to get wrong than to notice: that the rule here is the *same* rule the loader
+ * applies, and that a suggestion is offered only when folding actually reaches
+ * a name the rule accepts.
+ */
+
+describe('nearestProfileName', () => {
+  test('folds the separators and cases people actually type', () => {
+    expect(nearestProfileName('my-profile')).toBe('my_profile');
+    expect(nearestProfileName('My Profile')).toBe('my_profile');
+    expect(nearestProfileName('work.2')).toBe('work_2');
+    expect(nearestProfileName('Personal')).toBe('personal');
+  });
+
+  test('drops punctuation, never a character that carries a word', () => {
+    expect(nearestProfileName('-work')).toBe('work');
+    // `fa` is a legal name and a different one, so this is a case with no
+    // nearest name — only the rule, and a choice that is the operator's.
+    expect(nearestProfileName('2fa')).toBeUndefined();
+  });
+
+  test('offers nothing rather than inventing a name', () => {
+    expect(nearestProfileName('2026')).toBeUndefined();
+    expect(nearestProfileName('---')).toBeUndefined();
+    expect(nearestProfileName('')).toBeUndefined();
+  });
+
+  test('never suggests a name the guard would go on to refuse', () => {
+    for (const name of ['my-profile', 'My Profile', 'work.2', '-work', '2fa', '---', '']) {
+      const nearest = nearestProfileName(name);
+      if (nearest !== undefined) expect(() => assertProfileName(nearest, 'local')).not.toThrow();
+    }
+  });
+});
+
+describe('assertProfileName', () => {
+  test('accepts what the config contract accepts', () => {
+    for (const name of ['personal', 'work', 'work_2', 'a']) {
+      expect(() => assertProfileName(name, 'local')).not.toThrow();
+    }
+  });
+
+  /**
+   * The wording comes from the schema, and this is the test that keeps it
+   * there. A second copy of the regex in the guard could accept a name the
+   * loader refuses, which is the leftover again — reported by a different
+   * sentence, one release later.
+   */
+  test("refuses with the loader's own wording", () => {
+    expect(() => assertProfileName('my-profile', 'local')).toThrow(
+      /must be lowercase letters, digits, and underscores, starting with a letter/,
+    );
+  });
+
+  test('names the command that would have worked', () => {
+    expect(() => assertProfileName('my-profile', 'cloud')).toThrow(
+      'lanes link profile add my_profile --workspace cloud',
+    );
+  });
+
+  test('falls back to a placeholder when the caller has no target yet', () => {
+    expect(() => assertProfileName('my-profile')).toThrow(
+      'lanes link profile add my_profile --workspace <name>',
+    );
+  });
+
+  test('states the rule alone when nothing can be suggested', () => {
+    expect(() => assertProfileName('2026', 'local')).toThrow(/must be lowercase letters/);
+    expect(() => assertProfileName('2026', 'local')).not.toThrow(/Try:/);
+  });
+
+  test('says that nothing was written, which is the whole of the fix', () => {
+    expect(() => assertProfileName('my-profile', 'local')).toThrow(/Nothing was written\./);
+  });
+});

--- a/src/cli/commands/profile/name.ts
+++ b/src/cli/commands/profile/name.ts
@@ -1,0 +1,78 @@
+import { ConfigError, configSchema } from '#profile';
+
+/**
+ * Refusing a profile name before anything is written for it.
+ *
+ * The rule was only ever enforced by reading the file back. `createProfile`
+ * wrote `profiles/<name>/profile.yaml` and *then* parsed it, so a name the
+ * contract does not accept — anything with a hyphen, a capital, a dot —
+ * reported an error and left the profile behind. Every command that could have
+ * taken it away resolves it first and failed on the same parse, so the only way
+ * out was deleting the file by hand, or the bucket object on a deployed
+ * workspace. Issue #219.
+ *
+ * The guard sits in front of the first write rather than beside it because
+ * `profile add` on an empty directory writes three things — `workspaces.yaml`,
+ * `connections.yaml`, then the profile — and a name that cannot be used should
+ * not bring a workspace into existence on its way to being refused.
+ */
+
+/**
+ * The one spelling of the rule, reached through the schema that enforces it.
+ *
+ * Not a second regex here. `instance.profile` is `identifier`
+ * (`profile/primitives.ts`), and a copy of that pattern in the guard would be
+ * free to drift from the copy in the parse — which is the same failure this
+ * whole file exists to remove, one release later and harder to see: a name the
+ * guard accepts and the loader does not is exactly the leftover again. Reading
+ * the field means the message below is also the loader's own wording, so an
+ * operator who somehow reaches both is told the same thing twice rather than
+ * two different things.
+ */
+const rule = configSchema.shape.instance.shape.profile;
+
+/**
+ * The nearest name the rule accepts, where folding gets to one.
+ *
+ * Case and separators are what people actually type — `my-profile`, `My
+ * Profile`, `work.2` — and all three fold cleanly. Punctuation is all this
+ * drops: `2fa` would fold to `fa`, which is a legal name and a *different* one,
+ * so a leading digit gets no suggestion at all. Inventing a name for somebody
+ * is worse than stating the rule and letting them choose it.
+ *
+ * The result is put back through the rule rather than assumed to satisfy it,
+ * which is what makes the folding above a heuristic that cannot be wrong: a
+ * suggestion the guard would itself go on to refuse is not offered.
+ */
+export function nearestProfileName(name: string): string | undefined {
+  const folded = name
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '_')
+    .replace(/^_+/, '')
+    .replace(/_+$/, '');
+
+  return folded !== name && rule.safeParse(folded).success ? folded : undefined;
+}
+
+/**
+ * Throw unless `name` is one the config contract will accept.
+ *
+ * `target` only shapes the suggestion, so a caller that has not resolved one
+ * yet may leave it out; the command printed then names `<name>` where the
+ * workspace goes, which is what the rest of the CLI's usage lines do.
+ */
+export function assertProfileName(name: string, target?: string | undefined): void {
+  const checked = rule.safeParse(name);
+  if (checked.success) return;
+
+  const why = checked.error.issues[0]?.message ?? 'not a name the config contract accepts';
+  const nearest = nearestProfileName(name);
+  const suggestion = nearest
+    ? `\n  Try: lanes link profile add ${nearest} --workspace ${target ?? '<name>'}`
+    : '';
+
+  // That nothing was written is the sentence worth printing. The defect this
+  // replaces reported an error *and* left a profile, so an operator who has
+  // seen the old behaviour has every reason to go looking for the litter.
+  throw new ConfigError(`Profile name "${name}": ${why}.${suggestion}\n  Nothing was written.`);
+}


### PR DESCRIPTION
Closes #219.

`profile add` wrote the profile and then parsed it back. The rule the name has to satisfy lives in the schema — `instance.profile` is `identifier`, `/^[a-z][a-z0-9_]*$/` — so it was only ever enforced by that read, which happens after the file exists. `lanes link profile add my-profile` therefore reported an error *and* left the profile behind.

The error was never the problem. The leftover was, because nothing in the CLI could take it away again: `profile remove` and `doctor --fix` both resolve the profile before acting and failed on the same parse, and `listProfiles` reads directory names rather than configs, so it went on being listed like any other.

Before:

```console
$ lanes link profile add my-profile --workspace local
error  /tmp/repro/profiles/my-profile/profile.yaml:
  instance.profile: must be lowercase letters, digits, and underscores, starting with a letter

$ lanes link profile list --workspace local
   my-profile  /tmp/repro/profiles/my-profile/profile.yaml
```

After:

```console
$ lanes link profile add my-profile --workspace local
error  Profile name "my-profile": must be lowercase letters, digits, and underscores, starting with a letter.
  Try: lanes link profile add my_profile --workspace local
  Nothing was written.
```

## What the change is

`assertProfileName` is the first statement in `createProfile`, ahead of `resolveWorkspaceRoot`, and that position is load-bearing rather than tidy. On a bare directory this command is what brings a workspace into existence — `workspaces.yaml`, then `connections.yaml`, then the profile — so a guard placed beside the write it guards would still have left the first two behind. A refused name now leaves an empty directory, which is what one of the tests asserts.

The rule is read out of `configSchema` rather than restated. A second copy of that regex would be free to drift from the copy in the loader, and a name the guard accepts and the loader refuses is this same defect again, one release later and harder to see. Reading the field also means the refusal carries the loader's own wording.

The suggestion drops punctuation and nothing else. `my-profile`, `My Profile` and `work.2` all fold cleanly; `2fa` would fold to `fa`, which is a legal name and a different one, so a leading digit gets no suggestion at all. Whatever the folding produces is put back through the rule before it is offered, so a suggestion the guard would itself refuse cannot be printed.

## Not fixed here

`profile remove` still refuses a profile it cannot parse — the second half of the issue, which it raises as a separate consideration. That is what made this unrecoverable rather than merely annoying, but a removal without a config cannot enumerate the secrets and blobs the profile owns, and `remove.ts` is built around never deleting the one record of where those live. Deciding what a config-less removal should say about the credentials it cannot see is a separate argument.

## Testing

`bun test` (3623 pass, 0 fail) and `bun run typecheck` green. Reproduced the issue on `develop` first, and verified the fix against a scratch workspace on both a populated and an empty target.