### PR TITLE
lanes auth was outside the check that refuses a mistyped flag

### DIFF
--- a/src/cli/commands/auth-dispatch.test.ts
+++ b/src/cli/commands/auth-dispatch.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, test } from 'bun:test';
+
+import { runAuth } from './auth-dispatch.ts';
+
+/**
+ * `lanes auth` refuses a flag it does not read.
+ *
+ * It did not, for a structural reason rather than an oversight: `lanes.ts`
+ * routes this area before `main.ts`, and `assertKnownFlags` is called inside
+ * `main.ts`. So the check that covers every `link` command never saw this one,
+ * and `parseArgv` hands back every `--anything` it finds.
+ *
+ * Every case here refuses before any command runs, so none of them reads a
+ * session, opens a browser, or writes anything.
+ */
+describe('lanes auth refuses a flag it does not read', () => {
+  test('the misspelling that was silently dropped', async () => {
+    // `login` would otherwise fall back to `LANES_API_URL` and then to the
+    // default broker, and nothing it prints names which one it used.
+    await expect(runAuth(['login', '--api_url', 'https://example.invalid'])).rejects.toThrow(
+      'Did you mean --api-url?',
+    );
+  });
+
+  test('and any other unknown flag', async () => {
+    await expect(runAuth(['status', '--workspace', 'cloud'])).rejects.toThrow(
+      'Unknown flag "--workspace" for "lanes auth status"',
+    );
+  });
+
+  test('the command it names is the one that was typed', async () => {
+    await expect(runAuth(['workspaces', '--nope'])).rejects.toThrow('"lanes auth workspaces"');
+    await expect(runAuth(['--nope'])).rejects.toThrow('"lanes auth"');
+  });
+
+  test('--help is answered rather than allowed through', async () => {
+    // Allowlisting it without answering it would be the same defect: before
+    // this, `lanes auth --help` printed the status.
+    const lines: string[] = [];
+    const original = console.log;
+    console.log = (line: string): void => void lines.push(line);
+    try {
+      await runAuth(['--help']);
+    } finally {
+      console.log = original;
+    }
+
+    expect(lines.join('\n')).toContain('lanes auth login');
+    expect(lines.join('\n')).toContain('--api-url <url>');
+  });
+});

--- a/src/cli/commands/auth-dispatch.ts
+++ b/src/cli/commands/auth-dispatch.ts
@@ -1,4 +1,5 @@
 import { parseArgv } from '../argv.ts';
+import { refuseUnknownFlags } from '../unknown-flags.ts';
 import { authLogin, authLogout, authStatus, authWorkspaces } from './auth.ts';
 
 /**
@@ -20,9 +21,31 @@ const USAGE = `lanes auth — who this machine is signed in as
   --api-url <url>         a self-hosted API, instead of the default
 `;
 
+/**
+ * Every flag this area reads, written out rather than derived.
+ *
+ * `selection.ts` builds its allowlist from the tables that say what a `link`
+ * command must be told. Nothing here needs a profile or a workspace, so there is
+ * no table to derive from and three names is the whole of it.
+ */
+const ACCEPTED = new Set(['help', 'json', 'api-url']);
+
 export async function runAuth(argv: readonly string[]): Promise<void> {
   const { command, flags } = parseArgv(argv);
   const [first] = command;
+
+  // Before anything reads a flag, and the reason is `--api-url`: misspelled, it
+  // was dropped and the sign-in went to the default broker instead of the one
+  // named, which nothing on the success path prints. See `../unknown-flags.ts`.
+  refuseUnknownFlags(`lanes auth${first === undefined ? '' : ` ${first}`}`, ACCEPTED, flags);
+
+  // `--help` as well as `help`. Allowing the flag through without answering it
+  // would be the same defect the line above exists to stop: it was accepted and
+  // ignored, so `lanes auth --help` printed the status instead of the usage.
+  if (first === 'help' || flags['help'] === true) {
+    console.log(USAGE);
+    return;
+  }
 
   const options = {
     json: flags['json'] === true,
@@ -39,9 +62,6 @@ export async function runAuth(argv: readonly string[]): Promise<void> {
       return authStatus(options);
     case 'workspaces':
       return authWorkspaces(options);
-    case 'help':
-      console.log(USAGE);
-      return;
     default:
       throw new Error(`Unknown: lanes auth ${first}\n\n${USAGE}`);
   }

--- a/src/cli/selection.ts
+++ b/src/cli/selection.ts
@@ -1,7 +1,6 @@
-import { ConfigError } from '#profile';
 import type { Flags } from './argv.ts';
 import { ACCEPTS } from './accepts.ts';
-import { nearest } from './nearest.ts';
+import { refuseUnknownFlags } from './unknown-flags.ts';
 
 export { ACCEPTS } from './accepts.ts';
 
@@ -344,12 +343,11 @@ export const EXPLICIT_WORKSPACE = new Set([
 const UNIVERSAL = ['help', 'json', 'quiet'];
 
 /**
- * Refuse a flag this command does not read, and guess what was meant.
+ * What this command accepts, and the refusal of anything else.
  *
- * This is the fix for the reported bug rather than a nicety. `profile add
- * --workspace cloud` was accepted and dropped, and nothing could refuse it because
- * `parseArgv` returns every `--anything` it sees and no command ever inspected
- * the leftovers. A typo was swallowed the same way on every command in the CLI.
+ * The allowlist is derived here because the tables that answer it are here. The
+ * refusal itself is in `./unknown-flags.ts`, shared with `lanes auth` — which is
+ * routed before `main.ts` and so never reached this function at all.
  */
 /**
  * Commands that name their profile as an argument, and so refuse the flag.
@@ -378,13 +376,5 @@ export function assertKnownFlags(first: string, second: string | undefined, flag
 
   const named = [first, second].filter(Boolean).join(' ');
 
-  for (const given of Object.keys(flags)) {
-    if (allowed.has(given)) continue;
-
-    throw new ConfigError(
-      `Unknown flag "--${given}" for "lanes link ${named}".` +
-        (nearest(given, allowed) ? `\n  Did you mean --${nearest(given, allowed)}?` : '') +
-        `\n  Accepts: ${[...allowed].sort().map((name) => `--${name}`).join(' ')}`,
-    );
-  }
+  refuseUnknownFlags(`lanes link ${named}`, allowed, flags);
 }

--- a/src/cli/unknown-flags.test.ts
+++ b/src/cli/unknown-flags.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, test } from 'bun:test';
+
+import { refuseUnknownFlags } from './unknown-flags.ts';
+
+/**
+ * The refusal, tested where it now lives rather than through one of its callers.
+ *
+ * `selection.test.ts` exercises it thoroughly through `assertKnownFlags`, but
+ * only ever with an allowlist derived from the `link` tables. The point of the
+ * extraction is that a second area supplies its own, so the cases that matter
+ * here are the ones about the *message*: what a caller's own allowlist puts in
+ * front of the operator.
+ */
+describe('refusing a flag a command does not read', () => {
+  const allowed = new Set(['help', 'json', 'api-url']);
+
+  test('an accepted flag passes', () => {
+    expect(() => refuseUnknownFlags('lanes auth login', allowed, { json: true })).not.toThrow();
+    expect(() =>
+      refuseUnknownFlags('lanes auth login', allowed, { 'api-url': 'https://example.invalid' }),
+    ).not.toThrow();
+  });
+
+  test('an unknown flag is refused, and the message names the command', () => {
+    expect(() => refuseUnknownFlags('lanes auth login', allowed, { nope: true })).toThrow(
+      'Unknown flag "--nope" for "lanes auth login"',
+    );
+  });
+
+  test('a near miss is guessed', () => {
+    // The case this whole change is for. `--api_url` is one edit from
+    // `--api-url`, and the old behaviour was to drop it in silence.
+    expect(() =>
+      refuseUnknownFlags('lanes auth login', allowed, { api_url: 'https://example.invalid' }),
+    ).toThrow('Did you mean --api-url?');
+  });
+
+  test('the message lists what is accepted, sorted', () => {
+    try {
+      refuseUnknownFlags('lanes auth', allowed, { wat: true });
+      expect.unreachable();
+    } catch (error) {
+      expect((error as Error).message).toContain('Accepts: --api-url --help --json');
+    }
+  });
+
+  test('the first unknown flag is the one reported', () => {
+    // Reporting one is deliberate: an operator fixes one flag and runs again,
+    // and a list of three refusals reads as three separate problems.
+    expect(() => refuseUnknownFlags('lanes auth', allowed, { aaa: true, zzz: true })).toThrow(
+      '--aaa',
+    );
+  });
+});

--- a/src/cli/unknown-flags.ts
+++ b/src/cli/unknown-flags.ts
@@ -1,0 +1,45 @@
+import { ConfigError } from '#profile';
+import type { Flags } from './argv.ts';
+import { nearest } from './nearest.ts';
+
+/**
+ * Refuse a flag this command does not read, and guess what was meant.
+ *
+ * This is the fix for a reported bug rather than a nicety. `profile add
+ * --workspace cloud` was accepted and dropped, and nothing could refuse it
+ * because `parseArgv` returns every `--anything` it sees and no command ever
+ * inspected the leftovers. A typo was swallowed the same way on every command in
+ * the CLI.
+ *
+ * It lives here, rather than inside `assertKnownFlags` where it was written,
+ * because `lanes auth` is not in the `link` area and so never reached that
+ * function: `lanes.ts` routes it before `main.ts`, which is where the check is
+ * called. The allowlist is the caller's to state — `selection.ts` derives one
+ * from its tables, and `auth-dispatch.ts` writes out the three flags it reads —
+ * but the refusal must be the same one, or the two areas disagree about whether
+ * a mistyped flag is an error.
+ *
+ * What it cost while `auth` was outside it: `lanes auth login --api_url <url>`
+ * dropped the flag, and `login` then fell back to `LANES_API_URL` and finally to
+ * the default. So a sign-in aimed at a self-hosted broker silently went to the
+ * default one, and nothing on the success path names the broker it used. The
+ * subject that comes back is minted by the wrong identity provider, so the
+ * profile that lists the right one refuses it — which presents as "signed in,
+ * but not a member" rather than as a typo.
+ */
+export function refuseUnknownFlags(
+  named: string,
+  allowed: ReadonlySet<string>,
+  flags: Flags,
+): void {
+  for (const given of Object.keys(flags)) {
+    if (allowed.has(given)) continue;
+
+    const guess = nearest(given, allowed);
+    throw new ConfigError(
+      `Unknown flag "--${given}" for "${named}".` +
+        (guess ? `\n  Did you mean --${guess}?` : '') +
+        `\n  Accepts: ${[...allowed].sort().map((name) => `--${name}`).join(' ')}`,
+    );
+  }
+}


### PR DESCRIPTION
Found while verifying #233. That PR removed a dead `ACCEPTS` row for the command #232 deleted; this
is why the row could go dead without anything noticing.

## The gap

`assertKnownFlags` is called at `main.ts:99`. `lanes.ts` routes two areas *before* `main.ts` is
imported:

```
lanes.ts:66   if (area === 'auth')          → auth-dispatch.ts
lanes.ts:75   if (area === 'set-workspace') → set-workspace.ts
lanes.ts:84   if (area === 'link')          → main.ts     ← the check lives in here
```

So the check that covers every `link` command never saw `auth`. `runAuth` read the two keys it
wanted out of the flag bag and dropped everything else:

```console
$ lanes auth status --api_url https://example.invalid --bogus-flag x
ok    signed in as …                       # both silently ignored

$ lanes link status --workspace <name> --bogus-flag x
error  Unknown flag "--bogus-flag" for "lanes link status".
```

## Why it matters, which is one flag

Most of it is cosmetic. `--api-url` is not. Misspelled, it is dropped, and `login.ts:115` falls
through:

```ts
const apiUrl = options.apiUrl ?? process.env['LANES_API_URL'] ?? DEFAULT_API_URL;
```

So a sign-in aimed at a self-hosted broker goes to the default one instead, and `authLogin` prints
the email and subject and never the API URL — silent exactly where it counts. The subject that comes
back is minted by the wrong identity provider, so a profile whose `members:` lists the right one
refuses it. The symptom is *"signed in fine, but the endpoint says I am not a member"*, which is a
long way from a mistyped flag.

Two things already limit it, and neither is a reason to leave it: anyone setting `LANES_API_URL`
rather than passing the flag is covered by that same fallback, and `lanes auth status` does print
`api` and says when a session was not issued by the default. So it is detectable afterwards, just not
at the moment it happens.

I checked the thing that would have made this common: `parseArgv` handles `--api-url=value` as well
as `--api-url value`, so the `=` form is not a hazard. This needs an actual misspelling.

## The fix is the guess that already existed

The refusal moves to `unknown-flags.ts` — same message, same `nearest` guess — so `--api_url` now
answers:

```console
$ lanes auth status --api_url https://example.invalid
error  Unknown flag "--api_url" for "lanes auth status".
  Did you mean --api-url?
  Accepts: --api-url --help --json
```

What each area supplies is its own allowlist. `selection.ts` derives one from the tables that say
what a `link` command must be told; `auth` writes out its three flags, because nothing there needs a
profile or a workspace and there is no table to derive from. I deliberately did **not** give `auth` a
`SELECTION`/`ACCEPTS` row: those values are profile/workspace requirements, which this area has no
notion of, and the helper in `selection.test.ts` that reads dispatch `case` labels cannot see
`auth-dispatch.ts` anyway.

`--help` is answered rather than allowlisted. `lanes auth --help` printed the *status*, because the
flag was accepted and ignored. Putting `help` in an allowlist while nothing read it would have been
the same defect with a longer paper trail.

## What was run

- `bun test` — 3721 pass, 12 skip, 0 fail (3712 before; 9 new).
- `bun run typecheck` — clean.
- End to end against the real CLI: the misspelling refused with the guess above; `lanes auth --help`
  prints usage; `--json` and `--api-url` still work.
- **Regression-checked the `link` side of the extraction**, since the refusal it uses moved:
  `link status --bogus-flag` and `link status --porfile personal` produce byte-identical output to
  before, guess included.

## What was NOT covered

No deployment. Nothing here reaches the wire — it is CLI flag parsing, and both commands involved
read.

`lanes auth login` itself was not run. It opens a browser and writes a real session, and the three
refusal paths all throw before any command executes, so the tests cover the change without it. The
untested remainder is that a *correct* `--api-url` still reaches `login()`, which is unchanged code
on an unchanged call.

`set-workspace` is left outside the check on purpose: it reads only `--json` and takes its name
positionally, so a stray flag costs it the positional and it prints usage. Nothing silent remains
there, and bringing it in would mean deciding what `--help` prints, which is a separate question.
