### PR TITLE
A profile whose config will not load can be removed

### DIFF
--- a/docs/detailed/adr/078-a-removal-works-on-a-config-that-will-not-load.md
+++ b/docs/detailed/adr/078-a-removal-works-on-a-config-that-will-not-load.md
@@ -1,0 +1,135 @@
+# ADR-078: A removal works on a config that will not load
+
+**Status:** accepted · **Extends** [ADR-051](051-tasks-and-assets-are-their-own-stores.md) — "a
+refusal at load has to name a command, and the command has to exist" — from repair to removal
+
+## Context
+
+`lanes link profile add my-profile` wrote `profiles/my-profile/profile.yaml` and then parsed it back.
+The rule the name has to satisfy lives in the schema, so it was only ever enforced by that read — and
+the read happens after the file exists. The command reported an error *and* left the profile behind.
+
+The error was never the problem. The leftover was, because nothing in the tool could take it away:
+
+```console
+$ lanes link profile remove my-profile --workspace local --yes --delete-data
+error  /tmp/repro/profiles/my-profile/profile.yaml:
+  instance.profile: must be lowercase letters, digits, and underscores, starting with a letter
+```
+
+`profile remove` and `doctor --fix` both resolve the profile before acting and died on the same parse,
+while `listProfiles` reads directory names rather than configs — so it stayed listed like any other
+profile, and the only way out was deleting the file by hand, or the bucket object on a deployed
+workspace. Issue #219.
+
+The name guard that stops `profile add` creating one is a separate change and is already in. It does
+not help the profiles already on disk, and it addresses one cause out of several: a hand edit, an
+interrupted write, or a contract the installed version does not recognise all end in the same place.
+
+ADR-051 has already had this argument once, about the other command:
+
+> A refusal at load has to name a command, and the command has to exist.
+
+There it made `doctor --fix` the route back from a config the loader refuses. The same sentence applies
+to removal, and more sharply — being able to delete something broken is exactly when it matters most.
+
+## Decision
+
+**`profile remove` degrades rather than refusing, automatically, and reports what it could not see.**
+
+No `--broken` or `--force` flag. The command an operator already reaches for is the one that has to
+work; a flag would be a second thing to discover at the moment they are least able to. The gates that
+were already there stay: `confirmedByName` still asks for the name, and the disposition question is
+still asked.
+
+### What makes it safe: a gap shrinks the plan, it can never widen it
+
+Removal derives its credential refs from what the profile *declares*, then keeps only those the store
+actually holds. So a field that could not be read contributes no ref, and the removal deletes less than
+it might have — never something that was somebody else's. This is the property the whole design turns
+on:
+
+> What a config that will not load costs is a line that is missing, never one that is wrong.
+
+`RemovalSubject` exists to keep it true. The four things `removalPlan` reads off a config are a type
+rather than a docstring, so a fifth cannot be added without confronting the degraded reader beside it.
+
+### The directory's name is authoritative
+
+`layout.blobs(profile)` is what addresses the blob tree, so a hand-edited `instance.profile` reaching
+it would let `profile remove my_profile` empty `profiles/other/`. Every key comes from the directory —
+which is also what the operator typed and what `listProfiles` showed them. The file's own value is
+needed for exactly one thing, the middle segment of `vault/<profile>/<connection>`, and where the two
+disagree the ref is reported as unreachable rather than guessed at.
+
+### One degraded path, not two
+
+A `profile.yaml` refused by the schema but perfectly good as YAML — which is what #219 produces —
+yields every field, so the plan is identical to a parsed one. Filing that under "partial removal" would
+owe the operator an explanation that is not true. A file that will not parse as YAML is the same read
+with nothing to read: every field lands unread and the same code runs.
+
+### The decision point is structural, not a `catch`
+
+`ConfigError` comes out of profile resolution for a missing `--workspace`, an undeclared target, a
+pointer chain that will not follow, a contract-3 layout, and a profile that is simply not there — as
+well as for the parse. A `try` around the whole resolution would read "you typed the wrong workspace"
+as "this profile is broken", and `--yes --delete-data` would then run a removal to completion in a
+workspace nobody meant.
+
+`locateProfile` splits the resolution so only the parse is caught. `resolveSelection` never reads a
+config — it asks the workspace whether the file exists — which is the property that makes the split
+possible, and the one `migratedRenamedProviders` already relies on. `resolveProfileOnly` becomes three
+lines on top of it, so there is one resolution path rather than two that can drift.
+
+### Exit 0 iff nothing was left, not iff the config parsed
+
+`renderOutcome`'s contract is already "a live credential left behind must not look like success to a
+script". The trigger is *something is left*, never *something threw*. Keying the code on the parse gets
+both halves wrong at once: the profile #219 produces reads every field and leaves nothing, so reporting
+failure for it means the cleanup script that hit the bug still fails — on a profile that is now gone —
+and it gives that the same code as a deployed profile that really did strand a sealed document. Two
+states, one code, no information.
+
+Where something *is* unreachable, the outcome says **"running this again will not find them: the
+profile is gone"**. The existing exit-1 pairs with "fix the above and run the same command again",
+which works only because a failure keeps the config — the record of where everything lives. Here there
+is nothing left to re-derive from.
+
+### `--migrate-to` is refused
+
+Not because the mechanics fail: `migratesAcross` is a key-prefix test and `resolveCollisions` opens the
+destination by name, and both work fine here. It is the asymmetry in what going wrong costs.
+`--delete-data` fails toward having deleted less than it should, which is the direction everything else
+here leans. `--migrate-to` fails toward putting bytes nobody could account for into a profile that is
+currently correct, under a connection it may not grant — invisible to every command that reads it, and
+with nothing to undo it. The refusal names the two ways forward, as every refusal in this command does.
+
+## Consequences
+
+**Three functions take a name where they took a `Config`.** `openStorage`, `recordConfigChange` and
+`publishWorkspace` each read one thing off the parsed file — the profile's name, or nothing at all —
+and requiring the whole of it is what stopped a removal opening the stores, writing the audit row, and
+telling the endpoint. This is the narrowing `openSecrets` already made, for the reason its own docstring
+gives: a caller that must work while the file on disk will not parse cannot be asked for the parsed
+file. `targetInput()` keeps `profile` and `config.instance.profile` from drifting apart.
+
+**The endpoint is still told, and it matters more here rather than less.** A config that will not load
+*today* is not a profile that was never served: the served set is built at boot and at `/reload` and at
+no other time, so a file that parsed at the last boot is being served right now, from memory, with live
+credentials. The reload is the only thing that drops it before a restart.
+
+**A salvaged config goes through `findSecrets` before anything is kept.** A parsed one has been through
+that check on its raw object, deliberately and before the schema; without this the degraded path would
+be the one route by which a config value reaches a terminal, an audit row and a `--json` document
+unchecked.
+
+**`doctor --fix` still refuses a profile it cannot parse.** Repairing one means rewriting
+`instance.profile` or renaming its directory, which is a choice about the operator's data rather than a
+deletion, and it is a separate argument. What has changed is that there is now a way out that does not
+involve leaving the tool.
+
+**Four files where there were two.** `subject.ts` is what a profile declares, `removal.ts` what a
+removal deletes, `preview.ts` the plan an operator decides from, `perform.ts` the doing of it. The
+budget in `architecture.test.ts` pointed at each split, and in each case it was pointing at two subjects
+rather than at length.

--- a/docs/detailed/adr/README.md
+++ b/docs/detailed/adr/README.md
@@ -90,6 +90,7 @@ Run.
 | [075](075-the-list-a-client-caches-must-stop-changing.md) | The typed tool list stays and gains a search beside it, so a client that never re-reads can still reach a new connection |
 | [076](076-an-endpoint-may-advertise-less-than-it-reaches.md) | An endpoint may advertise less than it reaches, so a catalogue too large for its clients can shrink without any capability leaving it |
 | [077](077-the-workspace-lives-under-the-lanes-home.md) | The workspace moves to `~/.lanes/link`, a checkout gets `~/.lanes-dev`, and the old root is recognised until `update` moves it |
+| [078](078-a-removal-works-on-a-config-that-will-not-load.md) | A removal works on a config that will not load, deleting by name what it cannot enumerate and reporting the rest |
 
 Where an ADR departs from init.md, it says so at the top. Three are significant:
 

--- a/src/cli/audit-change.test.ts
+++ b/src/cli/audit-change.test.ts
@@ -35,7 +35,12 @@ async function workspace(): Promise<{ root: string; config: Config }> {
 
 async function tail(root: string, config: Config) {
   const resolved = await openTarget(root, 'local');
-  const input = { declared: resolved.declared, config, root: resolved.workspaceRoot, target: 'local' };
+  const input = {
+    declared: resolved.declared,
+    profile: config.instance.profile,
+    root: resolved.workspaceRoot,
+    target: 'local',
+  };
   return openAudit(await openStorage(input, await openSecrets(input))).tail({ limit: 50 });
 }
 
@@ -49,7 +54,7 @@ describe('recordConfigChange', () => {
   test('a change is readable back through the same tail that reads tool calls', async () => {
     const { root, config } = await workspace();
 
-    await recordConfigChange(config, root, 'local', {
+    await recordConfigChange(config.instance.profile, root, 'local', {
       capability: 'config.member.add',
       scope: 'personal',
       arguments: { subject: 'lanes:someone', role: 'member' },
@@ -72,7 +77,7 @@ describe('recordConfigChange', () => {
   test('a workspace-scoped change carries the connection it was about', async () => {
     const { root, config } = await workspace();
 
-    await recordConfigChange(config, root, 'local', {
+    await recordConfigChange(config.instance.profile, root, 'local', {
       capability: 'config.connection.create',
       scope: 'local',
       connection: 'gmail.work',
@@ -88,11 +93,16 @@ describe('recordConfigChange', () => {
     const { root, config } = await workspace();
 
     for (const capability of ['config.profile.add', 'config.policy.allow'] as const) {
-      await recordConfigChange(config, root, 'local', { capability, scope: 'personal' });
+      await recordConfigChange(config.instance.profile, root, 'local', { capability, scope: 'personal' });
     }
 
     const resolved = await openTarget(root, 'local');
-    const input = { declared: resolved.declared, config, root: resolved.workspaceRoot, target: 'local' };
+    const input = {
+    declared: resolved.declared,
+    profile: config.instance.profile,
+    root: resolved.workspaceRoot,
+    target: 'local',
+  };
     const store = openAudit(await openStorage(input, await openSecrets(input)));
 
     expect((await store.tail({ limit: 50 })).map((event) => event.capability)).toEqual(
@@ -113,7 +123,7 @@ describe('recordConfigChange', () => {
     // A workspace that is not in the registry: `openTarget` throws, which is
     // the shape of every real failure here — an unreachable bucket, a missing
     // credential. The change is already on disk by now, so this must warn.
-    await recordConfigChange(config, '/nonexistent', 'nowhere', {
+    await recordConfigChange(config.instance.profile, '/nonexistent', 'nowhere', {
       capability: 'config.member.add',
       scope: 'personal',
     }, (note) => notes.push(note));

--- a/src/cli/audit-change.ts
+++ b/src/cli/audit-change.ts
@@ -87,8 +87,17 @@ export interface ConfigChange {
   readonly arguments?: Readonly<Record<string, unknown>> | undefined;
 }
 
+/**
+ * A name rather than the config it is written in.
+ *
+ * The only thing this ever read off the `Config` was the profile's name, and
+ * only to tell `openStorage` whose blob root to use — `change.scope` already
+ * carried the name for the row itself. Taking the parsed file for that is what
+ * stopped `profile remove` recording the removal of a profile whose config will
+ * not parse (#219), which is exactly the removal most worth having a row for.
+ */
 export async function recordConfigChange(
-  config: Config,
+  profile: string,
   root: string,
   target: string,
   change: ConfigChange,
@@ -96,7 +105,7 @@ export async function recordConfigChange(
 ): Promise<void> {
   try {
     const resolved = await openTarget(root, target);
-    const input = { declared: resolved.declared, config, root: resolved.workspaceRoot, target };
+    const input = { declared: resolved.declared, profile, root: resolved.workspaceRoot, target };
     const audit = openAudit(await openStorage(input, await openSecrets(input)));
 
     try {
@@ -202,7 +211,7 @@ export async function recordDataChange(
     const resolved = await openTarget(root, runtime.target);
     const input = {
       declared: resolved.declared,
-      config: runtime.config,
+      profile: runtime.config.instance.profile,
       root: resolved.workspaceRoot,
       target: runtime.target,
     };

--- a/src/cli/commands/connect/index.ts
+++ b/src/cli/commands/connect/index.ts
@@ -362,7 +362,7 @@ export async function runConnect(
     // workspace even when a profile was granted it in the same breath — the
     // grant is its own event, written by `grant`.
     await recordConfigChange(
-      runtime.config,
+      runtime.config.instance.profile,
       runtime.resolution.workspaceRoot,
       runtime.target,
       {

--- a/src/cli/commands/connection.ts
+++ b/src/cli/commands/connection.ts
@@ -249,7 +249,7 @@ export async function removeConnection(
     // the account away from every profile that named it, and a row saying only
     // "gmail.work removed" would leave a reader to work out which agents
     // stopped being able to reach it.
-    await recordConfigChange(runtime.config, root, target, {
+    await recordConfigChange(runtime.config.instance.profile, root, target, {
       capability: 'config.connection.remove',
       scope: target,
       connection: key,

--- a/src/cli/commands/knowledge/index.ts
+++ b/src/cli/commands/knowledge/index.ts
@@ -250,16 +250,16 @@ async function useLocal(flags: KnowledgeFlags): Promise<void> {
 async function openLocalStores(
   runtime: Runtime,
 ): Promise<{ storage: BlobStore; skills: BlobStore | null }> {
-  const { openStorage } = await import('#deployments/target.ts');
+  const { openStorage, targetInput } = await import('#deployments/target.ts');
   const declared = runtime.declared;
 
   const factory = await openStorage(
-    {
+    targetInput({
       declared,
       config: runtime.config,
       root: runtime.resolution.workspaceRoot,
       target: runtime.target,
-    },
+    }),
     runtime.credentials,
   );
   // The *granted* connection, beside the profile. `layout.skills` changed

--- a/src/cli/commands/members.ts
+++ b/src/cli/commands/members.ts
@@ -155,7 +155,7 @@ export async function membersAdd(
   await document.save();
 
   await recordConfigChange(
-    config,
+    config.instance.profile,
     resolution.workspaceRoot,
     target,
     {
@@ -194,7 +194,7 @@ export async function membersRemove(
   await document.save();
 
   await recordConfigChange(
-    config,
+    config.instance.profile,
     resolution.workspaceRoot,
     target,
     { capability: 'config.member.remove', scope: resolution.profile, arguments: { subject } },

--- a/src/cli/commands/operate/pair.ts
+++ b/src/cli/commands/operate/pair.ts
@@ -216,7 +216,7 @@ export async function pair(flags: PairFlags, deps: PairDeps = {}): Promise<void>
   // rotation, that whatever a browser was holding stopped working at that
   // moment.
   if (existing === null) {
-    await recordConfigChange(chosen.config, root, target, {
+    await recordConfigChange(chosen.config.instance.profile, root, target, {
       capability: rotating ? 'config.pair.rotate' : 'config.pair.mint',
       scope: target,
       arguments: { readPort, certificate },
@@ -310,7 +310,7 @@ async function pairDeployed(input: {
   if (existing === null) await credentials.set(PAIR_TOKEN_REF, token);
 
   if (existing === null) {
-    await recordConfigChange(chosen.config, root, target, {
+    await recordConfigChange(chosen.config.instance.profile, root, target, {
       capability: rotating ? 'config.pair.rotate' : 'config.pair.mint',
       scope: target,
       arguments: { endpoint },

--- a/src/cli/commands/operate/policy.ts
+++ b/src/cli/commands/operate/policy.ts
@@ -99,7 +99,7 @@ export async function policyRule(
   await document.save();
 
   await recordConfigChange(
-    config,
+    config.instance.profile,
     resolution.workspaceRoot,
     target,
     {

--- a/src/cli/commands/profile.ts
+++ b/src/cli/commands/profile.ts
@@ -131,7 +131,7 @@ export async function profileAdd(
   // creates cloud resources and edits nothing here, so recording it as an `add`
   // would put a config change in the log that no file reflects.
   if (created) {
-    await recordConfigChange(config, resolution.workspaceRoot, primary, {
+    await recordConfigChange(config.instance.profile, resolution.workspaceRoot, primary, {
       capability: 'config.profile.add',
       scope: name,
       arguments: { port: created.port, workspace: primary },

--- a/src/cli/commands/profile/disposition.ts
+++ b/src/cli/commands/profile/disposition.ts
@@ -57,11 +57,24 @@ export async function settleDisposition(
   flags: { readonly deleteData?: boolean | undefined; readonly migrateTo?: string | undefined },
   prompter: Prompter,
   someoneToAsk: boolean,
+  /**
+   * Why migrating is not on offer, where it is not.
+   *
+   * Set by a removal working from a config that would not load (#219). The
+   * whole message rather than a boolean, because the caller is the one that
+   * knows *why* — and a refusal that only says "no" for a question the prompt
+   * was about to ask is worse than the question.
+   */
+  migrationRefused?: string | undefined,
 ): Promise<Disposition | null> {
   if (flags.migrateTo !== undefined && flags.deleteData === true) {
     throw new ConfigError(
       '--delete-data and --migrate-to say opposite things about the same bytes. Pass one.',
     );
+  }
+
+  if (flags.migrateTo !== undefined && migrationRefused !== undefined) {
+    throw new ConfigError(migrationRefused);
   }
 
   if (flags.migrateTo !== undefined) return { kind: 'migrate', into: flags.migrateTo };
@@ -71,19 +84,24 @@ export async function settleDisposition(
     throw new ConfigError(
       `"${profile}" owns memory, tasks, assets and skills, and this does not guess at what ` +
         'becomes of them.\n' +
-        '  Say which: --delete-data, or --migrate-to <profile>',
+        (migrationRefused !== undefined
+          ? '  Say so: --delete-data'
+          : '  Say which: --delete-data, or --migrate-to <profile>'),
     );
   }
 
   const answer = (
     await prompter.ask(
-      `What becomes of ${profile}'s memory, tasks, assets and skills?\n` +
-        `  [d] delete them   [m] move them into another profile   [anything else] stop`,
+      (migrationRefused !== undefined ? `${migrationRefused}\n\n` : '') +
+        `What becomes of ${profile}'s memory, tasks, assets and skills?\n` +
+        (migrationRefused !== undefined
+          ? '  [d] delete them   [anything else] stop'
+          : '  [d] delete them   [m] move them into another profile   [anything else] stop'),
     )
   ).trim().toLowerCase();
 
   if (answer === 'd') return { kind: 'delete' };
-  if (answer !== 'm') return null;
+  if (answer !== 'm' || migrationRefused !== undefined) return null;
 
   const into = (await prompter.ask('Move them into which profile?')).trim();
   return into.length === 0 ? null : { kind: 'migrate', into };

--- a/src/cli/commands/profile/perform.ts
+++ b/src/cli/commands/profile/perform.ts
@@ -1,0 +1,263 @@
+import type { SecretStore } from '#secrets';
+import type { BlobStore } from '#stores/blobs';
+import { fail, ok, print, style, warn } from '../../output.ts';
+import type { RemovalItem, RemovalPlan } from './removal.ts';
+
+/**
+ * Performing a removal, and being honest about the parts that did not happen.
+ *
+ * Split from `remove.ts`, along the seam that file's own docstring had already
+ * drawn: this sentence described the executor, the outcome and its exit code,
+ * and nothing about the command that decides what to remove. `confirm.ts`
+ * records the same split for the same reason — "not too long, two things".
+ *
+ * Best effort by choice: a target whose project has been deleted must not be
+ * able to strand a profile on the machine forever, so one refusal does not stop
+ * the rest. The price is real — a deletion that fails leaves a live credential
+ * behind — and everything here exists to make that visible rather than quiet.
+ */
+
+export interface RemovalResult {
+  readonly item: RemovalItem;
+  /** `kept` is deliberate: not attempted, because something before it failed. */
+  readonly status: 'removed' | 'failed' | 'kept';
+  readonly error?: string;
+  /** The exact command that finishes this one by hand. */
+  readonly retry?: string;
+}
+
+export interface RemovalOutcome {
+  readonly profile: string;
+  readonly results: readonly RemovalResult[];
+  /** How many items are still there. Non-zero means a credential is still live. */
+  readonly survived: number;
+  /**
+   * What the plan could not name, because the config would not load.
+   *
+   * Carried through from `RemovalPlan.unreachable` so the exit code can account
+   * for it — see `renderOutcome`.
+   */
+  readonly unreachable: readonly string[];
+}
+
+export interface RunDeps {
+  openSecrets: (target: string) => Promise<SecretStore>;
+  openBlobs: (target: string, area?: string) => Promise<BlobStore>;
+  removeConfig: (path: string) => Promise<void>;
+  /** The emptied profile directory. A blob delete cannot remove a directory. */
+  removeDirectory: (path: string) => Promise<void>;
+  clearDefaultProfile: () => Promise<void>;
+  retry?: ((item: RemovalItem, cause: string) => string | undefined) | undefined;
+}
+
+const reason = (cause: unknown): string => (cause instanceof Error ? cause.message : String(cause));
+
+/**
+ * The items that only make sense once everything else is actually gone.
+ *
+ * **`file` is in here, and that is the whole of its reason.** It is
+ * `rm -rf profiles/<profile>`, and it carries a target rather than `null`, so
+ * the original `target === null` test let it run after a failed object — taking
+ * the bytes a `--migrate-to` had not managed to copy, and `profile.yaml`, which
+ * the sweep deliberately leaves for last. `renderOutcome` then printed "the
+ * profile's config was kept, so nothing is stranded" about a directory that no
+ * longer existed. Same shape as the defect this file records having shipped
+ * once already.
+ */
+const isRecordOfWhereThingsAre = (item: RemovalItem): boolean =>
+  item.kind === 'file' ||
+  (item.target === null && (item.kind === 'config' || item.kind === 'workspace-key'));
+
+export async function executeRemoval(
+  plan: RemovalPlan,
+  deps: RunDeps,
+): Promise<RemovalOutcome> {
+  const results: RemovalResult[] = [];
+  let failed = 0;
+
+  // One store per target, however many items it holds. Opening a Secret
+  // Manager client per secret would turn a tidy removal into a rate limit.
+  const secrets = new Map<string, Promise<SecretStore>>();
+  const blobs = new Map<string, Promise<BlobStore>>();
+
+  const secretStore = (target: string): Promise<SecretStore> => {
+    const existing = secrets.get(target) ?? deps.openSecrets(target);
+    secrets.set(target, existing);
+    return existing;
+  };
+
+  const blobStore = (target: string, area?: string): Promise<BlobStore> => {
+    const key = `${target}:${area ?? ''}`;
+    const existing = blobs.get(key) ?? deps.openBlobs(target, area);
+    blobs.set(key, existing);
+    return existing;
+  };
+
+  for (const item of plan.items) {
+    // The config is the only record of where everything else lives. Deleting it
+    // after a failure would strand precisely the credential that failed: still
+    // live, and nothing left that knows where it is. Keeping it means the retry
+    // is this same command rather than a hand-assembled console session.
+    if (failed > 0 && isRecordOfWhereThingsAre(item)) {
+      results.push({ item, status: 'kept' });
+      continue;
+    }
+
+    try {
+      switch (item.kind) {
+        case 'secret':
+          await (await secretStore(item.target!)).delete(item.id);
+          break;
+
+        case 'blob': {
+          const store = await blobStore(item.target!, item.area);
+
+          // Read across *before* deleting, and verify it landed — the same rule
+          // the contract migrations follow, for the same reason: a copy that
+          // half happened and a source that is already gone is the one state
+          // with nothing to retry from. A collision was resolved while this was
+          // still a plan, so the destination is free.
+          if (item.movedTo !== undefined) {
+            const [area, key] = item.movedTo;
+            const bytes = await store.get(item.id);
+
+            if (bytes !== null) {
+              const into = await blobStore(item.target!, area);
+              await into.put(key, bytes);
+              if ((await into.get(key)) === null) {
+                throw new Error(`${area}/${key} did not read back after being written`);
+              }
+            }
+          }
+
+          await store.delete(item.id);
+          break;
+        }
+
+        case 'config':
+          if (item.target === null) await deps.removeConfig(item.id);
+          else {
+            // `profiles/<name>.yaml` in the target's bucket — outside the
+            // profile's blob tree, so it needs its own area.
+            const [area, ...rest] = item.id.split('/');
+            await (await blobStore(item.target, area)).delete(rest.join('/'));
+          }
+          break;
+
+        case 'workspace-key':
+          await deps.clearDefaultProfile();
+          break;
+
+        case 'file':
+          await deps.removeDirectory(item.id);
+          break;
+      }
+
+      results.push({ item, status: 'removed' });
+    } catch (cause) {
+      const error = reason(cause);
+      const retry = deps.retry?.(item, error);
+      failed += 1;
+      results.push({ item, status: 'failed', error, ...(retry ? { retry } : {}) });
+    }
+  }
+
+  return {
+    profile: plan.profile,
+    results,
+    survived: results.filter((result) => result.status !== 'removed').length,
+    unreachable: plan.unreachable,
+  };
+}
+
+/**
+ * What happened, and what is still out there.
+ *
+ * The exit code is the load-bearing part. Best effort means the command can
+ * finish having left a live credential behind, and to a script silence is
+ * indistinguishable from success — so anything that survived makes this exit
+ * non-zero, and names itself with the command that finishes it.
+ *
+ * **Exit 0 iff every item was removed *and* nothing was unreachable — not iff
+ * the config parsed.** The contract above is "something is left", never
+ * "something threw", and keying it on the parse would get both halves wrong at
+ * once: the profile that #219 actually produces reads every field and leaves
+ * nothing, so reporting failure for it would mean the fix did not fix the
+ * cleanup script that hit this in the first place — and it would give that the
+ * same code as a deployed profile that really did strand a sealed document.
+ * Two states, one code, no information.
+ */
+export function renderOutcome(outcome: RemovalOutcome): void {
+  const removed = outcome.results.filter((result) => result.status === 'removed');
+  const failed = outcome.results.filter((result) => result.status === 'failed');
+  const kept = outcome.results.filter((result) => result.status === 'kept');
+
+  print();
+  if (outcome.survived === 0 && outcome.unreachable.length === 0) {
+    print(ok(`Removed profile ${style.bold(outcome.profile)} — ${removed.length} item(s).`));
+    print();
+    return;
+  }
+
+  // Nothing failed; what happened is that the config would not load and this
+  // could not tell whether one of the refs it left behind was the profile's.
+  //
+  // **A separate sentence from the retry below, and it has to be.** That one
+  // says "run the same command again", which works only because a failure keeps
+  // the config — the record of where everything lives. Here the profile is gone
+  // and there is nothing left to re-derive from, so the same advice would send
+  // somebody to a command that can no longer help them.
+  if (outcome.survived === 0) {
+    print(
+      warn(
+        `Removed profile ${style.bold(outcome.profile)} — ${removed.length} item(s), from a ` +
+          'config that would not load.',
+      ),
+    );
+    print();
+    print(`  ${style.bold('Not reachable, so not removed')}`);
+    for (const line of outcome.unreachable) print(style.dim(`    ${line}`));
+    print();
+    print(
+      'Running this again will not find them: the profile is gone. Delete them where they are, ' +
+        'or leave them if they were never created.',
+    );
+    print();
+
+    process.exitCode = 1;
+    return;
+  }
+
+  print(
+    fail(
+      `Removed ${removed.length} item(s) of profile ${style.bold(outcome.profile)}, and ${failed.length} refused.`,
+    ),
+  );
+  print();
+
+  for (const result of failed) {
+    print(`  ${result.item.id}`);
+    if (result.error) print(style.dim(`    ${result.error}`));
+    if (result.retry) print(style.dim(`    finish it with: ${result.retry}`));
+  }
+  print();
+
+  if (kept.length > 0) {
+    // Said plainly, because the alternative reading — that the profile is
+    // half-gone and needs unpicking by hand — is the one an operator will
+    // assume from a failure report.
+    print(
+      `The profile's config was kept, so nothing is stranded: fix the above and run the same command again.`,
+    );
+    print();
+  }
+
+  // A live credential left behind must not look like success to a script.
+  process.exitCode = 1;
+}
+
+/** The command that finishes a refusal by hand, where one can be named. */
+export function retryCommand(item: RemovalItem): string | undefined {
+  if (item.kind !== 'secret') return undefined;
+  return `lanes link profile remove <name> --target ${item.target} # or delete ${item.id} in that store`;
+}

--- a/src/cli/commands/profile/preview.ts
+++ b/src/cli/commands/profile/preview.ts
@@ -1,0 +1,126 @@
+import { layout } from '#profile';
+import { print, style, warn } from '../../output.ts';
+import type { RemovalItem, RemovalPlan, SubjectReport } from './removal.ts';
+
+/**
+ * The plan, as the thing an operator decides from.
+ *
+ * Split from `removal.ts` when the degraded banner arrived and took that file
+ * past the budget — the same seam `confirm.ts` records finding, and the same
+ * kind of seam: one file was planning a removal and describing one. What must
+ * not change is that this renders *the value that is executed*, so there is no
+ * second description of the work to fall out of step with the first.
+ *
+ * It prints references and keys and never a value. The plan holds no values to
+ * print, and `removalSubject` runs `findSecrets` over anything it salvaged
+ * before it can reach here.
+ */
+
+const KIND_LABEL: Record<RemovalItem['kind'], string> = {
+  secret: 'credential',
+  blob: 'object',
+  file: 'file',
+  config: 'config',
+  'workspace-key': 'workspace',
+};
+
+export function renderPlan(plan: RemovalPlan): void {
+  print();
+  print(`Removing profile ${style.bold(plan.profile)} would delete:`);
+  print();
+
+  renderDegraded(plan.subject);
+
+  if (plan.items.length === 0) {
+    print(style.dim('  nothing — there is no trace of this profile left to remove.'));
+  }
+
+  const targets = [...new Set(plan.items.map((item) => item.target))];
+  for (const target of targets) {
+    const items = plan.items.filter((item) => item.target === target);
+    print(`  ${style.bold(target ?? 'workspace')}`);
+    for (const item of items) {
+      const note = item.note ? style.dim(` — ${item.note}`) : '';
+      const shown = item.area === undefined ? item.id : `${item.area}/${item.id}`;
+      const into = item.movedTo ? style.dim(` → ${item.movedTo[0]}/${item.movedTo[1]}`) : '';
+      print(`    ${KIND_LABEL[item.kind].padEnd(10)} ${shown}${into}${note}`);
+    }
+    print();
+  }
+
+  for (const { target, refs } of plan.untouched) {
+    // Named rather than counted, because the operator is the only one who can
+    // tell an orphan from another profile's live credential — and this command
+    // deliberately will not guess.
+    print(`  ${style.bold(target)}: present but not declared by this profile, so left alone`);
+    for (const ref of refs) print(style.dim(`    ${ref}`));
+    print();
+  }
+
+  for (const warning of plan.warnings) print(warn(warning));
+  if (plan.warnings.length > 0) print();
+
+  if (plan.unreachable.length > 0) {
+    print(`  ${style.bold('Not reachable from a config that will not load, so not removed')}`);
+    for (const line of plan.unreachable) print(style.dim(`    ${line}`));
+    print();
+  }
+}
+
+/**
+ * What was read of a config that would not load, before the items it produced.
+ *
+ * The question this has to answer is "which of the items below are guesses",
+ * and the answer is none of them: every one comes from listing a store, from
+ * the target's own declaration, or from the name the operator typed. A field
+ * this could not read removes a line from the plan and can never add a wrong
+ * one — so the paragraph says that outright rather than leaving an operator to
+ * decide how much of the preview to believe.
+ */
+function renderDegraded(subject: SubjectReport): void {
+  if (subject.loaded) return;
+
+  const nothing = subject.unread.length === FIELD_LABELS.size;
+  print(
+    warn(
+      `${layout.profileConfig(subject.name)} will not load, so this is working from ` +
+        (nothing ? 'the file\'s name alone — nothing could be read from it, not even as YAML:'
+                 : 'what could be read of it:'),
+    ),
+  );
+
+  for (const [field, label] of FIELD_LABELS) {
+    print(`        ${label.padEnd(18)}${style.dim(described(subject, field))}`);
+  }
+
+  print(style.dim('      Everything below was found by listing the stores, not by reading that'));
+  print(style.dim('      file. What a config that will not load costs is a line that is missing'));
+  print(style.dim('      here, never one that is wrong.'));
+  if (subject.refusal !== null) print(style.dim(`      What refused it: ${subject.refusal}`));
+  print();
+}
+
+const FIELD_LABELS = new Map([
+  ['name', 'instance.profile'],
+  ['grants', 'vault connection'],
+  ['auth', 'authorization'],
+  ['knowledge', 'knowledge'],
+]);
+
+/** One field's line: what was read, or that it could not be. */
+function described(subject: SubjectReport, field: string): string {
+  if (subject.unread.includes(field)) return 'could not be read';
+
+  switch (field) {
+    case 'name':
+      return subject.assumedName
+        ? `${subject.name} (the directory's — the file names another)`
+        : subject.name;
+    case 'grants':
+      return subject.vaultConnection ?? 'none granted';
+    case 'auth':
+      return subject.clientIdRef ?? 'no client id declared';
+    default:
+      return subject.knowledgeRepo ?? 'not declared';
+  }
+}

--- a/src/cli/commands/profile/removal.test.ts
+++ b/src/cli/commands/profile/removal.test.ts
@@ -2,14 +2,9 @@ import { describe, expect, test } from 'bun:test';
 import type { Config, TargetConfig } from '#profile';
 import type { SecretRef, SecretStore } from '#secrets';
 import type { BlobMetadata, BlobStore } from '#stores/blobs';
-import { buildRegistry } from '../../runtime/registry.ts';
-import {
-  declaredRefs,
-  removalPlan,
-  renderPlan,
-  type RemovalItem,
-  type RemovalPlan,
-} from './removal.ts';
+import { removalPlan, type RemovalItem, type RemovalPlan } from './removal.ts';
+import { renderPlan } from './preview.ts';
+import { declaredRefs, subjectOf, type RemovalSubject } from './subject.ts';
 
 /**
  * Which credentials a profile may have its removal delete.
@@ -19,8 +14,6 @@ import {
  * to one project shares a flat namespace, so `list()` answers with other
  * profiles' credentials too — and deleting those is not recoverable.
  */
-
-const registry = buildRegistry();
 
 const target = (over: Partial<TargetConfig> = {}): TargetConfig =>
   ({
@@ -39,9 +32,12 @@ const config = (over: Partial<Config> = {}): Config =>
     ...over,
   }) as unknown as Config;
 
+/** What a removal reads of a profile whose config loaded. */
+const subject = (over: Partial<Config> = {}): RemovalSubject => subjectOf(config(over));
+
 describe('declaredRefs', () => {
   test('covers nothing an account owns, and no endpoint token', () => {
-    const refs = declaredRefs(config(), target());
+    const refs = declaredRefs(subject(), target());
 
     // **Not the endpoint token.** It is the workspace's since ADR-068, so a
     // profile declares none and removing one cannot reach it. This is the fix
@@ -61,7 +57,7 @@ describe('declaredRefs', () => {
 
   test('an oidc audience ref travels with the profile, because it is the profile\'s', () => {
     const refs = declaredRefs(
-      config({
+      subject({
         auth: {
           mode: 'bearer',
           authorization: {
@@ -84,8 +80,8 @@ describe('declaredRefs', () => {
     // would attach one target's vault to another's removal.
     const sealed = target({ vault: { adapter: 'secret', ref: 'vault/document' } } as never);
 
-    expect(declaredRefs(config(), sealed)).toContain('vault/document');
-    expect(declaredRefs(config(), target())).not.toContain('vault/document');
+    expect(declaredRefs(subject(), sealed)).toContain('vault/document');
+    expect(declaredRefs(subject(), target())).not.toContain('vault/document');
   });
 
   test('a secret adapter with no ref names the profile and connection, not a constant', () => {
@@ -97,8 +93,8 @@ describe('declaredRefs', () => {
     // material belonging to a profile the operator asked to be gone.
     const sealed = target({ vault: { adapter: 'secret' } } as never);
 
-    expect(declaredRefs(config(), sealed)).toContain('vault/personal/main');
-    expect(declaredRefs(config(), sealed)).not.toContain('vault/document');
+    expect(declaredRefs(subject(), sealed)).toContain('vault/personal/main');
+    expect(declaredRefs(subject(), sealed)).not.toContain('vault/document');
   });
 
   test('a connection whose provider no longer resolves contributes nothing', () => {
@@ -108,7 +104,7 @@ describe('declaredRefs', () => {
       connections: [{ id: 'x', provider: 'no_such_provider', account: 'x' }],
     } as never);
 
-    const refs = declaredRefs(gone, target());
+    const refs = declaredRefs(subjectOf(gone), target());
 
     expect(refs).not.toContain('no_such_provider/x');
   });
@@ -126,7 +122,7 @@ describe('declaredRefs', () => {
     } as never);
 
     const refs = declaredRefs(
-      withConnections,
+      subjectOf(withConnections),
       target({ vault: { adapter: 'secret', ref: 'vault/document' } } as never),
     );
 
@@ -140,7 +136,7 @@ describe('declaredRefs', () => {
     // no longer a case at all: it is not a profile's to declare (ADR-068).
     const sealed = target({ vault: { adapter: 'secret', ref: 'vault/document' } } as never);
 
-    expect(declaredRefs(config(), sealed, [config()])).toEqual([]);
+    expect(declaredRefs(subject(), sealed, [subject()])).toEqual([]);
   });
 
   test('with nobody staying, the vault is still the profile\'s to lose', () => {
@@ -150,7 +146,7 @@ describe('declaredRefs', () => {
     // issued tokens intact, because they were never that profile's.
     const sealed = target({ vault: { adapter: 'secret', ref: 'vault/document' } } as never);
 
-    expect(declaredRefs(config(), sealed, [])).toEqual(['vault/document']);
+    expect(declaredRefs(subject(), sealed, [])).toEqual(['vault/document']);
   });
 });
 
@@ -187,7 +183,7 @@ describe('removalPlan', () => {
     // It used to loop over every target the profile declared. A profile lives in
     // exactly one (ADR-052), so the caller resolves that one and hands its
     // adapters in — there is no set here to iterate.
-    const plan = await removalPlan(config(), '/ws', 'personal', registry, {
+    const plan = await removalPlan(subject(), '/ws', 'personal', {
       target: 'local',
       declared: target(),
       disposition: { kind: 'delete' as const },
@@ -209,7 +205,7 @@ describe('removalPlan', () => {
     // then would have queued every byte in the workspace for deletion because
     // one profile was going. The profile has a directory again (ADR-066), so
     // the sweep is bounded by it.
-    const plan = await removalPlan(config(), '/ws', 'personal', registry, {
+    const plan = await removalPlan(subject(), '/ws', 'personal', {
       target: 'local',
       declared: target(),
       disposition: { kind: 'delete' as const },
@@ -239,7 +235,7 @@ describe('removalPlan', () => {
   });
 
   test('--migrate-to sends every object into the other profile rather than deleting it', async () => {
-    const plan = await removalPlan(config(), '/ws', 'personal', registry, {
+    const plan = await removalPlan(subject(), '/ws', 'personal', {
       target: 'local',
       declared: target(),
       disposition: { kind: 'migrate' as const, into: 'work' },
@@ -269,7 +265,7 @@ describe('removalPlan', () => {
     // hold `vault.d/lan5.enc` since the owner layer merged, so a copy always
     // collided and had its source deleted, leaving the items unreachable.
     await expect(
-      removalPlan(config(), '/ws', 'personal', registry, {
+      removalPlan(subject(), '/ws', 'personal', {
         target: 'local',
         declared: target(),
         disposition: { kind: 'migrate' as const, into: 'work' },
@@ -279,7 +275,7 @@ describe('removalPlan', () => {
       }),
     ).rejects.toThrow(/vault cannot be merged[\s\S]*--delete-data/);
 
-    const plan = await removalPlan(config(), '/ws', 'personal', registry, {
+    const plan = await removalPlan(subject(), '/ws', 'personal', {
       target: 'local',
       declared: target(),
       disposition: { kind: 'migrate' as const, into: 'work' },
@@ -301,7 +297,7 @@ describe('removalPlan', () => {
     // the preview they confirm from and the execution has no decision to make.
     // The suffix goes before the extension: an asset's key is whatever the file
     // was called, and `note.md-2` is a file nothing will open.
-    const plan = await removalPlan(config(), '/ws', 'personal', registry, {
+    const plan = await removalPlan(subject(), '/ws', 'personal', {
       target: 'local',
       declared: target(),
       disposition: { kind: 'migrate' as const, into: 'work' },
@@ -325,7 +321,7 @@ describe('removalPlan', () => {
     // Renaming only the directory is worse: the frontmatter keeps declaring the
     // old name, and `skills list` then refuses for the whole profile.
     await expect(
-      removalPlan(config(), '/ws', 'personal', registry, {
+      removalPlan(subject(), '/ws', 'personal', {
         target: 'local',
         declared: target(),
         disposition: { kind: 'migrate' as const, into: 'work' },
@@ -339,7 +335,7 @@ describe('removalPlan', () => {
   });
 
   test('a skill only one of them has migrates, whole', async () => {
-    const plan = await removalPlan(config(), '/ws', 'personal', registry, {
+    const plan = await removalPlan(subject(), '/ws', 'personal', {
       target: 'local',
       declared: target(),
       disposition: { kind: 'migrate' as const, into: 'work' },
@@ -359,7 +355,7 @@ describe('removalPlan', () => {
   });
 
   test('the local config is the last item, because it is the record of where things are', async () => {
-    const plan = await removalPlan(config(), '/ws', 'personal', registry, {
+    const plan = await removalPlan(subject(), '/ws', 'personal', {
       target: 'local',
       declared: target(),
       disposition: { kind: 'delete' as const },
@@ -375,11 +371,9 @@ describe('removalPlan', () => {
     // sealed per target and named by it, so it goes with the removal. Contrasted
     // against an account's, which outlives the profile whatever the profile said.
     const plan = await removalPlan(
-      config(),
+      subject(),
       '/ws',
-      'personal',
-      registry,
-      {
+      'personal', {
         target: 'local',
         declared: target({ vault: { adapter: 'secret', ref: 'vault/document' } } as never),
         disposition: { kind: 'delete' as const },
@@ -394,7 +388,7 @@ describe('removalPlan', () => {
   });
 
   test('the profile config goes too, because it lives in that target', async () => {
-    const plan = await removalPlan(config(), '/ws', 'personal', registry, {
+    const plan = await removalPlan(subject(), '/ws', 'personal', {
       target: 'cloud',
       declared: target(),
       disposition: { kind: 'delete' as const },
@@ -409,7 +403,7 @@ describe('removalPlan', () => {
   });
 
   test('a deployed target warns that its endpoint keeps answering with nothing behind it', async () => {
-    const plan = await removalPlan(config(), '/ws', 'personal', registry, {
+    const plan = await removalPlan(subject(), '/ws', 'personal', {
       target: 'cloud',
       declared: target({
         deploy: { platform: 'cloudrun', project: 'my-project', region: 'r', service: 's' },
@@ -446,6 +440,17 @@ function captured(body: () => void): string {
 
 const samplePlan = (over: Partial<RemovalPlan> = {}): RemovalPlan => ({
   profile: 'personal',
+  unreachable: [],
+  subject: {
+    loaded: true,
+    name: 'personal',
+    assumedName: false,
+    vaultConnection: null,
+    clientIdRef: null,
+    knowledgeRepo: null,
+    unread: [],
+    refusal: null,
+  },
   items: [
     { target: 'local', kind: 'secret', id: 'gmail/someone' },
     { target: 'local', kind: 'blob', id: 'state.kv/a' },

--- a/src/cli/commands/profile/removal.ts
+++ b/src/cli/commands/profile/removal.ts
@@ -2,15 +2,11 @@ import {
   layout,
   PROFILE_FILE,
   profilePath,
-  vaultRef,
-  workspacePath,
-  type Config,
   type TargetConfig,
 } from '#profile';
 import type { SecretStore } from '#secrets';
 import type { BlobStore } from '#stores/blobs';
-import { credentialRefFor, ownClientRefsFor, type ProviderRegistry } from '#registry';
-import { print, style, warn } from '../../output.ts';
+import { declaredRefs, unreachableRefs, type RemovalSubject } from './subject.ts';
 import {
   migratesAcross,
   refuseSealedVault,
@@ -27,90 +23,6 @@ import {
  * shown and what runs from drifting apart. `../../../deployments/driver.ts`
  * gives the same reason for the same shape.
  */
-
-/**
- * The credential references this profile declares, and only those.
- *
- * Locally the profile is the boundary: its credentials are a file inside its own
- * directory, and deleting the directory is the whole operation. In Secret
- * Manager they are flat names in one project, so two profiles deployed to the
- * same project share a namespace and `list()` hands back the other one's as
- * readily as its own. Deriving from what this profile declares is the only
- * answer that cannot delete something that was never ours, and a secret deleted
- * in the wrong project is not recoverable.
- *
- * The cost is that a genuinely orphaned ref — one whose connection was removed
- * from config long ago — is not derivable and so is not deleted. The caller
- * reports those rather than guessing, which is the honest position: a guess
- * here is indistinguishable from another profile's credential.
- */
-export function declaredRefs(
-  config: Config,
-  declared: TargetConfig,
-  /**
-   * What the profiles that are staying declare.
-   *
-   * Nothing in here is deleted, however plainly the profile being removed also
-   * declares it. The vault ref is read off the target and is identical for every
-   * profile there, which once made a sibling's sealed items unrecoverable in
-   * this command.
-   *
-   * **The endpoint token was the sharpest case here and is no longer a case.**
-   * Every profile took the default `token_ref: profile/token` out of one
-   * per-workspace store, so removing one deleted the token its siblings were
-   * served by. What fixed it is not a better survivor check: the token was never
-   * a profile's to declare (ADR-068), so removing one cannot reach it now.
-   */
-  survivors: readonly Config[] = [],
-): string[] {
-  const refs = new Set<string>();
-
-  // Read off the *target*, not the profile. `vaultTargetSchema` sits inside
-  // `targetSchema`, so two targets may seal the same items in different places;
-  // taking it from the profile would attach one target's vault to another
-  // target's removal.
-  //
-  // **Through `vaultRef`, because the name carries the connection.** This said
-  // `vault/document`, the contract-2 constant, while `openVault` seals under
-  // `vault/<connection>` (ADR-059) — so removing a profile queued a ref nothing
-  // had ever written and left the real document behind. Under-deletion rather
-  // than over, since the survivor set was wrong the same way and they cancelled,
-  // but what stayed behind is sealed credential material belonging to a profile
-  // the operator asked to be gone. Per connection also makes the survivor check
-  // mean something: two profiles granting different vaults no longer look like
-  // one document to it.
-  if (declared.vault?.adapter === 'secret') {
-    refs.add(vaultRef(declared, config));
-  }
-
-  // **No connection credentials.** They belong to the workspace now (ADR-057),
-  // and every one of them may be granted by a profile that is staying. Removing
-  // a profile therefore removes no account and no credential — `lanes link
-  // disconnect` is the command that does that, and it is the one that knows how
-  // to check whether anybody else still needs the credential first.
-  //
-  // This is the sharpest edge in the whole decoupling, so `renderPlan` says it
-  // out loud rather than leaving an operator to infer it from a short list:
-  // "remove the work profile" used to mean "revoke what work could reach", and
-  // it does not any more.
-  if (config.auth.authorization?.mode === 'oidc') {
-    refs.add(config.auth.authorization.client_id_ref);
-  }
-
-  // Shared with a profile that is staying, so not ours to delete. Computed the
-  // same way for the survivors as for this one, because "what does a profile
-  // declare" has to have one answer.
-  const kept = new Set(
-    survivors.flatMap((other) => [
-      ...(declared.vault?.adapter === 'secret' ? [vaultRef(declared, other)] : []),
-      ...(other.auth.authorization?.mode === 'oidc'
-        ? [other.auth.authorization.client_id_ref]
-        : []),
-    ]),
-  );
-
-  return [...refs].filter((ref) => !kept.has(ref));
-}
 
 export interface RemovalItem {
   /** `null` for a workspace-level item — the config file, the default-profile key. */
@@ -139,6 +51,31 @@ export interface RemovalPlan {
   /** Present in a target's store, not declared by this profile. Left alone. */
   readonly untouched: readonly { readonly target: string; readonly refs: readonly string[] }[];
   readonly warnings: readonly string[];
+  /**
+   * What a config that would not load stopped this from being able to name.
+   *
+   * **Not folded into `warnings`, deliberately.** A warning says "this survives
+   * by design" — the repository, the deployed service, the accounts every
+   * profile shares — and is true of a perfectly ordinary removal. One of these
+   * says "this removal cannot see whether it survives", which is a different
+   * sentence and the one that decides the exit code.
+   */
+  readonly unreachable: readonly string[];
+  /** What could be read of the profile, for `--json` and for the preview. */
+  readonly subject: SubjectReport;
+}
+
+/** The degraded read, in a shape fit to print and to serialise. */
+export interface SubjectReport {
+  readonly loaded: boolean;
+  readonly name: string;
+  readonly assumedName: boolean;
+  readonly vaultConnection: string | null;
+  /** A reference name, never a value — the plan prints refs everywhere else too. */
+  readonly clientIdRef: string | null;
+  readonly knowledgeRepo: string | null;
+  readonly unread: readonly string[];
+  readonly refusal: string | null;
 }
 
 export interface PlanOptions {
@@ -165,7 +102,7 @@ export interface PlanOptions {
    * `declaredRefs`. Defaulted to empty, which is the single-profile workspace
    * and the shape every existing caller had.
    */
-  readonly survivors?: readonly Config[] | undefined;
+  readonly survivors?: readonly RemovalSubject[] | undefined;
 }
 
 const reason = (cause: unknown): string => (cause instanceof Error ? cause.message : String(cause));
@@ -180,10 +117,9 @@ const reason = (cause: unknown): string => (cause instanceof Error ? cause.messa
  * before they confirm, rather than discovering it half way through.
  */
 export async function removalPlan(
-  config: Config,
+  subject: RemovalSubject,
   root: string,
   profile: string,
-  registry: ProviderRegistry,
   options: PlanOptions,
 ): Promise<RemovalPlan> {
   const items: RemovalItem[] = [];
@@ -210,9 +146,9 @@ export async function removalPlan(
     // `rm -r data/<profile>` used to be the whole of "what could this profile
     // reach". So it is said before the operator confirms rather than discovered
     // afterwards.
-    if (config.knowledge) {
+    if (subject.knowledgeRepo !== null) {
       warnings.push(
-        `This profile keeps its memory and skills in ${config.knowledge.repo}. ` +
+        `This profile keeps its memory and skills in ${subject.knowledgeRepo}. ` +
           'Nothing here touches a repository, so they survive this removal — delete them there ' +
           'if you want them gone.',
       );
@@ -227,7 +163,7 @@ export async function removalPlan(
     try {
       const secrets = await options.openSecrets(name);
       const present = await secrets.list();
-      const mine = new Set(declaredRefs(config, declared, options.survivors ?? []));
+      const mine = new Set(declaredRefs(subject, declared, options.survivors ?? []));
 
       for (const ref of present) if (mine.has(ref)) items.push({ target: name, kind: 'secret', id: ref });
 
@@ -343,55 +279,21 @@ export async function removalPlan(
   // before this point leaves data a later run can still find.
   items.push({ target: null, kind: 'config', id: profilePath(root, profile) });
 
-  return { profile, items, untouched, warnings };
-}
-
-const KIND_LABEL: Record<RemovalItem['kind'], string> = {
-  secret: 'credential',
-  blob: 'object',
-  file: 'file',
-  config: 'config',
-  'workspace-key': 'workspace',
-};
-
-/**
- * The plan, as the thing an operator decides from.
- *
- * Rendered from the same value that is executed, so there is no second
- * description of the work to fall out of step with the first. It prints
- * references and keys and never a value — the plan holds no values to print.
- */
-export function renderPlan(plan: RemovalPlan): void {
-  print();
-  print(`Removing profile ${style.bold(plan.profile)} would delete:`);
-  print();
-
-  if (plan.items.length === 0) {
-    print(style.dim('  nothing — there is no trace of this profile left to remove.'));
-  }
-
-  const targets = [...new Set(plan.items.map((item) => item.target))];
-  for (const target of targets) {
-    const items = plan.items.filter((item) => item.target === target);
-    print(`  ${style.bold(target ?? 'workspace')}`);
-    for (const item of items) {
-      const note = item.note ? style.dim(` — ${item.note}`) : '';
-      const shown = item.area === undefined ? item.id : `${item.area}/${item.id}`;
-      const into = item.movedTo ? style.dim(` → ${item.movedTo[0]}/${item.movedTo[1]}`) : '';
-      print(`    ${KIND_LABEL[item.kind].padEnd(10)} ${shown}${into}${note}`);
-    }
-    print();
-  }
-
-  for (const { target, refs } of plan.untouched) {
-    // Named rather than counted, because the operator is the only one who can
-    // tell an orphan from another profile's live credential — and this command
-    // deliberately will not guess.
-    print(`  ${style.bold(target)}: present but not declared by this profile, so left alone`);
-    for (const ref of refs) print(style.dim(`    ${ref}`));
-    print();
-  }
-
-  for (const warning of plan.warnings) print(warn(warning));
-  if (plan.warnings.length > 0) print();
+  return {
+    profile,
+    items,
+    untouched,
+    warnings,
+    unreachable: unreachableRefs(subject, declared, options.target),
+    subject: {
+      loaded: subject.config !== null,
+      name: subject.name,
+      assumedName: subject.assumedName,
+      vaultConnection: subject.vaultConnection,
+      clientIdRef: subject.clientIdRef,
+      knowledgeRepo: subject.knowledgeRepo,
+      unread: [...subject.unread],
+      refusal: subject.refusal,
+    },
+  };
 }

--- a/src/cli/commands/profile/remove.test.ts
+++ b/src/cli/commands/profile/remove.test.ts
@@ -8,7 +8,7 @@ import {
   renderOutcome,
   type RemovalOutcome,
   type RunDeps,
-} from './remove.ts';
+} from './perform.ts';
 import { confirmedByName } from './confirm.ts';
 
 /**
@@ -58,11 +58,23 @@ function blobs(keys: string[] = [], failOn?: string): BlobStore & { deleted: str
 const item = (over: Partial<RemovalItem>): RemovalItem =>
   ({ target: 'local', kind: 'secret', id: 'gmail/someone', ...over }) as RemovalItem;
 
-const plan = (items: RemovalItem[]): RemovalPlan => ({
+const plan = (items: RemovalItem[], over: Partial<RemovalPlan> = {}): RemovalPlan => ({
   profile: 'personal',
   items,
   untouched: [],
   warnings: [],
+  unreachable: [],
+  subject: {
+    loaded: true,
+    name: 'personal',
+    assumedName: false,
+    vaultConnection: null,
+    clientIdRef: null,
+    knowledgeRepo: null,
+    unread: [],
+    refusal: null,
+  },
+  ...over,
 });
 
 function deps(over: Partial<RunDeps> = {}): RunDeps & { removedConfig: string[]; cleared: number } {
@@ -215,6 +227,7 @@ const outcome = (over: Partial<RemovalOutcome> = {}): RemovalOutcome => ({
   profile: 'personal',
   results: [{ item: item({ kind: 'secret', id: 'gmail/someone' }), status: 'removed' }],
   survived: 0,
+  unreachable: [],
   ...over,
 });
 
@@ -302,6 +315,48 @@ function prompter(answer: string, interactive = true): Prompter & { asked: strin
     confirm: async () => true,
   };
 }
+
+/**
+ * The exit-code rule, both ways — #219.
+ *
+ * Exit 0 iff every item was removed *and* nothing was unreachable, which is
+ * deliberately not the same as "iff the config parsed". The contract this file
+ * already states is "something is left must not look like success to a script",
+ * and a config that would not load is only a way of *not knowing* whether
+ * something is left.
+ */
+describe('renderOutcome, on a removal whose config would not load', () => {
+  test('a clean degraded run is success, because nothing was left', () => {
+    // The case #219 actually produces: every field reads, so the removal named
+    // everything it could have and left nothing. Reporting failure here would
+    // mean the cleanup script that hit the bug still fails afterwards.
+    const before = process.exitCode;
+    const { out } = captured(() => renderOutcome(outcome()));
+
+    expect(out).toContain('Removed profile');
+    expect(out).not.toContain('Not reachable');
+    expect(process.exitCode).toBe(before);
+  });
+
+  test('something it could not see is not success, and says re-running will not help', () => {
+    const before = process.exitCode;
+    const { out } = captured(() =>
+      renderOutcome(outcome({ unreachable: ['a sealed vault document, if this profile granted one'] })),
+    );
+
+    expect(out).toContain('Not reachable');
+    expect(out).toContain('a sealed vault document');
+
+    // The distinction from a *failed* item, which keeps the config and can be
+    // retried. Here the profile is gone, so the same advice would send somebody
+    // to a command that can no longer help them.
+    expect(out).toContain('Running this again will not find them');
+    expect(out).not.toContain('run the same command again');
+
+    expect(process.exitCode).toBe(1);
+    process.exitCode = before;
+  });
+});
 
 describe('confirmedByName', () => {
   test('--yes proceeds without asking anything', async () => {

--- a/src/cli/commands/profile/remove.ts
+++ b/src/cli/commands/profile/remove.ts
@@ -1,8 +1,7 @@
-import type { SecretStore } from '#secrets';
-import type { BlobStore } from '#stores/blobs';
 import {
   ConfigError,
   WORKSPACE_FILE,
+  loadWorkspaceProfiles,
   openTarget,
   readWorkspace,
   readWorkspaceFile,
@@ -16,219 +15,33 @@ import { terminalPrompter, type Prompter } from '../../prompt.ts';
 import { confirmedByName } from './confirm.ts';
 import { recordConfigChange } from '../../audit-change.ts';
 import { nextAfterEdit, publishProfileEdit } from '../../publish.ts';
-import { announceProfile, emit, fail, ok, print, style } from '../../output.ts';
+import { announceProfile, emit, print, style } from '../../output.ts';
 import {
-  buildRegistryWithWorkspace,
+  locateProfile,
   openBlobStoreFor,
   openSecretStoreFor,
-  resolveProfileOnly,
   type GlobalFlags,
 } from '../../runtime.ts';
-import { loadWorkspaceProfiles } from '#profile';
-import { removalPlan, renderPlan, type RemovalItem, type RemovalPlan } from './removal.ts';
-import { settleDisposition, type Disposition } from './disposition.ts';
+import { executeRemoval, renderOutcome, retryCommand } from './perform.ts';
+import { removalPlan } from './removal.ts';
+import { renderPlan } from './preview.ts';
+import { removalSubject, subjectOf } from './subject.ts';
+import { settleDisposition } from './disposition.ts';
 
 /**
- * Performing a removal, and being honest about the parts that did not happen.
+ * `lanes link profile remove`, and the one thing it must never refuse.
  *
- * Best effort by choice: a target whose project has been deleted must not be
- * able to strand a profile on the machine forever, so one refusal does not stop
- * the rest. The price is real — a deletion that fails leaves a live credential
- * behind — and everything here exists to make that visible rather than quiet.
- */
-
-export interface RemovalResult {
-  readonly item: RemovalItem;
-  /** `kept` is deliberate: not attempted, because something before it failed. */
-  readonly status: 'removed' | 'failed' | 'kept';
-  readonly error?: string;
-  /** The exact command that finishes this one by hand. */
-  readonly retry?: string;
-}
-
-export interface RemovalOutcome {
-  readonly profile: string;
-  readonly results: readonly RemovalResult[];
-  /** How many items are still there. Non-zero means a credential is still live. */
-  readonly survived: number;
-}
-
-export interface RunDeps {
-  openSecrets: (target: string) => Promise<SecretStore>;
-  openBlobs: (target: string, area?: string) => Promise<BlobStore>;
-  removeConfig: (path: string) => Promise<void>;
-  /** The emptied profile directory. A blob delete cannot remove a directory. */
-  removeDirectory: (path: string) => Promise<void>;
-  clearDefaultProfile: () => Promise<void>;
-  retry?: ((item: RemovalItem, cause: string) => string | undefined) | undefined;
-}
-
-const reason = (cause: unknown): string => (cause instanceof Error ? cause.message : String(cause));
-
-/**
- * The items that only make sense once everything else is actually gone.
+ * The command resolves the profile by *existence* and reads its config
+ * separately, because until it did, a `profile.yaml` the schema refused could
+ * be listed and never removed: every command that might have taken it away
+ * parsed it first and died on the same error, so the only way out was deleting
+ * the file by hand — or the bucket object, on a deployed workspace (#219).
  *
- * **`file` is in here, and that is the whole of its reason.** It is
- * `rm -rf profiles/<profile>`, and it carries a target rather than `null`, so
- * the original `target === null` test let it run after a failed object — taking
- * the bytes a `--migrate-to` had not managed to copy, and `profile.yaml`, which
- * the sweep deliberately leaves for last. `renderOutcome` then printed "the
- * profile's config was kept, so nothing is stranded" about a directory that no
- * longer existed. Same shape as the defect this file records having shipped
- * once already.
+ * What makes that safe is in `subject.ts`, and it is one property: a field the
+ * file did not yield removes a line from the plan and can never add a wrong
+ * one. The preview says so before anything is confirmed, and anything this
+ * could not see is reported and carried into the exit code.
  */
-const isRecordOfWhereThingsAre = (item: RemovalItem): boolean =>
-  item.kind === 'file' ||
-  (item.target === null && (item.kind === 'config' || item.kind === 'workspace-key'));
-
-export async function executeRemoval(
-  plan: RemovalPlan,
-  deps: RunDeps,
-): Promise<RemovalOutcome> {
-  const results: RemovalResult[] = [];
-  let failed = 0;
-
-  // One store per target, however many items it holds. Opening a Secret
-  // Manager client per secret would turn a tidy removal into a rate limit.
-  const secrets = new Map<string, Promise<SecretStore>>();
-  const blobs = new Map<string, Promise<BlobStore>>();
-
-  const secretStore = (target: string): Promise<SecretStore> => {
-    const existing = secrets.get(target) ?? deps.openSecrets(target);
-    secrets.set(target, existing);
-    return existing;
-  };
-
-  const blobStore = (target: string, area?: string): Promise<BlobStore> => {
-    const key = `${target}:${area ?? ''}`;
-    const existing = blobs.get(key) ?? deps.openBlobs(target, area);
-    blobs.set(key, existing);
-    return existing;
-  };
-
-  for (const item of plan.items) {
-    // The config is the only record of where everything else lives. Deleting it
-    // after a failure would strand precisely the credential that failed: still
-    // live, and nothing left that knows where it is. Keeping it means the retry
-    // is this same command rather than a hand-assembled console session.
-    if (failed > 0 && isRecordOfWhereThingsAre(item)) {
-      results.push({ item, status: 'kept' });
-      continue;
-    }
-
-    try {
-      switch (item.kind) {
-        case 'secret':
-          await (await secretStore(item.target!)).delete(item.id);
-          break;
-
-        case 'blob': {
-          const store = await blobStore(item.target!, item.area);
-
-          // Read across *before* deleting, and verify it landed — the same rule
-          // the contract migrations follow, for the same reason: a copy that
-          // half happened and a source that is already gone is the one state
-          // with nothing to retry from. A collision was resolved while this was
-          // still a plan, so the destination is free.
-          if (item.movedTo !== undefined) {
-            const [area, key] = item.movedTo;
-            const bytes = await store.get(item.id);
-
-            if (bytes !== null) {
-              const into = await blobStore(item.target!, area);
-              await into.put(key, bytes);
-              if ((await into.get(key)) === null) {
-                throw new Error(`${area}/${key} did not read back after being written`);
-              }
-            }
-          }
-
-          await store.delete(item.id);
-          break;
-        }
-
-        case 'config':
-          if (item.target === null) await deps.removeConfig(item.id);
-          else {
-            // `profiles/<name>.yaml` in the target's bucket — outside the
-            // profile's blob tree, so it needs its own area.
-            const [area, ...rest] = item.id.split('/');
-            await (await blobStore(item.target, area)).delete(rest.join('/'));
-          }
-          break;
-
-        case 'workspace-key':
-          await deps.clearDefaultProfile();
-          break;
-
-        case 'file':
-          await deps.removeDirectory(item.id);
-          break;
-      }
-
-      results.push({ item, status: 'removed' });
-    } catch (cause) {
-      const error = reason(cause);
-      const retry = deps.retry?.(item, error);
-      failed += 1;
-      results.push({ item, status: 'failed', error, ...(retry ? { retry } : {}) });
-    }
-  }
-
-  return {
-    profile: plan.profile,
-    results,
-    survived: results.filter((result) => result.status !== 'removed').length,
-  };
-}
-
-/**
- * What happened, and what is still out there.
- *
- * The exit code is the load-bearing part. Best effort means the command can
- * finish having left a live credential behind, and to a script silence is
- * indistinguishable from success — so anything that survived makes this exit
- * non-zero, and names itself with the command that finishes it.
- */
-export function renderOutcome(outcome: RemovalOutcome): void {
-  const removed = outcome.results.filter((result) => result.status === 'removed');
-  const failed = outcome.results.filter((result) => result.status === 'failed');
-  const kept = outcome.results.filter((result) => result.status === 'kept');
-
-  print();
-  if (outcome.survived === 0) {
-    print(ok(`Removed profile ${style.bold(outcome.profile)} — ${removed.length} item(s).`));
-    print();
-    return;
-  }
-
-  print(
-    fail(
-      `Removed ${removed.length} item(s) of profile ${style.bold(outcome.profile)}, and ${failed.length} refused.`,
-    ),
-  );
-  print();
-
-  for (const result of failed) {
-    print(`  ${result.item.id}`);
-    if (result.error) print(style.dim(`    ${result.error}`));
-    if (result.retry) print(style.dim(`    finish it with: ${result.retry}`));
-  }
-  print();
-
-  if (kept.length > 0) {
-    // Said plainly, because the alternative reading — that the profile is
-    // half-gone and needs unpicking by hand — is the one an operator will
-    // assume from a failure report.
-    print(
-      `The profile's config was kept, so nothing is stranded: fix the above and run the same command again.`,
-    );
-    print();
-  }
-
-  // A live credential left behind must not look like success to a script.
-  process.exitCode = 1;
-}
 
 export interface RemoveFlags extends GlobalFlags {
   readonly dryRun?: boolean | undefined;
@@ -251,17 +64,31 @@ export interface RemoveFlags extends GlobalFlags {
  * in the tool.
  */
 export async function removeProfile(name: string, flags: RemoveFlags): Promise<void> {
-  const { selection, config, target } = await resolveProfileOnly({ ...flags, profile: name });
-  announceProfile(selection);
+  // Located, not resolved. Everything up to and including finding the file
+  // throws exactly as it always did — a workspace that is not declared, a
+  // pointer that will not follow, a profile that is not there. Only the *parse*
+  // is allowed to fail softly, and only here. A `try` around the whole
+  // resolution would have read "you typed the wrong workspace" as "this profile
+  // is broken", and `--yes --delete-data` would then have run a removal to
+  // completion somewhere nobody meant.
+  const found = await locateProfile({ ...flags, profile: name });
+  announceProfile(found.selection);
 
-  const root = selection.workspaceRoot;
-  const registry = await buildRegistryWithWorkspace(root);
+  const subject = await removalSubject(found);
+  const target = found.target;
+  const root = found.selection.workspaceRoot;
   const files = workspaceFiles(root);
   const { declared } = await openTarget(root, target);
 
   const prompter = flags.prompter ?? terminalPrompter;
   const someoneToAsk = flags.prompter ? prompter.interactive : process.stdin.isTTY;
-  const disposition = await settleDisposition(name, flags, prompter, someoneToAsk);
+  const disposition = await settleDisposition(
+    name,
+    flags,
+    prompter,
+    someoneToAsk,
+    migrationRefusal(subject.config === null, name, target),
+  );
 
   if (disposition === null) {
     print(style.dim('  cancelled — nothing was removed'));
@@ -280,18 +107,20 @@ export async function removeProfile(name: string, flags: RemoveFlags): Promise<v
     }
   }
 
-  const plan = await removalPlan(config, root, name, registry, {
+  const plan = await removalPlan(subject, root, name, {
     target,
     declared,
     disposition,
     openSecrets: (target) => openSecretStoreFor(root, target),
-    openBlobs: (target, area) => openBlobStoreFor(config, root, target, area),
+    openBlobs: (target, area) => openBlobStoreFor(name, root, target, area),
     readDefaultProfile: async () => (await readWorkspace(root))?.default_profile,
     // What the workspace keeps. The credential store is one file for all of
     // them now, so anything a survivor declares is not this removal's to delete.
+    // Survivors always parse — `loaded` is the ones that did — so the kept set
+    // is exact even when the subject's own file is not.
     survivors: (await loadWorkspaceProfiles(root)).loaded
       .filter((one) => one.profile !== name)
-      .map((one) => one.config),
+      .map((one) => subjectOf(one.config)),
   });
 
   renderPlan(plan);
@@ -306,19 +135,24 @@ export async function removeProfile(name: string, flags: RemoveFlags): Promise<v
 
   const outcome = await executeRemoval(plan, {
     openSecrets: (target) => openSecretStoreFor(root, target),
-    openBlobs: (target, area) => openBlobStoreFor(config, root, target, area),
+    openBlobs: (target, area) => openBlobStoreFor(name, root, target, area),
     removeConfig: async (path) => await files.delete(relativeToRoot(root, path)),
     removeDirectory: async (path) => await rm(workspacePath(root, path), { recursive: true, force: true }),
     clearDefaultProfile: async () => await clearDefault(root),
     retry: retryCommand,
   });
 
-  // Before the render, and against the config loaded above — the profile's file
-  // is gone by now, so a helper that re-read it would find nothing.
-  await recordConfigChange(config, root, target, {
+  // Before the render, and against what was read above — the profile's file is
+  // gone by now, so a helper that re-read it would find nothing. A removal
+  // whose config would not load records the row anyway, without the connection
+  // list it could not read: the removal that most deserves a row is the one
+  // nothing could account for.
+  await recordConfigChange(name, root, target, {
     capability: 'config.profile.remove',
     scope: name,
-    arguments: { connections: config.grants.map((grant) => grant.connection) },
+    arguments: subject.config
+      ? { connections: subject.config.grants.map((grant) => grant.connection) }
+      : { unreadable: subject.refusal ?? 'the config would not load' },
   });
 
   // And the endpoint is told, as it is told about every other config edit
@@ -326,14 +160,24 @@ export async function removeProfile(name: string, flags: RemoveFlags): Promise<v
   // listed at boot, so without this a profile that has been *removed*, with its
   // credentials and its stores deleted, stayed reachable until the revision
   // happened to restart: the operator believing they had revoked something they
-  // had not. Wrapped because the removal has already happened and a failure to
-  // announce it cannot undo it; `publishWorkspace` copies what the local store
-  // has, which no longer includes this profile, so nothing here can put the
-  // file back. A throw is reported as nothing — `renderOutcome` owns the exit
-  // code, derived from what survived on the stores.
+  // had not.
+  //
+  // **A config that will not load today is not a profile that was never
+  // served**, which is the reading that would make skipping this look safe. The
+  // set is built at boot and at `/reload` and at no other time, so a file that
+  // parsed at the last boot is being served right now, from memory, with live
+  // credentials — and this reload is the only thing that drops it before a
+  // restart. So the notify matters *more* here, not less.
+  //
+  // Wrapped because the removal has already happened and a failure to announce
+  // it cannot undo it; `publishWorkspace` copies what the local store has, which
+  // no longer includes this profile, so nothing here can put the file back. A
+  // throw is reported as nothing — `renderOutcome` owns the exit code, derived
+  // from what survived on the stores.
   let published: string | undefined;
   try {
     const resolution = { workspaceRoot: root, profile: name };
+    const config = subject.config ?? undefined;
     published = nextAfterEdit(await publishProfileEdit({ resolution, config, target }));
   } catch {
     // See above.
@@ -367,8 +211,27 @@ async function clearDefault(root: string): Promise<void> {
   await writeWorkspaceFile(workspaceFiles(root), WORKSPACE_FILE, String(document));
 }
 
-/** The command that finishes a refusal by hand, where one can be named. */
-function retryCommand(item: RemovalItem): string | undefined {
-  if (item.kind !== 'secret') return undefined;
-  return `lanes link profile remove <name> --target ${item.target} # or delete ${item.id} in that store`;
+/**
+ * Why a broken profile's bytes will not be moved into a working one.
+ *
+ * Not because the mechanics fail — `migratesAcross` is a key-prefix test and
+ * `resolveCollisions` opens the destination by name, so both work perfectly well
+ * here. It is the asymmetry in what going wrong costs. `--delete-data` fails
+ * toward having deleted less than it should, which is the direction everything
+ * else in this design already leans. `--migrate-to` fails toward putting bytes
+ * nobody could account for into a profile that is currently correct, under a
+ * connection it may not even grant — invisible to every command that reads it,
+ * and with nothing to undo it.
+ */
+function migrationRefusal(degraded: boolean, name: string, target: string): string | undefined {
+  if (!degraded) return undefined;
+
+  return (
+    `"${name}"'s config will not load, so this will not move its bytes into another profile. ` +
+    'Which connection each note sits under is something only that file says — and a note ' +
+    'arriving under a connection the destination does not grant is invisible to every command, ' +
+    'in a profile that is currently correct.\n' +
+    `  See what is there:  lanes link profile remove ${name} --workspace ${target} --dry-run\n` +
+    `  Remove it as it is: lanes link profile remove ${name} --workspace ${target} --delete-data`
+  );
 }

--- a/src/cli/commands/profile/subject.test.ts
+++ b/src/cli/commands/profile/subject.test.ts
@@ -1,0 +1,166 @@
+import { afterAll, describe, expect, test } from 'bun:test';
+import type { Config, TargetConfig } from '#profile';
+import { profileYaml, workspaceYaml, writeProfileFixture } from '#profile/testing.ts';
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { locateProfile } from '../../runtime.ts';
+import { declaredRefs, removalSubject, subjectOf, unreachableRefs } from './subject.ts';
+
+/**
+ * What a removal can read of a profile whose config will not load — #219.
+ *
+ * The property under test is not the wording of any field. It is that a field
+ * this cannot read *shrinks* what a removal will delete and can never widen it:
+ * `declaredRefs` derives from what the profile declares, and a declaration that
+ * could not be read declares nothing. Everything else here supports that one.
+ */
+
+const roots: string[] = [];
+const previousHome = process.env['LANES_LINK_HOME'];
+
+/**
+ * A profile the loader refuses, found the way `removeProfile` finds one.
+ *
+ * The directory is `my-profile` throughout, because that is the case #219
+ * produces and because the name is *why* the document is refused: a hyphen is
+ * outside `identifier`. So these fixtures are broken for the reason the issue's
+ * are, rather than broken in a way invented for a test.
+ */
+async function located(body: string) {
+  const root = await mkdtemp(join(tmpdir(), 'lanes-link-subject-'));
+  roots.push(root);
+  process.env['LANES_LINK_HOME'] = root;
+
+  await writeFile(join(root, 'workspaces.yaml'), workspaceYaml(['local']));
+  await writeProfileFixture(root, 'my-profile', body);
+
+  return locateProfile({ profile: 'my-profile', target: 'local' });
+}
+
+afterAll(async () => {
+  if (previousHome === undefined) delete process.env['LANES_LINK_HOME'];
+  else process.env['LANES_LINK_HOME'] = previousHome;
+  await Promise.all(roots.map((root) => rm(root, { recursive: true, force: true })));
+});
+
+const target = (over: Partial<TargetConfig> = {}): TargetConfig =>
+  ({ credentials: { adapter: 'file' }, storage: { adapter: 'filesystem' }, ...over }) as unknown as TargetConfig;
+
+const sealed = target({ vault: { adapter: 'secret' } } as never);
+
+describe('removalSubject', () => {
+  /**
+   * The flagship case, and the reason there is one degraded path rather than
+   * two. `profile add my-profile` wrote perfectly good YAML whose only fault is
+   * a name the schema refuses — so everything a removal needs reads cleanly and
+   * the plan is identical to a parsed one. A design that filed this under
+   * "lesser removal" would owe the operator an explanation that is not true.
+   */
+  test('recovers every field from a document the schema refused', async () => {
+    const subject = await removalSubject(await located(profileYaml('my-profile')));
+
+    expect(subject.config).toBeNull();
+    expect(subject.refusal).toContain('must be lowercase letters');
+    expect([...subject.unread]).toEqual([]);
+    expect(subject.name).toBe('my-profile');
+    expect(subject.assumedName).toBe(false);
+    expect(subject.vaultConnection).toBe('lan5');
+  });
+
+  test('a file that is not YAML yields nothing, and says so per field', async () => {
+    const subject = await removalSubject(await located('contract: 5\ninstance:\n  profile: [\n'));
+
+    expect([...subject.unread].sort()).toEqual(['auth', 'grants', 'knowledge', 'name']);
+    // Still the directory's name, which is the one the operator typed.
+    expect(subject.name).toBe('my-profile');
+    expect(subject.assumedName).toBe(true);
+  });
+
+  test('a wrongly-shaped field is unread, not read as absent', async () => {
+    // The distinction that matters: `grants: gmail` is not "no grants", it is
+    // "this could not be read". Treating it as absence would let the removal
+    // report certainty it does not have.
+    const subject = await removalSubject(
+      await located('contract: 5\ninstance:\n  profile: my-profile\ngrants: not-a-list\n'),
+    );
+
+    expect(subject.unread.has('grants')).toBe(true);
+    expect(subject.vaultConnection).toBeNull();
+  });
+
+  test('an absent auth block is a complete read, not a gap', async () => {
+    // Most profiles declare no `authorization`, so counting its absence as
+    // unread would put "an OIDC client id, if this profile declared one" under
+    // every degraded removal ever run.
+    const subject = await removalSubject(
+      await located('contract: 5\ninstance:\n  profile: my-profile\ngrants: []\n'),
+    );
+
+    expect(subject.unread.has('auth')).toBe(false);
+    expect(subject.clientIdRef).toBeNull();
+  });
+
+  test('a name that disagrees with the directory is flagged, and the directory wins', async () => {
+    // `layout.blobs(profile)` addresses the blob tree, so a hand-edited
+    // `instance.profile` reaching it would let one profile's removal empty
+    // another's directory.
+    const subject = await removalSubject(await located(profileYaml('somebody-else')));
+
+    expect(subject.name).toBe('my-profile');
+    expect(subject.assumedName).toBe(true);
+  });
+});
+
+describe('declaredRefs, from a subject that could not be read', () => {
+  /**
+   * The guarantee. Without it a degraded removal could queue a name that is not
+   * this profile's, and in Secret Manager that deletion is not recoverable.
+   */
+  test('a subject with nothing read declares no ref at all', async () => {
+    const subject = await removalSubject(await located('contract: 5\ninstance:\n  profile: [\n'));
+
+    expect(declaredRefs(subject, sealed)).toEqual([]);
+    expect(declaredRefs(subject, target())).toEqual([]);
+  });
+
+  test('and what it could not name is reported rather than passed over', async () => {
+    const subject = await removalSubject(await located('contract: 5\ninstance:\n  profile: [\n'));
+    const missing = unreachableRefs(subject, sealed, 'cloud');
+
+    expect(missing.join('\n')).toContain('vault/my-profile/');
+    expect(missing.join('\n')).toContain('OIDC client id');
+  });
+
+  test('a subject that read everything declares exactly what a parsed one does', async () => {
+    // Parity, which is what makes the #219 case a full removal rather than a
+    // partial one. The salvaged subject and the parsed subject must agree.
+    const salvaged = await removalSubject(await located(profileYaml('my-profile')));
+    const parsed = subjectOf({
+      contract: 5,
+      instance: { profile: 'my-profile' },
+      auth: { mode: 'bearer' },
+      grants: [{ connection: 'lanes_vault.lan5', allow: [], deny: [] }],
+      members: [],
+    } as unknown as Config);
+
+    expect(declaredRefs(salvaged, sealed)).toEqual(declaredRefs(parsed, sealed));
+    expect(unreachableRefs(salvaged, sealed, 'cloud')).toEqual([]);
+  });
+
+  test('a survivor keeps the ref it shares, even when the subject was salvaged', async () => {
+    // The check that once made a sibling's sealed items unrecoverable. It has to
+    // keep working on the degraded path, where the subject's ref was derived
+    // rather than parsed.
+    const salvaged = await removalSubject(await located(profileYaml('my-profile')));
+    const survivor = subjectOf({
+      contract: 5,
+      instance: { profile: 'my-profile' },
+      auth: { mode: 'bearer' },
+      grants: [{ connection: 'lanes_vault.lan5', allow: [], deny: [] }],
+      members: [],
+    } as unknown as Config);
+
+    expect(declaredRefs(salvaged, sealed, [survivor])).toEqual([]);
+  });
+});

--- a/src/cli/commands/profile/subject.ts
+++ b/src/cli/commands/profile/subject.ts
@@ -1,0 +1,347 @@
+import { ConfigDocument } from '../../config-edit.ts';
+import {
+  findSecrets,
+  sealedVaultRef,
+  soleGrantFor,
+  type Config,
+  type TargetConfig,
+} from '#profile';
+import type { LocatedProfile } from '../../runtime.ts';
+import { reasonOf } from '../../output.ts';
+
+/**
+ * What a removal could read of the profile it is removing.
+ *
+ * The seam against `removal.ts` is that this is what a profile *declares* and
+ * that is what a removal *deletes*. It exists because the second has to work
+ * when the first cannot be had: a `profile.yaml` the schema refuses could be
+ * listed but never removed, and every command that might have taken it away
+ * resolved it first and failed on the same parse — so the only way out was
+ * deleting the file by hand, or the bucket object on a deployed workspace
+ * (#219).
+ *
+ * **The governing property, and the one to keep: what a config that will not
+ * load costs is a line that is missing, never one that is wrong.** Removal
+ * derives its credential refs from what the profile declares and then keeps only
+ * those the store actually holds, so a field this cannot read *shrinks* the
+ * plan. It can never point the plan at somebody else's credential. Everything
+ * below is arranged to preserve that, and a change here that lets an unread
+ * field widen the plan has broken the design rather than extended it.
+ *
+ * The closed set is a type rather than a docstring on purpose. `removalPlan`
+ * reads four things off a config and no more; while that was only written down,
+ * a fifth was one careless line away from being added with no degraded reader
+ * beside it.
+ */
+
+/** The fields a removal reads, named so an unread one can be reported as such. */
+export type SubjectField = 'name' | 'grants' | 'auth' | 'knowledge';
+
+export interface RemovalSubject {
+  /** The parsed config, or `null` — which is the whole of the degraded mode. */
+  readonly config: Config | null;
+  /**
+   * The profile's name, from the *directory*.
+   *
+   * **Never from the file.** `layout.blobs(profile)` is what addresses the blob
+   * tree, so a hand-edited `instance.profile` reaching it would let `profile
+   * remove my_profile` empty `profiles/other/`. The directory is also what the
+   * operator typed and what `listProfiles` showed them, which is the only name
+   * any of this was ever about.
+   */
+  readonly name: string;
+  /**
+   * Whether the file's own `instance.profile` agreed with the directory.
+   *
+   * The one thing the file's value is needed for is the middle segment of
+   * `vault/<profile>/<connection>` — the name under which a sealed document was
+   * written. Where the two disagree there are two candidates and no way to
+   * choose, so the ref is reported as unreachable rather than guessed at.
+   */
+  readonly assumedName: boolean;
+  /** `auth.authorization.client_id_ref`, where the block is `oidc`. */
+  readonly clientIdRef: string | null;
+  /** The `lanes_vault` connection this profile grants, `null` where none is. */
+  readonly vaultConnection: string | null;
+  /** `knowledge.repo`, for the warning that a repository survives a removal. */
+  readonly knowledgeRepo: string | null;
+  /** The loader's refusal, first line only, as `loadWorkspaceProfiles` squashes it. */
+  readonly refusal: string | null;
+  /** Fields the file did not yield. Always empty for a parsed config. */
+  readonly unread: ReadonlySet<SubjectField>;
+}
+
+/** Every field, for a profile whose config loaded. */
+export function subjectOf(config: Config): RemovalSubject {
+  return {
+    config,
+    name: config.instance.profile,
+    assumedName: false,
+    clientIdRef:
+      config.auth.authorization?.mode === 'oidc' ? config.auth.authorization.client_id_ref : null,
+    vaultConnection: soleGrantFor(config, 'lanes_vault') ?? null,
+    knowledgeRepo: config.knowledge?.repo ?? null,
+    refusal: null,
+    unread: new Set(),
+  };
+}
+
+const ALL_FIELDS: readonly SubjectField[] = ['name', 'grants', 'auth', 'knowledge'];
+
+/**
+ * What could be salvaged of a profile whose config will not load.
+ *
+ * One path, not two. In the case #219 produces the file is perfectly good YAML
+ * whose only fault is `instance.profile`, so every field below reads cleanly and
+ * the plan is identical to the one a parsed config would have produced — calling
+ * that a lesser removal would be a sentence this code cannot support. A file
+ * that will not parse *as YAML* is the same read with nothing to read:
+ * `ConfigDocument.open` throws, every field lands in `unread`, and the caller
+ * reports four missing lines instead of none.
+ *
+ * **`findSecrets` before anything is kept.** A parsed config has been through
+ * that check on its raw object, deliberately and before the schema
+ * (`profile/load.ts`); a salvaged one has not. Without this the degraded path
+ * would be the one route by which a config value reaches a terminal, an audit
+ * row and a `--json` document unchecked, which is the hole the loader's ordering
+ * exists to close.
+ */
+export async function removalSubject(found: LocatedProfile): Promise<RemovalSubject> {
+  if (found.loaded !== null) return subjectOf(found.loaded.config);
+
+  const directory = found.selection.profile;
+  const refusal = reasonOf(found.refusal);
+
+  const raw = await rawDocument(found.selection.workspaceRoot, directory);
+  if (raw === null) {
+    return {
+      config: null,
+      name: directory,
+      assumedName: true,
+      clientIdRef: null,
+      vaultConnection: null,
+      knowledgeRepo: null,
+      refusal,
+      unread: new Set(ALL_FIELDS),
+    };
+  }
+
+  // Anything the secret detector flags is dropped rather than carried: it would
+  // otherwise be printed in the preview and written into the audit row.
+  const flagged = new Set(findSecrets(raw).map((finding) => finding.path));
+  const clean = (path: string, value: string | null): string | null =>
+    value !== null && flagged.has(path) ? null : value;
+
+  const unread = new Set<SubjectField>();
+
+  const instance = asRecord(raw['instance']);
+  const auth = asRecord(raw['auth']);
+  const authorization = asRecord(auth?.['authorization']);
+  const knowledge = asRecord(raw['knowledge']);
+
+  const declaredName = asString(instance?.['profile']);
+  if (declaredName === null) unread.add('name');
+
+  const grants = asArray(raw['grants']);
+  if (grants === null) unread.add('grants');
+
+  // **An absent `authorization` block is a complete read, not a gap.** The
+  // schema makes it optional and most profiles do not declare one, so treating
+  // absence as unread would put "an OIDC client id, if this profile declared
+  // one" under every degraded removal ever run. What is unread is an `auth`
+  // block that could not be read at all, or an `oidc` one whose ref could not.
+  const clientIdRef =
+    authorization?.['mode'] === 'oidc'
+      ? clean('auth.authorization.client_id_ref', asString(authorization['client_id_ref']))
+      : null;
+
+  // An `auth` key that is *there* and unreadable is a gap; one that is absent
+  // is not. A profile with no `auth` block declares no `authorization` and so
+  // no client id, which is a complete answer — and the common one, since the
+  // whole block is optional.
+  if (raw['auth'] !== undefined && auth === undefined) unread.add('auth');
+  else if (authorization?.['mode'] === 'oidc' && clientIdRef === null) unread.add('auth');
+
+  return {
+    config: null,
+    name: directory,
+    assumedName: declaredName !== directory,
+    clientIdRef,
+    vaultConnection: grants === null ? null : vaultGrantIn(grants),
+    knowledgeRepo: clean('knowledge.repo', asString(knowledge?.['repo'])),
+    refusal,
+    unread,
+  };
+}
+
+/**
+ * The sealed-vault ref this removal may delete, where it can name one.
+ *
+ * `null` means "there is no such ref, or this cannot name it" and the caller
+ * reports the second case through `unreachableRefs`. Guessing instead would be
+ * the one way this design could point a deletion at a name that is not this
+ * profile's — every other unread field can only shrink the plan.
+ */
+export function sealedRefFor(subject: RemovalSubject, declared: TargetConfig): string | null {
+  if (declared.vault?.adapter !== 'secret') return null;
+  if (subject.config === null && (subject.assumedName || subject.unread.has('grants'))) return null;
+
+  return sealedVaultRef(declared, subject.name, subject.vaultConnection);
+}
+
+/**
+ * The credential references this profile declares, and only those.
+ *
+ * Locally the profile is the boundary: its credentials are a file inside its own
+ * directory, and deleting the directory is the whole operation. In Secret
+ * Manager they are flat names in one project, so two profiles deployed to the
+ * same project share a namespace and `list()` hands back the other one's as
+ * readily as its own. Deriving from what this profile declares is the only
+ * answer that cannot delete something that was never ours, and a secret deleted
+ * in the wrong project is not recoverable.
+ *
+ * The cost is that a genuinely orphaned ref — one whose connection was removed
+ * from config long ago — is not derivable and so is not deleted. The caller
+ * reports those rather than guessing, which is the honest position: a guess here
+ * is indistinguishable from another profile's credential.
+ *
+ * **A subject rather than a config**, so the same derivation runs whether the
+ * file parsed or was salvaged. A field that could not be read contributes no
+ * ref, which is the property this whole file is built to preserve.
+ */
+export function declaredRefs(
+  subject: RemovalSubject,
+  declared: TargetConfig,
+  /**
+   * What the profiles that are staying declare.
+   *
+   * Nothing in here is deleted, however plainly the profile being removed also
+   * declares it. The vault ref is read off the target and is identical for every
+   * profile there, which once made a sibling's sealed items unrecoverable in
+   * this command.
+   *
+   * **The endpoint token was the sharpest case here and is no longer a case.**
+   * Every profile took the default `token_ref: profile/token` out of one
+   * per-workspace store, so removing one deleted the token its siblings were
+   * served by. What fixed it is not a better survivor check: the token was never
+   * a profile's to declare (ADR-068), so removing one cannot reach it now.
+   *
+   * Survivors always parse — they come from `loadWorkspaceProfiles().loaded` —
+   * so the kept set is exact even when the subject's own file is not.
+   */
+  survivors: readonly RemovalSubject[] = [],
+): string[] {
+  const refs = new Set<string>();
+
+  // Read off the *target*, not the profile. `vaultTargetSchema` sits inside
+  // `targetSchema`, so two targets may seal the same items in different places;
+  // taking it from the profile would attach one target's vault to another
+  // target's removal.
+  //
+  // **Through the one spelling, because the name carries the connection.** This
+  // said `vault/document`, the contract-2 constant, while `openVault` seals under
+  // `vault/<connection>` (ADR-059) — so removing a profile queued a ref nothing
+  // had ever written and left the real document behind. Under-deletion rather
+  // than over, since the survivor set was wrong the same way and they cancelled,
+  // but what stayed behind is sealed credential material belonging to a profile
+  // the operator asked to be gone. Per connection also makes the survivor check
+  // mean something: two profiles granting different vaults no longer look like
+  // one document to it.
+  const sealed = sealedRefFor(subject, declared);
+  if (sealed !== null) refs.add(sealed);
+
+  // **No connection credentials.** They belong to the workspace now (ADR-057),
+  // and every one of them may be granted by a profile that is staying. Removing
+  // a profile therefore removes no account and no credential — `lanes link
+  // disconnect` is the command that does that, and it is the one that knows how
+  // to check whether anybody else still needs the credential first.
+  //
+  // This is the sharpest edge in the whole decoupling, so `renderPlan` says it
+  // out loud rather than leaving an operator to infer it from a short list:
+  // "remove the work profile" used to mean "revoke what work could reach", and
+  // it does not any more.
+  if (subject.clientIdRef !== null) refs.add(subject.clientIdRef);
+
+  // Shared with a profile that is staying, so not ours to delete. Computed the
+  // same way for the survivors as for this one, because "what does a profile
+  // declare" has to have one answer.
+  const kept = new Set(
+    survivors.flatMap((other) =>
+      [sealedRefFor(other, declared), other.clientIdRef].filter((ref) => ref !== null),
+    ),
+  );
+
+  return [...refs].filter((ref) => !kept.has(ref));
+}
+
+/**
+ * What a config that will not load stops this removal from being able to name.
+ *
+ * Not the same thing as a warning, and kept apart from one for that reason. A
+ * warning says "this survives by design" — the repository, the deployed service,
+ * the connections every profile shares. These say "this removal cannot see
+ * whether it survives", which is the sentence that carries the exit code.
+ *
+ * Nothing here is ever invisible: `renderPlan` already names every ref the
+ * store holds that this removal did not delete, under "present but not declared
+ * by this profile". What these lines add is that one of those may have been this
+ * profile's and there was no way to tell.
+ */
+export function unreachableRefs(
+  subject: RemovalSubject,
+  declared: TargetConfig,
+  target: string,
+): string[] {
+  const missing: string[] = [];
+  if (subject.config !== null) return missing;
+
+  if (declared.vault?.adapter === 'secret' && sealedRefFor(subject, declared) === null) {
+    missing.push(
+      `a sealed vault document, if this profile granted one — look under vault/${subject.name}/ ` +
+        `in ${target}'s credential store`,
+    );
+  }
+
+  if (subject.unread.has('auth')) {
+    missing.push(
+      `an OIDC client id, if this profile declared one — it would be among the refs listed above ` +
+        `as ${target}'s, not this profile's`,
+    );
+  }
+
+  return missing;
+}
+
+/** The document as plain data, or `null` where there is nothing to read. */
+async function rawDocument(
+  workspaceRoot: string,
+  profile: string,
+): Promise<Record<string, unknown> | null> {
+  try {
+    const parsed = (await ConfigDocument.open(workspaceRoot, profile)).toJSON();
+    return asRecord(parsed) ?? null;
+  } catch {
+    // Not valid YAML, an alias cycle, or gone between the two reads. None of it
+    // is worth failing a removal over — the caller is about to delete the file
+    // either way, and every field is reported unread.
+    return null;
+  }
+}
+
+const asRecord = (value: unknown): Record<string, unknown> | undefined =>
+  typeof value === 'object' && value !== null && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : undefined;
+
+const asString = (value: unknown): string | null => (typeof value === 'string' ? value : null);
+
+const asArray = (value: unknown): unknown[] | null => (Array.isArray(value) ? value : null);
+
+/** `soleGrantFor(config, 'lanes_vault')`, over rows that have been through no schema. */
+function vaultGrantIn(grants: readonly unknown[]): string | null {
+  for (const grant of grants) {
+    const connection = asString(asRecord(grant)?.['connection']);
+    if (connection?.startsWith('lanes_vault.')) return connection.slice('lanes_vault.'.length);
+  }
+  return null;
+}

--- a/src/cli/commands/profile/unreadable.test.ts
+++ b/src/cli/commands/profile/unreadable.test.ts
@@ -1,0 +1,154 @@
+import { afterAll, describe, expect, test } from 'bun:test';
+import { connectionsYaml, profileYaml, workspaceYaml, writeProfileFixture } from '#profile/testing.ts';
+import { existsSync } from 'node:fs';
+import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { removeProfile } from './remove.ts';
+
+/**
+ * Removing a profile whose config will not load — issue #219.
+ *
+ * The defect was never the error. It was the leftover: `profile add` wrote a
+ * name the contract refuses and then parsed it back, so the profile existed,
+ * `listProfiles` showed it like any other, and every command that could have
+ * taken it away resolved it first and died on the same parse. The only way out
+ * was deleting the file by hand, or the bucket object on a deployed workspace.
+ *
+ * These are on disk rather than against injected stores, deliberately. The unit
+ * seams in `remove.test.ts` and `removal.test.ts` prove the planner and the
+ * executor behave; only a real directory proves the property the issue is about,
+ * which is that afterwards there is nothing left.
+ */
+
+const roots: string[] = [];
+const previousHome = process.env['LANES_LINK_HOME'];
+
+/** A workspace holding a healthy `personal`, and whatever `broken` is given. */
+async function workspace(brokenBody: string): Promise<string> {
+  const root = await mkdtemp(join(tmpdir(), 'lanes-link-unreadable-'));
+  roots.push(root);
+  process.env['LANES_LINK_HOME'] = root;
+
+  await writeFile(join(root, 'workspaces.yaml'), workspaceYaml(['local']));
+  await writeFile(join(root, 'connections.yaml'), connectionsYaml());
+  await writeProfileFixture(root, 'personal', profileYaml('personal'));
+  await writeProfileFixture(root, 'broken', brokenBody);
+
+  // Something in its blob tree, because a directory with only a config in it
+  // would pass a weaker version of these tests than the ones that matter.
+  await writeFile(join(root, 'profiles', 'broken', 'note.md'), 'a note');
+  return root;
+}
+
+/** The document #219 actually produces: perfect YAML, a name the schema refuses. */
+const REFUSED_NAME = profileYaml('my-profile');
+
+afterAll(async () => {
+  if (previousHome === undefined) delete process.env['LANES_LINK_HOME'];
+  else process.env['LANES_LINK_HOME'] = previousHome;
+  await Promise.all(roots.map((root) => rm(root, { recursive: true, force: true })));
+});
+
+/** Silence the preview and the outcome; these assert against disk. */
+async function quietly(body: () => Promise<void>): Promise<void> {
+  const write = process.stdout.write.bind(process.stdout);
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (process.stdout as any).write = (): boolean => true;
+  try {
+    await body();
+  } finally {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (process.stdout as any).write = write;
+  }
+}
+
+describe('removing a profile whose config will not load', () => {
+  test('the leftover is gone, and the sibling is untouched', async () => {
+    const root = await workspace(REFUSED_NAME);
+    const before = process.exitCode;
+
+    await quietly(() =>
+      removeProfile('broken', { target: 'local', yes: true, deleteData: true }),
+    );
+
+    // The property the issue is about. Everything else here is detail.
+    expect(existsSync(join(root, 'profiles', 'broken'))).toBe(false);
+
+    expect(existsSync(join(root, 'profiles', 'personal', 'profile.yaml'))).toBe(true);
+    expect(await readFile(join(root, 'profiles', 'personal', 'profile.yaml'), 'utf8')).toContain(
+      'profile: personal',
+    );
+
+    // **Exit 0, and this is the assertion that keys the whole exit-code rule.**
+    // Every field of this document reads cleanly, so the removal named
+    // everything it could have named and left nothing. Reporting failure here
+    // would mean the cleanup script that hit #219 in the first place still
+    // fails — on a profile that is now gone.
+    expect(process.exitCode).toBe(before);
+    process.exitCode = before;
+  });
+
+  test('a file that is not even YAML is still removable', async () => {
+    // The proof there is one degraded path rather than two. `ConfigDocument`
+    // throws here where it parsed above, and that is the only difference: every
+    // field lands unread and the same code runs.
+    const root = await workspace('contract: 5\ninstance:\n  profile: [\n');
+    const before = process.exitCode;
+
+    await quietly(() =>
+      removeProfile('broken', { target: 'local', yes: true, deleteData: true }),
+    );
+
+    expect(existsSync(join(root, 'profiles', 'broken'))).toBe(false);
+    expect(existsSync(join(root, 'profiles', 'personal', 'profile.yaml'))).toBe(true);
+
+    // Non-zero, because nothing could be read: this removal cannot say whether
+    // one of the refs it left behind was the profile's own. That is a different
+    // outcome from the test above and must not share its exit code.
+    expect(process.exitCode).toBe(1);
+    process.exitCode = before;
+  });
+
+  /**
+   * The hazard the structural split exists to prevent.
+   *
+   * Catching `ConfigError` around the resolution would have been the small
+   * change, and it would have read "you typed the wrong workspace" as "this
+   * profile is broken" — then run a degraded removal to completion under
+   * `--yes --delete-data`, in a workspace nobody meant. `locateProfile` catches
+   * only the parse, so everything before it throws exactly as it always did.
+   */
+  test('a workspace that is not declared still refuses, and removes nothing', async () => {
+    const root = await workspace(REFUSED_NAME);
+
+    await expect(
+      removeProfile('broken', { target: 'nowhere', yes: true, deleteData: true }),
+    ).rejects.toThrow(/nowhere/);
+
+    expect(existsSync(join(root, 'profiles', 'broken', 'profile.yaml'))).toBe(true);
+    expect(existsSync(join(root, 'profiles', 'personal', 'profile.yaml'))).toBe(true);
+  });
+
+  test('a profile that does not exist still refuses, and removes nothing', async () => {
+    const root = await workspace(REFUSED_NAME);
+
+    await expect(
+      removeProfile('ghost', { target: 'local', yes: true, deleteData: true }),
+    ).rejects.toThrow(/ghost/);
+
+    expect(existsSync(join(root, 'profiles', 'broken', 'profile.yaml'))).toBe(true);
+    expect(existsSync(join(root, 'profiles', 'personal', 'profile.yaml'))).toBe(true);
+  });
+
+  test('--migrate-to is refused, and nothing has run when it is', async () => {
+    const root = await workspace(REFUSED_NAME);
+
+    await expect(
+      removeProfile('broken', { target: 'local', yes: true, migrateTo: 'personal' }),
+    ).rejects.toThrow(/will not move its bytes/);
+
+    expect(existsSync(join(root, 'profiles', 'broken', 'profile.yaml'))).toBe(true);
+    expect(existsSync(join(root, 'profiles', 'personal', 'profile.yaml'))).toBe(true);
+  });
+});

--- a/src/cli/commands/relabel.ts
+++ b/src/cli/commands/relabel.ts
@@ -62,7 +62,7 @@ export async function renameConnection(
     document.setIn(['connections', located.index, 'label'], label);
     await document.save();
 
-    await recordConfigChange(config, root, target, {
+    await recordConfigChange(config.instance.profile, root, target, {
       capability: 'config.connection.relabel',
       scope: target,
       connection: key,

--- a/src/cli/config-repair-sweep.ts
+++ b/src/cli/config-repair-sweep.ts
@@ -8,7 +8,7 @@ import {
 } from '#profile';
 import { newConnectionsTemplate } from './config-templates.ts';
 import { ConfigDocument } from './config-edit.ts';
-import { ok, print, style, warn } from './output.ts';
+import { ok, print, reasonOf, style, warn } from './output.ts';
 import { DEFAULT_SURFACES, ensureOwnerLayer, repairLines, repaired } from './config-repair.ts';
 
 /**
@@ -66,23 +66,6 @@ export async function ensureRegistryContract(
   document.setIn(['contract'], contract);
   await document.save();
   return true;
-}
-
-/**
- * The first line of an error that actually says something.
- *
- * `message.split('\n')[0]` was the whole of this, and a `ConfigError` from a
- * schema failure is `<path>:\n  <field>: <reason>` — so the warning rendered as
- * "could not give personal its owner layer: /…/personal.yaml:" and named no
- * reason at all. Seen for real on an upgrade, twice, with nothing after the
- * colon.
- */
-function reasonOf(error: unknown): string {
-  if (!(error instanceof Error)) return String(error);
-
-  const lines = error.message.split('\n').map((line) => line.trim());
-  const said = lines.find((line) => line !== '' && !line.endsWith(':'));
-  return said ?? lines.find((line) => line !== '') ?? error.message;
 }
 
 /** `memory, tasks, assets, skills, vault, setup and entities`, in repair order. */

--- a/src/cli/output.ts
+++ b/src/cli/output.ts
@@ -341,3 +341,24 @@ export function table(rows: ReadonlyArray<readonly string[]>): void {
 export const ok = (text: string) => `${style.green('ok')}    ${text}`;
 export const warn = (text: string) => `${style.yellow('warn')}  ${text}`;
 export const fail = (text: string) => `${style.red('fail')}  ${text}`;
+
+/**
+ * The first line of an error that actually says something.
+ *
+ * `message.split('\n')[0]` was the whole of this, and a `ConfigError` from a
+ * schema failure is `<path>:\n  <field>: <reason>` — so a warning rendered as
+ * "could not give personal its owner layer: /…/personal.yaml:" and named no
+ * reason at all. Seen for real on an upgrade, twice, with nothing after the
+ * colon.
+ *
+ * Promoted out of `config-repair-sweep.ts` when `removalSubject` became the
+ * second caller that has to squash a `ConfigError` into one line an operator
+ * can read. Two copies of this is the failure above, waiting.
+ */
+export function reasonOf(error: unknown): string {
+  if (!(error instanceof Error)) return String(error);
+
+  const lines = error.message.split('\n').map((line) => line.trim());
+  const said = lines.find((line) => line !== '' && !line.endsWith(':'));
+  return said ?? lines.find((line) => line !== '') ?? error.message;
+}

--- a/src/cli/publish.ts
+++ b/src/cli/publish.ts
@@ -61,7 +61,18 @@ export interface PublishOutcome {
  * should read has landed would reload the previous config and report success.
  */
 export async function publishAndNotify(input: {
-  readonly config: Config;
+  /**
+   * Absent where the profile's config would not load (#219).
+   *
+   * `publishWorkspace` never reads it — it copies what the local store holds —
+   * and `notifyReload` wants it only for `localUrl`, the last of three answers
+   * to "where is the endpoint" and the one that only applies when nothing is
+   * recorded as running. So a removal whose config would not parse still
+   * publishes and still notifies a deployed target or a recorded local one,
+   * which is exactly when the notify matters most: the endpoint may be serving
+   * that profile right now from a config that parsed at its last boot.
+   */
+  readonly config?: Config | undefined;
   readonly workspaceRoot: string;
   readonly target: string;
   /** Every profile the edit touched. See `publishWorkspace`. */
@@ -108,7 +119,8 @@ export function publishRuntimeEdit(runtime: Runtime): Promise<PublishOutcome> {
  */
 export async function publishProfileEdit(input: {
   readonly resolution: { readonly workspaceRoot: string; readonly profile: string };
-  readonly config: Config;
+  /** Absent where the profile's config would not load — see `publishAndNotify`. */
+  readonly config?: Config | undefined;
   readonly target: string;
   /** Every profile the edit touched, where it reached more than the one named. */
   readonly touched?: readonly string[] | undefined;
@@ -126,7 +138,7 @@ export async function publishProfileEdit(input: {
 
 /** Ask a running endpoint to re-read its config. Never throws. */
 async function notifyReload(input: {
-  readonly config: Config;
+  readonly config?: Config | undefined;
   readonly workspaceRoot: string;
   readonly target: string;
   /**
@@ -160,7 +172,19 @@ async function notifyReload(input: {
     const { declared } = await openTarget(input.workspaceRoot, input.target);
     const deployed = await deployedUrl(declared.deploy);
     const recorded = deployed ? null : await readEndpointRecord(input.workspaceRoot);
-    const base = deployed ?? recorded?.url ?? localUrl(input.config);
+    const local = input.config ? localUrl(input.config) : null;
+    const base = deployed ?? recorded?.url ?? local;
+
+    // Nothing deployed, nothing recorded, and no config to derive a port from.
+    // There is no endpoint to tell, and saying so is better than guessing at a
+    // port — this is only reachable from a removal whose config would not load.
+    if (base === null) {
+      return {
+        served: false,
+        reason:
+          'nothing is recorded as listening for this workspace, so there is no endpoint to tell',
+      };
+    }
     url = base.replace(/\/mcp$/, '/reload');
   } catch (error) {
     return { served: false, reason: `could not work out where the endpoint is: ${message(error)}` };

--- a/src/cli/runtime.ts
+++ b/src/cli/runtime.ts
@@ -21,8 +21,10 @@ export {
   openSecretStoreFor,
   ownerPrincipal,
   resolveProfile,
+  locateProfile,
   resolveProfileOnly,
   type GlobalFlags,
+  type LocatedProfile,
 } from './runtime/select.ts';
 
 export {

--- a/src/cli/runtime/open.ts
+++ b/src/cli/runtime/open.ts
@@ -30,6 +30,7 @@ import {
   openSecrets,
   openStorage,
   type StorageFactory,
+  targetInput,
   type TargetInput,
 } from '#deployments/target.ts';
 import { knowledgeRoutes, openKnowledge, type FetchLike, type KnowledgeStores } from '#deployments/knowledge.ts';
@@ -95,7 +96,7 @@ export async function openRuntime(
 
   const declared = resolved.declared;
   const root = resolved.workspaceRoot;
-  const adapters: TargetInput = { declared, config, root, target };
+  const adapters: TargetInput = targetInput({ declared, config, root, target });
 
   // The workspace's accounts, and the check that this profile's grants name
   // real ones (ADR-057). Read here rather than inside `resolveProfile` because

--- a/src/cli/runtime/select.test.ts
+++ b/src/cli/runtime/select.test.ts
@@ -47,7 +47,7 @@ describe('openBlobStoreFor', () => {
   test('opens the target storage, rooted where the layout says', async () => {
     const root = await workspace();
 
-    const store = await openBlobStoreFor(config(), root, 'local');
+    const store = await openBlobStoreFor(config().instance.profile, root, 'local');
     await store.put('note.txt', new TextEncoder().encode('x'));
 
     expect((await store.list()).map((blob) => blob.key)).toContain('note.txt');
@@ -59,8 +59,8 @@ describe('openBlobStoreFor', () => {
     // needs a store that is not rooted at `data/<profile>`.
     const root = await workspace();
 
-    const own = await openBlobStoreFor(config(), root, 'local');
-    const elsewhere = await openBlobStoreFor(config(), root, 'local', 'profiles');
+    const own = await openBlobStoreFor(config().instance.profile, root, 'local');
+    const elsewhere = await openBlobStoreFor(config().instance.profile, root, 'local', 'profiles');
 
     await own.put('a.txt', new TextEncoder().encode('x'));
 
@@ -74,7 +74,7 @@ describe('openBlobStoreFor', () => {
     // any profile that declares somewhere else.
     const root = await workspace('elsewhere/mine');
 
-    const store = await openBlobStoreFor(config(), root, 'local');
+    const store = await openBlobStoreFor(config().instance.profile, root, 'local');
     await store.put('note.txt', new TextEncoder().encode('x'));
 
     expect(existsSync(join(root, 'elsewhere/mine/note.txt'))).toBe(true);
@@ -84,6 +84,6 @@ describe('openBlobStoreFor', () => {
   test('refuses a target the workspace does not declare', async () => {
     const root = await workspace();
 
-    await expect(openBlobStoreFor(config(), root, 'cloud')).rejects.toThrow(/cloud/);
+    await expect(openBlobStoreFor(config().instance.profile, root, 'cloud')).rejects.toThrow(/cloud/);
   });
 });

--- a/src/cli/runtime/select.ts
+++ b/src/cli/runtime/select.ts
@@ -1,4 +1,4 @@
-import { generateProfileToken, ownerPrincipal } from '#auth';
+import { ownerPrincipal } from '#auth';
 import type { SecretStore } from '#secrets';
 import type { BlobStore } from '#stores/blobs';
 import {
@@ -10,6 +10,7 @@ import {
   resolveWorkspaceRoot,
   requireTarget,
   type Config,
+  type LoadedConfig,
   type ProfileSelection,
   type ResolvedTarget,
   type Resolution,
@@ -106,6 +107,53 @@ export async function resolveProfileOnly(
   flags: GlobalFlags,
   options: { env?: Record<string, string | undefined> } = {},
 ): Promise<{ selection: ProfileSelection; config: Config; target: string }> {
+  const found = await locateProfile(flags, options);
+  if (found.loaded === null) throw found.refusal;
+
+  return { selection: found.selection, config: found.loaded.config, target: found.target };
+}
+
+/**
+ * The profile that was named, and the config only if it would load.
+ *
+ * `resolveProfileOnly` above is this plus a rethrow, and that is the whole
+ * point: one resolution path, so the caller that has to survive a config which
+ * will not parse cannot drift from the eight that do not.
+ *
+ * **It exists because catching around `resolveProfileOnly` is not safe.**
+ * `ConfigError` comes out of that call for a missing `--workspace`, a target
+ * the registry does not declare, a pointer chain that will not follow, a
+ * contract-3 layout, and a profile that is simply not there — as well as for
+ * the parse. A `try` around the whole thing would read "you typed the wrong
+ * workspace" as "this profile is broken", and `profile remove --yes
+ * --delete-data` would then run a removal to completion in a workspace nobody
+ * meant. Everything up to and including `resolveSelection` therefore still
+ * throws exactly as it did; only the parse is caught, and only here.
+ *
+ * `resolveSelection` never reads a profile's config — it asks the workspace
+ * whether the file exists — which is the property that makes this split
+ * possible at all, and the same one `migratedRenamedProviders` relies on.
+ *
+ * `refusal` is `unknown` so it can be rethrown verbatim: a `ConfigError`
+ * carries `findings`, and re-wrapping it would drop them.
+ */
+export type LocatedProfile =
+  | {
+      readonly selection: ProfileSelection;
+      readonly target: string;
+      readonly loaded: LoadedConfig;
+    }
+  | {
+      readonly selection: ProfileSelection;
+      readonly target: string;
+      readonly loaded: null;
+      readonly refusal: unknown;
+    };
+
+export async function locateProfile(
+  flags: GlobalFlags,
+  options: { env?: Record<string, string | undefined> } = {},
+): Promise<LocatedProfile> {
   const env = options.env !== undefined ? { env: options.env } : {};
   const localRoot = resolveWorkspaceRoot(env);
   const registry = await readRegistry(localRoot);
@@ -113,9 +161,12 @@ export async function resolveProfileOnly(
   const root = await resolveTargetWorkspace(localRoot, target);
 
   const selection = await resolveSelection({ profileFlag: flags.profile, root, ...env });
-  const { config } = await loadProfileConfig(root, selection.profile);
 
-  return { selection, config, target };
+  try {
+    return { selection, target, loaded: await loadProfileConfig(root, selection.profile) };
+  } catch (refusal) {
+    return { selection, target, loaded: null, refusal };
+  }
 }
 
 /**
@@ -145,16 +196,23 @@ export async function openSecretStoreFor(root: string, target: string): Promise<
  * profile's blob tree; `profiles` is where a deployed revision reads its config
  * from (ADR-023), which lives outside that tree and still belongs to the
  * profile being removed.
+ *
+ * **A name, not the config it is written in.** The name is the whole of what
+ * reaches the store — `layout.blobs(profile)` is the default area and nothing
+ * else was ever read — and taking a `Config` for it meant a removal could not
+ * open the stores of the one profile it most needs to: the one whose config
+ * will not parse (#219). `openSecrets` above was narrowed for the same reason
+ * and says so; this is that argument applied to the other store.
  */
 export async function openBlobStoreFor(
-  config: Config,
+  profile: string,
   root: string,
   target: string,
   area?: string,
 ): Promise<BlobStore> {
   const resolved = await openTarget(root, target);
 
-  const input = { declared: resolved.declared, config, root: resolved.workspaceRoot, target };
+  const input = { declared: resolved.declared, profile, root: resolved.workspaceRoot, target };
   const storage = await openStorage(input, await openSecrets(input));
   return area === undefined ? storage() : storage(area);
 }

--- a/src/deployments/grants.test.ts
+++ b/src/deployments/grants.test.ts
@@ -102,7 +102,7 @@ beforeAll(async () => {
 
   try {
     const storage = await openStorage(
-      { declared: target, config, root: '/nowhere', target: 'cloud' },
+      { declared: target, profile: config.instance.profile, root: '/nowhere', target: 'cloud' },
       {} as SecretStore,
     );
 

--- a/src/deployments/target.ts
+++ b/src/deployments/target.ts
@@ -32,11 +32,46 @@ import { createBlobAuditStore } from './adapters/audit-blob.ts';
  * cannot fail a `lanes link start` that was never going to talk to Google.
  */
 
-export interface TargetInput {
+/**
+ * What opening a store needs, without the config it used to be read out of.
+ *
+ * `openStorage` reads exactly one thing off a profile — its *name*, to work out
+ * whose blob root an omitted `area` means. Taking the whole `Config` for that
+ * is what stopped a removal opening the store of a profile whose config will
+ * not parse (#219), because there was no config to hand it and synthesising one
+ * meant inventing a name.
+ *
+ * The narrowing is the one `openSecrets` below already made, for the same
+ * reason it gives: a caller that must work while the file on disk will not
+ * parse cannot be asked for the parsed file. Keep them the same shape.
+ */
+export interface StorageInput {
+  readonly declared: TargetConfig;
+  readonly root: string;
+  readonly target: string;
+  /** Whose blob root an omitted `area` means. */
+  readonly profile: string;
+}
+
+export interface TargetInput extends StorageInput {
+  readonly config: Config;
+}
+
+/**
+ * A `TargetInput` from the two things that used to disagree.
+ *
+ * `profile` and `config.instance.profile` are the same fact written twice, and
+ * the whole value of narrowing `openStorage` is lost if a caller can set them
+ * to different strings. Every construction site goes through here so they
+ * cannot.
+ */
+export function targetInput(input: {
   readonly declared: TargetConfig;
   readonly config: Config;
   readonly root: string;
   readonly target: string;
+}): TargetInput {
+  return { ...input, profile: input.config.instance.profile };
 }
 
 /**
@@ -214,15 +249,15 @@ function parseHeaders(raw: string, ref: string): Record<string, string> {
 }
 
 export async function openStorage(
-  input: TargetInput,
+  input: StorageInput,
   secrets: SecretStore,
 ): Promise<StorageFactory> {
-  const { declared, config, root, target } = input;
+  const { declared, profile, root, target } = input;
 
   switch (declared.storage.adapter) {
     case 'filesystem': {
       const { createFilesystemBlobStore } = await import('./adapters/filesystem.ts');
-      const base = declared.storage.path ?? layout.blobs(config.instance.profile);
+      const base = declared.storage.path ?? layout.blobs(profile);
       return (area) =>
         createFilesystemBlobStore({ root: workspacePath(root, area === undefined ? base : area) });
     }
@@ -240,7 +275,7 @@ export async function openStorage(
 
       const { createGcsBlobStore } = await import('./adapters/gcs.ts');
       const base = prefix ?? '';
-      const root = layout.blobs(config.instance.profile);
+      const root = layout.blobs(profile);
 
       return (area) =>
         createGcsBlobStore({
@@ -270,7 +305,7 @@ export async function openStorage(
 
       const { createS3BlobStore } = await import('./adapters/s3.ts');
       const base = prefix ?? '';
-      const root = layout.blobs(config.instance.profile);
+      const root = layout.blobs(profile);
 
       return (area) =>
         createS3BlobStore({

--- a/src/deployments/upload.ts
+++ b/src/deployments/upload.ts
@@ -177,7 +177,16 @@ export async function uploadWorkspace(
  * surprise nobody asked for.
  */
 export async function publishWorkspace(input: {
-  readonly config: Config;
+  /**
+   * Unused, and optional for the caller that has none.
+   *
+   * This copies what the local store holds rather than anything off a parsed
+   * config, and always has. Keeping the parameter required meant a removal
+   * could not publish for a profile whose config would not load (#219) — which
+   * is the removal whose publish matters most, because the endpoint may be
+   * serving that profile from a config that parsed at its last boot.
+   */
+  readonly config?: Config | undefined;
   readonly workspaceRoot: string;
   readonly target: string;
   /**

--- a/src/profile/connections.ts
+++ b/src/profile/connections.ts
@@ -268,8 +268,29 @@ export function vaultRef(declared: TargetConfig | undefined, config: Config): st
   //
   // A `ref` the target states outright still wins: a deployment already sealing
   // under one name has to keep opening it.
-  const connection = soleGrantFor(config, 'lanes_vault') ?? 'main';
-  return declared?.vault?.ref ?? `vault/${config.instance.profile}/${connection}`;
+  return sealedVaultRef(declared, config.instance.profile, soleGrantFor(config, 'lanes_vault'));
+}
+
+/**
+ * The same name, for a caller holding a profile and a connection.
+ *
+ * `vaultRef` above is this with both read off a `Config`, and it delegates
+ * rather than respelling the pattern for the reason its own docstring records:
+ * two derivations of this name once disagreed and cost every deployed workspace
+ * its vault. There is one spelling, and it is here.
+ *
+ * The caller that cannot use `vaultRef` is a removal working from a config that
+ * will not parse (#219) — it has the profile's name and, where the file could
+ * still be read as YAML, the granted connection. `null` for the connection is
+ * "the file did not say", which falls back to `main` exactly as an absent grant
+ * does.
+ */
+export function sealedVaultRef(
+  declared: TargetConfig | undefined,
+  profile: string,
+  connection: string | null | undefined,
+): string {
+  return declared?.vault?.ref ?? `vault/${profile}/${connection ?? 'main'}`;
 }
 
 /**

--- a/src/profile/index.ts
+++ b/src/profile/index.ts
@@ -52,6 +52,7 @@ export {
   sameAccount,
   selectConnections,
   soleGrantFor,
+  sealedVaultRef,
   vaultRef,
   type SelectedConnection,
 } from './connections.ts';


### PR DESCRIPTION
Closes #219 — the half [#220](https://github.com/lanes-sh/link/pull/220) left open.

`profile remove` resolved the profile before acting, so a `profile.yaml` the loader refuses could be listed and never taken away. `doctor --fix` failed on the same parse, and `listProfiles` reads directory names rather than configs — so it stayed listed like any other profile, and the only way out was deleting the file by hand, or the bucket object on a deployed workspace.

The name guard in #220 stops the CLI creating one. It does nothing for the ones already on disk, and it covers one cause out of several — a hand edit, an interrupted write, or a contract the installed version does not recognise all end in the same place.

Before:

```console
$ lanes link profile remove my-profile --workspace local --yes --delete-data
error  /tmp/repro/profiles/my-profile/profile.yaml:
  instance.profile: must be lowercase letters, digits, and underscores, starting with a letter
```

After — the case #219 actually produces, where the file is perfect YAML whose only fault is the name, so every field reads and the plan is identical to a parsed one:

```console
$ lanes link profile remove my-profile --workspace local --dry-run --delete-data
Removing profile my-profile would delete:

warn  profiles/my-profile/profile.yaml will not load, so this is working from what could be read of it:
        instance.profile  my-profile
        vault connection  lan5
        authorization     no client id declared
        knowledge         not declared
      Everything below was found by listing the stores, not by reading that
      file. What a config that will not load costs is a line that is missing
      here, never one that is wrong.
      What refused it: instance.profile: must be lowercase letters, digits, and underscores, starting with a letter

  local
    object     profiles/my-profile/lanes_memory/lan1/note.md
    file       profiles/my-profile — the profile directory, once emptied
  workspace
    config     /tmp/repro/profiles/my-profile/profile.yaml
```

## What makes it safe

**A gap shrinks the plan and can never widen it.** Refs are derived from what the profile declares and then intersected with what the store holds, so a field that could not be read declares nothing — the removal deletes less than it might have, never somebody else's credential. `RemovalSubject` makes the closed set a type rather than a docstring, so a fifth field cannot be added without confronting the degraded reader beside it.

**The directory's name is authoritative, the file's `instance.profile` is not.** `layout.blobs(profile)` addresses the blob tree, so a hand-edited value reaching it would let `profile remove my_profile` empty `profiles/other/`. Where the two disagree, the sealed-vault ref is reported unreachable rather than guessed at.

**The decision point is a split, not a `catch`.** `ConfigError` comes out of profile resolution for a missing `--workspace`, an undeclared target, a pointer chain, a contract-3 layout and a profile that is not there — as well as for the parse. A `try` around the whole thing would read "you typed the wrong workspace" as "this profile is broken" and, under `--yes --delete-data`, run to completion somewhere nobody meant. `locateProfile` catches only the parse; `resolveProfileOnly` is three lines on top of it. Two tests hold that door shut.

**Exit 0 iff nothing was left, not iff the config parsed.** The #219 profile leaves nothing, so reporting failure would mean the cleanup script that hit the bug still fails — on a profile that is gone. A wholly unreadable file exits 1 and names what it could not see, saying that re-running will not help, because unlike a failed item there is no config left to re-derive from.

**`--migrate-to` is refused** — not because the mechanics fail, but on blast radius. `--delete-data` fails toward having deleted less than it should; migrating fails toward putting unaccounted-for bytes into a profile that is currently correct, with nothing to undo it.

## The cascade

Three functions took a whole `Config` to read the profile's name, or nothing at all — `openStorage`, `recordConfigChange`, `publishWorkspace` — and that is what stopped a removal opening the stores, writing the audit row and telling the endpoint. Each now takes a name. This is the narrowing `openSecrets` already made, for the reason its own docstring gives: *"Narrowing the parameter is what lets a migration open it, which it must be able to do while the profiles on disk … will not parse."*

The endpoint is still notified, and it matters **more** here: the served set is built at boot and at `/reload` and nowhere else, so a config that will not load today may have loaded at the last boot and be serving right now, from memory, with live credentials.

`removalPlan`'s `registry` parameter is dropped — it was dead, along with two of its imports.

## Not in this change

`doctor --fix` still refuses a profile it cannot parse. Repairing one means rewriting `instance.profile` or renaming its directory, which is a choice about the operator's data rather than a deletion. Separate argument.

## Testing

`bun test` (3650 pass, 0 fail — 16 new) and `bun run typecheck` green. Verified end-to-end against real scratch workspaces: the #219 document removes cleanly at exit 0 with the sibling untouched; a file that is not valid YAML removes at exit 1 with what it could not see named; `--workspace nowhere` and a nonexistent profile both still throw and remove nothing.

ADR-078 records the decision.