### PR TITLE
chore: 0.16.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lanes-sh/link",
-  "version": "0.15.0",
+  "version": "0.16.0",
   "description": "A self-hostable MCP gateway for all your connections, memory, tasks, files, and secrets",
   "license": "Apache-2.0",
   "homepage": "https://lanes.sh/link",


### PR DESCRIPTION
A minor rather than a patch, because a command was removed and a credential
shape was added.

`lanes link auth` is gone. It was never a sign-in command — it probed whether
each connection could still authenticate, by attempting the renewal — and the
name said the opposite of what it did. The probe itself stays: `probeConnections`
and `classifyOAuth` moved out of the command module, because `doctor` asks the
same question and must not answer it a second, differently-wrong way.

An API key is now verified rather than stored. The endpoint accepts an RS256
assertion signed by the Lanes API, audience-bound to itself, and resolves what it
reaches through the member lists it already reads — so the two credential shapes
sit in the chain together and no deployment has to be cut over. A long-lived key
and a 120-second redirect assertion are not interchangeable: each verifier
requires its own type claim and rejects the other's, which is the detail the
whole change rests on. Nothing here mints one yet; that is a route on the API.

Availability, and the reason this release was rehearsed twice against a real
deployment. A credential row the endpoint cannot read now refuses itself instead
of the endpoint. Secret Manager answers a missing binding with 403 rather than
404 and the adapter throws, and the static-token link — which runs first and
unconditionally — read every row with no guard, so one unreadable row returned an
error to every caller, including the credential that had been working, and the
OAuth tokens and signed keys behind it were never asked. It is now skipped and
named in the log. `/health` goes through the same path as every other surface, so
the same failure is a 503 with a reason rather than a bare 500 on the one surface
`deploy` and `status` poll.

That report is written once rather than on every reload, which took a second fix:
the first version compared the rendered lines, and Secret Manager mints a fresh
troubleshooter id into every denial, so one standing fault arrived as a different
string each read and never matched. Eight reloads wrote eight lines. Keyed on
which rows failed, eleven reloads write one. No test could have caught it — a
stub throws the message it was given.

Two flag-checking defects, both of which made a command refuse the argument it is
named after. `workspace show --workspace <name>` was rejected, because the
requirement table had no row for the two-word spelling and the lookup falls back
to the bare word, whose requirement is `none`. `lanes auth` was routed before the
check that refuses an unknown flag, so a misspelled `--api-url` was dropped and
the sign-in went to the default broker with nothing on the success path saying
so. A new test asserts every allowlist key has a requirement row, which is what
made the first one silent.

Four comments described a credential that had already been withdrawn, including
the paragraph `lanes link pair` prints to an operator before they answer a
prompt.