### PR TITLE
The benchmark was measuring a fixture, not a surface

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -217,6 +217,17 @@ per line. Keep your own handles there: git only knows the address you commit und
 that leaked here came from a personal mailbox git had never seen. A denylist inside the repository
 cannot work, because writing the name into it is the thing being prevented.
 
+**The rule is about what becomes public, and the test only reaches the files.** A pull request
+body, a commit message, an issue comment and a review reply are all public on this repository and
+none of them is scanned by anything — `architecture.test.ts` reads the tree, so a commit message
+is outside it and a PR body was never in it. The rehearsal section above makes this sharper rather
+than softer: it asks for what was deployed and exercised to be written into a pull request, which
+is an invitation to paste a project, a bucket, a service name, a revision, an endpoint URL, or the
+address an account was connected under. Name none of them. "A developer project", "a real target",
+"the previous revision" carry everything a reviewer needs, and a reviewer who needs the actual
+identifier is someone who already has it. The one check that exists runs before a commit lands and
+not before a comment is posted, so this one is on you.
+
 ## Where things are
 
 One package, one `src/`, fourteen components. Cross-component imports go through the

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -127,6 +127,37 @@ the set that actually opened, so those are the two places to look. `notifyReload
 published against that set, which is why a command no longer says "Serving it now" for a profile
 the endpoint refused.
 
+**A new feature gets the same rehearsal, and the rule is not only about fixes.** Anything that
+changes what reaches the wire — a new tool, a new field on an advertised schema, a renamed id, a
+change to what `tools/list` or a search result carries — is deployed to a real target from its
+branch and exercised against the endpoint before the pull request is called done. A harness proves
+the code. It cannot prove that a hosted client still parses the result, because the harness is not
+the client and an output schema the spec requires a server to conform to is checked by whoever
+consumes it. Write what was run into the pull request body, and write what was *not* covered
+beside it.
+
+What exercising it means, at minimum:
+
+- **`POST /reload`, `/health`, and the container log, all three.** Each answers a different
+  question, and any one of them alone has already been believed wrongly: `/health` is filtered to
+  the caller's own member profiles, so a profile missing from it may be a membership problem
+  rather than a serving one, and only the log carries `not serving <profile>: <reason>`.
+- **`tools/list` read off the wire, counted, and compared with the `tools` that `/reload`
+  returned.** Those two disagreeing is the failure ADR-032 exists for.
+- **The feature reached both ways it can be** — the typed tool and `lanes_tools_call` — because
+  under `surface: crunched` most callers only have the second, and that is the path a unit test is
+  least likely to be exercising.
+- **A refusal, not just a success.** Name a profile the caller is not on, and name one profile
+  with another profile's connection. A feature is not verified until its refusals are, and those
+  depend on the member list the deployed endpoint actually loaded rather than on the one in the
+  test fixture.
+- **Do it on a sandbox profile.** One holding the owner layer and no external account means a
+  wrong call during a rehearsal writes nothing to a real mailbox, calendar, or bank.
+
+A revision is recoverable and this is why it is safe to ask for: Cloud Run keeps the previous one
+and traffic can be moved back, which a published npm version cannot be. Note the revision that was
+serving before you deployed, so moving back is one command and not an investigation.
+
 ## A release publishes, and npm does not give a version back
 
 [The development lifecycle](https://lanes.sh/docs/link/releasing) is the lifecycle end to end — the two

--- a/README.md
+++ b/README.md
@@ -125,6 +125,27 @@ bunq](https://lanes.sh/docs/link/bunq) first. **Most providers are untested** ag
 account, and the tables mark which with a †. See [`src/providers/README.md`](src/providers/README.md)
 for what that means.
 
+## Spend your context on the question, not the menu
+
+Connecting everything has a cost nobody mentions. A dozen accounts is hundreds of tools, and
+every one of them is described to your agent before it reads a word of what you asked. On one
+two-profile endpoint that came to 278 tools and roughly 180,000 tokens: most of a context window,
+spent on a menu.
+
+Lanes Link can serve a short list instead. Your agent gets a search tool and a call tool, asks for
+what it needs, and gets back the few capabilities that answer, with their full arguments. The same
+endpoint drops to 28 tools and about 8,000 tokens. Nothing becomes unreachable, and no permission
+changes: it is the same dispatcher, the same policy, the same audit row.
+
+Turn it on per profile, in `profile.yaml`:
+
+```yaml
+surface: crunched
+```
+
+**[How it finds the right tool](docs/detailed/search.md)** covers the ranking, what it scores
+today, and what was weighed against it.
+
 ## Run it anywhere
 
 The same code and the same config in all three. Only the storage adapters change.
@@ -152,6 +173,7 @@ the revision on its first run.
 | **[Every command](https://lanes.sh/docs/link/commands)** | Arguments and flags, one entry each |
 | **[In the Lanes desktop app](https://lanes.sh/docs/desktop/lanes-link)** | The page that drives it |
 | **[Full reference](https://lanes.sh/docs/link)** | Architecture, configuration, security, writing a provider |
+| **[How it finds the right tool](docs/detailed/search.md)** | Why the tool list is short, and how the search ranks |
 
 ## Security
 

--- a/docs/detailed/search.md
+++ b/docs/detailed/search.md
@@ -1,0 +1,158 @@
+# How Lanes Link finds the right tool
+
+Connect a dozen accounts and your agent is handed hundreds of tools, every one of them described
+in full before it reads your first word. This page covers what that costs, what Lanes Link serves
+instead, and how well the search that replaces it actually works.
+
+## What a full tool list costs you
+
+Measured on one deployed endpoint with two profiles and eleven providers:
+
+| | tools | on the wire | roughly |
+|---|---|---|---|
+| `surface: full` | 278 | 702 KB | 180,000 tokens |
+| `surface: crunched` | 28 | 31 KB | 8,000 tokens |
+
+180,000 tokens is not a large fraction of a context window. It is most of one, spent before the
+agent has read the request. The ceiling is not set here either: most providers are MCP servers
+whose schemas are their authors' own, so no amount of care in this repository moves them.
+
+Hosted clients make it worse rather than better. Some cap the aggregate tool list across all
+connectors and truncate alphabetically, mid-namespace, with no error.
+
+## Serve a short list instead
+
+A profile can declare how much of what it reaches goes into `tools/list`:
+
+```yaml
+surface: crunched
+```
+
+Under `crunched` the endpoint advertises the owner layer plus two stable names,
+`lanes_tools_search` and `lanes_tools_call`. Everything else stays reachable through the second
+of those. No capability is lost. What shrinks is exposition, not authority.
+
+The search returns full JSON Schema for its strongest matches, not just names. That is the whole
+design: a search returning only names costs a second round trip and loses the accuracy that
+published evaluations attribute to deferred tool loading.
+
+## Measure it yourself
+
+Both commands run the real ranking over a fixture corpus. Neither needs a workspace, a
+credential, or a network.
+
+```console
+$ bun run bench:retrieval
+$ bun run probe "latest email in inbox"
+```
+
+For how your own providers rank, ask a running endpoint with `lanes link tools --json`.
+
+## How the ranking works
+
+Term presence, weighted by where the term appears, scaled by how much it narrows the field, then
+adjusted for what the question implies. There is no term-frequency component and no document
+length normalisation.
+
+**Where a word appears decides what it is worth.** An operation's own name scores 3, its title 2,
+its provider 1.5, its description 1, and its argument names 0.5. The vendor's name is scored
+apart from the operation's name deliberately: scored together, a provider whose id contains a
+domain word wins every query in that domain on spelling alone.
+
+**A word matching everything decides nothing.** Each provider's keywords are appended to every
+one of its capabilities identically, so without weighting by rarity every mail tool scored the
+same on a mail question and alphabetical order picked the winner. Terms are weighted by inverse
+document frequency, floored rather than decayed to zero, because such a word is uninformative
+rather than wrong.
+
+**A question about several accounts gets several answers.** Matches are ordered one per provider
+before any provider gets a second entry, so two connected mailboxes both appear. Which of them
+you meant is not something the endpoint knows, and answering as though one existed is worse than
+returning both with their accounts named.
+
+**An answer is budgeted in bytes, not matches.** Three matches is under a kilobyte of one
+provider's schemas and 40 KB of another's. The budget is 16 KB, three matches explained by
+default and ten at most, and the best match is always rendered in full even if it alone exceeds
+the budget.
+
+## What it scores today
+
+Over 139 capabilities across twenty providers, against 36 questions:
+
+| | |
+|---|---|
+| answer ranks first | 56% |
+| answer in the first three | 72% |
+| answer carries a schema | 72% |
+| mean answer size | 1,841 B |
+| ranking 1,000 capabilities | 10.6 ms per query |
+
+These numbers read 94% and 100% earlier in this repository's history, and nothing about the
+ranking got worse. The corpus did. It was eleven providers and 51 capabilities against sixteen
+questions, where the deployed endpoint above holds 278. Giving providers the depth real APIs
+have took top-1 from 94% to 88% on its own; adding a second calendar and a second issue tracker,
+then twenty more questions, took it the rest of the way.
+
+The honest floor is the one worth defending, so the old figure is recorded rather than quietly
+replaced. `src/server/mcp/ranking.test.ts` names every individual miss, which is the guard that
+catches a regression a percentage would hide.
+
+## What it gets wrong
+
+Three failure modes are open and reproducible with `bun run probe`.
+
+**A common verb in an operation's name beats the subject of the question.** An operation called
+`findMeetingTimes` takes the first slot on "find a document", because *find* matches its name at
+weight 3 while *document* matches a file provider's description at weight 1.
+
+**A provider's identifying word is discounted by its own depth.** Rarity is computed across the
+capabilities that matched, so the deeper a provider is, the more the word that identifies it
+looks like a word that says nothing. On "add a reminder", *reminder* scored 0.357 against *add*
+at 0.540, and every task capability lost to three unrelated operations whose names contain *add*.
+
+**Short words do not reach their own plurals.** A prefix match needs four characters, so "bugs"
+does not find "bug" and the query returns nothing at all.
+
+The design goal on record is to be good enough to find the right *provider*, not good enough to
+replace a client-side index. Accuracy at provider granularity would be the fairer measure of
+that, and it is not measured yet.
+
+## Alternatives weighed
+
+**Vector embeddings.** No vector database is needed at this scale. A few hundred capabilities is
+a packed `Float32Array` and a brute-force dot product, well under a millisecond, and vector
+stores start earning their keep around six orders of magnitude higher. Storage is a derived,
+fingerprinted blob, and `src/providers/entities/catalogue.ts` is a working precedent for one.
+The real cost is elsewhere: embedding the query is a network round trip on every search and a new
+outbound credential, in a repository that has so far declined every vendor client library. An
+embedding also erases what this ranker is best at, including the exact-id short circuit and the
+penalty on destructive verbs nobody asked for. The shape would be reciprocal rank fusion across
+both rankers with a mandatory lexical fallback, never a replacement. The honest gain is deleting
+a hand-maintained synonym table rather than a large jump in accuracy.
+
+**Full BM25.** Adds term frequency and document length normalisation. Presence-only scoring is
+already length-insensitive, which is part of why it survives vendor descriptions of wildly
+different lengths, and the explicit stopword list here does what a BM25 index does implicitly.
+The upside is real and small on text this short. It would not touch any of the three failure
+modes above, which are about field weighting and rarity, not about counting.
+
+**Leaving it to the client.** The best clients already defer tool loading and run their own index
+locally, with no round trip, and deferred definitions never enter the initial prompt so prompt
+caching survives. A stateless endpoint cannot match that last property, because a discovery call
+rebuilds the server. This surface is the fallback for clients that do not, which is what bounds
+how good it has to be.
+
+## Notes
+
+**Where the decisions are recorded.** ADR-075 for the two stable names and why search returns
+schemas, ADR-076 for `surface: crunched` and the measurement above.
+
+**Why a miss can trigger a reload.** Under `crunched`, "nothing reachable matches" is not a hedge
+a model retries, it is a claim about your accounts. An endpoint that missed a config change would
+be making that claim wrongly, so a miss re-reads the config once before answering, rate limited
+to one probe every ten seconds.
+
+**Why the search result carries a read-only hint.** Under `crunched` there is no typed tool to
+carry the annotation, so the search result is the only place a client can learn a call is safe to
+make. It appears only where the provider classified the operation, never as a negative, because
+the absence has to keep meaning "assume not".

--- a/docs/testing-search.md
+++ b/docs/testing-search.md
@@ -1,7 +1,8 @@
 # Testing the search by hand
 
-Two commands. Neither needs a workspace, a credential, or a network — both run the real ranking
-and rendering over a fixture corpus of eleven providers and 51 capabilities.
+Two commands. Neither needs a workspace, a credential, or a network. Both run the real ranking
+and rendering over a fixture corpus of twenty providers and 139 capabilities, built to the depth a
+deployed endpoint has.
 
 ## Is the ranking still good?
 
@@ -10,18 +11,22 @@ $ bun run bench:retrieval
 ```
 
 ```
-  retrieval over 51 capabilities, 16 questions
+  retrieval over 139 capabilities, 36 questions
   ──────────────────────────────────────────────────────────
-  answer ranks first           94%  (was 31%, +63)
-  answer in the first three   100%  (was 63%, +37)
-  answer carries a schema     100%  (was 81%, +19)
-  mean answer size           1393 B  (was 4063 B, -2670)
+  answer ranks first           56%  (was 31%, +25)
+  answer in the first three    72%  (was 63%, +9)
+  answer carries a schema      72%  (was 81%, -9)
+  mean answer size           1841 B  (was 4063 B, -2222)
   ──────────────────────────────────────────────────────────
 ```
 
 The floors are asserted, so a change that makes ranking worse fails. The percentages are printed
-rather than only checked, because a slide from 100% to 91% passes a 90% floor and is still a
-regression.
+rather than only checked, because a slide that still clears a floor is still a regression.
+
+These read 94% and 100% against the smaller corpus this fixture replaced, and the ranking did not
+change to make them 56% and 72%. [How Lanes Link finds the right tool](detailed/search.md) has the
+measurement, the three failure modes behind it, and what was weighed against the current
+approach.
 
 ## What does it answer to *this* question?
 
@@ -43,6 +48,7 @@ named tool to prefer.
 ## mailhub_search_messages          ← the wire name, or the capability id under --crunched
 capability: mailhub.search_messages
 reachable:  personal: mailhub.acct1  ← which profile and connection to pass
+read-only:  yes                      ← only where the provider classified it
 
 arguments (JSON Schema — `profile` and `connection` are added by this endpoint):
 ...

--- a/src/server/mcp/query.ts
+++ b/src/server/mcp/query.ts
@@ -232,15 +232,3 @@ export const AMBIGUOUS_VERBS = new Set(['schedule', 'book', 'draft', 'reply', 'f
 /** The verbs that take something away, as distinct from the ones that add. */
 export const DESTRUCTIVE_VERBS = new Set(['delete', 'remove', 'trash', 'clear', 'archive', 'untrash']);
 
-/**
- * Whether a capability only reads, as its own name says.
- *
- * The same reading `fit` uses to order results, exposed so a caller can ask for
- * it outright. `readOnly: true` is a filter on the answer and never a claim
- * about authority: policy decides what may be called, and a hint about
- * behaviour cannot grant or withhold anything.
- */
-export function reads(id: string): boolean {
-  const rest = id.split('.').slice(1);
-  return actionOf(rest.flatMap((segment) => words(segment))) === 'read';
-}

--- a/src/server/mcp/ranking-corpus.ts
+++ b/src/server/mcp/ranking-corpus.ts
@@ -25,17 +25,47 @@ function withKeywords(description: string, keywords: readonly string[]): string 
   return `${description}\n\nAlso: ${keywords.join(', ')}.`;
 }
 
-function tool(id: string, title: string, description: string): [string, MergedCapability] {
+/**
+ * The arguments an operation takes, as a vendor documents them.
+ *
+ * Present because the ranking reads them and a fixture where every capability
+ * took the same `id` could not show whether that helps or hurts. They are also
+ * what the byte budget is spent on, so a corpus without them measures an answer
+ * size no real endpoint produces.
+ */
+type Args = Readonly<Record<string, string>>;
+
+/** What a vendor gives an operation when it documents nothing in particular. */
+const PLAIN: Args = { id: 'The identifier of the resource.' };
+
+function tool(
+  id: string,
+  title: string,
+  description: string,
+  args: Args = PLAIN,
+): [string, MergedCapability] {
   return [
     id,
     {
       reachable: new Map([['personal', [`${id.split('.')[0]}.acct1`]]]),
       capability: undefined,
+      // Read off the name here, which is the one thing the endpoint itself may
+      // not do. This stands in for what a connector assigned from a vendor's
+      // request method, and writing sixty of them out by hand would be the same
+      // answer with more chances to typo it.
+      reads: /(^|[._])(list|get|search|history|retrieve|read|query|freebusy)/.test(
+        id.split('.').slice(1).join('.'),
+      ),
       discovered: {
         name: 'ignored',
         title,
         description,
-        inputSchema: { type: 'object', properties: { id: { type: 'string' } } },
+        inputSchema: {
+          type: 'object',
+          properties: Object.fromEntries(
+            Object.entries(args).map(([name, description]) => [name, { type: 'string', description }]),
+          ),
+        },
       },
     } as unknown as MergedCapability,
   ];
@@ -46,10 +76,10 @@ function provider(
   id: string,
   label: string,
   keywords: readonly string[],
-  capabilities: readonly (readonly [string, string, string])[],
+  capabilities: readonly (readonly [string, string, string, Args?])[],
 ): [string, MergedCapability][] {
-  return capabilities.map(([name, title, description]) =>
-    tool(`${id}.${name}`, `${label}: ${title}`, withKeywords(description, keywords)),
+  return capabilities.map(([name, title, description, args]) =>
+    tool(`${id}.${name}`, `${label}: ${title}`, withKeywords(description, keywords), args),
   );
 }
 
@@ -67,7 +97,18 @@ const WHO = ['contact', 'address book', 'person', 'people'] as const;
  */
 export const CORPUS: Map<string, MergedCapability> = new Map([
   ...provider('postbox', 'Postbox', MAIL, [
-    ['users.messages.list', 'list messages', "Lists the messages in the user's mailbox."],
+    [
+      'users.messages.list',
+      'list messages',
+      "Lists the messages in the user's mailbox.",
+      {
+        userId: 'The user whose mailbox to list.',
+        q: 'Only return messages matching the specified query.',
+        labelIds: 'Only return messages with all of the specified label IDs.',
+        maxResults: 'Maximum number of messages to return.',
+        pageToken: 'Page token to retrieve a specific page of results.',
+      },
+    ],
     ['users.messages.get', 'get messages', 'Gets the specified message.'],
     [
       'users.messages.modify',
@@ -93,7 +134,20 @@ export const CORPUS: Map<string, MergedCapability> = new Map([
     ['users.labels.update', 'update labels', 'Updates the specified label.'],
     ['users.labels.patch', 'patch labels', 'Patch the specified label.'],
     ['users.threads.list', 'list threads', "Lists the threads in the user's mailbox."],
-    ['send_message', 'send message', 'Send a message, with attachments, or save it as a draft.'],
+    [
+      'send_message',
+      'send message',
+      'Send a message, with attachments, or save it as a draft.',
+      {
+        to: 'Recipients.',
+        cc: 'Carbon-copy recipients.',
+        bcc: 'Blind carbon-copy recipients.',
+        subject: 'The subject line.',
+        body: 'The message body.',
+        attachments: 'Files to attach, by asset name or inline content.',
+        draft: 'Save as a draft instead of sending.',
+      },
+    ],
   ]),
   ...provider('forge', 'Forge', REPO, [
     ['get_latest_release', 'get latest release', 'Get the latest release in a repository.'],
@@ -102,45 +156,133 @@ export const CORPUS: Map<string, MergedCapability> = new Map([
     ['list_issues', 'list issues', 'List issues in a repository.'],
     ['get_issue', 'get issue', 'Get a single issue by number.'],
     ['list_commits', 'list commits', 'List commits on a branch.'],
+    ['list_branches', 'list branches', 'List branches in a repository.'],
+    ['create_issue', 'create issue', 'Create a new issue in a repository.'],
+    ['add_issue_comment', 'add issue comment', 'Add a comment to an existing issue.'],
+    ['list_releases', 'list releases', 'List the releases in a repository.'],
+    ['get_file_contents', 'get file contents', 'Get the contents of a file or directory.'],
+    ['search_code', 'search code', 'Search for code across repositories.'],
+    ['list_workflow_runs', 'list workflow runs', 'List workflow runs for a repository.'],
   ]),
   ...provider('agenda', 'Agenda', MEET, [
     ['events.list', 'list events', 'Returns events on the specified agenda.'],
     ['events.get', 'get events', 'Returns an event based on its identifier.'],
-    ['events.insert', 'insert events', 'Creates an event.'],
+    [
+      'events.insert',
+      'insert events',
+      'Creates an event.',
+      {
+        calendarId: 'Calendar identifier.',
+        summary: 'Title of the event.',
+        start: 'The start time.',
+        end: 'The end time.',
+        attendees: 'The people invited.',
+        location: 'Geographic location as free-form text.',
+        conferenceData: 'Conferencing details for the event.',
+      },
+    ],
     ['events.delete', 'delete events', 'Deletes an event.'],
     ['calendars.list', 'list calendars', "Returns the calendars on the user's calendar list."],
+    ['calendars.get', 'get calendars', 'Returns metadata for a calendar.'],
+    ['events.patch', 'patch events', 'Updates an event. This method supports patch semantics.'],
+    ['events.move', 'move events', 'Moves an event to another calendar.'],
+    ['events.instances', 'list event instances', 'Returns instances of the specified recurring event.'],
+    ['freebusy.query', 'query free/busy', 'Returns free/busy information for a set of calendars.'],
+    ['acl.list', 'list acl', 'Returns the rules in the access control list for the calendar.'],
   ]),
   ...provider('filestore', 'Filestore', FILES, [
     ['files.list', 'list files', "Lists the user's files."],
     ['files.get', 'get files', "Gets a file's metadata or content by ID."],
-    ['files.create', 'create files', 'Creates a new file.'],
+    [
+      'files.create',
+      'create files',
+      'Creates a new file.',
+      {
+        name: 'The name of the file.',
+        mimeType: 'The MIME type of the file.',
+        parents: 'The IDs of the parent folders.',
+        content: 'The bytes to upload.',
+      },
+    ],
     ['permissions.list', 'list permissions', "Lists a file's or shared drive's permissions."],
+    ['permissions.create', 'create permissions', 'Creates a permission for a file or shared drive.'],
+    ['permissions.delete', 'delete permissions', 'Deletes a permission.'],
+    ['files.copy', 'copy files', "Creates a copy of a file and applies any requested updates."],
+    ['files.update', 'update files', "Updates a file's metadata, content, or both."],
+    ['files.delete', 'delete files', "Permanently deletes a file owned by the user without moving it to the trash."],
+    ['files.export', 'export files', 'Exports a document to the requested MIME type.'],
+    ['files.emptyTrash', 'empty trash', "Permanently deletes all of the user's trashed files."],
+    ['drives.list', 'list drives', "Lists the user's shared drives."],
+    ['changes.list', 'list changes', 'Lists the changes for a user or shared drive.'],
+    ['revisions.list', 'list revisions', "Lists a file's revisions."],
   ]),
   ...provider('checklist', 'Checklist', TODO, [
     ['tasks.list', 'list tasks', 'Returns all tasks in the specified task list.'],
-    ['tasks.insert', 'insert tasks', 'Creates a new task on the specified task list.'],
+    [
+      'tasks.insert',
+      'insert tasks',
+      'Creates a new task on the specified task list.',
+      {
+        tasklist: 'Task list identifier.',
+        title: 'Title of the task.',
+        due: 'Due date of the task.',
+        notes: 'Notes describing the task.',
+      },
+    ],
     ['tasks.patch', 'patch tasks', 'Updates the specified task.'],
     ['tasklists.list', 'list tasklists', "Returns all the authenticated user's task lists."],
+    ['tasks.get', 'get tasks', 'Returns the specified task.'],
+    ['tasks.delete', 'delete tasks', 'Deletes the specified task from the task list.'],
+    ['tasks.move', 'move tasks', 'Moves the specified task to another position in the task list.'],
+    ['tasklists.insert', 'insert tasklists', 'Creates a new task list and adds it to the list.'],
   ]),
   ...provider('rolodex', 'Rolodex', WHO, [
     ['people.searchContacts', 'search contacts', "Provides a list of contacts matching the query."],
     ['people.get', 'get people', 'Provides information about a person.'],
     ['people.connections.list', 'list connections', "Provides a list of the authenticated user's rolodex."],
+    ['people.createContact', 'create contact', 'Create a new contact and return the person resource.'],
+    ['people.updateContact', 'update contact', 'Update contact data for an existing contact person.'],
+    ['people.deleteContact', 'delete contact', 'Delete a contact person.'],
+    ['otherContacts.list', 'list other contacts', 'List all other contacts, formerly known as "read-only contacts".'],
   ]),
   ...provider('chatter', 'Chatter', ['chat', 'channel', 'conversation', 'dm'], [
     ['chat.postMessage', 'post message', 'Sends a message to a channel.'],
     ['conversations.history', 'conversation history', "Fetches a conversation's history of messages and events."],
     ['conversations.list', 'list conversations', 'Lists all channels in a workspace.'],
+    ['conversations.replies', 'conversation replies', "Retrieves a thread of messages posted to a conversation."],
+    ['users.list', 'list users', 'Lists all users in a workspace.'],
+    ['reactions.add', 'add reaction', 'Adds a reaction to an item.'],
+    [
+      'files.upload',
+      'upload file',
+      'Uploads or creates a file.',
+      {
+        channels: 'Comma-separated list of channel names or IDs where the file will be shared.',
+        file: 'File contents.',
+        filename: 'Filename of the file.',
+        initial_comment: 'The message text introducing the file.',
+      },
+    ],
   ]),
   ...provider('tracker', 'Tracker', ['issue', 'ticket', 'project', 'backlog'], [
     ['list_issues', 'list issues', 'List issues in a team.'],
     ['create_issue', 'create issue', 'Create a new issue.'],
     ['get_issue', 'get issue', 'Get an issue by identifier.'],
+    ['update_issue', 'update issue', 'Update an existing issue.'],
+    ['list_projects', 'list projects', 'List projects in a workspace.'],
+    ['list_teams', 'list teams', 'List teams in a workspace.'],
+    ['create_comment', 'create comment', 'Add a comment to an issue.'],
+    ['list_cycles', 'list cycles', 'List the cycles for a team.'],
   ]),
   ...provider('notebook', 'Notebook', ['page', 'note', 'wiki', 'database'], [
     ['search', 'search', 'Searches all pages and databases shared with the integration.'],
     ['pages.retrieve', 'retrieve pages', 'Retrieves a page object.'],
     ['blocks.children.list', 'list block children', 'Returns a paginated array of child block objects.'],
+    ['databases.query', 'query database', 'Gets a list of pages contained in the database.'],
+    ['pages.create', 'create page', 'Creates a new page in the specified database or as a child of a page.'],
+    ['pages.update', 'update page', 'Updates the properties of a page in a database.'],
+    ['blocks.children.append', 'append block children', 'Creates and appends new children blocks to the parent block.'],
+    ['comments.list', 'list comments', 'Retrieves a list of un-resolved comment objects from a page or block.'],
   ]),
   // An *authored* capability, whose description is written rather than generated
   // — so it says "mailbox", "most recent" and "reading" in those words, where a
@@ -156,50 +298,83 @@ export const CORPUS: Map<string, MergedCapability> = new Map([
       'Search a mailbox and return message summaries, most recent first. Reading does not mark anything as read.',
     ],
   ]),
+  // A second calendar, and a second issue tracker.
+  //
+  // Two accounts in one domain is the case the endpoint exists for and the case
+  // the ranking finds hardest: the vendors describe the same operation in
+  // different words, so whichever wrote the sentence closer to the question wins
+  // a slot its account did not earn. Mail already had this. Nothing else did,
+  // and every calendar and issue query was therefore easier here than on a real
+  // endpoint.
+  ...provider('dayplan', 'Dayplan', MEET, [
+    ['events.list', 'list events', 'Get a list of event objects in the specified calendar.'],
+    ['events.create', 'create event', 'Create an event in the specified calendar.'],
+    ['events.delete', 'delete event', 'Remove an event from the specified calendar.'],
+    ['calendars.list', 'list calendars', "Get all the user's calendars."],
+    [
+      'findMeetingTimes',
+      'find meeting times',
+      'Suggest meeting times and locations based on organizer and attendee availability.',
+    ],
+    ['events.accept', 'accept event', 'Accept the specified event in a user calendar.'],
+  ]),
+  ...provider('ticketdesk', 'Ticketdesk', ['issue', 'ticket', 'sprint', 'board', 'bug', 'status', 'workflow', 'assignee'], [
+    ['search_issues', 'search issues', 'Search for issues using a structured query language.'],
+    ['get_issue', 'get issue', 'Returns the details for an issue.'],
+    ['create_issue', 'create issue', 'Creates an issue or, where the option to create subtasks is enabled, a subtask.'],
+    ['add_comment', 'add comment', 'Adds a comment to an issue.'],
+    ['list_transitions', 'list transitions', 'Returns either all transitions or a transition that can be performed by the user on an issue.'],
+    ['list_boards', 'list boards', 'Returns all boards. This only includes boards that the user has permission to view.'],
+    ['list_sprints', 'list sprints', 'Returns all sprints from a board, for a given board ID.'],
+  ]),
+  // The long tail: providers nothing asks about, describing themselves in the
+  // register an upstream MCP server actually uses. They are here to crowd, which
+  // is most of what the 278 on a real endpoint do — and the reason a benchmark
+  // over a corpus of only the providers being asked about reads high.
+  ...provider('payflow', 'Payflow', ['payment', 'invoice', 'charge', 'refund', 'subscription', 'customer', 'billing', 'paid'], [
+    ['charges.list', 'list charges', 'Returns a list of charges you have previously created.'],
+    ['charges.create', 'create charge', 'To charge a credit card or other payment source, you create a Charge object.'],
+    ['customers.list', 'list customers', 'Returns a list of your customers.'],
+    ['customers.create', 'create customer', 'Creates a new customer object.'],
+    ['invoices.list', 'list invoices', 'You can list all invoices, or list the invoices for a specific customer.'],
+    ['invoices.send', 'send invoice', 'Invoices are sent to customers automatically according to your subscription settings.'],
+    ['refunds.create', 'create refund', 'When you create a new refund, you must specify a Charge or a PaymentIntent object on which to create it.'],
+    ['subscriptions.list', 'list subscriptions', 'By default, returns a list of subscriptions that have not been canceled.'],
+  ]),
+  ...provider('pulse', 'Pulse', ['analytics', 'event', 'funnel', 'cohort', 'dashboard', 'signup', 'conversion', 'retention', 'metric'], [
+    ['events.query', 'query events', 'Query events with a set of filters and a time range.'],
+    ['insights.get', 'get insight', 'Retrieve a single insight by its short id.'],
+    ['cohorts.list', 'list cohorts', 'Return a paginated list of cohorts for the project.'],
+    ['dashboards.list', 'list dashboards', 'Return a paginated list of dashboards for the project.'],
+    ['persons.list', 'list persons', 'Return a paginated list of persons matching the supplied filters.'],
+  ]),
+  ...provider('sentinel', 'Sentinel', ['error', 'exception', 'trace', 'release', 'alert', 'bug', 'crash', 'stacktrace'], [
+    ['issues.list', 'list issues', 'Return a list of issues bound to a project.'],
+    ['issues.get', 'get issue', 'Return details on an individual issue.'],
+    ['events.list', 'list events', 'Return a list of events bound to an issue.'],
+    ['releases.list', 'list releases', 'Return a list of releases for a given organization.'],
+    ['projects.list', 'list projects', 'Return a list of projects available to the authenticated session.'],
+  ]),
+  ...provider('deckhand', 'Deckhand', ['deploy', 'build', 'environment', 'log', 'domain', 'release', 'preview', 'failed'], [
+    ['deployments.list', 'list deployments', 'List deployments under the authenticated user or team.'],
+    ['deployments.get', 'get deployment', 'Retrieves information for a deployment by its unique identifier.'],
+    ['projects.list', 'list projects', 'Allows to retrieve the list of projects of the authenticated user or team.'],
+    ['logs.get', 'get logs', 'Get the build logs of a deployment by deployment ID and build ID.'],
+    ['domains.list', 'list domains', 'Retrieves a list of domains registered for the authenticating user.'],
+    ['env.list', 'list environment variables', 'Retrieve the environment variables for a given project.'],
+  ]),
+  ...provider('bookshelf', 'Bookshelf', ['content', 'entry', 'asset', 'locale', 'space', 'article', 'post', 'publish', 'draft'], [
+    ['entries.list', 'list entries', 'Returns a collection of entries in a space.'],
+    ['entries.get', 'get entry', 'Returns a single entry by its identifier.'],
+    ['entries.create', 'create entry', 'Creates a new entry in the given space and content type.'],
+    ['entries.publish', 'publish entry', 'Publishes an entry, making it available on the delivery API.'],
+    ['assets.list', 'list assets', 'Returns a collection of assets in a space.'],
+    ['contentTypes.list', 'list content types', 'Returns a collection of content types in a space.'],
+  ]),
+
   // A provider nobody has heard of, whose vocabulary nothing else shares.
   ...provider('acme_crm', 'Acme CRM', ['customer', 'lead', 'deal', 'pipeline'], [
     ['leads.list', 'list leads', 'Return the leads in a pipeline stage.'],
     ['deals.get', 'get deal', 'Return a single deal by its reference.'],
   ]),
 ]);
-
-/**
- * What a person asks, and the capability that answers it.
- *
- * `top1` is the strict claim: this exact capability ranks first. Queries live
- * here rather than in the test so the benchmark can reuse them, and so adding a
- * case is a data change.
- */
-export const QUERIES: readonly { query: string; expect: string | readonly string[]; note?: string }[] = [
-  {
-    query: 'latest email in inbox',
-    // Three capabilities can honestly answer this and one of them is *better*
-    // than the two list operations: an authored `search_messages` says it
-    // returns summaries most recent first, which is the question. Accepting it
-    // is not widening the goalposts — it is the right answer arriving.
-    //
-    // Two mail accounts are connected and the query names neither, so which
-    // vendor answers is genuinely undetermined — the search returns both with
-    // their accounts named, and the caller picks. What is *not* undetermined is
-    // the operation: enumerating a mailbox, never fetching one message by an id
-    // the caller does not have. Asserting the vendor here would be asserting a
-    // preference the endpoint has no basis for.
-    expect: ['mailhub.search_messages', 'postbox.users.messages.list', 'mailhub.listMessages'],
-    note: 'the query that started this',
-  },
-  { query: 'last email received', expect: ['mailhub.search_messages', 'postbox.users.messages.list', 'mailhub.listMessages'] },
-  { query: 'read my most recent mail', expect: ['mailhub.search_messages', 'postbox.users.messages.list', 'mailhub.listMessages'] },
-  { query: 'send an email', expect: ['postbox.send_message', 'mailhub.sendMail'] },
-  { query: 'archive a message', expect: 'postbox.users.messages.modify', note: 'reachable only through the hint text' },
-  { query: 'latest release', expect: 'forge.get_latest_release', note: 'must survive the fix for "latest email"' },
-  { query: 'open pull requests', expect: 'forge.list_pull_requests' },
-  { query: 'what meetings do i have', expect: 'agenda.events.list' },
-  { query: 'schedule an appointment', expect: 'agenda.events.insert' },
-  { query: 'find a document', expect: 'filestore.files.list' },
-  { query: 'my todo list', expect: 'checklist.tasks.list' },
-  { query: 'add a reminder', expect: 'checklist.tasks.insert' },
-  { query: 'look up a contact', expect: 'rolodex.people.searchContacts' },
-  { query: 'post to a channel', expect: 'chatter.chat.postMessage' },
-  { query: 'search my notes', expect: 'notebook.search' },
-  { query: 'leads in the pipeline', expect: 'acme_crm.leads.list' },
-];

--- a/src/server/mcp/ranking-queries.ts
+++ b/src/server/mcp/ranking-queries.ts
@@ -1,0 +1,78 @@
+/**
+ * The questions, and the capability that answers each one.
+ *
+ * Beside the corpus rather than inside it because they are two subjects: one is
+ * a surface to rank against, the other is what people ask of it. Adding a
+ * question is the cheapest way to make the benchmark mean more, and it should
+ * not mean opening the file that decides what there is to find.
+ *
+ * `top1` is the strict claim: this exact capability ranks first. A list means
+ * several capabilities answer honestly and any of them ranking first is right,
+ * which is a statement about the surface and not a loosened goalpost.
+ */
+export const QUERIES: readonly { query: string; expect: string | readonly string[]; note?: string }[] = [
+  {
+    query: 'latest email in inbox',
+    // Three capabilities can honestly answer this and one of them is *better*
+    // than the two list operations: an authored `search_messages` says it
+    // returns summaries most recent first, which is the question. Accepting it
+    // is not widening the goalposts — it is the right answer arriving.
+    //
+    // Two mail accounts are connected and the query names neither, so which
+    // vendor answers is genuinely undetermined — the search returns both with
+    // their accounts named, and the caller picks. What is *not* undetermined is
+    // the operation: enumerating a mailbox, never fetching one message by an id
+    // the caller does not have. Asserting the vendor here would be asserting a
+    // preference the endpoint has no basis for.
+    expect: ['mailhub.search_messages', 'postbox.users.messages.list', 'mailhub.listMessages'],
+    note: 'the query that started this',
+  },
+  { query: 'last email received', expect: ['mailhub.search_messages', 'postbox.users.messages.list', 'mailhub.listMessages'] },
+  { query: 'read my most recent mail', expect: ['mailhub.search_messages', 'postbox.users.messages.list', 'mailhub.listMessages'] },
+  { query: 'send an email', expect: ['postbox.send_message', 'mailhub.sendMail'] },
+  { query: 'archive a message', expect: 'postbox.users.messages.modify', note: 'reachable only through the hint text' },
+  { query: 'latest release', expect: 'forge.get_latest_release', note: 'must survive the fix for "latest email"' },
+  { query: 'open pull requests', expect: 'forge.list_pull_requests' },
+  // Two calendars are connected and neither query names one, so the same
+  // reasoning the mail queries carry applies here: the operation is determined,
+  // the account is not. Asserting `agenda` would assert a preference this
+  // endpoint has no basis for. It reads as a loosened goalpost and is the
+  // opposite — the corpus gained a second calendar, so the honest claim is
+  // narrower than it was, not wider.
+  { query: 'what meetings do i have', expect: ['agenda.events.list', 'dayplan.events.list'] },
+  { query: 'schedule an appointment', expect: ['agenda.events.insert', 'dayplan.events.create'] },
+  { query: 'find a document', expect: 'filestore.files.list' },
+  { query: 'my todo list', expect: 'checklist.tasks.list' },
+  { query: 'add a reminder', expect: 'checklist.tasks.insert' },
+  { query: 'look up a contact', expect: 'rolodex.people.searchContacts' },
+  { query: 'post to a channel', expect: 'chatter.chat.postMessage' },
+  { query: 'search my notes', expect: 'notebook.search' },
+  { query: 'leads in the pipeline', expect: 'acme_crm.leads.list' },
+
+  // Questions about the rest of the surface.
+  //
+  // Sixteen questions put each one worth six points of the score, which is why
+  // the number used to move in jumps and why a single fixable case looked like a
+  // trend. These are written as questions first and checked afterwards: a set
+  // chosen by which ones already passed would measure nothing except itself.
+  { query: 'files shared with me', expect: 'filestore.files.list' },
+  { query: 'who has access to this file', expect: 'filestore.permissions.list' },
+  { query: 'make a copy of a document', expect: 'filestore.files.copy' },
+  { query: 'delete a file permanently', expect: 'filestore.files.delete' },
+  { query: 'am i free on thursday', expect: ['agenda.freebusy.query', 'dayplan.findMeetingTimes'] },
+  { query: 'cancel a meeting', expect: ['agenda.events.delete', 'dayplan.events.delete'] },
+  { query: 'reply in a thread', expect: 'chatter.conversations.replies' },
+  { query: 'upload a file to a channel', expect: 'chatter.files.upload' },
+  { query: 'bugs reported this week', expect: ['sentinel.issues.list', 'tracker.list_issues', 'ticketdesk.search_issues'] },
+  { query: 'why did the build fail', expect: 'deckhand.logs.get' },
+  { query: 'which version is deployed', expect: 'deckhand.deployments.list' },
+  { query: 'refund a customer', expect: 'payflow.refunds.create' },
+  { query: 'unpaid invoices', expect: 'payflow.invoices.list' },
+  { query: 'how many signups last month', expect: 'pulse.events.query' },
+  { query: 'publish a blog post', expect: 'bookshelf.entries.publish' },
+  { query: 'move an issue to done', expect: ['ticketdesk.list_transitions', 'tracker.update_issue'] },
+  { query: 'comment on a ticket', expect: ['ticketdesk.add_comment', 'tracker.create_comment'] },
+  { query: 'what is in this pull request', expect: 'forge.list_pull_requests' },
+  { query: 'save someone to my address book', expect: 'rolodex.people.createContact' },
+  { query: 'a meeting with attendees and a location', expect: 'agenda.events.insert', note: 'reachable only through argument names' },
+];

--- a/src/server/mcp/ranking.test.ts
+++ b/src/server/mcp/ranking.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from 'bun:test';
-import { CORPUS, QUERIES } from './ranking-corpus.ts';
+import { CORPUS } from './ranking-corpus.ts';
+import { QUERIES } from './ranking-queries.ts';
 import { searchCapabilities } from './search-index.ts';
 
 /**
@@ -38,26 +39,68 @@ describe('how often the search is right', () => {
    * trades one query for another shows up as a number moving rather than as a
    * test that has to be edited to keep passing.
    */
-  test('the answer ranks first for at least nine questions in ten', () => {
+  /**
+   * These numbers used to read 94% and 100%, and nothing about the ranking got
+   * worse to make them 56% and 72%.
+   *
+   * The corpus did. It was eleven providers and 51 capabilities against sixteen
+   * questions, where a deployed endpoint measured 278 capabilities (ADR-076) and
+   * nobody asks it only sixteen things. Giving the providers the depth real APIs
+   * have, adding a second calendar and a second issue tracker, and asking twenty
+   * more questions is what moved it — each step measured on its own, and the
+   * depth alone took top-1 from 94% to 88%.
+   *
+   * So the old number was a property of the fixture. It is written down here
+   * rather than quietly replaced, because the honest floor is the one worth
+   * defending and a benchmark that flatters is worse than none.
+   */
+  test('the answer ranks first for more than half the questions', () => {
     const missed = QUERIES.filter(({ query, expect: want }) => place(query, want) !== 0).map(
       ({ query }) => query,
     );
 
-    // "my todo list" is the one that misses, and it is genuinely ambiguous:
-    // `tasklists.list` returns the caller's task *lists*, which a query naming
-    // "list" can honestly be read as asking for. Left as a miss rather than
-    // written into the expectations, so the number stays comparable.
-    expect(missed).toEqual(['my todo list']);
-    expect((100 * (QUERIES.length - missed.length)) / QUERIES.length).toBeGreaterThanOrEqual(90);
+    // Named rather than counted, so a change that trades one miss for another
+    // shows up as an edit here instead of a number that did not move.
+    expect(missed).toEqual([
+      'what meetings do i have',
+      'find a document',
+      'my todo list',
+      'add a reminder',
+      'files shared with me',
+      'who has access to this file',
+      'cancel a meeting',
+      'reply in a thread',
+      'bugs reported this week',
+      'why did the build fail',
+      'which version is deployed',
+      'refund a customer',
+      'how many signups last month',
+      'move an issue to done',
+      'save someone to my address book',
+      'a meeting with attendees and a location',
+    ]);
+    expect((100 * (QUERIES.length - missed.length)) / QUERIES.length).toBeGreaterThanOrEqual(55);
   });
 
-  test('the answer is in the first three for at least nineteen in twenty', () => {
+  test('the answer is in the first three for seven questions in ten', () => {
     const outside = QUERIES.filter(({ query, expect: want }) => {
       const at = place(query, want);
       return at < 0 || at >= 3;
     });
 
-    expect(outside.map(({ query }) => query)).toEqual([]);
+    expect(outside.map(({ query }) => query)).toEqual([
+      'my todo list',
+      'add a reminder',
+      'files shared with me',
+      'who has access to this file',
+      'cancel a meeting',
+      'bugs reported this week',
+      'why did the build fail',
+      'how many signups last month',
+      'move an issue to done',
+      'save someone to my address book',
+    ]);
+    expect((100 * (QUERIES.length - outside.length)) / QUERIES.length).toBeGreaterThanOrEqual(70);
   });
 
   /**
@@ -101,9 +144,15 @@ describe('how often the search is right', () => {
    * is a deletion the caller then has to decline.
    */
   test('an ambiguous write does not offer to destroy something', () => {
-    expect(ranked(searchCapabilities('schedule an appointment', CORPUS))[0]).toBe(
-      'agenda.events.insert',
-    );
+    // The claim is about the *operation*, not the account. Two calendars now
+    // answer this and the query names neither, so asserting one vendor asserted
+    // a preference the endpoint has no basis for and failed the moment the
+    // second one arrived. What must hold is that creating wins and deleting
+    // does not appear at the head of the answer.
+    const first = ranked(searchCapabilities('schedule an appointment', CORPUS))[0];
+
+    expect(first).toBeDefined();
+    expect(['agenda.events.insert', 'dayplan.events.create']).toContain(first as string);
   });
 });
 

--- a/src/server/mcp/ranking.ts
+++ b/src/server/mcp/ranking.ts
@@ -1,11 +1,8 @@
-import { isTool } from '#connectivity';
 import type { MergedCapability } from './visibility.ts';
 import { toolNameFor } from './naming.ts';
 import { exactly, fieldsOf, holds, scoreEntry, searchable, words } from './searchable.ts';
 import {
   actionOf,
-  READ_VERBS,
-  WRITE_VERBS,
   DESTRUCTIVE_VERBS,
   type Intent,
   intentOf,
@@ -119,7 +116,16 @@ function inverseFrequency(
  * name the *vendor*, which is where the wrong answers came from — expanding
  * "email" reached `sendMail` and `outlook_mail` by their spelling, so a query
  * to *read* the newest mail ranked the tool that *sends* it, twice over.
+ *
+ * An argument name is at the foot of both ladders: the weakest evidence here,
+ * and often the only place a word the caller used was written down at all.
  */
+/** The weight of the strongest field this term reaches, and nothing below it. */
+function first(term: string, ...ladder: readonly (readonly [readonly string[], number])[]): number {
+  for (const [field, weight] of ladder) if (holds(field, term)) return weight;
+  return 0;
+}
+
 function weighted(
   id: string,
   entry: MergedCapability,
@@ -135,37 +141,29 @@ function weighted(
   for (const term of terms) {
     const confidence = typed.get(term) ?? 1;
     const inferred = confidence < 1;
+    // An inferred term may name the *operation*, but never the vendor.
+    //
+    // Description-only was too strict, and a real endpoint showed where. Gmail's
+    // three list operations describe themselves almost identically — "Lists all
+    // labels / the drafts / the messages in the user's mailbox" — and the
+    // provider keywords appended to each carry the word *message*, so expanding
+    // "email" matched all three in the description and settled nothing. The one
+    // field that distinguishes them is the operation's own name, and that was
+    // the field an inferred term could not reach.
+    //
+    // The vendor's name stays out of reach, because that is what the restriction
+    // was for: a provider called `outlook_mail` otherwise wins every mail query
+    // on spelling. Scored below a typed name hit, since it is still an inference.
     const hit = inferred
-      ? // An inferred term may name the *operation*, but never the vendor.
-        //
-        // Description-only was too strict, and a real endpoint showed where.
-        // Gmail's three list operations describe themselves almost identically —
-        // "Lists all labels / the drafts / the messages in the user's mailbox" —
-        // and the provider keywords appended to each carry the word *message*,
-        // so expanding "email" matched all three in the description and settled
-        // nothing. The one field that distinguishes them is the operation's own
-        // name, and that was the field an inferred term could not reach.
-        //
-        // The vendor's name stays out of reach, because that is what the
-        // restriction was for: a provider called `outlook_mail` otherwise wins
-        // every mail query on spelling. Scored below a typed name hit, since it
-        // is still an inference.
-        holds(fields.name, term)
-        ? 1.5
-        : holds(fields.title, term)
-          ? 1.2
-          : holds(fields.description, term)
-            ? 1
-            : 0
-      : holds(fields.name, term)
-        ? 3
-        : holds(fields.title, term)
-          ? 2
-          : holds(fields.provider, term)
-            ? 1.5
-            : holds(fields.description, term)
-              ? 1
-              : 0;
+      ? first(term, [fields.name, 1.5], [fields.title, 1.2], [fields.description, 1], [fields.parameters, 0.5])
+      : first(
+          term,
+          [fields.name, 3],
+          [fields.title, 2],
+          [fields.provider, 1.5],
+          [fields.description, 1],
+          [fields.parameters, 0.5],
+        );
 
     // For an inferred term only, a word that *is* it outweighs one that merely
     // starts with it. `holds` cannot draw this line and should not — as the
@@ -385,7 +383,13 @@ export function rank(query: string, merged: Map<string, MergedCapability>): Matc
   // provider still cuts at half. A query that names none may well be about
   // several: two mail accounts both answer "read most recent email", and which
   // one was meant is not something this endpoint knows.
-  const named = terms.some((term) => providers.has(term));
+  //
+  // Read off what the caller *typed*, never off the expansion: a synonym is not
+  // the caller naming a vendor. "add a reminder" expands *reminder* to
+  // *checklist*, a provider id here, so the half-cut fell on a question that had
+  // named nobody and took every task capability with it. Same rule as the vendor
+  // field in `weighted`, applied where the expansion was still being read.
+  const named = queryWords(query).some((word) => providers.has(word));
   const ratio = named ? 2 : 8;
   const best = matches[0]?.score ?? 0;
   return matches.filter((match) => match.score * ratio > best);

--- a/src/server/mcp/render.ts
+++ b/src/server/mcp/render.ts
@@ -1,5 +1,6 @@
 import type { Match } from './ranking.ts';
-import { schemaFor, shapeOf } from './search-index.ts';
+import { schemaFor } from './search-index.ts';
+import { shapeOf } from './searchable.ts';
 import type { MergedCapability } from './visibility.ts';
 
 /**
@@ -123,6 +124,12 @@ export function renderMatches(
     lines.push('');
     lines.push(`capability: ${match.id}`);
     lines.push(`reachable:  ${whereReachable(match.entry)}`);
+    // Only when the provider said so, and never the negative. Under `crunched`
+    // there is no typed tool to carry `readOnlyHint`, so this line is the only
+    // place a client learns a call is safe to make without asking — and the
+    // absence of it has to keep meaning "assume not", which is what a printed
+    // `read-only: no` would quietly turn into "declared unsafe".
+    if (match.entry.reads) lines.push('read-only:  yes');
     lines.push('');
     lines.push('arguments (JSON Schema — `profile` and `connection` are added by this endpoint):');
     lines.push('```json');

--- a/src/server/mcp/retrieval-bench.test.ts
+++ b/src/server/mcp/retrieval-bench.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from 'bun:test';
-import { CORPUS, QUERIES } from './ranking-corpus.ts';
+import { CORPUS } from './ranking-corpus.ts';
+import { QUERIES } from './ranking-queries.ts';
 import { searchCapabilities } from './search-index.ts';
 
 /**
@@ -21,7 +22,16 @@ import { searchCapabilities } from './search-index.ts';
  * them, so the diff carries the reason.
  */
 
-/** Where retrieval stood before any of this — the number to beat, not to keep. */
+/**
+ * Where retrieval stood before any of this — the number to beat, not to keep.
+ *
+ * Measured on the corpus as it was: eleven providers, 51 capabilities, sixteen
+ * questions. The corpus has since grown to the depth a real endpoint has, so the
+ * deltas printed against this are across two different surfaces and read as
+ * larger than the improvement was. Kept anyway, because the alternative is
+ * re-running the pre-ranking code against the new corpus to manufacture a
+ * comparison nobody ever measured.
+ */
 const BASELINE = { top1: 31, top3: 63, schema: 81, bytes: 4_063 } as const;
 
 /**
@@ -36,8 +46,17 @@ const BASELINE = { top1: 31, top3: 63, schema: 81, bytes: 4_063 } as const;
  *                               after:  28, all four hints on every one
  */
 
-/** Floors, set below today's measurement so ordinary noise does not fail CI. */
-const FLOOR = { top1: 90, top3: 95, schema: 90 } as const;
+/**
+ * Floors, set below today's measurement so ordinary noise does not fail CI.
+ *
+ * These read 90/95/90 while the corpus was 51 capabilities and sixteen
+ * questions. Neither the ranking nor the floors moved to bring them here: the
+ * corpus did, and 56/72 is what the same code scores against a surface shaped
+ * like a deployed one. `ranking.test.ts` names every miss behind these numbers,
+ * which is the guard that actually catches a regression — a percentage can hold
+ * while the cases behind it are swapped.
+ */
+const FLOOR = { top1: 55, top3: 70, schema: 70 } as const;
 
 /** The size of an answer matters as much as its accuracy — it is context spent. */
 const BYTE_BUDGET = 16 * 1024;

--- a/src/server/mcp/search-index.test.ts
+++ b/src/server/mcp/search-index.test.ts
@@ -13,11 +13,15 @@ import type { MergedCapability } from './visibility.ts';
 /** One discovered capability, of the shape an `http` provider yields. */
 function entry(
   description: string,
-  options: { title?: string; properties?: Record<string, unknown> } = {},
+  options: { title?: string; properties?: Record<string, unknown>; reads?: boolean } = {},
 ): MergedCapability {
   return {
     reachable: new Map([['personal', ['vendor_mail.main']]]),
     capability: undefined,
+    // What the connector assigned, as `mergeCapabilities` resolves it — from the
+    // request method for an `http` provider. Written out per entry because the
+    // read-only filter narrows on this and never on the id.
+    reads: options.reads ?? false,
     discovered: {
       name: 'ignored',
       ...(options.title === undefined ? {} : { title: options.title }),
@@ -38,7 +42,7 @@ const surface = new Map<string, MergedCapability>([
       properties: { to: { type: 'string' }, subject: { type: 'string' } },
     }),
   ],
-  ['vendor_mail.messages.list', entry('List the messages in a mailbox.')],
+  ['vendor_mail.messages.list', entry('List the messages in a mailbox.', { reads: true })],
   ['vendor_sheets.values.update', entry('Set values in a range of a spreadsheet.')],
   ['vendor_chat.post_message', entry('Post a message to a channel.')],
 ]);
@@ -252,6 +256,52 @@ describe('what comes back', () => {
 
     expect(answer).toContain('vendor_mail.messages.list');
     expect(answer).not.toContain('vendor_chat.post_message');
+  });
+
+  /**
+   * The two answers to "does this only read" disagree, and the filter has to
+   * take the provider's.
+   *
+   * A report run over POST is a read the name cannot show, and a get-or-create
+   * is a write whose name opens with `get`. Reading either off the id inverts
+   * both: the caller asking to be shown only safe operations would be handed the
+   * one that writes and denied the one that does not.
+   */
+  test('a read-only filter takes the provider\'s answer over the name', () => {
+    const reports = new Map<string, MergedCapability>([
+      [
+        'vendor_reports.run_report',
+        entry('Run a saved report and return its rows.', { reads: true }),
+      ],
+      [
+        'vendor_reports.get_or_create_report',
+        entry('Fetch a report by name, creating it if it does not exist.', { reads: false }),
+      ],
+    ]);
+
+    const answer = searchCapabilities('report', reports, undefined, { readOnly: true });
+
+    expect(answer).toContain('vendor_reports.run_report');
+    expect(answer).not.toContain('vendor_reports.get_or_create_report');
+  });
+
+  /**
+   * Under `surface: crunched` there is no typed tool to carry `readOnlyHint`, so
+   * a search result is the only place a client can learn a call is safe.
+   */
+  test('a match says whether it only reads', () => {
+    const { capabilities } = searchResults('mailbox', surface);
+
+    expect(capabilities[0]?.capability).toBe('vendor_mail.messages.list');
+    expect(capabilities[0]?.reads).toBe(true);
+    expect(searchCapabilities('mailbox', surface)).toContain('read-only:  yes');
+  });
+
+  test('a write is not described as read-only', () => {
+    const { capabilities } = searchResults('spreadsheet', surface);
+
+    expect(capabilities[0]?.reads).toBe(false);
+    expect(searchCapabilities('spreadsheet', surface)).not.toContain('read-only');
   });
 
   test('the structured copy carries what the prose says', () => {

--- a/src/server/mcp/search-index.ts
+++ b/src/server/mcp/search-index.ts
@@ -1,11 +1,8 @@
-import { isTool } from '#connectivity';
 import { z } from 'zod';
-import { toolNameFor } from './naming.ts';
-import { queryTerms, reads } from './query.ts';
+import { queryTerms } from './query.ts';
 import { type Match, rank } from './ranking.ts';
 import { afford, type Accounts, DEFAULT, renderMatches } from './render.ts';
-import { sanitizeSchema } from './schema.ts';
-import { scoreEntry, searchable, summaryOf } from './searchable.ts';
+import { scoreEntry, searchable, shapeOf } from './searchable.ts';
 import type { MergedCapability } from './visibility.ts';
 
 /**
@@ -19,60 +16,6 @@ import type { MergedCapability } from './visibility.ts';
  *
  * See `search.ts` for what the surface is for and why it exists (ADR-075).
  */
-
-/**
- * What an answer may cost, in bytes of the caller's context.
- *
- * A count was the wrong unit. Five matches is 900 bytes of one provider's
- * schemas and 40 KB of another's, so a fixed number either truncates the useful
- * answer or floods the context — and which it does depends on whose API the
- * caller happened to ask about.
- */
-const BUDGET = 16 * 1024;
-
-/** The most any one query will explain, however small the schemas are. */
-const MOST = 10;
-
-/**
- * The fewest, however large.
- *
- * The best match is rendered in full even when it alone exceeds the budget. An
- * answer that names the right capability and withholds its arguments is the
- * expensive kind of wrong: it costs a round trip *and* looks like an answer.
- */
-const FEWEST = 1;
-
-/** What one capability's title, description and schema are, whichever kind it is. */
-export function shapeOf(entry: MergedCapability): {
-  title: string | undefined;
-  description: string;
-  inputSchema: Record<string, unknown>;
-} {
-  const summary = summaryOf(entry);
-
-  if (entry.discovered) {
-    return { ...summary, inputSchema: sanitizeSchema(entry.discovered.inputSchema) };
-  }
-
-  const capability = entry.capability;
-  if (!capability || !isTool(capability)) return { ...summary, inputSchema: { type: 'object' } };
-
-  // Authored capabilities carry Zod, so the JSON Schema a caller needs is
-  // derived here rather than stored. `registerLocalTool` hands the SDK the Zod
-  // shape and lets it do the same conversion, so this is the same schema by a
-  // different route — not a second definition of it.
-  let inputSchema: Record<string, unknown> = { type: 'object' };
-  try {
-    inputSchema = z.toJSONSchema(capability.inputSchema as z.ZodType) as Record<string, unknown>;
-  } catch {
-    // A schema Zod will not convert is still a callable tool, and a search that
-    // threw would take out every other result with it.
-  }
-
-  return { ...summary, inputSchema };
-}
-
-
 
 /**
  * Search, rendered.
@@ -97,6 +40,35 @@ export function searchCapabilities(
 }
 
 /**
+ * Both halves of one answer, off one ranking.
+ *
+ * The tool returns prose and a structured copy of the same search, and asking
+ * for them separately ranked the whole reachable set twice for a single
+ * question: two passes to find the candidates, two more to weigh every term
+ * against each of them, and `shapeOf` converting the same Zod schemas again on
+ * the way out. Neither pass could see the other's work, and both were answering
+ * the same query with the same filters.
+ *
+ * `searchCapabilities` and `searchResults` stay as they are, because the corpus
+ * is the useful thing to hand a test. This is what the handler calls.
+ */
+export function searchAnswer(
+  query: string,
+  merged: Map<string, MergedCapability>,
+  surface: 'full' | 'crunched' | undefined,
+  filters: Filters = {},
+  accounts?: Accounts,
+): { text: string; structured: SearchResults } {
+  const matches = select(query, merged, filters);
+  const limit = filters.limit ?? DEFAULT;
+
+  return {
+    text: renderMatches(query, matches, surface, limit, accounts),
+    structured: resultsFrom(query, matches, limit, accounts),
+  };
+}
+
+/**
  * The same answer as data, for a client that would rather not parse prose.
  *
  * `tools/call` may carry `structuredContent` beside its text since the
@@ -111,7 +83,12 @@ export function searchResults(
   merged: Map<string, MergedCapability>,
   filters: Filters = {},
   accounts?: Accounts,
-): {
+): SearchResults {
+  return resultsFrom(query, select(query, merged, filters), filters.limit ?? DEFAULT, accounts);
+}
+
+/** The shape `searchResults` and `searchAnswer` both answer with. */
+export type SearchResults = {
   query: string;
   matched: number;
   reachable: { profile: string; connections: { connection: string; account: string }[] }[];
@@ -120,12 +97,20 @@ export function searchResults(
     tool: string;
     title: string | undefined;
     description: string;
+    reads: boolean;
     reachable: { profile: string; connections: string[] }[];
     inputSchema: Record<string, unknown>;
   }[];
-} {
-  const matches = select(query, merged, filters);
-  const { detailed } = afford(matches, filters.limit ?? DEFAULT);
+};
+
+/** The structured answer, off a ranking that has already been done. */
+function resultsFrom(
+  query: string,
+  matches: Match[],
+  limit: number,
+  accounts?: Accounts,
+): SearchResults {
+  const { detailed } = afford(matches, limit);
 
   return {
     query,
@@ -143,6 +128,7 @@ export function searchResults(
         tool: match.tool,
         title: shape.title,
         description: shape.description.split('\n\nAvailable connections')[0] ?? '',
+        reads: match.entry.reads,
         reachable: [...match.entry.reachable].map(([profile, connections]) => ({
           profile,
           connections: [...connections],
@@ -181,6 +167,11 @@ export const SEARCH_RESULT = {
             tool: z.string().describe('The tool name, if this endpoint advertises one for it.'),
             title: z.string().optional(),
             description: z.string(),
+            reads: z
+              .boolean()
+              .describe(
+                'Whether this only reads, as its provider classified it. False where the provider did not say.',
+              ),
             reachable: z
               .array(z.object({ profile: z.string(), connections: z.array(z.string()) }))
               .describe('Where it can be called, and as which account.'),
@@ -198,6 +189,12 @@ export const SEARCH_RESULT = {
  * ranking, which was already built only from what this caller may reach. A
  * filter naming something they cannot reach returns nothing, which is the same
  * answer they would get for a capability that does not exist (ADR-007).
+ *
+ * `readOnly` narrows on `entry.reads`, which is the provider's own
+ * classification, and not on the reading of the capability's name that `fit`
+ * uses to order results. Ordering may guess; a caller asking to be shown only
+ * the safe operations is relying on the answer, so where the provider said
+ * nothing this says nothing either and the capability is left out.
  */
 export type Filters = {
   readonly provider?: string | undefined;
@@ -215,7 +212,7 @@ function select(
 ): Match[] {
   return rank(query, merged).filter((match) => {
     if (filters.provider !== undefined && match.id.split('.')[0] !== filters.provider) return false;
-    if (filters.readOnly === true && !reads(match.id)) return false;
+    if (filters.readOnly === true && !match.entry.reads) return false;
     if (filters.profile !== undefined && !match.entry.reachable.has(filters.profile)) return false;
     if (filters.connection !== undefined) {
       const named = [...match.entry.reachable.values()].some((all) =>

--- a/src/server/mcp/search.ts
+++ b/src/server/mcp/search.ts
@@ -5,8 +5,7 @@ import type { McpServer } from '@modelcontextprotocol/server';
 import {
   type Filters,
   SEARCH_RESULT,
-  searchCapabilities,
-  searchResults,
+  searchAnswer,
 } from './search-index.ts';
 import { EXPAND, type ExpandArgument, expandIfReferences } from './expand-result.ts';
 import { validate } from './validate.ts';
@@ -163,19 +162,15 @@ export function registerSearchSurface(
       const { query, ...rest } = input;
       const filters: Filters = rest;
       const accounts = accountsByProfile(options);
-      const structured = searchResults(query, merged, filters, accounts);
 
-      // Both, deliberately. The text is what a model reads; the structured copy
-      // is what a client acts on without a regular expression. The spec asks for
-      // a serialized form in the text block too, and here the prose is the more
-      // useful thing to put there.
+      // Both, deliberately, and off one ranking. The text is what a model reads;
+      // the structured copy is what a client acts on without a regular
+      // expression. The spec asks for a serialized form in the text block too,
+      // and here the prose is the more useful thing to put there.
+      const { text, structured } = searchAnswer(query, merged, options.surface, filters, accounts);
+
       return {
-        content: [
-          {
-            type: 'text' as const,
-            text: searchCapabilities(query, merged, options.surface, filters, accounts),
-          },
-        ],
+        content: [{ type: 'text' as const, text }],
         structuredContent: structured as unknown as Record<string, unknown>,
       };
     },

--- a/src/server/mcp/searchable.ts
+++ b/src/server/mcp/searchable.ts
@@ -1,4 +1,6 @@
 import { isTool } from '#connectivity';
+import { z } from 'zod';
+import { sanitizeSchema } from './schema.ts';
 import type { MergedCapability } from './visibility.ts';
 
 /**
@@ -86,6 +88,36 @@ export function summaryOf(entry: MergedCapability): { title: string | undefined;
 
   return { title: capability.title, description: capability.description };
 }
+/** What one capability's title, description and schema are, whichever kind it is. */
+export function shapeOf(entry: MergedCapability): {
+  title: string | undefined;
+  description: string;
+  inputSchema: Record<string, unknown>;
+} {
+  const summary = summaryOf(entry);
+
+  if (entry.discovered) {
+    return { ...summary, inputSchema: sanitizeSchema(entry.discovered.inputSchema) };
+  }
+
+  const capability = entry.capability;
+  if (!capability || !isTool(capability)) return { ...summary, inputSchema: { type: 'object' } };
+
+  // Authored capabilities carry Zod, so the JSON Schema a caller needs is
+  // derived here rather than stored. `registerLocalTool` hands the SDK the Zod
+  // shape and lets it do the same conversion, so this is the same schema by a
+  // different route — not a second definition of it.
+  let inputSchema: Record<string, unknown> = { type: 'object' };
+  try {
+    inputSchema = z.toJSONSchema(capability.inputSchema as z.ZodType) as Record<string, unknown>;
+  } catch {
+    // A schema Zod will not convert is still a callable tool, and a search that
+    // threw would take out every other result with it.
+  }
+
+  return { ...summary, inputSchema };
+}
+
 /** Whether the search considers this entry at all. */
 export function searchable(entry: MergedCapability): boolean {
   return entry.discovered !== undefined || (!!entry.capability && isTool(entry.capability));
@@ -100,11 +132,70 @@ export function searchable(entry: MergedCapability): boolean {
  * reload for queries that then succeed anyway, and skip the reload for the ones
  * that needed it — both silent.
  *
- * Deliberately reads `summaryOf` rather than `shapeOf`: nothing here looks at a
- * schema, and `shapeOf` converts Zod to JSON Schema for every authored
- * capability it is handed.
+ * Reaches `shapeOf`, which converts Zod to JSON Schema for every authored
+ * capability it is handed. That was worth avoiding while this ran once per term
+ * per entry per pass; the memo below is what makes it affordable, so the two
+ * changes belong together and the schema field cannot be kept without it.
  */
 export function fieldsOf(id: string, entry: MergedCapability): Fields {
+  const seen = memo.get(entry);
+  if (seen !== undefined && seen.id === id) return seen.fields;
+
+  const fields = computeFields(id, entry);
+  memo.set(entry, { id, fields });
+  return fields;
+}
+
+/**
+ * The words in a capability's own arguments.
+ *
+ * Every other field is what a vendor wrote *about* an operation, and that is
+ * routinely thinner than what the operation takes. "send email with attachment"
+ * reached nothing: `attachments` is the name of an argument, and no summary of a
+ * send operation mentions one. The schema is the only place some of a
+ * capability's vocabulary is written down at all.
+ *
+ * Top-level properties and their own descriptions, and no deeper. A nested
+ * schema is mostly the vendor's structure rather than words a caller would
+ * search for, and flattening one puts hundreds of terms behind a single
+ * capability. `profile` and `connection` are added by this endpoint after this
+ * has run, so neither is here to match every query against everything.
+ */
+function parameterWords(entry: MergedCapability): string[] {
+  const properties = shapeOf(entry).inputSchema['properties'];
+  if (properties === null || typeof properties !== 'object') return [];
+
+  const found: string[] = [];
+  for (const [name, property] of Object.entries(properties as Record<string, unknown>)) {
+    found.push(...words(name));
+    if (property === null || typeof property !== 'object') continue;
+    const described = (property as { description?: unknown }).description;
+    if (typeof described === 'string') found.push(...words(described));
+  }
+
+  return found;
+}
+
+/**
+ * The same fields, tokenised once per entry instead of once per question asked
+ * of it.
+ *
+ * `scoreEntry` runs over every entry to find the candidates, `inverseFrequency`
+ * runs it again once per candidate per term, and the whole ranking runs twice
+ * where a search answers in prose and in structured form. Nothing between those
+ * passes changes the four strings being split, so they were split tens of times
+ * apiece for one query.
+ *
+ * Keyed on the entry and not the id, because a `MergedCapability` is rebuilt
+ * when the generation is, which is the moment the text behind it can change: the
+ * map empties itself and there is no expiry to get wrong. The id is kept beside
+ * the fields and checked anyway, so a caller that ever pairs an entry with a
+ * different id gets the right answer rather than a stale one. `validate.ts`
+ * caches compiled validators against the same key for the same reason.
+ */
+const memo = new WeakMap<MergedCapability, { id: string; fields: Fields }>();
+
+function computeFields(id: string, entry: MergedCapability): Fields {
   const summary = summaryOf(entry);
   const [vendor, ...rest] = id.split('.');
   // `titleFor` renders "<Provider>: <operation>", so the vendor's display name
@@ -121,6 +212,7 @@ export function fieldsOf(id: string, entry: MergedCapability): Fields {
     // what this searches — it is identical on every tool, so it would match
     // every term in it against everything.
     description: words(summary.description.split('\n\nAvailable connections')[0] ?? ''),
+    parameters: parameterWords(entry),
   };
 }
 export type Fields = {
@@ -128,9 +220,10 @@ export type Fields = {
   readonly title: string[];
   readonly provider: string[];
   readonly description: string[];
+  readonly parameters: string[];
 };
 export function scoreEntry(id: string, entry: MergedCapability, terms: readonly string[]): number {
-  const { name, title, provider, description } = fieldsOf(id, entry);
+  const { name, title, provider, description, parameters } = fieldsOf(id, entry);
 
   let score = 0;
   for (const term of terms) {
@@ -145,6 +238,11 @@ export function scoreEntry(id: string, entry: MergedCapability, terms: readonly 
     else if (holds(title, term)) score += 2;
     else if (holds(provider, term)) score += 1.5;
     else if (holds(description, term)) score += 1;
+    // Last, and worth half of prose. An argument name is evidence that a
+    // capability *deals in* the thing asked for, which is weaker than a vendor
+    // writing that it does: every mail operation takes an `id`, and a schema is
+    // machine vocabulary that was never chosen to describe anything.
+    else if (holds(parameters, term)) score += 0.5;
   }
 
   return score;


### PR DESCRIPTION
Four defects in the tool search, one search field added, and a measurement that turned out to be the point.

## The measurement

The retrieval benchmark read 94% top-1 and 100% top-3. It was measuring eleven providers and 51 capabilities against sixteen questions, where a deployed endpoint holds 278 (ADR-076). Growing the corpus toward that shape, one step at a time:

| corpus | top-1 | top-3 |
|---|---|---|
| 51 capabilities, 16 questions | 94% | 100% |
| providers at the depth real APIs have (96) | 88% | 94% |
| a second calendar, a second tracker, a long tail (139) | 75% | 88% |
| twenty more questions (36 total) | 56% | 72% |

The ranking did not get worse. The corpus stopped flattering it.

Floors move to 55/70/70 with the old figures recorded beside them, because a benchmark that flatters is worse than none. `ranking.test.ts` names every individual miss, since a percentage holds while the cases behind it are swapped.

Three failure modes are written up in the new doc rather than fixed here:

- a common verb in an operation's name beats the subject of the question, so `findMeetingTimes` takes the first slot on "find a document"
- a provider's identifying word is discounted by its own depth, because rarity is computed across matched candidates
- a four-character prefix guard stops "bugs" reaching "bug", and the query returns nothing at all

## The defects

**One ranking per request.** `lanes_tools_search` ranked the whole reachable set twice for one question, once for the prose answer and once for the structured copy, and `fieldsOf` re-tokenised every entry on every `scoreEntry` call inside each pass. `searchAnswer` now does both off one ranking, and the tokenised fields are memoised per entry on a WeakMap keyed the way `validate.ts` keys compiled validators. Ranking 1,000 capabilities went from 16.7 ms to 10.6 ms per query.

**`readOnly` filtered on a guess.** It read the capability's *name* while the provider's own classification sat on the entry as `entry.reads`, which is what typed tools already advertise as `readOnlyHint`. A report run over POST is a read the name cannot show; a get-or-create is a write whose name opens with `get`. Where the provider said nothing, the filter now says nothing either.

**A search result carried no read-only hint.** Under `surface: crunched` there is no typed tool to carry the annotation, so it was missing in the mode where search is the only channel a client has.

**The relevance cut read the expansion.** "Did the caller name a provider" was computed from expanded terms, so "add a reminder" expanded *reminder* to *checklist*, matched a provider id, tightened the cut from 8x to 2x, and removed every task capability from the answer. Same rule that keeps an inferred term out of the vendor field in `weighted`.

## The new field

Argument names are a fifth search field, weighted below description at 0.5. The schema is often the only place a word the caller used is written down: "send an email with an attachment" reached nothing, because `attachments` is an argument and no summary of a send operation mentions one. It depends on the memo above, which is why the two arrive together.

## Docs

`docs/detailed/search.md` is new: what a full tool list costs, how the ranking works, what it scores today, the three open failure modes, and vector embeddings, full BM25 and client-side indexes weighed against the current approach. `docs/testing-search.md` carries the new numbers. The README section is pitched on the context saving, which is measured and large, rather than on search accuracy.

Queries move to `ranking-queries.ts`: a surface to rank against and the questions asked of it are two subjects.

## Verification

`bun test` 3687 pass / 0 fail, `bun run typecheck` clean, `bun run bench:retrieval` as tabled above.

Rehearsed on a developer project, deployed from this branch, and exercised against the endpoint rather than the exit code. The previous revision was noted first and is still there.

- `POST /reload` and `/health` agree on three profiles; the container log carries no `not serving`.
- `tools/list` reads 29 off the wire, matching the `tools` count `/reload` returns. The advertised set is unchanged by this branch, which is the intended result.
- `structuredContent` carries the new `reads` field and a client parses it, in both polarities. This was the one thing the harness could not prove, since an output schema is checked by whoever consumes it.
- The `readOnly` filter returns 18 matches on a real surface, every one declaring `reads: true`.
- Argument-name indexing lands on real providers: "send an email with an attachment" answers with the two mail providers' send operations first.
- Refusals, on a sandbox profile holding the owner layer and no external account: a profile the caller is not on is rejected by the schema enum; one profile named with another profile's connection is refused and says which profile does offer it; a capability that profile does not reach is refused without disclosing whether it exists. The gateway then invoked a read capability successfully through `lanes_tools_call`.

One live confirmation of a failure mode the doc records: with a calendar provider connected, "what meetings do i have today" answers with a note-taking provider's `query-meeting-notes`, because a query word matching an operation's own name outscores the domain in a vendor's description. Reproduced on the endpoint, not only in the fixture.

Not covered: a hosted client (claude.ai, Claude Desktop) re-reading the tool list, which is a client-side cache rather than an endpoint behaviour.


