### PR TITLE
Two allowlist rows nothing read, one of them load-bearing

### DIFF
--- a/src/cli/accepts.ts
+++ b/src/cli/accepts.ts
@@ -51,13 +51,9 @@ export const ACCEPTS: Record<string, readonly string[]> = {
   // it undoes a provider rename this project shipped, and every other finding
   // there is something only the operator can decide.
   doctor: ['fix'],
-  // A filter, not a second subject: it narrows the answer to one connection so
-  // a caller can re-ask about the row it just repaired. Same shape as `attach`.
   // Declaring a connection names the account itself, because nothing can be
   // asked of a provider that is not authorised yet — see `connection-declare.ts`.
   'connection declare': ['id', 'account', 'label'],
-
-  auth: ['connection'],
   relabel: [],
   // A rule lands in a grant row, and a row names one connection (ADR-058), so
   // the flag is required rather than optional. It is listed here as well as

--- a/src/cli/selection.test.ts
+++ b/src/cli/selection.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, test } from 'bun:test';
 import { readFile } from 'node:fs/promises';
 import { readFileSync } from 'node:fs';
 import { join } from 'node:path';
-import { SELECTION, assertKnownFlags, requirementFor } from './selection.ts';
+import { ACCEPTS, SELECTION, assertKnownFlags, requirementFor } from './selection.ts';
 import { requireSelection } from './selection-require.ts';
 import { CONNECT_CUSTOM_FLAGS, RESERVED_BY_GRAMMAR } from './commands/connect/custom/spec.ts';
 
@@ -292,6 +292,26 @@ describe('every command is runnable in the spelling it demands', () => {
         requireSelection(first, second, flags, nowhere),
         `${key} is satisfied by ${JSON.stringify(flags)}`,
       ).resolves.toBeUndefined();
+    }
+  });
+
+  /**
+   * The same pair, read from the other side.
+   *
+   * The two tests above walk `SELECTION`, so neither can see an `ACCEPTS` key
+   * that has no row there — and such a key is dead in a way that does not error.
+   * `selectionKey` returns the bare first word when the pair is absent, so the
+   * row is never the row looked up and its flags are silently never allowed.
+   *
+   * Two had accumulated. `auth` outlived the command it belonged to and cost
+   * only a reader's time. `workspace show` was the expensive one: `--workspace`
+   * was refused on the command named after it while the older `target show`
+   * spelling accepted it, so the rename was half-done and nothing walking
+   * `SELECTION` could reach it.
+   */
+  test('every allowlist key has a row in the requirement table', () => {
+    for (const key of Object.keys(ACCEPTS)) {
+      expect(key in SELECTION, `ACCEPTS["${key}"] has a SELECTION row`).toBe(true);
     }
   });
 

--- a/src/cli/selection.ts
+++ b/src/cli/selection.ts
@@ -106,6 +106,11 @@ export const SELECTION: Record<string, Requires> = {
   'profile remove': 'workspace',
   // Editing who may consume one profile, so it names the profile.
   'profile members': 'profile+workspace',
+  // Both spellings, because `selectionKey` falls back to the bare word when the
+  // pair is absent — so a missing row here does not error, it silently makes the
+  // command `workspace`, whose requirement is `none`, and `--workspace` is then
+  // refused on the very command named after it.
+  'workspace show': 'workspace',
   'target show': 'workspace',
 
   // These read one profile's file and open nothing. The target is what says


### PR DESCRIPTION
Found while verifying #232 against a real deployment — the command it removed was gone from
dispatch, but its allowlist row was not.

`accepts.ts` and `selection.ts` are two halves of one table: what a command must be told, and what
it will listen to. `assertKnownFlags` reads both under the key `selectionKey` computes, and that key
falls back to the bare first word when the pair is absent from `SELECTION`. So an `ACCEPTS` row whose
key has no `SELECTION` row is never the row looked up. It does not error. Its flags are simply never
allowed.

Two had accumulated, and they cost very different amounts.

## The cheap one

`auth: ['connection']` outlived its command. The bare `lanes link auth` went in #232 and the row
stayed, together with the comment describing its `--connection` filter. Blame shows the comment and
the row arrived in one commit, and that `connection declare` was later inserted between them — which
is how the comment came to sit above a row it does not describe. Dead data, nothing more.

## The one that was doing damage

`'workspace show': ['workspace']` is unreachable for the same reason, and the effect is visible:

```console
$ lanes link workspace show --workspace <name>
error  Unknown flag "--workspace" for "lanes link workspace show".
  Accepts: --help --json --quiet

$ lanes link target show --workspace <name>
<name> ─────────────────────────────────────────
  workspace    ...
```

The flag was refused on the command named after it, while the older spelling accepted it. Both print
the same thing once reached, so this is the `--target` → `--workspace` rename half-done rather than
two commands that legitimately differ: `SELECTION` gained `'target show'` and never gained
`'workspace show'`. Adding the row is the fix; the positional form (`workspace show <name>`) kept
working throughout, which is why nothing surfaced it.

## Why no test caught either

`every command is runnable in the spelling it demands` walks `Object.keys(SELECTION)` — so it cannot
see a key that is missing from exactly there. Its own docstring makes the argument this needed:
*"a requirement and an allowlist that disagree cannot be caught by testing either one, which is why
this asserts the pair"*. It asserted the pair in one direction. It now asserts it in both.

## What was run

- `bun test` — 3712 pass, 12 skip, 0 fail (3711 before; the new test is the difference).
- `bun run typecheck` — clean.
- **The guard was checked against both orphans**, not just written: putting the `auth` row back
  fails it with `ACCEPTS["auth"] has a SELECTION row`, and removing the new `workspace show` row
  fails it with the same message for that key. A first attempt asserted
  `selectionKey(first, second) === key`, which is vacuous for a one-word key — it passed with the
  `auth` row restored. That is why the invariant is stated against `SELECTION` membership instead.
- `lanes link workspace show --workspace <name>` exercised against a real cloud workspace before and
  after: refused before, prints the workspace after, and identical to what `target show` prints.

## What was NOT covered

No deployment needed — nothing here reaches the wire. This is CLI flag parsing only, and the two
commands involved both read.

I have not audited whether any *other* rename left the same gap in the opposite direction — a
`SELECTION` row whose command no longer dispatches. The existing tests cover part of that and the
regex helper in `selection.test.ts` cannot see a command dispatched by an `if` rather than a `case`
(`connection declare` is one), so a clean assertion there needs that helper widened first. Out of
scope here.
