### PR TITLE
Four comments describing a credential that was withdrawn

### DIFF
--- a/src/cli/commands/operate/pair.ts
+++ b/src/cli/commands/operate/pair.ts
@@ -22,18 +22,23 @@ import { pairingGuidance, pairingLink } from './pairing-link.ts';
  * `lanes link pair` — let the Lanes dashboard read this machine (ADR-063).
  *
  * Three things, and each is the operator's to decline. It installs a locally
- * trusted certificate, mints a credential that reads the whole workspace and
- * writes the owner's own data in it, and hands the browser a link carrying it.
- * None of that happens without being asked for, and none of it is implied by
- * `start`.
+ * trusted certificate, records that somebody opted this endpoint in, and hands
+ * the browser a link carrying the address. None of that happens without being
+ * asked for, and none of it is implied by `start`.
  *
- * **The credential is not read-only, since ADR-069.** It edits and deletes
- * memory, tasks, assets, skills and entities, in every profile the workspace
- * holds, and it still reaches no connection, token, policy rule, configuration
- * or vault value. That is a widening of something a year of notes calls a read,
- * so the paragraph this command prints says it before the operator answers —
- * and a token minted before that release gains it silently, which is the reason
- * saying it here is not decoration.
+ * **What it mints is a marker, not a credential, since ADR-079.** This docstring
+ * said the opposite for a release: that the token "reads the whole workspace and
+ * writes the owner's own data in it", which was true under ADR-069 and stopped
+ * being true when the read surface started resolving a real bearer through the
+ * endpoint's own authenticator. Nothing verifies `workspace/pair_token` now —
+ * `server/read/open.ts` says so at the one place that still reads it — and its
+ * only remaining job is that its existence is what decides whether the loopback
+ * read port binds at all.
+ *
+ * So the credential question moved to whoever opens the link: they sign in with
+ * Lanes and reach the profiles whose `members:` name them. `pairingGuidance()`
+ * is the paragraph that says that to the operator, and it is the copy to keep
+ * right — this one is for whoever edits the command.
  *
  * **The certificate is the largest side effect any command in this CLI has.**
  * It is a persistent change to the machine's trust store, made by a CLI, and
@@ -317,8 +322,10 @@ async function pairDeployed(input: {
 
   // An empty string, not just a missing ref: `lanes link deploy` creates this
   // secret with no version so the revision's IAM binding has something to
-  // attach to, and a secret that exists with no version reads back as null
-  // here and as `unpaired` there. Either shape means nobody has paired yet.
+  // attach to, and a secret that exists with no version reads back as null both
+  // here and in the endpoint. Either shape means nobody has paired yet, and
+  // there it means the read port does not bind rather than that a request is
+  // refused — nothing answers `unpaired`, which this said until ADR-079.
   const existing = held === '' ? null : held;
   const token = existing ?? `llp_${randomBytes(32).toString('base64url')}`;
   if (existing === null) await credentials.set(PAIR_TOKEN_REF, token);

--- a/src/cli/commands/operate/serve.ts
+++ b/src/cli/commands/operate/serve.ts
@@ -133,7 +133,10 @@ export async function start(
  * `lanes auth status` says how long that has left to run.
  *
  * The CI token is the exception and stays one (ADR-009): a headless runner has
- * no browser, presents `llk_…`, and reaches the whole workspace.
+ * no browser and presents `llk_…`. What it reaches is every profile whose
+ * `members:` names the subject its row was issued to, and nothing else — this
+ * said "the whole workspace", which was true until ADR-068 made a row name a
+ * person, and is the reach that release exists to have removed.
  */
 async function requireSignIn(): Promise<void> {
   if ((await readSession()) !== null) return;

--- a/src/deployments/prepare.ts
+++ b/src/deployments/prepare.ts
@@ -157,9 +157,13 @@ export async function readableRefs(
   // went healthy.
   //
   // Bound, the deployed-but-never-paired case becomes the 404 instead — a
-  // secret that exists with no version — which reads back as null and renders
-  // as `401 {error:'unpaired'}`. The grant is what turns a crash into a
-  // refusal.
+  // secret that exists with no version, which reads back as null. The grant is
+  // what turns a crash into an ordinary absence.
+  //
+  // It used to render as `401 {error:'unpaired'}` and no longer does: ADR-079
+  // withdrew the pairing token as a credential, so the surface answers
+  // `{error:'unauthorized', signIn:true}` to anyone without a bearer and this
+  // ref is only consulted to decide whether the loopback port binds.
   //
   // Deciding it by asking *whether the workspace is paired* is the thing that
   // cannot happen: that means opening a credential store inside `readableRefs`,


### PR DESCRIPTION
ADR-079 stopped the pairing token being a credential and ADR-068 stopped the static token reaching
the whole workspace. Both landed. Four comments did not follow, and each states a security property
that is now false.

| Where | Said | Actually |
|---|---|---|
| `cli/commands/operate/pair.ts:24` | pairing "mints a credential that reads the whole workspace and writes the owner's own data in it", plus a paragraph on editing and deleting memory, tasks, assets, skills and entities | nothing verifies `workspace/pair_token`; its existence only decides whether the loopback read port binds (`server/read/open.ts:23`) |
| `cli/commands/operate/pair.ts:321` | a versionless secret "reads back as null here and as `unpaired` there" | there is no `unpaired`; the surface answers `{error:'unauthorized', signIn:true}` |
| `cli/commands/operate/serve.ts:135` | the CI token "reaches the whole workspace" | it reaches every profile whose `members:` names the subject its row was issued to — the exact reach ADR-068 exists to have removed |
| `deployments/prepare.ts:161` | renders as `401 {error:'unpaired'}` | same absent shape as above |

`grep -rn unpaired src/` returns no response shape by that name. The remaining hits in
`server/mcp/instructions.ts` are a different sense of the word — a provider surface being paired or
not — and are correct.

**The paragraph `pair` prints was already right** and is untouched. `pairingGuidance()` was
corrected in fce5367 and says the link carries an address rather than a key. What was left stale is
the docstring above the command, which is the copy whoever edits it reads first.

Comments only; no behaviour changes.

## Why its own change

A wrong comment about what a credential reaches gets read as an account of the system and then
repeated. All four of these were — into a plan for reworking this surface, as settled fact, before
the code was checked against them. Riding along inside a functional change is how they stayed
wrong through two releases that made them wrong.

## What was run

- `bun test` — 3683 pass, 0 fail, 12 skip. Identical to the `develop` baseline, as expected for a
  comment-only change.
- `bun run typecheck` — clean.

## What was NOT covered

No deployment rehearsal, and none is owed: nothing here changes what reaches the wire. No string in
this diff is printed, returned, or serialised — `pairingGuidance()`, which is the operator-facing
text, is not modified, and `pair.test.ts` already asserts its content.
