### PR TITLE
An API key is signed, not stored

### DIFF
--- a/docs/detailed/adr/080-an-api-key-is-signed-not-stored.md
+++ b/docs/detailed/adr/080-an-api-key-is-signed-not-stored.md
@@ -1,0 +1,152 @@
+# ADR-080: An API key is signed, not stored
+
+**Status:** accepted · **Completes** [ADR-068](068-a-credential-names-a-person.md) ·
+**Amends** [ADR-062](062-the-consent-page-asks-lanes-who-you-are.md),
+[ADR-018](018-the-gate-is-in-the-application.md)
+
+## Context
+
+There is no difference between "the API key" and "the `lanes link token`". They are
+one object under two names, and the code says so — `server/read/routes.ts` calls
+the `llk_` rows "the workspace's static API keys" while the command that mints
+them is `token issue`. Asked what the token family was *for*, the honest answer
+was: it is the API key, and the CLI is the thing that mints it.
+
+That second half is the problem, and it is not the naming.
+
+A `llk_` token is a random string the workspace keeps a copy of. So:
+
+- **The endpoint's answer is a comparison, not a verification.** `BearerAuthenticator`
+  reads every `tokens:` row's value out of the credential store and compares in
+  constant time. The credential and its verifier are the same secret.
+- **A key has to be transported before it works.** Minted locally, it lives in the
+  local store; a deployed revision reads a different store, so a key is useful
+  there only after `secrets push` and a Secret Manager version exists. Nothing
+  says so at mint time.
+- **The mint is in the wrong place.** A credential is issued by whoever can
+  authenticate the person it names. The CLI cannot: it holds a session and takes
+  `--subject <id>` on trust, so `token issue --subject lanes:<someone-else>`
+  mints a working credential for a person who was never asked.
+
+ADR-068 fixed what a token *means* — a row names a person, and reach follows from
+`members:`. It did not change who mints one or how it is checked, because at the
+time there was nowhere else to mint it. ADR-062 built that somewhere: the consent
+page asks `api.lanes.sh` who you are and the endpoint verifies a signed assertion
+against published keys, holding no secret of its own.
+
+So the endpoint already verifies one Lanes-signed credential. The static token is
+the part of the surface that did not get the same treatment.
+
+## Decision
+
+**An API key is signed by `api.lanes.sh` and verified against its published keys.
+Nothing on this side holds a copy.**
+
+A key is an RS256 JWT: `iss` the API, `sub` a `lanes:<uid>`, `aud` this endpoint's
+own resource URL, `kind: api_key`, and an `exp`. The dashboard mints it, because
+the dashboard is where the person is already authenticated.
+
+The endpoint verifies it with the machinery ADR-062 already put there — the same
+JWKS cache, the same RS256-over-`crypto.subtle` check, the same exact-match
+audience comparison. `lanes/signed.ts` is that machinery, extracted; `assertion.ts`
+and `api-key.ts` are the two sets of rules on top of it. One key cache, one
+rotation window, one audience comparison.
+
+Reach is unchanged and is the point: the subject resolves through `members:` on
+every request, exactly as an issued token's does. A key decides nothing about
+what it opens.
+
+### The two credentials must not be interchangeable, and the asymmetry is deliberate
+
+An assertion and a key are signed by the same issuer, may name the same audience,
+and name the same person. Only the `kind` claim separates a credential that
+crosses one redirect from one that lives in a CI secret for ninety days.
+
+- **`api-key.ts` requires `kind: api_key`.** Nothing has ever issued a key, so
+  this side can demand the claim from its first day — and demanding it is what
+  makes an assertion unusable here, since an assertion carries none.
+- **`assertion.ts` rejects `kind: api_key` and tolerates its absence.** It cannot
+  require `kind: assertion`: assertions minted before this claim existed must go
+  on working, and breaking sign-in is not an acceptable price for symmetry.
+
+Both directions are closed by that pair, and neither depends on the lifetime
+ceiling. Relying on the ceiling alone would be wrong: a key minted with a short
+`exp` has an `iat` consistent with it and would pass.
+
+### The audience is the only thing that makes a key mean *this* endpoint
+
+An issued token is bound to this endpoint by living in its store. An OIDC token is
+bound by an audience the operator configured. A Lanes-signed key is bound by
+nothing except `aud`, because its issuer signs for every Lanes endpoint there is.
+
+So `Authenticator.authenticate` gains an optional `AuthContext` carrying the
+resource identifier the caller addressed — the same string
+`protectedResourceMetadata` publishes, derived from `Host` and
+`X-Forwarded-Proto` because this endpoint does not know its own public URL from
+config.
+
+**Optional in the type, mandatory in effect.** `LanesKeyAuthenticator` refuses
+when it is absent rather than skipping the check. That is ADR-079's lesson stated
+one layer down: an unset field must not resolve to the widest answer. It is
+optional only so the three links that ignore it, and the test doubles that predate
+it, need not mention it.
+
+The loopback read listener supplies the *MCP server's* URL rather than its own.
+It binds one port above the endpoint, so a resource built from its own `Host`
+would name an address no key was ever minted for.
+
+A workspace-scoped audience was considered and rejected. `lanes_workspace` is the
+only Lanes-side identifier a target carries, it is optional and hand-written, and
+it exists as a convenience check for `profile members add`. Making it the thing a
+credential is verified against would turn a field most targets do not set into a
+gate, and a roster check into an authorization decision — which is exactly what
+the access model says it must never be.
+
+### Revocation is `members:`, and what that cannot do is stated
+
+Reach is resolved per request, so `lanes link profile members remove` stops a key
+within the member cache's window — seconds, and the same lever that already
+revokes every other shape.
+
+What it cannot do is revoke *one* key while leaving that person's others working.
+Nothing here holds a list of issued keys to strike one from, and nothing should:
+that list belongs to whoever mints them. Per-key revocation is the dashboard's,
+and until it exists the honest statement is that a key is revoked by removing the
+person, not the key.
+
+### What this costs
+
+**Verification stops being offline.** A `llk_` comparison needed no network. A
+signed key needs a key set fetched from the API. The cache is an hour and a fetch
+failure leaves previously-known keys answering, so the exposure is a cold endpoint
+during an API outage — but a self-hoster pointing `LANES_API_URL` elsewhere must
+publish a JWKS there. This is the same dependency ADR-062 already took on for
+sign-in; it now covers the headless path too.
+
+## Consequences
+
+`BearerAuthenticator`, `generateProfileToken`, the `llk_` prefix, the `tokens:`
+block and the `lanes link token` family all become removable — but **not in this
+change**, and the ordering is not incidental. The four CLI commands that call
+their own endpoint (`outputs`, `tools`, the reload notification, and
+`mcp add --headless`) get their credential from `anyIssuedToken`, and
+`mcp add --headless` requires one rather than degrading. Until the API can hand
+the CLI a short-lived endpoint-audienced token, deleting the mint would leave
+those commands with nothing.
+
+So both links sit in the chain at once. Static rows first, because that is still a
+constant-time comparison against a cached value; the declared gate next, because
+an issued token is a lookup in this endpoint's own state; the signed key last,
+because it is the only link that may have to fetch a key set. A credential that is
+not a JWT fails that link on its first `split`, so the ordering costs the other
+two nothing.
+
+The key link is **unconditional**, unlike the OAuth gate. It is the headless path,
+and making it depend on `auth.authorization` would mean a profile declaring no
+remote-client model could not be reached by a machine at all — which is the case
+the static token existed for.
+
+Removing the static family needs a contract bump and a migration that drops
+`tokens:` rows and their `tokens/*` values. That is a breaking change to a
+published package: every headless registration in the wild presents a `llk_`.
+ADR-066 records what a rename cost a client that had already fetched the old list.

--- a/docs/detailed/adr/README.md
+++ b/docs/detailed/adr/README.md
@@ -92,6 +92,7 @@ Run.
 | [077](077-the-workspace-lives-under-the-lanes-home.md) | The workspace moves to `~/.lanes/link`, a checkout gets `~/.lanes-dev`, and the old root is recognised until `update` moves it |
 | [078](078-a-removal-works-on-a-config-that-will-not-load.md) | A removal works on a config that will not load, deleting by name what it cannot enumerate and reporting the rest |
 | [079](079-the-dashboard-credential-names-a-person.md) | The dashboard's pairing token buys a session naming the person at the browser, and reaching every profile becomes a value a credential must carry rather than a field nobody set |
+| [080](080-an-api-key-is-signed-not-stored.md) | The API key and the `lanes link token` were one object under two names; the dashboard mints it, `api.lanes.sh` signs it, and the endpoint verifies it against published keys instead of holding a copy |
 
 Where an ADR departs from init.md, it says so at the top. Three are significant:
 

--- a/src/auth/index.test.ts
+++ b/src/auth/index.test.ts
@@ -4,12 +4,16 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { createFileSecretStore, generateCredentialKey, type SecretStore } from '#secrets';
 import {
+  AuthenticatorChain,
   BearerAuthenticator,
   generateProfileToken,
   machinePrincipal,
   mayReach,
   parseBearer,
   tokensMatch,
+  type AuthContext,
+  type Authenticator,
+  type AuthOutcome,
 } from './index.ts';
 
 function storeWith(entries: Record<string, string>): SecretStore {
@@ -354,5 +358,70 @@ describe('how often the credential store is read', () => {
     await auth.authenticate('Bearer llk_rotated_in_a_moment_ago');
 
     expect(reads()).toBe(warm + 1);
+  });
+});
+
+/**
+ * What the chain does with the context, which is the contract the key link needs.
+ *
+ * `LanesKeyAuthenticator` refuses when it is not told which endpoint was
+ * addressed, so a chain that accepted a context and forwarded nothing would turn
+ * every API key into a refusal — and it would do it silently, because a refused
+ * key is indistinguishable from a wrong one from outside. Hence a test of the
+ * forwarding itself rather than only of the links.
+ */
+describe('the chain and the context', () => {
+  /** A link that records what it was asked and answers from a fixed verdict. */
+  function recording(outcome: AuthOutcome): {
+    link: Authenticator;
+    seen: { context?: AuthContext | undefined; calls: number };
+  } {
+    const seen: { context?: AuthContext | undefined; calls: number } = { calls: 0 };
+    return {
+      seen,
+      link: {
+        authenticate: async (_header, context) => {
+          seen.calls += 1;
+          seen.context = context;
+          return outcome;
+        },
+      },
+    };
+  }
+
+  const ADDRESSED: AuthContext = { resource: 'https://link.example.com/mcp' };
+
+  test('every link is told which endpoint was addressed', async () => {
+    const first = recording({ ok: false, reason: 'invalid' });
+    const second = recording({ ok: false, reason: 'invalid' });
+
+    await new AuthenticatorChain([first.link, second.link]).authenticate('Bearer x', ADDRESSED);
+
+    expect(first.seen.context).toEqual(ADDRESSED);
+    expect(second.seen.context).toEqual(ADDRESSED);
+  });
+
+  test('a caller that names no endpoint forwards that, rather than inventing one', async () => {
+    const only = recording({ ok: false, reason: 'invalid' });
+
+    await new AuthenticatorChain([only.link]).authenticate('Bearer x');
+
+    expect(only.seen.context).toBeUndefined();
+  });
+
+  test('the first link to recognise the credential still wins, and later ones are not asked', async () => {
+    const yes = recording({
+      ok: true,
+      principal: { id: 'lanes:EXAMPLE', profile: 'personal', kind: 'machine', profiles: ['personal'] },
+    });
+    const never = recording({ ok: false, reason: 'invalid' });
+
+    const outcome = await new AuthenticatorChain([yes.link, never.link]).authenticate(
+      'Bearer x',
+      ADDRESSED,
+    );
+
+    expect(outcome.ok).toBe(true);
+    expect(never.seen.calls).toBe(0);
   });
 });

--- a/src/auth/index.ts
+++ b/src/auth/index.ts
@@ -43,16 +43,46 @@ export type AuthOutcome =
   | { readonly ok: false; readonly reason: 'missing' | 'malformed' | 'invalid' | 'not_configured' };
 
 /**
+ * What the request says about who is being addressed.
+ *
+ * Only one field, and only one authenticator reads it: a credential somebody
+ * *else* signed has to name this endpoint, or a key minted for one deployment
+ * opens every deployment the same issuer serves — the confused-deputy case the
+ * MCP authorization spec calls out. A token this endpoint minted needs none of
+ * this, because being in this endpoint's store is already the binding.
+ *
+ * **Optional in the type and mandatory in effect.** A link that needs it refuses
+ * when it is absent rather than skipping the check, which is ADR-079's lesson
+ * stated one layer down: an absent field must not resolve to the widest answer.
+ * It is optional here only so the implementations that ignore it, and the test
+ * doubles that predate it, do not have to mention it.
+ */
+export interface AuthContext {
+  /**
+   * This endpoint's resource identifier, exactly as the client addressed it.
+   *
+   * The same string `protectedResourceMetadata` publishes and an assertion's
+   * `aud` must match — built from `Host` and `X-Forwarded-Proto`, because this
+   * endpoint does not know its own public URL from config. See
+   * `server/oauth.ts`.
+   */
+  readonly resource: string;
+}
+
+/**
  * Anything that can turn an `Authorization` header into a principal.
  *
  * Extracted so the endpoint can accept more than one kind of proof without the
- * request path learning what kinds exist. There are two: a static token the
- * operator holds, and a token this endpoint or an issuer handed to a client
- * that completed an authorization flow. Both arrive in the same header, and the
- * server does not care which answered.
+ * request path learning what kinds exist. There are three: a static token the
+ * operator holds, a token this endpoint or an issuer handed to a client that
+ * completed an authorization flow, and an API key `api.lanes.sh` signed. All
+ * arrive in the same header, and the server does not care which answered.
  */
 export interface Authenticator {
-  authenticate(authorizationHeader: string | null | undefined): Promise<AuthOutcome>;
+  authenticate(
+    authorizationHeader: string | null | undefined,
+    context?: AuthContext,
+  ): Promise<AuthOutcome>;
   invalidateCache?(): void;
 }
 
@@ -76,12 +106,15 @@ export class AuthenticatorChain implements Authenticator {
     this.#links = links;
   }
 
-  async authenticate(authorizationHeader: string | null | undefined): Promise<AuthOutcome> {
+  async authenticate(
+    authorizationHeader: string | null | undefined,
+    context?: AuthContext,
+  ): Promise<AuthOutcome> {
     const rank = { invalid: 3, not_configured: 2, malformed: 1, missing: 0 } as const;
     let worst: Extract<AuthOutcome, { ok: false }> = { ok: false, reason: 'missing' };
 
     for (const link of this.#links) {
-      const outcome = await link.authenticate(authorizationHeader);
+      const outcome = await link.authenticate(authorizationHeader, context);
       if (outcome.ok) return outcome;
       if (rank[outcome.reason] > rank[worst.reason]) worst = outcome;
     }
@@ -326,8 +359,15 @@ export {
   type OAuthResult,
 } from './oauth/server.ts';
 export { AssertionVerifier, type Assertion } from './lanes/assertion.ts';
-export { lanesFederation, DEFAULT_WEB_URL, type FederationOptions } from './lanes/federation.ts';
+export { ApiKeyVerifier, type ApiKeySubject } from './lanes/api-key.ts';
+export {
+  lanesApiKeyVerifier,
+  lanesApiUrl,
+  lanesFederation,
+  DEFAULT_WEB_URL,
+  type FederationOptions,
+} from './lanes/federation.ts';
 export { matchesRegistered } from './oauth/redirects.ts';
 export { OAuthStore, hashToken, randomToken } from './oauth/store.ts';
 export { OidcVerifier, type OidcVerifierOptions, type VerifiedSubject } from './oidc.ts';
-export { IssuedTokenAuthenticator, OidcAuthenticator } from './remote.ts';
+export { IssuedTokenAuthenticator, LanesKeyAuthenticator, OidcAuthenticator } from './remote.ts';

--- a/src/auth/lanes/api-key.test.ts
+++ b/src/auth/lanes/api-key.test.ts
@@ -1,0 +1,225 @@
+import { beforeAll, describe, expect, test } from 'bun:test';
+import { ApiKeyVerifier } from './api-key.ts';
+import { AssertionVerifier } from './assertion.ts';
+
+/**
+ * Believing an API key the dashboard minted.
+ *
+ * Signed with a real key pair rather than stubbed, for the reason
+ * `./assertion.test.ts` gives: every check here is about a token somebody else
+ * could have written, and a double that returns "valid" would exercise the
+ * branches and prove nothing.
+ *
+ * The two tests that matter most are in `a credential for the other purpose`.
+ * An assertion and a key are signed by the same issuer, for the same audience,
+ * naming the same person — the *only* thing separating a two-minute redirect
+ * credential from a ninety-day one is that each verifier refuses the other's.
+ * If those two ever go green by accident, a captured assertion becomes a
+ * long-lived key and a key becomes a way through the consent flow.
+ */
+
+const ISSUER = 'https://api.example.com';
+const JWKS_URL = `${ISSUER}/.well-known/jwks.json`;
+const RESOURCE = 'https://link.example.com/mcp';
+const KID = 'a-key-id';
+const DAY = 24 * 60 * 60;
+
+let keys: CryptoKeyPair;
+let jwks: { keys: unknown[] };
+
+async function generate(): Promise<CryptoKeyPair> {
+  return (await crypto.subtle.generateKey(
+    { name: 'RSASSA-PKCS1-v1_5', modulusLength: 2048, publicExponent: new Uint8Array([1, 0, 1]), hash: 'SHA-256' },
+    true,
+    ['sign', 'verify'],
+  )) as CryptoKeyPair;
+}
+
+beforeAll(async () => {
+  keys = await generate();
+  const jwk = await crypto.subtle.exportKey('jwk', keys.publicKey);
+  jwks = { keys: [{ ...jwk, kid: KID, alg: 'RS256', use: 'sig' }] };
+});
+
+function encode(value: unknown): string {
+  return Buffer.from(JSON.stringify(value)).toString('base64url');
+}
+
+/** A key as the API would mint one, with anything overridden for a test. */
+async function key(
+  claims: Record<string, unknown> = {},
+  header: Record<string, unknown> = {},
+  signWith?: CryptoKey,
+): Promise<string> {
+  const now = Math.floor(Date.now() / 1000);
+  const body =
+    `${encode({ alg: 'RS256', typ: 'JWT', kid: KID, ...header })}.` +
+    `${encode({
+      iss: ISSUER,
+      aud: RESOURCE,
+      sub: 'FIREBASEUID000000000000000000',
+      email: 'ada.lovelace@example.com',
+      kind: 'api_key',
+      iat: now,
+      exp: now + 90 * DAY,
+      ...claims,
+    })}`;
+
+  const signature = await crypto.subtle.sign(
+    { name: 'RSASSA-PKCS1-v1_5' },
+    signWith ?? keys.privateKey,
+    new TextEncoder().encode(body),
+  );
+
+  return `${body}.${Buffer.from(signature).toString('base64url')}`;
+}
+
+type Call = (input: string | URL | Request, init?: RequestInit) => Promise<Response>;
+
+function verifier(overrides: { fetch?: Call; now?: () => number } = {}): ApiKeyVerifier {
+  return new ApiKeyVerifier({
+    jwksUrl: JWKS_URL,
+    issuer: ISSUER,
+    fetch: overrides.fetch ?? (async () => Response.json(jwks)),
+    ...(overrides.now ? { now: overrides.now } : {}),
+  });
+}
+
+const EXPECTED = { audience: RESOURCE };
+
+describe('a key the API signed', () => {
+  test('names the person, prefixed so a profile can hold the subject', async () => {
+    const verified = await verifier().verify(await key(), EXPECTED);
+
+    expect(verified?.subject).toBe('lanes:FIREBASEUID000000000000000000');
+    expect(verified?.email).toBe('ada.lovelace@example.com');
+  });
+
+  test('needs no nonce, because it crosses no redirect', async () => {
+    // The claim that binds an assertion to one authorization request has nothing
+    // to bind to here: a key is presented on every request, forever.
+    expect(await verifier().verify(await key(), EXPECTED)).not.toBeNull();
+  });
+
+  test('lives for ninety days without complaint', async () => {
+    const later = Date.now() + 80 * DAY * 1000;
+    const verified = await verifier({ now: () => later }).verify(await key(), EXPECTED);
+
+    expect(verified).not.toBeNull();
+  });
+});
+
+describe('a credential for the other purpose', () => {
+  test('a key is refused where an assertion belongs', async () => {
+    // Same issuer, same audience, same person, and a lifetime the assertion's
+    // own ceiling would also catch — but this must fail on `kind`, because a key
+    // minted with a short expiry would slip past that ceiling.
+    const assertions = new AssertionVerifier({
+      jwksUrl: JWKS_URL,
+      issuer: ISSUER,
+      fetch: async () => Response.json(jwks),
+    });
+
+    const shortLived = await key({ nonce: 'a-nonce', exp: Math.floor(Date.now() / 1000) + 60 });
+
+    expect(await assertions.verify(shortLived, { audience: RESOURCE, nonce: 'a-nonce' })).toBeNull();
+  });
+
+  test('an assertion is refused as a key', async () => {
+    // An assertion carries no `kind`, and this verifier requires one. That
+    // asymmetry is deliberate: see the comment in `./api-key.ts`.
+    const asAssertion = await key({ kind: undefined, nonce: 'a-nonce' });
+
+    expect(await verifier().verify(asAssertion, EXPECTED)).toBeNull();
+  });
+
+  test('an unknown kind is refused rather than treated as a key', async () => {
+    expect(await verifier().verify(await key({ kind: 'something_else' }), EXPECTED)).toBeNull();
+  });
+});
+
+describe('a key nobody should believe', () => {
+  test('signed by a different key', async () => {
+    const impostor = await generate();
+
+    expect(await verifier().verify(await key({}, {}, impostor.privateKey), EXPECTED)).toBeNull();
+  });
+
+  test('minted for somebody else’s endpoint', async () => {
+    // The confused-deputy case. A valid key, for a real person, naming an
+    // audience that is not us.
+    const elsewhere = await key({ aud: 'https://other.example.net/mcp' });
+
+    expect(await verifier().verify(elsewhere, EXPECTED)).toBeNull();
+  });
+
+  test('an audience that merely starts with ours', async () => {
+    const nearly = await key({ aud: `${RESOURCE}.evil.example.net` });
+
+    expect(await verifier().verify(nearly, EXPECTED)).toBeNull();
+  });
+
+  test('from an issuer we were not told to trust', async () => {
+    expect(await verifier().verify(await key({ iss: 'https://evil.example.net' }), EXPECTED)).toBeNull();
+  });
+
+  test('expired', async () => {
+    const past = Math.floor(Date.now() / 1000) - 10 * DAY;
+
+    expect(await verifier().verify(await key({ iat: past - 60, exp: past }), EXPECTED)).toBeNull();
+  });
+
+  test('with no expiry at all', async () => {
+    // An unbounded key is not a thing this endpoint accepts, and the check is
+    // the lifetime ceiling rather than a separate rule: a missing `exp` reports
+    // an infinite lifetime.
+    expect(await verifier().verify(await key({ exp: undefined }), EXPECTED)).toBeNull();
+  });
+
+  test('claiming a lifetime past the ceiling', async () => {
+    const now = Math.floor(Date.now() / 1000);
+    const decade = await key({ iat: now, exp: now + 3650 * DAY });
+
+    expect(await verifier().verify(decade, EXPECTED)).toBeNull();
+  });
+
+  test('with no subject', async () => {
+    expect(await verifier().verify(await key({ sub: undefined }), EXPECTED)).toBeNull();
+  });
+
+  test('naming an algorithm we do not verify', async () => {
+    // Pinned rather than read. `none` and HMAC-with-the-public-key both live here.
+    expect(await verifier().verify(await key({}, { alg: 'none' }), EXPECTED)).toBeNull();
+  });
+
+  test('naming a key id that was never published', async () => {
+    expect(await verifier().verify(await key({}, { kid: 'not-a-key' }), EXPECTED)).toBeNull();
+  });
+
+  test('when the key set cannot be fetched at all', async () => {
+    const offline = verifier({ fetch: async () => new Response('nope', { status: 503 }) });
+
+    expect(await offline.verify(await key(), EXPECTED)).toBeNull();
+  });
+});
+
+describe('the key set', () => {
+  test('an outage does not forget keys already fetched', async () => {
+    // What keeps a verified endpoint working while the API is down. The first
+    // call warms the cache; the second finds the fetch failing and must still
+    // answer from what it already had.
+    let calls = 0;
+    const flaky: Call = async () => {
+      calls += 1;
+      return calls === 1 ? Response.json(jwks) : new Response('down', { status: 500 });
+    };
+
+    const one = verifier({ fetch: flaky });
+    expect(await one.verify(await key(), EXPECTED)).not.toBeNull();
+
+    // Forces a refetch by asking for a kid the warm cache does not hold, which
+    // is the only path that reaches the network again inside the TTL.
+    expect(await one.verify(await key({}, { kid: 'other' }), EXPECTED)).toBeNull();
+    expect(await one.verify(await key(), EXPECTED)).not.toBeNull();
+  });
+});

--- a/src/auth/lanes/api-key.ts
+++ b/src/auth/lanes/api-key.ts
@@ -1,0 +1,101 @@
+import {
+  API_KEY_KIND,
+  CLOCK_SKEW_MS,
+  JwksVerifier,
+  claimedLifetimeMs,
+  credentialKind,
+  subjectFromClaims,
+  type JwksVerifierOptions,
+  type SignedSubject,
+} from './signed.ts';
+
+/**
+ * An API key the dashboard minted and `api.lanes.sh` signed.
+ *
+ * The credential for a caller with no browser — a CI job, a cron, a container —
+ * and the replacement for the static token this CLI used to mint itself. Both
+ * halves of that change matter:
+ *
+ * **It is verified, not compared.** The old token was a random string the
+ * workspace held a copy of, so the endpoint's answer to "is this the right
+ * credential" was a constant-time comparison against its own credential store.
+ * A signed key is checked against a published key, so nothing on this side holds
+ * a secret, nothing has to be copied to a deployed target before a key works,
+ * and a key issued a minute ago is accepted by an endpoint that has never heard
+ * of it.
+ *
+ * **It names a person, and that was already the rule.** The subject is a
+ * `lanes:<uid>`, resolved through `members:` on every request exactly as an OAuth
+ * token's is (ADR-068). The key decides nothing about reach; a profile listing
+ * that uid does.
+ *
+ * What this costs, stated plainly: verifying a key needs a key set fetched from
+ * the API, where the old comparison needed no network at all. The cache in
+ * `JwksVerifier` is an hour and survives an API outage, so the exposure is a
+ * cold endpoint during an outage — but a self-hoster pointing `LANES_API_URL`
+ * somewhere else must publish a JWKS there.
+ *
+ * **Revocation is `members:`, and it is the only revocation this shape has.**
+ * Reach is resolved per request, so `lanes link profile members remove` stops a
+ * key within the member cache's window — seconds. What it cannot do is revoke
+ * *one* key while leaving that person's others working: nothing here holds a
+ * list of issued keys to strike one from. That belongs to whoever mints them.
+ */
+
+/** Who an API key names, once it has been believed. */
+export type ApiKeySubject = SignedSubject;
+
+export type ApiKeyVerifierOptions = JwksVerifierOptions;
+
+/**
+ * The longest life this endpoint will honour, whatever the key claims.
+ *
+ * A key is *meant* to be long-lived, so this is not the tight ceiling an
+ * assertion carries — it is a backstop against one mistake: a key minted with an
+ * `exp` decades out is indistinguishable from a correct one until somebody reads
+ * the claims, and by then it has been in a CI secret for a year. Four hundred
+ * days is a year with slack, and is the same reasoning that stopped browsers
+ * honouring multi-year certificates.
+ *
+ * A key missing `exp` or `iat` reports an infinite lifetime and is refused here,
+ * which is the answer we want: an API key with no expiry is not a thing this
+ * endpoint accepts.
+ */
+const MAX_LIFETIME_MS = 400 * 24 * 60 * 60_000;
+
+export class ApiKeyVerifier {
+  readonly #keys: JwksVerifier;
+
+  constructor(options: ApiKeyVerifierOptions) {
+    this.#keys = new JwksVerifier(options);
+  }
+
+  /**
+   * The person this key names, or null.
+   *
+   * Null rather than a reason, for the reason every verifier here gives: the
+   * holder of a rejected credential cannot act on *which* check failed, and an
+   * attacker can.
+   */
+  async verify(token: string, expected: { audience: string }): Promise<ApiKeySubject | null> {
+    const payload = await this.#keys.payload(token);
+    if (payload === null) return null;
+
+    // **Required, not merely "not an assertion".** This is the asymmetry with
+    // `./assertion.ts`, and it is deliberate: that verifier *rejects* a key and
+    // tolerates a token with no `kind` at all, because assertions minted before
+    // this claim existed must go on working and breaking sign-in is not an
+    // acceptable cost. Nothing has ever issued an API key, so this side can
+    // demand the claim from its first day — and demanding it is what makes an
+    // assertion unusable here, since an assertion does not carry one.
+    if (credentialKind(payload) !== API_KEY_KIND) return null;
+
+    if (claimedLifetimeMs(payload) > MAX_LIFETIME_MS + CLOCK_SKEW_MS) return null;
+
+    return subjectFromClaims(payload, {
+      issuer: this.#keys.issuer,
+      audience: expected.audience,
+      now: this.#keys.now(),
+    });
+  }
+}

--- a/src/auth/lanes/assertion.ts
+++ b/src/auth/lanes/assertion.ts
@@ -1,4 +1,13 @@
-import type { FetchLike } from './login.ts';
+import {
+  API_KEY_KIND,
+  CLOCK_SKEW_MS,
+  JwksVerifier,
+  claimedLifetimeMs,
+  credentialKind,
+  subjectFromClaims,
+  type JwksVerifierOptions,
+  type SignedSubject,
+} from './signed.ts';
 
 /**
  * Verifying that lanes.sh vouched for the person at the browser.
@@ -8,93 +17,36 @@ import type { FetchLike } from './login.ts';
  * it asks lanes.sh "who is this", and gets back a signed statement it can check
  * without trusting the browser that carried it.
  *
- * Four checks, and each of them is load-bearing:
+ * The signature, the published keys, the issuer and the audience are
+ * `./signed.ts`, because a second Lanes-signed credential now goes through the
+ * same checks. What is left here is what makes this one an *assertion* rather
+ * than an API key, and there are three of them:
  *
- *  - **Signature**, against the API's published JWKS. Without it the assertion
- *    is a string the browser handed us and anyone could write one.
- *  - **Audience**, which must be *this endpoint's own resource URL*. An
- *    assertion minted for somebody else's endpoint is a valid assertion; using
- *    it here is the confused-deputy case the MCP authorization spec calls out,
- *    and this is the only thing that stops it.
  *  - **Nonce**, single-use, minted by this endpoint when the flow began. It
  *    binds the assertion to *this* authorization request, so one captured on a
  *    different endpoint of ours cannot be replayed into this one.
- *  - **Expiry**, tight. The assertion crosses one redirect, so a minute is
+ *  - **Expiry, tight.** The assertion crosses one redirect, so a minute is
  *    generous and anything longer is a bearer credential in a browser history.
- *
- * Verification is intentionally a public-key check and not a call back to the
- * API. The endpoint may be behind somebody's firewall; it must be able to
- * verify while only ever having *fetched* a key, and a cached JWKS makes the
- * whole flow work with the API unreachable for the length of the cache.
- *
- * No JWT library. RS256 over a JWK is `crypto.subtle.importKey` plus
- * `crypto.subtle.verify`, which is 30 lines and no supply chain — the same
- * reasoning that has `connectivity/auth/oauth-jwt/key.ts` signing with subtle
- * rather than pulling one in.
+ *  - **Not an API key.** A key is signed by the same issuer and may name the
+ *    same audience, so without this a ninety-day credential could be presented
+ *    where a two-minute one belongs — and the lifetime ceiling below would not
+ *    catch it, because a key's `exp` and `iat` are consistent with each other.
+ *    See `./api-key.ts` for the other half of the pair.
  */
 
 /** What an assertion says once it has been believed. */
-export interface Assertion {
-  /** `lanes:<uid>`, the same string `lanes auth login` stores and `members:` names. */
-  readonly subject: string;
-  readonly email: string | null;
-}
+export type Assertion = SignedSubject;
 
-export interface AssertionVerifierOptions {
-  /** Where the signing keys are published. */
-  readonly jwksUrl: string;
-  /** Who is allowed to have signed. Checked against `iss`. */
-  readonly issuer: string;
-  readonly fetch?: FetchLike | undefined;
-  readonly now?: (() => number) | undefined;
-  /** How long a fetched key set is reused. */
-  readonly cacheTtlMs?: number | undefined;
-}
-
-/**
- * One published key, as it arrives.
- *
- * Loose on purpose: `importKey` is the thing that decides whether a JWK is
- * usable, and re-deciding that here with a stricter type would mean a key the
- * platform accepts being dropped by our own schema.
- */
-type Jwk = Record<string, unknown> & { kid?: unknown; kty?: unknown; alg?: unknown };
-
-/** An hour. A key rotation is noticed within it, and a miss refetches anyway. */
-const DEFAULT_CACHE_TTL_MS = 60 * 60_000;
-
-/**
- * The shortest interval between two refetches provoked by an unknown key id.
- *
- * Without it, a token naming a key that does not exist costs a round trip to
- * the API — and since anyone can send one unauthenticated, every endpoint
- * becomes an amplifier pointed at us. A minute bounds that at one request per
- * endpoint per minute while still letting a genuine rotation land promptly.
- */
-const MISS_REFETCH_MS = 60_000;
+export type AssertionVerifierOptions = JwksVerifierOptions;
 
 /** Assertions cross one redirect; more than this is a credential left lying about. */
 const MAX_LIFETIME_MS = 120_000;
 
-/** Clocks differ. Small enough that it does not extend the window meaningfully. */
-const CLOCK_SKEW_MS = 30_000;
-
-/** What `importKey('jwk', …)` takes, without depending on a lib.dom global. */
-type JsonWebKeyLike = Parameters<typeof crypto.subtle.importKey>[1] extends infer T
-  ? Extract<T, { kty?: string | undefined }>
-  : never;
-
 export class AssertionVerifier {
-  readonly #options: AssertionVerifierOptions;
-  readonly #fetch: FetchLike;
-  readonly #now: () => number;
-  #keys: { at: number; byKid: Map<string, CryptoKey> } | null = null;
-  #missedAt = Number.NEGATIVE_INFINITY;
+  readonly #keys: JwksVerifier;
 
   constructor(options: AssertionVerifierOptions) {
-    this.#options = options;
-    this.#fetch = options.fetch ?? ((input, init) => globalThis.fetch(input, init));
-    this.#now = options.now ?? Date.now;
+    this.#keys = new JwksVerifier(options);
   }
 
   /**
@@ -106,151 +58,30 @@ export class AssertionVerifier {
    * legitimate user nothing they can act on. What *is* actionable — expiry — is
    * the one case the caller can infer by retrying.
    */
-  async verify(token: string, expected: { audience: string; nonce: string }): Promise<Assertion | null> {
-    const parts = token.split('.');
-    if (parts.length !== 3) return null;
+  async verify(
+    token: string,
+    expected: { audience: string; nonce: string },
+  ): Promise<Assertion | null> {
+    const payload = await this.#keys.payload(token);
+    if (payload === null) return null;
 
-    const [encodedHeader, encodedPayload, encodedSignature] = parts as [string, string, string];
-
-    const header = decodeJson(encodedHeader);
-    const payload = decodeJson(encodedPayload);
-    if (header === null || payload === null) return null;
-
-    // Pinned, not read. `alg` arrives inside the token, so honouring it is how
-    // the `none` algorithm and the HMAC-with-the-public-key confusions work.
-    if (header['alg'] !== 'RS256') return null;
-
-    const kid = typeof header['kid'] === 'string' ? header['kid'] : null;
-    if (kid === null) return null;
-
-    const key = await this.#key(kid);
-    if (key === null) return null;
-
-    const signed = new TextEncoder().encode(`${encodedHeader}.${encodedPayload}`);
-    const signature = base64url(encodedSignature);
-    if (signature === null) return null;
-
-    const valid = await crypto.subtle.verify(
-      { name: 'RSASSA-PKCS1-v1_5' },
-      key,
-      signature,
-      signed,
-    );
-    if (!valid) return null;
-
-    return this.#claims(payload, expected);
-  }
-
-  /** Everything that is true of a verified signature but not yet of this token. */
-  #claims(payload: Record<string, unknown>, expected: { audience: string; nonce: string }): Assertion | null {
-    if (payload['iss'] !== this.#options.issuer) return null;
-
-    // Exact match, per RFC 8707. A prefix or suffix comparison here would admit
-    // an assertion minted for a different endpoint on the same host.
-    const audience = payload['aud'];
-    const audiences = Array.isArray(audience) ? audience : [audience];
-    if (!audiences.includes(expected.audience)) return null;
+    // **Before anything else that could pass.** A credential minted for the
+    // other purpose is refused on what it says it is, not on whether its other
+    // claims happen to fit.
+    if (credentialKind(payload) === API_KEY_KIND) return null;
 
     if (payload['nonce'] !== expected.nonce) return null;
-
-    const now = this.#now();
-    const exp = typeof payload['exp'] === 'number' ? payload['exp'] * 1000 : 0;
-    const iat = typeof payload['iat'] === 'number' ? payload['iat'] * 1000 : 0;
-
-    if (exp <= now - CLOCK_SKEW_MS) return null;
-    if (iat > now + CLOCK_SKEW_MS) return null;
 
     // Checked here as well as trusted from the issuer. A deployment that
     // widened its own expiry would silently turn a redirect-scoped assertion
     // into a long-lived bearer token, and this endpoint is the party that has
     // to live with that.
-    if (exp - iat > MAX_LIFETIME_MS + CLOCK_SKEW_MS) return null;
+    if (claimedLifetimeMs(payload) > MAX_LIFETIME_MS + CLOCK_SKEW_MS) return null;
 
-    const subject = payload['sub'];
-    if (typeof subject !== 'string' || subject.length === 0) return null;
-
-    return {
-      // The API signs the raw uid; the prefix is added at exactly one place in
-      // the client, here and in `login.ts`, so the two cannot disagree about
-      // what a subject looks like.
-      subject: subject.startsWith('lanes:') ? subject : `lanes:${subject}`,
-      email: typeof payload['email'] === 'string' ? payload['email'] : null,
-    };
-  }
-
-  /**
-   * The signing key with that id.
-   *
-   * A miss against a warm cache refetches, because that is what a key rotation
-   * looks like from here and the alternative is every endpoint refusing until
-   * its cache lapses. It refetches at most once a minute, because the *other*
-   * thing a miss looks like is an invented key id, and those arrive
-   * unauthenticated and as fast as anyone cares to send them.
-   */
-  async #key(kid: string): Promise<CryptoKey | null> {
-    const ttl = this.#options.cacheTtlMs ?? DEFAULT_CACHE_TTL_MS;
-    const now = this.#now();
-    const fresh = this.#keys !== null && now - this.#keys.at < ttl;
-
-    if (fresh) {
-      const hit = this.#keys?.byKid.get(kid);
-      if (hit) return hit;
-      if (now - this.#missedAt < MISS_REFETCH_MS) return null;
-      this.#missedAt = now;
-    }
-
-    const loaded = await this.#load();
-    return loaded.get(kid) ?? null;
-  }
-
-  async #load(): Promise<Map<string, CryptoKey>> {
-    const byKid = new Map<string, CryptoKey>();
-
-    const response = await this.#fetch(this.#options.jwksUrl).catch(() => null);
-    if (response === null || !response.ok) {
-      // Left uncached, so the next attempt tries again rather than treating an
-      // outage as "there are no keys" for an hour. Whatever was already known
-      // still answers, which is what keeps a verified endpoint working while
-      // the API is down.
-      return this.#keys?.byKid ?? byKid;
-    }
-
-    const body = (await response.json().catch(() => ({}))) as { keys?: Jwk[] };
-
-    for (const jwk of body.keys ?? []) {
-      if (jwk.kty !== 'RSA' || (jwk.alg !== undefined && jwk.alg !== 'RS256')) continue;
-      if (typeof jwk.kid !== 'string') continue;
-
-      const key = await crypto.subtle
-        .importKey('jwk', jwk as JsonWebKeyLike, { name: 'RSASSA-PKCS1-v1_5', hash: 'SHA-256' }, false, [
-          'verify',
-        ])
-        .catch(() => null);
-
-      if (key !== null) byKid.set(jwk.kid, key);
-    }
-
-    this.#keys = { at: this.#now(), byKid };
-    return byKid;
-  }
-}
-
-function base64url(value: string): ArrayBuffer | null {
-  try {
-    const bytes = Buffer.from(value, 'base64url');
-    return bytes.buffer.slice(bytes.byteOffset, bytes.byteOffset + bytes.byteLength) as ArrayBuffer;
-  } catch {
-    return null;
-  }
-}
-
-function decodeJson(value: string): Record<string, unknown> | null {
-  const bytes = base64url(value);
-  if (bytes === null) return null;
-  try {
-    const parsed: unknown = JSON.parse(new TextDecoder().decode(bytes));
-    return typeof parsed === 'object' && parsed !== null ? (parsed as Record<string, unknown>) : null;
-  } catch {
-    return null;
+    return subjectFromClaims(payload, {
+      issuer: this.#keys.issuer,
+      audience: expected.audience,
+      now: this.#keys.now(),
+    });
   }
 }

--- a/src/auth/lanes/federation.ts
+++ b/src/auth/lanes/federation.ts
@@ -1,3 +1,4 @@
+import { ApiKeyVerifier } from './api-key.ts';
 import { AssertionVerifier } from './assertion.ts';
 import { DEFAULT_API_URL } from './login.ts';
 import type { Federation } from '../oauth/server.ts';
@@ -29,8 +30,38 @@ export interface FederationOptions {
   readonly fetch?: ConstructorParameters<typeof AssertionVerifier>[0]['fetch'];
 }
 
+/**
+ * Which API this endpoint believes about identity.
+ *
+ * One function, because there are now two things that have to agree about it —
+ * the consent flow's assertion verifier and the API-key verifier — and an
+ * endpoint that trusted one issuer for sign-in and another for keys would be a
+ * hole nobody would find by reading either file alone.
+ */
+export function lanesApiUrl(override?: string | undefined): string {
+  return override ?? process.env['LANES_API_URL'] ?? DEFAULT_API_URL;
+}
+
+/**
+ * The verifier for API keys the dashboard minted.
+ *
+ * Here rather than in `#server`, beside the federation it shares an issuer and a
+ * key set with. The audience is not settled here: it is whatever the request
+ * said this endpoint is, which only the request knows — see `AuthContext`.
+ */
+export function lanesApiKeyVerifier(
+  options: { readonly apiUrl?: string | undefined; readonly fetch?: FederationOptions['fetch'] } = {},
+): ApiKeyVerifier {
+  const apiUrl = lanesApiUrl(options.apiUrl);
+  return new ApiKeyVerifier({
+    jwksUrl: `${apiUrl}/.well-known/jwks.json`,
+    issuer: apiUrl,
+    ...(options.fetch ? { fetch: options.fetch } : {}),
+  });
+}
+
 export function lanesFederation(options: FederationOptions): Federation {
-  const apiUrl = options.apiUrl ?? process.env['LANES_API_URL'] ?? DEFAULT_API_URL;
+  const apiUrl = lanesApiUrl(options.apiUrl);
   const webUrl = options.webUrl ?? process.env['LANES_WEB_URL'] ?? DEFAULT_WEB_URL;
 
   const verifier = new AssertionVerifier({

--- a/src/auth/lanes/signed.ts
+++ b/src/auth/lanes/signed.ts
@@ -1,0 +1,299 @@
+import type { FetchLike } from './login.ts';
+
+/**
+ * Believing something `api.lanes.sh` signed, without deciding what it means.
+ *
+ * Split out of `./assertion.ts` when a second credential arrived that this
+ * endpoint must verify the same way and judge differently. The signature, the
+ * published keys and the claims *every* Lanes-signed token has to satisfy are
+ * here; what makes one a redirect assertion and another a long-lived API key is
+ * in the two files that build on this.
+ *
+ * The split is not tidying. Both credentials are RS256 over the same JWKS from
+ * the same issuer, so a second copy of the key cache would mean two caches with
+ * two rotation windows, and a second copy of the audience check would mean two
+ * chances to get the confused-deputy comparison wrong. There is one of each, and
+ * the differences are stated as rules on top rather than reimplemented beneath.
+ *
+ * No JWT library, for the reason `./assertion.ts` has always given: RS256 over a
+ * JWK is `crypto.subtle.importKey` plus `crypto.subtle.verify`, which is thirty
+ * lines and no supply chain.
+ */
+
+/** What a verified token says that both credentials say the same way. */
+export interface SignedSubject {
+  /** `lanes:<uid>`, the same string `lanes auth login` stores and `members:` names. */
+  readonly subject: string;
+  readonly email: string | null;
+}
+
+export interface JwksVerifierOptions {
+  /** Where the signing keys are published. */
+  readonly jwksUrl: string;
+  /** Who is allowed to have signed. Checked against `iss` by `subjectFromClaims`. */
+  readonly issuer: string;
+  readonly fetch?: FetchLike | undefined;
+  readonly now?: (() => number) | undefined;
+  /** How long a fetched key set is reused. */
+  readonly cacheTtlMs?: number | undefined;
+}
+
+/**
+ * One published key, as it arrives.
+ *
+ * Loose on purpose: `importKey` is the thing that decides whether a JWK is
+ * usable, and re-deciding that here with a stricter type would mean a key the
+ * platform accepts being dropped by our own schema.
+ */
+type Jwk = Record<string, unknown> & { kid?: unknown; kty?: unknown; alg?: unknown };
+
+/** An hour. A key rotation is noticed within it, and a miss refetches anyway. */
+const DEFAULT_CACHE_TTL_MS = 60 * 60_000;
+
+/**
+ * The shortest interval between two refetches provoked by an unknown key id.
+ *
+ * Without it, a token naming a key that does not exist costs a round trip to
+ * the API — and since anyone can send one unauthenticated, every endpoint
+ * becomes an amplifier pointed at us. A minute bounds that at one request per
+ * endpoint per minute while still letting a genuine rotation land promptly.
+ */
+const MISS_REFETCH_MS = 60_000;
+
+/** Clocks differ. Small enough that it does not extend any window meaningfully. */
+export const CLOCK_SKEW_MS = 30_000;
+
+/** What `importKey('jwk', …)` takes, without depending on a lib.dom global. */
+type JsonWebKeyLike = Parameters<typeof crypto.subtle.importKey>[1] extends infer T
+  ? Extract<T, { kty?: string | undefined }>
+  : never;
+
+/**
+ * The issuer's keys, and whether this token was signed with one of them.
+ *
+ * Signature only. It answers "did `api.lanes.sh` write this", which is the same
+ * question for every Lanes-signed credential, and nothing about what the token
+ * is for — so a caller that forgets to check the claims gets a payload rather
+ * than a principal, and `subjectFromClaims` is the only way to turn one into the
+ * other.
+ *
+ * Verification is intentionally a public-key check and not a call back to the
+ * API. The endpoint may be behind somebody's firewall; it must be able to verify
+ * while only ever having *fetched* a key, and a cached JWKS makes the whole flow
+ * work with the API unreachable for the length of the cache.
+ */
+export class JwksVerifier {
+  readonly #options: JwksVerifierOptions;
+  readonly #fetch: FetchLike;
+  readonly #now: () => number;
+  #keys: { at: number; byKid: Map<string, CryptoKey> } | null = null;
+  #missedAt = Number.NEGATIVE_INFINITY;
+
+  constructor(options: JwksVerifierOptions) {
+    this.#options = options;
+    this.#fetch = options.fetch ?? ((input, init) => globalThis.fetch(input, init));
+    this.#now = options.now ?? Date.now;
+  }
+
+  get issuer(): string {
+    return this.#options.issuer;
+  }
+
+  now(): number {
+    return this.#now();
+  }
+
+  /**
+   * The payload of a token this issuer signed, or null.
+   *
+   * Null rather than a reason, the same way `AssertionVerifier.verify` has always
+   * answered: "the signature did not verify" versus "the key id was unknown"
+   * tells an attacker which of their attempts got closer while telling a
+   * legitimate caller nothing they can act on.
+   */
+  async payload(token: string): Promise<Record<string, unknown> | null> {
+    const parts = token.split('.');
+    if (parts.length !== 3) return null;
+
+    const [encodedHeader, encodedPayload, encodedSignature] = parts as [string, string, string];
+
+    const header = decodeJson(encodedHeader);
+    const payload = decodeJson(encodedPayload);
+    if (header === null || payload === null) return null;
+
+    // Pinned, not read. `alg` arrives inside the token, so honouring it is how
+    // the `none` algorithm and the HMAC-with-the-public-key confusions work.
+    if (header['alg'] !== 'RS256') return null;
+
+    const kid = typeof header['kid'] === 'string' ? header['kid'] : null;
+    if (kid === null) return null;
+
+    const key = await this.#key(kid);
+    if (key === null) return null;
+
+    const signature = base64url(encodedSignature);
+    if (signature === null) return null;
+
+    const valid = await crypto.subtle.verify(
+      { name: 'RSASSA-PKCS1-v1_5' },
+      key,
+      signature,
+      new TextEncoder().encode(`${encodedHeader}.${encodedPayload}`),
+    );
+
+    return valid ? payload : null;
+  }
+
+  /**
+   * The signing key with that id.
+   *
+   * A miss against a warm cache refetches, because that is what a key rotation
+   * looks like from here and the alternative is every endpoint refusing until
+   * its cache lapses. It refetches at most once a minute, because the *other*
+   * thing a miss looks like is an invented key id, and those arrive
+   * unauthenticated and as fast as anyone cares to send them.
+   */
+  async #key(kid: string): Promise<CryptoKey | null> {
+    const ttl = this.#options.cacheTtlMs ?? DEFAULT_CACHE_TTL_MS;
+    const now = this.#now();
+    const fresh = this.#keys !== null && now - this.#keys.at < ttl;
+
+    if (fresh) {
+      const hit = this.#keys?.byKid.get(kid);
+      if (hit) return hit;
+      if (now - this.#missedAt < MISS_REFETCH_MS) return null;
+      this.#missedAt = now;
+    }
+
+    const loaded = await this.#load();
+    return loaded.get(kid) ?? null;
+  }
+
+  async #load(): Promise<Map<string, CryptoKey>> {
+    const byKid = new Map<string, CryptoKey>();
+
+    const response = await this.#fetch(this.#options.jwksUrl).catch(() => null);
+    if (response === null || !response.ok) {
+      // Left uncached, so the next attempt tries again rather than treating an
+      // outage as "there are no keys" for an hour. Whatever was already known
+      // still answers, which is what keeps a verified endpoint working while
+      // the API is down.
+      return this.#keys?.byKid ?? byKid;
+    }
+
+    const body = (await response.json().catch(() => ({}))) as { keys?: Jwk[] };
+
+    for (const jwk of body.keys ?? []) {
+      if (jwk.kty !== 'RSA' || (jwk.alg !== undefined && jwk.alg !== 'RS256')) continue;
+      if (typeof jwk.kid !== 'string') continue;
+
+      const key = await crypto.subtle
+        .importKey('jwk', jwk as JsonWebKeyLike, { name: 'RSASSA-PKCS1-v1_5', hash: 'SHA-256' }, false, [
+          'verify',
+        ])
+        .catch(() => null);
+
+      if (key !== null) byKid.set(jwk.kid, key);
+    }
+
+    this.#keys = { at: this.#now(), byKid };
+    return byKid;
+  }
+}
+
+/**
+ * The claims every Lanes-signed credential must satisfy, whatever it is for.
+ *
+ * Three of them, and each is load-bearing:
+ *
+ *  - **Issuer**, against the API this endpoint was told to trust. Without it a
+ *    signature from any key we happen to have cached would do.
+ *  - **Audience**, which must be *this endpoint's own resource URL*, matched
+ *    exactly per RFC 8707. A token minted for somebody else's endpoint is a
+ *    valid token; using it here is the confused-deputy case the MCP
+ *    authorization spec calls out, and this is the only thing that stops it. A
+ *    prefix or suffix comparison would admit a token minted for a different
+ *    endpoint on the same host.
+ *  - **Expiry and issuance**, with a small skew. How *long* a credential may
+ *    live is not decided here — that is the one rule that genuinely differs
+ *    between a token crossing a single redirect and a key living in a CI
+ *    secret — so each caller checks its own ceiling.
+ */
+export function subjectFromClaims(
+  payload: Record<string, unknown>,
+  expected: { readonly issuer: string; readonly audience: string; readonly now: number },
+): SignedSubject | null {
+  if (payload['iss'] !== expected.issuer) return null;
+
+  const audience = payload['aud'];
+  const audiences = Array.isArray(audience) ? audience : [audience];
+  if (!audiences.includes(expected.audience)) return null;
+
+  const exp = typeof payload['exp'] === 'number' ? payload['exp'] * 1000 : 0;
+  const iat = typeof payload['iat'] === 'number' ? payload['iat'] * 1000 : 0;
+
+  if (exp <= expected.now - CLOCK_SKEW_MS) return null;
+  if (iat > expected.now + CLOCK_SKEW_MS) return null;
+
+  const subject = payload['sub'];
+  if (typeof subject !== 'string' || subject.length === 0) return null;
+
+  return {
+    // The API signs the raw uid; the prefix is added at exactly one place in the
+    // client, so nothing here and in `login.ts` can disagree about what a
+    // subject looks like.
+    subject: subject.startsWith('lanes:') ? subject : `lanes:${subject}`,
+    email: typeof payload['email'] === 'string' ? payload['email'] : null,
+  };
+}
+
+/**
+ * How long a token claims to be good for, in milliseconds.
+ *
+ * Returned rather than checked, because the ceiling is what distinguishes the
+ * two credentials and each states its own. A token missing either claim reports
+ * `Infinity`, so a caller comparing against a ceiling refuses it — which is the
+ * right answer for both of them and is why this does not return null.
+ */
+export function claimedLifetimeMs(payload: Record<string, unknown>): number {
+  const exp = typeof payload['exp'] === 'number' ? payload['exp'] * 1000 : null;
+  const iat = typeof payload['iat'] === 'number' ? payload['iat'] * 1000 : null;
+  return exp === null || iat === null ? Number.POSITIVE_INFINITY : exp - iat;
+}
+
+/**
+ * Which Lanes-signed credential this is, as the payload declares it.
+ *
+ * A claim rather than the JOSE `typ` header, because the header almost certainly
+ * already says `JWT` and overloading it would mean asking the API to change
+ * something a client may be reading. Unknown and absent are the same answer —
+ * null — and the two callers treat that differently on purpose: see
+ * `./api-key.ts`.
+ */
+export function credentialKind(payload: Record<string, unknown>): string | null {
+  const kind = payload['kind'];
+  return typeof kind === 'string' && kind.length > 0 ? kind : null;
+}
+
+/** What a long-lived API key declares itself to be. */
+export const API_KEY_KIND = 'api_key';
+
+export function base64url(value: string): ArrayBuffer | null {
+  try {
+    const bytes = Buffer.from(value, 'base64url');
+    return bytes.buffer.slice(bytes.byteOffset, bytes.byteOffset + bytes.byteLength) as ArrayBuffer;
+  } catch {
+    return null;
+  }
+}
+
+function decodeJson(value: string): Record<string, unknown> | null {
+  const bytes = base64url(value);
+  if (bytes === null) return null;
+  try {
+    const parsed: unknown = JSON.parse(new TextDecoder().decode(bytes));
+    return typeof parsed === 'object' && parsed !== null ? (parsed as Record<string, unknown>) : null;
+  } catch {
+    return null;
+  }
+}

--- a/src/auth/remote.test.ts
+++ b/src/auth/remote.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from 'bun:test';
-import { IssuedTokenAuthenticator, OidcAuthenticator } from './remote.ts';
+import { IssuedTokenAuthenticator, LanesKeyAuthenticator, OidcAuthenticator } from './remote.ts';
 import { EVERY_PROFILE, mayReach } from './principal.ts';
+import type { ApiKeyVerifier } from './lanes/api-key.ts';
 import type { OidcVerifier } from './oidc.ts';
 import { OAuthStore } from './oauth/store.ts';
 import type { KeyValueStore } from '#stores/state';
@@ -316,5 +317,133 @@ describe('a token from an external issuer', () => {
 
     expect(outcome.ok).toBe(false);
     expect(!outcome.ok && outcome.reason).toBe('invalid');
+  });
+});
+
+/**
+ * What an API key the dashboard minted turns into.
+ *
+ * The resolution is the same shape as the two above and is not what these tests
+ * are for. What is different, and what the first two cases hold, is that this is
+ * the only link whose credential was signed by an issuer serving every Lanes
+ * endpoint — so the audience is the only thing making a key mean *this* endpoint,
+ * and a caller that does not say which endpoint was addressed must be refused
+ * rather than trusted.
+ */
+
+/** A verifier that answers from a table, and records the audience it was given. */
+function stubKeyVerifier(
+  answers: Record<string, string>,
+  seen?: { audience?: string },
+): ApiKeyVerifier {
+  return {
+    verify: async (token: string, expected: { audience: string }) => {
+      if (seen) seen.audience = expected.audience;
+      const subject = answers[token];
+      return subject ? { subject, email: null } : null;
+    },
+  } as unknown as ApiKeyVerifier;
+}
+
+describe('an API key the API signed', () => {
+  const SUBJECT = 'lanes:EXAMPLEUID00000000000000000';
+  const ADDRESSED = { resource: 'https://link.example.com/mcp' };
+
+  test('reaches only the profiles whose members: name its subject', async () => {
+    const auth = new LanesKeyAuthenticator(
+      stubKeyVerifier({ theirs: SUBJECT }),
+      'personal',
+      async (subject) => (subject === SUBJECT ? ['personal'] : []),
+    );
+
+    const outcome = await auth.authenticate('Bearer theirs', ADDRESSED);
+
+    expect(outcome.ok).toBe(true);
+    if (!outcome.ok) return;
+    expect(outcome.principal.id).toBe(SUBJECT);
+    expect(outcome.principal.kind).toBe('member');
+    expect(outcome.principal.profiles).toEqual(['personal']);
+    expect(mayReach(outcome.principal, 'personal')).toBe(true);
+    expect(mayReach(outcome.principal, 'work')).toBe(false);
+  });
+
+  test('is refused when the caller did not say which endpoint was addressed', async () => {
+    // Fail closed. Verifying without an audience would accept a key minted for
+    // any endpoint the same issuer signs for, which is the whole reason the
+    // audience is checked at all.
+    const auth = new LanesKeyAuthenticator(
+      stubKeyVerifier({ theirs: SUBJECT }),
+      'personal',
+      async () => ['personal'],
+    );
+
+    const outcome = await auth.authenticate('Bearer theirs');
+
+    expect(outcome).toEqual({ ok: false, reason: 'invalid' });
+  });
+
+  test('checks the key against the endpoint the request named', async () => {
+    const seen: { audience?: string } = {};
+    const auth = new LanesKeyAuthenticator(
+      stubKeyVerifier({ theirs: SUBJECT }, seen),
+      'personal',
+      async () => ['personal'],
+    );
+
+    await auth.authenticate('Bearer theirs', ADDRESSED);
+
+    expect(seen.audience).toBe('https://link.example.com/mcp');
+  });
+
+  test('a subject no profile names reaches nothing, and that is not an error', async () => {
+    const auth = new LanesKeyAuthenticator(
+      stubKeyVerifier({ theirs: SUBJECT }),
+      'personal',
+      async () => [],
+    );
+
+    const outcome = await auth.authenticate('Bearer theirs', ADDRESSED);
+
+    expect(outcome.ok).toBe(true);
+    if (!outcome.ok) return;
+    expect(outcome.principal.profiles).toEqual([]);
+    expect(outcome.principal.profiles).not.toBe(EVERY_PROFILE);
+    expect(mayReach(outcome.principal, 'personal')).toBe(false);
+  });
+
+  test('a key the verifier does not believe is invalid, not missing', async () => {
+    const auth = new LanesKeyAuthenticator(stubKeyVerifier({}), 'personal', async () => ['personal']);
+
+    expect(await auth.authenticate('Bearer nope', ADDRESSED)).toEqual({
+      ok: false,
+      reason: 'invalid',
+    });
+  });
+
+  test('a member lookup that throws fails closed', async () => {
+    // The alternative is a bucket outage widening what a key reaches, which is
+    // the direction nothing here is allowed to fail in.
+    const auth = new LanesKeyAuthenticator(
+      stubKeyVerifier({ theirs: SUBJECT }),
+      'personal',
+      async () => {
+        throw new Error('the store is unreachable');
+      },
+    );
+
+    expect(await auth.authenticate('Bearer theirs', ADDRESSED)).toEqual({
+      ok: false,
+      reason: 'invalid',
+    });
+  });
+
+  test('no credential is missing, and a malformed one says so', async () => {
+    const auth = new LanesKeyAuthenticator(stubKeyVerifier({}), 'personal', async () => []);
+
+    expect(await auth.authenticate(null, ADDRESSED)).toEqual({ ok: false, reason: 'missing' });
+    expect(await auth.authenticate('Basic abc', ADDRESSED)).toEqual({
+      ok: false,
+      reason: 'malformed',
+    });
   });
 });

--- a/src/auth/remote.ts
+++ b/src/auth/remote.ts
@@ -1,14 +1,16 @@
 import {
   memberPrincipal,
   parseBearer,
+  type AuthContext,
   type AuthOutcome,
   type Authenticator,
 } from './index.ts';
+import type { ApiKeyVerifier } from './lanes/api-key.ts';
 import type { OAuthStore } from './oauth/store.ts';
 import type { OidcVerifier } from './oidc.ts';
 
 /**
- * The two ways a remote client's token becomes a principal.
+ * The three ways a remote client's token becomes a principal.
  *
  * A token this endpoint issued now carries *who completed the flow* and which
  * profiles named them, so it resolves to a member principal (ADR-060). Both were
@@ -121,6 +123,70 @@ export class OidcAuthenticator implements Authenticator {
       // The issuer being unreachable, or misconfigured, is not an authorisation.
       // Failing closed here means an outage at the identity provider closes the
       // endpoint rather than opening it.
+      return { ok: false, reason: 'invalid' };
+    }
+  }
+}
+
+/**
+ * An API key `api.lanes.sh` signed, verified against its published keys.
+ *
+ * The third shape, and the one that replaces a credential this CLI used to mint
+ * itself. It resolves the same way the other two do — a subject, then the
+ * profiles whose `members:` name them — so `mayReach` gets no special case and
+ * nothing here decides reach.
+ *
+ * **It is the only link that needs to know which endpoint was addressed.** An
+ * issued token is bound to this endpoint by living in its store; an OIDC token
+ * by an audience the operator configured. A key is signed by an issuer that
+ * serves every Lanes endpoint, so the audience is the *only* thing standing
+ * between a key minted for one deployment and every other deployment. Absent, it
+ * refuses: an unchecked audience here would make a key a skeleton key across
+ * every endpoint the issuer signs for, which is precisely the failure ADR-079
+ * spent its argument on one level up.
+ */
+export class LanesKeyAuthenticator implements Authenticator {
+  readonly #verifier: ApiKeyVerifier;
+  readonly #profile: string;
+  readonly #profilesFor: (subject: string) => Promise<readonly string[]>;
+
+  constructor(
+    verifier: ApiKeyVerifier,
+    profile: string,
+    profilesFor: (subject: string) => Promise<readonly string[]>,
+  ) {
+    this.#verifier = verifier;
+    this.#profile = profile;
+    this.#profilesFor = profilesFor;
+  }
+
+  async authenticate(
+    header: string | null | undefined,
+    context?: AuthContext,
+  ): Promise<AuthOutcome> {
+    const presented = parseBearer(header);
+    if (presented === null) return { ok: false, reason: header ? 'malformed' : 'missing' };
+
+    // Fail closed on a caller that did not say who was addressed. `invalid`
+    // rather than `not_configured`: the credential was not examined, and the
+    // chain's ranking treats `invalid` as the more specific answer — which is
+    // right, because something reached this link with a bearer it could not
+    // judge, and that is worth surfacing over "nobody has set this up".
+    if (context === undefined) return { ok: false, reason: 'invalid' };
+
+    try {
+      const verified = await this.#verifier.verify(presented, { audience: context.resource });
+      if (!verified) return { ok: false, reason: 'invalid' };
+
+      // Resolved per request, never cached with the credential. This is what
+      // makes `profile members remove` the revocation for a key, and it is the
+      // only one a signed credential has — see `./lanes/api-key.ts`.
+      const profiles = await this.#profilesFor(verified.subject);
+      return { ok: true, principal: memberPrincipal(verified.subject, this.#profile, profiles) };
+    } catch {
+      // A JWKS fetch that throws, or a resolver that does. Closed, for the
+      // reason `OidcAuthenticator` gives: an outage at the identity provider
+      // must close the endpoint rather than open it.
       return { ok: false, reason: 'invalid' };
     }
   }

--- a/src/server/authorization.ts
+++ b/src/server/authorization.ts
@@ -1,10 +1,12 @@
 import {
   AuthenticatorChain,
   IssuedTokenAuthenticator,
+  LanesKeyAuthenticator,
   OAuthServer,
   OAuthStore,
   OidcAuthenticator,
   OidcVerifier,
+  lanesApiKeyVerifier,
   lanesFederation,
   type Authenticator,
 } from '#auth';
@@ -107,14 +109,29 @@ export async function openAuthorization(
  * The dashboard used to have a credential of its own that named no person, and
  * the surfaces it reached were the ones nothing filtered.
  *
- * Null gate means bearer-token-only: the workspace's static API keys, each
- * naming the uid it was issued to (ADR-068), and no chain to build.
+ * **Order is cost, and it has not changed.** The workspace's own static rows
+ * first, because that is a constant-time comparison against a cached value; the
+ * declared gate next, because an issued token is a lookup in this endpoint's own
+ * state; the Lanes-signed key last, because it is the only link that may have to
+ * fetch a key set. A credential that is not a JWT fails that link on its first
+ * `split`, so putting it last costs the other two nothing.
+ *
+ * **The key link is unconditional**, unlike the gate. It is the headless path —
+ * what a CI job presents when it has no browser to complete a flow in — and
+ * making it depend on `auth.authorization` would mean a profile that declared no
+ * remote-client model could not be reached by a machine at all, which is the
+ * case the static token existed for.
  */
 export function endpointAuthenticator(
   primary: Runtime,
   gate: { readonly authenticator: Authenticator } | null,
+  members: (subject: string) => Promise<readonly string[]>,
 ): Authenticator {
-  return gate
-    ? new AuthenticatorChain([primary.authenticator, gate.authenticator])
-    : primary.authenticator;
+  const profile = primary.resolution.profile;
+
+  return new AuthenticatorChain([
+    primary.authenticator,
+    ...(gate ? [gate.authenticator] : []),
+    new LanesKeyAuthenticator(lanesApiKeyVerifier(), profile, members),
+  ]);
 }

--- a/src/server/edge.ts
+++ b/src/server/edge.ts
@@ -1,4 +1,10 @@
-import { challenge, type AuthOutcome, type Authenticator, type ChallengeError } from '#auth';
+import {
+  challenge,
+  type AuthContext,
+  type AuthOutcome,
+  type Authenticator,
+  type ChallengeError,
+} from '#auth';
 import type { Logger } from '#connectivity';
 import { RateLimiter } from '#policy';
 
@@ -371,9 +377,10 @@ export async function authenticateRequest(
   authenticator: Authenticator,
   request: Request,
   log: Logger,
+  context?: AuthContext,
 ): Promise<AuthOutcome | Response> {
   try {
-    return await authenticator.authenticate(request.headers.get('authorization'));
+    return await authenticator.authenticate(request.headers.get('authorization'), context);
   } catch (error) {
     log.error('could not authenticate', {
       message: error instanceof Error ? error.message : String(error),

--- a/src/server/endpoint.ts
+++ b/src/server/endpoint.ts
@@ -225,13 +225,13 @@ export async function startEndpoint(options: EndpointOptions): Promise<RunningEn
     // disagree about what a pairing token may do (ADR-069).
     const data = dataSurface(() => serving);
 
-    const gate = await openAuthorization(primary, log, async (subject) =>
+    // One closure for the gate and the key link, so neither can disagree on reach.
+    const membersOf = async (subject: string): Promise<readonly string[]> =>
       [...serving]
-        .filter(([, runtime]) =>
-          runtime.config.members.some((member) => member.subject === subject),
-        )
-        .map(([name]) => name),
-    );
+        .filter(([, runtime]) => runtime.config.members.some((m) => m.subject === subject))
+        .map(([name]) => name);
+
+    const gate = await openAuthorization(primary, log, membersOf);
 
     // The authenticator and the authorization gate are built once, from the
     // runtime this endpoint booted with, and are deliberately not part of what
@@ -278,7 +278,7 @@ export async function startEndpoint(options: EndpointOptions): Promise<RunningEn
       },
     );
 
-    const authenticator = endpointAuthenticator(primary, gate);
+    const authenticator = endpointAuthenticator(primary, gate, membersOf);
 
     const server = serve({
       generations,
@@ -296,7 +296,7 @@ export async function startEndpoint(options: EndpointOptions): Promise<RunningEn
         primary,
         profiles: () => generations.current.profiles,
         log,
-        authenticate: (header) => authenticator.authenticate(header),
+        authenticate: (header, context) => authenticator.authenticate(header, context),
         version: runningVersion,
         data,
       }),
@@ -316,7 +316,7 @@ export async function startEndpoint(options: EndpointOptions): Promise<RunningEn
       () => generations.current.profiles,
       log,
       runningVersion,
-      (header) => authenticator.authenticate(header),
+      (header, context) => authenticator.authenticate(header, context),
       data,
       gate?.surface,
     );

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -18,6 +18,7 @@ import {
 import {
   handleAuthorization,
   isAuthorizationPath,
+  publicOrigin,
   resourceMetadataUrl,
   type AuthorizationSurface,
 } from './oauth.ts';
@@ -153,6 +154,9 @@ export function createRequestHandler(options: ServerOptions): RequestHandler {
       }
 
       const url = new URL(request.url);
+      // Who the caller addressed, so a Lanes-signed key binds to this endpoint
+      // rather than to every endpoint its issuer signs for.
+      const addressed = { resource: `${publicOrigin(request)}${MCP_PATH}` };
 
       // Ahead of every path that answers without a credential, because the
       // ceiling further down is inside the `401` branch and so has never covered
@@ -192,9 +196,8 @@ export function createRequestHandler(options: ServerOptions): RequestHandler {
         // And they are the *caller's* since ADR-068: this listed every profile
         // served to anybody holding a credential, so a delegated member read the
         // ones `mayReach` keeps out of their own enum.
-        const named = await options.authenticator.authenticate(
-          request.headers.get('authorization'),
-        );
+        const auth = request.headers.get('authorization');
+        const named = await options.authenticator.authenticate(auth, addressed);
         const who = named.ok ? named.principal : null;
         const mine = options.generations.current.names().filter((n) => who && mayReach(who, n));
         return Response.json({
@@ -222,7 +225,7 @@ export function createRequestHandler(options: ServerOptions): RequestHandler {
         return new Response('Not found', { status: 404 });
       }
 
-      const attempt = await authenticateRequest(options.authenticator, request, options.log);
+      const attempt = await authenticateRequest(options.authenticator, request, options.log, addressed);
       if (attempt instanceof Response) return attempt;
       const outcome = attempt;
 

--- a/src/server/read/deployed.ts
+++ b/src/server/read/deployed.ts
@@ -2,6 +2,8 @@ import type { Runtime } from '#cli/runtime.ts';
 import type { Logger } from '#connectivity';
 import type { Authenticator } from '#auth';
 import type { ProfileRuntime } from '../mcp/visibility.ts';
+import { MCP_PATH } from '../index.ts';
+import { publicOrigin } from '../oauth.ts';
 import { connectionRows } from './connections.ts';
 import type { ReadDeps } from './routes.ts';
 import type { DataSurface } from '#cli/owner-data/surface.ts';
@@ -47,6 +49,9 @@ export function deployedReadDeps(input: {
     // workspace's own manifests are all named the same way.
     providerName: (id) => primary.registry.manifest(id)?.name,
     authenticate: input.authenticate,
+    // Same origin as `/mcp` here, so the same derivation. Cloud Run routes one
+    // port and these paths hang off it.
+    resource: (request) => `${publicOrigin(request)}${MCP_PATH}`,
     endpoint: { kind: 'deployed', version: input.version, certificateExpiresAt: null },
     ...(input.data ? { data: input.data } : {}),
     log,

--- a/src/server/read/open.ts
+++ b/src/server/read/open.ts
@@ -81,6 +81,10 @@ export async function openReadListener(
       // Who is calling, resolved exactly as `/mcp` resolves it. The endpoint's
       // own authenticator, so a bearer works on both binds or on neither.
       authenticate,
+      // **The MCP server's URL, not this listener's.** This bind is a port above
+      // the endpoint, so its own `Host` names an address no credential was ever
+      // minted for. A key's audience is the endpoint clients call.
+      resource: () => server.url,
       endpoint: { kind: 'local', version, certificateExpiresAt: expiryOf(cert) },
       ...(data ? { data } : {}),
       // **The authorization paths, on this port too.** A page on

--- a/src/server/read/routes.ts
+++ b/src/server/read/routes.ts
@@ -166,6 +166,23 @@ export interface ReadDeps {
    * every other path behaves exactly as it did before this surface existed.
    */
   readonly data?: DataSurface | undefined;
+  /**
+   * This endpoint's resource identifier, for the one authenticator that checks it.
+   *
+   * A function of the request rather than a string, because the two binds answer
+   * differently and neither can guess the other's. A deployed endpoint serves
+   * these paths on its own origin, so the resource is derived from the request
+   * exactly as `/mcp` derives it. The loopback listener is a *second* port — one
+   * above the MCP port — so a resource built from its own `Host` would name an
+   * address no key was ever minted for, and it passes the MCP server's URL
+   * instead.
+   *
+   * Optional, and absent means a Lanes-signed key cannot be judged here and is
+   * refused. That is the safe direction and the reason it is not defaulted: a
+   * fallback guess would be a guess about which endpoint a credential was minted
+   * for, which is the one thing the audience check exists to not do.
+   */
+  readonly resource?: ((request: Request) => string) | undefined;
   readonly allowedOrigins?: readonly string[] | undefined;
   readonly log?: Logger | undefined;
 }
@@ -242,7 +259,10 @@ export async function readRoutes(request: Request, deps: ReadDeps): Promise<Resp
   // indistinguishable from a 500 on a bug. `authenticateRequest` wraps the
   // `/mcp` path the same way, for the same reason.
   const outcome = await deps
-    .authenticate(request.headers.get('authorization'))
+    .authenticate(
+      request.headers.get('authorization'),
+      deps.resource ? { resource: deps.resource(request) } : undefined,
+    )
     .catch((reason: unknown) => {
       deps.log?.warn('could not resolve the caller', {
         reason: reason instanceof Error ? reason.message : String(reason),


### PR DESCRIPTION
There is no difference between "the API key" and "the `lanes link token`". They are one object
under two names, and the code already said so — `read/routes.ts` calls the `llk_` rows "the
workspace's static API keys" while the command that mints them is `token issue`.

The naming was never the problem. The mint was:

- **The endpoint compares rather than verifies.** `BearerAuthenticator` reads every `tokens:`
  row's value out of the credential store and compares in constant time. The credential and its
  verifier are the same secret.
- **A key has to be transported before it works.** Minted locally it lives in the local store; a
  deployed revision reads a different one, so a key works there only after `secrets push`.
- **The CLI cannot authenticate the subject it is handed.** It holds a session and takes
  `--subject <id>` on trust, so `token issue --subject <someone-else>` mints a working credential
  for a person who was never asked.

ADR-068 fixed what a token *means* — a row names a person, reach follows from `members:`. It could
not change who mints one, because at the time there was nowhere else to. ADR-062 built that
somewhere. This is the static token getting the same treatment.

An API key becomes an RS256 JWT the dashboard mints and the API signs, verified here against the
JWKS this endpoint already fetches. `lanes/signed.ts` is that machinery extracted; `assertion.ts`
and `api-key.ts` are two sets of rules on top of it, so there is one key cache, one rotation
window and one exact-match audience comparison rather than two of each.

Full reasoning in [ADR-080](docs/detailed/adr/080-an-api-key-is-signed-not-stored.md).

## Two decisions worth reviewing rather than skimming

**The `kind` claim is asymmetric, deliberately.** `api-key.ts` *requires* `kind: api_key`;
`assertion.ts` *rejects* it but tolerates its absence. Requiring `kind: assertion` would refuse
every assertion minted today and break sign-in, and nothing has ever issued a key, so only one
side can demand its claim. Both confusion directions are still closed, and neither rests on the
lifetime ceiling — a key minted with a short `exp` has a consistent `iat` and would pass one.

**`Authenticator.authenticate` gains an optional `AuthContext`.** A key's issuer signs for every
endpoint, so `aud` is the only thing making one mean *this* endpoint, and the resource identifier
is request-derived. `LanesKeyAuthenticator` refuses when it is absent rather than skipping the
check — ADR-079's lesson one layer down. The loopback read listener passes the MCP server's URL,
not its own, because it binds a port above the endpoint.

A workspace-scoped audience was considered and rejected: `lanes_workspace` is optional,
hand-written, and exists as a convenience check for `profile members add`. Verifying credentials
against it would turn a field most targets do not set into a gate.

## Nothing is deleted, and that is the point of the staging

`outputs`, `tools`, the reload notification and `mcp add --headless` all get their credential from
`anyIssuedToken`, and the last requires one rather than degrading. Until the API can hand the CLI a
short-lived endpoint-audienced token, deleting the mint leaves those with nothing. So both links
sit in the chain: static rows first (a cached constant-time compare), the declared gate next (a
local lookup), the signed key last (the only one that may fetch).

The key link is unconditional, unlike the OAuth gate — it is the headless path, and gating it on
`auth.authorization` would mean a profile declaring no remote-client model could not be reached by
a machine at all.

## What was run

- `bun test` — 3711 pass, 0 fail, 12 skip (baseline on `develop` was 3695 pass, 0 fail). 28 new
  tests.
- `bun run typecheck` — clean.
- `src/auth/lanes/api-key.test.ts` — 18 cases, signed with a real RSA key pair rather than a stub,
  because every check here is about a token somebody else could have written. Includes both
  confusion directions, a near-miss audience (`<resource>.evil.example.net`), an absent `exp`, a
  lifetime past the ceiling, `alg: none`, an unpublished `kid`, and an outage that must not make
  the verifier forget keys it already held.
- `src/auth/remote.test.ts` — the authenticator: reach from `members:`, a subject no profile names
  reaching nothing, a member lookup that throws failing closed, and the fail-closed path when no
  endpoint was named.
- `src/auth/index.test.ts` — the chain forwards the context to every link. Without this a key
  would be refused silently and indistinguishably from a wrong one.
- `src/architecture.test.ts` — green, including the file-size budget. `server/index.ts` and
  `server/endpoint.ts` both sat 1–4 lines under it and my comments tipped them over; they are
  tightened rather than added to `KNOWN_LONG`, since neither gained a second subject.

## What was NOT covered

**No deployment rehearsal, and it is not possible yet.** The rule in `CLAUDE.md` asks for a real
target exercised from the branch. Nothing mints a `kind: api_key` credential yet, so there is no
key to present — the verifier can only be exercised against locally-generated signatures, which is
what the tests above do. When the API side exists, the rehearsal still owed is:

- `POST /reload`, `/health`, and the container log, all three.
- `tools/list` off the wire, counted against what `/reload` returned.
- A key reaching both the typed tool and `lanes_tools_call`.
- The refusals: a uid on no member list, a key audienced to a different endpoint, an expired key,
  and a key naming one profile with another profile's connection.
- Both links live at once — an existing static token and a new key opening the same endpoint.

**Also untested here:** the audience actually threaded from a live `Host`/`X-Forwarded-Proto` pair.
The derivation is `publicOrigin` + `MCP_PATH`, both already covered, but the composition is only
asserted at unit level.

Draft until the rehearsal is possible.
