### PR TITLE
One CORS decision, and a refresh that names nobody stops rather than looping

### DIFF
--- a/docs/detailed/adr/079-the-dashboard-credential-names-a-person.md
+++ b/docs/detailed/adr/079-the-dashboard-credential-names-a-person.md
@@ -94,12 +94,20 @@ calling*, and there was already exactly one place that answers.
 
 Two things follow, and both are small:
 
-**`/register` and `/token` need CORS.** Every client before this was
-server-side or native — a connector calls both from its own backend, and
-`/authorize` and the callback are top-level navigations that carry no `Origin`.
-A page's `fetch` is not exempt, so without a grant the flow fails at
-registration with an opaque network error. They take `READ_ORIGINS`, the same
-list the reads take, imported rather than restated.
+**The authorization paths already had the CORS they need**, and this is worth
+recording because it was got wrong first. `cors.ts`'s `surfaceOf` has always
+classified them `public` and answered with a wildcard, for a reason stated
+there: they answer without a credential by design, so a wildcard hands a page
+exactly what `curl` already has. A second, *named* grant was written into
+`oauth.ts` for the dashboard's sake, and it was redundant on every bind where
+`corsAware` runs — which overwrote it — and needed on exactly one bind, the
+loopback read listener, which does not run `corsAware` at all. So the listener
+wraps its handler in `corsAware` instead, and there is still one CORS decision
+in the codebase rather than two.
+
+The reads keep their own *named* grant, and the contrast is the point: an
+authorization document is public, while `/state` returns every connection,
+profile and audit entry the workspace holds.
 
 **On loopback the authorization paths ride the TLS read port.** A page on
 `https://lanes.sh` cannot fetch `http://127.0.0.1:7337/register` — mixed

--- a/src/auth/oauth/grant.ts
+++ b/src/auth/oauth/grant.ts
@@ -75,6 +75,27 @@ export async function refresh(
     return invalid('invalid_grant', 'That refresh token is unknown or expired.');
   }
 
+  // **A chain that cannot name its holder ends here** (ADR-079). `who` carries
+  // `subject` only when the record has one, so a refresh minted before subjects
+  // existed would rotate into a *new* access token with no subject — which
+  // `IssuedTokenAuthenticator` refuses. The client then sees a `200` from this
+  // endpoint followed by a `401` on every call it makes with what it was just
+  // given, retries the refresh, and gets the same pair again. That presents as
+  // a connector stuck in a loop rather than as one that needs signing in, which
+  // is what happened to the first connector this shipped to.
+  //
+  // Refused here instead, and `invalid_grant` is the right code: it is the one
+  // answer that tells a client to discard the grant and start the authorization
+  // flow again, which is exactly the single step that fixes this.
+  if (record.subject === undefined) {
+    context.log?.warn('refresh token names nobody', { clientId: record.clientId, family: record.family });
+    return invalid(
+      'invalid_grant',
+      'That authorization was granted before this endpoint recorded who a token belongs to. ' +
+        'Sign in again to replace it.',
+    );
+  }
+
   // A spent token presented again used to take its whole family with it, on
   // the reading that a replay is a theft. Against a real connector that was
   // wrong twice over, and ADR-035 has the evidence. Two answers replace it,

--- a/src/server/oauth.test.ts
+++ b/src/server/oauth.test.ts
@@ -1,5 +1,5 @@
 import { afterAll, beforeAll, describe, expect, test } from 'bun:test';
-import { pkceChallengeFor } from '#auth';
+import { OAuthStore, pkceChallengeFor } from '#auth';
 import { allocatePort, startHarness, STRANGER, TEST_TOKEN, type Harness } from './harness.ts';
 
 /**
@@ -781,5 +781,78 @@ describe('the static token still works', () => {
     });
 
     expect(await response.json()).toMatchObject({ reason: 'invalid' });
+  });
+});
+
+/**
+ * A grant made before this endpoint recorded who a token belongs to.
+ *
+ * `IssuedTokenAuthenticator` refuses a subject-less access token (ADR-079), and
+ * `who` carries `subject` only when the record has one — so without the check
+ * below a legacy refresh rotates cleanly into a token that is refused on every
+ * call. The client sees a `200` here, a `401` on the next request, retries, and
+ * gets the same pair again: a connector stuck in a loop rather than one that
+ * needs signing in. That is what the first real connector this shipped to did.
+ *
+ * `invalid_grant` is the answer because it is the one code that tells a client
+ * to discard the grant and start the authorization flow, which is the single
+ * step that fixes it.
+ */
+describe('a refresh token that names nobody', () => {
+  /** A record as 0.7 wrote them: a family, a scope, and no subject. */
+  async function legacyRefresh(clientId: string): Promise<string> {
+    // On the harness's clock, not the wall's: earlier tests move `skewMs`
+    // forward past the reuse window, so a record stamped from `Date.now()`
+    // alone reads as already expired and the refusal under test never runs.
+    const store = new OAuthStore(harness.state.kv, () => Date.now() + skewMs);
+    const token = 'llr_a_grant_from_before_subjects';
+
+    await store.putToken(token, {
+      clientId,
+      kind: 'refresh',
+      scope: 'mcp',
+      family: 'llf_legacy',
+      expiresAt: Date.now() + skewMs + 600_000,
+    });
+
+    return token;
+  }
+
+  test('is refused, rather than rotated into a token that cannot be used', async () => {
+    const clientId = await register();
+
+    const response = await tokenRequest({
+      grant_type: 'refresh_token',
+      refresh_token: await legacyRefresh(clientId),
+      client_id: clientId,
+    });
+
+    expect(response.status).toBe(400);
+    const body = (await response.json()) as { error?: string; error_description?: string };
+    expect(body.error).toBe('invalid_grant');
+    // The message has to say what to do, because the client cannot work it out:
+    // nothing about a rotation that succeeds explains a 401 on the next call.
+    expect(body.error_description).toContain('Sign in again');
+  });
+
+  test('a refresh that does name somebody still rotates', async () => {
+    // The other half, so the check above cannot be passing for the wrong reason.
+    const clientId = await register();
+    const first = await tokenRequest({
+      grant_type: 'authorization_code',
+      code: await codeFrom(await authorise(clientId)),
+      client_id: clientId,
+      code_verifier: VERIFIER,
+      redirect_uri: REDIRECT,
+    });
+    const { refresh_token } = (await first.json()) as { refresh_token: string };
+
+    const rotated = await tokenRequest({
+      grant_type: 'refresh_token',
+      refresh_token,
+      client_id: clientId,
+    });
+
+    expect(rotated.status).toBe(200);
   });
 });

--- a/src/server/oauth.ts
+++ b/src/server/oauth.ts
@@ -5,8 +5,6 @@ import {
   type OAuthServer,
 } from '#auth';
 import { noticePage } from '#cli/callback-page.ts';
-import { cors } from './read/http.ts';
-import { READ_ORIGINS } from './read/routes.ts';
 
 /**
  * The HTTP surface of the authorization flow.
@@ -96,37 +94,6 @@ export function resourceMetadataUrl(request: Request): string {
   return `${publicOrigin(request)}${PROTECTED_RESOURCE_PATH}`;
 }
 
-/**
- * The two paths a browser client calls with `fetch`, and so the two that need CORS.
- *
- * Until ADR-079 every client here was server-side or native: a connector calls
- * `/register` and `/token` from its own backend, and `/authorize` and the
- * callback are top-level navigations that carry no `Origin` and need no grant.
- * The dashboard is the first client that is a *page*, and a page's `fetch` is
- * subject to the same-origin policy — so without this the flow fails at
- * registration with an opaque network error rather than a refusal.
- *
- * The metadata documents are deliberately not in the set. They are public by
- * design (a client reads them before it holds anything) and are fetched
- * cross-origin without a grant.
- */
-const BROWSER_PATHS: readonly string[] = [REGISTER_PATH, TOKEN_PATH];
-
-/**
- * The origins allowed to drive the flow from a page.
- *
- * The same list the read surface uses, imported rather than restated: the
- * dashboard is the one page that does either of these, so two lists would be
- * two places to add the next origin and one place to forget it.
- */
-function browserGrant(request: Request, path: string): Record<string, string> {
-  if (!BROWSER_PATHS.includes(path)) return {};
-
-  const origin = request.headers.get('origin');
-  const allowed = origin !== null && READ_ORIGINS.includes(origin);
-  return cors(origin, allowed, 'POST, OPTIONS', 'authorization, content-type');
-}
-
 export async function handleAuthorization(
   request: Request,
   surface: AuthorizationSurface,
@@ -135,15 +102,6 @@ export async function handleAuthorization(
   const origin = publicOrigin(request);
   const path = url.pathname;
 
-  // Answered before anything reads the request, because a preflight carries no
-  // body and no credential — that is what it is for.
-  if (request.method === 'OPTIONS' && BROWSER_PATHS.includes(path)) {
-    const grant = browserGrant(request, path);
-    // `cors` returns `Vary: Origin` even on a refusal, so the presence of the
-    // allow header — not of any header — is what says the origin was named.
-    const named = grant['access-control-allow-origin'] !== undefined;
-    return new Response(null, { status: named ? 204 : 403, headers: grant });
-  }
 
   // Both spellings: the bare document, and the one suffixed with the resource's
   // own path, which is what a client probes first when the `401` pointed it
@@ -169,10 +127,7 @@ export async function handleAuthorization(
   if (!server) return new Response('Not found', { status: 404 });
 
   if (path === REGISTER_PATH && request.method === 'POST') {
-    return withHeaders(
-      render(await server.register(await safeJson(request)), request),
-      browserGrant(request, path),
-    );
+    return render(await server.register(await safeJson(request)), request);
   }
 
   // Who this endpoint is, from the point of view of *this* request. Derived
@@ -196,10 +151,7 @@ export async function handleAuthorization(
   }
 
   if (path === TOKEN_PATH && request.method === 'POST') {
-    return withHeaders(
-      render(await server.token(new URLSearchParams(await request.text())), request),
-      browserGrant(request, path),
-    );
+    return render(await server.token(new URLSearchParams(await request.text())), request);
   }
 
   return new Response('Method not allowed', { status: 405 });
@@ -240,24 +192,5 @@ function json(body: unknown, status = 200): Response {
       // and it is the default for a POST anyway.
       'cache-control': 'no-store',
     },
-  });
-}
-
-/**
- * Add headers to a response without rebuilding it.
- *
- * `render` decides status and body; this decides who may read the result. Kept
- * apart so the CORS grant cannot change either — a helper that reconstructed
- * the response would have to know about every `OAuthResult` kind.
- */
-function withHeaders(response: Response, headers: Record<string, string>): Response {
-  if (Object.keys(headers).length === 0) return response;
-
-  const merged = new Headers(response.headers);
-  for (const [name, value] of Object.entries(headers)) merged.set(name, value);
-  return new Response(response.body, {
-    status: response.status,
-    statusText: response.statusText,
-    headers: merged,
   });
 }

--- a/src/server/read/listener.test.ts
+++ b/src/server/read/listener.test.ts
@@ -331,7 +331,13 @@ describe('signing in is reachable from the browser', () => {
     expect(await response.json()).toMatchObject({ resource: `${base}/mcp` });
   });
 
-  test('a preflight on /register from the dashboard is granted', async () => {
+  test('a preflight on /register is granted, without naming an origin', async () => {
+    // **Wildcarded, and that is `corsAware`'s long-standing answer for this
+    // surface** (`cors.ts`, `surfaceOf`): these paths answer without a
+    // credential by design, so a wildcard hands a page exactly what `curl`
+    // already has. Reusing it is what keeps one CORS decision in the codebase
+    // rather than two — a second, named grant written for this bind was tried
+    // and was redundant everywhere `corsAware` runs.
     const response = await fetch(`${base}/register`, {
       method: 'OPTIONS',
       headers: { origin: ORIGIN, 'access-control-request-method': 'POST' },
@@ -339,34 +345,45 @@ describe('signing in is reachable from the browser', () => {
     } as RequestInit);
 
     expect(response.status).toBe(204);
-    expect(response.headers.get('access-control-allow-origin')).toBe(ORIGIN);
-    // Never a wildcard, never ambient — the same two the reads hold.
+    expect(response.headers.get('access-control-allow-origin')).toBe('*');
+    // Never ambient, wildcard or not: with `*` a browser refuses to send
+    // credentials anyway, and the header is absent so nothing relies on that.
     expect(response.headers.get('access-control-allow-credentials')).toBeNull();
   });
 
-  test('a preflight from anywhere else is refused, and told nothing', async () => {
-    const response = await fetch(`${base}/token`, {
-      method: 'OPTIONS',
-      headers: { origin: HOSTILE, 'access-control-request-method': 'POST' },
+  test('the reads are named, so the two surfaces are graded differently', async () => {
+    // The contrast worth pinning. `/register` is public and wildcarded; `/state`
+    // returns every connection, profile and audit entry this workspace holds,
+    // so it names one origin and echoes it.
+    const permitted = await fetch(`${base}/state`, {
+      headers: { origin: ORIGIN },
       tls: { rejectUnauthorized: false },
     } as RequestInit);
 
-    expect(response.status).toBe(403);
-    expect(response.headers.get('access-control-allow-origin')).toBeNull();
+    expect(permitted.headers.get('access-control-allow-origin')).toBe(ORIGIN);
+
+    const refused = await fetch(`${base}/state`, {
+      headers: { origin: HOSTILE },
+      tls: { rejectUnauthorized: false },
+    } as RequestInit);
+
+    expect(refused.status).toBe(403);
+    expect(refused.headers.get('access-control-allow-origin')).toBeNull();
     // Set even on a refusal, or a cache in between serves one origin's answer
     // to another.
-    expect(response.headers.get('vary')).toBe('Origin');
+    expect(refused.headers.get('vary')).toBe('Origin');
   });
 
-  test('the reads are still gated, so delegating these opened nothing', async () => {
-    // The authorization paths answer before the credential check, deliberately:
-    // the first request a client makes is the one that discovers how to
-    // authenticate. This asserts that widening did not reach past them.
+  test('the reads are still gated, so delegating the flow opened nothing', async () => {
+    // The authorization paths answer before any credential check, deliberately:
+    // a client's first request is the one that discovers how to authenticate.
+    // This asserts the widening did not reach past them.
     const response = await fetch(`${base}/state`, {
       headers: { origin: ORIGIN },
       tls: { rejectUnauthorized: false },
     } as RequestInit);
 
     expect(response.status).toBe(401);
+    expect(await response.json()).toEqual({ error: 'unauthorized', signIn: true });
   });
 });

--- a/src/server/read/listener.ts
+++ b/src/server/read/listener.ts
@@ -1,5 +1,6 @@
-import { readRoutes, type ReadDeps } from './routes.ts';
+import { READ_ORIGINS, readRoutes, type ReadDeps } from './routes.ts';
 import { handleAuthorization, isAuthorizationPath, type AuthorizationSurface } from '../oauth.ts';
+import { corsAware } from '../cors.ts';
 
 /**
  * The read surface on loopback: its own port, over TLS (ADR-063).
@@ -29,6 +30,16 @@ import { handleAuthorization, isAuthorizationPath, type AuthorizationSurface } f
  * `OAuthStore` sits behind both, so which port minted a token does not matter
  * to what the token opens — and the MCP listener keeps answering its own copy
  * of these paths for every client already registered against it.
+ *
+ * **Their CORS is `corsAware`'s, not this file's.** `surfaceOf` has always
+ * called the authorization paths `public` and answered them with a wildcard,
+ * for a reason `cors.ts` states: they answer without a credential by design, so
+ * a wildcard hands a page what `curl` already has. Wrapping the handler is
+ * therefore the whole of it — the alternative, a second grant written here, was
+ * tried and is redundant on any bind where `corsAware` runs, which is every
+ * bind but this one. Everything `corsAware` does not classify falls through
+ * untouched, and `readRoutes` answers those with its own *named* grant, because
+ * what they return is the workspace rather than a public document.
  */
 
 export { READ_ORIGINS, type AuditTail, type ReadDeps } from './routes.ts';
@@ -66,13 +77,20 @@ export function serveRead(options: ReadListenerOptions): RunningReadListener {
     // discovers how to authenticate, so requiring a credential to reach the
     // document that says where credentials come from would close the loop it
     // exists to open. `server/index.ts` orders them the same way.
-    fetch: (request) => {
-      const url = new URL(request.url);
-      if (options.authorization && isAuthorizationPath(url.pathname)) {
-        return handleAuthorization(request, options.authorization);
-      }
-      return readRoutes(request, options);
-    },
+    fetch: corsAware(
+      async (request) => {
+        const url = new URL(request.url);
+        if (options.authorization && isAuthorizationPath(url.pathname)) {
+          return await handleAuthorization(request, options.authorization);
+        }
+        return await readRoutes(request, options);
+      },
+      // No credentialed paths: `readRoutes` grants its own, by name. This is
+      // here only so the authorization paths get the `public` treatment they
+      // get everywhere else.
+      [],
+      { allowedOrigins: READ_ORIGINS },
+    ),
   });
 
   return {


### PR DESCRIPTION
Two things found by deploying the ADR-079 rework to a real endpoint and driving a browser flow against it.

## The CORS grant I added was a second implementation of one that already existed

`cors.ts`'s `surfaceOf` has always classified the authorization paths as `public` and answered them with a wildcard, and it states why:

> The authorization surface answers without a credential by design, so a wildcard there hands a page what `curl` already has.

So the named grant written into `oauth.ts` was **redundant on every bind where `corsAware` runs** — which overwrote it with the wildcard anyway, observed on the deployed endpoint — and **needed on exactly one bind**, the loopback read listener, which does not run `corsAware` at all.

That listener wraps its handler in `corsAware` now, and `oauth.ts` goes back to having no opinion about origins. The reads keep their own *named* grant, and the contrast is the point: an authorization document is public, while `/state` returns every connection, profile and audit entry the workspace holds.

## A refresh that names nobody looped instead of stopping

`IssuedTokenAuthenticator` refuses a subject-less access token (ADR-079), and `who` carries `subject` only when the record has one. So a refresh token minted before subjects existed rotated cleanly:

```
POST /token   -> 200, here is an access token
POST /mcp     -> 401
POST /token   -> 200, here is another one
POST /mcp     -> 401
```

A connector stuck in a loop rather than one that needs signing in — and it is what the first connector this shipped to actually did, reporting only "token expired".

Refused at the refresh instead, with `invalid_grant` and a message naming the one step that fixes it. `invalid_grant` is the right code: it is the one answer that tells a client to discard the grant and start the authorization flow again.

## Tests

`bun test` and `bun run typecheck` pass — 3684 tests, 0 fail. The refresh case is driven over real HTTP against a record written as 0.7 wrote them, on the harness's own clock; the CORS contrast is asserted on the TLS read listener, which is the bind that needed it.