### PR TITLE
lanes link auth is gone; the probe it wrapped is not

### DIFF
--- a/src/cli/commands/auth.ts
+++ b/src/cli/commands/auth.ts
@@ -6,10 +6,11 @@ import { print, ok, prose, style, warn } from '../output.ts';
 /**
  * `lanes auth` — who this machine is signed in as.
  *
- * A separate area from `lanes link auth`, which is a per-connection credential
- * diagnostic and answers a different question entirely. Neither is renamed and
- * neither gains an alias: one spelling per command, and the help text on each
- * says which is which.
+ * The only `auth` in this CLI, which it was not. `lanes link auth` sat beside it
+ * as a per-connection credential diagnostic answering an entirely different
+ * question, and the two were told apart by help text. That command is gone —
+ * `doctor` asks what it asked — so there is one spelling and nothing to
+ * disambiguate.
  *
  * Sign-in is required to consume a profile, local endpoints included (ADR-060).
  * That is a real dependency on lanes.sh for a self-hostable tool, and the shape

--- a/src/cli/commands/operate.ts
+++ b/src/cli/commands/operate.ts
@@ -21,7 +21,12 @@
  */
 
 export { check, doctor, plan } from './operate/inspect.ts';
-export { auth, classifyOAuth, type AuthFlags, type AuthVerdict, type ConnectionAuth } from './operate/auth.ts';
+export {
+  classifyOAuth,
+  probeConnections,
+  type ConnectionAuth,
+  type ConnectionVerdict,
+} from './operate/connection-probe.ts';
 export { status } from './operate/status.ts';
 export { outputs, type OutputsFlags } from './operate/outputs.ts';
 export { tools, type ToolsFlags } from './operate/tools.ts';

--- a/src/cli/commands/operate/connection-probe.test.ts
+++ b/src/cli/commands/operate/connection-probe.test.ts
@@ -2,13 +2,13 @@ import { describe, expect, test } from 'bun:test';
 import { ReauthRequired } from '#connectivity/auth/index.ts';
 import { defineProvider } from '#connectivity';
 import type { SecretRef, SecretStore } from '#secrets';
-import { classifyOAuth, probeConnections } from './auth.ts';
+import { classifyOAuth, probeConnections } from './connection-probe.ts';
 import type { Runtime } from '../../runtime.ts';
 
 /**
  * The mapping, on its own.
  *
- * Everything expensive about `lanes link auth` is I/O, and everything that
+ * Everything expensive about the probe is I/O, and everything that
  * could be *wrong* about it is this function. Both ways it can lie have a test
  * here, because both are the kind of bug that ships quietly: one tells someone
  * to sign in again when their network is simply down, and the other tells them

--- a/src/cli/commands/operate/connection-probe.ts
+++ b/src/cli/commands/operate/connection-probe.ts
@@ -2,17 +2,16 @@ import type { ConnectionConfig } from '#profile';
 import { credentialResolver, ReauthRequired } from '#connectivity/auth/index.ts';
 import type { ResolvedCredential } from '#connectivity/auth/credential.ts';
 import { credentialRefFor } from '#registry';
-import { announceWorkspace, emit, fail, ok, print, warn } from '../../output.ts';
-import { readConnections } from '#profile';
-import {
-  grantedConnections,
-  openWorkspaceRuntime,
-  type GlobalFlags,
-  type Runtime,
-} from '../../runtime.ts';
+import type { Runtime } from '../../runtime.ts';
 
 /**
  * Whether each connection could still authenticate, asked rather than guessed.
+ *
+ * **This was `lanes link auth` and is no longer a command.** The name collided
+ * with `lanes auth`, which is sign-in and a different subject entirely, and the
+ * only consumer outside this repository was the desktop app's pre-0.8.0 settings
+ * arm — the one it stopped rendering when connections moved to the dashboard.
+ * `doctor` asks the question now, which it already did.
  *
  * `doctor` used to answer a version of this from the *age* of a stored
  * credential, which is wrong in both directions: it dates a credential from
@@ -27,15 +26,15 @@ import {
  * cost is one token-endpoint round trip per connection that has genuinely
  * lapsed — which is exactly the set worth asking about.
  *
- * **This command writes.** A successful refresh persists the new token, which on
- * a deployed target is a secret-store version per refreshed connection. That is
+ * **This writes.** A successful refresh persists the new token, which on a
+ * deployed target is a secret-store version per refreshed connection. That is
  * deliberate — it is the same write the serve path makes, and it warms the token
- * for the next real call — but it is why the read-only wording `check`, `plan`
- * and `doctor` carry does not appear here.
+ * for the next real call — but it is worth knowing that `doctor`, whose wording
+ * is otherwise read-only, reaches something that does not.
  */
 
 /** What can be said about one connection's ability to authenticate. */
-export type AuthVerdict =
+export type ConnectionVerdict =
   /** Resolved. The vendor accepted it just now, or its access token is still live. */
   | 'ok'
   /** Stored, and cannot be renewed without a person. The signal this exists for. */
@@ -55,7 +54,7 @@ export interface ConnectionAuth {
   readonly id: string;
   /** The manifest's `auth.kind`, so a reader can tell why a verdict is what it is. */
   readonly method: string;
-  readonly verdict: AuthVerdict;
+  readonly verdict: ConnectionVerdict;
   /** Whether answering cost a token-endpoint round trip. */
   readonly refreshed: boolean;
   readonly detail?: string;
@@ -96,7 +95,7 @@ export type ProbeResult =
  * saying the opposite of what the next real call will find. So the stored
  * expiry is checked here rather than that behaviour being changed.
  */
-export function classifyOAuth(result: ProbeResult): AuthVerdict {
+export function classifyOAuth(result: ProbeResult): ConnectionVerdict {
   switch (result.outcome) {
     case 'resolved':
       return result.staleAccessToken ? 'reauth' : 'ok';
@@ -139,17 +138,13 @@ function storedExpiry(raw: string | null): number | null {
   }
 }
 
-export interface AuthFlags extends GlobalFlags {
-  readonly json?: boolean | undefined;
-  /** Narrow to one connection, by `provider.id`. A filter, not a second subject. */
-  readonly connection?: string | undefined;
-}
-
 /**
  * Every connection's verdict, probed concurrently.
  *
- * Exported because `doctor` asks the same question and must not answer it a
- * second, differently-wrong way — that divergence is the bug this replaced.
+ * `doctor` is the one caller, and this stays its own module rather than moving
+ * into `inspect.ts` for the reason it was extracted in the first place: `doctor`
+ * used to answer this a second, differently-wrong way, and a seam is what stops
+ * that coming back.
  */
 export async function probeConnections(
   runtime: Runtime,
@@ -251,83 +246,11 @@ export async function probeConnections(
   return mapWithLimit(connections, CONCURRENCY, probe);
 }
 
-export async function auth(flags: AuthFlags): Promise<void> {
-  const runtime = await openWorkspaceRuntime(flags);
-
-  try {
-    const { profile, target } = runtime.resolution;
-    const forSelection = (command: string) => `${command} --workspace ${target}`;
-
-    // Every connection the workspace holds, not the ones one profile grants.
-    // Whether an account can still authenticate is a fact about the account
-    // (ADR-057), and scoping it to a profile's grants meant an account that had
-    // just been connected could not be checked until somebody granted it —
-    // which is exactly the moment you want to check.
-    //
-    // `--profile` narrows to what that profile can reach, because "can the
-    // things this profile uses still sign in" is also a real question.
-    const all = flags.profile === undefined
-      ? (await readConnections(runtime.resolution.workspaceRoot)).connections
-      : grantedConnections(runtime);
-
-    const wanted = flags.connection;
-    const connections = wanted ? all.filter((c) => `${c.provider}.${c.id}` === wanted) : all;
-
-    if (wanted && connections.length === 0) {
-      throw new Error(
-        `No connection "${wanted}" in workspace ${target}. Run: ${forSelection('lanes link connection list')}`,
-      );
-    }
-
-    const results = await probeConnections(runtime, connections, forSelection);
-    const needsSomeone = results.filter((r) => r.verdict === 'reauth' || r.verdict === 'missing');
-
-    // Always zero, and this is load-bearing rather than an oversight: the
-    // desktop app discards stdout when the CLI exits non-zero, which is exactly
-    // why it cannot read `doctor`. A connection needing a person is the answer
-    // this command was asked for, not a failure to produce one.
-    return emit(flags.json, { profile, target, ok: needsSomeone.length === 0, connections: results }, () => {
-      announceWorkspace(runtime.resolution);
-
-      for (const result of results) {
-        const line = `${result.key} — ${describe(result.verdict)}`;
-        if (result.verdict === 'reauth') print(fail(`${line}\n      ${result.fix}`));
-        else if (result.verdict === 'missing') print(warn(`${line}\n      ${result.fix}`));
-        else print(ok(line));
-      }
-
-      if (needsSomeone.length > 0) {
-        print();
-        print(fail(`${needsSomeone.length} connection(s) need you to sign in again`));
-      }
-    });
-  } finally {
-    await runtime.close();
-  }
-}
-
-function describe(verdict: AuthVerdict): string {
-  switch (verdict) {
-    case 'ok':
-      return 'authenticated';
-    case 'reauth':
-      return 'signed out, and cannot renew itself';
-    case 'missing':
-      return 'no credential stored';
-    case 'stored':
-      return 'credential stored, not exercised';
-    case 'none':
-      return 'needs no credential';
-    case 'unknown':
-      return 'could not be checked';
-  }
-}
-
 /**
  * `Promise.all` with a ceiling, in the ten lines it takes.
  *
  * A pool rather than chunks: chunking would make every batch wait for its
- * slowest member, which is the shape this command is trying to avoid.
+ * slowest member, which is the shape this is trying to avoid.
  */
 async function mapWithLimit<T, R>(
   items: readonly T[],

--- a/src/cli/commands/operate/findings.ts
+++ b/src/cli/commands/operate/findings.ts
@@ -19,7 +19,7 @@ import type { DoctorFinding } from './inspect.ts';
  *
  * `credentialAge` used to sit beside it and date a credential from the OAuth
  * provider's stamp. It is gone: dating a credential answers "when did this last
- * refresh", which is not the question anyone was asking. `operate/auth.ts`
+ * refresh", which is not the question anyone was asking. `operate/connection-probe.ts`
  * asks the real one by attempting the renewal.
  */
 

--- a/src/cli/commands/operate/inspect.ts
+++ b/src/cli/commands/operate/inspect.ts
@@ -7,7 +7,7 @@ import { openRuntime, resolveProfileOnly, type GlobalFlags, type Runtime } from 
 import type { FetchLike } from '#deployments/knowledge.ts';
 import { unboundRotatableRefs } from '#deployments/bind.ts';
 import { duplicateAccountFindings, reportCapabilityDrift } from './findings.ts';
-import { probeConnections } from './auth.ts';
+import { probeConnections } from './connection-probe.ts';
 import { migratedContract, migratedRenamedProviders } from './migrate.ts';
 import { reportWorkspaceHomeMove } from '../../workspace-home-migrate.ts';
 import { reachabilityFindings } from './reachability.ts';
@@ -173,8 +173,9 @@ export async function doctor(flags: DoctorFlags): Promise<void> {
     // the problem.
     //
     // `probeConnections` answers it by attempting the renewal, which is the only
-    // thing that actually knows. Same classifier as `lanes link auth`, so the two
-    // cannot drift apart again.
+    // thing that actually knows. It kept its own module when `lanes link auth`
+    // was removed, because the divergence it was extracted to stop was this
+    // command answering the question a second, differently-wrong way.
     const probed = await probeConnections(runtime, grantedConnections(runtime), forSelection);
 
     for (const result of probed) {

--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -10,7 +10,6 @@ import {
   attachFile,
   auditTail,
   auditVerify,
-  auth,
   check,
   configShow,
   desktop,
@@ -399,10 +398,6 @@ export async function run(argv: readonly string[]): Promise<void> {
     case 'doctor':
       return doctor({ ...global, json, fix: flags['fix'] === true });
 
-    // Beside `doctor` because it answers half of what `doctor` used to guess at,
-    // and answers it by asking rather than by dating a credential.
-    case 'auth':
-      return auth({ ...global, json, connection: text(flags, 'connection') });
     case 'status':
       return status({ ...global, json });
     case 'outputs':

--- a/src/cli/selection.ts
+++ b/src/cli/selection.ts
@@ -164,10 +164,6 @@ export const SELECTION: Record<string, Requires> = {
   secrets: 'workspace',
   plan: 'profile+workspace',
   doctor: 'profile+workspace',
-  // Whether an account can still sign in is a fact about the account. Scoped to
-  // a profile's grants it could not check one that had just been connected,
-  // which is when you most want to.
-  auth: 'workspace',
   // Target-scoped: see the note above. `--profile` narrows each to one profile.
   status: 'workspace',
   // Its subject has always been the endpoint rather than a profile — its own

--- a/src/cli/usage-data.ts
+++ b/src/cli/usage-data.ts
@@ -291,8 +291,6 @@ export const SECTIONS: readonly Section[] = [
         command: 'doctor --fix',
         description: 'apply a repair it can make itself, such as a provider this project renamed under you',
       },
-      { command: 'auth [--json]', description: 'whether each connection can still sign in' },
-      { command: 'auth --connection <key>', description: 'just this one' },
       { command: 'tools [--json]', description: 'what the endpoint advertises to a client' },
       { command: 'plan', description: 'what reconcile would change' },
       { command: 'audit tail [--limit N] [--denied-only] [--format md]' },


### PR DESCRIPTION
The name was the problem. `lanes auth` is sign-in; `lanes link auth` was a per-connection credential
diagnostic. Two different subjects, told apart by help text — `cli/commands/auth.ts` carried a
paragraph whose entire job was saying which was which.

It also had no consumer left. The desktop app is the only caller outside this repository, and it
renders the verdicts on its **pre-0.8.0** settings arm — the one it stopped showing when connections
and profiles moved to the dashboard (`MANAGED_FROM = '0.8.0'`). A current app still invokes the
command and never reads the result, so what goes away is a subprocess, not a panel.

## What stays, and why it does not get folded away

`probeConnections` is kept and stays its own module. `doctor` calls it, and the reason it was
extracted in the first place is the reason it is not now merged into `inspect.ts`: `doctor` used to
answer this question a second, differently-wrong way — by dating a credential from when its access
token last refreshed, which reads a healthy connection nobody has called in a fortnight as stale,
and a grant revoked an hour ago as fresh. The seam is what stops that returning.

So the file moves to `operate/connection-probe.ts`, named for what it is rather than for the command
that wrapped it, and `AuthVerdict` becomes `ConnectionVerdict`. The tests move with it unchanged,
which is what makes the move reviewable as a move.

Deleted: `auth()`, its `describe()`, `AuthFlags`, the dispatch case in `main.ts`, two rows in
`usage-data.ts`, and the `auth: 'workspace'` row in `selection.ts`. Three comments that described the
command — including the disambiguation paragraph in `commands/auth.ts`, which has nothing left to
disambiguate — are corrected rather than deleted.

## Breaking

Anyone scripting `lanes link auth --json` loses it. `lanes link doctor --json` reports the same
verdicts through the same classifier, with two differences worth stating: it is scoped to one
profile's grants rather than to every connection the workspace holds, and it exits non-zero when it
finds something.

## Follow-up outside this repository

The desktop app should stop calling it. Nothing breaks if it does not — `run_json_within` fails, the
value is stored carrying an `error`, and the managed arm never reads it — but every settings visit
would spawn a subprocess that cannot succeed. Not required for this to merge.

## What was run

- `bun test` — 3683 pass, 0 fail, 12 skip. Identical to the `develop` baseline.
- `bun run typecheck` — clean.
- `selection.test.ts` and `usage.test.ts` pass, which is the pair that would catch a command removed
  from the grammar but left in the selection table, or the reverse.
- Swept `src/` and `docs/` for `link auth`: the four remaining mentions are the corrected comments.

One run under load reported 2 failures without emitting which; three subsequent clean runs, plus the
captured run above, all exited 0. That run took 57s against a ~30s typical, so it reads as timing
flake under concurrent load rather than anything here — this change removes a command and moves a
file, and touches no timing-sensitive path. Flagging it rather than burying it.

## What was NOT covered

No deployment rehearsal, and none is owed: this changes the CLI's grammar, not what the endpoint puts
on the wire. No server code is touched.

The desktop app's behaviour after removal is reasoned from its source, not observed — I did not build
and run it against a CLI without the command.
