### PR TITLE
A standing denial was said on every reload, because its wording changed

### DIFF
--- a/src/auth/bearer.ts
+++ b/src/auth/bearer.ts
@@ -92,12 +92,24 @@ interface LoadedToken {
   readonly value: string;
 }
 
+/**
+ * An issued row the store would not answer for.
+ *
+ * The id is kept apart from the reason because the two are read for different
+ * things: the id is what decides whether this is news (see `#report`), and the
+ * reason is only ever printed.
+ */
+interface UnreadableRow {
+  readonly id: string;
+  readonly reason: string;
+}
+
 export class BearerAuthenticator implements Authenticator {
   readonly #options: AuthenticatorOptions;
   readonly #now: () => number;
   #cached: readonly LoadedToken[] | null = null;
   #readAt = 0;
-  /** The last set of unreadable rows reported, so a standing fault says it once. */
+  /** Which rows were named last, so a standing fault says it once. */
   #reported: string | null = null;
 
   constructor(options: AuthenticatorOptions) {
@@ -173,7 +185,7 @@ export class BearerAuthenticator implements Authenticator {
 
     const rows = await this.#options.tokens();
     const loaded: LoadedToken[] = [];
-    const unreadable: string[] = [];
+    const unreadable: UnreadableRow[] = [];
     for (const row of rows) {
       let value: string | null;
       try {
@@ -194,7 +206,7 @@ export class BearerAuthenticator implements Authenticator {
         // text in the message, so narrowing to a 403 would mean matching on
         // prose. And the broader rule is the one worth holding: whatever stops
         // a row being read, the answer is that the row matches nothing.
-        unreadable.push(`${row.id}: ${firstLine(error)}`);
+        unreadable.push({ id: row.id, reason: firstLine(error) });
         continue;
       }
       // A row whose credential is gone is not an error to report here. It is
@@ -217,14 +229,31 @@ export class BearerAuthenticator implements Authenticator {
    * and a line each time would bury the one that mattered. Reporting recovery
    * too — the empty set is a change like any other — is what makes the last
    * line about a row the current answer rather than a thing to correlate.
+   *
+   * **Keyed on which rows, not on what they said, and that is the whole of the
+   * fix.** The first version compared the rendered lines, reason included, and
+   * on a deployed target it never matched twice: Secret Manager mints a fresh
+   * IAM troubleshooter `errorId` into every `PERMISSION_DENIED` message, so the
+   * same standing denial arrived as a different string each read and the
+   * comparison above was always a change. Eight reloads wrote eight lines. A
+   * unit test could not see it — a stub throws the message it was given — so
+   * what caught it was reading the log of a real endpoint with an unreadable
+   * row, which is what the rehearsal in `CLAUDE.md` is for.
+   *
+   * The cost is that a row whose *reason* changes while it stays unreadable is
+   * not said again. That is the right trade: the set of rows this endpoint
+   * cannot honour is the state an operator acts on, and a second reason for a
+   * row already named changes nothing they would do.
    */
-  #report(unreadable: readonly string[]): void {
-    const signature = unreadable.join('\n');
+  #report(unreadable: readonly UnreadableRow[]): void {
+    const signature = unreadable.map((row) => row.id).join('\n');
     if (signature === this.#reported) return;
     this.#reported = signature;
     // One line per row, in the shape `not serving <profile>: <reason>` already
     // uses, because the two are read in the same place for the same purpose.
-    for (const row of unreadable) this.#options.report?.(`not honouring ${row}`);
+    for (const row of unreadable) {
+      this.#options.report?.(`not honouring ${row.id}: ${row.reason}`);
+    }
   }
 
   /**

--- a/src/auth/index.test.ts
+++ b/src/auth/index.test.ts
@@ -545,6 +545,56 @@ describe('a credential that cannot be read', () => {
     expect(said).toHaveLength(1);
   });
 
+  test('said once even though the store words the same denial differently each read', async () => {
+    // What the test above could not see, and a deployed endpoint did.
+    //
+    // Secret Manager mints a fresh IAM troubleshooter `errorId` into every
+    // `PERMISSION_DENIED` body, so one standing denial arrives as a different
+    // string on every read. The first version of the dedupe compared the
+    // rendered lines, reason included, so it never matched twice: eight reloads
+    // against a real target wrote eight lines for one unfixed grant. A stub
+    // that throws a constant could not reproduce it, which is why this one does
+    // not.
+    let clock = 0;
+    let denials = 0;
+    const said: string[] = [];
+    const auth = new BearerAuthenticator({
+      profile: 'personal',
+      tokens: async () => TWO_ROWS,
+      credentials: {
+        ...storeWith({ 'tokens/tok2': 'llk_good' }),
+        async get(ref) {
+          if (ref === 'tokens/tok1') {
+            denials += 1;
+            throw new Error(
+              `Secret Manager could not read ${ref} (HTTP 403). PERMISSION_DENIED: ` +
+                `Permission denied. Remediate access with this Troubleshooter URL - ` +
+                `https://console.example/troubleshooter;errorId=unique-${denials}`,
+            );
+          }
+          return 'llk_good';
+        },
+      },
+      profilesFor: async () => ['personal'],
+      report: (m) => said.push(m),
+      now: () => clock,
+    });
+
+    await auth.authenticate('Bearer llk_good');
+    clock += 10_000;
+    await auth.authenticate('Bearer llk_good');
+    clock += 10_000;
+    await auth.authenticate('Bearer llk_good');
+
+    // Three distinct messages from the store, one line out.
+    expect(denials).toBe(3);
+    expect(said).toHaveLength(1);
+    // And the reason is still carried — dropping it to make the key stable
+    // would have taken the only text that says what to fix.
+    expect(said[0]).toContain('tok1');
+    expect(said[0]).toContain('PERMISSION_DENIED');
+  });
+
   test('a row that becomes readable is not reported again', async () => {
     let clock = 0;
     let denied = ['tokens/tok1'];


### PR DESCRIPTION
A follow-on to #235, found by doing the rehearsal that pull request said it had not done.

#235 made an unreadable credential row skip rather than fail the endpoint, and reports the
skip once — comparing the rendered lines, reason included, to decide whether the set had
changed. On a deployed target that comparison never matches twice. Secret Manager mints a
fresh IAM troubleshooter `errorId` into every `PERMISSION_DENIED` body, so one standing
denial arrives as a different string on each read and every reload looks like a change.

Measured against a real target: eight reloads, eight lines, eight distinct `errorId`s for a
single unfixed grant. At a five second cache window that is roughly seventeen thousand lines
a day — the noise the dedupe exists to prevent, and it would have buried the line that
mattered.

## What changed

- **The dedupe key is the set of row ids, not the rendered lines.** The reason is still
  printed — it is the only text that says what to fix — it just no longer decides whether
  the line is new.
- A row whose *reason* changes while it stays unreadable is not said again. That is the
  trade, and it is the right way round: the set of rows the endpoint cannot honour is the
  state an operator acts on, and a second wording for a row already named changes nothing
  they would do.

## Why the existing test missed it

The `said once` test in #235 throws a constant from its stub, so its signature was stable by
construction — it could not observe the failure. The new test varies the message on each
read, and was confirmed to fail against the old key while every other test in that file
still passed. That asymmetry is the finding: a harness cannot produce a vendor's own
per-denial identifier.

## Verified

`bun test` (3731 pass, 0 fail) and `bun run typecheck`, both green.

**And against a real deployment, which is what caught this.** Deployed from this branch to a
target, noting the serving revision first:

- The reproduction, before the fix: issue a token against a deployed target — that reliably
  creates a row with no read grant — then drive reloads past the cache window. Eight reloads
  wrote eight lines.
- The same reproduction on this branch: eleven reloads, **one** line, carrying the row id and
  the reason.
- Throughout, the working credential kept authenticating and `/health` kept answering, so
  the #235 behaviour this builds on was re-confirmed rather than assumed.
- `POST /reload`, `/health` (credentialed and not) and the container log, all three.
  `tools/list` read off the wire, counted, and equal to the `tools` `/reload` returned.
- Both paths to a capability — the typed tool and `lanes_tools_call` — on a sandbox profile
  holding only the owner layer.
- Four refusals: a profile the caller cannot reach, one profile named with another's
  connection, a garbage bearer, and an RS256-shaped token with an unknown `kid`.
- The test row was revoked afterwards and no orphaned secret remained.

**Not covered:** recovery is asserted in the unit tests but was not re-driven on the
endpoint this time — #235's rehearsal confirmed the line stops after a revoke, and nothing
here changes that path.

## Still open, and not this

`token issue` writes a secret it never grants a read for, so a deployed target gets an
unreadable row every time; `secrets push` has the same gap, and `connect` already solves it
with `bindConnectionCredentials`. That is the cause; these two pull requests are the blast
radius. Tracked separately.
