### PR TITLE
An unreadable credential refuses one row, not the endpoint

### DIFF
--- a/src/auth/bearer.ts
+++ b/src/auth/bearer.ts
@@ -1,0 +1,285 @@
+/**
+ * The credential the workspace keeps a copy of.
+ *
+ * Beside `remote.ts` rather than inside `index.ts`, and the split is the one
+ * the file was already asking for: `index.ts` is the shape every surface shares
+ * — an outcome, a chain, how a bearer is parsed and compared — while each way
+ * of *proving* a credential is its own subject. Three of them were already in
+ * `remote.ts`; this is the fourth, and the only one whose answer is a
+ * comparison against something stored rather than a verification.
+ *
+ * It imports its shared pieces back from `index.ts` exactly as `remote.ts`
+ * does, so `#auth` stays the one name every other component uses.
+ */
+
+import type { SecretRef, SecretStore } from '#secrets';
+
+import {
+  machinePrincipal,
+  parseBearer,
+  tokensMatch,
+  type AuthOutcome,
+  type Authenticator,
+} from './index.ts';
+
+/**
+ * One issued token, as the authenticator needs it.
+ *
+ * Structurally what `connections.yaml` holds, declared here rather than
+ * imported: `auth` may not reach `#profile` (the architecture test enforces the
+ * direction), and the rows arrive as a closure for the same reason
+ * `profilesFor` does.
+ */
+export interface IssuedToken {
+  readonly id: string;
+  readonly subject: string;
+  readonly ref: SecretRef;
+}
+
+export interface AuthenticatorOptions {
+  /**
+   * The primary, which is what `principal.profile` starts as.
+   *
+   * Not what the token reaches — that is `profilesFor(subject)`. It is where
+   * the connection was opened, and every dispatch rewrites it with `forProfile`.
+   */
+  readonly profile: string;
+  /** The workspace's issued tokens. Re-read on every reload, so a revoke lands. */
+  readonly tokens: () => Promise<readonly IssuedToken[]>;
+  readonly credentials: SecretStore;
+  /**
+   * Which profiles list this subject as a member.
+   *
+   * The same resolver the OAuth path is handed (`server/endpoint.ts`), passed in
+   * rather than reached for, so discovery and enforcement cannot disagree about
+   * a subject's reach.
+   */
+  readonly profilesFor: (subject: string) => Promise<readonly string[]>;
+  /**
+   * Where a row that could not be read is reported.
+   *
+   * A closure rather than a logger, for the same reason `tokens` and
+   * `profilesFor` are closures: `auth` may not reach the components that own
+   * one. `cli/runtime/open.ts` supplies it.
+   *
+   * Optional because most callers are tests, and because the skip is already
+   * correct without it — but a caller serving requests should pass one. A
+   * credential the operator issued and this endpoint cannot read is invisible
+   * otherwise, which is the failure `server/container.ts` was rewritten about.
+   */
+  readonly report?: (message: string) => void;
+  /** Injectable for tests. Only the cache window reads it. */
+  readonly now?: () => number;
+}
+
+/**
+ * How long a cached token may answer before the store is consulted again.
+ *
+ * The cache is here so the common case — a valid token, on every request — is a
+ * comparison rather than a file read or a Secret Manager call. What it must not
+ * do is outlive a rotation. `lanes link token rotate` is the only revocation
+ * this system has, and an unbounded cache meant a revoked token kept opening the
+ * endpoint until the process restarted, while the replacement was refused.
+ *
+ * Five seconds makes rotation effectively immediate and still collapses a burst
+ * of calls onto one read.
+ */
+const CACHE_TTL_MS = 5_000;
+
+/** An issued row, with its value read out of the store. */
+interface LoadedToken {
+  readonly subject: string;
+  readonly value: string;
+}
+
+export class BearerAuthenticator implements Authenticator {
+  readonly #options: AuthenticatorOptions;
+  readonly #now: () => number;
+  #cached: readonly LoadedToken[] | null = null;
+  #readAt = 0;
+  /** The last set of unreadable rows reported, so a standing fault says it once. */
+  #reported: string | null = null;
+
+  constructor(options: AuthenticatorOptions) {
+    this.#options = options;
+    this.#now = options.now ?? Date.now;
+  }
+
+  async authenticate(authorizationHeader: string | null | undefined): Promise<AuthOutcome> {
+    const presented = parseBearer(authorizationHeader);
+    if (presented === null) {
+      return { ok: false, reason: authorizationHeader ? 'malformed' : 'missing' };
+    }
+
+    const fresh = this.#cached !== null && this.#now() - this.#readAt < CACHE_TTL_MS;
+    let rows = fresh ? this.#cached! : await this.#reload();
+    let matched = find(presented, rows);
+
+    // A miss against a *cached* set is ambiguous: either the credential is
+    // wrong, or it is the right one and this process has not seen the rotation
+    // or the issue that produced it. One re-read separates the two, and it is
+    // what makes a rotated-in token work on its first call rather than after
+    // the window. Only a cached comparison can be wrong this way, so a fresh
+    // read never pays for a second one — which is what keeps a wrong token from
+    // costing a store read per attempt.
+    //
+    // **And only for something that could be one of these tokens.** A hosted
+    // connector presents an OAuth token: the next link in the chain handles it
+    // and it can never match a row here. Without that condition the ambiguity
+    // above was permanent for such a caller — a healthy endpoint has no static
+    // rows, so the match always failed and the "one re-read" fired on every
+    // request, re-confirming an empty list at the cost of a bucket read, a YAML
+    // parse and a schema validation. The cache never protected anything,
+    // because the path that consulted it was the path that always missed.
+    if (fresh && matched === null && couldBeProfileToken(presented)) {
+      rows = await this.#reload();
+      matched = find(presented, rows);
+    }
+
+    if (rows.length === 0) {
+      // No token has been issued. Fail closed, and distinctly from a wrong one:
+      // `lanes link doctor` reads this to say "issue one" rather than "check it".
+      return { ok: false, reason: 'not_configured' };
+    }
+
+    if (matched === null) return { ok: false, reason: 'invalid' };
+
+    // **Resolved per request, not cached with the value.** Membership is read
+    // when a token is minted for an OAuth client (ADR-060) because there is a
+    // mint to read it at; a static token has none, so this is the only place
+    // the question can be asked. It is what makes `profile members remove`
+    // take effect on the next call rather than on the next rotation.
+    //
+    // A resolver that throws fails closed. The alternative — falling back to
+    // "every profile" — would restore exactly the behaviour ADR-068 removes,
+    // and would do it precisely when something is already wrong.
+    let profiles: readonly string[];
+    try {
+      profiles = await this.#options.profilesFor(matched.subject);
+    } catch {
+      return { ok: false, reason: 'invalid' };
+    }
+
+    return {
+      ok: true,
+      principal: machinePrincipal(matched.subject, this.#options.profile, profiles),
+    };
+  }
+
+  async #reload(): Promise<readonly LoadedToken[]> {
+    // Both caches, or neither: the store holds its own decrypted copy, so
+    // re-reading without dropping that first re-reads the same stale value.
+    this.#options.credentials.refresh?.();
+
+    const rows = await this.#options.tokens();
+    const loaded: LoadedToken[] = [];
+    const unreadable: string[] = [];
+    for (const row of rows) {
+      let value: string | null;
+      try {
+        value = await this.#options.credentials.get(row.ref);
+      } catch (error) {
+        // **One row may not decide whether anybody can authenticate.**
+        //
+        // This is `openReconciled`'s rule at the credential level: a sibling it
+        // cannot open is skipped rather than allowed to fail the endpoint for
+        // the rest. Here the blast radius was larger still, because this link
+        // runs *first* in the chain — so a single unreadable row refused OAuth
+        // tokens and Lanes-signed keys too, which never got reached. A live
+        // endpoint answered every caller with an error, including the token
+        // that had been working, until the offending row was revoked.
+        //
+        // Caught by shape rather than by status, deliberately. The store that
+        // produces this throws a bare `Error` whose status survives only as
+        // text in the message, so narrowing to a 403 would mean matching on
+        // prose. And the broader rule is the one worth holding: whatever stops
+        // a row being read, the answer is that the row matches nothing.
+        unreadable.push(`${row.id}: ${firstLine(error)}`);
+        continue;
+      }
+      // A row whose credential is gone is not an error to report here. It is
+      // what a half-finished `secrets push` looks like, and the row simply
+      // matches nothing — `doctor` is where that is worth a sentence.
+      if (value) loaded.push({ subject: row.subject, value });
+    }
+
+    this.#report(unreadable);
+    this.#cached = loaded;
+    this.#readAt = this.#now();
+    return loaded;
+  }
+
+  /**
+   * Say which rows could not be read, when that set changes.
+   *
+   * On change rather than on every reload: the window above collapses a burst
+   * onto one read, but a grant nobody fixes is still a read every five seconds,
+   * and a line each time would bury the one that mattered. Reporting recovery
+   * too — the empty set is a change like any other — is what makes the last
+   * line about a row the current answer rather than a thing to correlate.
+   */
+  #report(unreadable: readonly string[]): void {
+    const signature = unreadable.join('\n');
+    if (signature === this.#reported) return;
+    this.#reported = signature;
+    // One line per row, in the shape `not serving <profile>: <reason>` already
+    // uses, because the two are read in the same place for the same purpose.
+    for (const row of unreadable) this.#options.report?.(`not honouring ${row}`);
+  }
+
+  /**
+   * Drop the cached set immediately.
+   *
+   * The window above already bounds how long a rotation goes unnoticed, so this
+   * is an optimisation rather than the mechanism — nothing's correctness may
+   * depend on it being called, because for a long time nothing called it.
+   */
+  invalidateCache(): void {
+    this.#cached = null;
+  }
+}
+
+/**
+ * The part of a failure fit to print beside a name.
+ *
+ * `server/endpoint.ts` trims the same way for the same reason, and this is a
+ * copy rather than a shared import because `auth` may not reach that component
+ * — see the dependency directions in `architecture.test.ts`.
+ */
+function firstLine(error: unknown): string {
+  const text = error instanceof Error ? error.message : String(error);
+  return text.split('\n')[0] ?? '';
+}
+
+/**
+ * The row a presented token matches, or null.
+ *
+ * Every row is compared even after one matches. Returning early would make the
+ * time taken describe *which* row answered, and the whole point of
+ * `tokensMatch` is that a comparison here leaks nothing about the value it is
+ * comparing against.
+ */
+function find(presented: string, rows: readonly LoadedToken[]): LoadedToken | null {
+  let found: LoadedToken | null = null;
+  for (const row of rows) if (tokensMatch(presented, row.value)) found = row;
+  return found;
+}
+
+/**
+ * Whether a presented credential could be one of *these* tokens at all.
+ *
+ * `generateProfileToken` mints every one with this prefix, which
+ * `secret-detection.ts` and the edge limiter already recognise — so it is exact.
+ */
+const couldBeProfileToken = (presented: string): boolean =>
+  presented.startsWith(PROFILE_TOKEN_PREFIX);
+
+/** What a minted profile token starts with. */
+const PROFILE_TOKEN_PREFIX = 'llk_';
+/**
+ * Mint a profile token: 32 random bytes, base64url, prefixed so it is
+ * recognisable in a config file and greppable in a leak.
+ */
+export function generateProfileToken(): string {
+  return `${PROFILE_TOKEN_PREFIX}${Buffer.from(crypto.getRandomValues(new Uint8Array(32))).toString('base64url')}`;
+}

--- a/src/auth/index.test.ts
+++ b/src/auth/index.test.ts
@@ -16,6 +16,30 @@ import {
   type AuthOutcome,
 } from './index.ts';
 
+/**
+ * A store where the named refs throw instead of answering.
+ *
+ * What a missing Secret Manager binding actually looks like: the adapter
+ * answers null for a 404 and *throws* for a 403, because a missing binding is
+ * denied rather than absent. A bare `Error` with the status only in its
+ * message, because that is what the adapter constructs.
+ */
+function storeRefusing(entries: Record<string, string>, denied: readonly string[]): SecretStore {
+  const base = storeWith(entries);
+  return {
+    ...base,
+    async get(ref) {
+      if (denied.includes(ref)) {
+        throw new Error(
+          `Secret Manager could not read ${ref} (HTTP 403). PERMISSION_DENIED: ` +
+            'Permission "secretmanager.versions.access" denied',
+        );
+      }
+      return base.get(ref);
+    },
+  };
+}
+
 function storeWith(entries: Record<string, string>): SecretStore {
   const map = new Map(Object.entries(entries));
   return {
@@ -84,10 +108,11 @@ describe('authentication', () => {
   /** One issued row, and the profiles its subject is a member of. */
   const issued = (
     overrides: {
-      credentials?: ReturnType<typeof storeWith>;
+      credentials?: SecretStore;
       profilesFor?: (subject: string) => Promise<readonly string[]>;
       now?: () => number;
       rows?: readonly { id: string; subject: string; ref: string }[];
+      report?: (message: string) => void;
     } = {},
   ) => ({
     profile: 'personal',
@@ -96,6 +121,7 @@ describe('authentication', () => {
     credentials: overrides.credentials ?? storeWith({ 'tokens/tok1': 'llk_correct' }),
     profilesFor: overrides.profilesFor ?? (async () => ['personal']),
     ...(overrides.now ? { now: overrides.now } : {}),
+    ...(overrides.report ? { report: overrides.report } : {}),
   });
 
   const options = issued();
@@ -423,5 +449,163 @@ describe('the chain and the context', () => {
 
     expect(outcome.ok).toBe(true);
     expect(never.seen.calls).toBe(0);
+  });
+});
+
+describe('a credential that cannot be read', () => {
+  /**
+   * The endpoint went down for everyone because one row was unreadable.
+   *
+   * Issuing a token against a deployed target created the secret container but
+   * not the resource-level grant that lets the runtime identity read it. Secret
+   * Manager answers a missing binding with 403 rather than 404 — so that an
+   * identity cannot enumerate secrets by their error codes — and the adapter
+   * returns null for the 404 and throws for the 403. The throw left `#reload`,
+   * left `authenticate`, left the chain, and every caller was refused,
+   * including the token that had been working.
+   *
+   * The rule these hold is `openReconciled`'s, one layer down: what cannot be
+   * read is skipped and said out loud, not allowed to answer for everyone else.
+   */
+  const SUBJECT = 'lanes:abc123';
+  const TWO_ROWS = [
+    { id: 'tok1', subject: SUBJECT, ref: 'tokens/tok1' },
+    { id: 'tok2', subject: SUBJECT, ref: 'tokens/tok2' },
+  ];
+
+  const withRefusal = (overrides: { report?: (message: string) => void } = {}) => ({
+    profile: 'personal',
+    tokens: async () => TWO_ROWS,
+    credentials: storeRefusing({ 'tokens/tok2': 'llk_good' }, ['tokens/tok1']),
+    profilesFor: async () => ['personal'],
+    ...(overrides.report ? { report: overrides.report } : {}),
+  });
+
+  test('the row beside it still authenticates', async () => {
+    const auth = new BearerAuthenticator(withRefusal());
+
+    const outcome = await auth.authenticate('Bearer llk_good');
+
+    expect(outcome.ok).toBe(true);
+  });
+
+  test('a wrong token is still refused, rather than excused by the unreadable row', async () => {
+    const auth = new BearerAuthenticator(withRefusal());
+
+    expect(await auth.authenticate('Bearer llk_wrong')).toEqual({ ok: false, reason: 'invalid' });
+  });
+
+  test('every row unreadable refuses, rather than throwing', async () => {
+    const auth = new BearerAuthenticator({
+      profile: 'personal',
+      tokens: async () => TWO_ROWS,
+      credentials: storeRefusing({}, ['tokens/tok1', 'tokens/tok2']),
+      profilesFor: async () => ['personal'],
+    });
+
+    // `not_configured` rather than a fourth reason: from here it is
+    // indistinguishable from a workspace that has issued nothing, and the
+    // report below is what carries the difference to whoever can act on it.
+    expect(await auth.authenticate('Bearer llk_good')).toEqual({
+      ok: false,
+      reason: 'not_configured',
+    });
+  });
+
+  test('the unreadable row is named, with what the store said', async () => {
+    const said: string[] = [];
+    const auth = new BearerAuthenticator(withRefusal({ report: (m) => said.push(m) }));
+
+    await auth.authenticate('Bearer llk_good');
+
+    expect(said).toHaveLength(1);
+    expect(said[0]).toContain('tok1');
+    expect(said[0]).toContain('PERMISSION_DENIED');
+    // The row that reads fine is not named, or the line stops being a list of
+    // what is wrong.
+    expect(said[0]).not.toContain('tok2');
+  });
+
+  test('a standing fault is said once, not on every reload', async () => {
+    let clock = 0;
+    const said: string[] = [];
+    const auth = new BearerAuthenticator({
+      ...withRefusal({ report: (m) => said.push(m) }),
+      now: () => clock,
+    });
+
+    await auth.authenticate('Bearer llk_good');
+    clock += 10_000; // past the cache window, so the next call re-reads
+    await auth.authenticate('Bearer llk_good');
+    clock += 10_000;
+    await auth.authenticate('Bearer llk_good');
+
+    // Three reads, one line. A grant nobody has fixed yet is a read every five
+    // seconds, and a line each time would bury the one that mattered.
+    expect(said).toHaveLength(1);
+  });
+
+  test('a row that becomes readable is not reported again', async () => {
+    let clock = 0;
+    let denied = ['tokens/tok1'];
+    const said: string[] = [];
+    const auth = new BearerAuthenticator({
+      profile: 'personal',
+      tokens: async () => TWO_ROWS,
+      credentials: {
+        ...storeWith({ 'tokens/tok1': 'llk_first', 'tokens/tok2': 'llk_good' }),
+        async get(ref) {
+          if (denied.includes(ref)) throw new Error(`denied ${ref}`);
+          return ref === 'tokens/tok1' ? 'llk_first' : 'llk_good';
+        },
+      },
+      profilesFor: async () => ['personal'],
+      report: (m) => said.push(m),
+      now: () => clock,
+    });
+
+    await auth.authenticate('Bearer llk_good');
+    expect(said).toHaveLength(1);
+
+    denied = [];
+    clock += 10_000;
+
+    // The grant landed: the row it was refusing now opens the endpoint, and
+    // nothing new is said about it.
+    expect((await auth.authenticate('Bearer llk_first')).ok).toBe(true);
+    expect(said).toHaveLength(1);
+  });
+
+  test('a later link in the chain is still reached', async () => {
+    // The amplification, and the reason this was worth fixing on its own
+    // merits. This link runs first and is unconditional, so before the skip a
+    // single unreadable static row refused the OAuth tokens and the
+    // Lanes-signed keys behind it — credentials that have nothing to do with
+    // the store that failed, and that never got asked.
+    const signed: Authenticator = {
+      authenticate: async () => ({
+        ok: true,
+        principal: {
+          id: 'lanes:signed',
+          profile: 'personal',
+          kind: 'machine',
+          profiles: ['personal'],
+        },
+      }),
+    };
+
+    const chain = new AuthenticatorChain([
+      new BearerAuthenticator({
+        profile: 'personal',
+        tokens: async () => TWO_ROWS,
+        credentials: storeRefusing({}, ['tokens/tok1', 'tokens/tok2']),
+        profilesFor: async () => ['personal'],
+      }),
+      signed,
+    ]);
+
+    const outcome = await chain.authenticate('Bearer a.signed.jwt');
+
+    expect(outcome.ok).toBe(true);
   });
 });

--- a/src/auth/index.ts
+++ b/src/auth/index.ts
@@ -1,8 +1,10 @@
 /**
  * Client identity.
  *
- * M1: one bearer token per profile, resolved from the credential store. The
- * token is the identity — holding it makes you the profile's owner principal.
+ * What every way of proving a credential has in common: the outcome, the
+ * interface, the chain that tries them in order, and how a bearer is parsed and
+ * compared. Each proof itself is its own file — `bearer.ts` for the rows this
+ * workspace stores, `remote.ts` for the three it verifies rather than holds.
  *
  * Target: the OAuth 2.1 resource-server model the MCP spec expects, where this
  * module validates tokens issued by an external authorization server. Client
@@ -18,9 +20,8 @@
  */
 
 import { timingSafeEqual } from 'node:crypto';
-import type { SecretRef, SecretStore } from '#secrets';
 
-import { machinePrincipal, type Principal } from './principal.ts';
+import type { Principal } from './principal.ts';
 
 /**
  * The principal model lives in `./principal.ts`, and is re-exported here so
@@ -149,200 +150,6 @@ export function tokensMatch(a: string, b: string): boolean {
   return timingSafeEqual(hash(a), hash(b));
 }
 
-/**
- * One issued token, as the authenticator needs it.
- *
- * Structurally what `connections.yaml` holds, declared here rather than
- * imported: `auth` may not reach `#profile` (the architecture test enforces the
- * direction), and the rows arrive as a closure for the same reason
- * `profilesFor` does.
- */
-export interface IssuedToken {
-  readonly id: string;
-  readonly subject: string;
-  readonly ref: SecretRef;
-}
-
-export interface AuthenticatorOptions {
-  /**
-   * The primary, which is what `principal.profile` starts as.
-   *
-   * Not what the token reaches — that is `profilesFor(subject)`. It is where
-   * the connection was opened, and every dispatch rewrites it with `forProfile`.
-   */
-  readonly profile: string;
-  /** The workspace's issued tokens. Re-read on every reload, so a revoke lands. */
-  readonly tokens: () => Promise<readonly IssuedToken[]>;
-  readonly credentials: SecretStore;
-  /**
-   * Which profiles list this subject as a member.
-   *
-   * The same resolver the OAuth path is handed (`server/endpoint.ts`), passed in
-   * rather than reached for, so discovery and enforcement cannot disagree about
-   * a subject's reach.
-   */
-  readonly profilesFor: (subject: string) => Promise<readonly string[]>;
-  /** Injectable for tests. Only the cache window reads it. */
-  readonly now?: () => number;
-}
-
-/**
- * How long a cached token may answer before the store is consulted again.
- *
- * The cache is here so the common case — a valid token, on every request — is a
- * comparison rather than a file read or a Secret Manager call. What it must not
- * do is outlive a rotation. `lanes link token rotate` is the only revocation
- * this system has, and an unbounded cache meant a revoked token kept opening the
- * endpoint until the process restarted, while the replacement was refused.
- *
- * Five seconds makes rotation effectively immediate and still collapses a burst
- * of calls onto one read.
- */
-const CACHE_TTL_MS = 5_000;
-
-/** An issued row, with its value read out of the store. */
-interface LoadedToken {
-  readonly subject: string;
-  readonly value: string;
-}
-
-export class BearerAuthenticator implements Authenticator {
-  readonly #options: AuthenticatorOptions;
-  readonly #now: () => number;
-  #cached: readonly LoadedToken[] | null = null;
-  #readAt = 0;
-
-  constructor(options: AuthenticatorOptions) {
-    this.#options = options;
-    this.#now = options.now ?? Date.now;
-  }
-
-  async authenticate(authorizationHeader: string | null | undefined): Promise<AuthOutcome> {
-    const presented = parseBearer(authorizationHeader);
-    if (presented === null) {
-      return { ok: false, reason: authorizationHeader ? 'malformed' : 'missing' };
-    }
-
-    const fresh = this.#cached !== null && this.#now() - this.#readAt < CACHE_TTL_MS;
-    let rows = fresh ? this.#cached! : await this.#reload();
-    let matched = find(presented, rows);
-
-    // A miss against a *cached* set is ambiguous: either the credential is
-    // wrong, or it is the right one and this process has not seen the rotation
-    // or the issue that produced it. One re-read separates the two, and it is
-    // what makes a rotated-in token work on its first call rather than after
-    // the window. Only a cached comparison can be wrong this way, so a fresh
-    // read never pays for a second one — which is what keeps a wrong token from
-    // costing a store read per attempt.
-    //
-    // **And only for something that could be one of these tokens.** A hosted
-    // connector presents an OAuth token: the next link in the chain handles it
-    // and it can never match a row here. Without that condition the ambiguity
-    // above was permanent for such a caller — a healthy endpoint has no static
-    // rows, so the match always failed and the "one re-read" fired on every
-    // request, re-confirming an empty list at the cost of a bucket read, a YAML
-    // parse and a schema validation. The cache never protected anything,
-    // because the path that consulted it was the path that always missed.
-    if (fresh && matched === null && couldBeProfileToken(presented)) {
-      rows = await this.#reload();
-      matched = find(presented, rows);
-    }
-
-    if (rows.length === 0) {
-      // No token has been issued. Fail closed, and distinctly from a wrong one:
-      // `lanes link doctor` reads this to say "issue one" rather than "check it".
-      return { ok: false, reason: 'not_configured' };
-    }
-
-    if (matched === null) return { ok: false, reason: 'invalid' };
-
-    // **Resolved per request, not cached with the value.** Membership is read
-    // when a token is minted for an OAuth client (ADR-060) because there is a
-    // mint to read it at; a static token has none, so this is the only place
-    // the question can be asked. It is what makes `profile members remove`
-    // take effect on the next call rather than on the next rotation.
-    //
-    // A resolver that throws fails closed. The alternative — falling back to
-    // "every profile" — would restore exactly the behaviour ADR-068 removes,
-    // and would do it precisely when something is already wrong.
-    let profiles: readonly string[];
-    try {
-      profiles = await this.#options.profilesFor(matched.subject);
-    } catch {
-      return { ok: false, reason: 'invalid' };
-    }
-
-    return {
-      ok: true,
-      principal: machinePrincipal(matched.subject, this.#options.profile, profiles),
-    };
-  }
-
-  async #reload(): Promise<readonly LoadedToken[]> {
-    // Both caches, or neither: the store holds its own decrypted copy, so
-    // re-reading without dropping that first re-reads the same stale value.
-    this.#options.credentials.refresh?.();
-
-    const rows = await this.#options.tokens();
-    const loaded: LoadedToken[] = [];
-    for (const row of rows) {
-      const value = await this.#options.credentials.get(row.ref);
-      // A row whose credential is gone is not an error to report here. It is
-      // what a half-finished `secrets push` looks like, and the row simply
-      // matches nothing — `doctor` is where that is worth a sentence.
-      if (value) loaded.push({ subject: row.subject, value });
-    }
-
-    this.#cached = loaded;
-    this.#readAt = this.#now();
-    return loaded;
-  }
-
-  /**
-   * Drop the cached set immediately.
-   *
-   * The window above already bounds how long a rotation goes unnoticed, so this
-   * is an optimisation rather than the mechanism — nothing's correctness may
-   * depend on it being called, because for a long time nothing called it.
-   */
-  invalidateCache(): void {
-    this.#cached = null;
-  }
-}
-
-/**
- * The row a presented token matches, or null.
- *
- * Every row is compared even after one matches. Returning early would make the
- * time taken describe *which* row answered, and the whole point of
- * `tokensMatch` is that a comparison here leaks nothing about the value it is
- * comparing against.
- */
-function find(presented: string, rows: readonly LoadedToken[]): LoadedToken | null {
-  let found: LoadedToken | null = null;
-  for (const row of rows) if (tokensMatch(presented, row.value)) found = row;
-  return found;
-}
-
-/**
- * Whether a presented credential could be one of *these* tokens at all.
- *
- * `generateProfileToken` mints every one with this prefix, which
- * `secret-detection.ts` and the edge limiter already recognise — so it is exact.
- */
-const couldBeProfileToken = (presented: string): boolean =>
-  presented.startsWith(PROFILE_TOKEN_PREFIX);
-
-/** What a minted profile token starts with. */
-const PROFILE_TOKEN_PREFIX = 'llk_';
-/**
- * Mint a profile token: 32 random bytes, base64url, prefixed so it is
- * recognisable in a config file and greppable in a leak.
- */
-export function generateProfileToken(): string {
-  return `${PROFILE_TOKEN_PREFIX}${Buffer.from(crypto.getRandomValues(new Uint8Array(32))).toString('base64url')}`;
-}
-
 export {
   authorizationServerMetadata,
   challenge,
@@ -371,3 +178,9 @@ export { matchesRegistered } from './oauth/redirects.ts';
 export { OAuthStore, hashToken, randomToken } from './oauth/store.ts';
 export { OidcVerifier, type OidcVerifierOptions, type VerifiedSubject } from './oidc.ts';
 export { IssuedTokenAuthenticator, LanesKeyAuthenticator, OidcAuthenticator } from './remote.ts';
+export {
+  BearerAuthenticator,
+  generateProfileToken,
+  type AuthenticatorOptions,
+  type IssuedToken,
+} from './bearer.ts';

--- a/src/cli/runtime/open.ts
+++ b/src/cli/runtime/open.ts
@@ -317,6 +317,14 @@ export async function openRuntime(
       tokens: async () => (await readConnections(root)).tokens,
       credentials,
       profilesFor: membersResolver(root),
+      // **`error`, where the two closures above use `warn`, and that is the
+      // point of it.** This logger is filtered by level and the container opens
+      // its runtime with `quiet: true`, which sets the threshold to `error` —
+      // so a warning here is discarded in precisely the place this matters. The
+      // others are addressed to somebody at a terminal; this one is addressed
+      // to whoever is reading a deployed endpoint's log wondering why a
+      // credential it holds stopped working.
+      report: (message) => logger.error(message),
     }),
     connectorFor,
     authorizeRequest,

--- a/src/server/index.test.ts
+++ b/src/server/index.test.ts
@@ -1,9 +1,12 @@
 import { afterAll, describe, expect, test } from 'bun:test';
 import type { Icon } from '@modelcontextprotocol/server';
 import { allocatePort, rpc, startHarness, wireProfiles, TEST_TOKEN } from './harness.ts';
-import { isLoopback } from './index.ts';
+import { createRequestHandler, isLoopback } from './index.ts';
+import { Generations } from './generations.ts';
 import { SURFACE_TOOL_NAMES } from './mcp/index.ts';
 import { parseConfig, type Config } from '#profile';
+import type { Authenticator } from '#auth';
+import { silentLogger } from './logging.ts';
 import manifest from '../../package.json' with { type: 'json' };
 
 /** The stripe fill, so the two rects that are *not* stripes can be picked out. */
@@ -1335,5 +1338,83 @@ describe('operational logging', () => {
     } finally {
       await listening.stop();
     }
+  });
+});
+
+describe('health, when the credential store will not answer', () => {
+  /**
+   * `/health` was the one surface that asked the authenticator directly.
+   *
+   * Every other path goes through `authenticateRequest`, which turns a store
+   * that throws into a 503 naming the fault. This one did not, and there is no
+   * `catch` above it and no `error` handler on `Bun.serve` — so an unreadable
+   * credential reached the caller as a bare 500 with nothing logged at all. It
+   * is the surface `deploy` and `status` poll, which is the worst place for a
+   * failure with no explanation attached.
+   */
+  /**
+   * An authenticator that fails while *judging* a credential.
+   *
+   * It gives up on a missing bearer first, because every real link does — see
+   * `parseBearer` in `auth/index.ts` and the three in `auth/remote.ts`, all of
+   * which return `missing` before reading anything. A stub that threw
+   * unconditionally would pass the test below for a reason no deployment has.
+   *
+   * What still reaches here after a row-level read is skipped: the workspace's
+   * own `connections.yaml` is read to get the rows at all, so a bucket that has
+   * stopped answering throws before any row is looked at.
+   */
+  const throwing: Authenticator = {
+    authenticate: async (header) => {
+      if (!header) return { ok: false, reason: 'missing' };
+      throw new Error('the workspace bucket did not answer');
+    },
+  };
+
+  function handlerWith(authenticator: Authenticator, log = silentLogger()) {
+    const { profiles } = wireProfiles({
+      profile: 'personal',
+      port: allocatePort(),
+      policy: `  allow:\n    - "example.*"`,
+    });
+    const nothing = () => Promise.resolve();
+
+    return createRequestHandler({
+      generations: new Generations({ profiles, close: nothing }, async () => ({ profiles, close: nothing }), {
+        primary: 'personal',
+        log,
+      }),
+      primary: 'personal',
+      authenticator,
+      log,
+    });
+  }
+
+  const health = (credentialed: boolean): Request =>
+    new Request('https://endpoint.example/health', {
+      headers: credentialed ? { authorization: `Bearer ${TEST_TOKEN}` } : {},
+    });
+
+  test('a credentialed caller is told the endpoint could not check, not that it is broken', async () => {
+    const errors: string[] = [];
+    const log = { ...silentLogger(), error: (message: string) => errors.push(message) };
+
+    const response = await handlerWith(throwing, log).fetch(health(true));
+
+    expect(response.status).toBe(503);
+    expect(response.headers.get('retry-after')).toBe('2');
+    expect(await response.json()).toMatchObject({ error: 'unavailable' });
+    // And it is in the log, which is the half that was missing entirely.
+    expect(errors).toContain('could not authenticate');
+  });
+
+  test('the platform probe still passes, because it presents no credential', async () => {
+    // The reason this change cannot flap a revision. Cloud Run's own probe is
+    // uncredentialed, and authentication gives up on a missing bearer before it
+    // reads any store — so the store being unreachable never reaches the probe.
+    const response = await handlerWith(throwing).fetch(health(false));
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({ status: 'ok' });
   });
 });

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -196,8 +196,9 @@ export function createRequestHandler(options: ServerOptions): RequestHandler {
         // And they are the *caller's* since ADR-068: this listed every profile
         // served to anybody holding a credential, so a delegated member read the
         // ones `mayReach` keeps out of their own enum.
-        const auth = request.headers.get('authorization');
-        const named = await options.authenticator.authenticate(auth, addressed);
+        // Via `authenticateRequest` like the rest: asked directly, a throw was a 500.
+        const named = await authenticateRequest(options.authenticator, request, options.log, addressed);
+        if (named instanceof Response) return named;
         const who = named.ok ? named.principal : null;
         const mine = options.generations.current.names().filter((n) => who && mayReach(who, n));
         return Response.json({


### PR DESCRIPTION
Issuing a token against a deployed target creates the secret container but not the
resource-level grant that lets the runtime identity read it. Secret Manager answers a
missing binding with 403 rather than 404, and the adapter returns null for the 404 and
throws for the 403. `BearerAuthenticator.#reload` read every row with no `try`, so the
throw left `#reload`, left `authenticate`, left the chain, and the endpoint answered
every caller with an error — including the token that had been working — until the row
was revoked.

The blast radius was larger than one credential. This link runs *first* and is
unconditional, ahead of the declared gate and the Lanes-signed key, so one unreadable
static row also refused the OAuth tokens and signed API keys behind it. They never got
asked.

## What changed

- **A row that cannot be read is skipped and reported**, which is `openReconciled`'s
  rule one layer down. Caught by shape rather than by status: the store throws a bare
  `Error` whose status survives only as text in the message, so narrowing to a 403 would
  mean matching on prose.
- **Reported through a closure**, because `auth` may not reach the component that owns a
  logger — the same reason `tokens` and `profilesFor` arrive that way. Wired to `error`
  rather than `warn`, because the logger is filtered by level and the container opens its
  runtime with `quiet: true`; a warning would be discarded in exactly the place this
  matters. On change rather than per reload, or an unfixed grant writes a line every five
  seconds.
- **`/health` goes through `authenticateRequest`** like every other surface. It was
  asking the authenticator directly, with no catch above it and no `error` handler on
  `Bun.serve`, so the same failure reached the caller as a bare 500 with nothing logged —
  on the surface `deploy` and `status` poll.
- **`BearerAuthenticator` moves to `bearer.ts`** beside `remote.ts`. The file-size budget
  refused the change; this is the seam it was pointing at rather than a concession.

## Rejected

- **Collapsing 403 to null in the adapter.** `prepare.ts` and `provision-profile.ts` both
  depend on the throw to tell an unbound ref from an empty one. An unprovisioned profile
  would open an empty vault instead of reporting.
- **Keeping the last known-good value for a row whose read fails.** That is a cache
  outliving its store, which is what `CACHE_TTL_MS` exists to prevent.

## Verified

`bun test` (3730 pass, 0 fail) and `bun run typecheck`, both green. Every new test was
confirmed to fail against the unfixed code first — including the chain case, which is
the one a row-loop-only test would miss.

**Not covered: this has not been exercised against a real deployment.** The behaviour
is about how a deployed endpoint answers when its credential store refuses a read, and a
harness cannot prove that. To rehearse it, from this branch, noting the serving revision
first so traffic can be moved back:

1. Deploy to a target with `LANES_LINK_DEV=0`.
2. Issue a token against that target — that is what reliably creates a row with no read
   grant — then confirm an *existing* credential still authenticates.
3. Check all three: `POST /reload`, `/health`, and the container log for the
   `not honouring <id>: <reason>` line.
4. Revoke the row, or provision the binding with `profile add`, and confirm the line
   stops.

## Known rough edge, not fixed here

When *every* row is unreadable the outcome is `not_configured`, which `doctor` reads as
"issue one" when the truth is "grant the read". A fourth `AuthOutcome` reason is read by
`doctor` and ranked by the chain, and ripples further than the log line is worth.

## Follow-ups

`token issue` still writes a secret it never grants a read for, so a deployed target gets
an unreadable row every time; `secrets push` has the same gap. `connect` already solves
this with `bindConnectionCredentials`.
