### PR TITLE
chore: 0.15.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lanes-sh/link",
-  "version": "0.14.0",
+  "version": "0.15.0",
   "description": "A self-hostable MCP gateway for all your connections, memory, tasks, files, and secrets",
   "license": "Apache-2.0",
   "homepage": "https://lanes.sh/link",


### PR DESCRIPTION
A minor rather than a patch: the unreleased set adds two commands for reading what the search answers (#221), serves a profile without a redeploy (#214), and moves a workspace under the Lanes home so a checkout resolves its own (#218).

Version only. No other file changes.
