### PR TITLE
Two commands for reading what the search answers

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -20,6 +20,7 @@ Every page is also served as plain Markdown: add `.md` to the path, for example
 | [`detailed/adr/`](detailed/adr/) | The architecture decision records: why each choice was made, and what it cost |
 | [`detailed/init.md`](detailed/init.md) | The original specification, amended to match what was built |
 | [`detailed/admission.md`](detailed/admission.md) | Where a vendor admits the client rather than the operator: programmes, catalogues, and waitlists |
+| [`testing-search.md`](testing-search.md) | Two commands for checking what capability search answers, and how to read it |
 
 Those are engineering history and standing constraints rather than documentation, so they stay
 with the source.

--- a/docs/testing-search.md
+++ b/docs/testing-search.md
@@ -1,0 +1,78 @@
+# Testing the search by hand
+
+Two commands. Neither needs a workspace, a credential, or a network — both run the real ranking
+and rendering over a fixture corpus of eleven providers and 51 capabilities.
+
+## Is the ranking still good?
+
+```console
+$ bun run bench:retrieval
+```
+
+```
+  retrieval over 51 capabilities, 16 questions
+  ──────────────────────────────────────────────────────────
+  answer ranks first           94%  (was 31%, +63)
+  answer in the first three   100%  (was 63%, +37)
+  answer carries a schema     100%  (was 81%, +19)
+  mean answer size           1393 B  (was 4063 B, -2670)
+  ──────────────────────────────────────────────────────────
+```
+
+The floors are asserted, so a change that makes ranking worse fails. The percentages are printed
+rather than only checked, because a slide from 100% to 91% passes a 90% floor and is still a
+regression.
+
+## What does it answer to *this* question?
+
+```console
+$ bun run probe "latest email in inbox"
+$ bun run probe --limit 6 "move a file to a folder"
+$ bun run probe --crunched "archive a message"
+```
+
+`--limit` is how many get explained in full — three by default, ten at most. `--crunched` shows
+what a profile with `surface: crunched` answers, where the capability id leads because there is no
+named tool to prefer.
+
+### Reading the answer
+
+```
+16 matches for "latest email in inbox".
+
+## mailhub_search_messages          ← the wire name, or the capability id under --crunched
+capability: mailhub.search_messages
+reachable:  personal: mailhub.acct1  ← which profile and connection to pass
+
+arguments (JSON Schema — `profile` and `connection` are added by this endpoint):
+...
+
+13 further matches scored lower and are not shown.
+```
+
+Two things are worth checking, and both are easiest to see with `--limit 6`:
+
+- **The first few are one per provider.** Two connected mailboxes should both appear before either
+  provider gets a second entry. Ranked purely by score the better-worded provider fills every slot
+  and the second mailbox never shows up.
+- **Every entry carries its full input schema.** A match named without its arguments costs a round
+  trip and looks like an answer.
+
+## Against your own accounts
+
+The corpus is a model of a surface, not yours. For how *your* providers rank, ask a running
+endpoint:
+
+```console
+$ lanes link tools --json
+```
+
+To point a scratch endpoint at a throwaway workspace rather than your real one:
+
+```console
+$ export LANES_LINK_HOME=/tmp/lanes-link-scratch
+$ lanes link start --port 7401
+```
+
+Without `LANES_LINK_HOME` the command finds your real workspace — the profiles, credentials and
+audit log the deployed endpoint reads.

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "lanes": "bun run ./src/cli/lanes.ts",
     "audit": "bun audit",
     "bench:retrieval": "bun test src/server/mcp/retrieval-bench.test.ts",
+    "probe": "bun run ./scripts/probe.ts",
     "vendor:bunq": "bun run ./src/providers/bunq/specs/vendor.ts",
     "vendor:discord": "bun run ./src/providers/discord/specs/vendor.ts",
     "vendor:google": "bun run ./src/providers/google/specs/vendor.ts",

--- a/scripts/probe.ts
+++ b/scripts/probe.ts
@@ -1,0 +1,44 @@
+/**
+ * Ask the search a question and print what it would answer.
+ *
+ * The companion to `bench:retrieval`: that one measures whether ranking has
+ * regressed, this one answers "what does it say to *this* query". Both run the
+ * real ranking and rendering over the committed fixture corpus, so neither
+ * needs a workspace, a credential, or a network — there is nothing here that
+ * can reach an account.
+ *
+ * Not shipped: `package.json`'s `files` covers `bin`, `src` and `instructions`,
+ * and this is none of them.
+ */
+import { CORPUS } from '../src/server/mcp/ranking-corpus.ts';
+import { searchCapabilities } from '../src/server/mcp/search-index.ts';
+
+const argv = process.argv.slice(2);
+const words: string[] = [];
+let limit: number | undefined;
+let surface: 'full' | 'crunched' = 'full';
+
+for (let at = 0; at < argv.length; at += 1) {
+  const arg = argv[at] ?? '';
+  if (arg === '--limit') limit = Number(argv[(at += 1)]);
+  else if (arg === '--crunched') surface = 'crunched';
+  else words.push(arg);
+}
+
+const query = words.join(' ');
+
+if (query.length === 0) {
+  console.log('Ask it something:\n');
+  console.log('  bun run probe "latest email in inbox"');
+  console.log('  bun run probe --limit 6 "move a file to a folder"');
+  console.log('  bun run probe --crunched "archive a message"\n');
+  process.exit(1);
+}
+
+const answer = searchCapabilities(query, CORPUS, surface, limit === undefined ? {} : { limit });
+
+console.log(answer);
+console.log('\n' + '─'.repeat(64));
+console.log(
+  `${CORPUS.size} capabilities searched · ${answer.length} B answered · surface ${surface}`,
+);


### PR DESCRIPTION
`bench:retrieval` answers one question — has retrieval got worse. It cannot answer the other one a
person actually asks, which is *what does the search say to this query*. Until now the only ways to
find out were to deploy and ask a real endpoint, or to read `render.ts` and imagine it.

```console
$ bun run probe "latest email in inbox"
$ bun run probe --limit 6 "move a file to a folder"
$ bun run probe --crunched "archive a message"
```

It runs the real ranking and the real rendering over the same committed corpus the benchmark uses,
so it needs no workspace, no credential and no network. There is nothing in it that *can* reach an
account, which is what makes it safe to poke at while changing scoring.

`--limit 6` is the useful one, because it shows the property that is hardest to see and easiest to
break:

```
## mailhub_search_messages      ← one per provider first…
## postbox_users_messages_list
## forge_get_latest_release
## mailhub_listMessages         ← …then depth
## postbox_users_drafts_list
## postbox_users_labels_list
```

## What is here

| | |
|---|---|
| `scripts/probe.ts` | The script. Under `scripts/` rather than `src/`, so `files` keeps it out of the published package |
| `docs/testing-search.md` | Two commands, and how to read the answer |
| `docs/README.md` | A row pointing at it |
| `package.json` | `bun run probe` |

The doc is the light layer CONTRIBUTING describes — what to type, in order. The one piece of
reasoning it keeps is *how to read the answer*, because the two properties worth checking are not
obvious from looking at one result: that the first few are one per provider rather than three from
the best-worded one, and that every entry carries its schema. Both are failures this surface has
actually had.

It also names `LANES_LINK_HOME` where a reader would otherwise reach for `lanes link start` and
write into their real workspace.

## Checks

`bun test` 3581 pass, 0 fail. `bun run typecheck` clean. Every command in the doc was run and its
output matched what the doc shows. The no-real-identifiers rule was confirmed to cover the new doc
by putting an address in it and watching it fail.