### PR TITLE
0.16.0

### DIFF
--- a/docs/detailed/adr/080-an-api-key-is-signed-not-stored.md
+++ b/docs/detailed/adr/080-an-api-key-is-signed-not-stored.md
@@ -1,0 +1,152 @@
+# ADR-080: An API key is signed, not stored
+
+**Status:** accepted · **Completes** [ADR-068](068-a-credential-names-a-person.md) ·
+**Amends** [ADR-062](062-the-consent-page-asks-lanes-who-you-are.md),
+[ADR-018](018-the-gate-is-in-the-application.md)
+
+## Context
+
+There is no difference between "the API key" and "the `lanes link token`". They are
+one object under two names, and the code says so — `server/read/routes.ts` calls
+the `llk_` rows "the workspace's static API keys" while the command that mints
+them is `token issue`. Asked what the token family was *for*, the honest answer
+was: it is the API key, and the CLI is the thing that mints it.
+
+That second half is the problem, and it is not the naming.
+
+A `llk_` token is a random string the workspace keeps a copy of. So:
+
+- **The endpoint's answer is a comparison, not a verification.** `BearerAuthenticator`
+  reads every `tokens:` row's value out of the credential store and compares in
+  constant time. The credential and its verifier are the same secret.
+- **A key has to be transported before it works.** Minted locally, it lives in the
+  local store; a deployed revision reads a different store, so a key is useful
+  there only after `secrets push` and a Secret Manager version exists. Nothing
+  says so at mint time.
+- **The mint is in the wrong place.** A credential is issued by whoever can
+  authenticate the person it names. The CLI cannot: it holds a session and takes
+  `--subject <id>` on trust, so `token issue --subject lanes:<someone-else>`
+  mints a working credential for a person who was never asked.
+
+ADR-068 fixed what a token *means* — a row names a person, and reach follows from
+`members:`. It did not change who mints one or how it is checked, because at the
+time there was nowhere else to mint it. ADR-062 built that somewhere: the consent
+page asks `api.lanes.sh` who you are and the endpoint verifies a signed assertion
+against published keys, holding no secret of its own.
+
+So the endpoint already verifies one Lanes-signed credential. The static token is
+the part of the surface that did not get the same treatment.
+
+## Decision
+
+**An API key is signed by `api.lanes.sh` and verified against its published keys.
+Nothing on this side holds a copy.**
+
+A key is an RS256 JWT: `iss` the API, `sub` a `lanes:<uid>`, `aud` this endpoint's
+own resource URL, `kind: api_key`, and an `exp`. The dashboard mints it, because
+the dashboard is where the person is already authenticated.
+
+The endpoint verifies it with the machinery ADR-062 already put there — the same
+JWKS cache, the same RS256-over-`crypto.subtle` check, the same exact-match
+audience comparison. `lanes/signed.ts` is that machinery, extracted; `assertion.ts`
+and `api-key.ts` are the two sets of rules on top of it. One key cache, one
+rotation window, one audience comparison.
+
+Reach is unchanged and is the point: the subject resolves through `members:` on
+every request, exactly as an issued token's does. A key decides nothing about
+what it opens.
+
+### The two credentials must not be interchangeable, and the asymmetry is deliberate
+
+An assertion and a key are signed by the same issuer, may name the same audience,
+and name the same person. Only the `kind` claim separates a credential that
+crosses one redirect from one that lives in a CI secret for ninety days.
+
+- **`api-key.ts` requires `kind: api_key`.** Nothing has ever issued a key, so
+  this side can demand the claim from its first day — and demanding it is what
+  makes an assertion unusable here, since an assertion carries none.
+- **`assertion.ts` rejects `kind: api_key` and tolerates its absence.** It cannot
+  require `kind: assertion`: assertions minted before this claim existed must go
+  on working, and breaking sign-in is not an acceptable price for symmetry.
+
+Both directions are closed by that pair, and neither depends on the lifetime
+ceiling. Relying on the ceiling alone would be wrong: a key minted with a short
+`exp` has an `iat` consistent with it and would pass.
+
+### The audience is the only thing that makes a key mean *this* endpoint
+
+An issued token is bound to this endpoint by living in its store. An OIDC token is
+bound by an audience the operator configured. A Lanes-signed key is bound by
+nothing except `aud`, because its issuer signs for every Lanes endpoint there is.
+
+So `Authenticator.authenticate` gains an optional `AuthContext` carrying the
+resource identifier the caller addressed — the same string
+`protectedResourceMetadata` publishes, derived from `Host` and
+`X-Forwarded-Proto` because this endpoint does not know its own public URL from
+config.
+
+**Optional in the type, mandatory in effect.** `LanesKeyAuthenticator` refuses
+when it is absent rather than skipping the check. That is ADR-079's lesson stated
+one layer down: an unset field must not resolve to the widest answer. It is
+optional only so the three links that ignore it, and the test doubles that predate
+it, need not mention it.
+
+The loopback read listener supplies the *MCP server's* URL rather than its own.
+It binds one port above the endpoint, so a resource built from its own `Host`
+would name an address no key was ever minted for.
+
+A workspace-scoped audience was considered and rejected. `lanes_workspace` is the
+only Lanes-side identifier a target carries, it is optional and hand-written, and
+it exists as a convenience check for `profile members add`. Making it the thing a
+credential is verified against would turn a field most targets do not set into a
+gate, and a roster check into an authorization decision — which is exactly what
+the access model says it must never be.
+
+### Revocation is `members:`, and what that cannot do is stated
+
+Reach is resolved per request, so `lanes link profile members remove` stops a key
+within the member cache's window — seconds, and the same lever that already
+revokes every other shape.
+
+What it cannot do is revoke *one* key while leaving that person's others working.
+Nothing here holds a list of issued keys to strike one from, and nothing should:
+that list belongs to whoever mints them. Per-key revocation is the dashboard's,
+and until it exists the honest statement is that a key is revoked by removing the
+person, not the key.
+
+### What this costs
+
+**Verification stops being offline.** A `llk_` comparison needed no network. A
+signed key needs a key set fetched from the API. The cache is an hour and a fetch
+failure leaves previously-known keys answering, so the exposure is a cold endpoint
+during an API outage — but a self-hoster pointing `LANES_API_URL` elsewhere must
+publish a JWKS there. This is the same dependency ADR-062 already took on for
+sign-in; it now covers the headless path too.
+
+## Consequences
+
+`BearerAuthenticator`, `generateProfileToken`, the `llk_` prefix, the `tokens:`
+block and the `lanes link token` family all become removable — but **not in this
+change**, and the ordering is not incidental. The four CLI commands that call
+their own endpoint (`outputs`, `tools`, the reload notification, and
+`mcp add --headless`) get their credential from `anyIssuedToken`, and
+`mcp add --headless` requires one rather than degrading. Until the API can hand
+the CLI a short-lived endpoint-audienced token, deleting the mint would leave
+those commands with nothing.
+
+So both links sit in the chain at once. Static rows first, because that is still a
+constant-time comparison against a cached value; the declared gate next, because
+an issued token is a lookup in this endpoint's own state; the signed key last,
+because it is the only link that may have to fetch a key set. A credential that is
+not a JWT fails that link on its first `split`, so the ordering costs the other
+two nothing.
+
+The key link is **unconditional**, unlike the OAuth gate. It is the headless path,
+and making it depend on `auth.authorization` would mean a profile declaring no
+remote-client model could not be reached by a machine at all — which is the case
+the static token existed for.
+
+Removing the static family needs a contract bump and a migration that drops
+`tokens:` rows and their `tokens/*` values. That is a breaking change to a
+published package: every headless registration in the wild presents a `llk_`.
+ADR-066 records what a rename cost a client that had already fetched the old list.

--- a/docs/detailed/adr/README.md
+++ b/docs/detailed/adr/README.md
@@ -92,6 +92,7 @@ Run.
 | [077](077-the-workspace-lives-under-the-lanes-home.md) | The workspace moves to `~/.lanes/link`, a checkout gets `~/.lanes-dev`, and the old root is recognised until `update` moves it |
 | [078](078-a-removal-works-on-a-config-that-will-not-load.md) | A removal works on a config that will not load, deleting by name what it cannot enumerate and reporting the rest |
 | [079](079-the-dashboard-credential-names-a-person.md) | The dashboard's pairing token buys a session naming the person at the browser, and reaching every profile becomes a value a credential must carry rather than a field nobody set |
+| [080](080-an-api-key-is-signed-not-stored.md) | The API key and the `lanes link token` were one object under two names; the dashboard mints it, `api.lanes.sh` signs it, and the endpoint verifies it against published keys instead of holding a copy |
 
 Where an ADR departs from init.md, it says so at the top. Three are significant:
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lanes-sh/link",
-  "version": "0.15.0",
+  "version": "0.16.0",
   "description": "A self-hostable MCP gateway for all your connections, memory, tasks, files, and secrets",
   "license": "Apache-2.0",
   "homepage": "https://lanes.sh/link",

--- a/src/auth/bearer.ts
+++ b/src/auth/bearer.ts
@@ -1,0 +1,285 @@
+/**
+ * The credential the workspace keeps a copy of.
+ *
+ * Beside `remote.ts` rather than inside `index.ts`, and the split is the one
+ * the file was already asking for: `index.ts` is the shape every surface shares
+ * — an outcome, a chain, how a bearer is parsed and compared — while each way
+ * of *proving* a credential is its own subject. Three of them were already in
+ * `remote.ts`; this is the fourth, and the only one whose answer is a
+ * comparison against something stored rather than a verification.
+ *
+ * It imports its shared pieces back from `index.ts` exactly as `remote.ts`
+ * does, so `#auth` stays the one name every other component uses.
+ */
+
+import type { SecretRef, SecretStore } from '#secrets';
+
+import {
+  machinePrincipal,
+  parseBearer,
+  tokensMatch,
+  type AuthOutcome,
+  type Authenticator,
+} from './index.ts';
+
+/**
+ * One issued token, as the authenticator needs it.
+ *
+ * Structurally what `connections.yaml` holds, declared here rather than
+ * imported: `auth` may not reach `#profile` (the architecture test enforces the
+ * direction), and the rows arrive as a closure for the same reason
+ * `profilesFor` does.
+ */
+export interface IssuedToken {
+  readonly id: string;
+  readonly subject: string;
+  readonly ref: SecretRef;
+}
+
+export interface AuthenticatorOptions {
+  /**
+   * The primary, which is what `principal.profile` starts as.
+   *
+   * Not what the token reaches — that is `profilesFor(subject)`. It is where
+   * the connection was opened, and every dispatch rewrites it with `forProfile`.
+   */
+  readonly profile: string;
+  /** The workspace's issued tokens. Re-read on every reload, so a revoke lands. */
+  readonly tokens: () => Promise<readonly IssuedToken[]>;
+  readonly credentials: SecretStore;
+  /**
+   * Which profiles list this subject as a member.
+   *
+   * The same resolver the OAuth path is handed (`server/endpoint.ts`), passed in
+   * rather than reached for, so discovery and enforcement cannot disagree about
+   * a subject's reach.
+   */
+  readonly profilesFor: (subject: string) => Promise<readonly string[]>;
+  /**
+   * Where a row that could not be read is reported.
+   *
+   * A closure rather than a logger, for the same reason `tokens` and
+   * `profilesFor` are closures: `auth` may not reach the components that own
+   * one. `cli/runtime/open.ts` supplies it.
+   *
+   * Optional because most callers are tests, and because the skip is already
+   * correct without it — but a caller serving requests should pass one. A
+   * credential the operator issued and this endpoint cannot read is invisible
+   * otherwise, which is the failure `server/container.ts` was rewritten about.
+   */
+  readonly report?: (message: string) => void;
+  /** Injectable for tests. Only the cache window reads it. */
+  readonly now?: () => number;
+}
+
+/**
+ * How long a cached token may answer before the store is consulted again.
+ *
+ * The cache is here so the common case — a valid token, on every request — is a
+ * comparison rather than a file read or a Secret Manager call. What it must not
+ * do is outlive a rotation. `lanes link token rotate` is the only revocation
+ * this system has, and an unbounded cache meant a revoked token kept opening the
+ * endpoint until the process restarted, while the replacement was refused.
+ *
+ * Five seconds makes rotation effectively immediate and still collapses a burst
+ * of calls onto one read.
+ */
+const CACHE_TTL_MS = 5_000;
+
+/** An issued row, with its value read out of the store. */
+interface LoadedToken {
+  readonly subject: string;
+  readonly value: string;
+}
+
+export class BearerAuthenticator implements Authenticator {
+  readonly #options: AuthenticatorOptions;
+  readonly #now: () => number;
+  #cached: readonly LoadedToken[] | null = null;
+  #readAt = 0;
+  /** The last set of unreadable rows reported, so a standing fault says it once. */
+  #reported: string | null = null;
+
+  constructor(options: AuthenticatorOptions) {
+    this.#options = options;
+    this.#now = options.now ?? Date.now;
+  }
+
+  async authenticate(authorizationHeader: string | null | undefined): Promise<AuthOutcome> {
+    const presented = parseBearer(authorizationHeader);
+    if (presented === null) {
+      return { ok: false, reason: authorizationHeader ? 'malformed' : 'missing' };
+    }
+
+    const fresh = this.#cached !== null && this.#now() - this.#readAt < CACHE_TTL_MS;
+    let rows = fresh ? this.#cached! : await this.#reload();
+    let matched = find(presented, rows);
+
+    // A miss against a *cached* set is ambiguous: either the credential is
+    // wrong, or it is the right one and this process has not seen the rotation
+    // or the issue that produced it. One re-read separates the two, and it is
+    // what makes a rotated-in token work on its first call rather than after
+    // the window. Only a cached comparison can be wrong this way, so a fresh
+    // read never pays for a second one — which is what keeps a wrong token from
+    // costing a store read per attempt.
+    //
+    // **And only for something that could be one of these tokens.** A hosted
+    // connector presents an OAuth token: the next link in the chain handles it
+    // and it can never match a row here. Without that condition the ambiguity
+    // above was permanent for such a caller — a healthy endpoint has no static
+    // rows, so the match always failed and the "one re-read" fired on every
+    // request, re-confirming an empty list at the cost of a bucket read, a YAML
+    // parse and a schema validation. The cache never protected anything,
+    // because the path that consulted it was the path that always missed.
+    if (fresh && matched === null && couldBeProfileToken(presented)) {
+      rows = await this.#reload();
+      matched = find(presented, rows);
+    }
+
+    if (rows.length === 0) {
+      // No token has been issued. Fail closed, and distinctly from a wrong one:
+      // `lanes link doctor` reads this to say "issue one" rather than "check it".
+      return { ok: false, reason: 'not_configured' };
+    }
+
+    if (matched === null) return { ok: false, reason: 'invalid' };
+
+    // **Resolved per request, not cached with the value.** Membership is read
+    // when a token is minted for an OAuth client (ADR-060) because there is a
+    // mint to read it at; a static token has none, so this is the only place
+    // the question can be asked. It is what makes `profile members remove`
+    // take effect on the next call rather than on the next rotation.
+    //
+    // A resolver that throws fails closed. The alternative — falling back to
+    // "every profile" — would restore exactly the behaviour ADR-068 removes,
+    // and would do it precisely when something is already wrong.
+    let profiles: readonly string[];
+    try {
+      profiles = await this.#options.profilesFor(matched.subject);
+    } catch {
+      return { ok: false, reason: 'invalid' };
+    }
+
+    return {
+      ok: true,
+      principal: machinePrincipal(matched.subject, this.#options.profile, profiles),
+    };
+  }
+
+  async #reload(): Promise<readonly LoadedToken[]> {
+    // Both caches, or neither: the store holds its own decrypted copy, so
+    // re-reading without dropping that first re-reads the same stale value.
+    this.#options.credentials.refresh?.();
+
+    const rows = await this.#options.tokens();
+    const loaded: LoadedToken[] = [];
+    const unreadable: string[] = [];
+    for (const row of rows) {
+      let value: string | null;
+      try {
+        value = await this.#options.credentials.get(row.ref);
+      } catch (error) {
+        // **One row may not decide whether anybody can authenticate.**
+        //
+        // This is `openReconciled`'s rule at the credential level: a sibling it
+        // cannot open is skipped rather than allowed to fail the endpoint for
+        // the rest. Here the blast radius was larger still, because this link
+        // runs *first* in the chain — so a single unreadable row refused OAuth
+        // tokens and Lanes-signed keys too, which never got reached. A live
+        // endpoint answered every caller with an error, including the token
+        // that had been working, until the offending row was revoked.
+        //
+        // Caught by shape rather than by status, deliberately. The store that
+        // produces this throws a bare `Error` whose status survives only as
+        // text in the message, so narrowing to a 403 would mean matching on
+        // prose. And the broader rule is the one worth holding: whatever stops
+        // a row being read, the answer is that the row matches nothing.
+        unreadable.push(`${row.id}: ${firstLine(error)}`);
+        continue;
+      }
+      // A row whose credential is gone is not an error to report here. It is
+      // what a half-finished `secrets push` looks like, and the row simply
+      // matches nothing — `doctor` is where that is worth a sentence.
+      if (value) loaded.push({ subject: row.subject, value });
+    }
+
+    this.#report(unreadable);
+    this.#cached = loaded;
+    this.#readAt = this.#now();
+    return loaded;
+  }
+
+  /**
+   * Say which rows could not be read, when that set changes.
+   *
+   * On change rather than on every reload: the window above collapses a burst
+   * onto one read, but a grant nobody fixes is still a read every five seconds,
+   * and a line each time would bury the one that mattered. Reporting recovery
+   * too — the empty set is a change like any other — is what makes the last
+   * line about a row the current answer rather than a thing to correlate.
+   */
+  #report(unreadable: readonly string[]): void {
+    const signature = unreadable.join('\n');
+    if (signature === this.#reported) return;
+    this.#reported = signature;
+    // One line per row, in the shape `not serving <profile>: <reason>` already
+    // uses, because the two are read in the same place for the same purpose.
+    for (const row of unreadable) this.#options.report?.(`not honouring ${row}`);
+  }
+
+  /**
+   * Drop the cached set immediately.
+   *
+   * The window above already bounds how long a rotation goes unnoticed, so this
+   * is an optimisation rather than the mechanism — nothing's correctness may
+   * depend on it being called, because for a long time nothing called it.
+   */
+  invalidateCache(): void {
+    this.#cached = null;
+  }
+}
+
+/**
+ * The part of a failure fit to print beside a name.
+ *
+ * `server/endpoint.ts` trims the same way for the same reason, and this is a
+ * copy rather than a shared import because `auth` may not reach that component
+ * — see the dependency directions in `architecture.test.ts`.
+ */
+function firstLine(error: unknown): string {
+  const text = error instanceof Error ? error.message : String(error);
+  return text.split('\n')[0] ?? '';
+}
+
+/**
+ * The row a presented token matches, or null.
+ *
+ * Every row is compared even after one matches. Returning early would make the
+ * time taken describe *which* row answered, and the whole point of
+ * `tokensMatch` is that a comparison here leaks nothing about the value it is
+ * comparing against.
+ */
+function find(presented: string, rows: readonly LoadedToken[]): LoadedToken | null {
+  let found: LoadedToken | null = null;
+  for (const row of rows) if (tokensMatch(presented, row.value)) found = row;
+  return found;
+}
+
+/**
+ * Whether a presented credential could be one of *these* tokens at all.
+ *
+ * `generateProfileToken` mints every one with this prefix, which
+ * `secret-detection.ts` and the edge limiter already recognise — so it is exact.
+ */
+const couldBeProfileToken = (presented: string): boolean =>
+  presented.startsWith(PROFILE_TOKEN_PREFIX);
+
+/** What a minted profile token starts with. */
+const PROFILE_TOKEN_PREFIX = 'llk_';
+/**
+ * Mint a profile token: 32 random bytes, base64url, prefixed so it is
+ * recognisable in a config file and greppable in a leak.
+ */
+export function generateProfileToken(): string {
+  return `${PROFILE_TOKEN_PREFIX}${Buffer.from(crypto.getRandomValues(new Uint8Array(32))).toString('base64url')}`;
+}

--- a/src/auth/bearer.ts
+++ b/src/auth/bearer.ts
@@ -92,12 +92,24 @@ interface LoadedToken {
   readonly value: string;
 }
 
+/**
+ * An issued row the store would not answer for.
+ *
+ * The id is kept apart from the reason because the two are read for different
+ * things: the id is what decides whether this is news (see `#report`), and the
+ * reason is only ever printed.
+ */
+interface UnreadableRow {
+  readonly id: string;
+  readonly reason: string;
+}
+
 export class BearerAuthenticator implements Authenticator {
   readonly #options: AuthenticatorOptions;
   readonly #now: () => number;
   #cached: readonly LoadedToken[] | null = null;
   #readAt = 0;
-  /** The last set of unreadable rows reported, so a standing fault says it once. */
+  /** Which rows were named last, so a standing fault says it once. */
   #reported: string | null = null;
 
   constructor(options: AuthenticatorOptions) {
@@ -173,7 +185,7 @@ export class BearerAuthenticator implements Authenticator {
 
     const rows = await this.#options.tokens();
     const loaded: LoadedToken[] = [];
-    const unreadable: string[] = [];
+    const unreadable: UnreadableRow[] = [];
     for (const row of rows) {
       let value: string | null;
       try {
@@ -194,7 +206,7 @@ export class BearerAuthenticator implements Authenticator {
         // text in the message, so narrowing to a 403 would mean matching on
         // prose. And the broader rule is the one worth holding: whatever stops
         // a row being read, the answer is that the row matches nothing.
-        unreadable.push(`${row.id}: ${firstLine(error)}`);
+        unreadable.push({ id: row.id, reason: firstLine(error) });
         continue;
       }
       // A row whose credential is gone is not an error to report here. It is
@@ -217,14 +229,31 @@ export class BearerAuthenticator implements Authenticator {
    * and a line each time would bury the one that mattered. Reporting recovery
    * too — the empty set is a change like any other — is what makes the last
    * line about a row the current answer rather than a thing to correlate.
+   *
+   * **Keyed on which rows, not on what they said, and that is the whole of the
+   * fix.** The first version compared the rendered lines, reason included, and
+   * on a deployed target it never matched twice: Secret Manager mints a fresh
+   * IAM troubleshooter `errorId` into every `PERMISSION_DENIED` message, so the
+   * same standing denial arrived as a different string each read and the
+   * comparison above was always a change. Eight reloads wrote eight lines. A
+   * unit test could not see it — a stub throws the message it was given — so
+   * what caught it was reading the log of a real endpoint with an unreadable
+   * row, which is what the rehearsal in `CLAUDE.md` is for.
+   *
+   * The cost is that a row whose *reason* changes while it stays unreadable is
+   * not said again. That is the right trade: the set of rows this endpoint
+   * cannot honour is the state an operator acts on, and a second reason for a
+   * row already named changes nothing they would do.
    */
-  #report(unreadable: readonly string[]): void {
-    const signature = unreadable.join('\n');
+  #report(unreadable: readonly UnreadableRow[]): void {
+    const signature = unreadable.map((row) => row.id).join('\n');
     if (signature === this.#reported) return;
     this.#reported = signature;
     // One line per row, in the shape `not serving <profile>: <reason>` already
     // uses, because the two are read in the same place for the same purpose.
-    for (const row of unreadable) this.#options.report?.(`not honouring ${row}`);
+    for (const row of unreadable) {
+      this.#options.report?.(`not honouring ${row.id}: ${row.reason}`);
+    }
   }
 
   /**

--- a/src/auth/index.test.ts
+++ b/src/auth/index.test.ts
@@ -16,6 +16,30 @@ import {
   type AuthOutcome,
 } from './index.ts';
 
+/**
+ * A store where the named refs throw instead of answering.
+ *
+ * What a missing Secret Manager binding actually looks like: the adapter
+ * answers null for a 404 and *throws* for a 403, because a missing binding is
+ * denied rather than absent. A bare `Error` with the status only in its
+ * message, because that is what the adapter constructs.
+ */
+function storeRefusing(entries: Record<string, string>, denied: readonly string[]): SecretStore {
+  const base = storeWith(entries);
+  return {
+    ...base,
+    async get(ref) {
+      if (denied.includes(ref)) {
+        throw new Error(
+          `Secret Manager could not read ${ref} (HTTP 403). PERMISSION_DENIED: ` +
+            'Permission "secretmanager.versions.access" denied',
+        );
+      }
+      return base.get(ref);
+    },
+  };
+}
+
 function storeWith(entries: Record<string, string>): SecretStore {
   const map = new Map(Object.entries(entries));
   return {
@@ -84,10 +108,11 @@ describe('authentication', () => {
   /** One issued row, and the profiles its subject is a member of. */
   const issued = (
     overrides: {
-      credentials?: ReturnType<typeof storeWith>;
+      credentials?: SecretStore;
       profilesFor?: (subject: string) => Promise<readonly string[]>;
       now?: () => number;
       rows?: readonly { id: string; subject: string; ref: string }[];
+      report?: (message: string) => void;
     } = {},
   ) => ({
     profile: 'personal',
@@ -96,6 +121,7 @@ describe('authentication', () => {
     credentials: overrides.credentials ?? storeWith({ 'tokens/tok1': 'llk_correct' }),
     profilesFor: overrides.profilesFor ?? (async () => ['personal']),
     ...(overrides.now ? { now: overrides.now } : {}),
+    ...(overrides.report ? { report: overrides.report } : {}),
   });
 
   const options = issued();
@@ -423,5 +449,163 @@ describe('the chain and the context', () => {
 
     expect(outcome.ok).toBe(true);
     expect(never.seen.calls).toBe(0);
+  });
+});
+
+describe('a credential that cannot be read', () => {
+  /**
+   * The endpoint went down for everyone because one row was unreadable.
+   *
+   * Issuing a token against a deployed target created the secret container but
+   * not the resource-level grant that lets the runtime identity read it. Secret
+   * Manager answers a missing binding with 403 rather than 404 — so that an
+   * identity cannot enumerate secrets by their error codes — and the adapter
+   * returns null for the 404 and throws for the 403. The throw left `#reload`,
+   * left `authenticate`, left the chain, and every caller was refused,
+   * including the token that had been working.
+   *
+   * The rule these hold is `openReconciled`'s, one layer down: what cannot be
+   * read is skipped and said out loud, not allowed to answer for everyone else.
+   */
+  const SUBJECT = 'lanes:abc123';
+  const TWO_ROWS = [
+    { id: 'tok1', subject: SUBJECT, ref: 'tokens/tok1' },
+    { id: 'tok2', subject: SUBJECT, ref: 'tokens/tok2' },
+  ];
+
+  const withRefusal = (overrides: { report?: (message: string) => void } = {}) => ({
+    profile: 'personal',
+    tokens: async () => TWO_ROWS,
+    credentials: storeRefusing({ 'tokens/tok2': 'llk_good' }, ['tokens/tok1']),
+    profilesFor: async () => ['personal'],
+    ...(overrides.report ? { report: overrides.report } : {}),
+  });
+
+  test('the row beside it still authenticates', async () => {
+    const auth = new BearerAuthenticator(withRefusal());
+
+    const outcome = await auth.authenticate('Bearer llk_good');
+
+    expect(outcome.ok).toBe(true);
+  });
+
+  test('a wrong token is still refused, rather than excused by the unreadable row', async () => {
+    const auth = new BearerAuthenticator(withRefusal());
+
+    expect(await auth.authenticate('Bearer llk_wrong')).toEqual({ ok: false, reason: 'invalid' });
+  });
+
+  test('every row unreadable refuses, rather than throwing', async () => {
+    const auth = new BearerAuthenticator({
+      profile: 'personal',
+      tokens: async () => TWO_ROWS,
+      credentials: storeRefusing({}, ['tokens/tok1', 'tokens/tok2']),
+      profilesFor: async () => ['personal'],
+    });
+
+    // `not_configured` rather than a fourth reason: from here it is
+    // indistinguishable from a workspace that has issued nothing, and the
+    // report below is what carries the difference to whoever can act on it.
+    expect(await auth.authenticate('Bearer llk_good')).toEqual({
+      ok: false,
+      reason: 'not_configured',
+    });
+  });
+
+  test('the unreadable row is named, with what the store said', async () => {
+    const said: string[] = [];
+    const auth = new BearerAuthenticator(withRefusal({ report: (m) => said.push(m) }));
+
+    await auth.authenticate('Bearer llk_good');
+
+    expect(said).toHaveLength(1);
+    expect(said[0]).toContain('tok1');
+    expect(said[0]).toContain('PERMISSION_DENIED');
+    // The row that reads fine is not named, or the line stops being a list of
+    // what is wrong.
+    expect(said[0]).not.toContain('tok2');
+  });
+
+  test('a standing fault is said once, not on every reload', async () => {
+    let clock = 0;
+    const said: string[] = [];
+    const auth = new BearerAuthenticator({
+      ...withRefusal({ report: (m) => said.push(m) }),
+      now: () => clock,
+    });
+
+    await auth.authenticate('Bearer llk_good');
+    clock += 10_000; // past the cache window, so the next call re-reads
+    await auth.authenticate('Bearer llk_good');
+    clock += 10_000;
+    await auth.authenticate('Bearer llk_good');
+
+    // Three reads, one line. A grant nobody has fixed yet is a read every five
+    // seconds, and a line each time would bury the one that mattered.
+    expect(said).toHaveLength(1);
+  });
+
+  test('a row that becomes readable is not reported again', async () => {
+    let clock = 0;
+    let denied = ['tokens/tok1'];
+    const said: string[] = [];
+    const auth = new BearerAuthenticator({
+      profile: 'personal',
+      tokens: async () => TWO_ROWS,
+      credentials: {
+        ...storeWith({ 'tokens/tok1': 'llk_first', 'tokens/tok2': 'llk_good' }),
+        async get(ref) {
+          if (denied.includes(ref)) throw new Error(`denied ${ref}`);
+          return ref === 'tokens/tok1' ? 'llk_first' : 'llk_good';
+        },
+      },
+      profilesFor: async () => ['personal'],
+      report: (m) => said.push(m),
+      now: () => clock,
+    });
+
+    await auth.authenticate('Bearer llk_good');
+    expect(said).toHaveLength(1);
+
+    denied = [];
+    clock += 10_000;
+
+    // The grant landed: the row it was refusing now opens the endpoint, and
+    // nothing new is said about it.
+    expect((await auth.authenticate('Bearer llk_first')).ok).toBe(true);
+    expect(said).toHaveLength(1);
+  });
+
+  test('a later link in the chain is still reached', async () => {
+    // The amplification, and the reason this was worth fixing on its own
+    // merits. This link runs first and is unconditional, so before the skip a
+    // single unreadable static row refused the OAuth tokens and the
+    // Lanes-signed keys behind it — credentials that have nothing to do with
+    // the store that failed, and that never got asked.
+    const signed: Authenticator = {
+      authenticate: async () => ({
+        ok: true,
+        principal: {
+          id: 'lanes:signed',
+          profile: 'personal',
+          kind: 'machine',
+          profiles: ['personal'],
+        },
+      }),
+    };
+
+    const chain = new AuthenticatorChain([
+      new BearerAuthenticator({
+        profile: 'personal',
+        tokens: async () => TWO_ROWS,
+        credentials: storeRefusing({}, ['tokens/tok1', 'tokens/tok2']),
+        profilesFor: async () => ['personal'],
+      }),
+      signed,
+    ]);
+
+    const outcome = await chain.authenticate('Bearer a.signed.jwt');
+
+    expect(outcome.ok).toBe(true);
   });
 });

--- a/src/auth/index.test.ts
+++ b/src/auth/index.test.ts
@@ -545,6 +545,56 @@ describe('a credential that cannot be read', () => {
     expect(said).toHaveLength(1);
   });
 
+  test('said once even though the store words the same denial differently each read', async () => {
+    // What the test above could not see, and a deployed endpoint did.
+    //
+    // Secret Manager mints a fresh IAM troubleshooter `errorId` into every
+    // `PERMISSION_DENIED` body, so one standing denial arrives as a different
+    // string on every read. The first version of the dedupe compared the
+    // rendered lines, reason included, so it never matched twice: eight reloads
+    // against a real target wrote eight lines for one unfixed grant. A stub
+    // that throws a constant could not reproduce it, which is why this one does
+    // not.
+    let clock = 0;
+    let denials = 0;
+    const said: string[] = [];
+    const auth = new BearerAuthenticator({
+      profile: 'personal',
+      tokens: async () => TWO_ROWS,
+      credentials: {
+        ...storeWith({ 'tokens/tok2': 'llk_good' }),
+        async get(ref) {
+          if (ref === 'tokens/tok1') {
+            denials += 1;
+            throw new Error(
+              `Secret Manager could not read ${ref} (HTTP 403). PERMISSION_DENIED: ` +
+                `Permission denied. Remediate access with this Troubleshooter URL - ` +
+                `https://console.example/troubleshooter;errorId=unique-${denials}`,
+            );
+          }
+          return 'llk_good';
+        },
+      },
+      profilesFor: async () => ['personal'],
+      report: (m) => said.push(m),
+      now: () => clock,
+    });
+
+    await auth.authenticate('Bearer llk_good');
+    clock += 10_000;
+    await auth.authenticate('Bearer llk_good');
+    clock += 10_000;
+    await auth.authenticate('Bearer llk_good');
+
+    // Three distinct messages from the store, one line out.
+    expect(denials).toBe(3);
+    expect(said).toHaveLength(1);
+    // And the reason is still carried — dropping it to make the key stable
+    // would have taken the only text that says what to fix.
+    expect(said[0]).toContain('tok1');
+    expect(said[0]).toContain('PERMISSION_DENIED');
+  });
+
   test('a row that becomes readable is not reported again', async () => {
     let clock = 0;
     let denied = ['tokens/tok1'];

--- a/src/auth/index.test.ts
+++ b/src/auth/index.test.ts
@@ -4,12 +4,16 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { createFileSecretStore, generateCredentialKey, type SecretStore } from '#secrets';
 import {
+  AuthenticatorChain,
   BearerAuthenticator,
   generateProfileToken,
   machinePrincipal,
   mayReach,
   parseBearer,
   tokensMatch,
+  type AuthContext,
+  type Authenticator,
+  type AuthOutcome,
 } from './index.ts';
 
 function storeWith(entries: Record<string, string>): SecretStore {
@@ -354,5 +358,70 @@ describe('how often the credential store is read', () => {
     await auth.authenticate('Bearer llk_rotated_in_a_moment_ago');
 
     expect(reads()).toBe(warm + 1);
+  });
+});
+
+/**
+ * What the chain does with the context, which is the contract the key link needs.
+ *
+ * `LanesKeyAuthenticator` refuses when it is not told which endpoint was
+ * addressed, so a chain that accepted a context and forwarded nothing would turn
+ * every API key into a refusal — and it would do it silently, because a refused
+ * key is indistinguishable from a wrong one from outside. Hence a test of the
+ * forwarding itself rather than only of the links.
+ */
+describe('the chain and the context', () => {
+  /** A link that records what it was asked and answers from a fixed verdict. */
+  function recording(outcome: AuthOutcome): {
+    link: Authenticator;
+    seen: { context?: AuthContext | undefined; calls: number };
+  } {
+    const seen: { context?: AuthContext | undefined; calls: number } = { calls: 0 };
+    return {
+      seen,
+      link: {
+        authenticate: async (_header, context) => {
+          seen.calls += 1;
+          seen.context = context;
+          return outcome;
+        },
+      },
+    };
+  }
+
+  const ADDRESSED: AuthContext = { resource: 'https://link.example.com/mcp' };
+
+  test('every link is told which endpoint was addressed', async () => {
+    const first = recording({ ok: false, reason: 'invalid' });
+    const second = recording({ ok: false, reason: 'invalid' });
+
+    await new AuthenticatorChain([first.link, second.link]).authenticate('Bearer x', ADDRESSED);
+
+    expect(first.seen.context).toEqual(ADDRESSED);
+    expect(second.seen.context).toEqual(ADDRESSED);
+  });
+
+  test('a caller that names no endpoint forwards that, rather than inventing one', async () => {
+    const only = recording({ ok: false, reason: 'invalid' });
+
+    await new AuthenticatorChain([only.link]).authenticate('Bearer x');
+
+    expect(only.seen.context).toBeUndefined();
+  });
+
+  test('the first link to recognise the credential still wins, and later ones are not asked', async () => {
+    const yes = recording({
+      ok: true,
+      principal: { id: 'lanes:EXAMPLE', profile: 'personal', kind: 'machine', profiles: ['personal'] },
+    });
+    const never = recording({ ok: false, reason: 'invalid' });
+
+    const outcome = await new AuthenticatorChain([yes.link, never.link]).authenticate(
+      'Bearer x',
+      ADDRESSED,
+    );
+
+    expect(outcome.ok).toBe(true);
+    expect(never.seen.calls).toBe(0);
   });
 });

--- a/src/auth/index.ts
+++ b/src/auth/index.ts
@@ -1,8 +1,10 @@
 /**
  * Client identity.
  *
- * M1: one bearer token per profile, resolved from the credential store. The
- * token is the identity — holding it makes you the profile's owner principal.
+ * What every way of proving a credential has in common: the outcome, the
+ * interface, the chain that tries them in order, and how a bearer is parsed and
+ * compared. Each proof itself is its own file — `bearer.ts` for the rows this
+ * workspace stores, `remote.ts` for the three it verifies rather than holds.
  *
  * Target: the OAuth 2.1 resource-server model the MCP spec expects, where this
  * module validates tokens issued by an external authorization server. Client
@@ -18,9 +20,8 @@
  */
 
 import { timingSafeEqual } from 'node:crypto';
-import type { SecretRef, SecretStore } from '#secrets';
 
-import { machinePrincipal, type Principal } from './principal.ts';
+import type { Principal } from './principal.ts';
 
 /**
  * The principal model lives in `./principal.ts`, and is re-exported here so
@@ -149,200 +150,6 @@ export function tokensMatch(a: string, b: string): boolean {
   return timingSafeEqual(hash(a), hash(b));
 }
 
-/**
- * One issued token, as the authenticator needs it.
- *
- * Structurally what `connections.yaml` holds, declared here rather than
- * imported: `auth` may not reach `#profile` (the architecture test enforces the
- * direction), and the rows arrive as a closure for the same reason
- * `profilesFor` does.
- */
-export interface IssuedToken {
-  readonly id: string;
-  readonly subject: string;
-  readonly ref: SecretRef;
-}
-
-export interface AuthenticatorOptions {
-  /**
-   * The primary, which is what `principal.profile` starts as.
-   *
-   * Not what the token reaches — that is `profilesFor(subject)`. It is where
-   * the connection was opened, and every dispatch rewrites it with `forProfile`.
-   */
-  readonly profile: string;
-  /** The workspace's issued tokens. Re-read on every reload, so a revoke lands. */
-  readonly tokens: () => Promise<readonly IssuedToken[]>;
-  readonly credentials: SecretStore;
-  /**
-   * Which profiles list this subject as a member.
-   *
-   * The same resolver the OAuth path is handed (`server/endpoint.ts`), passed in
-   * rather than reached for, so discovery and enforcement cannot disagree about
-   * a subject's reach.
-   */
-  readonly profilesFor: (subject: string) => Promise<readonly string[]>;
-  /** Injectable for tests. Only the cache window reads it. */
-  readonly now?: () => number;
-}
-
-/**
- * How long a cached token may answer before the store is consulted again.
- *
- * The cache is here so the common case — a valid token, on every request — is a
- * comparison rather than a file read or a Secret Manager call. What it must not
- * do is outlive a rotation. `lanes link token rotate` is the only revocation
- * this system has, and an unbounded cache meant a revoked token kept opening the
- * endpoint until the process restarted, while the replacement was refused.
- *
- * Five seconds makes rotation effectively immediate and still collapses a burst
- * of calls onto one read.
- */
-const CACHE_TTL_MS = 5_000;
-
-/** An issued row, with its value read out of the store. */
-interface LoadedToken {
-  readonly subject: string;
-  readonly value: string;
-}
-
-export class BearerAuthenticator implements Authenticator {
-  readonly #options: AuthenticatorOptions;
-  readonly #now: () => number;
-  #cached: readonly LoadedToken[] | null = null;
-  #readAt = 0;
-
-  constructor(options: AuthenticatorOptions) {
-    this.#options = options;
-    this.#now = options.now ?? Date.now;
-  }
-
-  async authenticate(authorizationHeader: string | null | undefined): Promise<AuthOutcome> {
-    const presented = parseBearer(authorizationHeader);
-    if (presented === null) {
-      return { ok: false, reason: authorizationHeader ? 'malformed' : 'missing' };
-    }
-
-    const fresh = this.#cached !== null && this.#now() - this.#readAt < CACHE_TTL_MS;
-    let rows = fresh ? this.#cached! : await this.#reload();
-    let matched = find(presented, rows);
-
-    // A miss against a *cached* set is ambiguous: either the credential is
-    // wrong, or it is the right one and this process has not seen the rotation
-    // or the issue that produced it. One re-read separates the two, and it is
-    // what makes a rotated-in token work on its first call rather than after
-    // the window. Only a cached comparison can be wrong this way, so a fresh
-    // read never pays for a second one — which is what keeps a wrong token from
-    // costing a store read per attempt.
-    //
-    // **And only for something that could be one of these tokens.** A hosted
-    // connector presents an OAuth token: the next link in the chain handles it
-    // and it can never match a row here. Without that condition the ambiguity
-    // above was permanent for such a caller — a healthy endpoint has no static
-    // rows, so the match always failed and the "one re-read" fired on every
-    // request, re-confirming an empty list at the cost of a bucket read, a YAML
-    // parse and a schema validation. The cache never protected anything,
-    // because the path that consulted it was the path that always missed.
-    if (fresh && matched === null && couldBeProfileToken(presented)) {
-      rows = await this.#reload();
-      matched = find(presented, rows);
-    }
-
-    if (rows.length === 0) {
-      // No token has been issued. Fail closed, and distinctly from a wrong one:
-      // `lanes link doctor` reads this to say "issue one" rather than "check it".
-      return { ok: false, reason: 'not_configured' };
-    }
-
-    if (matched === null) return { ok: false, reason: 'invalid' };
-
-    // **Resolved per request, not cached with the value.** Membership is read
-    // when a token is minted for an OAuth client (ADR-060) because there is a
-    // mint to read it at; a static token has none, so this is the only place
-    // the question can be asked. It is what makes `profile members remove`
-    // take effect on the next call rather than on the next rotation.
-    //
-    // A resolver that throws fails closed. The alternative — falling back to
-    // "every profile" — would restore exactly the behaviour ADR-068 removes,
-    // and would do it precisely when something is already wrong.
-    let profiles: readonly string[];
-    try {
-      profiles = await this.#options.profilesFor(matched.subject);
-    } catch {
-      return { ok: false, reason: 'invalid' };
-    }
-
-    return {
-      ok: true,
-      principal: machinePrincipal(matched.subject, this.#options.profile, profiles),
-    };
-  }
-
-  async #reload(): Promise<readonly LoadedToken[]> {
-    // Both caches, or neither: the store holds its own decrypted copy, so
-    // re-reading without dropping that first re-reads the same stale value.
-    this.#options.credentials.refresh?.();
-
-    const rows = await this.#options.tokens();
-    const loaded: LoadedToken[] = [];
-    for (const row of rows) {
-      const value = await this.#options.credentials.get(row.ref);
-      // A row whose credential is gone is not an error to report here. It is
-      // what a half-finished `secrets push` looks like, and the row simply
-      // matches nothing — `doctor` is where that is worth a sentence.
-      if (value) loaded.push({ subject: row.subject, value });
-    }
-
-    this.#cached = loaded;
-    this.#readAt = this.#now();
-    return loaded;
-  }
-
-  /**
-   * Drop the cached set immediately.
-   *
-   * The window above already bounds how long a rotation goes unnoticed, so this
-   * is an optimisation rather than the mechanism — nothing's correctness may
-   * depend on it being called, because for a long time nothing called it.
-   */
-  invalidateCache(): void {
-    this.#cached = null;
-  }
-}
-
-/**
- * The row a presented token matches, or null.
- *
- * Every row is compared even after one matches. Returning early would make the
- * time taken describe *which* row answered, and the whole point of
- * `tokensMatch` is that a comparison here leaks nothing about the value it is
- * comparing against.
- */
-function find(presented: string, rows: readonly LoadedToken[]): LoadedToken | null {
-  let found: LoadedToken | null = null;
-  for (const row of rows) if (tokensMatch(presented, row.value)) found = row;
-  return found;
-}
-
-/**
- * Whether a presented credential could be one of *these* tokens at all.
- *
- * `generateProfileToken` mints every one with this prefix, which
- * `secret-detection.ts` and the edge limiter already recognise — so it is exact.
- */
-const couldBeProfileToken = (presented: string): boolean =>
-  presented.startsWith(PROFILE_TOKEN_PREFIX);
-
-/** What a minted profile token starts with. */
-const PROFILE_TOKEN_PREFIX = 'llk_';
-/**
- * Mint a profile token: 32 random bytes, base64url, prefixed so it is
- * recognisable in a config file and greppable in a leak.
- */
-export function generateProfileToken(): string {
-  return `${PROFILE_TOKEN_PREFIX}${Buffer.from(crypto.getRandomValues(new Uint8Array(32))).toString('base64url')}`;
-}
-
 export {
   authorizationServerMetadata,
   challenge,
@@ -371,3 +178,9 @@ export { matchesRegistered } from './oauth/redirects.ts';
 export { OAuthStore, hashToken, randomToken } from './oauth/store.ts';
 export { OidcVerifier, type OidcVerifierOptions, type VerifiedSubject } from './oidc.ts';
 export { IssuedTokenAuthenticator, LanesKeyAuthenticator, OidcAuthenticator } from './remote.ts';
+export {
+  BearerAuthenticator,
+  generateProfileToken,
+  type AuthenticatorOptions,
+  type IssuedToken,
+} from './bearer.ts';

--- a/src/auth/index.ts
+++ b/src/auth/index.ts
@@ -43,16 +43,46 @@ export type AuthOutcome =
   | { readonly ok: false; readonly reason: 'missing' | 'malformed' | 'invalid' | 'not_configured' };
 
 /**
+ * What the request says about who is being addressed.
+ *
+ * Only one field, and only one authenticator reads it: a credential somebody
+ * *else* signed has to name this endpoint, or a key minted for one deployment
+ * opens every deployment the same issuer serves — the confused-deputy case the
+ * MCP authorization spec calls out. A token this endpoint minted needs none of
+ * this, because being in this endpoint's store is already the binding.
+ *
+ * **Optional in the type and mandatory in effect.** A link that needs it refuses
+ * when it is absent rather than skipping the check, which is ADR-079's lesson
+ * stated one layer down: an absent field must not resolve to the widest answer.
+ * It is optional here only so the implementations that ignore it, and the test
+ * doubles that predate it, do not have to mention it.
+ */
+export interface AuthContext {
+  /**
+   * This endpoint's resource identifier, exactly as the client addressed it.
+   *
+   * The same string `protectedResourceMetadata` publishes and an assertion's
+   * `aud` must match — built from `Host` and `X-Forwarded-Proto`, because this
+   * endpoint does not know its own public URL from config. See
+   * `server/oauth.ts`.
+   */
+  readonly resource: string;
+}
+
+/**
  * Anything that can turn an `Authorization` header into a principal.
  *
  * Extracted so the endpoint can accept more than one kind of proof without the
- * request path learning what kinds exist. There are two: a static token the
- * operator holds, and a token this endpoint or an issuer handed to a client
- * that completed an authorization flow. Both arrive in the same header, and the
- * server does not care which answered.
+ * request path learning what kinds exist. There are three: a static token the
+ * operator holds, a token this endpoint or an issuer handed to a client that
+ * completed an authorization flow, and an API key `api.lanes.sh` signed. All
+ * arrive in the same header, and the server does not care which answered.
  */
 export interface Authenticator {
-  authenticate(authorizationHeader: string | null | undefined): Promise<AuthOutcome>;
+  authenticate(
+    authorizationHeader: string | null | undefined,
+    context?: AuthContext,
+  ): Promise<AuthOutcome>;
   invalidateCache?(): void;
 }
 
@@ -76,12 +106,15 @@ export class AuthenticatorChain implements Authenticator {
     this.#links = links;
   }
 
-  async authenticate(authorizationHeader: string | null | undefined): Promise<AuthOutcome> {
+  async authenticate(
+    authorizationHeader: string | null | undefined,
+    context?: AuthContext,
+  ): Promise<AuthOutcome> {
     const rank = { invalid: 3, not_configured: 2, malformed: 1, missing: 0 } as const;
     let worst: Extract<AuthOutcome, { ok: false }> = { ok: false, reason: 'missing' };
 
     for (const link of this.#links) {
-      const outcome = await link.authenticate(authorizationHeader);
+      const outcome = await link.authenticate(authorizationHeader, context);
       if (outcome.ok) return outcome;
       if (rank[outcome.reason] > rank[worst.reason]) worst = outcome;
     }
@@ -326,8 +359,15 @@ export {
   type OAuthResult,
 } from './oauth/server.ts';
 export { AssertionVerifier, type Assertion } from './lanes/assertion.ts';
-export { lanesFederation, DEFAULT_WEB_URL, type FederationOptions } from './lanes/federation.ts';
+export { ApiKeyVerifier, type ApiKeySubject } from './lanes/api-key.ts';
+export {
+  lanesApiKeyVerifier,
+  lanesApiUrl,
+  lanesFederation,
+  DEFAULT_WEB_URL,
+  type FederationOptions,
+} from './lanes/federation.ts';
 export { matchesRegistered } from './oauth/redirects.ts';
 export { OAuthStore, hashToken, randomToken } from './oauth/store.ts';
 export { OidcVerifier, type OidcVerifierOptions, type VerifiedSubject } from './oidc.ts';
-export { IssuedTokenAuthenticator, OidcAuthenticator } from './remote.ts';
+export { IssuedTokenAuthenticator, LanesKeyAuthenticator, OidcAuthenticator } from './remote.ts';

--- a/src/auth/lanes/api-key.test.ts
+++ b/src/auth/lanes/api-key.test.ts
@@ -1,0 +1,225 @@
+import { beforeAll, describe, expect, test } from 'bun:test';
+import { ApiKeyVerifier } from './api-key.ts';
+import { AssertionVerifier } from './assertion.ts';
+
+/**
+ * Believing an API key the dashboard minted.
+ *
+ * Signed with a real key pair rather than stubbed, for the reason
+ * `./assertion.test.ts` gives: every check here is about a token somebody else
+ * could have written, and a double that returns "valid" would exercise the
+ * branches and prove nothing.
+ *
+ * The two tests that matter most are in `a credential for the other purpose`.
+ * An assertion and a key are signed by the same issuer, for the same audience,
+ * naming the same person — the *only* thing separating a two-minute redirect
+ * credential from a ninety-day one is that each verifier refuses the other's.
+ * If those two ever go green by accident, a captured assertion becomes a
+ * long-lived key and a key becomes a way through the consent flow.
+ */
+
+const ISSUER = 'https://api.example.com';
+const JWKS_URL = `${ISSUER}/.well-known/jwks.json`;
+const RESOURCE = 'https://link.example.com/mcp';
+const KID = 'a-key-id';
+const DAY = 24 * 60 * 60;
+
+let keys: CryptoKeyPair;
+let jwks: { keys: unknown[] };
+
+async function generate(): Promise<CryptoKeyPair> {
+  return (await crypto.subtle.generateKey(
+    { name: 'RSASSA-PKCS1-v1_5', modulusLength: 2048, publicExponent: new Uint8Array([1, 0, 1]), hash: 'SHA-256' },
+    true,
+    ['sign', 'verify'],
+  )) as CryptoKeyPair;
+}
+
+beforeAll(async () => {
+  keys = await generate();
+  const jwk = await crypto.subtle.exportKey('jwk', keys.publicKey);
+  jwks = { keys: [{ ...jwk, kid: KID, alg: 'RS256', use: 'sig' }] };
+});
+
+function encode(value: unknown): string {
+  return Buffer.from(JSON.stringify(value)).toString('base64url');
+}
+
+/** A key as the API would mint one, with anything overridden for a test. */
+async function key(
+  claims: Record<string, unknown> = {},
+  header: Record<string, unknown> = {},
+  signWith?: CryptoKey,
+): Promise<string> {
+  const now = Math.floor(Date.now() / 1000);
+  const body =
+    `${encode({ alg: 'RS256', typ: 'JWT', kid: KID, ...header })}.` +
+    `${encode({
+      iss: ISSUER,
+      aud: RESOURCE,
+      sub: 'FIREBASEUID000000000000000000',
+      email: 'ada.lovelace@example.com',
+      kind: 'api_key',
+      iat: now,
+      exp: now + 90 * DAY,
+      ...claims,
+    })}`;
+
+  const signature = await crypto.subtle.sign(
+    { name: 'RSASSA-PKCS1-v1_5' },
+    signWith ?? keys.privateKey,
+    new TextEncoder().encode(body),
+  );
+
+  return `${body}.${Buffer.from(signature).toString('base64url')}`;
+}
+
+type Call = (input: string | URL | Request, init?: RequestInit) => Promise<Response>;
+
+function verifier(overrides: { fetch?: Call; now?: () => number } = {}): ApiKeyVerifier {
+  return new ApiKeyVerifier({
+    jwksUrl: JWKS_URL,
+    issuer: ISSUER,
+    fetch: overrides.fetch ?? (async () => Response.json(jwks)),
+    ...(overrides.now ? { now: overrides.now } : {}),
+  });
+}
+
+const EXPECTED = { audience: RESOURCE };
+
+describe('a key the API signed', () => {
+  test('names the person, prefixed so a profile can hold the subject', async () => {
+    const verified = await verifier().verify(await key(), EXPECTED);
+
+    expect(verified?.subject).toBe('lanes:FIREBASEUID000000000000000000');
+    expect(verified?.email).toBe('ada.lovelace@example.com');
+  });
+
+  test('needs no nonce, because it crosses no redirect', async () => {
+    // The claim that binds an assertion to one authorization request has nothing
+    // to bind to here: a key is presented on every request, forever.
+    expect(await verifier().verify(await key(), EXPECTED)).not.toBeNull();
+  });
+
+  test('lives for ninety days without complaint', async () => {
+    const later = Date.now() + 80 * DAY * 1000;
+    const verified = await verifier({ now: () => later }).verify(await key(), EXPECTED);
+
+    expect(verified).not.toBeNull();
+  });
+});
+
+describe('a credential for the other purpose', () => {
+  test('a key is refused where an assertion belongs', async () => {
+    // Same issuer, same audience, same person, and a lifetime the assertion's
+    // own ceiling would also catch — but this must fail on `kind`, because a key
+    // minted with a short expiry would slip past that ceiling.
+    const assertions = new AssertionVerifier({
+      jwksUrl: JWKS_URL,
+      issuer: ISSUER,
+      fetch: async () => Response.json(jwks),
+    });
+
+    const shortLived = await key({ nonce: 'a-nonce', exp: Math.floor(Date.now() / 1000) + 60 });
+
+    expect(await assertions.verify(shortLived, { audience: RESOURCE, nonce: 'a-nonce' })).toBeNull();
+  });
+
+  test('an assertion is refused as a key', async () => {
+    // An assertion carries no `kind`, and this verifier requires one. That
+    // asymmetry is deliberate: see the comment in `./api-key.ts`.
+    const asAssertion = await key({ kind: undefined, nonce: 'a-nonce' });
+
+    expect(await verifier().verify(asAssertion, EXPECTED)).toBeNull();
+  });
+
+  test('an unknown kind is refused rather than treated as a key', async () => {
+    expect(await verifier().verify(await key({ kind: 'something_else' }), EXPECTED)).toBeNull();
+  });
+});
+
+describe('a key nobody should believe', () => {
+  test('signed by a different key', async () => {
+    const impostor = await generate();
+
+    expect(await verifier().verify(await key({}, {}, impostor.privateKey), EXPECTED)).toBeNull();
+  });
+
+  test('minted for somebody else’s endpoint', async () => {
+    // The confused-deputy case. A valid key, for a real person, naming an
+    // audience that is not us.
+    const elsewhere = await key({ aud: 'https://other.example.net/mcp' });
+
+    expect(await verifier().verify(elsewhere, EXPECTED)).toBeNull();
+  });
+
+  test('an audience that merely starts with ours', async () => {
+    const nearly = await key({ aud: `${RESOURCE}.evil.example.net` });
+
+    expect(await verifier().verify(nearly, EXPECTED)).toBeNull();
+  });
+
+  test('from an issuer we were not told to trust', async () => {
+    expect(await verifier().verify(await key({ iss: 'https://evil.example.net' }), EXPECTED)).toBeNull();
+  });
+
+  test('expired', async () => {
+    const past = Math.floor(Date.now() / 1000) - 10 * DAY;
+
+    expect(await verifier().verify(await key({ iat: past - 60, exp: past }), EXPECTED)).toBeNull();
+  });
+
+  test('with no expiry at all', async () => {
+    // An unbounded key is not a thing this endpoint accepts, and the check is
+    // the lifetime ceiling rather than a separate rule: a missing `exp` reports
+    // an infinite lifetime.
+    expect(await verifier().verify(await key({ exp: undefined }), EXPECTED)).toBeNull();
+  });
+
+  test('claiming a lifetime past the ceiling', async () => {
+    const now = Math.floor(Date.now() / 1000);
+    const decade = await key({ iat: now, exp: now + 3650 * DAY });
+
+    expect(await verifier().verify(decade, EXPECTED)).toBeNull();
+  });
+
+  test('with no subject', async () => {
+    expect(await verifier().verify(await key({ sub: undefined }), EXPECTED)).toBeNull();
+  });
+
+  test('naming an algorithm we do not verify', async () => {
+    // Pinned rather than read. `none` and HMAC-with-the-public-key both live here.
+    expect(await verifier().verify(await key({}, { alg: 'none' }), EXPECTED)).toBeNull();
+  });
+
+  test('naming a key id that was never published', async () => {
+    expect(await verifier().verify(await key({}, { kid: 'not-a-key' }), EXPECTED)).toBeNull();
+  });
+
+  test('when the key set cannot be fetched at all', async () => {
+    const offline = verifier({ fetch: async () => new Response('nope', { status: 503 }) });
+
+    expect(await offline.verify(await key(), EXPECTED)).toBeNull();
+  });
+});
+
+describe('the key set', () => {
+  test('an outage does not forget keys already fetched', async () => {
+    // What keeps a verified endpoint working while the API is down. The first
+    // call warms the cache; the second finds the fetch failing and must still
+    // answer from what it already had.
+    let calls = 0;
+    const flaky: Call = async () => {
+      calls += 1;
+      return calls === 1 ? Response.json(jwks) : new Response('down', { status: 500 });
+    };
+
+    const one = verifier({ fetch: flaky });
+    expect(await one.verify(await key(), EXPECTED)).not.toBeNull();
+
+    // Forces a refetch by asking for a kid the warm cache does not hold, which
+    // is the only path that reaches the network again inside the TTL.
+    expect(await one.verify(await key({}, { kid: 'other' }), EXPECTED)).toBeNull();
+    expect(await one.verify(await key(), EXPECTED)).not.toBeNull();
+  });
+});

--- a/src/auth/lanes/api-key.ts
+++ b/src/auth/lanes/api-key.ts
@@ -1,0 +1,101 @@
+import {
+  API_KEY_KIND,
+  CLOCK_SKEW_MS,
+  JwksVerifier,
+  claimedLifetimeMs,
+  credentialKind,
+  subjectFromClaims,
+  type JwksVerifierOptions,
+  type SignedSubject,
+} from './signed.ts';
+
+/**
+ * An API key the dashboard minted and `api.lanes.sh` signed.
+ *
+ * The credential for a caller with no browser — a CI job, a cron, a container —
+ * and the replacement for the static token this CLI used to mint itself. Both
+ * halves of that change matter:
+ *
+ * **It is verified, not compared.** The old token was a random string the
+ * workspace held a copy of, so the endpoint's answer to "is this the right
+ * credential" was a constant-time comparison against its own credential store.
+ * A signed key is checked against a published key, so nothing on this side holds
+ * a secret, nothing has to be copied to a deployed target before a key works,
+ * and a key issued a minute ago is accepted by an endpoint that has never heard
+ * of it.
+ *
+ * **It names a person, and that was already the rule.** The subject is a
+ * `lanes:<uid>`, resolved through `members:` on every request exactly as an OAuth
+ * token's is (ADR-068). The key decides nothing about reach; a profile listing
+ * that uid does.
+ *
+ * What this costs, stated plainly: verifying a key needs a key set fetched from
+ * the API, where the old comparison needed no network at all. The cache in
+ * `JwksVerifier` is an hour and survives an API outage, so the exposure is a
+ * cold endpoint during an outage — but a self-hoster pointing `LANES_API_URL`
+ * somewhere else must publish a JWKS there.
+ *
+ * **Revocation is `members:`, and it is the only revocation this shape has.**
+ * Reach is resolved per request, so `lanes link profile members remove` stops a
+ * key within the member cache's window — seconds. What it cannot do is revoke
+ * *one* key while leaving that person's others working: nothing here holds a
+ * list of issued keys to strike one from. That belongs to whoever mints them.
+ */
+
+/** Who an API key names, once it has been believed. */
+export type ApiKeySubject = SignedSubject;
+
+export type ApiKeyVerifierOptions = JwksVerifierOptions;
+
+/**
+ * The longest life this endpoint will honour, whatever the key claims.
+ *
+ * A key is *meant* to be long-lived, so this is not the tight ceiling an
+ * assertion carries — it is a backstop against one mistake: a key minted with an
+ * `exp` decades out is indistinguishable from a correct one until somebody reads
+ * the claims, and by then it has been in a CI secret for a year. Four hundred
+ * days is a year with slack, and is the same reasoning that stopped browsers
+ * honouring multi-year certificates.
+ *
+ * A key missing `exp` or `iat` reports an infinite lifetime and is refused here,
+ * which is the answer we want: an API key with no expiry is not a thing this
+ * endpoint accepts.
+ */
+const MAX_LIFETIME_MS = 400 * 24 * 60 * 60_000;
+
+export class ApiKeyVerifier {
+  readonly #keys: JwksVerifier;
+
+  constructor(options: ApiKeyVerifierOptions) {
+    this.#keys = new JwksVerifier(options);
+  }
+
+  /**
+   * The person this key names, or null.
+   *
+   * Null rather than a reason, for the reason every verifier here gives: the
+   * holder of a rejected credential cannot act on *which* check failed, and an
+   * attacker can.
+   */
+  async verify(token: string, expected: { audience: string }): Promise<ApiKeySubject | null> {
+    const payload = await this.#keys.payload(token);
+    if (payload === null) return null;
+
+    // **Required, not merely "not an assertion".** This is the asymmetry with
+    // `./assertion.ts`, and it is deliberate: that verifier *rejects* a key and
+    // tolerates a token with no `kind` at all, because assertions minted before
+    // this claim existed must go on working and breaking sign-in is not an
+    // acceptable cost. Nothing has ever issued an API key, so this side can
+    // demand the claim from its first day — and demanding it is what makes an
+    // assertion unusable here, since an assertion does not carry one.
+    if (credentialKind(payload) !== API_KEY_KIND) return null;
+
+    if (claimedLifetimeMs(payload) > MAX_LIFETIME_MS + CLOCK_SKEW_MS) return null;
+
+    return subjectFromClaims(payload, {
+      issuer: this.#keys.issuer,
+      audience: expected.audience,
+      now: this.#keys.now(),
+    });
+  }
+}

--- a/src/auth/lanes/assertion.ts
+++ b/src/auth/lanes/assertion.ts
@@ -1,4 +1,13 @@
-import type { FetchLike } from './login.ts';
+import {
+  API_KEY_KIND,
+  CLOCK_SKEW_MS,
+  JwksVerifier,
+  claimedLifetimeMs,
+  credentialKind,
+  subjectFromClaims,
+  type JwksVerifierOptions,
+  type SignedSubject,
+} from './signed.ts';
 
 /**
  * Verifying that lanes.sh vouched for the person at the browser.
@@ -8,93 +17,36 @@ import type { FetchLike } from './login.ts';
  * it asks lanes.sh "who is this", and gets back a signed statement it can check
  * without trusting the browser that carried it.
  *
- * Four checks, and each of them is load-bearing:
+ * The signature, the published keys, the issuer and the audience are
+ * `./signed.ts`, because a second Lanes-signed credential now goes through the
+ * same checks. What is left here is what makes this one an *assertion* rather
+ * than an API key, and there are three of them:
  *
- *  - **Signature**, against the API's published JWKS. Without it the assertion
- *    is a string the browser handed us and anyone could write one.
- *  - **Audience**, which must be *this endpoint's own resource URL*. An
- *    assertion minted for somebody else's endpoint is a valid assertion; using
- *    it here is the confused-deputy case the MCP authorization spec calls out,
- *    and this is the only thing that stops it.
  *  - **Nonce**, single-use, minted by this endpoint when the flow began. It
  *    binds the assertion to *this* authorization request, so one captured on a
  *    different endpoint of ours cannot be replayed into this one.
- *  - **Expiry**, tight. The assertion crosses one redirect, so a minute is
+ *  - **Expiry, tight.** The assertion crosses one redirect, so a minute is
  *    generous and anything longer is a bearer credential in a browser history.
- *
- * Verification is intentionally a public-key check and not a call back to the
- * API. The endpoint may be behind somebody's firewall; it must be able to
- * verify while only ever having *fetched* a key, and a cached JWKS makes the
- * whole flow work with the API unreachable for the length of the cache.
- *
- * No JWT library. RS256 over a JWK is `crypto.subtle.importKey` plus
- * `crypto.subtle.verify`, which is 30 lines and no supply chain — the same
- * reasoning that has `connectivity/auth/oauth-jwt/key.ts` signing with subtle
- * rather than pulling one in.
+ *  - **Not an API key.** A key is signed by the same issuer and may name the
+ *    same audience, so without this a ninety-day credential could be presented
+ *    where a two-minute one belongs — and the lifetime ceiling below would not
+ *    catch it, because a key's `exp` and `iat` are consistent with each other.
+ *    See `./api-key.ts` for the other half of the pair.
  */
 
 /** What an assertion says once it has been believed. */
-export interface Assertion {
-  /** `lanes:<uid>`, the same string `lanes auth login` stores and `members:` names. */
-  readonly subject: string;
-  readonly email: string | null;
-}
+export type Assertion = SignedSubject;
 
-export interface AssertionVerifierOptions {
-  /** Where the signing keys are published. */
-  readonly jwksUrl: string;
-  /** Who is allowed to have signed. Checked against `iss`. */
-  readonly issuer: string;
-  readonly fetch?: FetchLike | undefined;
-  readonly now?: (() => number) | undefined;
-  /** How long a fetched key set is reused. */
-  readonly cacheTtlMs?: number | undefined;
-}
-
-/**
- * One published key, as it arrives.
- *
- * Loose on purpose: `importKey` is the thing that decides whether a JWK is
- * usable, and re-deciding that here with a stricter type would mean a key the
- * platform accepts being dropped by our own schema.
- */
-type Jwk = Record<string, unknown> & { kid?: unknown; kty?: unknown; alg?: unknown };
-
-/** An hour. A key rotation is noticed within it, and a miss refetches anyway. */
-const DEFAULT_CACHE_TTL_MS = 60 * 60_000;
-
-/**
- * The shortest interval between two refetches provoked by an unknown key id.
- *
- * Without it, a token naming a key that does not exist costs a round trip to
- * the API — and since anyone can send one unauthenticated, every endpoint
- * becomes an amplifier pointed at us. A minute bounds that at one request per
- * endpoint per minute while still letting a genuine rotation land promptly.
- */
-const MISS_REFETCH_MS = 60_000;
+export type AssertionVerifierOptions = JwksVerifierOptions;
 
 /** Assertions cross one redirect; more than this is a credential left lying about. */
 const MAX_LIFETIME_MS = 120_000;
 
-/** Clocks differ. Small enough that it does not extend the window meaningfully. */
-const CLOCK_SKEW_MS = 30_000;
-
-/** What `importKey('jwk', …)` takes, without depending on a lib.dom global. */
-type JsonWebKeyLike = Parameters<typeof crypto.subtle.importKey>[1] extends infer T
-  ? Extract<T, { kty?: string | undefined }>
-  : never;
-
 export class AssertionVerifier {
-  readonly #options: AssertionVerifierOptions;
-  readonly #fetch: FetchLike;
-  readonly #now: () => number;
-  #keys: { at: number; byKid: Map<string, CryptoKey> } | null = null;
-  #missedAt = Number.NEGATIVE_INFINITY;
+  readonly #keys: JwksVerifier;
 
   constructor(options: AssertionVerifierOptions) {
-    this.#options = options;
-    this.#fetch = options.fetch ?? ((input, init) => globalThis.fetch(input, init));
-    this.#now = options.now ?? Date.now;
+    this.#keys = new JwksVerifier(options);
   }
 
   /**
@@ -106,151 +58,30 @@ export class AssertionVerifier {
    * legitimate user nothing they can act on. What *is* actionable — expiry — is
    * the one case the caller can infer by retrying.
    */
-  async verify(token: string, expected: { audience: string; nonce: string }): Promise<Assertion | null> {
-    const parts = token.split('.');
-    if (parts.length !== 3) return null;
+  async verify(
+    token: string,
+    expected: { audience: string; nonce: string },
+  ): Promise<Assertion | null> {
+    const payload = await this.#keys.payload(token);
+    if (payload === null) return null;
 
-    const [encodedHeader, encodedPayload, encodedSignature] = parts as [string, string, string];
-
-    const header = decodeJson(encodedHeader);
-    const payload = decodeJson(encodedPayload);
-    if (header === null || payload === null) return null;
-
-    // Pinned, not read. `alg` arrives inside the token, so honouring it is how
-    // the `none` algorithm and the HMAC-with-the-public-key confusions work.
-    if (header['alg'] !== 'RS256') return null;
-
-    const kid = typeof header['kid'] === 'string' ? header['kid'] : null;
-    if (kid === null) return null;
-
-    const key = await this.#key(kid);
-    if (key === null) return null;
-
-    const signed = new TextEncoder().encode(`${encodedHeader}.${encodedPayload}`);
-    const signature = base64url(encodedSignature);
-    if (signature === null) return null;
-
-    const valid = await crypto.subtle.verify(
-      { name: 'RSASSA-PKCS1-v1_5' },
-      key,
-      signature,
-      signed,
-    );
-    if (!valid) return null;
-
-    return this.#claims(payload, expected);
-  }
-
-  /** Everything that is true of a verified signature but not yet of this token. */
-  #claims(payload: Record<string, unknown>, expected: { audience: string; nonce: string }): Assertion | null {
-    if (payload['iss'] !== this.#options.issuer) return null;
-
-    // Exact match, per RFC 8707. A prefix or suffix comparison here would admit
-    // an assertion minted for a different endpoint on the same host.
-    const audience = payload['aud'];
-    const audiences = Array.isArray(audience) ? audience : [audience];
-    if (!audiences.includes(expected.audience)) return null;
+    // **Before anything else that could pass.** A credential minted for the
+    // other purpose is refused on what it says it is, not on whether its other
+    // claims happen to fit.
+    if (credentialKind(payload) === API_KEY_KIND) return null;
 
     if (payload['nonce'] !== expected.nonce) return null;
-
-    const now = this.#now();
-    const exp = typeof payload['exp'] === 'number' ? payload['exp'] * 1000 : 0;
-    const iat = typeof payload['iat'] === 'number' ? payload['iat'] * 1000 : 0;
-
-    if (exp <= now - CLOCK_SKEW_MS) return null;
-    if (iat > now + CLOCK_SKEW_MS) return null;
 
     // Checked here as well as trusted from the issuer. A deployment that
     // widened its own expiry would silently turn a redirect-scoped assertion
     // into a long-lived bearer token, and this endpoint is the party that has
     // to live with that.
-    if (exp - iat > MAX_LIFETIME_MS + CLOCK_SKEW_MS) return null;
+    if (claimedLifetimeMs(payload) > MAX_LIFETIME_MS + CLOCK_SKEW_MS) return null;
 
-    const subject = payload['sub'];
-    if (typeof subject !== 'string' || subject.length === 0) return null;
-
-    return {
-      // The API signs the raw uid; the prefix is added at exactly one place in
-      // the client, here and in `login.ts`, so the two cannot disagree about
-      // what a subject looks like.
-      subject: subject.startsWith('lanes:') ? subject : `lanes:${subject}`,
-      email: typeof payload['email'] === 'string' ? payload['email'] : null,
-    };
-  }
-
-  /**
-   * The signing key with that id.
-   *
-   * A miss against a warm cache refetches, because that is what a key rotation
-   * looks like from here and the alternative is every endpoint refusing until
-   * its cache lapses. It refetches at most once a minute, because the *other*
-   * thing a miss looks like is an invented key id, and those arrive
-   * unauthenticated and as fast as anyone cares to send them.
-   */
-  async #key(kid: string): Promise<CryptoKey | null> {
-    const ttl = this.#options.cacheTtlMs ?? DEFAULT_CACHE_TTL_MS;
-    const now = this.#now();
-    const fresh = this.#keys !== null && now - this.#keys.at < ttl;
-
-    if (fresh) {
-      const hit = this.#keys?.byKid.get(kid);
-      if (hit) return hit;
-      if (now - this.#missedAt < MISS_REFETCH_MS) return null;
-      this.#missedAt = now;
-    }
-
-    const loaded = await this.#load();
-    return loaded.get(kid) ?? null;
-  }
-
-  async #load(): Promise<Map<string, CryptoKey>> {
-    const byKid = new Map<string, CryptoKey>();
-
-    const response = await this.#fetch(this.#options.jwksUrl).catch(() => null);
-    if (response === null || !response.ok) {
-      // Left uncached, so the next attempt tries again rather than treating an
-      // outage as "there are no keys" for an hour. Whatever was already known
-      // still answers, which is what keeps a verified endpoint working while
-      // the API is down.
-      return this.#keys?.byKid ?? byKid;
-    }
-
-    const body = (await response.json().catch(() => ({}))) as { keys?: Jwk[] };
-
-    for (const jwk of body.keys ?? []) {
-      if (jwk.kty !== 'RSA' || (jwk.alg !== undefined && jwk.alg !== 'RS256')) continue;
-      if (typeof jwk.kid !== 'string') continue;
-
-      const key = await crypto.subtle
-        .importKey('jwk', jwk as JsonWebKeyLike, { name: 'RSASSA-PKCS1-v1_5', hash: 'SHA-256' }, false, [
-          'verify',
-        ])
-        .catch(() => null);
-
-      if (key !== null) byKid.set(jwk.kid, key);
-    }
-
-    this.#keys = { at: this.#now(), byKid };
-    return byKid;
-  }
-}
-
-function base64url(value: string): ArrayBuffer | null {
-  try {
-    const bytes = Buffer.from(value, 'base64url');
-    return bytes.buffer.slice(bytes.byteOffset, bytes.byteOffset + bytes.byteLength) as ArrayBuffer;
-  } catch {
-    return null;
-  }
-}
-
-function decodeJson(value: string): Record<string, unknown> | null {
-  const bytes = base64url(value);
-  if (bytes === null) return null;
-  try {
-    const parsed: unknown = JSON.parse(new TextDecoder().decode(bytes));
-    return typeof parsed === 'object' && parsed !== null ? (parsed as Record<string, unknown>) : null;
-  } catch {
-    return null;
+    return subjectFromClaims(payload, {
+      issuer: this.#keys.issuer,
+      audience: expected.audience,
+      now: this.#keys.now(),
+    });
   }
 }

--- a/src/auth/lanes/federation.ts
+++ b/src/auth/lanes/federation.ts
@@ -1,3 +1,4 @@
+import { ApiKeyVerifier } from './api-key.ts';
 import { AssertionVerifier } from './assertion.ts';
 import { DEFAULT_API_URL } from './login.ts';
 import type { Federation } from '../oauth/server.ts';
@@ -29,8 +30,38 @@ export interface FederationOptions {
   readonly fetch?: ConstructorParameters<typeof AssertionVerifier>[0]['fetch'];
 }
 
+/**
+ * Which API this endpoint believes about identity.
+ *
+ * One function, because there are now two things that have to agree about it —
+ * the consent flow's assertion verifier and the API-key verifier — and an
+ * endpoint that trusted one issuer for sign-in and another for keys would be a
+ * hole nobody would find by reading either file alone.
+ */
+export function lanesApiUrl(override?: string | undefined): string {
+  return override ?? process.env['LANES_API_URL'] ?? DEFAULT_API_URL;
+}
+
+/**
+ * The verifier for API keys the dashboard minted.
+ *
+ * Here rather than in `#server`, beside the federation it shares an issuer and a
+ * key set with. The audience is not settled here: it is whatever the request
+ * said this endpoint is, which only the request knows — see `AuthContext`.
+ */
+export function lanesApiKeyVerifier(
+  options: { readonly apiUrl?: string | undefined; readonly fetch?: FederationOptions['fetch'] } = {},
+): ApiKeyVerifier {
+  const apiUrl = lanesApiUrl(options.apiUrl);
+  return new ApiKeyVerifier({
+    jwksUrl: `${apiUrl}/.well-known/jwks.json`,
+    issuer: apiUrl,
+    ...(options.fetch ? { fetch: options.fetch } : {}),
+  });
+}
+
 export function lanesFederation(options: FederationOptions): Federation {
-  const apiUrl = options.apiUrl ?? process.env['LANES_API_URL'] ?? DEFAULT_API_URL;
+  const apiUrl = lanesApiUrl(options.apiUrl);
   const webUrl = options.webUrl ?? process.env['LANES_WEB_URL'] ?? DEFAULT_WEB_URL;
 
   const verifier = new AssertionVerifier({

--- a/src/auth/lanes/signed.ts
+++ b/src/auth/lanes/signed.ts
@@ -1,0 +1,299 @@
+import type { FetchLike } from './login.ts';
+
+/**
+ * Believing something `api.lanes.sh` signed, without deciding what it means.
+ *
+ * Split out of `./assertion.ts` when a second credential arrived that this
+ * endpoint must verify the same way and judge differently. The signature, the
+ * published keys and the claims *every* Lanes-signed token has to satisfy are
+ * here; what makes one a redirect assertion and another a long-lived API key is
+ * in the two files that build on this.
+ *
+ * The split is not tidying. Both credentials are RS256 over the same JWKS from
+ * the same issuer, so a second copy of the key cache would mean two caches with
+ * two rotation windows, and a second copy of the audience check would mean two
+ * chances to get the confused-deputy comparison wrong. There is one of each, and
+ * the differences are stated as rules on top rather than reimplemented beneath.
+ *
+ * No JWT library, for the reason `./assertion.ts` has always given: RS256 over a
+ * JWK is `crypto.subtle.importKey` plus `crypto.subtle.verify`, which is thirty
+ * lines and no supply chain.
+ */
+
+/** What a verified token says that both credentials say the same way. */
+export interface SignedSubject {
+  /** `lanes:<uid>`, the same string `lanes auth login` stores and `members:` names. */
+  readonly subject: string;
+  readonly email: string | null;
+}
+
+export interface JwksVerifierOptions {
+  /** Where the signing keys are published. */
+  readonly jwksUrl: string;
+  /** Who is allowed to have signed. Checked against `iss` by `subjectFromClaims`. */
+  readonly issuer: string;
+  readonly fetch?: FetchLike | undefined;
+  readonly now?: (() => number) | undefined;
+  /** How long a fetched key set is reused. */
+  readonly cacheTtlMs?: number | undefined;
+}
+
+/**
+ * One published key, as it arrives.
+ *
+ * Loose on purpose: `importKey` is the thing that decides whether a JWK is
+ * usable, and re-deciding that here with a stricter type would mean a key the
+ * platform accepts being dropped by our own schema.
+ */
+type Jwk = Record<string, unknown> & { kid?: unknown; kty?: unknown; alg?: unknown };
+
+/** An hour. A key rotation is noticed within it, and a miss refetches anyway. */
+const DEFAULT_CACHE_TTL_MS = 60 * 60_000;
+
+/**
+ * The shortest interval between two refetches provoked by an unknown key id.
+ *
+ * Without it, a token naming a key that does not exist costs a round trip to
+ * the API — and since anyone can send one unauthenticated, every endpoint
+ * becomes an amplifier pointed at us. A minute bounds that at one request per
+ * endpoint per minute while still letting a genuine rotation land promptly.
+ */
+const MISS_REFETCH_MS = 60_000;
+
+/** Clocks differ. Small enough that it does not extend any window meaningfully. */
+export const CLOCK_SKEW_MS = 30_000;
+
+/** What `importKey('jwk', …)` takes, without depending on a lib.dom global. */
+type JsonWebKeyLike = Parameters<typeof crypto.subtle.importKey>[1] extends infer T
+  ? Extract<T, { kty?: string | undefined }>
+  : never;
+
+/**
+ * The issuer's keys, and whether this token was signed with one of them.
+ *
+ * Signature only. It answers "did `api.lanes.sh` write this", which is the same
+ * question for every Lanes-signed credential, and nothing about what the token
+ * is for — so a caller that forgets to check the claims gets a payload rather
+ * than a principal, and `subjectFromClaims` is the only way to turn one into the
+ * other.
+ *
+ * Verification is intentionally a public-key check and not a call back to the
+ * API. The endpoint may be behind somebody's firewall; it must be able to verify
+ * while only ever having *fetched* a key, and a cached JWKS makes the whole flow
+ * work with the API unreachable for the length of the cache.
+ */
+export class JwksVerifier {
+  readonly #options: JwksVerifierOptions;
+  readonly #fetch: FetchLike;
+  readonly #now: () => number;
+  #keys: { at: number; byKid: Map<string, CryptoKey> } | null = null;
+  #missedAt = Number.NEGATIVE_INFINITY;
+
+  constructor(options: JwksVerifierOptions) {
+    this.#options = options;
+    this.#fetch = options.fetch ?? ((input, init) => globalThis.fetch(input, init));
+    this.#now = options.now ?? Date.now;
+  }
+
+  get issuer(): string {
+    return this.#options.issuer;
+  }
+
+  now(): number {
+    return this.#now();
+  }
+
+  /**
+   * The payload of a token this issuer signed, or null.
+   *
+   * Null rather than a reason, the same way `AssertionVerifier.verify` has always
+   * answered: "the signature did not verify" versus "the key id was unknown"
+   * tells an attacker which of their attempts got closer while telling a
+   * legitimate caller nothing they can act on.
+   */
+  async payload(token: string): Promise<Record<string, unknown> | null> {
+    const parts = token.split('.');
+    if (parts.length !== 3) return null;
+
+    const [encodedHeader, encodedPayload, encodedSignature] = parts as [string, string, string];
+
+    const header = decodeJson(encodedHeader);
+    const payload = decodeJson(encodedPayload);
+    if (header === null || payload === null) return null;
+
+    // Pinned, not read. `alg` arrives inside the token, so honouring it is how
+    // the `none` algorithm and the HMAC-with-the-public-key confusions work.
+    if (header['alg'] !== 'RS256') return null;
+
+    const kid = typeof header['kid'] === 'string' ? header['kid'] : null;
+    if (kid === null) return null;
+
+    const key = await this.#key(kid);
+    if (key === null) return null;
+
+    const signature = base64url(encodedSignature);
+    if (signature === null) return null;
+
+    const valid = await crypto.subtle.verify(
+      { name: 'RSASSA-PKCS1-v1_5' },
+      key,
+      signature,
+      new TextEncoder().encode(`${encodedHeader}.${encodedPayload}`),
+    );
+
+    return valid ? payload : null;
+  }
+
+  /**
+   * The signing key with that id.
+   *
+   * A miss against a warm cache refetches, because that is what a key rotation
+   * looks like from here and the alternative is every endpoint refusing until
+   * its cache lapses. It refetches at most once a minute, because the *other*
+   * thing a miss looks like is an invented key id, and those arrive
+   * unauthenticated and as fast as anyone cares to send them.
+   */
+  async #key(kid: string): Promise<CryptoKey | null> {
+    const ttl = this.#options.cacheTtlMs ?? DEFAULT_CACHE_TTL_MS;
+    const now = this.#now();
+    const fresh = this.#keys !== null && now - this.#keys.at < ttl;
+
+    if (fresh) {
+      const hit = this.#keys?.byKid.get(kid);
+      if (hit) return hit;
+      if (now - this.#missedAt < MISS_REFETCH_MS) return null;
+      this.#missedAt = now;
+    }
+
+    const loaded = await this.#load();
+    return loaded.get(kid) ?? null;
+  }
+
+  async #load(): Promise<Map<string, CryptoKey>> {
+    const byKid = new Map<string, CryptoKey>();
+
+    const response = await this.#fetch(this.#options.jwksUrl).catch(() => null);
+    if (response === null || !response.ok) {
+      // Left uncached, so the next attempt tries again rather than treating an
+      // outage as "there are no keys" for an hour. Whatever was already known
+      // still answers, which is what keeps a verified endpoint working while
+      // the API is down.
+      return this.#keys?.byKid ?? byKid;
+    }
+
+    const body = (await response.json().catch(() => ({}))) as { keys?: Jwk[] };
+
+    for (const jwk of body.keys ?? []) {
+      if (jwk.kty !== 'RSA' || (jwk.alg !== undefined && jwk.alg !== 'RS256')) continue;
+      if (typeof jwk.kid !== 'string') continue;
+
+      const key = await crypto.subtle
+        .importKey('jwk', jwk as JsonWebKeyLike, { name: 'RSASSA-PKCS1-v1_5', hash: 'SHA-256' }, false, [
+          'verify',
+        ])
+        .catch(() => null);
+
+      if (key !== null) byKid.set(jwk.kid, key);
+    }
+
+    this.#keys = { at: this.#now(), byKid };
+    return byKid;
+  }
+}
+
+/**
+ * The claims every Lanes-signed credential must satisfy, whatever it is for.
+ *
+ * Three of them, and each is load-bearing:
+ *
+ *  - **Issuer**, against the API this endpoint was told to trust. Without it a
+ *    signature from any key we happen to have cached would do.
+ *  - **Audience**, which must be *this endpoint's own resource URL*, matched
+ *    exactly per RFC 8707. A token minted for somebody else's endpoint is a
+ *    valid token; using it here is the confused-deputy case the MCP
+ *    authorization spec calls out, and this is the only thing that stops it. A
+ *    prefix or suffix comparison would admit a token minted for a different
+ *    endpoint on the same host.
+ *  - **Expiry and issuance**, with a small skew. How *long* a credential may
+ *    live is not decided here — that is the one rule that genuinely differs
+ *    between a token crossing a single redirect and a key living in a CI
+ *    secret — so each caller checks its own ceiling.
+ */
+export function subjectFromClaims(
+  payload: Record<string, unknown>,
+  expected: { readonly issuer: string; readonly audience: string; readonly now: number },
+): SignedSubject | null {
+  if (payload['iss'] !== expected.issuer) return null;
+
+  const audience = payload['aud'];
+  const audiences = Array.isArray(audience) ? audience : [audience];
+  if (!audiences.includes(expected.audience)) return null;
+
+  const exp = typeof payload['exp'] === 'number' ? payload['exp'] * 1000 : 0;
+  const iat = typeof payload['iat'] === 'number' ? payload['iat'] * 1000 : 0;
+
+  if (exp <= expected.now - CLOCK_SKEW_MS) return null;
+  if (iat > expected.now + CLOCK_SKEW_MS) return null;
+
+  const subject = payload['sub'];
+  if (typeof subject !== 'string' || subject.length === 0) return null;
+
+  return {
+    // The API signs the raw uid; the prefix is added at exactly one place in the
+    // client, so nothing here and in `login.ts` can disagree about what a
+    // subject looks like.
+    subject: subject.startsWith('lanes:') ? subject : `lanes:${subject}`,
+    email: typeof payload['email'] === 'string' ? payload['email'] : null,
+  };
+}
+
+/**
+ * How long a token claims to be good for, in milliseconds.
+ *
+ * Returned rather than checked, because the ceiling is what distinguishes the
+ * two credentials and each states its own. A token missing either claim reports
+ * `Infinity`, so a caller comparing against a ceiling refuses it — which is the
+ * right answer for both of them and is why this does not return null.
+ */
+export function claimedLifetimeMs(payload: Record<string, unknown>): number {
+  const exp = typeof payload['exp'] === 'number' ? payload['exp'] * 1000 : null;
+  const iat = typeof payload['iat'] === 'number' ? payload['iat'] * 1000 : null;
+  return exp === null || iat === null ? Number.POSITIVE_INFINITY : exp - iat;
+}
+
+/**
+ * Which Lanes-signed credential this is, as the payload declares it.
+ *
+ * A claim rather than the JOSE `typ` header, because the header almost certainly
+ * already says `JWT` and overloading it would mean asking the API to change
+ * something a client may be reading. Unknown and absent are the same answer —
+ * null — and the two callers treat that differently on purpose: see
+ * `./api-key.ts`.
+ */
+export function credentialKind(payload: Record<string, unknown>): string | null {
+  const kind = payload['kind'];
+  return typeof kind === 'string' && kind.length > 0 ? kind : null;
+}
+
+/** What a long-lived API key declares itself to be. */
+export const API_KEY_KIND = 'api_key';
+
+export function base64url(value: string): ArrayBuffer | null {
+  try {
+    const bytes = Buffer.from(value, 'base64url');
+    return bytes.buffer.slice(bytes.byteOffset, bytes.byteOffset + bytes.byteLength) as ArrayBuffer;
+  } catch {
+    return null;
+  }
+}
+
+function decodeJson(value: string): Record<string, unknown> | null {
+  const bytes = base64url(value);
+  if (bytes === null) return null;
+  try {
+    const parsed: unknown = JSON.parse(new TextDecoder().decode(bytes));
+    return typeof parsed === 'object' && parsed !== null ? (parsed as Record<string, unknown>) : null;
+  } catch {
+    return null;
+  }
+}

--- a/src/auth/remote.test.ts
+++ b/src/auth/remote.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from 'bun:test';
-import { IssuedTokenAuthenticator, OidcAuthenticator } from './remote.ts';
+import { IssuedTokenAuthenticator, LanesKeyAuthenticator, OidcAuthenticator } from './remote.ts';
 import { EVERY_PROFILE, mayReach } from './principal.ts';
+import type { ApiKeyVerifier } from './lanes/api-key.ts';
 import type { OidcVerifier } from './oidc.ts';
 import { OAuthStore } from './oauth/store.ts';
 import type { KeyValueStore } from '#stores/state';
@@ -316,5 +317,133 @@ describe('a token from an external issuer', () => {
 
     expect(outcome.ok).toBe(false);
     expect(!outcome.ok && outcome.reason).toBe('invalid');
+  });
+});
+
+/**
+ * What an API key the dashboard minted turns into.
+ *
+ * The resolution is the same shape as the two above and is not what these tests
+ * are for. What is different, and what the first two cases hold, is that this is
+ * the only link whose credential was signed by an issuer serving every Lanes
+ * endpoint — so the audience is the only thing making a key mean *this* endpoint,
+ * and a caller that does not say which endpoint was addressed must be refused
+ * rather than trusted.
+ */
+
+/** A verifier that answers from a table, and records the audience it was given. */
+function stubKeyVerifier(
+  answers: Record<string, string>,
+  seen?: { audience?: string },
+): ApiKeyVerifier {
+  return {
+    verify: async (token: string, expected: { audience: string }) => {
+      if (seen) seen.audience = expected.audience;
+      const subject = answers[token];
+      return subject ? { subject, email: null } : null;
+    },
+  } as unknown as ApiKeyVerifier;
+}
+
+describe('an API key the API signed', () => {
+  const SUBJECT = 'lanes:EXAMPLEUID00000000000000000';
+  const ADDRESSED = { resource: 'https://link.example.com/mcp' };
+
+  test('reaches only the profiles whose members: name its subject', async () => {
+    const auth = new LanesKeyAuthenticator(
+      stubKeyVerifier({ theirs: SUBJECT }),
+      'personal',
+      async (subject) => (subject === SUBJECT ? ['personal'] : []),
+    );
+
+    const outcome = await auth.authenticate('Bearer theirs', ADDRESSED);
+
+    expect(outcome.ok).toBe(true);
+    if (!outcome.ok) return;
+    expect(outcome.principal.id).toBe(SUBJECT);
+    expect(outcome.principal.kind).toBe('member');
+    expect(outcome.principal.profiles).toEqual(['personal']);
+    expect(mayReach(outcome.principal, 'personal')).toBe(true);
+    expect(mayReach(outcome.principal, 'work')).toBe(false);
+  });
+
+  test('is refused when the caller did not say which endpoint was addressed', async () => {
+    // Fail closed. Verifying without an audience would accept a key minted for
+    // any endpoint the same issuer signs for, which is the whole reason the
+    // audience is checked at all.
+    const auth = new LanesKeyAuthenticator(
+      stubKeyVerifier({ theirs: SUBJECT }),
+      'personal',
+      async () => ['personal'],
+    );
+
+    const outcome = await auth.authenticate('Bearer theirs');
+
+    expect(outcome).toEqual({ ok: false, reason: 'invalid' });
+  });
+
+  test('checks the key against the endpoint the request named', async () => {
+    const seen: { audience?: string } = {};
+    const auth = new LanesKeyAuthenticator(
+      stubKeyVerifier({ theirs: SUBJECT }, seen),
+      'personal',
+      async () => ['personal'],
+    );
+
+    await auth.authenticate('Bearer theirs', ADDRESSED);
+
+    expect(seen.audience).toBe('https://link.example.com/mcp');
+  });
+
+  test('a subject no profile names reaches nothing, and that is not an error', async () => {
+    const auth = new LanesKeyAuthenticator(
+      stubKeyVerifier({ theirs: SUBJECT }),
+      'personal',
+      async () => [],
+    );
+
+    const outcome = await auth.authenticate('Bearer theirs', ADDRESSED);
+
+    expect(outcome.ok).toBe(true);
+    if (!outcome.ok) return;
+    expect(outcome.principal.profiles).toEqual([]);
+    expect(outcome.principal.profiles).not.toBe(EVERY_PROFILE);
+    expect(mayReach(outcome.principal, 'personal')).toBe(false);
+  });
+
+  test('a key the verifier does not believe is invalid, not missing', async () => {
+    const auth = new LanesKeyAuthenticator(stubKeyVerifier({}), 'personal', async () => ['personal']);
+
+    expect(await auth.authenticate('Bearer nope', ADDRESSED)).toEqual({
+      ok: false,
+      reason: 'invalid',
+    });
+  });
+
+  test('a member lookup that throws fails closed', async () => {
+    // The alternative is a bucket outage widening what a key reaches, which is
+    // the direction nothing here is allowed to fail in.
+    const auth = new LanesKeyAuthenticator(
+      stubKeyVerifier({ theirs: SUBJECT }),
+      'personal',
+      async () => {
+        throw new Error('the store is unreachable');
+      },
+    );
+
+    expect(await auth.authenticate('Bearer theirs', ADDRESSED)).toEqual({
+      ok: false,
+      reason: 'invalid',
+    });
+  });
+
+  test('no credential is missing, and a malformed one says so', async () => {
+    const auth = new LanesKeyAuthenticator(stubKeyVerifier({}), 'personal', async () => []);
+
+    expect(await auth.authenticate(null, ADDRESSED)).toEqual({ ok: false, reason: 'missing' });
+    expect(await auth.authenticate('Basic abc', ADDRESSED)).toEqual({
+      ok: false,
+      reason: 'malformed',
+    });
   });
 });

--- a/src/auth/remote.ts
+++ b/src/auth/remote.ts
@@ -1,14 +1,16 @@
 import {
   memberPrincipal,
   parseBearer,
+  type AuthContext,
   type AuthOutcome,
   type Authenticator,
 } from './index.ts';
+import type { ApiKeyVerifier } from './lanes/api-key.ts';
 import type { OAuthStore } from './oauth/store.ts';
 import type { OidcVerifier } from './oidc.ts';
 
 /**
- * The two ways a remote client's token becomes a principal.
+ * The three ways a remote client's token becomes a principal.
  *
  * A token this endpoint issued now carries *who completed the flow* and which
  * profiles named them, so it resolves to a member principal (ADR-060). Both were
@@ -121,6 +123,70 @@ export class OidcAuthenticator implements Authenticator {
       // The issuer being unreachable, or misconfigured, is not an authorisation.
       // Failing closed here means an outage at the identity provider closes the
       // endpoint rather than opening it.
+      return { ok: false, reason: 'invalid' };
+    }
+  }
+}
+
+/**
+ * An API key `api.lanes.sh` signed, verified against its published keys.
+ *
+ * The third shape, and the one that replaces a credential this CLI used to mint
+ * itself. It resolves the same way the other two do — a subject, then the
+ * profiles whose `members:` name them — so `mayReach` gets no special case and
+ * nothing here decides reach.
+ *
+ * **It is the only link that needs to know which endpoint was addressed.** An
+ * issued token is bound to this endpoint by living in its store; an OIDC token
+ * by an audience the operator configured. A key is signed by an issuer that
+ * serves every Lanes endpoint, so the audience is the *only* thing standing
+ * between a key minted for one deployment and every other deployment. Absent, it
+ * refuses: an unchecked audience here would make a key a skeleton key across
+ * every endpoint the issuer signs for, which is precisely the failure ADR-079
+ * spent its argument on one level up.
+ */
+export class LanesKeyAuthenticator implements Authenticator {
+  readonly #verifier: ApiKeyVerifier;
+  readonly #profile: string;
+  readonly #profilesFor: (subject: string) => Promise<readonly string[]>;
+
+  constructor(
+    verifier: ApiKeyVerifier,
+    profile: string,
+    profilesFor: (subject: string) => Promise<readonly string[]>,
+  ) {
+    this.#verifier = verifier;
+    this.#profile = profile;
+    this.#profilesFor = profilesFor;
+  }
+
+  async authenticate(
+    header: string | null | undefined,
+    context?: AuthContext,
+  ): Promise<AuthOutcome> {
+    const presented = parseBearer(header);
+    if (presented === null) return { ok: false, reason: header ? 'malformed' : 'missing' };
+
+    // Fail closed on a caller that did not say who was addressed. `invalid`
+    // rather than `not_configured`: the credential was not examined, and the
+    // chain's ranking treats `invalid` as the more specific answer — which is
+    // right, because something reached this link with a bearer it could not
+    // judge, and that is worth surfacing over "nobody has set this up".
+    if (context === undefined) return { ok: false, reason: 'invalid' };
+
+    try {
+      const verified = await this.#verifier.verify(presented, { audience: context.resource });
+      if (!verified) return { ok: false, reason: 'invalid' };
+
+      // Resolved per request, never cached with the credential. This is what
+      // makes `profile members remove` the revocation for a key, and it is the
+      // only one a signed credential has — see `./lanes/api-key.ts`.
+      const profiles = await this.#profilesFor(verified.subject);
+      return { ok: true, principal: memberPrincipal(verified.subject, this.#profile, profiles) };
+    } catch {
+      // A JWKS fetch that throws, or a resolver that does. Closed, for the
+      // reason `OidcAuthenticator` gives: an outage at the identity provider
+      // must close the endpoint rather than open it.
       return { ok: false, reason: 'invalid' };
     }
   }

--- a/src/cli/accepts.ts
+++ b/src/cli/accepts.ts
@@ -51,13 +51,9 @@ export const ACCEPTS: Record<string, readonly string[]> = {
   // it undoes a provider rename this project shipped, and every other finding
   // there is something only the operator can decide.
   doctor: ['fix'],
-  // A filter, not a second subject: it narrows the answer to one connection so
-  // a caller can re-ask about the row it just repaired. Same shape as `attach`.
   // Declaring a connection names the account itself, because nothing can be
   // asked of a provider that is not authorised yet — see `connection-declare.ts`.
   'connection declare': ['id', 'account', 'label'],
-
-  auth: ['connection'],
   relabel: [],
   // A rule lands in a grant row, and a row names one connection (ADR-058), so
   // the flag is required rather than optional. It is listed here as well as

--- a/src/cli/commands/auth-dispatch.test.ts
+++ b/src/cli/commands/auth-dispatch.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, test } from 'bun:test';
+
+import { runAuth } from './auth-dispatch.ts';
+
+/**
+ * `lanes auth` refuses a flag it does not read.
+ *
+ * It did not, for a structural reason rather than an oversight: `lanes.ts`
+ * routes this area before `main.ts`, and `assertKnownFlags` is called inside
+ * `main.ts`. So the check that covers every `link` command never saw this one,
+ * and `parseArgv` hands back every `--anything` it finds.
+ *
+ * Every case here refuses before any command runs, so none of them reads a
+ * session, opens a browser, or writes anything.
+ */
+describe('lanes auth refuses a flag it does not read', () => {
+  test('the misspelling that was silently dropped', async () => {
+    // `login` would otherwise fall back to `LANES_API_URL` and then to the
+    // default broker, and nothing it prints names which one it used.
+    await expect(runAuth(['login', '--api_url', 'https://example.invalid'])).rejects.toThrow(
+      'Did you mean --api-url?',
+    );
+  });
+
+  test('and any other unknown flag', async () => {
+    await expect(runAuth(['status', '--workspace', 'cloud'])).rejects.toThrow(
+      'Unknown flag "--workspace" for "lanes auth status"',
+    );
+  });
+
+  test('the command it names is the one that was typed', async () => {
+    await expect(runAuth(['workspaces', '--nope'])).rejects.toThrow('"lanes auth workspaces"');
+    await expect(runAuth(['--nope'])).rejects.toThrow('"lanes auth"');
+  });
+
+  test('--help is answered rather than allowed through', async () => {
+    // Allowlisting it without answering it would be the same defect: before
+    // this, `lanes auth --help` printed the status.
+    const lines: string[] = [];
+    const original = console.log;
+    console.log = (line: string): void => void lines.push(line);
+    try {
+      await runAuth(['--help']);
+    } finally {
+      console.log = original;
+    }
+
+    expect(lines.join('\n')).toContain('lanes auth login');
+    expect(lines.join('\n')).toContain('--api-url <url>');
+  });
+});

--- a/src/cli/commands/auth-dispatch.ts
+++ b/src/cli/commands/auth-dispatch.ts
@@ -1,4 +1,5 @@
 import { parseArgv } from '../argv.ts';
+import { refuseUnknownFlags } from '../unknown-flags.ts';
 import { authLogin, authLogout, authStatus, authWorkspaces } from './auth.ts';
 
 /**
@@ -20,9 +21,31 @@ const USAGE = `lanes auth — who this machine is signed in as
   --api-url <url>         a self-hosted API, instead of the default
 `;
 
+/**
+ * Every flag this area reads, written out rather than derived.
+ *
+ * `selection.ts` builds its allowlist from the tables that say what a `link`
+ * command must be told. Nothing here needs a profile or a workspace, so there is
+ * no table to derive from and three names is the whole of it.
+ */
+const ACCEPTED = new Set(['help', 'json', 'api-url']);
+
 export async function runAuth(argv: readonly string[]): Promise<void> {
   const { command, flags } = parseArgv(argv);
   const [first] = command;
+
+  // Before anything reads a flag, and the reason is `--api-url`: misspelled, it
+  // was dropped and the sign-in went to the default broker instead of the one
+  // named, which nothing on the success path prints. See `../unknown-flags.ts`.
+  refuseUnknownFlags(`lanes auth${first === undefined ? '' : ` ${first}`}`, ACCEPTED, flags);
+
+  // `--help` as well as `help`. Allowing the flag through without answering it
+  // would be the same defect the line above exists to stop: it was accepted and
+  // ignored, so `lanes auth --help` printed the status instead of the usage.
+  if (first === 'help' || flags['help'] === true) {
+    console.log(USAGE);
+    return;
+  }
 
   const options = {
     json: flags['json'] === true,
@@ -39,9 +62,6 @@ export async function runAuth(argv: readonly string[]): Promise<void> {
       return authStatus(options);
     case 'workspaces':
       return authWorkspaces(options);
-    case 'help':
-      console.log(USAGE);
-      return;
     default:
       throw new Error(`Unknown: lanes auth ${first}\n\n${USAGE}`);
   }

--- a/src/cli/commands/auth.ts
+++ b/src/cli/commands/auth.ts
@@ -6,10 +6,11 @@ import { print, ok, prose, style, warn } from '../output.ts';
 /**
  * `lanes auth` — who this machine is signed in as.
  *
- * A separate area from `lanes link auth`, which is a per-connection credential
- * diagnostic and answers a different question entirely. Neither is renamed and
- * neither gains an alias: one spelling per command, and the help text on each
- * says which is which.
+ * The only `auth` in this CLI, which it was not. `lanes link auth` sat beside it
+ * as a per-connection credential diagnostic answering an entirely different
+ * question, and the two were told apart by help text. That command is gone —
+ * `doctor` asks what it asked — so there is one spelling and nothing to
+ * disambiguate.
  *
  * Sign-in is required to consume a profile, local endpoints included (ADR-060).
  * That is a real dependency on lanes.sh for a self-hostable tool, and the shape

--- a/src/cli/commands/operate.ts
+++ b/src/cli/commands/operate.ts
@@ -21,7 +21,12 @@
  */
 
 export { check, doctor, plan } from './operate/inspect.ts';
-export { auth, classifyOAuth, type AuthFlags, type AuthVerdict, type ConnectionAuth } from './operate/auth.ts';
+export {
+  classifyOAuth,
+  probeConnections,
+  type ConnectionAuth,
+  type ConnectionVerdict,
+} from './operate/connection-probe.ts';
 export { status } from './operate/status.ts';
 export { outputs, type OutputsFlags } from './operate/outputs.ts';
 export { tools, type ToolsFlags } from './operate/tools.ts';

--- a/src/cli/commands/operate/connection-probe.test.ts
+++ b/src/cli/commands/operate/connection-probe.test.ts
@@ -2,13 +2,13 @@ import { describe, expect, test } from 'bun:test';
 import { ReauthRequired } from '#connectivity/auth/index.ts';
 import { defineProvider } from '#connectivity';
 import type { SecretRef, SecretStore } from '#secrets';
-import { classifyOAuth, probeConnections } from './auth.ts';
+import { classifyOAuth, probeConnections } from './connection-probe.ts';
 import type { Runtime } from '../../runtime.ts';
 
 /**
  * The mapping, on its own.
  *
- * Everything expensive about `lanes link auth` is I/O, and everything that
+ * Everything expensive about the probe is I/O, and everything that
  * could be *wrong* about it is this function. Both ways it can lie have a test
  * here, because both are the kind of bug that ships quietly: one tells someone
  * to sign in again when their network is simply down, and the other tells them

--- a/src/cli/commands/operate/connection-probe.ts
+++ b/src/cli/commands/operate/connection-probe.ts
@@ -2,17 +2,16 @@ import type { ConnectionConfig } from '#profile';
 import { credentialResolver, ReauthRequired } from '#connectivity/auth/index.ts';
 import type { ResolvedCredential } from '#connectivity/auth/credential.ts';
 import { credentialRefFor } from '#registry';
-import { announceWorkspace, emit, fail, ok, print, warn } from '../../output.ts';
-import { readConnections } from '#profile';
-import {
-  grantedConnections,
-  openWorkspaceRuntime,
-  type GlobalFlags,
-  type Runtime,
-} from '../../runtime.ts';
+import type { Runtime } from '../../runtime.ts';
 
 /**
  * Whether each connection could still authenticate, asked rather than guessed.
+ *
+ * **This was `lanes link auth` and is no longer a command.** The name collided
+ * with `lanes auth`, which is sign-in and a different subject entirely, and the
+ * only consumer outside this repository was the desktop app's pre-0.8.0 settings
+ * arm — the one it stopped rendering when connections moved to the dashboard.
+ * `doctor` asks the question now, which it already did.
  *
  * `doctor` used to answer a version of this from the *age* of a stored
  * credential, which is wrong in both directions: it dates a credential from
@@ -27,15 +26,15 @@ import {
  * cost is one token-endpoint round trip per connection that has genuinely
  * lapsed — which is exactly the set worth asking about.
  *
- * **This command writes.** A successful refresh persists the new token, which on
- * a deployed target is a secret-store version per refreshed connection. That is
+ * **This writes.** A successful refresh persists the new token, which on a
+ * deployed target is a secret-store version per refreshed connection. That is
  * deliberate — it is the same write the serve path makes, and it warms the token
- * for the next real call — but it is why the read-only wording `check`, `plan`
- * and `doctor` carry does not appear here.
+ * for the next real call — but it is worth knowing that `doctor`, whose wording
+ * is otherwise read-only, reaches something that does not.
  */
 
 /** What can be said about one connection's ability to authenticate. */
-export type AuthVerdict =
+export type ConnectionVerdict =
   /** Resolved. The vendor accepted it just now, or its access token is still live. */
   | 'ok'
   /** Stored, and cannot be renewed without a person. The signal this exists for. */
@@ -55,7 +54,7 @@ export interface ConnectionAuth {
   readonly id: string;
   /** The manifest's `auth.kind`, so a reader can tell why a verdict is what it is. */
   readonly method: string;
-  readonly verdict: AuthVerdict;
+  readonly verdict: ConnectionVerdict;
   /** Whether answering cost a token-endpoint round trip. */
   readonly refreshed: boolean;
   readonly detail?: string;
@@ -96,7 +95,7 @@ export type ProbeResult =
  * saying the opposite of what the next real call will find. So the stored
  * expiry is checked here rather than that behaviour being changed.
  */
-export function classifyOAuth(result: ProbeResult): AuthVerdict {
+export function classifyOAuth(result: ProbeResult): ConnectionVerdict {
   switch (result.outcome) {
     case 'resolved':
       return result.staleAccessToken ? 'reauth' : 'ok';
@@ -139,17 +138,13 @@ function storedExpiry(raw: string | null): number | null {
   }
 }
 
-export interface AuthFlags extends GlobalFlags {
-  readonly json?: boolean | undefined;
-  /** Narrow to one connection, by `provider.id`. A filter, not a second subject. */
-  readonly connection?: string | undefined;
-}
-
 /**
  * Every connection's verdict, probed concurrently.
  *
- * Exported because `doctor` asks the same question and must not answer it a
- * second, differently-wrong way — that divergence is the bug this replaced.
+ * `doctor` is the one caller, and this stays its own module rather than moving
+ * into `inspect.ts` for the reason it was extracted in the first place: `doctor`
+ * used to answer this a second, differently-wrong way, and a seam is what stops
+ * that coming back.
  */
 export async function probeConnections(
   runtime: Runtime,
@@ -251,83 +246,11 @@ export async function probeConnections(
   return mapWithLimit(connections, CONCURRENCY, probe);
 }
 
-export async function auth(flags: AuthFlags): Promise<void> {
-  const runtime = await openWorkspaceRuntime(flags);
-
-  try {
-    const { profile, target } = runtime.resolution;
-    const forSelection = (command: string) => `${command} --workspace ${target}`;
-
-    // Every connection the workspace holds, not the ones one profile grants.
-    // Whether an account can still authenticate is a fact about the account
-    // (ADR-057), and scoping it to a profile's grants meant an account that had
-    // just been connected could not be checked until somebody granted it —
-    // which is exactly the moment you want to check.
-    //
-    // `--profile` narrows to what that profile can reach, because "can the
-    // things this profile uses still sign in" is also a real question.
-    const all = flags.profile === undefined
-      ? (await readConnections(runtime.resolution.workspaceRoot)).connections
-      : grantedConnections(runtime);
-
-    const wanted = flags.connection;
-    const connections = wanted ? all.filter((c) => `${c.provider}.${c.id}` === wanted) : all;
-
-    if (wanted && connections.length === 0) {
-      throw new Error(
-        `No connection "${wanted}" in workspace ${target}. Run: ${forSelection('lanes link connection list')}`,
-      );
-    }
-
-    const results = await probeConnections(runtime, connections, forSelection);
-    const needsSomeone = results.filter((r) => r.verdict === 'reauth' || r.verdict === 'missing');
-
-    // Always zero, and this is load-bearing rather than an oversight: the
-    // desktop app discards stdout when the CLI exits non-zero, which is exactly
-    // why it cannot read `doctor`. A connection needing a person is the answer
-    // this command was asked for, not a failure to produce one.
-    return emit(flags.json, { profile, target, ok: needsSomeone.length === 0, connections: results }, () => {
-      announceWorkspace(runtime.resolution);
-
-      for (const result of results) {
-        const line = `${result.key} — ${describe(result.verdict)}`;
-        if (result.verdict === 'reauth') print(fail(`${line}\n      ${result.fix}`));
-        else if (result.verdict === 'missing') print(warn(`${line}\n      ${result.fix}`));
-        else print(ok(line));
-      }
-
-      if (needsSomeone.length > 0) {
-        print();
-        print(fail(`${needsSomeone.length} connection(s) need you to sign in again`));
-      }
-    });
-  } finally {
-    await runtime.close();
-  }
-}
-
-function describe(verdict: AuthVerdict): string {
-  switch (verdict) {
-    case 'ok':
-      return 'authenticated';
-    case 'reauth':
-      return 'signed out, and cannot renew itself';
-    case 'missing':
-      return 'no credential stored';
-    case 'stored':
-      return 'credential stored, not exercised';
-    case 'none':
-      return 'needs no credential';
-    case 'unknown':
-      return 'could not be checked';
-  }
-}
-
 /**
  * `Promise.all` with a ceiling, in the ten lines it takes.
  *
  * A pool rather than chunks: chunking would make every batch wait for its
- * slowest member, which is the shape this command is trying to avoid.
+ * slowest member, which is the shape this is trying to avoid.
  */
 async function mapWithLimit<T, R>(
   items: readonly T[],

--- a/src/cli/commands/operate/findings.ts
+++ b/src/cli/commands/operate/findings.ts
@@ -19,7 +19,7 @@ import type { DoctorFinding } from './inspect.ts';
  *
  * `credentialAge` used to sit beside it and date a credential from the OAuth
  * provider's stamp. It is gone: dating a credential answers "when did this last
- * refresh", which is not the question anyone was asking. `operate/auth.ts`
+ * refresh", which is not the question anyone was asking. `operate/connection-probe.ts`
  * asks the real one by attempting the renewal.
  */
 

--- a/src/cli/commands/operate/inspect.ts
+++ b/src/cli/commands/operate/inspect.ts
@@ -7,7 +7,7 @@ import { openRuntime, resolveProfileOnly, type GlobalFlags, type Runtime } from 
 import type { FetchLike } from '#deployments/knowledge.ts';
 import { unboundRotatableRefs } from '#deployments/bind.ts';
 import { duplicateAccountFindings, reportCapabilityDrift } from './findings.ts';
-import { probeConnections } from './auth.ts';
+import { probeConnections } from './connection-probe.ts';
 import { migratedContract, migratedRenamedProviders } from './migrate.ts';
 import { reportWorkspaceHomeMove } from '../../workspace-home-migrate.ts';
 import { reachabilityFindings } from './reachability.ts';
@@ -173,8 +173,9 @@ export async function doctor(flags: DoctorFlags): Promise<void> {
     // the problem.
     //
     // `probeConnections` answers it by attempting the renewal, which is the only
-    // thing that actually knows. Same classifier as `lanes link auth`, so the two
-    // cannot drift apart again.
+    // thing that actually knows. It kept its own module when `lanes link auth`
+    // was removed, because the divergence it was extracted to stop was this
+    // command answering the question a second, differently-wrong way.
     const probed = await probeConnections(runtime, grantedConnections(runtime), forSelection);
 
     for (const result of probed) {

--- a/src/cli/commands/operate/pair.ts
+++ b/src/cli/commands/operate/pair.ts
@@ -22,18 +22,23 @@ import { pairingGuidance, pairingLink } from './pairing-link.ts';
  * `lanes link pair` — let the Lanes dashboard read this machine (ADR-063).
  *
  * Three things, and each is the operator's to decline. It installs a locally
- * trusted certificate, mints a credential that reads the whole workspace and
- * writes the owner's own data in it, and hands the browser a link carrying it.
- * None of that happens without being asked for, and none of it is implied by
- * `start`.
+ * trusted certificate, records that somebody opted this endpoint in, and hands
+ * the browser a link carrying the address. None of that happens without being
+ * asked for, and none of it is implied by `start`.
  *
- * **The credential is not read-only, since ADR-069.** It edits and deletes
- * memory, tasks, assets, skills and entities, in every profile the workspace
- * holds, and it still reaches no connection, token, policy rule, configuration
- * or vault value. That is a widening of something a year of notes calls a read,
- * so the paragraph this command prints says it before the operator answers —
- * and a token minted before that release gains it silently, which is the reason
- * saying it here is not decoration.
+ * **What it mints is a marker, not a credential, since ADR-079.** This docstring
+ * said the opposite for a release: that the token "reads the whole workspace and
+ * writes the owner's own data in it", which was true under ADR-069 and stopped
+ * being true when the read surface started resolving a real bearer through the
+ * endpoint's own authenticator. Nothing verifies `workspace/pair_token` now —
+ * `server/read/open.ts` says so at the one place that still reads it — and its
+ * only remaining job is that its existence is what decides whether the loopback
+ * read port binds at all.
+ *
+ * So the credential question moved to whoever opens the link: they sign in with
+ * Lanes and reach the profiles whose `members:` name them. `pairingGuidance()`
+ * is the paragraph that says that to the operator, and it is the copy to keep
+ * right — this one is for whoever edits the command.
  *
  * **The certificate is the largest side effect any command in this CLI has.**
  * It is a persistent change to the machine's trust store, made by a CLI, and
@@ -317,8 +322,10 @@ async function pairDeployed(input: {
 
   // An empty string, not just a missing ref: `lanes link deploy` creates this
   // secret with no version so the revision's IAM binding has something to
-  // attach to, and a secret that exists with no version reads back as null
-  // here and as `unpaired` there. Either shape means nobody has paired yet.
+  // attach to, and a secret that exists with no version reads back as null both
+  // here and in the endpoint. Either shape means nobody has paired yet, and
+  // there it means the read port does not bind rather than that a request is
+  // refused — nothing answers `unpaired`, which this said until ADR-079.
   const existing = held === '' ? null : held;
   const token = existing ?? `llp_${randomBytes(32).toString('base64url')}`;
   if (existing === null) await credentials.set(PAIR_TOKEN_REF, token);

--- a/src/cli/commands/operate/serve.ts
+++ b/src/cli/commands/operate/serve.ts
@@ -133,7 +133,10 @@ export async function start(
  * `lanes auth status` says how long that has left to run.
  *
  * The CI token is the exception and stays one (ADR-009): a headless runner has
- * no browser, presents `llk_…`, and reaches the whole workspace.
+ * no browser and presents `llk_…`. What it reaches is every profile whose
+ * `members:` names the subject its row was issued to, and nothing else — this
+ * said "the whole workspace", which was true until ADR-068 made a row name a
+ * person, and is the reach that release exists to have removed.
  */
 async function requireSignIn(): Promise<void> {
   if ((await readSession()) !== null) return;

--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -10,7 +10,6 @@ import {
   attachFile,
   auditTail,
   auditVerify,
-  auth,
   check,
   configShow,
   desktop,
@@ -399,10 +398,6 @@ export async function run(argv: readonly string[]): Promise<void> {
     case 'doctor':
       return doctor({ ...global, json, fix: flags['fix'] === true });
 
-    // Beside `doctor` because it answers half of what `doctor` used to guess at,
-    // and answers it by asking rather than by dating a credential.
-    case 'auth':
-      return auth({ ...global, json, connection: text(flags, 'connection') });
     case 'status':
       return status({ ...global, json });
     case 'outputs':

--- a/src/cli/runtime/open.ts
+++ b/src/cli/runtime/open.ts
@@ -317,6 +317,14 @@ export async function openRuntime(
       tokens: async () => (await readConnections(root)).tokens,
       credentials,
       profilesFor: membersResolver(root),
+      // **`error`, where the two closures above use `warn`, and that is the
+      // point of it.** This logger is filtered by level and the container opens
+      // its runtime with `quiet: true`, which sets the threshold to `error` —
+      // so a warning here is discarded in precisely the place this matters. The
+      // others are addressed to somebody at a terminal; this one is addressed
+      // to whoever is reading a deployed endpoint's log wondering why a
+      // credential it holds stopped working.
+      report: (message) => logger.error(message),
     }),
     connectorFor,
     authorizeRequest,

--- a/src/cli/selection.test.ts
+++ b/src/cli/selection.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, test } from 'bun:test';
 import { readFile } from 'node:fs/promises';
 import { readFileSync } from 'node:fs';
 import { join } from 'node:path';
-import { SELECTION, assertKnownFlags, requirementFor } from './selection.ts';
+import { ACCEPTS, SELECTION, assertKnownFlags, requirementFor } from './selection.ts';
 import { requireSelection } from './selection-require.ts';
 import { CONNECT_CUSTOM_FLAGS, RESERVED_BY_GRAMMAR } from './commands/connect/custom/spec.ts';
 
@@ -292,6 +292,26 @@ describe('every command is runnable in the spelling it demands', () => {
         requireSelection(first, second, flags, nowhere),
         `${key} is satisfied by ${JSON.stringify(flags)}`,
       ).resolves.toBeUndefined();
+    }
+  });
+
+  /**
+   * The same pair, read from the other side.
+   *
+   * The two tests above walk `SELECTION`, so neither can see an `ACCEPTS` key
+   * that has no row there — and such a key is dead in a way that does not error.
+   * `selectionKey` returns the bare first word when the pair is absent, so the
+   * row is never the row looked up and its flags are silently never allowed.
+   *
+   * Two had accumulated. `auth` outlived the command it belonged to and cost
+   * only a reader's time. `workspace show` was the expensive one: `--workspace`
+   * was refused on the command named after it while the older `target show`
+   * spelling accepted it, so the rename was half-done and nothing walking
+   * `SELECTION` could reach it.
+   */
+  test('every allowlist key has a row in the requirement table', () => {
+    for (const key of Object.keys(ACCEPTS)) {
+      expect(key in SELECTION, `ACCEPTS["${key}"] has a SELECTION row`).toBe(true);
     }
   });
 

--- a/src/cli/selection.ts
+++ b/src/cli/selection.ts
@@ -106,6 +106,11 @@ export const SELECTION: Record<string, Requires> = {
   'profile remove': 'workspace',
   // Editing who may consume one profile, so it names the profile.
   'profile members': 'profile+workspace',
+  // Both spellings, because `selectionKey` falls back to the bare word when the
+  // pair is absent — so a missing row here does not error, it silently makes the
+  // command `workspace`, whose requirement is `none`, and `--workspace` is then
+  // refused on the very command named after it.
+  'workspace show': 'workspace',
   'target show': 'workspace',
 
   // These read one profile's file and open nothing. The target is what says

--- a/src/cli/selection.ts
+++ b/src/cli/selection.ts
@@ -1,7 +1,6 @@
-import { ConfigError } from '#profile';
 import type { Flags } from './argv.ts';
 import { ACCEPTS } from './accepts.ts';
-import { nearest } from './nearest.ts';
+import { refuseUnknownFlags } from './unknown-flags.ts';
 
 export { ACCEPTS } from './accepts.ts';
 
@@ -344,12 +343,11 @@ export const EXPLICIT_WORKSPACE = new Set([
 const UNIVERSAL = ['help', 'json', 'quiet'];
 
 /**
- * Refuse a flag this command does not read, and guess what was meant.
+ * What this command accepts, and the refusal of anything else.
  *
- * This is the fix for the reported bug rather than a nicety. `profile add
- * --workspace cloud` was accepted and dropped, and nothing could refuse it because
- * `parseArgv` returns every `--anything` it sees and no command ever inspected
- * the leftovers. A typo was swallowed the same way on every command in the CLI.
+ * The allowlist is derived here because the tables that answer it are here. The
+ * refusal itself is in `./unknown-flags.ts`, shared with `lanes auth` — which is
+ * routed before `main.ts` and so never reached this function at all.
  */
 /**
  * Commands that name their profile as an argument, and so refuse the flag.
@@ -378,13 +376,5 @@ export function assertKnownFlags(first: string, second: string | undefined, flag
 
   const named = [first, second].filter(Boolean).join(' ');
 
-  for (const given of Object.keys(flags)) {
-    if (allowed.has(given)) continue;
-
-    throw new ConfigError(
-      `Unknown flag "--${given}" for "lanes link ${named}".` +
-        (nearest(given, allowed) ? `\n  Did you mean --${nearest(given, allowed)}?` : '') +
-        `\n  Accepts: ${[...allowed].sort().map((name) => `--${name}`).join(' ')}`,
-    );
-  }
+  refuseUnknownFlags(`lanes link ${named}`, allowed, flags);
 }

--- a/src/cli/selection.ts
+++ b/src/cli/selection.ts
@@ -164,10 +164,6 @@ export const SELECTION: Record<string, Requires> = {
   secrets: 'workspace',
   plan: 'profile+workspace',
   doctor: 'profile+workspace',
-  // Whether an account can still sign in is a fact about the account. Scoped to
-  // a profile's grants it could not check one that had just been connected,
-  // which is when you most want to.
-  auth: 'workspace',
   // Target-scoped: see the note above. `--profile` narrows each to one profile.
   status: 'workspace',
   // Its subject has always been the endpoint rather than a profile — its own

--- a/src/cli/unknown-flags.test.ts
+++ b/src/cli/unknown-flags.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, test } from 'bun:test';
+
+import { refuseUnknownFlags } from './unknown-flags.ts';
+
+/**
+ * The refusal, tested where it now lives rather than through one of its callers.
+ *
+ * `selection.test.ts` exercises it thoroughly through `assertKnownFlags`, but
+ * only ever with an allowlist derived from the `link` tables. The point of the
+ * extraction is that a second area supplies its own, so the cases that matter
+ * here are the ones about the *message*: what a caller's own allowlist puts in
+ * front of the operator.
+ */
+describe('refusing a flag a command does not read', () => {
+  const allowed = new Set(['help', 'json', 'api-url']);
+
+  test('an accepted flag passes', () => {
+    expect(() => refuseUnknownFlags('lanes auth login', allowed, { json: true })).not.toThrow();
+    expect(() =>
+      refuseUnknownFlags('lanes auth login', allowed, { 'api-url': 'https://example.invalid' }),
+    ).not.toThrow();
+  });
+
+  test('an unknown flag is refused, and the message names the command', () => {
+    expect(() => refuseUnknownFlags('lanes auth login', allowed, { nope: true })).toThrow(
+      'Unknown flag "--nope" for "lanes auth login"',
+    );
+  });
+
+  test('a near miss is guessed', () => {
+    // The case this whole change is for. `--api_url` is one edit from
+    // `--api-url`, and the old behaviour was to drop it in silence.
+    expect(() =>
+      refuseUnknownFlags('lanes auth login', allowed, { api_url: 'https://example.invalid' }),
+    ).toThrow('Did you mean --api-url?');
+  });
+
+  test('the message lists what is accepted, sorted', () => {
+    try {
+      refuseUnknownFlags('lanes auth', allowed, { wat: true });
+      expect.unreachable();
+    } catch (error) {
+      expect((error as Error).message).toContain('Accepts: --api-url --help --json');
+    }
+  });
+
+  test('the first unknown flag is the one reported', () => {
+    // Reporting one is deliberate: an operator fixes one flag and runs again,
+    // and a list of three refusals reads as three separate problems.
+    expect(() => refuseUnknownFlags('lanes auth', allowed, { aaa: true, zzz: true })).toThrow(
+      '--aaa',
+    );
+  });
+});

--- a/src/cli/unknown-flags.ts
+++ b/src/cli/unknown-flags.ts
@@ -1,0 +1,45 @@
+import { ConfigError } from '#profile';
+import type { Flags } from './argv.ts';
+import { nearest } from './nearest.ts';
+
+/**
+ * Refuse a flag this command does not read, and guess what was meant.
+ *
+ * This is the fix for a reported bug rather than a nicety. `profile add
+ * --workspace cloud` was accepted and dropped, and nothing could refuse it
+ * because `parseArgv` returns every `--anything` it sees and no command ever
+ * inspected the leftovers. A typo was swallowed the same way on every command in
+ * the CLI.
+ *
+ * It lives here, rather than inside `assertKnownFlags` where it was written,
+ * because `lanes auth` is not in the `link` area and so never reached that
+ * function: `lanes.ts` routes it before `main.ts`, which is where the check is
+ * called. The allowlist is the caller's to state — `selection.ts` derives one
+ * from its tables, and `auth-dispatch.ts` writes out the three flags it reads —
+ * but the refusal must be the same one, or the two areas disagree about whether
+ * a mistyped flag is an error.
+ *
+ * What it cost while `auth` was outside it: `lanes auth login --api_url <url>`
+ * dropped the flag, and `login` then fell back to `LANES_API_URL` and finally to
+ * the default. So a sign-in aimed at a self-hosted broker silently went to the
+ * default one, and nothing on the success path names the broker it used. The
+ * subject that comes back is minted by the wrong identity provider, so the
+ * profile that lists the right one refuses it — which presents as "signed in,
+ * but not a member" rather than as a typo.
+ */
+export function refuseUnknownFlags(
+  named: string,
+  allowed: ReadonlySet<string>,
+  flags: Flags,
+): void {
+  for (const given of Object.keys(flags)) {
+    if (allowed.has(given)) continue;
+
+    const guess = nearest(given, allowed);
+    throw new ConfigError(
+      `Unknown flag "--${given}" for "${named}".` +
+        (guess ? `\n  Did you mean --${guess}?` : '') +
+        `\n  Accepts: ${[...allowed].sort().map((name) => `--${name}`).join(' ')}`,
+    );
+  }
+}

--- a/src/cli/usage-data.ts
+++ b/src/cli/usage-data.ts
@@ -291,8 +291,6 @@ export const SECTIONS: readonly Section[] = [
         command: 'doctor --fix',
         description: 'apply a repair it can make itself, such as a provider this project renamed under you',
       },
-      { command: 'auth [--json]', description: 'whether each connection can still sign in' },
-      { command: 'auth --connection <key>', description: 'just this one' },
       { command: 'tools [--json]', description: 'what the endpoint advertises to a client' },
       { command: 'plan', description: 'what reconcile would change' },
       { command: 'audit tail [--limit N] [--denied-only] [--format md]' },

--- a/src/deployments/prepare.ts
+++ b/src/deployments/prepare.ts
@@ -157,9 +157,13 @@ export async function readableRefs(
   // went healthy.
   //
   // Bound, the deployed-but-never-paired case becomes the 404 instead — a
-  // secret that exists with no version — which reads back as null and renders
-  // as `401 {error:'unpaired'}`. The grant is what turns a crash into a
-  // refusal.
+  // secret that exists with no version, which reads back as null. The grant is
+  // what turns a crash into an ordinary absence.
+  //
+  // It used to render as `401 {error:'unpaired'}` and no longer does: ADR-079
+  // withdrew the pairing token as a credential, so the surface answers
+  // `{error:'unauthorized', signIn:true}` to anyone without a bearer and this
+  // ref is only consulted to decide whether the loopback port binds.
   //
   // Deciding it by asking *whether the workspace is paired* is the thing that
   // cannot happen: that means opening a credential store inside `readableRefs`,

--- a/src/server/authorization.ts
+++ b/src/server/authorization.ts
@@ -1,10 +1,12 @@
 import {
   AuthenticatorChain,
   IssuedTokenAuthenticator,
+  LanesKeyAuthenticator,
   OAuthServer,
   OAuthStore,
   OidcAuthenticator,
   OidcVerifier,
+  lanesApiKeyVerifier,
   lanesFederation,
   type Authenticator,
 } from '#auth';
@@ -107,14 +109,29 @@ export async function openAuthorization(
  * The dashboard used to have a credential of its own that named no person, and
  * the surfaces it reached were the ones nothing filtered.
  *
- * Null gate means bearer-token-only: the workspace's static API keys, each
- * naming the uid it was issued to (ADR-068), and no chain to build.
+ * **Order is cost, and it has not changed.** The workspace's own static rows
+ * first, because that is a constant-time comparison against a cached value; the
+ * declared gate next, because an issued token is a lookup in this endpoint's own
+ * state; the Lanes-signed key last, because it is the only link that may have to
+ * fetch a key set. A credential that is not a JWT fails that link on its first
+ * `split`, so putting it last costs the other two nothing.
+ *
+ * **The key link is unconditional**, unlike the gate. It is the headless path —
+ * what a CI job presents when it has no browser to complete a flow in — and
+ * making it depend on `auth.authorization` would mean a profile that declared no
+ * remote-client model could not be reached by a machine at all, which is the
+ * case the static token existed for.
  */
 export function endpointAuthenticator(
   primary: Runtime,
   gate: { readonly authenticator: Authenticator } | null,
+  members: (subject: string) => Promise<readonly string[]>,
 ): Authenticator {
-  return gate
-    ? new AuthenticatorChain([primary.authenticator, gate.authenticator])
-    : primary.authenticator;
+  const profile = primary.resolution.profile;
+
+  return new AuthenticatorChain([
+    primary.authenticator,
+    ...(gate ? [gate.authenticator] : []),
+    new LanesKeyAuthenticator(lanesApiKeyVerifier(), profile, members),
+  ]);
 }

--- a/src/server/edge.ts
+++ b/src/server/edge.ts
@@ -1,4 +1,10 @@
-import { challenge, type AuthOutcome, type Authenticator, type ChallengeError } from '#auth';
+import {
+  challenge,
+  type AuthContext,
+  type AuthOutcome,
+  type Authenticator,
+  type ChallengeError,
+} from '#auth';
 import type { Logger } from '#connectivity';
 import { RateLimiter } from '#policy';
 
@@ -371,9 +377,10 @@ export async function authenticateRequest(
   authenticator: Authenticator,
   request: Request,
   log: Logger,
+  context?: AuthContext,
 ): Promise<AuthOutcome | Response> {
   try {
-    return await authenticator.authenticate(request.headers.get('authorization'));
+    return await authenticator.authenticate(request.headers.get('authorization'), context);
   } catch (error) {
     log.error('could not authenticate', {
       message: error instanceof Error ? error.message : String(error),

--- a/src/server/endpoint.ts
+++ b/src/server/endpoint.ts
@@ -225,13 +225,13 @@ export async function startEndpoint(options: EndpointOptions): Promise<RunningEn
     // disagree about what a pairing token may do (ADR-069).
     const data = dataSurface(() => serving);
 
-    const gate = await openAuthorization(primary, log, async (subject) =>
+    // One closure for the gate and the key link, so neither can disagree on reach.
+    const membersOf = async (subject: string): Promise<readonly string[]> =>
       [...serving]
-        .filter(([, runtime]) =>
-          runtime.config.members.some((member) => member.subject === subject),
-        )
-        .map(([name]) => name),
-    );
+        .filter(([, runtime]) => runtime.config.members.some((m) => m.subject === subject))
+        .map(([name]) => name);
+
+    const gate = await openAuthorization(primary, log, membersOf);
 
     // The authenticator and the authorization gate are built once, from the
     // runtime this endpoint booted with, and are deliberately not part of what
@@ -278,7 +278,7 @@ export async function startEndpoint(options: EndpointOptions): Promise<RunningEn
       },
     );
 
-    const authenticator = endpointAuthenticator(primary, gate);
+    const authenticator = endpointAuthenticator(primary, gate, membersOf);
 
     const server = serve({
       generations,
@@ -296,7 +296,7 @@ export async function startEndpoint(options: EndpointOptions): Promise<RunningEn
         primary,
         profiles: () => generations.current.profiles,
         log,
-        authenticate: (header) => authenticator.authenticate(header),
+        authenticate: (header, context) => authenticator.authenticate(header, context),
         version: runningVersion,
         data,
       }),
@@ -316,7 +316,7 @@ export async function startEndpoint(options: EndpointOptions): Promise<RunningEn
       () => generations.current.profiles,
       log,
       runningVersion,
-      (header) => authenticator.authenticate(header),
+      (header, context) => authenticator.authenticate(header, context),
       data,
       gate?.surface,
     );

--- a/src/server/index.test.ts
+++ b/src/server/index.test.ts
@@ -1,9 +1,12 @@
 import { afterAll, describe, expect, test } from 'bun:test';
 import type { Icon } from '@modelcontextprotocol/server';
 import { allocatePort, rpc, startHarness, wireProfiles, TEST_TOKEN } from './harness.ts';
-import { isLoopback } from './index.ts';
+import { createRequestHandler, isLoopback } from './index.ts';
+import { Generations } from './generations.ts';
 import { SURFACE_TOOL_NAMES } from './mcp/index.ts';
 import { parseConfig, type Config } from '#profile';
+import type { Authenticator } from '#auth';
+import { silentLogger } from './logging.ts';
 import manifest from '../../package.json' with { type: 'json' };
 
 /** The stripe fill, so the two rects that are *not* stripes can be picked out. */
@@ -1335,5 +1338,83 @@ describe('operational logging', () => {
     } finally {
       await listening.stop();
     }
+  });
+});
+
+describe('health, when the credential store will not answer', () => {
+  /**
+   * `/health` was the one surface that asked the authenticator directly.
+   *
+   * Every other path goes through `authenticateRequest`, which turns a store
+   * that throws into a 503 naming the fault. This one did not, and there is no
+   * `catch` above it and no `error` handler on `Bun.serve` — so an unreadable
+   * credential reached the caller as a bare 500 with nothing logged at all. It
+   * is the surface `deploy` and `status` poll, which is the worst place for a
+   * failure with no explanation attached.
+   */
+  /**
+   * An authenticator that fails while *judging* a credential.
+   *
+   * It gives up on a missing bearer first, because every real link does — see
+   * `parseBearer` in `auth/index.ts` and the three in `auth/remote.ts`, all of
+   * which return `missing` before reading anything. A stub that threw
+   * unconditionally would pass the test below for a reason no deployment has.
+   *
+   * What still reaches here after a row-level read is skipped: the workspace's
+   * own `connections.yaml` is read to get the rows at all, so a bucket that has
+   * stopped answering throws before any row is looked at.
+   */
+  const throwing: Authenticator = {
+    authenticate: async (header) => {
+      if (!header) return { ok: false, reason: 'missing' };
+      throw new Error('the workspace bucket did not answer');
+    },
+  };
+
+  function handlerWith(authenticator: Authenticator, log = silentLogger()) {
+    const { profiles } = wireProfiles({
+      profile: 'personal',
+      port: allocatePort(),
+      policy: `  allow:\n    - "example.*"`,
+    });
+    const nothing = () => Promise.resolve();
+
+    return createRequestHandler({
+      generations: new Generations({ profiles, close: nothing }, async () => ({ profiles, close: nothing }), {
+        primary: 'personal',
+        log,
+      }),
+      primary: 'personal',
+      authenticator,
+      log,
+    });
+  }
+
+  const health = (credentialed: boolean): Request =>
+    new Request('https://endpoint.example/health', {
+      headers: credentialed ? { authorization: `Bearer ${TEST_TOKEN}` } : {},
+    });
+
+  test('a credentialed caller is told the endpoint could not check, not that it is broken', async () => {
+    const errors: string[] = [];
+    const log = { ...silentLogger(), error: (message: string) => errors.push(message) };
+
+    const response = await handlerWith(throwing, log).fetch(health(true));
+
+    expect(response.status).toBe(503);
+    expect(response.headers.get('retry-after')).toBe('2');
+    expect(await response.json()).toMatchObject({ error: 'unavailable' });
+    // And it is in the log, which is the half that was missing entirely.
+    expect(errors).toContain('could not authenticate');
+  });
+
+  test('the platform probe still passes, because it presents no credential', async () => {
+    // The reason this change cannot flap a revision. Cloud Run's own probe is
+    // uncredentialed, and authentication gives up on a missing bearer before it
+    // reads any store — so the store being unreachable never reaches the probe.
+    const response = await handlerWith(throwing).fetch(health(false));
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({ status: 'ok' });
   });
 });

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -18,6 +18,7 @@ import {
 import {
   handleAuthorization,
   isAuthorizationPath,
+  publicOrigin,
   resourceMetadataUrl,
   type AuthorizationSurface,
 } from './oauth.ts';
@@ -153,6 +154,9 @@ export function createRequestHandler(options: ServerOptions): RequestHandler {
       }
 
       const url = new URL(request.url);
+      // Who the caller addressed, so a Lanes-signed key binds to this endpoint
+      // rather than to every endpoint its issuer signs for.
+      const addressed = { resource: `${publicOrigin(request)}${MCP_PATH}` };
 
       // Ahead of every path that answers without a credential, because the
       // ceiling further down is inside the `401` branch and so has never covered
@@ -192,9 +196,8 @@ export function createRequestHandler(options: ServerOptions): RequestHandler {
         // And they are the *caller's* since ADR-068: this listed every profile
         // served to anybody holding a credential, so a delegated member read the
         // ones `mayReach` keeps out of their own enum.
-        const named = await options.authenticator.authenticate(
-          request.headers.get('authorization'),
-        );
+        const auth = request.headers.get('authorization');
+        const named = await options.authenticator.authenticate(auth, addressed);
         const who = named.ok ? named.principal : null;
         const mine = options.generations.current.names().filter((n) => who && mayReach(who, n));
         return Response.json({
@@ -222,7 +225,7 @@ export function createRequestHandler(options: ServerOptions): RequestHandler {
         return new Response('Not found', { status: 404 });
       }
 
-      const attempt = await authenticateRequest(options.authenticator, request, options.log);
+      const attempt = await authenticateRequest(options.authenticator, request, options.log, addressed);
       if (attempt instanceof Response) return attempt;
       const outcome = attempt;
 

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -196,8 +196,9 @@ export function createRequestHandler(options: ServerOptions): RequestHandler {
         // And they are the *caller's* since ADR-068: this listed every profile
         // served to anybody holding a credential, so a delegated member read the
         // ones `mayReach` keeps out of their own enum.
-        const auth = request.headers.get('authorization');
-        const named = await options.authenticator.authenticate(auth, addressed);
+        // Via `authenticateRequest` like the rest: asked directly, a throw was a 500.
+        const named = await authenticateRequest(options.authenticator, request, options.log, addressed);
+        if (named instanceof Response) return named;
         const who = named.ok ? named.principal : null;
         const mine = options.generations.current.names().filter((n) => who && mayReach(who, n));
         return Response.json({

--- a/src/server/read/deployed.ts
+++ b/src/server/read/deployed.ts
@@ -2,6 +2,8 @@ import type { Runtime } from '#cli/runtime.ts';
 import type { Logger } from '#connectivity';
 import type { Authenticator } from '#auth';
 import type { ProfileRuntime } from '../mcp/visibility.ts';
+import { MCP_PATH } from '../index.ts';
+import { publicOrigin } from '../oauth.ts';
 import { connectionRows } from './connections.ts';
 import type { ReadDeps } from './routes.ts';
 import type { DataSurface } from '#cli/owner-data/surface.ts';
@@ -47,6 +49,9 @@ export function deployedReadDeps(input: {
     // workspace's own manifests are all named the same way.
     providerName: (id) => primary.registry.manifest(id)?.name,
     authenticate: input.authenticate,
+    // Same origin as `/mcp` here, so the same derivation. Cloud Run routes one
+    // port and these paths hang off it.
+    resource: (request) => `${publicOrigin(request)}${MCP_PATH}`,
     endpoint: { kind: 'deployed', version: input.version, certificateExpiresAt: null },
     ...(input.data ? { data: input.data } : {}),
     log,

--- a/src/server/read/open.ts
+++ b/src/server/read/open.ts
@@ -81,6 +81,10 @@ export async function openReadListener(
       // Who is calling, resolved exactly as `/mcp` resolves it. The endpoint's
       // own authenticator, so a bearer works on both binds or on neither.
       authenticate,
+      // **The MCP server's URL, not this listener's.** This bind is a port above
+      // the endpoint, so its own `Host` names an address no credential was ever
+      // minted for. A key's audience is the endpoint clients call.
+      resource: () => server.url,
       endpoint: { kind: 'local', version, certificateExpiresAt: expiryOf(cert) },
       ...(data ? { data } : {}),
       // **The authorization paths, on this port too.** A page on

--- a/src/server/read/routes.ts
+++ b/src/server/read/routes.ts
@@ -166,6 +166,23 @@ export interface ReadDeps {
    * every other path behaves exactly as it did before this surface existed.
    */
   readonly data?: DataSurface | undefined;
+  /**
+   * This endpoint's resource identifier, for the one authenticator that checks it.
+   *
+   * A function of the request rather than a string, because the two binds answer
+   * differently and neither can guess the other's. A deployed endpoint serves
+   * these paths on its own origin, so the resource is derived from the request
+   * exactly as `/mcp` derives it. The loopback listener is a *second* port — one
+   * above the MCP port — so a resource built from its own `Host` would name an
+   * address no key was ever minted for, and it passes the MCP server's URL
+   * instead.
+   *
+   * Optional, and absent means a Lanes-signed key cannot be judged here and is
+   * refused. That is the safe direction and the reason it is not defaulted: a
+   * fallback guess would be a guess about which endpoint a credential was minted
+   * for, which is the one thing the audience check exists to not do.
+   */
+  readonly resource?: ((request: Request) => string) | undefined;
   readonly allowedOrigins?: readonly string[] | undefined;
   readonly log?: Logger | undefined;
 }
@@ -242,7 +259,10 @@ export async function readRoutes(request: Request, deps: ReadDeps): Promise<Resp
   // indistinguishable from a 500 on a bug. `authenticateRequest` wraps the
   // `/mcp` path the same way, for the same reason.
   const outcome = await deps
-    .authenticate(request.headers.get('authorization'))
+    .authenticate(
+      request.headers.get('authorization'),
+      deps.resource ? { resource: deps.resource(request) } : undefined,
+    )
     .catch((reason: unknown) => {
       deps.log?.warn('could not resolve the caller', {
         reason: reason instanceof Error ? reason.message : String(reason),


### PR DESCRIPTION
Seven pull requests, a minor rather than a patch because a command was removed and a
credential shape was added.

## What is in it

**`lanes link auth` is gone** (#232). It was never a sign-in command — it probed whether each
connection could still authenticate, by attempting the renewal — and the name said the
opposite of what it did. The probe stays: `probeConnections` and `classifyOAuth` moved out of
the command module, because `doctor` asks the same question and must not answer it a second,
differently-wrong way. This is the removal that makes the release a minor.

**An API key is verified rather than stored** (#230). The endpoint accepts an RS256 assertion
signed by the Lanes API, audience-bound to itself, and resolves what it reaches through the
member lists it already reads. Both shapes sit in the chain together, so no deployment has to
be cut over. A long-lived key and a 120-second redirect assertion are not interchangeable:
each verifier requires its own type claim and rejects the other's. Nothing mints one yet —
that is a route on the API, and until it exists this is a verifier with no issuer.

**Availability** (#235, #236). A credential row the endpoint cannot read now refuses itself
instead of the endpoint. The static-token link runs first and unconditionally and read every
row with no guard, so one unreadable row returned an error to every caller — including the
credential that had been working — and the OAuth tokens and signed keys behind it were never
asked. It is now skipped and named in the log, `/health` goes through the same path as every
other surface so the same failure is a 503 with a reason rather than a bare 500, and the
report is written once rather than on every reload.

**Two flag defects, both of which made a command refuse the argument it is named after**
(#233, #234). `workspace show --workspace <name>` was rejected, because the requirement table
had no row for the two-word spelling and the lookup falls back to the bare word. `lanes auth`
was routed before the check that refuses an unknown flag, so a misspelled `--api-url` was
dropped and the sign-in went to the default broker with nothing on the success path saying so.
A new test asserts every allowlist key has a requirement row, which is what made the first one
silent.

**Four comments described a credential that had already been withdrawn** (#231), including the
paragraph `lanes link pair` prints to an operator before they answer a prompt.

## Verified

`bun test` (3731 pass, 0 fail) and `bun run typecheck` green on the integration branch at this
tree.

**Rehearsed twice against a real deployment**, from the branch, noting the serving revision
first each time — because two of these changes are about how a deployed endpoint behaves when
its credential store refuses a read, which no harness can prove.

- The reproduction that motivated #235 was re-run against the built revision: issuing a token
  against a deployed target reliably creates a row with no read grant. Before, that returned
  an error to every caller; now the working credential keeps authenticating and the log names
  the skipped row.
- #236 was found *by* that rehearsal and fixed in a second round: eight reloads had written
  eight lines, because the store varies the wording of each denial. Eleven reloads now write
  one.
- `POST /reload`, `/health` credentialed and not, and the container log — all three, both
  rounds. `tools/list` read off the wire, counted, and equal to the `tools` `/reload`
  returned.
- Both paths to a capability, the typed tool and the generic call, on a sandbox profile holding
  only the owner layer.
- Four refusals: a profile the caller cannot reach, one profile named with another's
  connection, a garbage bearer, and an RS256-shaped token with an unknown key id.
- The test row was revoked after each round and no orphaned secret remained.

The revision built from this tree is what a target is serving now, and it is byte-identical to
this branch.

**Not covered:** the signed-key path has no issuer to test against, so it is exercised only by
its refusals — a well-formed assertion signed by the real API cannot be produced until that
route exists. Recovery after a revoke was confirmed in the first round and not re-driven in the
second; nothing in #236 touches that path.

## Known, and tracked rather than fixed here

Issuing a token writes a secret the deployed runtime is never granted to read, so a deployed
target gets an unreadable row every time and the command still reports success. Pushing
secrets has the same gap; connecting an account already does it correctly. #235 and #236 are
the blast radius, not the cause.
