### PR TITLE
The operator's own cloud project and bucket are out of the tree

### DIFF
--- a/docs/detailed/adr/052-a-target-owns-its-workspace.md
+++ b/docs/detailed/adr/052-a-target-owns-its-workspace.md
@@ -24,8 +24,8 @@ personal  cloud declared  7 connection(s)
 ```
 
 ```console
-$ LANES_LINK_HOME=gs://personal-lanes lanes link profile list
-gs://personal-lanes  personal   # 15 connections: gmail ×2, drive, calendar, sheets,
+$ LANES_LINK_HOME=gs://your-bucket lanes link profile list
+gs://your-bucket  personal   # 15 connections: gmail ×2, drive, calendar, sheets,
                                 # tasks, contacts, slack, icloud ×3, bunq, memory, skills
 ```
 
@@ -43,8 +43,8 @@ targets:
     credentials: { adapter: file, path: ./data/personal/credentials.enc }
     storage: { adapter: filesystem, path: ./data/personal }
   cloud:
-    credentials: { adapter: gcp-secret-manager, project: personal-lanes }
-    storage: { adapter: gcs, bucket: personal-lanes }
+    credentials: { adapter: gcp-secret-manager, project: my-project }
+    storage: { adapter: gcs, bucket: your-bucket }
     deploy: { platform: cloudrun, region: europe-west1, service: lanes-link-personal-mcp }
 ```
 
@@ -74,16 +74,16 @@ targets:
     credentials: { adapter: file }
     storage: { adapter: filesystem }
   cloud:
-    workspace: gs://personal-lanes      # a pointer, and nothing else
+    workspace: gs://your-bucket      # a pointer, and nothing else
 ```
 
 ```yaml
-# gs://personal-lanes/lanes-link.yaml — authoritative for itself
+# gs://your-bucket/lanes-link.yaml — authoritative for itself
 contract: 2
 targets:
   cloud:
-    credentials: { adapter: gcp-secret-manager, project: personal-lanes }
-    storage: { adapter: gcs, bucket: personal-lanes }
+    credentials: { adapter: gcp-secret-manager, project: my-project }
+    storage: { adapter: gcs, bucket: your-bucket }
     deploy: { platform: cloudrun, region: europe-west1, service: lanes-link-personal-mcp }
 ```
 

--- a/src/cli/workspace-migrate.test.ts
+++ b/src/cli/workspace-migrate.test.ts
@@ -24,7 +24,7 @@ const legacy = (profile: string, targets: string): string =>
 
 const LOCAL = `  local:\n    credentials: { adapter: file, path: ./data/PROFILE/credentials.enc }\n    storage: { adapter: filesystem, path: ./data/PROFILE }\n`;
 
-const CLOUD = `  cloud:\n    credentials: { adapter: gcp-secret-manager, project: my-project }\n    storage: { adapter: gcs, bucket: personal-lanes }\n    vault: { adapter: secret }\n`;
+const CLOUD = `  cloud:\n    credentials: { adapter: gcp-secret-manager, project: my-project }\n    storage: { adapter: gcs, bucket: your-bucket }\n    vault: { adapter: secret }\n`;
 
 async function workspace(
   profiles: Record<string, string>,
@@ -54,7 +54,7 @@ describe('hoisting a profile’s targets into the workspace', () => {
     const registry = await readRegistry(root);
 
     expect(registry['local']?.storage?.adapter).toBe('filesystem');
-    expect(registry['cloud']?.at).toBe('gs://personal-lanes');
+    expect(registry['cloud']?.at).toBe('gs://your-bucket');
     expect(registry['cloud']?.storage).toBeUndefined();
   });
 
@@ -104,7 +104,7 @@ describe('migrating the workspace a target already lives in', () => {
   const parse = (yaml: string) =>
     legacyTargetSchema.parse({
       credentials: { adapter: 'gcp-secret-manager', project: 'my-project' },
-      storage: { adapter: 'gcs', bucket: 'personal-lanes' },
+      storage: { adapter: 'gcs', bucket: 'your-bucket' },
       vault: { adapter: 'secret' },
       ...(yaml === 'filesystem'
         ? { credentials: { adapter: 'file' }, storage: { adapter: 'filesystem' } }
@@ -117,17 +117,17 @@ describe('migrating the workspace a target already lives in', () => {
     // `openTarget` refuses as a loop — leaving `deploy` unable to run against the
     // bucket it had just migrated, on the one command the refusal names as the fix.
     const fromLaptop = toEntry('cloud', parse('gcs'), 'personal', '/Users/x/.lanes-link');
-    expect(fromLaptop?.at).toBe('gs://personal-lanes');
+    expect(fromLaptop?.at).toBe('gs://your-bucket');
 
-    const fromBucket = toEntry('cloud', parse('gcs'), 'personal', 'gs://personal-lanes');
+    const fromBucket = toEntry('cloud', parse('gcs'), 'personal', 'gs://your-bucket');
     expect(fromBucket?.at).toBeUndefined();
-    expect(fromBucket?.storage?.bucket).toBe('personal-lanes');
+    expect(fromBucket?.storage?.bucket).toBe('your-bucket');
   });
 
   test('and a filesystem target is dropped, because a bucket can never open one', () => {
     // The bucket's copy of a profile was uploaded from a laptop, so it carries
     // that laptop's `local:` block — paths on a disk the endpoint has never seen.
-    expect(toEntry('local', parse('filesystem'), 'personal', 'gs://personal-lanes')).toBeNull();
+    expect(toEntry('local', parse('filesystem'), 'personal', 'gs://your-bucket')).toBeNull();
 
     // On the machine that owns it, it is kept.
     expect(toEntry('local', parse('filesystem'), 'personal', '/Users/x/.lanes-link')).not.toBeNull();

--- a/src/deployments/bootstrap.test.ts
+++ b/src/deployments/bootstrap.test.ts
@@ -21,7 +21,7 @@ import {
 
 const target = (vault?: TargetConfig['vault']): TargetConfig =>
   ({
-    credentials: { adapter: 'gcp-secret-manager', project: 'personal-lanes' },
+    credentials: { adapter: 'gcp-secret-manager', project: 'my-project' },
     storage: { adapter: 'gcs', bucket: 'lanes-link-demo-data' },
     ...(vault ? { vault } : {}),
   }) as TargetConfig;
@@ -55,10 +55,10 @@ describe('writing a surveyed target into YAML', () => {
     expect(
       deepWithoutUndefined({
         platform: 'cloudrun',
-        project: 'personal-lanes',
+        project: 'my-project',
         service_account: undefined,
       }),
-    ).toEqual({ platform: 'cloudrun', project: 'personal-lanes' });
+    ).toEqual({ platform: 'cloudrun', project: 'my-project' });
   });
 
   test('nested blocks are cleaned too, because a target is blocks of blocks', () => {

--- a/src/deployments/steps.test.ts
+++ b/src/deployments/steps.test.ts
@@ -144,7 +144,7 @@ describe('which failures are worth waiting out', () => {
   test('the shapes Google uses for an API that is not ready', () => {
     for (const message of [
       'PERMISSION_DENIED: The caller does not have permission',
-      'Cloud Build API has not been used in project personal-lanes before or it is disabled',
+      'Cloud Build API has not been used in project my-project before or it is disabled',
       'SERVICE_DISABLED',
       'Error 403: Cloud Run Admin API is not enabled',
     ]) {


### PR DESCRIPTION
Four files named a real Google Cloud project and a real GCS bucket — three test files and ADR-052, dating from #81 and the initial import. **A bucket name is a global namespace**, so this one does not merely identify someone: it names something nobody else can create.

Replaced with the two placeholders `CLAUDE.md` already names: `my-project` and `your-bucket`.

## How it survived

`src/cli/workspace-migrate.test.ts` shows it:

```
credentials: { adapter: gcp-secret-manager, project: my-project }
storage: { adapter: gcs, bucket: <the real one> }
```

Already scrubbed for the project, left for the bucket two words later. So the line had been read, half-fixed, and passed review.

## The guard had nothing to compare against

`src/architecture.test.ts` checks handles against the committer's git identity and against `.private-identifiers` — gitignored, one token per line, because "a denylist in the repository cannot work, because writing the name into a checked-in list is the thing being prevented."

That file had never been written for this repository. So the check ran with an empty set and passed. Declaring the name locally makes it fail on all nineteen occurrences, which is how the list here was produced rather than grepped for — and it will keep failing if any of them comes back.

**Nothing about the check changes in this PR.** What changes is that there is now a reason to keep that file: it holds the names git cannot know, which is precisely the case the check's own comment describes —

> git only ever knows the address someone commits under, and the handle that leaked here came from a personal mailbox git has never seen.

Worth adding your own cloud project, bucket, and any handle to `.private-identifiers` on each machine you commit from; it stays out of the tree by definition.

## Note on history

This removes the names from the tree, not from the history — they remain in the commits that introduced them. Rewriting history for this is a judgement call rather than an obvious yes, given the repo is already public and the names are a project and a bucket rather than a credential. Flagging it rather than deciding it.

## Tests

`bun test` and `bun run typecheck` pass — 3684 tests, 0 fail.